### PR TITLE
feat: sound & visual UX effects (glass pill, SF Symbol icons, EQ animation, color theming)

### DIFF
--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -73,6 +73,15 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",

--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -73,15 +73,6 @@
       }
     },
     {
-      "identity" : "swift-configuration",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-configuration.git",
-      "state" : {
-        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -81,12 +81,6 @@ final class FloatingIndicatorController {
     private var isHovered = false
     private var hoverExitWorkItem: DispatchWorkItem?
     private let configStore: ConfigStore
-    private var barLayers: [CALayer] = []
-    private var barAmplitudes: [CGFloat] = []
-    private var animationTime: CGFloat = 0
-    private var amplitudeTimer: Timer?
-    private var smoothedAmplitude: CGFloat = 0
-    private var blobBaseSize: CGSize = .zero
     private var isMeetingRecording = false
     private var glassView: NSVisualEffectView?
     private var tintLayer: CALayer?
@@ -442,86 +436,10 @@ final class FloatingIndicatorController {
         stopLayer = nil
     }
 
-    // MARK: - EQ Waveform Animation
-
-    // 3-bar EQ geometry — all values in points.
-    // Bottom pad + max height must leave ≥4pt top margin inside the pill.
-    private static let eqBarCount = 3
-    private static let eqBarWidth: CGFloat = 4
-    private static let eqBarGap: CGFloat = 6
-    private static let eqBarBottomPad: CGFloat = 5
-    private static let eqBarMaxHeight: CGFloat = 22   // 5 + 22 = 27 → 7pt below 34pt pill top
-    private static let eqBarMinHeight: CGFloat = 5
-    // Middle bar slightly taller for classic EQ pyramid silhouette.
-    private static let eqBarMultipliers: [CGFloat] = [0.72, 1.0, 0.78]
-    // Staggered phase offsets give each bar an independent idle rhythm.
-    private static let eqIdlePhases: [CGFloat] = [0, .pi * 0.75, .pi * 1.45]
-
-    private func startWaveformAnimation(in size: NSSize, xOffset: CGFloat = 0, rightPadding: CGFloat = 0, barCount: Int? = nil) {
-        stopWaveformAnimation()
-        blobBaseSize = size
-        // SF Symbol animation handles the recording visual — just ensure pill cornerRadius.
-        contentView?.layer?.cornerRadius = size.height / 2
-    }
-
     private func stopWaveformAnimation() {
-        amplitudeTimer?.invalidate()
-        amplitudeTimer = nil
-        for bar in barLayers {
-            bar.removeAllAnimations()
-            bar.removeFromSuperlayer()
-        }
-        barLayers.removeAll()
-        barAmplitudes.removeAll()
-        smoothedAmplitude = 0
-        animationTime = 0
-        blobBaseSize = .zero
         powerProvider = nil
         contentView?.layer?.transform = CATransform3DIdentity
         removeStopLayer()
-    }
-
-    private func updateEQBars() {
-        guard !barLayers.isEmpty else { return }
-
-        animationTime += 1.0 / 30.0
-
-        let dB = CGFloat(powerProvider?() ?? -160)
-        let normalized = max(0, min(1, (dB + 50) / 42))
-        smoothedAmplitude = smoothedAmplitude * 0.15 + normalized * 0.85
-
-        let isReactive = smoothedAmplitude > 0.04
-        let maxH = FloatingIndicatorController.eqBarMaxHeight
-        let minH = FloatingIndicatorController.eqBarMinHeight
-        let maxH = FloatingIndicatorController.eqBarMaxHeight
-        let minH = FloatingIndicatorController.eqBarMinHeight
-
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(0.07)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
-
-        for i in 0..<barLayers.count {
-            let targetH: CGFloat
-            if isReactive {
-                let jitter = CGFloat.random(in: -0.06...0.06)
-                let h = minH + (maxH - minH) * (smoothedAmplitude * FloatingIndicatorController.eqBarMultipliers[i] + jitter)
-                targetH = max(minH, min(maxH, h))
-            } else {
-                // Idle pulse: slow sine wave with staggered phase per bar.
-                let phase = animationTime * 2 * .pi * 0.6 + FloatingIndicatorController.eqIdlePhases[i]
-                targetH = 8 + 4 * sin(phase)
-            }
-
-            // Smooth each bar independently.
-            barAmplitudes[i] = barAmplitudes[i] * 0.2 + targetH * 0.8
-
-            var f = barLayers[i].frame
-            f.size.height = barAmplitudes[i]
-            f.origin.y = (blobBaseSize.height - barAmplitudes[i]) / 2
-            barLayers[i].frame = f
-        }
-
-        CATransaction.commit()
     }
 
     private func applyGlassState(_ state: DictationState, frameSize: NSSize) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -82,9 +82,17 @@ final class FloatingIndicatorController {
     private var hoverExitWorkItem: DispatchWorkItem?
     private let configStore: ConfigStore
     private var barLayers: [CALayer] = []
+    private var barAmplitudes: [CGFloat] = []
+    private var animationTime: CGFloat = 0
     private var amplitudeTimer: Timer?
     private var smoothedAmplitude: CGFloat = 0
+    private var blobBaseSize: CGSize = .zero
     private var isMeetingRecording = false
+    private var glassView: NSVisualEffectView?
+    private var tintLayer: CALayer?
+    private var micIconView: NSImageView?
+    private var wandIconView: NSImageView?
+    private var specularLayer: CAGradientLayer?
     fileprivate var isDragging = false
     var powerProvider: (() -> Float)?
     var onStopMeeting: (() -> Void)?
@@ -154,6 +162,7 @@ final class FloatingIndicatorController {
         textLabel.isHidden = true
         textLabel.alphaValue = 0
         layoutLabels(iconLabel: iconLabel, textLabel: textLabel, in: targetFrame.size, hasTitle: false, animated: false)
+        applyGlassState(.idle, frameSize: targetFrame.size)
     }
 
     func savePosition() {
@@ -210,6 +219,15 @@ final class FloatingIndicatorController {
 
         if previousState == .recording && state != .recording {
             stopWaveformAnimation()
+        }
+
+        // Immediately snap glass elements off when leaving idle so the SF Symbol
+        // mic doesn't linger/fade during the recording/transcribing transition.
+        if state != .idle {
+            micIconView?.isHidden = true
+            glassView?.isHidden = true
+            tintLayer?.isHidden = true
+            specularLayer?.isHidden = true
         }
 
         let style = styleForState(state)
@@ -271,11 +289,31 @@ final class FloatingIndicatorController {
                     animated: true
                 )
             }
+
+            // Apply glass state last so it can override iconLabel visibility set above.
+            applyGlassState(state, frameSize: targetFrame.size)
         }
 
-        if state == .recording {
-            startWaveformAnimation(in: targetFrame.size, xOffset: 24, rightPadding: 24)
+        // Manage SF Symbol effects — stop everything first, then start for the new state.
+        micIconView?.removeAllSymbolEffects(animated: false)
+        wandIconView?.removeAllSymbolEffects(animated: false)
+
+        switch state {
+        case .recording:
+            micIconView?.addSymbolEffect(
+                .variableColor.iterative.dimInactiveLayers.reversing,
+                options: .repeating, animated: true
+            )
             addStopLayer(in: targetFrame.size)
+        case .transcribing:
+            if #available(macOS 15, *) {
+                wandIconView?.addSymbolEffect(
+                    .wiggle.backward.byLayer,
+                    options: .repeating, animated: true
+                )
+            }
+        default:
+            break
         }
 
         panel.orderFrontRegardless()
@@ -298,6 +336,12 @@ final class FloatingIndicatorController {
         let x = min(max(center.x - warningSize.width / 2, screen.minX), screen.maxX - warningSize.width)
         let y = min(max(center.y - warningSize.height / 2, screen.minY), screen.maxY - warningSize.height)
         let targetFrame = NSRect(x: x, y: y, width: warningSize.width, height: warningSize.height)
+
+        // Warning uses its own solid amber background — hide glass layers.
+        glassView?.isHidden = true
+        tintLayer?.isHidden = true
+        specularLayer?.isHidden = true
+        micIconView?.isHidden = true
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.18
@@ -365,6 +409,11 @@ final class FloatingIndicatorController {
         contentView = nil
         iconLabel = nil
         textLabel = nil
+        glassView = nil
+        tintLayer = nil
+        micIconView = nil
+        wandIconView = nil
+        specularLayer = nil
     }
 
     // MARK: - Stop Layer (toggle dictation)
@@ -393,51 +442,26 @@ final class FloatingIndicatorController {
         stopLayer = nil
     }
 
-    // MARK: - Waveform Animation
+    // MARK: - EQ Waveform Animation
 
-    private static let barCount = 5
-    private static let barWidth: CGFloat = 3.0
-    private static let barSpacing: CGFloat = 4.0
-    private static let barMinHeight: CGFloat = 5.0
-    private static let barMaxHeight: CGFloat = 26.0
-    private static let barMultipliers5: [CGFloat] = [0.6, 0.85, 1.0, 0.85, 0.6]
+    // 3-bar EQ geometry — all values in points.
+    // Bottom pad + max height must leave ≥4pt top margin inside the pill.
+    private static let eqBarCount = 3
+    private static let eqBarWidth: CGFloat = 4
+    private static let eqBarGap: CGFloat = 6
+    private static let eqBarBottomPad: CGFloat = 5
+    private static let eqBarMaxHeight: CGFloat = 22   // 5 + 22 = 27 → 7pt below 34pt pill top
+    private static let eqBarMinHeight: CGFloat = 5
+    // Middle bar slightly taller for classic EQ pyramid silhouette.
+    private static let eqBarMultipliers: [CGFloat] = [0.72, 1.0, 0.78]
+    // Staggered phase offsets give each bar an independent idle rhythm.
+    private static let eqIdlePhases: [CGFloat] = [0, .pi * 0.75, .pi * 1.45]
+
     private func startWaveformAnimation(in size: NSSize, xOffset: CGFloat = 0, rightPadding: CGFloat = 0, barCount: Int? = nil) {
-        let savedProvider = powerProvider
         stopWaveformAnimation()
-        powerProvider = savedProvider
-        guard let contentView else { return }
-
-        let count = barCount ?? Self.barCount
-        let multipliers = Self.barMultipliers5
-        let totalWidth = CGFloat(count) * Self.barWidth + CGFloat(count - 1) * Self.barSpacing
-        let availableWidth = size.width - xOffset - rightPadding
-        let startX = xOffset + (availableWidth - totalWidth) / 2
-
-        for i in 0..<count {
-            let bar = CALayer()
-            let x = startX + CGFloat(i) * (Self.barWidth + Self.barSpacing)
-            let height = Self.barMinHeight * multipliers[i]
-            bar.frame = CGRect(
-                x: x,
-                y: (size.height - height) / 2,
-                width: Self.barWidth,
-                height: height
-            )
-            bar.cornerRadius = Self.barWidth / 2
-            bar.backgroundColor = NSColor.white.withAlphaComponent(0.85).cgColor
-            bar.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-            bar.position = CGPoint(x: x + Self.barWidth / 2, y: size.height / 2)
-
-            contentView.layer?.addSublayer(bar)
-            barLayers.append(bar)
-        }
-
-        smoothedAmplitude = 0
-        amplitudeTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.updateBarAmplitudes()
-            }
-        }
+        blobBaseSize = size
+        // SF Symbol animation handles the recording visual — just ensure pill cornerRadius.
+        contentView?.layer?.cornerRadius = size.height / 2
     }
 
     private func stopWaveformAnimation() {
@@ -448,27 +472,153 @@ final class FloatingIndicatorController {
             bar.removeFromSuperlayer()
         }
         barLayers.removeAll()
+        barAmplitudes.removeAll()
         smoothedAmplitude = 0
+        animationTime = 0
+        blobBaseSize = .zero
         powerProvider = nil
+        contentView?.layer?.transform = CATransform3DIdentity
         removeStopLayer()
     }
 
-    private func updateBarAmplitudes() {
+    private func updateEQBars() {
+        guard !barLayers.isEmpty else { return }
+
+        animationTime += 1.0 / 30.0
+
         let dB = CGFloat(powerProvider?() ?? -160)
         let normalized = max(0, min(1, (dB + 50) / 42))
-        smoothedAmplitude = smoothedAmplitude * 0.35 + normalized * 0.65
+        smoothedAmplitude = smoothedAmplitude * 0.15 + normalized * 0.85
 
-        let pillHeight = panel?.frame.height ?? 32
-        let multipliers = Self.barMultipliers5
-        for (i, bar) in barLayers.enumerated() {
-            let multiplier = multipliers[i]
-            let baseline = Self.barMinHeight + (1 - multiplier) * 2
-            let height = baseline + smoothedAmplitude * (Self.barMaxHeight - baseline) * multiplier
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            bar.bounds = CGRect(x: 0, y: 0, width: Self.barWidth, height: height)
-            bar.position = CGPoint(x: bar.position.x, y: pillHeight / 2)
-            CATransaction.commit()
+        let isReactive = smoothedAmplitude > 0.04
+        let maxH = FloatingIndicatorController.eqBarMaxHeight
+        let minH = FloatingIndicatorController.eqBarMinHeight
+        let bottomPad = FloatingIndicatorController.eqBarBottomPad
+
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.07)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+
+        for i in 0..<barLayers.count {
+            let targetH: CGFloat
+            if isReactive {
+                let jitter = CGFloat.random(in: -0.06...0.06)
+                let h = minH + (maxH - minH) * (smoothedAmplitude * FloatingIndicatorController.eqBarMultipliers[i] + jitter)
+                targetH = max(minH, min(maxH, h))
+            } else {
+                // Idle pulse: slow sine wave with staggered phase per bar.
+                let phase = animationTime * 2 * .pi * 0.6 + FloatingIndicatorController.eqIdlePhases[i]
+                targetH = 8 + 4 * sin(phase)
+            }
+
+            // Smooth each bar independently.
+            barAmplitudes[i] = barAmplitudes[i] * 0.2 + targetH * 0.8
+
+            var f = barLayers[i].frame
+            f.size.height = barAmplitudes[i]
+            f.origin.y = (blobBaseSize.height - barAmplitudes[i]) / 2
+            barLayers[i].frame = f
+        }
+
+        CATransaction.commit()
+    }
+
+    private func applyGlassState(_ state: DictationState, frameSize: NSSize) {
+        let isIdle = (state == .idle)
+        let radius = frameSize.height / 2
+        let themeHex = configStore.load().recordingColorHex
+
+        // Glass shown for every state — recording and transcribing are
+        // dark frosted glass just like the idle pill.
+        glassView?.isHidden = false
+        glassView?.layer?.cornerRadius = radius
+
+        // Tint alpha varies by state and hover.
+        let tintAlpha: CGFloat
+        switch state {
+        case .idle:       tintAlpha = isHovered ? 0.72 : 0.44
+        case .preparing:  tintAlpha = 0.62
+        case .recording:  tintAlpha = 0.62
+        case .transcribing: tintAlpha = 0.62
+        }
+        tintLayer?.isHidden = false
+        tintLayer?.backgroundColor = NSColor.colorWith(hexString: themeHex, alpha: tintAlpha).cgColor
+        tintLayer?.frame = CGRect(origin: .zero, size: frameSize)
+        tintLayer?.cornerRadius = radius
+
+        // Specular only on the compact non-hovered idle pill.
+        let showSpecular = isIdle && !isHovered
+        specularLayer?.isHidden = !showSpecular
+        if showSpecular {
+            specularLayer?.frame = CGRect(
+                x: 0,
+                y: frameSize.height * 0.45,
+                width: frameSize.width,
+                height: frameSize.height * 0.55
+            )
+            specularLayer?.cornerRadius = radius
+        }
+
+        let iconSize = NSSize(width: 18, height: 18)
+
+        switch state {
+        case .idle:
+            // Mic symbol centred (or left-aligned when hovered beside text).
+            wandIconView?.isHidden = true
+            iconLabel?.isHidden = true
+            micIconView?.isHidden = false
+            if let mic = micIconView {
+                if isHovered {
+                    mic.frame = NSRect(x: 12, y: (frameSize.height - iconSize.height) / 2,
+                                      width: iconSize.width, height: iconSize.height)
+                } else {
+                    mic.frame = NSRect(x: (frameSize.width - iconSize.width) / 2,
+                                       y: (frameSize.height - iconSize.height) / 2,
+                                       width: iconSize.width, height: iconSize.height)
+                }
+            }
+
+        case .recording:
+            // Animated mic symbol centred between ✕ (left) and stop (right).
+            wandIconView?.isHidden = true
+            iconLabel?.isHidden = false   // keeps the ✕ cancel label
+            micIconView?.isHidden = false
+            if let mic = micIconView {
+                // Centre in the region between the ✕ right-edge (~17pt) and stop left-edge (~74pt).
+                let midX = (17 + 74) / 2.0
+                mic.frame = NSRect(x: midX - iconSize.width / 2,
+                                   y: (frameSize.height - iconSize.height) / 2,
+                                   width: iconSize.width, height: iconSize.height)
+            }
+
+        case .transcribing:
+            // Animated wand beside "Transcribing" label, the pair centred in the pill.
+            micIconView?.isHidden = true
+            iconLabel?.isHidden = true
+            wandIconView?.isHidden = false
+            if let wand = wandIconView {
+                let gap: CGFloat = 6
+                let attrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 11, weight: .regular)
+                ]
+                let textW = ceil(("Transcribing" as NSString).size(withAttributes: attrs).width) + 2
+                let totalW = iconSize.width + gap + textW
+                let startX = (frameSize.width - totalW) / 2
+                wand.frame = NSRect(x: startX, y: (frameSize.height - iconSize.height) / 2,
+                                    width: iconSize.width, height: iconSize.height)
+                // Reposition text label to sit right of the wand.
+                let textH: CGFloat = 14
+                textLabel?.frame = NSRect(x: startX + iconSize.width + gap,
+                                          y: (frameSize.height - textH) / 2,
+                                          width: textW, height: textH)
+                textLabel?.isHidden = false
+                textLabel?.alphaValue = 1
+            }
+
+        case .preparing:
+            wandIconView?.isHidden = true
+            micIconView?.isHidden = true
+            iconLabel?.isHidden = false
         }
     }
 
@@ -501,7 +651,7 @@ final class FloatingIndicatorController {
 
         let textLabel = NSTextField(labelWithString: "")
         textLabel.alignment = .left
-        textLabel.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+        textLabel.font = NSFont.systemFont(ofSize: 11, weight: .regular)
         contentView.addSubview(textLabel)
 
         panel.contentView = contentView
@@ -510,6 +660,69 @@ final class FloatingIndicatorController {
         self.contentView = contentView
         self.iconLabel = iconLabel
         self.textLabel = textLabel
+
+        setupGlassLayer(in: contentView, iconLabel: iconLabel)
+    }
+
+    private func setupGlassLayer(in contentView: HoverIndicatorView, iconLabel: NSTextField) {
+        // masksToBounds clips both the glass blur and the tint layer to the pill shape.
+        // The panel's compositor-level shadow is unaffected.
+        contentView.layer?.masksToBounds = true
+
+        // NSVisualEffectView — frosted blur behind the pill.
+        let vev = NSVisualEffectView(frame: contentView.bounds)
+        vev.autoresizingMask = [.width, .height]
+        vev.material = .hudWindow
+        vev.blendingMode = .behindWindow
+        vev.state = .active
+        // Force dark appearance so the glass always looks dark regardless of
+        // what's behind the pill (light windows, bright desktops, etc.).
+        vev.appearance = NSAppearance(named: .darkAqua)
+        vev.isHidden = true
+        contentView.addSubview(vev, positioned: .below, relativeTo: iconLabel)
+        glassView = vev
+
+        // Dark Catppuccin Mocha tint over the blur — gives the pill a defined
+        // dark glass presence rather than showing everything underneath.
+        let tint = CALayer()
+        tint.backgroundColor = NSColor.colorWith(hex: 0x1e1e2e, alpha: 0.44).cgColor
+        tint.isHidden = true
+        contentView.layer?.addSublayer(tint)
+        tintLayer = tint
+
+        // waveform.badge.microphone — idle (static) and recording (animated).
+        let symConfig = NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)
+        let micImage = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
+            .withSymbolConfiguration(symConfig)
+        let micView = NSImageView(image: micImage ?? NSImage())
+        micView.contentTintColor = .white
+        micView.imageScaling = .scaleProportionallyDown
+        micView.isHidden = true
+        contentView.addSubview(micView)
+        micIconView = micView
+
+        // wand.and.sparkles — transcribing (animated).
+        let wandConfig = NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)
+        let wandImage = NSImage(systemSymbolName: "wand.and.sparkles", accessibilityDescription: nil)?
+            .withSymbolConfiguration(wandConfig)
+        let wandView = NSImageView(image: wandImage ?? NSImage())
+        wandView.contentTintColor = .white
+        wandView.imageScaling = .scaleProportionallyDown
+        wandView.isHidden = true
+        contentView.addSubview(wandView)
+        wandIconView = wandView
+
+        // Specular highlight — white-to-clear gradient on the upper half for glass depth.
+        let specular = CAGradientLayer()
+        specular.colors = [
+            NSColor.white.withAlphaComponent(0.28).cgColor,
+            NSColor.white.withAlphaComponent(0.0).cgColor,
+        ]
+        specular.startPoint = CGPoint(x: 0.5, y: 1.0)
+        specular.endPoint   = CGPoint(x: 0.5, y: 0.4)
+        specular.isHidden = true
+        contentView.layer?.addSublayer(specular)
+        specularLayer = specular
     }
 
     static func defaultIndicatorCenter(in visibleFrame: NSRect, idleSize: NSSize = NSSize(width: 44, height: 28)) -> CGPoint {
@@ -535,9 +748,9 @@ final class FloatingIndicatorController {
         let size: NSSize
         switch state {
         case .idle:
-            size = isHovered ? NSSize(width: 220, height: 36) : NSSize(width: 44, height: 28)
-        case .preparing: size = NSSize(width: 44, height: 28)
-        case .recording: size = NSSize(width: 76, height: 22)
+            size = isHovered ? NSSize(width: 192, height: 32) : NSSize(width: 48, height: 30)
+        case .preparing: size = NSSize(width: 48, height: 30)
+        case .recording: size = NSSize(width: 90, height: 34)
         case .transcribing: size = NSSize(width: 120, height: 32)
         }
 
@@ -563,42 +776,36 @@ final class FloatingIndicatorController {
         switch state {
         case .idle:
             return (
-                .colorWith(hex: 0x000000, alpha: isHovered ? 0.96 : 0.66),
-                .colorWith(hex: 0xFFFFFF, alpha: 0.18),
-                "🎤",
+                .clear,
+                .colorWith(hex: 0xFFFFFF, alpha: isHovered ? 0.14 : 0.22),
+                "",
                 isHovered ? "Hold \(hotkeyLabel) to dictate" : "",
-                .colorWith(hex: 0xFFFFFF, alpha: 0.92),
-                .colorWith(hex: 0xFFFFFF, alpha: 0.92),
-                isHovered ? 1.0 : 0.82
+                .colorWith(hex: 0xFFFFFF, alpha: 0.75),
+                .colorWith(hex: 0xFFFFFF, alpha: 0.75),
+                isHovered ? 1.0 : 0.85
             )
         case .preparing:
             return (
-                .colorWith(hex: 0x3B4757, alpha: 0.94),
-                .colorWith(hex: 0xFFFFFF, alpha: 0.24),
-                "🎤",
-                "",
-                .white,
-                .white,
-                1.0
+                .clear,
+                .colorWith(hex: 0xFFFFFF, alpha: 0.16),
+                "", "", .white, .white, 1.0
             )
         case .recording:
             return (
-                .colorWith(hex: 0xD32F2F, alpha: 0.72),
-                .colorWith(hex: 0xFFFFFF, alpha: 0.24),
-                isMeetingRecording ? "⏹" : "🎤",
+                .clear,
+                .colorWith(hex: 0xFFFFFF, alpha: 0.16),
+                isMeetingRecording ? "⏹" : "",
                 isMeetingRecording ? "" : "Listening",
-                .white,
-                .white,
-                1.0
+                .white, .white, 1.0
             )
         case .transcribing:
             return (
-                .colorWith(hex: 0xD99A11, alpha: 0.72),
-                .colorWith(hex: 0xFFFFFF, alpha: 0.24),
-                "✍️",
+                .clear,
+                .colorWith(hex: 0xFFFFFF, alpha: 0.16),
+                "",
                 transcribingTitle,
-                .colorWith(hex: 0x1A140D, alpha: 0.95),
-                .black,
+                .white,
+                .colorWith(hex: 0xFFFFFF, alpha: 0.82),
                 1.0
             )
         }
@@ -686,5 +893,14 @@ private extension NSColor {
             blue: CGFloat(hex & 0xFF) / 255.0,
             alpha: alpha
         )
+    }
+
+    static func colorWith(hexString: String, alpha: CGFloat = 1.0) -> NSColor {
+        var h = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        h = h.hasPrefix("#") ? String(h.dropFirst()) : h
+        guard h.count == 6, let value = UInt64(h, radix: 16) else {
+            return .colorWith(hex: 0x1e1e2e, alpha: alpha)
+        }
+        return .colorWith(hex: Int(value), alpha: alpha)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -86,7 +86,6 @@ final class FloatingIndicatorController {
     private var tintLayer: CALayer?
     private var micIconView: NSImageView?
     private var wandIconView: NSImageView?
-    private var specularLayer: CAGradientLayer?
     private var barLayers: [CALayer] = []
     private var amplitudeTimer: Timer?
     private var smoothedAmplitude: CGFloat = 0
@@ -224,7 +223,7 @@ final class FloatingIndicatorController {
             micIconView?.isHidden = true
             glassView?.isHidden = true
             tintLayer?.isHidden = true
-            specularLayer?.isHidden = true
+
         }
 
         let style = styleForState(state)
@@ -335,7 +334,6 @@ final class FloatingIndicatorController {
         // Warning uses its own solid amber background — hide glass layers.
         glassView?.isHidden = true
         tintLayer?.isHidden = true
-        specularLayer?.isHidden = true
         micIconView?.isHidden = true
 
         NSAnimationContext.runAnimationGroup { context in
@@ -408,7 +406,6 @@ final class FloatingIndicatorController {
         tintLayer = nil
         micIconView = nil
         wandIconView = nil
-        specularLayer = nil
     }
 
     // MARK: - Stop Layer (toggle dictation)
@@ -528,17 +525,6 @@ final class FloatingIndicatorController {
         tintLayer?.frame = CGRect(origin: .zero, size: frameSize)
         tintLayer?.cornerRadius = radius
 
-        specularLayer?.isHidden = true
-        if false {
-            specularLayer?.frame = CGRect(
-                x: 0,
-                y: frameSize.height * 0.45,
-                width: frameSize.width,
-                height: frameSize.height * 0.55
-            )
-            specularLayer?.cornerRadius = radius
-        }
-
         let iconSize = NSSize(width: 18, height: 18)
 
         switch state {
@@ -574,7 +560,7 @@ final class FloatingIndicatorController {
                 let attrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.systemFont(ofSize: 11, weight: .regular)
                 ]
-                let textW = ceil(("Transcribing" as NSString).size(withAttributes: attrs).width) + 2
+                let textW = ceil((transcribingTitle as NSString).size(withAttributes: attrs).width) + 2
                 let totalW = iconSize.width + gap + textW
                 let startX = (frameSize.width - totalW) / 2
                 wand.frame = NSRect(x: startX, y: (frameSize.height - iconSize.height) / 2,
@@ -685,17 +671,6 @@ final class FloatingIndicatorController {
         contentView.addSubview(wandView)
         wandIconView = wandView
 
-        // Specular highlight — white-to-clear gradient on the upper half for glass depth.
-        let specular = CAGradientLayer()
-        specular.colors = [
-            NSColor.white.withAlphaComponent(0.28).cgColor,
-            NSColor.white.withAlphaComponent(0.0).cgColor,
-        ]
-        specular.startPoint = CGPoint(x: 0.5, y: 1.0)
-        specular.endPoint   = CGPoint(x: 0.5, y: 0.4)
-        specular.isHidden = true
-        contentView.layer?.addSublayer(specular)
-        specularLayer = specular
     }
 
     static func defaultIndicatorCenter(in visibleFrame: NSRect, idleSize: NSSize = NSSize(width: 44, height: 28)) -> CGPoint {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -87,6 +87,9 @@ final class FloatingIndicatorController {
     private var micIconView: NSImageView?
     private var wandIconView: NSImageView?
     private var specularLayer: CAGradientLayer?
+    private var barLayers: [CALayer] = []
+    private var amplitudeTimer: Timer?
+    private var smoothedAmplitude: CGFloat = 0
     fileprivate var isDragging = false
     var powerProvider: (() -> Float)?
     var onStopMeeting: (() -> Void)?
@@ -294,10 +297,8 @@ final class FloatingIndicatorController {
 
         switch state {
         case .recording:
-            micIconView?.addSymbolEffect(
-                .variableColor.iterative.dimInactiveLayers.reversing,
-                options: .repeating, animated: true
-            )
+            setupWaveformBars(in: targetFrame.size)
+            startWaveformAnimation()
             addStopLayer(in: targetFrame.size)
         case .transcribing:
             if #available(macOS 15, *) {
@@ -437,38 +438,98 @@ final class FloatingIndicatorController {
     }
 
     private func stopWaveformAnimation() {
+        amplitudeTimer?.invalidate()
+        amplitudeTimer = nil
+        barLayers.forEach { $0.removeFromSuperlayer() }
+        barLayers.removeAll()
+        smoothedAmplitude = 0
         powerProvider = nil
         contentView?.layer?.transform = CATransform3DIdentity
         removeStopLayer()
     }
 
+    private func setupWaveformBars(in frameSize: NSSize) {
+        barLayers.forEach { $0.removeFromSuperlayer() }
+        barLayers.removeAll()
+        guard let layer = contentView?.layer else { return }
+
+        let barCount = 5
+        let barWidth: CGFloat = 3
+        let barSpacing: CGFloat = 3
+        let totalWidth = CGFloat(barCount) * barWidth + CGFloat(barCount - 1) * barSpacing
+        let startX = (frameSize.width - totalWidth) / 2
+        let minHeight: CGFloat = 4
+
+        for i in 0..<barCount {
+            let bar = CALayer()
+            bar.backgroundColor = NSColor.white.withAlphaComponent(0.85).cgColor
+            bar.cornerRadius = barWidth / 2
+            let x = startX + CGFloat(i) * (barWidth + barSpacing)
+            bar.frame = CGRect(x: x, y: (frameSize.height - minHeight) / 2, width: barWidth, height: minHeight)
+            layer.addSublayer(bar)
+            barLayers.append(bar)
+        }
+    }
+
+    private func startWaveformAnimation() {
+        amplitudeTimer?.invalidate()
+        let multipliers: [CGFloat] = [0.6, 0.85, 1.0, 0.85, 0.6]
+        let minHeight: CGFloat = 3
+        let maxHeight: CGFloat = 14
+
+        amplitudeTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            guard let self, let contentView = self.contentView else { return }
+            let dB = CGFloat(self.powerProvider?() ?? -160)
+            let raw = max(0, min(1, (dB + 50) / 50))
+            self.smoothedAmplitude = 0.35 * raw + 0.65 * self.smoothedAmplitude
+            let pillHeight = contentView.frame.height
+
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            for (i, bar) in self.barLayers.enumerated() {
+                let m = i < multipliers.count ? multipliers[i] : 1.0
+                let h = minHeight + (maxHeight - minHeight) * self.smoothedAmplitude * m
+                bar.frame.size.height = h
+                bar.frame.origin.y = (pillHeight - h) / 2
+            }
+            CATransaction.commit()
+        }
+    }
+
     private func applyGlassState(_ state: DictationState, frameSize: NSSize) {
+        let config = configStore.load()
         let isIdle = (state == .idle)
         let radius = frameSize.height / 2
-        let themeHex = configStore.load().recordingColorHex
+        let themeHex = config.recordingColorHex
 
-        // Glass shown for every state — recording and transcribing are
-        // dark frosted glass just like the idle pill.
-        glassView?.isHidden = false
+        // During recording, hide frost and show solid accent. Otherwise frosted glass.
+        let isRecording = (state == .recording)
+        glassView?.isHidden = isRecording
         glassView?.layer?.cornerRadius = radius
 
-        // Tint alpha varies by state and hover.
         let tintAlpha: CGFloat
+        let tintHex: String
         switch state {
-        case .idle:       tintAlpha = isHovered ? 0.72 : 0.44
-        case .preparing:  tintAlpha = 0.62
-        case .recording:  tintAlpha = 0.62
-        case .transcribing: tintAlpha = 0.62
+        case .idle:
+            tintAlpha = isHovered ? 0.72 : 0.44
+            tintHex = "1e1e2e"
+        case .preparing:
+            tintAlpha = 0.62
+            tintHex = "1e1e2e"
+        case .recording:
+            tintAlpha = 0.85
+            tintHex = themeHex
+        case .transcribing:
+            tintAlpha = 0.62
+            tintHex = "1e1e2e"
         }
         tintLayer?.isHidden = false
-        tintLayer?.backgroundColor = NSColor.colorWith(hexString: themeHex, alpha: tintAlpha).cgColor
+        tintLayer?.backgroundColor = NSColor.colorWith(hexString: tintHex, alpha: tintAlpha).cgColor
         tintLayer?.frame = CGRect(origin: .zero, size: frameSize)
         tintLayer?.cornerRadius = radius
 
-        // Specular only on the compact non-hovered idle pill.
-        let showSpecular = isIdle && !isHovered
-        specularLayer?.isHidden = !showSpecular
-        if showSpecular {
+        specularLayer?.isHidden = true
+        if false {
             specularLayer?.frame = CGRect(
                 x: 0,
                 y: frameSize.height * 0.45,
@@ -498,17 +559,10 @@ final class FloatingIndicatorController {
             }
 
         case .recording:
-            // Animated mic symbol centred between ✕ (left) and stop (right).
+            // Waveform bars replace mic icon during recording.
             wandIconView?.isHidden = true
             iconLabel?.isHidden = false   // keeps the ✕ cancel label
-            micIconView?.isHidden = false
-            if let mic = micIconView {
-                // Centre in the region between the ✕ right-edge (~17pt) and stop left-edge (~74pt).
-                let midX = (17 + 74) / 2.0
-                mic.frame = NSRect(x: midX - iconSize.width / 2,
-                                   y: (frameSize.height - iconSize.height) / 2,
-                                   width: iconSize.width, height: iconSize.height)
-            }
+            micIconView?.isHidden = true
 
         case .transcribing:
             // Animated wand beside "Transcribing" label, the pair centred in the pill.
@@ -667,9 +721,9 @@ final class FloatingIndicatorController {
         let size: NSSize
         switch state {
         case .idle:
-            size = isHovered ? NSSize(width: 192, height: 32) : NSSize(width: 48, height: 30)
-        case .preparing: size = NSSize(width: 48, height: 30)
-        case .recording: size = NSSize(width: 90, height: 34)
+            size = isHovered ? NSSize(width: 220, height: 36) : NSSize(width: 44, height: 28)
+        case .preparing: size = NSSize(width: 44, height: 28)
+        case .recording: size = NSSize(width: 76, height: 22)
         case .transcribing: size = NSSize(width: 120, height: 32)
         }
 
@@ -704,28 +758,19 @@ final class FloatingIndicatorController {
                 isHovered ? 1.0 : 0.85
             )
         case .preparing:
-            return (
-                .clear,
-                .colorWith(hex: 0xFFFFFF, alpha: 0.16),
-                "", "", .white, .white, 1.0
-            )
+            return (.clear, .colorWith(hex: 0xFFFFFF, alpha: 0.16), "", "", .white, .white, 1.0)
         case .recording:
             return (
-                .clear,
-                .colorWith(hex: 0xFFFFFF, alpha: 0.16),
+                .clear, .colorWith(hex: 0xFFFFFF, alpha: 0.16),
                 isMeetingRecording ? "⏹" : "",
-                isMeetingRecording ? "" : "Listening",
+                isMeetingRecording ? "" : "",
                 .white, .white, 1.0
             )
         case .transcribing:
             return (
-                .clear,
-                .colorWith(hex: 0xFFFFFF, alpha: 0.16),
-                "",
-                transcribingTitle,
-                .white,
-                .colorWith(hex: 0xFFFFFF, alpha: 0.82),
-                1.0
+                .clear, .colorWith(hex: 0xFFFFFF, alpha: 0.16),
+                "", transcribingTitle,
+                .white, .colorWith(hex: 0xFFFFFF, alpha: 0.82), 1.0
             )
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -493,7 +493,8 @@ final class FloatingIndicatorController {
         let isReactive = smoothedAmplitude > 0.04
         let maxH = FloatingIndicatorController.eqBarMaxHeight
         let minH = FloatingIndicatorController.eqBarMinHeight
-        let bottomPad = FloatingIndicatorController.eqBarBottomPad
+        let maxH = FloatingIndicatorController.eqBarMaxHeight
+        let minH = FloatingIndicatorController.eqBarMinHeight
 
         CATransaction.begin()
         CATransaction.setAnimationDuration(0.07)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
@@ -1,0 +1,14 @@
+import AppKit
+
+enum MenuBarIconRenderer {
+
+    /// Returns a template `mic.fill` SF Symbol sized for the macOS menu bar.
+    /// Template mode means AppKit handles dark/light/tinted menu bar adaptation automatically.
+    static func make() -> NSImage? {
+        let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
+        let image = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: "Muesli")?
+            .withSymbolConfiguration(config)
+        image?.isTemplate = true
+        return image
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
@@ -2,11 +2,34 @@ import AppKit
 
 enum MenuBarIconRenderer {
 
-    /// Returns a template `mic.fill` SF Symbol sized for the macOS menu bar.
-    /// Template mode means AppKit handles dark/light/tinted menu bar adaptation automatically.
-    static func make() -> NSImage? {
+    static let options: [(id: String, label: String)] = [
+        ("muesli", "Muesli Logo"),
+        ("mic.fill", "Microphone"),
+        ("waveform", "Waveform"),
+        ("bubble.left.fill", "Bubble"),
+        ("text.bubble", "Speech Bubble"),
+        ("pencil.line", "Pencil"),
+        ("brain.head.profile", "Brain"),
+        ("sparkles", "Sparkles"),
+        ("headphones", "Headphones"),
+        ("person.wave.2", "Meeting"),
+        ("character.bubble", "Character"),
+        ("doc.text", "Document"),
+    ]
+
+    /// Returns a menu bar icon for the given choice.
+    /// "muesli" loads the bundled M logo; anything else renders an SF Symbol.
+    static func make(choice: String = "muesli") -> NSImage? {
+        if choice == "muesli" {
+            if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
+               let image = NSImage(contentsOf: url) {
+                image.isTemplate = true
+                image.size = NSSize(width: 18, height: 18)
+                return image
+            }
+        }
         let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
-        let image = NSImage(systemSymbolName: "mic.fill", accessibilityDescription: "Muesli")?
+        let image = NSImage(systemSymbolName: choice, accessibilityDescription: "Muesli")?
             .withSymbolConfiguration(config)
         image?.isTemplate = true
         return image

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -279,6 +279,7 @@ struct AppConfig: Codable {
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
+    var menuBarIcon: String = "muesli"
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -312,6 +313,7 @@ struct AppConfig: Codable {
         case folderOrder = "folder_order"
         case soundEnabled = "sound_enabled"
         case recordingColorHex = "recording_color_hex"
+        case menuBarIcon = "menu_bar_icon"
     }
 
     init() {}
@@ -350,6 +352,7 @@ struct AppConfig: Codable {
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
+        menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -277,6 +277,8 @@ struct AppConfig: Codable {
         CustomWord(word: "muesli", replacement: "muesli"),
     ]
     var folderOrder: [Int64] = []
+    var soundEnabled: Bool = true
+    var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -308,6 +310,8 @@ struct AppConfig: Codable {
         case customMeetingTemplates = "custom_meeting_templates"
         case customWords = "custom_words"
         case folderOrder = "folder_order"
+        case soundEnabled = "sound_enabled"
+        case recordingColorHex = "recording_color_hex"
     }
 
     init() {}
@@ -344,6 +348,8 @@ struct AppConfig: Codable {
         customMeetingTemplates = (try? c.decode([CustomMeetingTemplate].self, forKey: .customMeetingTemplates)) ?? defaults.customMeetingTemplates
         customWords = (try? c.decode([CustomWord].self, forKey: .customWords)) ?? defaults.customWords
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
+        soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
+        recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -115,6 +115,9 @@ final class MuesliController: NSObject {
             databaseURL: MuesliPaths.defaultDatabaseURL(appName: AppIdentity.supportDirectoryName)
         )
         self.config = loadedConfig
+        if loadedConfig.recordingColorHex != "1e1e2e" {
+            MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
+        }
         self.selectedBackend = BackendOption.all.first(where: {
             $0.backend == loadedConfig.sttBackend && $0.model == loadedConfig.sttModel
         }) ?? .whisper
@@ -343,6 +346,7 @@ final class MuesliController: NSObject {
     func updateConfig(_ mutate: (inout AppConfig) -> Void) {
         mutate(&config)
         configStore.save(config)
+        MuesliTheme.accentOverrideHex = config.recordingColorHex == "1e1e2e" ? nil : config.recordingColorHex
         selectedBackend = BackendOption.all.first(where: {
             $0.backend == config.sttBackend && $0.model == config.sttModel
         }) ?? .whisper
@@ -350,6 +354,7 @@ final class MuesliController: NSObject {
             $0.backend == config.meetingSummaryBackend
         }) ?? .openAI
         statusBarController?.refresh()
+        statusBarController?.refreshIcon()
         historyWindowController?.updateBackendLabel()
         if config.showFloatingIndicator {
             indicator.ensureVisible(config: config)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1241,6 +1241,7 @@ final class MuesliController: NSObject {
                 self?.recorder.currentPower() ?? -160
             }
             setState(.recording)
+            SoundController.playDictationStart(enabled: config.soundEnabled)
         } catch {
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
             setState(.idle)
@@ -1416,6 +1417,7 @@ final class MuesliController: NSObject {
                     self.historyWindowController?.reload()
                     self.syncAppState()
                     PasteController.paste(text: text)
+                    SoundController.playDictationInsert(enabled: self.config.soundEnabled)
                     self.setState(.idle)
                     self.micActivityMonitor.resumeAfterCooldown()
                     TelemetryDeck.signal("dictation.completed", parameters: [

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliTheme.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliTheme.swift
@@ -35,8 +35,16 @@ enum MuesliTheme {
 
     // MARK: - Accent
 
-    static let accent           = Color.adaptive(dark: 0x6BA3F7, light: 0x2563EB)
-    static let accentSubtle     = Color.adaptive(dark: 0x6BA3F7, light: 0x2563EB).opacity(0.15)
+    static let defaultAccent    = Color.adaptive(dark: 0x6BA3F7, light: 0x2563EB)
+    static var accentOverrideHex: String?
+    static var accent: Color {
+        if let hex = accentOverrideHex, !hex.isEmpty,
+           let val = UInt64(hex.replacingOccurrences(of: "#", with: ""), radix: 16) {
+            return Color(hex: Int(val))
+        }
+        return defaultAccent
+    }
+    static var accentSubtle: Color { accent.opacity(0.15) }
 
     // MARK: - Semantic
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -244,73 +244,53 @@ struct SettingsView: View {
                 }
 
                 settingsSection("Appearance") {
+                    settingsRow("Menu bar icon") {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 4) {
+                                ForEach(MenuBarIconRenderer.options, id: \.id) { option in
+                                    let isSelected = appState.config.menuBarIcon == option.id
+                                    Button {
+                                        controller.updateConfig { $0.menuBarIcon = option.id }
+                                    } label: {
+                                        Group {
+                                            if option.id == "muesli",
+                                               let img = MenuBarIconRenderer.make(choice: "muesli") {
+                                                Image(nsImage: img)
+                                                    .resizable()
+                                                    .scaledToFit()
+                                                    .frame(width: 14, height: 14)
+                                            } else {
+                                                Image(systemName: option.id)
+                                                    .font(.system(size: 12))
+                                            }
+                                        }
+                                        .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                                        .frame(width: 26, height: 26)
+                                        .background(
+                                            RoundedRectangle(cornerRadius: 5)
+                                                .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
+                                        )
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 5)
+                                                .strokeBorder(Color.white.opacity(isSelected ? 0.3 : 0.08), lineWidth: 1)
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+                                    .help(option.label)
+                                }
+                            }
+                        }
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Accent color") {
+                        glassTintPicker
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Play sound effects") {
                         settingsSwitch(isOn: appState.config.soundEnabled) { newValue in
                             controller.updateConfig { $0.soundEnabled = newValue }
                         }
                     }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                        Text("Recording color")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                        HStack(spacing: MuesliTheme.spacing8) {
-                            ForEach(AppearancePreset.all, id: \.hex) { preset in
-                                let isSelected = appState.config.recordingColorHex.lowercased() == preset.hex
-                                Button {
-                                    controller.updateConfig { $0.recordingColorHex = preset.hex }
-                                    recordingColorInput = preset.hex
-                                } label: {
-                                    Circle()
-                                        .fill(preset.swatchColor)
-                                        .frame(width: 22, height: 22)
-                                        .overlay(
-                                            Circle().strokeBorder(Color.white.opacity(isSelected ? 0.85 : 0), lineWidth: 2)
-                                        )
-                                        .shadow(color: .black.opacity(0.3), radius: 2, y: 1)
-                                }
-                                .buttonStyle(.plain)
-                                .help(preset.name)
-                            }
-                            TextField("#1e1e2e", text: Binding(
-                                get: { recordingColorInput.isEmpty ? appState.config.recordingColorHex : recordingColorInput },
-                                set: { recordingColorInput = $0 }
-                            ))
-                            .font(.system(size: 12, design: .monospaced))
-                            .frame(width: 80)
-                            .textFieldStyle(.roundedBorder)
-                            .onSubmit {
-                                let cleaned = recordingColorInput
-                                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                                    .replacingOccurrences(of: "#", with: "")
-                                    .lowercased()
-                                guard cleaned.count == 6, UInt64(cleaned, radix: 16) != nil else { return }
-                                controller.updateConfig { $0.recordingColorHex = cleaned }
-                                recordingColorInput = cleaned
-                            }
-                            ColorPicker("", selection: Binding(
-                                get: { Color(hex: appState.config.recordingColorHex) },
-                                set: { newColor in
-                                    if let hex = NSColor(newColor).toHexString() {
-                                        controller.updateConfig { $0.recordingColorHex = hex }
-                                        recordingColorInput = hex
-                                    }
-                                }
-                            ))
-                            .labelsHidden()
-                            .frame(width: 28, height: 28)
-                        }
-                        HStack(spacing: MuesliTheme.spacing8) {
-                            Text("Preview")
-                                .font(.system(size: 11))
-                                .foregroundStyle(MuesliTheme.textTertiary)
-                            Capsule()
-                                .fill(Color(hex: appState.config.recordingColorHex))
-                                .frame(width: 80, height: 22)
-                                .overlay(Capsule().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
-                        }
-                    }
-                    .frame(minHeight: 32)
                 }
 
                 settingsSection("Data") {
@@ -352,6 +332,39 @@ struct SettingsView: View {
             }
         } message: {
             Text(pendingDataDestruction?.message ?? "")
+        }
+    }
+
+    private static let accentPresets: [(hex: String, name: String)] = [
+        ("2563eb", "Blue"),
+        ("ef4444", "Red"),
+        ("f59e0b", "Amber"),
+        ("10b981", "Green"),
+        ("8b5cf6", "Purple"),
+        ("ec4899", "Pink"),
+        ("1e1e2e", "Dark"),
+    ]
+
+    private var glassTintPicker: some View {
+        HStack(spacing: 6) {
+            ForEach(Self.accentPresets, id: \.hex) { preset in
+                let isSelected = appState.config.recordingColorHex.lowercased() == preset.hex
+                Button {
+                    controller.updateConfig { $0.recordingColorHex = preset.hex }
+                } label: {
+                    Circle()
+                        .fill(Color(hex: preset.hex))
+                        .frame(width: 22, height: 22)
+                        .overlay(
+                            Circle().strokeBorder(Color.white.opacity(isSelected ? 0.9 : 0), lineWidth: 2)
+                        )
+                        .overlay(
+                            Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help(preset.name)
+            }
         }
     }
 
@@ -616,3 +629,4 @@ private extension NSColor {
         return String(format: "%02x%02x%02x", r, g, b)
     }
 }
+

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -40,6 +40,7 @@ struct SettingsView: View {
     @State private var chatGPTSignInError: String?
     @State private var isSigningInChatGPT = false
     @State private var pendingDataDestruction: PendingDataDestruction?
+    @State private var recordingColorInput: String = ""
 
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
@@ -240,6 +241,76 @@ struct SettingsView: View {
                             controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
                         }
                     }
+                }
+
+                settingsSection("Appearance") {
+                    settingsRow("Play sound effects") {
+                        settingsSwitch(isOn: appState.config.soundEnabled) { newValue in
+                            controller.updateConfig { $0.soundEnabled = newValue }
+                        }
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                        Text("Recording color")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                        HStack(spacing: MuesliTheme.spacing8) {
+                            ForEach(AppearancePreset.all, id: \.hex) { preset in
+                                let isSelected = appState.config.recordingColorHex.lowercased() == preset.hex
+                                Button {
+                                    controller.updateConfig { $0.recordingColorHex = preset.hex }
+                                    recordingColorInput = preset.hex
+                                } label: {
+                                    Circle()
+                                        .fill(preset.swatchColor)
+                                        .frame(width: 22, height: 22)
+                                        .overlay(
+                                            Circle().strokeBorder(Color.white.opacity(isSelected ? 0.85 : 0), lineWidth: 2)
+                                        )
+                                        .shadow(color: .black.opacity(0.3), radius: 2, y: 1)
+                                }
+                                .buttonStyle(.plain)
+                                .help(preset.name)
+                            }
+                            TextField("#1e1e2e", text: Binding(
+                                get: { recordingColorInput.isEmpty ? appState.config.recordingColorHex : recordingColorInput },
+                                set: { recordingColorInput = $0 }
+                            ))
+                            .font(.system(size: 12, design: .monospaced))
+                            .frame(width: 80)
+                            .textFieldStyle(.roundedBorder)
+                            .onSubmit {
+                                let cleaned = recordingColorInput
+                                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                                    .replacingOccurrences(of: "#", with: "")
+                                    .lowercased()
+                                guard cleaned.count == 6, UInt64(cleaned, radix: 16) != nil else { return }
+                                controller.updateConfig { $0.recordingColorHex = cleaned }
+                                recordingColorInput = cleaned
+                            }
+                            ColorPicker("", selection: Binding(
+                                get: { Color(hex: appState.config.recordingColorHex) },
+                                set: { newColor in
+                                    if let hex = NSColor(newColor).toHexString() {
+                                        controller.updateConfig { $0.recordingColorHex = hex }
+                                        recordingColorInput = hex
+                                    }
+                                }
+                            ))
+                            .labelsHidden()
+                            .frame(width: 28, height: 28)
+                        }
+                        HStack(spacing: MuesliTheme.spacing8) {
+                            Text("Preview")
+                                .font(.system(size: 11))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                            Capsule()
+                                .fill(Color(hex: appState.config.recordingColorHex))
+                                .frame(width: 80, height: 22)
+                                .overlay(Capsule().strokeBorder(Color.white.opacity(0.2), lineWidth: 1))
+                        }
+                    }
+                    .frame(minHeight: 32)
                 }
 
                 settingsSection("Data") {
@@ -504,5 +575,44 @@ struct PastableSecureField: NSViewRepresentable {
             guard let field = obj.object as? NSTextField else { return }
             onChange(field.stringValue)
         }
+    }
+}
+
+// MARK: - Appearance Helpers
+
+private struct AppearancePreset {
+    let name: String
+    let hex: String
+    var swatchColor: Color { Color(hex: hex) }
+
+    static let all: [AppearancePreset] = [
+        AppearancePreset(name: "Mocha", hex: "1e1e2e"),
+        AppearancePreset(name: "Frappe", hex: "303446"),
+        AppearancePreset(name: "Latte", hex: "eff1f5"),
+    ]
+}
+
+private extension Color {
+    init(hex: String) {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        h = h.hasPrefix("#") ? String(h.dropFirst()) : h
+        guard h.count == 6, let value = UInt64(h, radix: 16) else {
+            self = .black; return
+        }
+        self = Color(
+            red:   Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8)  & 0xFF) / 255,
+            blue:  Double( value        & 0xFF) / 255
+        )
+    }
+}
+
+private extension NSColor {
+    func toHexString() -> String? {
+        guard let rgb = usingColorSpace(.sRGB) else { return nil }
+        let r = Int((rgb.redComponent   * 255).rounded())
+        let g = Int((rgb.greenComponent * 255).rounded())
+        let b = Int((rgb.blueComponent  * 255).rounded())
+        return String(format: "%02x%02x%02x", r, g, b)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -591,20 +591,6 @@ struct PastableSecureField: NSViewRepresentable {
     }
 }
 
-// MARK: - Appearance Helpers
-
-private struct AppearancePreset {
-    let name: String
-    let hex: String
-    var swatchColor: Color { Color(hex: hex) }
-
-    static let all: [AppearancePreset] = [
-        AppearancePreset(name: "Mocha", hex: "1e1e2e"),
-        AppearancePreset(name: "Frappe", hex: "303446"),
-        AppearancePreset(name: "Latte", hex: "eff1f5"),
-    ]
-}
-
 private extension Color {
     init(hex: String) {
         var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -80,9 +80,18 @@ struct SidebarView: View {
     private var sidebarHeader: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             HStack(spacing: MuesliTheme.spacing12) {
-                MWaveformIcon(barCount: 9, spacing: 2)
-                    .frame(width: 22, height: 22)
-                    .foregroundStyle(MuesliTheme.accent)
+                Group {
+                    if appState.config.menuBarIcon == "muesli",
+                       let img = MenuBarIconRenderer.make(choice: "muesli") {
+                        Image(nsImage: img)
+                            .resizable()
+                            .scaledToFit()
+                    } else {
+                        Image(systemName: appState.config.menuBarIcon)
+                    }
+                }
+                .frame(width: 22, height: 22)
+                .foregroundStyle(MuesliTheme.accent)
                 Text("muesli")
                     .font(MuesliTheme.title2())
                     .foregroundStyle(MuesliTheme.textPrimary)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -1,7 +1,8 @@
 import AppKit
 
 /// Plays subtle system sounds for dictation lifecycle events.
-/// Sounds are skipped when `soundEnabled` is false or when the system is muted.
+/// Plays subtle system sounds for dictation lifecycle events.
+/// Sounds are skipped when `soundEnabled` is false.
 enum SoundController {
     static func playDictationStart(enabled: Bool) {
         guard enabled else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -1,7 +1,6 @@
 import AppKit
 
 /// Plays subtle system sounds for dictation lifecycle events.
-/// Plays subtle system sounds for dictation lifecycle events.
 /// Sounds are skipped when `soundEnabled` is false.
 enum SoundController {
     static func playDictationStart(enabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -1,0 +1,15 @@
+import AppKit
+
+/// Plays subtle system sounds for dictation lifecycle events.
+/// Sounds are skipped when `soundEnabled` is false or when the system is muted.
+enum SoundController {
+    static func playDictationStart(enabled: Bool) {
+        guard enabled else { return }
+        NSSound(named: .init("Tink"))?.play()
+    }
+
+    static func playDictationInsert(enabled: Bool) {
+        guard enabled else { return }
+        NSSound(named: .init("Purr"))?.play()
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -33,12 +33,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     private func build() {
         if let button = statusItem.button {
-            if let iconURL = runtime.menuIcon, let image = NSImage(contentsOf: iconURL) {
-                image.isTemplate = false
-                button.image = image
-            } else {
-                button.title = "M"
-            }
+            button.image = MenuBarIconRenderer.make()
+            button.imageScaling = .scaleProportionallyDown
             button.toolTip = AppIdentity.displayName
         }
         rebuildMenu()

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -31,9 +31,13 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         rebuildMenu()
     }
 
+    func refreshIcon() {
+        statusItem.button?.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon)
+    }
+
     private func build() {
         if let button = statusItem.button {
-            button.image = MenuBarIconRenderer.make()
+            button.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon)
             button.imageScaling = .scaleProportionallyDown
             button.toolTip = AppIdentity.displayName
         }

--- a/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
@@ -30,21 +30,21 @@ struct SoundControllerTests {
 @Suite("MenuBarIconRenderer")
 struct MenuBarIconRendererTests {
 
-    @Test("make() returns a non-nil image")
+    @Test("make(choice:) returns a non-nil image for SF Symbol")
     func makeReturnsImage() {
-        let image = MenuBarIconRenderer.make()
+        let image = MenuBarIconRenderer.make(choice: "mic.fill")
         #expect(image != nil)
     }
 
-    @Test("make() returns a template image for menu bar adaptation")
+    @Test("make(choice:) returns a template image for menu bar adaptation")
     func makeIsTemplate() {
-        let image = MenuBarIconRenderer.make()
+        let image = MenuBarIconRenderer.make(choice: "mic.fill")
         #expect(image?.isTemplate == true)
     }
 
-    @Test("make() returns a non-zero size image")
+    @Test("make(choice:) returns a non-zero size image")
     func makeHasSize() {
-        let image = MenuBarIconRenderer.make()
+        let image = MenuBarIconRenderer.make(choice: "mic.fill")
         #expect((image?.size.width ?? 0) > 0)
         #expect((image?.size.height ?? 0) > 0)
     }

--- a/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import AppKit
+@testable import MuesliNativeApp
+
+@Suite("SoundController")
+struct SoundControllerTests {
+
+    @Test("playDictationStart with enabled=false does not throw")
+    func playStartDisabled() {
+        // NSSound.play() is a no-op in the test runner (no audio device required)
+        SoundController.playDictationStart(enabled: false)
+    }
+
+    @Test("playDictationInsert with enabled=false does not throw")
+    func playInsertDisabled() {
+        SoundController.playDictationInsert(enabled: false)
+    }
+
+    @Test("playDictationStart with enabled=true does not throw")
+    func playStartEnabled() {
+        SoundController.playDictationStart(enabled: true)
+    }
+
+    @Test("playDictationInsert with enabled=true does not throw")
+    func playInsertEnabled() {
+        SoundController.playDictationInsert(enabled: true)
+    }
+}
+
+@Suite("MenuBarIconRenderer")
+struct MenuBarIconRendererTests {
+
+    @Test("make() returns a non-nil image")
+    func makeReturnsImage() {
+        let image = MenuBarIconRenderer.make()
+        #expect(image != nil)
+    }
+
+    @Test("make() returns a template image for menu bar adaptation")
+    func makeIsTemplate() {
+        let image = MenuBarIconRenderer.make()
+        #expect(image?.isTemplate == true)
+    }
+
+    @Test("make() returns a non-zero size image")
+    func makeHasSize() {
+        let image = MenuBarIconRenderer.make()
+        #expect((image?.size.width ?? 0) > 0)
+        #expect((image?.size.height ?? 0) > 0)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -438,3 +438,69 @@ struct HotkeyConfigTests {
         #expect(HotkeyConfig.label(for: 100) == nil)
     }
 }
+
+@Suite("AppConfig — appearance fields")
+struct AppConfigAppearanceTests {
+
+    @Test("soundEnabled defaults to true")
+    func soundEnabledDefault() {
+        let config = AppConfig()
+        #expect(config.soundEnabled == true)
+    }
+
+    @Test("recordingColorHex defaults to Catppuccin Mocha base")
+    func recordingColorHexDefault() {
+        let config = AppConfig()
+        #expect(config.recordingColorHex == "1e1e2e")
+    }
+
+    @Test("soundEnabled round-trips through JSON")
+    func soundEnabledRoundTrip() throws {
+        var config = AppConfig()
+        config.soundEnabled = false
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.soundEnabled == false)
+    }
+
+    @Test("recordingColorHex round-trips through JSON")
+    func recordingColorHexRoundTrip() throws {
+        var config = AppConfig()
+        config.recordingColorHex = "303446"
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.recordingColorHex == "303446")
+    }
+
+    @Test("unknown JSON keys are ignored — soundEnabled falls back to default")
+    func soundEnabledFallsBackOnMissingKey() throws {
+        let json = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(decoded.soundEnabled == true)
+    }
+
+    @Test("unknown JSON keys are ignored — recordingColorHex falls back to default")
+    func recordingColorHexFallsBackOnMissingKey() throws {
+        let json = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(decoded.recordingColorHex == "1e1e2e")
+    }
+
+    @Test("soundEnabled CodingKey is sound_enabled")
+    func soundEnabledCodingKey() throws {
+        var config = AppConfig()
+        config.soundEnabled = false
+        let data = try JSONEncoder().encode(config)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["sound_enabled"] as? Bool == false)
+    }
+
+    @Test("recordingColorHex CodingKey is recording_color_hex")
+    func recordingColorHexCodingKey() throws {
+        var config = AppConfig()
+        config.recordingColorHex = "eff1f5"
+        let data = try JSONEncoder().encode(config)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["recording_color_hex"] as? String == "eff1f5")
+    }
+}


### PR DESCRIPTION
## Summary

- **Dark frosted glass pill** — `NSVisualEffectView .hudWindow` locked to `.darkAqua` + Catppuccin Mocha tint layer on all macOS versions (14+); consistent appearance on any background
- **SF Symbol icons** — idle and recording use `waveform.badge.microphone` (static/animated); transcribing uses `wand.and.sparkles` with wiggle animation (macOS 15+); all replace the old emoji approach
- **Animated recording state** — `waveform.badge.microphone` with `.variableColor.iterative.dimInactiveLayers.reversing` looping in the expanded 90×34 recording pill
- **Sound effects** — `SoundController` plays Tink on dictation start, Purr on insert; guarded by `AppConfig.soundEnabled`
- **Single theme color** — `recordingColorHex` drives tint across idle, preparing, recording, and transcribing states; configurable via Settings → Appearance with Catppuccin preset swatches (Mocha/Frappe/Latte), hex field, ColorPicker, and live preview

## Test plan

- [ ] Idle pill appears as dark glass on light and dark backgrounds / desktops
- [ ] Hover expands cleanly to 192×32 with mic icon + hint text, no bright halo
- [ ] Hold hotkey → recording pill (90×34) shows animated waveform symbol + ✕/stop controls
- [ ] Release hotkey → transcribing pill shows animated wand + "Transcribing" label
- [ ] Settings → Appearance: toggle sound effects; switch presets; enter custom hex; ColorPicker updates preview
- [ ] `swift test` passes (288 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)