### PR TITLE
Add per-dictation delete action

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -361,6 +361,21 @@ public final class DictationStore {
         try exec("DELETE FROM dictations", db: db)
     }
 
+    public func deleteDictation(id: Int64) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "DELETE FROM dictations WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
     public func clearMeetings() throws {
         let db = try openDatabase()
         defer { sqlite3_close(db) }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationRowView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationRowView.swift
@@ -5,6 +5,7 @@ struct DictationRowView: View {
     let record: DictationRecord
     let timeOnly: String
     let onCopy: () -> Void
+    let onDelete: () -> Void
 
     @State private var isHovered = false
 
@@ -23,12 +24,23 @@ struct DictationRowView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Button(action: onCopy) {
-                Image(systemName: "doc.on.doc")
-                    .font(.system(size: 12))
-                    .foregroundStyle(MuesliTheme.textTertiary)
+            HStack(spacing: MuesliTheme.spacing8) {
+                Button(action: onCopy) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Copy dictation")
+
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Delete dictation")
             }
-            .buttonStyle(.plain)
             .opacity(isHovered ? 1 : 0)
         }
         .padding(.horizontal, MuesliTheme.spacing20)
@@ -40,5 +52,13 @@ struct DictationRowView: View {
             }
         }
         .onTapGesture(perform: onCopy)
+        .contextMenu {
+            Button("Copy") {
+                onCopy()
+            }
+            Button("Delete", role: .destructive) {
+                onDelete()
+            }
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -20,6 +20,8 @@ struct DictationsView: View {
     let appState: AppState
     let controller: MuesliController
     @State private var selectedFilter: DictationFilter = .all
+    @State private var dictationToDelete: DictationRecord?
+    @State private var showDeleteConfirmation = false
 
     private var groupedDictations: [(header: String, records: [DictationRecord])] {
         let calendar = Calendar.current
@@ -114,6 +116,9 @@ struct DictationsView: View {
                                             timeOnly: formatTimeOnly(record.timestamp)
                                         ) {
                                             controller.copyToClipboard(record.rawText)
+                                        } onDelete: {
+                                            dictationToDelete = record
+                                            showDeleteConfirmation = true
                                         }
                                     }
                                 }
@@ -138,6 +143,22 @@ struct DictationsView: View {
                     .padding(.bottom, MuesliTheme.spacing24)
                 }
             }
+        }
+        .alert(
+            "Delete this dictation?",
+            isPresented: $showDeleteConfirmation
+        ) {
+            Button("Cancel", role: .cancel) {
+                dictationToDelete = nil
+            }
+            Button("Delete", role: .destructive) {
+                if let dictation = dictationToDelete {
+                    controller.deleteDictation(id: dictation.id)
+                }
+                dictationToDelete = nil
+            }
+        } message: {
+            Text(deleteConfirmationMessage)
         }
     }
 
@@ -265,6 +286,25 @@ struct DictationsView: View {
             return clean.count > 5 ? String(clean.suffix(8).prefix(5)) : clean
         }
         return Self.timeFormatter.string(from: date)
+    }
+
+    private var deleteConfirmationMessage: String {
+        guard let dictationToDelete else {
+            return "This speech-to-text record will be permanently deleted."
+        }
+
+        let preview = dictationToDelete.rawText
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        let truncatedPreview: String
+        if preview.count > 90 {
+            truncatedPreview = String(preview.prefix(87)) + "..."
+        } else {
+            truncatedPreview = preview
+        }
+        return truncatedPreview.isEmpty
+            ? "This speech-to-text record will be permanently deleted."
+            : "\"\(truncatedPreview)\" will be permanently deleted."
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -525,6 +525,13 @@ final class MuesliController: NSObject {
         syncAppState()
     }
 
+    func deleteDictation(id: Int64) {
+        try? dictationStore.deleteDictation(id: id)
+        statusBarController?.refresh()
+        historyWindowController?.reload()
+        syncAppState()
+    }
+
     func clearMeetingHistory() {
         try? dictationStore.clearMeetings()
         statusBarController?.refresh()

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -246,6 +246,24 @@ struct DictationStoreTests {
         #expect(try store.recentDictations(limit: 100).isEmpty)
     }
 
+    @Test("delete dictation removes only the selected record")
+    func deleteSingleDictation() throws {
+        let store = try makeStore()
+        let now = Date()
+
+        try store.insertDictation(text: "keep me", durationSeconds: 1.0, startedAt: now, endedAt: now)
+        try store.insertDictation(text: "delete me", durationSeconds: 1.0, startedAt: now, endedAt: now.addingTimeInterval(1))
+
+        let rows = try store.recentDictations(limit: 10)
+        let recordToDelete = try #require(rows.first(where: { $0.rawText == "delete me" }))
+
+        try store.deleteDictation(id: recordToDelete.id)
+
+        let remaining = try store.recentDictations(limit: 10)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.rawText == "keep me")
+    }
+
     @Test("clear meetings removes all records")
     func clearMeetings() throws {
         let store = try makeStore()


### PR DESCRIPTION
## Summary
- add a storage and controller path for deleting a single dictation record
- add per-row delete actions in the dictations list with confirmation before removal
- add a focused store test covering deletion of one selected dictation

## Testing
- swift test --filter DictationStoreTests *(blocked locally by Swift toolchain/SDK mismatch and sandbox cache permission issues)*