### PR TITLE
Google Calendar OAuth integration + Coming Up section

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -60,6 +60,7 @@ public final class DictationStore {
             created_at TEXT DEFAULT (datetime('now'))
         );
         CREATE INDEX IF NOT EXISTS idx_meetings_start_time ON meetings(start_time DESC);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_meetings_calendar_event_id ON meetings(calendar_event_id) WHERE calendar_event_id IS NOT NULL;
         """
         try exec(createSQL, db: db)
 

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -299,6 +299,29 @@ public final class DictationStore {
         return makeMeetingRecord(statement)
     }
 
+    public func meetingByCalendarEventID(_ calendarEventID: String) throws -> MeetingRecord? {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt
+        FROM meetings
+        WHERE calendar_event_id = ?
+        LIMIT 1
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (calendarEventID as NSString).utf8String, -1, nil)
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            return nil
+        }
+        return makeMeetingRecord(statement)
+    }
+
     @discardableResult
     public func insertMeeting(
         title: String,

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -46,6 +46,7 @@ final class AppState {
     var isMeetingRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false
     var isGoogleCalendarAvailable: Bool = false
+    var isGoogleCalendarVerified: Bool = false
     var isGoogleCalendarAuthenticated: Bool = false
     var upcomingCalendarEvents: [UnifiedCalendarEvent] = []
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -45,6 +45,9 @@ final class AppState {
     // Live status
     var isMeetingRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false
+    var isGoogleCalendarAvailable: Bool = false
+    var isGoogleCalendarAuthenticated: Bool = false
+    var upcomingCalendarEvents: [UnifiedCalendarEvent] = []
 
     // Dictation pagination & filtering
     var dictationPageSize: Int = 50

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -37,6 +37,7 @@ final class CalendarMonitor {
         let predicate = store.predicateForEvents(withStart: now.addingTimeInterval(-3600), end: now.addingTimeInterval(60), calendars: nil)
         let events = store.events(matching: predicate)
         for event in events {
+            guard !event.isAllDay else { continue }
             guard let startDate = event.startDate, let endDate = event.endDate else { continue }
             if startDate <= now && endDate > now {
                 return UpcomingMeetingEvent(
@@ -60,6 +61,7 @@ final class CalendarMonitor {
 
         var nearby: CalendarEventContext?
         for event in events {
+            guard !event.isAllDay else { continue }
             guard let startDate = event.startDate, let endDate = event.endDate else { continue }
             let ctx = CalendarEventContext(
                 id: event.eventIdentifier ?? UUID().uuidString,
@@ -77,7 +79,8 @@ final class CalendarMonitor {
         return nearby
     }
 
-    /// Returns upcoming events from the local macOS calendar (EventKit) for the next N days.
+    /// Returns upcoming timed events from the local macOS calendar (EventKit) for the next N days.
+    /// All-day events are excluded — they're not useful for meeting recording.
     func upcomingEvents(daysAhead: Int = 7) -> [UnifiedCalendarEvent] {
         let now = Date()
         guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
@@ -85,12 +88,13 @@ final class CalendarMonitor {
         let events = store.events(matching: predicate)
         return events.compactMap { event in
             guard let startDate = event.startDate, let endDate = event.endDate else { return nil }
+            guard !event.isAllDay else { return nil }
             return UnifiedCalendarEvent(
                 id: event.eventIdentifier ?? UUID().uuidString,
                 title: event.title ?? "Meeting",
                 startDate: startDate,
                 endDate: endDate,
-                isAllDay: event.isAllDay,
+                isAllDay: false,
                 source: .eventKit
             )
         }.sorted { $0.startDate < $1.startDate }
@@ -102,6 +106,8 @@ final class CalendarMonitor {
         let predicate = store.predicateForEvents(withStart: now, end: end, calendars: nil)
         let events = store.events(matching: predicate)
         for event in events {
+            // Skip all-day events — they shouldn't trigger meeting recording
+            guard !event.isAllDay else { continue }
             guard let eventID = event.eventIdentifier, !notifiedEvents.contains(eventID) else {
                 continue
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -77,6 +77,25 @@ final class CalendarMonitor {
         return nearby
     }
 
+    /// Returns upcoming events from the local macOS calendar (EventKit) for the next N days.
+    func upcomingEvents(daysAhead: Int = 7) -> [UnifiedCalendarEvent] {
+        let now = Date()
+        guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
+        let predicate = store.predicateForEvents(withStart: now, end: future, calendars: nil)
+        let events = store.events(matching: predicate)
+        return events.compactMap { event in
+            guard let startDate = event.startDate, let endDate = event.endDate else { return nil }
+            return UnifiedCalendarEvent(
+                id: event.eventIdentifier ?? UUID().uuidString,
+                title: event.title ?? "Meeting",
+                startDate: startDate,
+                endDate: endDate,
+                isAllDay: event.isAllDay,
+                source: .eventKit
+            )
+        }.sorted { $0.startDate < $1.startDate }
+    }
+
     private func checkMeetings() {
         let now = Date()
         let end = now.addingTimeInterval(5 * 60)

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -317,6 +317,14 @@ final class FloatingIndicatorController {
         setState(state, config: config)
     }
 
+    /// Refresh the idle icon to match the user's selected menu bar icon.
+    func refreshIcon() {
+        let config = configStore.load()
+        let newImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? NSImage()
+        newImage.isTemplate = false
+        micIconView?.image = newImage
+    }
+
     /// Flash a brief warning message on the indicator pill, then snap back to idle.
     func showWarning(_ message: String, icon: String = "⚡", duration: TimeInterval = 2.5) {
         guard state == .idle else { return }
@@ -649,11 +657,11 @@ final class FloatingIndicatorController {
         contentView.layer?.addSublayer(tint)
         tintLayer = tint
 
-        // waveform.badge.microphone — idle (static) and recording (animated).
-        let symConfig = NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)
-        let micImage = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
-            .withSymbolConfiguration(symConfig)
-        let micView = NSImageView(image: micImage ?? NSImage())
+        // Idle icon — uses the user's selected menu bar icon from config
+        let config = configStore.load()
+        let idleImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? NSImage()
+        idleImage.isTemplate = false // we tint manually via contentTintColor
+        let micView = NSImageView(image: idleImage)
         micView.contentTintColor = .white
         micView.imageScaling = .scaleProportionallyDown
         micView.isHidden = true

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -320,7 +320,9 @@ final class FloatingIndicatorController {
     /// Refresh the idle icon to match the user's selected menu bar icon.
     func refreshIcon() {
         let config = configStore.load()
-        let newImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? NSImage()
+        let fallback = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)) ?? NSImage()
+        let newImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? fallback
         newImage.isTemplate = false
         micIconView?.image = newImage
     }
@@ -657,9 +659,12 @@ final class FloatingIndicatorController {
         contentView.layer?.addSublayer(tint)
         tintLayer = tint
 
-        // Idle icon — uses the user's selected menu bar icon from config
+        // Idle icon — uses the user's selected menu bar icon from config.
+        // Falls back to waveform.badge.microphone if the configured icon can't be loaded.
         let config = configStore.load()
-        let idleImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? NSImage()
+        let fallbackImage = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)) ?? NSImage()
+        let idleImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? fallbackImage
         idleImage.isTemplate = false // we tint manually via contentTintColor
         let micView = NSImageView(image: idleImage)
         micView.contentTintColor = .white

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
@@ -227,21 +227,31 @@ final class GoogleCalendarAuthManager {
                         return
                     }
 
-                    let html = """
-                    HTTP/1.1 200 OK\r
-                    Content-Type: text/html\r
-                    Connection: close\r
-                    \r
-                    <!DOCTYPE html><html><body style="font-family:-apple-system,system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a1a;color:#fff"><div style="text-align:center"><h2>Google Calendar connected</h2><p>You can close this window and return to Muesli.</p></div></body></html>
-                    """
-                    connection.send(
-                        content: html.data(using: .utf8),
-                        completion: .contentProcessed { _ in connection.cancel() }
-                    )
-
                     if let code {
+                        let successHtml = """
+                        HTTP/1.1 200 OK\r
+                        Content-Type: text/html\r
+                        Connection: close\r
+                        \r
+                        <!DOCTYPE html><html><body style="font-family:-apple-system,system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a1a;color:#fff"><div style="text-align:center"><h2>Google Calendar connected</h2><p>You can close this window and return to Muesli.</p></div></body></html>
+                        """
+                        connection.send(
+                            content: successHtml.data(using: .utf8),
+                            completion: .contentProcessed { _ in connection.cancel() }
+                        )
                         continuation.resume(returning: code)
                     } else {
+                        let deniedHtml = """
+                        HTTP/1.1 400 Bad Request\r
+                        Content-Type: text/html\r
+                        Connection: close\r
+                        \r
+                        <!DOCTYPE html><html><body style="font-family:-apple-system,system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a1a;color:#fff"><div style="text-align:center"><h2>Sign-in failed</h2><p>Access was denied or no authorization code received.</p></div></body></html>
+                        """
+                        connection.send(
+                            content: deniedHtml.data(using: .utf8),
+                            completion: .contentProcessed { _ in connection.cancel() }
+                        )
                         continuation.resume(throwing: GoogleCalendarAuthError.callbackMissingCode)
                     }
                 }
@@ -300,7 +310,12 @@ final class GoogleCalendarAuthManager {
             throw GoogleCalendarAuthError.tokenExchangeFailed("missing access_token in response")
         }
 
-        let refreshToken = json["refresh_token"] as? String ?? ""
+        guard let refreshToken = json["refresh_token"] as? String, !refreshToken.isEmpty else {
+            throw GoogleCalendarAuthError.tokenExchangeFailed(
+                "No refresh token received. Ensure access_type=offline and prompt=consent are set, " +
+                "or revoke access at https://myaccount.google.com/permissions and try again."
+            )
+        }
         let expiresIn = json["expires_in"] as? Double ?? 3600
         let expiresAtMs = (Date().timeIntervalSince1970 + expiresIn) * 1000.0
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
@@ -52,6 +52,9 @@ final class GoogleCalendarAuthManager {
     /// Whether Google Calendar credentials are configured (feature available)
     var isAvailable: Bool { credentials != nil }
 
+    /// Whether the Google OAuth app has passed verification review
+    var isVerified: Bool { credentials?.verified ?? false }
+
     /// Whether the user has completed OAuth and has tokens
     var isAuthenticated: Bool {
         tokenRead(key: "access_token") != nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
@@ -1,0 +1,381 @@
+import AppKit
+import CryptoKit
+import Foundation
+import Network
+
+enum GoogleCalendarAuthError: Error, LocalizedError {
+    case notAuthenticated
+    case notAvailable
+    case callbackTimeout
+    case callbackMissingCode
+    case callbackStateMismatch
+    case tokenExchangeFailed(String)
+    case refreshFailed(String)
+    case portInUse
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated: return "Not signed in to Google Calendar"
+        case .notAvailable: return "Google Calendar credentials not configured"
+        case .callbackTimeout: return "Sign-in timed out — no response from browser"
+        case .callbackMissingCode: return "OAuth callback missing authorization code"
+        case .callbackStateMismatch: return "OAuth state mismatch — possible CSRF attack"
+        case .tokenExchangeFailed(let msg): return "Token exchange failed: \(msg)"
+        case .refreshFailed(let msg): return "Token refresh failed: \(msg)"
+        case .portInUse: return "Callback port 1456 is already in use"
+        }
+    }
+}
+
+@MainActor
+final class GoogleCalendarAuthManager {
+    static let shared = GoogleCalendarAuthManager()
+
+    private static let authURL = "https://accounts.google.com/o/oauth2/v2/auth"
+    private static let tokenURL = "https://oauth2.googleapis.com/token"
+    private static let redirectURI = "http://localhost:1456/auth/callback"
+    private static let scopes = "https://www.googleapis.com/auth/calendar.events.readonly"
+    private static let callbackTimeoutSeconds: TimeInterval = 300
+
+    private let credentials: GoogleCalendarCredentials?
+
+    private var tokenFileURL: URL {
+        AppIdentity.supportDirectoryURL.appendingPathComponent("google-calendar-auth.json")
+    }
+
+    private init() {
+        credentials = GoogleCalendarCredentials.load()
+    }
+
+    // MARK: - Public API
+
+    /// Whether Google Calendar credentials are configured (feature available)
+    var isAvailable: Bool { credentials != nil }
+
+    /// Whether the user has completed OAuth and has tokens
+    var isAuthenticated: Bool {
+        tokenRead(key: "access_token") != nil
+    }
+
+    func signIn() async throws {
+        guard let credentials else { throw GoogleCalendarAuthError.notAvailable }
+        let (verifier, challenge) = generatePKCE()
+        let code = try await startCallbackServerAndOpenBrowser(
+            codeChallenge: challenge,
+            clientId: credentials.clientId
+        )
+        let tokens = try await exchangeCodeForTokens(
+            code: code,
+            codeVerifier: verifier,
+            credentials: credentials
+        )
+        saveTokens(tokens)
+        fputs("[google-cal] signed in successfully\n", stderr)
+    }
+
+    func signOut() {
+        deleteTokens()
+        fputs("[google-cal] signed out\n", stderr)
+    }
+
+    func validAccessToken() async throws -> String {
+        guard let credentials else { throw GoogleCalendarAuthError.notAvailable }
+        guard let accessToken = tokenRead(key: "access_token") else {
+            throw GoogleCalendarAuthError.notAuthenticated
+        }
+
+        // Check expiry with 30-second margin
+        if let expiresStr = tokenRead(key: "expires_at"),
+           let expiresMs = Double(expiresStr) {
+            let expiresAt = Date(timeIntervalSince1970: expiresMs / 1000.0)
+            if expiresAt > Date().addingTimeInterval(30) {
+                return accessToken
+            }
+            fputs("[google-cal] token expired, refreshing...\n", stderr)
+            guard let refreshToken = tokenRead(key: "refresh_token") else {
+                throw GoogleCalendarAuthError.notAuthenticated
+            }
+            let tokens = try await refreshAccessToken(
+                refreshToken: refreshToken,
+                credentials: credentials
+            )
+            saveTokens(tokens)
+            return tokens.accessToken
+        }
+
+        return accessToken
+    }
+
+    // MARK: - PKCE (reuses Data.base64URLEncoded() from ChatGPTAuthManager)
+
+    private func generatePKCE() -> (verifier: String, challenge: String) {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let verifier = Data(bytes).base64URLEncoded()
+        let challengeData = Data(SHA256.hash(data: Data(verifier.utf8)))
+        let challenge = challengeData.base64URLEncoded()
+        return (verifier, challenge)
+    }
+
+    private func generateState() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64URLEncoded()
+    }
+
+    // MARK: - OAuth Flow
+
+    private func buildAuthorizationURL(codeChallenge: String, state: String, clientId: String) -> URL? {
+        var components = URLComponents(string: Self.authURL)!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "redirect_uri", value: Self.redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: Self.scopes),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "access_type", value: "offline"),
+            URLQueryItem(name: "prompt", value: "consent"),
+        ]
+        return components.url
+    }
+
+    private func startCallbackServerAndOpenBrowser(codeChallenge: String, clientId: String) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let port: NWEndpoint.Port = 1456
+            let params = NWParameters.tcp
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: port)
+
+            guard let listener = try? NWListener(using: params) else {
+                continuation.resume(throwing: GoogleCalendarAuthError.portInUse)
+                return
+            }
+            var resumed = false
+
+            let timeoutWork = DispatchWorkItem { [weak listener] in
+                guard !resumed else { return }
+                resumed = true
+                listener?.cancel()
+                continuation.resume(throwing: GoogleCalendarAuthError.callbackTimeout)
+            }
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Self.callbackTimeoutSeconds,
+                execute: timeoutWork
+            )
+
+            let expectedState = self.generateState()
+
+            // Pre-build the auth URL on the main actor before entering the closure
+            let authURL = self.buildAuthorizationURL(
+                codeChallenge: codeChallenge,
+                state: expectedState,
+                clientId: clientId
+            )
+
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    // Listener is accepting connections — now safe to open browser
+                    if let authURL {
+                        DispatchQueue.main.async {
+                            NSWorkspace.shared.open(authURL)
+                        }
+                    }
+                case .failed:
+                    guard !resumed else { return }
+                    resumed = true
+                    timeoutWork.cancel()
+                    continuation.resume(throwing: GoogleCalendarAuthError.portInUse)
+                default:
+                    break
+                }
+            }
+
+            listener.newConnectionHandler = { connection in
+                connection.start(queue: .main)
+                connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, _, _ in
+                    defer {
+                        listener.cancel()
+                        timeoutWork.cancel()
+                    }
+                    guard !resumed else { return }
+                    resumed = true
+
+                    guard let data, let request = String(data: data, encoding: .utf8) else {
+                        continuation.resume(throwing: GoogleCalendarAuthError.callbackMissingCode)
+                        return
+                    }
+
+                    let code = self.extractParam(named: "code", from: request)
+                    let callbackState = self.extractParam(named: "state", from: request)
+
+                    guard callbackState == expectedState else {
+                        fputs("[google-cal] OAuth state mismatch — possible CSRF\n", stderr)
+                        let errorHtml = """
+                        HTTP/1.1 400 Bad Request\r
+                        Content-Type: text/html\r
+                        Connection: close\r
+                        \r
+                        <!DOCTYPE html><html><body style="font-family:-apple-system,system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a1a;color:#fff"><div style="text-align:center"><h2>Sign-in failed</h2><p>Security validation failed. Please try again.</p></div></body></html>
+                        """
+                        connection.send(
+                            content: errorHtml.data(using: .utf8),
+                            completion: .contentProcessed { _ in connection.cancel() }
+                        )
+                        continuation.resume(throwing: GoogleCalendarAuthError.callbackStateMismatch)
+                        return
+                    }
+
+                    let html = """
+                    HTTP/1.1 200 OK\r
+                    Content-Type: text/html\r
+                    Connection: close\r
+                    \r
+                    <!DOCTYPE html><html><body style="font-family:-apple-system,system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#1a1a1a;color:#fff"><div style="text-align:center"><h2>Google Calendar connected</h2><p>You can close this window and return to Muesli.</p></div></body></html>
+                    """
+                    connection.send(
+                        content: html.data(using: .utf8),
+                        completion: .contentProcessed { _ in connection.cancel() }
+                    )
+
+                    if let code {
+                        continuation.resume(returning: code)
+                    } else {
+                        continuation.resume(throwing: GoogleCalendarAuthError.callbackMissingCode)
+                    }
+                }
+            }
+
+            listener.start(queue: .main)
+        }
+    }
+
+    private func extractParam(named name: String, from httpRequest: String) -> String? {
+        guard let pathLine = httpRequest.split(separator: "\r\n").first ?? httpRequest.split(separator: "\n").first,
+              let pathPart = pathLine.split(separator: " ").dropFirst().first else {
+            return nil
+        }
+        guard let components = URLComponents(string: String(pathPart)) else { return nil }
+        return components.queryItems?.first(where: { $0.name == name })?.value
+    }
+
+    // MARK: - Token Exchange
+
+    private struct TokenResponse {
+        let accessToken: String
+        let refreshToken: String
+        let expiresAtMs: Double
+    }
+
+    private func exchangeCodeForTokens(
+        code: String,
+        codeVerifier: String,
+        credentials: GoogleCalendarCredentials
+    ) async throws -> TokenResponse {
+        let body: [String: String] = [
+            "grant_type": "authorization_code",
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+            "code": code,
+            "redirect_uri": Self.redirectURI,
+            "code_verifier": codeVerifier,
+        ]
+
+        var request = URLRequest(url: URL(string: Self.tokenURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown error"
+            throw GoogleCalendarAuthError.tokenExchangeFailed(errorBody)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String else {
+            throw GoogleCalendarAuthError.tokenExchangeFailed("missing access_token in response")
+        }
+
+        let refreshToken = json["refresh_token"] as? String ?? ""
+        let expiresIn = json["expires_in"] as? Double ?? 3600
+        let expiresAtMs = (Date().timeIntervalSince1970 + expiresIn) * 1000.0
+
+        return TokenResponse(accessToken: accessToken, refreshToken: refreshToken, expiresAtMs: expiresAtMs)
+    }
+
+    private func refreshAccessToken(
+        refreshToken: String,
+        credentials: GoogleCalendarCredentials
+    ) async throws -> TokenResponse {
+        let body: [String: String] = [
+            "grant_type": "refresh_token",
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+            "refresh_token": refreshToken,
+        ]
+
+        var request = URLRequest(url: URL(string: Self.tokenURL)!)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown error"
+            throw GoogleCalendarAuthError.refreshFailed(errorBody)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String else {
+            throw GoogleCalendarAuthError.refreshFailed("missing access_token in refresh response")
+        }
+
+        // Google may or may not return a new refresh token
+        let newRefreshToken = json["refresh_token"] as? String ?? refreshToken
+        let expiresIn = json["expires_in"] as? Double ?? 3600
+        let expiresAtMs = (Date().timeIntervalSince1970 + expiresIn) * 1000.0
+
+        return TokenResponse(accessToken: accessToken, refreshToken: newRefreshToken, expiresAtMs: expiresAtMs)
+    }
+
+    // MARK: - File-based Token Storage
+
+    private func saveTokens(_ tokens: TokenResponse) {
+        let dict: [String: String] = [
+            "access_token": tokens.accessToken,
+            "refresh_token": tokens.refreshToken,
+            "expires_at": String(format: "%.0f", tokens.expiresAtMs),
+        ]
+        do {
+            let dir = tokenFileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+            try data.write(to: tokenFileURL, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenFileURL.path)
+            var fileURL = tokenFileURL
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            try fileURL.setResourceValues(resourceValues)
+        } catch {
+            fputs("[google-cal] failed to save tokens: \(error)\n", stderr)
+        }
+    }
+
+    private func tokenRead(key: String) -> String? {
+        guard let data = try? Data(contentsOf: tokenFileURL),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return nil
+        }
+        return dict[key]
+    }
+
+    private func deleteTokens() {
+        try? FileManager.default.removeItem(at: tokenFileURL)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -80,7 +80,7 @@ final class GoogleCalendarClient {
                 return try await fetchUpcomingEvents(daysAhead: daysAhead, isRetry: true)
             }
 
-            // 401 mid-pagination — refresh token and retry this page once
+            // 401 on any page (first or mid-pagination) — refresh token and retry once
             if statusCode == 401 && !tokenRetried {
                 tokenRetried = true
                 token = try await auth.validAccessToken()

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -43,7 +43,12 @@ final class GoogleCalendarClient {
         repeat {
             var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
 
-            if let syncToken {
+            // pageToken takes priority (mid-pagination); syncToken only when no page in progress
+            if let pageToken {
+                components.queryItems = [
+                    URLQueryItem(name: "pageToken", value: pageToken),
+                ]
+            } else if let syncToken {
                 components.queryItems = [
                     URLQueryItem(name: "syncToken", value: syncToken),
                 ]
@@ -57,10 +62,6 @@ final class GoogleCalendarClient {
                     URLQueryItem(name: "orderBy", value: "startTime"),
                     URLQueryItem(name: "maxResults", value: "50"),
                 ]
-            }
-
-            if let pageToken {
-                components.queryItems?.append(URLQueryItem(name: "pageToken", value: pageToken))
             }
 
             var request = URLRequest(url: components.url!)

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -125,6 +125,18 @@ final class GoogleCalendarClient {
         cachedEvents.removeAll()
     }
 
+    private static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+    private static let dateOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = .current
+        return f
+    }()
+
     private func parseEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
         guard let id = item["id"] as? String,
               let summary = item["summary"] as? String else { return nil }
@@ -132,12 +144,8 @@ final class GoogleCalendarClient {
         let startDict = item["start"] as? [String: Any] ?? [:]
         let endDict = item["end"] as? [String: Any] ?? [:]
 
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime]
-
-        let dateOnlyFormatter = DateFormatter()
-        dateOnlyFormatter.dateFormat = "yyyy-MM-dd"
-        dateOnlyFormatter.timeZone = .current
+        let isoFormatter = Self.isoFormatter
+        let dateOnlyFormatter = Self.dateOnlyFormatter
 
         let startDate: Date
         let endDate: Date

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -30,84 +30,89 @@ final class GoogleCalendarClient {
     private var cachedEvents: [String: UnifiedCalendarEvent] = [:]
 
     /// Fetch upcoming events from the user's primary Google Calendar.
-    /// Uses sync tokens for incremental updates — first call does a full fetch,
-    /// subsequent calls return only changes since the last sync.
+    /// Uses sync tokens for incremental updates and handles pagination.
     func fetchUpcomingEvents(daysAhead: Int = 7) async throws -> [UnifiedCalendarEvent] {
         let token = try await auth.validAccessToken()
 
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime]
 
-        var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
+        var pageToken: String? = nil
 
-        if let syncToken {
-            // Incremental sync — only get changes since last fetch
-            components.queryItems = [
-                URLQueryItem(name: "syncToken", value: syncToken),
-            ]
-        } else {
-            // Full fetch — get all upcoming events
-            let now = Date()
-            guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
-            components.queryItems = [
-                URLQueryItem(name: "timeMin", value: isoFormatter.string(from: now)),
-                URLQueryItem(name: "timeMax", value: isoFormatter.string(from: future)),
-                URLQueryItem(name: "singleEvents", value: "true"),
-                URLQueryItem(name: "orderBy", value: "startTime"),
-                URLQueryItem(name: "maxResults", value: "50"),
-            ]
-        }
+        // Paginate through all results
+        repeat {
+            var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
 
-        var request = URLRequest(url: components.url!)
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
-
-        // 410 Gone = sync token expired, do a full re-fetch
-        if statusCode == 410 {
-            fputs("[google-cal] sync token expired, performing full re-fetch\n", stderr)
-            syncToken = nil
-            cachedEvents.removeAll()
-            return try await fetchUpcomingEvents(daysAhead: daysAhead)
-        }
-
-        guard statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? ""
-            fputs("[google-cal] API error \(statusCode): \(body.prefix(200))\n", stderr)
-            if statusCode == 401 || statusCode == 403 {
-                throw GoogleCalendarAuthError.notAuthenticated
+            if let syncToken {
+                components.queryItems = [
+                    URLQueryItem(name: "syncToken", value: syncToken),
+                ]
+            } else {
+                let now = Date()
+                guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
+                components.queryItems = [
+                    URLQueryItem(name: "timeMin", value: isoFormatter.string(from: now)),
+                    URLQueryItem(name: "timeMax", value: isoFormatter.string(from: future)),
+                    URLQueryItem(name: "singleEvents", value: "true"),
+                    URLQueryItem(name: "orderBy", value: "startTime"),
+                    URLQueryItem(name: "maxResults", value: "50"),
+                ]
             }
-            throw GoogleCalendarAuthError.refreshFailed("Calendar API returned \(statusCode)")
-        }
 
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return Array(cachedEvents.values).sorted { $0.startDate < $1.startDate }
-        }
+            if let pageToken {
+                components.queryItems?.append(URLQueryItem(name: "pageToken", value: pageToken))
+            }
 
-        // Update cached events with changes
-        if let items = json["items"] as? [[String: Any]] {
-            for item in items {
-                guard let id = item["id"] as? String else { continue }
+            var request = URLRequest(url: components.url!)
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-                // Cancelled events should be removed from cache
-                if item["status"] as? String == "cancelled" {
-                    cachedEvents.removeValue(forKey: id)
-                    continue
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+            if statusCode == 410 {
+                fputs("[google-cal] sync token expired, performing full re-fetch\n", stderr)
+                syncToken = nil
+                cachedEvents.removeAll()
+                return try await fetchUpcomingEvents(daysAhead: daysAhead)
+            }
+
+            guard statusCode == 200 else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                fputs("[google-cal] API error \(statusCode): \(body.prefix(200))\n", stderr)
+                if statusCode == 401 || statusCode == 403 {
+                    throw GoogleCalendarAuthError.notAuthenticated
                 }
+                throw GoogleCalendarAuthError.refreshFailed("Calendar API returned \(statusCode)")
+            }
 
-                if let event = parseEvent(item) {
-                    cachedEvents[id] = event
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                break
+            }
+
+            if let items = json["items"] as? [[String: Any]] {
+                for item in items {
+                    guard let id = item["id"] as? String else { continue }
+                    if item["status"] as? String == "cancelled" {
+                        cachedEvents.removeValue(forKey: id)
+                        continue
+                    }
+                    if let event = parseEvent(item) {
+                        cachedEvents[id] = event
+                    }
                 }
             }
-        }
 
-        // Store the new sync token for next incremental fetch
-        if let newSyncToken = json["nextSyncToken"] as? String {
-            syncToken = newSyncToken
-        }
+            // nextPageToken = more pages to fetch; nextSyncToken = done, use for incremental
+            if let nextPage = json["nextPageToken"] as? String {
+                pageToken = nextPage
+            } else {
+                pageToken = nil
+                if let newSyncToken = json["nextSyncToken"] as? String {
+                    syncToken = newSyncToken
+                }
+            }
+        } while pageToken != nil
 
-        // Filter to upcoming events only (past events may linger in cache)
         let now = Date()
         let events = cachedEvents.values.filter { $0.endDate > now }
         return events.sorted { $0.startDate < $1.startDate }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -58,7 +58,7 @@ final class GoogleCalendarClient {
                     URLQueryItem(name: "timeMax", value: isoFormatter.string(from: future)),
                     URLQueryItem(name: "singleEvents", value: "true"),
                     URLQueryItem(name: "orderBy", value: "startTime"),
-                    URLQueryItem(name: "maxResults", value: "50"),
+                    URLQueryItem(name: "maxResults", value: "250"),
                 ]
             }
 
@@ -147,7 +147,7 @@ final class GoogleCalendarClient {
         return f
     }()
 
-    private func parseEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
+    func parseEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
         guard let id = item["id"] as? String,
               let summary = item["summary"] as? String else { return nil }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -29,7 +29,7 @@ final class GoogleCalendarClient {
         let token = try await auth.validAccessToken()
 
         let now = Date()
-        let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now)!
+        guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -50,7 +50,11 @@ final class GoogleCalendarClient {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
             let body = String(data: data, encoding: .utf8) ?? ""
             fputs("[google-cal] API error \(statusCode): \(body.prefix(200))\n", stderr)
-            throw GoogleCalendarAuthError.tokenExchangeFailed("API returned \(statusCode)")
+            // 401/403 = token revoked or invalid — surface as auth error for auto-signout
+            if statusCode == 401 || statusCode == 403 {
+                throw GoogleCalendarAuthError.notAuthenticated
+            }
+            throw GoogleCalendarAuthError.refreshFailed("Calendar API returned \(statusCode)")
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -31,19 +31,16 @@ final class GoogleCalendarClient {
 
     /// Fetch upcoming events from the user's primary Google Calendar.
     /// Uses sync tokens for incremental updates and handles pagination.
-    func fetchUpcomingEvents(daysAhead: Int = 7) async throws -> [UnifiedCalendarEvent] {
-        let token = try await auth.validAccessToken()
+    func fetchUpcomingEvents(daysAhead: Int = 7, isRetry: Bool = false) async throws -> [UnifiedCalendarEvent] {
+        var token = try await auth.validAccessToken()
 
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime]
+        let isoFormatter = Self.isoFormatter
 
         var pageToken: String? = nil
 
-        // Paginate through all results
         repeat {
             var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
 
-            // pageToken takes priority (mid-pagination); syncToken only when no page in progress
             if let pageToken {
                 components.queryItems = [
                     URLQueryItem(name: "pageToken", value: pageToken),
@@ -70,11 +67,22 @@ final class GoogleCalendarClient {
             let (data, response) = try await URLSession.shared.data(for: request)
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
 
+            // 410 = sync token expired — retry once with full fetch
             if statusCode == 410 {
+                guard !isRetry else {
+                    fputs("[google-cal] 410 on full re-fetch, giving up\n", stderr)
+                    return Array(cachedEvents.values).sorted { $0.startDate < $1.startDate }
+                }
                 fputs("[google-cal] sync token expired, performing full re-fetch\n", stderr)
                 syncToken = nil
                 cachedEvents.removeAll()
-                return try await fetchUpcomingEvents(daysAhead: daysAhead)
+                return try await fetchUpcomingEvents(daysAhead: daysAhead, isRetry: true)
+            }
+
+            // 401 mid-pagination — refresh token and retry this page once
+            if statusCode == 401 && !isRetry {
+                token = try await auth.validAccessToken()
+                continue
             }
 
             guard statusCode == 200 else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -24,45 +24,99 @@ final class GoogleCalendarClient {
 
     private static let baseURL = "https://www.googleapis.com/calendar/v3"
 
+    /// Stored sync token from last full fetch — subsequent requests return only changes.
+    private var syncToken: String?
+    /// Cached events from last fetch, updated incrementally via sync tokens.
+    private var cachedEvents: [String: UnifiedCalendarEvent] = [:]
+
     /// Fetch upcoming events from the user's primary Google Calendar.
+    /// Uses sync tokens for incremental updates — first call does a full fetch,
+    /// subsequent calls return only changes since the last sync.
     func fetchUpcomingEvents(daysAhead: Int = 7) async throws -> [UnifiedCalendarEvent] {
         let token = try await auth.validAccessToken()
 
-        let now = Date()
-        guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
 
         var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
-        components.queryItems = [
-            URLQueryItem(name: "timeMin", value: formatter.string(from: now)),
-            URLQueryItem(name: "timeMax", value: formatter.string(from: future)),
-            URLQueryItem(name: "singleEvents", value: "true"),
-            URLQueryItem(name: "orderBy", value: "startTime"),
-            URLQueryItem(name: "maxResults", value: "50"),
-        ]
+
+        if let syncToken {
+            // Incremental sync — only get changes since last fetch
+            components.queryItems = [
+                URLQueryItem(name: "syncToken", value: syncToken),
+            ]
+        } else {
+            // Full fetch — get all upcoming events
+            let now = Date()
+            guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
+            components.queryItems = [
+                URLQueryItem(name: "timeMin", value: isoFormatter.string(from: now)),
+                URLQueryItem(name: "timeMax", value: isoFormatter.string(from: future)),
+                URLQueryItem(name: "singleEvents", value: "true"),
+                URLQueryItem(name: "orderBy", value: "startTime"),
+                URLQueryItem(name: "maxResults", value: "50"),
+            ]
+        }
 
         var request = URLRequest(url: components.url!)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
         let (data, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        // 410 Gone = sync token expired, do a full re-fetch
+        if statusCode == 410 {
+            fputs("[google-cal] sync token expired, performing full re-fetch\n", stderr)
+            syncToken = nil
+            cachedEvents.removeAll()
+            return try await fetchUpcomingEvents(daysAhead: daysAhead)
+        }
+
+        guard statusCode == 200 else {
             let body = String(data: data, encoding: .utf8) ?? ""
             fputs("[google-cal] API error \(statusCode): \(body.prefix(200))\n", stderr)
-            // 401/403 = token revoked or invalid — surface as auth error for auto-signout
             if statusCode == 401 || statusCode == 403 {
                 throw GoogleCalendarAuthError.notAuthenticated
             }
             throw GoogleCalendarAuthError.refreshFailed("Calendar API returned \(statusCode)")
         }
 
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let items = json["items"] as? [[String: Any]] else {
-            return []
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return Array(cachedEvents.values).sorted { $0.startDate < $1.startDate }
         }
 
-        return items.compactMap { parseEvent($0) }
+        // Update cached events with changes
+        if let items = json["items"] as? [[String: Any]] {
+            for item in items {
+                guard let id = item["id"] as? String else { continue }
+
+                // Cancelled events should be removed from cache
+                if item["status"] as? String == "cancelled" {
+                    cachedEvents.removeValue(forKey: id)
+                    continue
+                }
+
+                if let event = parseEvent(item) {
+                    cachedEvents[id] = event
+                }
+            }
+        }
+
+        // Store the new sync token for next incremental fetch
+        if let newSyncToken = json["nextSyncToken"] as? String {
+            syncToken = newSyncToken
+        }
+
+        // Filter to upcoming events only (past events may linger in cache)
+        let now = Date()
+        let events = cachedEvents.values.filter { $0.endDate > now }
+        return events.sorted { $0.startDate < $1.startDate }
+    }
+
+    /// Clear cached state (call on sign-out).
+    func resetSync() {
+        syncToken = nil
+        cachedEvents.removeAll()
     }
 
     private func parseEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
@@ -79,7 +133,6 @@ final class GoogleCalendarClient {
         dateOnlyFormatter.dateFormat = "yyyy-MM-dd"
         dateOnlyFormatter.timeZone = .current
 
-        // Timed events use dateTime, all-day events use date
         let startDate: Date
         let endDate: Date
         let isAllDay: Bool
@@ -128,7 +181,7 @@ final class GoogleCalendarClient {
         for gEvent in google {
             let isDuplicate = eventKit.contains { ekEvent in
                 ekEvent.title.lowercased() == gEvent.title.lowercased()
-                    && abs(ekEvent.startDate.timeIntervalSince(gEvent.startDate)) < 300 // 5 min window
+                    && abs(ekEvent.startDate.timeIntervalSince(gEvent.startDate)) < 300
             }
             if !isDuplicate {
                 merged.append(gEvent)

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -37,6 +37,7 @@ final class GoogleCalendarClient {
         let isoFormatter = Self.isoFormatter
 
         var pageToken: String? = nil
+        var tokenRetried = false
 
         repeat {
             var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
@@ -80,7 +81,8 @@ final class GoogleCalendarClient {
             }
 
             // 401 mid-pagination — refresh token and retry this page once
-            if statusCode == 401 && !isRetry {
+            if statusCode == 401 && !tokenRetried {
+                tokenRetried = true
                 token = try await auth.validAccessToken()
                 continue
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+// MARK: - Shared Calendar Event Model
+
+struct UnifiedCalendarEvent: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let isAllDay: Bool
+    let source: CalendarSource
+
+    enum CalendarSource: String {
+        case eventKit
+        case googleCalendar
+    }
+}
+
+// MARK: - Google Calendar API Client
+
+@MainActor
+final class GoogleCalendarClient {
+    private let auth = GoogleCalendarAuthManager.shared
+
+    private static let baseURL = "https://www.googleapis.com/calendar/v3"
+
+    /// Fetch upcoming events from the user's primary Google Calendar.
+    func fetchUpcomingEvents(daysAhead: Int = 7) async throws -> [UnifiedCalendarEvent] {
+        let token = try await auth.validAccessToken()
+
+        let now = Date()
+        let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now)!
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+
+        var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
+        components.queryItems = [
+            URLQueryItem(name: "timeMin", value: formatter.string(from: now)),
+            URLQueryItem(name: "timeMax", value: formatter.string(from: future)),
+            URLQueryItem(name: "singleEvents", value: "true"),
+            URLQueryItem(name: "orderBy", value: "startTime"),
+            URLQueryItem(name: "maxResults", value: "50"),
+        ]
+
+        var request = URLRequest(url: components.url!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let body = String(data: data, encoding: .utf8) ?? ""
+            fputs("[google-cal] API error \(statusCode): \(body.prefix(200))\n", stderr)
+            throw GoogleCalendarAuthError.tokenExchangeFailed("API returned \(statusCode)")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = json["items"] as? [[String: Any]] else {
+            return []
+        }
+
+        return items.compactMap { parseEvent($0) }
+    }
+
+    private func parseEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
+        guard let id = item["id"] as? String,
+              let summary = item["summary"] as? String else { return nil }
+
+        let startDict = item["start"] as? [String: Any] ?? [:]
+        let endDict = item["end"] as? [String: Any] ?? [:]
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        let dateOnlyFormatter = DateFormatter()
+        dateOnlyFormatter.dateFormat = "yyyy-MM-dd"
+        dateOnlyFormatter.timeZone = .current
+
+        // Timed events use dateTime, all-day events use date
+        let startDate: Date
+        let endDate: Date
+        let isAllDay: Bool
+
+        if let dateTimeStr = startDict["dateTime"] as? String,
+           let start = isoFormatter.date(from: dateTimeStr) {
+            startDate = start
+            isAllDay = false
+            if let endStr = endDict["dateTime"] as? String, let end = isoFormatter.date(from: endStr) {
+                endDate = end
+            } else {
+                endDate = start.addingTimeInterval(3600)
+            }
+        } else if let dateStr = startDict["date"] as? String,
+                  let start = dateOnlyFormatter.date(from: dateStr) {
+            startDate = start
+            isAllDay = true
+            if let endStr = endDict["date"] as? String, let end = dateOnlyFormatter.date(from: endStr) {
+                endDate = end
+            } else {
+                endDate = start.addingTimeInterval(86400)
+            }
+        } else {
+            return nil
+        }
+
+        return UnifiedCalendarEvent(
+            id: id,
+            title: summary,
+            startDate: startDate,
+            endDate: endDate,
+            isAllDay: isAllDay,
+            source: .googleCalendar
+        )
+    }
+
+    // MARK: - Merge & Deduplicate
+
+    /// Merge EventKit and Google Calendar events, deduplicating by title + start time proximity.
+    static func mergeEvents(
+        eventKit: [UnifiedCalendarEvent],
+        google: [UnifiedCalendarEvent]
+    ) -> [UnifiedCalendarEvent] {
+        var merged = eventKit
+
+        for gEvent in google {
+            let isDuplicate = eventKit.contains { ekEvent in
+                ekEvent.title.lowercased() == gEvent.title.lowercased()
+                    && abs(ekEvent.startDate.timeIntervalSince(gEvent.startDate)) < 300 // 5 min window
+            }
+            if !isDuplicate {
+                merged.append(gEvent)
+            }
+        }
+
+        return merged.sorted { $0.startDate < $1.startDate }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarCredentials.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarCredentials.swift
@@ -3,6 +3,9 @@ import Foundation
 struct GoogleCalendarCredentials {
     let clientId: String
     let clientSecret: String
+    /// Whether the OAuth app has passed Google's verification review.
+    /// When false, only test users can connect. UI shows "verification pending".
+    let verified: Bool
 
     /// Load credentials from app bundle (production) or ~/.config/muesli/ (dev).
     /// Returns nil if no credentials found — Google Calendar feature is disabled.
@@ -34,6 +37,7 @@ struct GoogleCalendarCredentials {
               !clientId.isEmpty, !clientSecret.isEmpty else {
             return nil
         }
-        return GoogleCalendarCredentials(clientId: clientId, clientSecret: clientSecret)
+        let verified = json["verified"] as? Bool ?? false
+        return GoogleCalendarCredentials(clientId: clientId, clientSecret: clientSecret, verified: verified)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarCredentials.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarCredentials.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct GoogleCalendarCredentials {
+    let clientId: String
+    let clientSecret: String
+
+    /// Load credentials from app bundle (production) or ~/.config/muesli/ (dev).
+    /// Returns nil if no credentials found — Google Calendar feature is disabled.
+    static func load() -> GoogleCalendarCredentials? {
+        // 1. Try app bundle (production builds embed via build script)
+        if let bundleURL = Bundle.main.url(forResource: "google-oauth", withExtension: "json"),
+           let creds = parse(url: bundleURL) {
+            fputs("[google-cal] credentials loaded from app bundle\n", stderr)
+            return creds
+        }
+
+        // 2. Try dev config file
+        let devPath = NSString("~/.config/muesli/google-oauth.json").expandingTildeInPath
+        let devURL = URL(fileURLWithPath: devPath)
+        if let creds = parse(url: devURL) {
+            fputs("[google-cal] credentials loaded from ~/.config/muesli/\n", stderr)
+            return creds
+        }
+
+        fputs("[google-cal] no credentials found — Google Calendar integration disabled\n", stderr)
+        return nil
+    }
+
+    private static func parse(url: URL) -> GoogleCalendarCredentials? {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let clientId = json["client_id"] as? String,
+              let clientSecret = json["client_secret"] as? String,
+              !clientId.isEmpty, !clientSecret.isEmpty else {
+            return nil
+        }
+        return GoogleCalendarCredentials(clientId: clientId, clientSecret: clientSecret)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -17,11 +17,13 @@ final class MeetingNotificationController {
         title: String,
         subtitle: String,
         actionLabel: String = "Start Recording",
+        dismissAfter: TimeInterval? = nil,
         onStartRecording: @escaping () -> Void,
         onDismiss: (() -> Void)? = nil
     ) {
         close()
 
+        let duration = dismissAfter ?? Self.dismissDuration
         self.onStartRecording = onStartRecording
         self.onDismiss = onDismiss
 
@@ -66,7 +68,7 @@ final class MeetingNotificationController {
         let shrink = CABasicAnimation(keyPath: "bounds.size.width")
         shrink.fromValue = width
         shrink.toValue = 0
-        shrink.duration = Self.dismissDuration
+        shrink.duration = duration
         shrink.timingFunction = CAMediaTimingFunction(name: .linear)
         shrink.fillMode = .forwards
         shrink.isRemovedOnCompletion = false
@@ -120,7 +122,7 @@ final class MeetingNotificationController {
         self.panel = panel
 
         // Auto-dismiss
-        dismissTimer = Timer.scheduledTimer(withTimeInterval: Self.dismissDuration, repeats: false) { [weak self] _ in
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
             DispatchQueue.main.async {
                 self?.animateOut {
                     self?.close()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -244,24 +244,30 @@ struct MeetingsView: View {
         let events: [UnifiedCalendarEvent]
     }
 
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "d"; return f
+    }()
+    private static let monthFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM"; return f
+    }()
+    private static let weekdayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "EEE"; return f
+    }()
+
     private var groupedUpcomingEvents: [UpcomingEventGroup] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-        // Filter out all-day events — not useful for meeting recording
         let timedEvents = appState.upcomingCalendarEvents.filter { !$0.isAllDay }
         let grouped = Dictionary(grouping: timedEvents) { event in
             calendar.startOfDay(for: event.startDate)
         }
-        let dayFormatter = DateFormatter()
-        dayFormatter.dateFormat = "d"
-        let monthFormatter = DateFormatter()
-        monthFormatter.dateFormat = "MMM"
-        let weekdayFormatter = DateFormatter()
-        weekdayFormatter.dateFormat = "EEE"
+        let dayFormatter = Self.dayFormatter
+        let monthFormatter = Self.monthFormatter
+        let weekdayFormatter = Self.weekdayFormatter
 
         return grouped.keys.sorted().map { date in
             let isToday = calendar.isDate(date, inSameDayAs: today)
-            let isTomorrow = calendar.isDate(date, inSameDayAs: calendar.date(byAdding: .day, value: 1, to: today)!)
+            let isTomorrow = calendar.date(byAdding: .day, value: 1, to: today).map { calendar.isDate(date, inSameDayAs: $0) } ?? false
             let dayLabel: String
             if isToday {
                 dayLabel = "Today"

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -195,6 +195,10 @@ struct MeetingsView: View {
     private var browserView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+                if !appState.upcomingCalendarEvents.isEmpty {
+                    comingUpSection
+                }
+
                 browserHeader
 
                 if filteredMeetings.isEmpty {
@@ -226,6 +230,128 @@ struct MeetingsView: View {
             .padding(.vertical, 32)
             .frame(maxWidth: .infinity, alignment: .center)
         }
+    }
+
+    // MARK: - Coming Up
+
+    private struct UpcomingEventGroup: Identifiable {
+        let id: String
+        let date: Date
+        let dayLabel: String
+        let dayNumber: String
+        let dayOfWeek: String
+        let isToday: Bool
+        let events: [UnifiedCalendarEvent]
+    }
+
+    private var groupedUpcomingEvents: [UpcomingEventGroup] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let grouped = Dictionary(grouping: appState.upcomingCalendarEvents) { event in
+            calendar.startOfDay(for: event.startDate)
+        }
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "d"
+        let monthFormatter = DateFormatter()
+        monthFormatter.dateFormat = "MMM"
+        let weekdayFormatter = DateFormatter()
+        weekdayFormatter.dateFormat = "EEE"
+
+        return grouped.keys.sorted().map { date in
+            let isToday = calendar.isDate(date, inSameDayAs: today)
+            let isTomorrow = calendar.isDate(date, inSameDayAs: calendar.date(byAdding: .day, value: 1, to: today)!)
+            let dayLabel: String
+            if isToday {
+                dayLabel = "Today"
+            } else if isTomorrow {
+                dayLabel = "Tomorrow"
+            } else {
+                dayLabel = monthFormatter.string(from: date)
+            }
+            return UpcomingEventGroup(
+                id: date.description,
+                date: date,
+                dayLabel: dayLabel,
+                dayNumber: dayFormatter.string(from: date),
+                dayOfWeek: weekdayFormatter.string(from: date),
+                isToday: isToday,
+                events: grouped[date]!.sorted { $0.startDate < $1.startDate }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var comingUpSection: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            Text("Coming Up")
+                .font(.custom("Cormorant Garamond", size: 22).weight(.medium))
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .padding(.bottom, 4)
+
+            ForEach(groupedUpcomingEvents) { group in
+                HStack(alignment: .top, spacing: 20) {
+                    // Date column
+                    VStack(alignment: .center, spacing: 2) {
+                        Text(group.dayNumber)
+                            .font(.system(size: 24, weight: .light, design: .default))
+                            .foregroundStyle(group.isToday ? MuesliTheme.accent : MuesliTheme.textPrimary)
+                        Text(group.dayLabel)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(group.isToday ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                        Text(group.dayOfWeek)
+                            .font(.system(size: 10))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+                    .frame(width: 60)
+
+                    // Events column
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(group.events) { event in
+                            HStack(spacing: 8) {
+                                RoundedRectangle(cornerRadius: 1.5)
+                                    .fill(group.isToday ? MuesliTheme.accent : MuesliTheme.textSecondary.opacity(0.4))
+                                    .frame(width: 3, height: 36)
+
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(event.title)
+                                        .font(.system(size: 13, weight: .medium))
+                                        .foregroundStyle(MuesliTheme.textPrimary)
+                                        .lineLimit(1)
+
+                                    if event.isAllDay {
+                                        Text("All day")
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(MuesliTheme.textSecondary)
+                                    } else {
+                                        Text(formatTimeRange(event))
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(MuesliTheme.textSecondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if group.id != groupedUpcomingEvents.last?.id {
+                    Divider()
+                        .foregroundStyle(MuesliTheme.surfaceBorder)
+                }
+            }
+        }
+        .padding(20)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private func formatTimeRange(_ event: UnifiedCalendarEvent) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return "\(formatter.string(from: event.startDate)) – \(formatter.string(from: event.endDate))"
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -247,7 +247,9 @@ struct MeetingsView: View {
     private var groupedUpcomingEvents: [UpcomingEventGroup] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-        let grouped = Dictionary(grouping: appState.upcomingCalendarEvents) { event in
+        // Filter out all-day events — not useful for meeting recording
+        let timedEvents = appState.upcomingCalendarEvents.filter { !$0.isAllDay }
+        let grouped = Dictionary(grouping: timedEvents) { event in
             calendar.startOfDay(for: event.startDate)
         }
         let dayFormatter = DateFormatter()
@@ -318,16 +320,38 @@ struct MeetingsView: View {
                                         .foregroundStyle(MuesliTheme.textPrimary)
                                         .lineLimit(1)
 
-                                    if event.isAllDay {
-                                        Text("All day")
-                                            .font(.system(size: 11))
-                                            .foregroundStyle(MuesliTheme.textSecondary)
-                                    } else {
-                                        Text(formatTimeRange(event))
-                                            .font(.system(size: 11))
-                                            .foregroundStyle(MuesliTheme.textSecondary)
-                                    }
+                                    Text(formatTimeRange(event))
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(MuesliTheme.textSecondary)
                                 }
+
+                                Spacer()
+
+                                Menu {
+                                    Button("All Meetings") {
+                                        controller.createMeetingFromCalendarEvent(event, folderID: nil)
+                                    }
+                                    Divider()
+                                    ForEach(appState.folders) { folder in
+                                        Button(folder.name) {
+                                            controller.createMeetingFromCalendarEvent(event, folderID: folder.id)
+                                        }
+                                    }
+                                } label: {
+                                    Text("Add to folder")
+                                        .font(.system(size: 10, weight: .medium))
+                                        .foregroundStyle(MuesliTheme.textSecondary)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 3)
+                                        .background(MuesliTheme.surfacePrimary)
+                                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 4)
+                                                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 0.5)
+                                        )
+                                }
+                                .menuStyle(.borderlessButton)
+                                .fixedSize()
                             }
                         }
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -296,7 +296,9 @@ struct MeetingsView: View {
                 .foregroundStyle(MuesliTheme.textPrimary)
                 .padding(.bottom, 4)
 
-            ForEach(groupedUpcomingEvents) { group in
+            let groups = groupedUpcomingEvents
+            let lastGroupId = groups.last?.id
+            ForEach(groups) { group in
                 HStack(alignment: .top, spacing: 20) {
                     // Date column
                     VStack(alignment: .center, spacing: 2) {
@@ -363,7 +365,7 @@ struct MeetingsView: View {
                     }
                 }
 
-                if group.id != groupedUpcomingEvents.last?.id {
+                if group.id != lastGroupId {
                     Divider()
                         .foregroundStyle(MuesliTheme.surfaceBorder)
                 }
@@ -378,10 +380,13 @@ struct MeetingsView: View {
         )
     }
 
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "HH:mm"; return f
+    }()
+
     private func formatTimeRange(_ event: UnifiedCalendarEvent) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return "\(formatter.string(from: event.startDate)) – \(formatter.string(from: event.endDate))"
+        let f = Self.timeFormatter
+        return "\(f.string(from: event.startDate)) – \(f.string(from: event.endDate))"
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -280,6 +280,7 @@ struct AppConfig: Codable {
     var soundEnabled: Bool = true
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
     var menuBarIcon: String = "muesli"
+    var showNextMeetingInMenuBar: Bool = true
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -314,6 +315,7 @@ struct AppConfig: Codable {
         case soundEnabled = "sound_enabled"
         case recordingColorHex = "recording_color_hex"
         case menuBarIcon = "menu_bar_icon"
+        case showNextMeetingInMenuBar = "show_next_meeting_in_menu_bar"
     }
 
     init() {}
@@ -353,6 +355,7 @@ struct AppConfig: Codable {
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
+        showNextMeetingInMenuBar = (try? c.decode(Bool.self, forKey: .showNextMeetingInMenuBar)) ?? defaults.showNextMeetingInMenuBar
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -510,6 +510,11 @@ final class MuesliController: NSObject {
             do {
                 let googleEvents = try await googleCalClient.fetchUpcomingEvents(daysAhead: 7)
                 ekEvents = GoogleCalendarClient.mergeEvents(eventKit: ekEvents, google: googleEvents)
+            } catch GoogleCalendarAuthError.notAuthenticated {
+                // Token revoked externally or permanently invalid — sign out so UI shows "Connect"
+                googleCalAuth.signOut()
+                syncAppState()
+                fputs("[muesli-native] Google Calendar token invalid, signed out\n", stderr)
             } catch {
                 fputs("[muesli-native] Google Calendar fetch failed: \(error)\n", stderr)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -537,23 +537,17 @@ final class MuesliController: NSObject {
 
     func startCalendarRefreshTimer() {
         calendarRefreshTimer?.invalidate()
+        calendarNotificationTimer?.invalidate()
+
+        // Single 60s timer: refresh events from Google Calendar + check for upcoming notifications
         calendarRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 await self.refreshUpcomingCalendarEvents()
-            }
-        }
-        Task { await refreshUpcomingCalendarEvents() }
-
-        // Check every 60s for upcoming events that need notifications
-        // (covers Google Calendar events not in EventKit's CalendarMonitor)
-        calendarNotificationTimer?.invalidate()
-        calendarNotificationTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            Task { @MainActor in
                 self.checkUpcomingCalendarNotifications()
             }
         }
+        Task { await refreshUpcomingCalendarEvents() }
     }
 
     /// Check merged calendar events (EventKit + Google) for events starting within 5 minutes.

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -766,6 +766,28 @@ final class MuesliController: NSObject {
         syncAppState()
     }
 
+    func createMeetingFromCalendarEvent(_ event: UnifiedCalendarEvent, folderID: Int64?) {
+        do {
+            let meetingID = try dictationStore.insertMeeting(
+                title: event.title,
+                calendarEventID: event.id,
+                startTime: event.startDate,
+                endTime: event.endDate,
+                rawTranscript: "",
+                formattedNotes: "",
+                micAudioPath: nil,
+                systemAudioPath: nil
+            )
+            if let folderID {
+                try? dictationStore.moveMeeting(id: meetingID, toFolder: folderID)
+            }
+            syncAppState()
+            fputs("[muesli-native] created meeting from calendar event: \(event.title) (folder=\(folderID.map(String.init) ?? "none"))\n", stderr)
+        } catch {
+            fputs("[muesli-native] failed to create meeting from calendar event: \(error)\n", stderr)
+        }
+    }
+
     func moveMeeting(id: Int64, toFolder folderID: Int64?) {
         try? dictationStore.moveMeeting(id: id, toFolder: folderID)
         syncAppState()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -86,6 +86,8 @@ final class MuesliController: NSObject {
     private let googleCalAuth = GoogleCalendarAuthManager.shared
     private let googleCalClient = GoogleCalendarClient()
     private var calendarRefreshTimer: Timer?
+    private var calendarNotificationTimer: Timer?
+    private var notifiedUpcomingEventIDs = Set<String>()
 
     private var statusBarController: StatusBarController?
     private var historyWindowController: RecentHistoryWindowController?
@@ -532,6 +534,42 @@ final class MuesliController: NSObject {
             }
         }
         Task { await refreshUpcomingCalendarEvents() }
+
+        // Check every 60s for upcoming events that need notifications
+        // (covers Google Calendar events not in EventKit's CalendarMonitor)
+        calendarNotificationTimer?.invalidate()
+        calendarNotificationTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                self.checkUpcomingCalendarNotifications()
+            }
+        }
+    }
+
+    /// Check merged calendar events (EventKit + Google) for events starting within 5 minutes.
+    /// Fires the meeting notification for events not yet notified.
+    private func checkUpcomingCalendarNotifications() {
+        guard config.showMeetingDetectionNotification,
+              !config.autoRecordMeetings,
+              !isMeetingRecording(),
+              !isStartingMeetingRecording else { return }
+
+        let now = Date()
+        let fiveMinutesFromNow = now.addingTimeInterval(5 * 60)
+
+        for event in appState.upcomingCalendarEvents {
+            guard !event.isAllDay else { continue }
+            guard event.startDate > now && event.startDate <= fiveMinutesFromNow else { continue }
+            guard !notifiedUpcomingEventIDs.contains(event.id) else { continue }
+
+            notifiedUpcomingEventIDs.insert(event.id)
+            handleUpcomingMeeting(UpcomingMeetingEvent(
+                id: event.id,
+                title: event.title,
+                startDate: event.startDate
+            ))
+            return // Show one notification at a time
+        }
     }
 
     func addCustomWord(_ word: CustomWord) {
@@ -1534,7 +1572,37 @@ final class MuesliController: NSObject {
         fputs("[muesli-native] meeting soon: \(event.title)\n", stderr)
         if config.autoRecordMeetings, !isMeetingRecording() {
             startMeetingRecording(title: event.title)
+            return
         }
+
+        // Show notification panel for calendar events (if not auto-recording)
+        guard config.showMeetingDetectionNotification,
+              !isMeetingRecording(),
+              !isStartingMeetingRecording else { return }
+
+        let minutesUntil = Int(ceil(event.startDate.timeIntervalSinceNow / 60))
+        let timeLabel: String
+        if minutesUntil > 0 {
+            timeLabel = "starts in \(minutesUntil) min"
+        } else if minutesUntil == 0 {
+            timeLabel = "starting now"
+        } else {
+            timeLabel = "started \(abs(minutesUntil)) min ago"
+        }
+
+        meetingNotification.show(
+            title: "Upcoming meeting",
+            subtitle: "\(event.title) · \(timeLabel)",
+            onStartRecording: { [weak self] in
+                guard let self else { return }
+                self.startMeetingRecording(title: event.title)
+            },
+            onDismiss: { [weak self] in
+                guard let self else { return }
+                self.micActivityMonitor.suppress()
+                self.micActivityMonitor.refreshState()
+            }
+        )
     }
 
     func serializedCustomWords() -> [[String: Any]] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -516,10 +516,15 @@ final class MuesliController: NSObject {
                 let googleEvents = try await googleCalClient.fetchUpcomingEvents(daysAhead: 7)
                 ekEvents = GoogleCalendarClient.mergeEvents(eventKit: ekEvents, google: googleEvents)
             } catch GoogleCalendarAuthError.notAuthenticated {
-                // Token revoked externally or permanently invalid — sign out so UI shows "Connect"
                 googleCalAuth.signOut()
+                googleCalClient.resetSync()
                 syncAppState()
                 fputs("[muesli-native] Google Calendar token invalid, signed out\n", stderr)
+            } catch GoogleCalendarAuthError.refreshFailed {
+                googleCalAuth.signOut()
+                googleCalClient.resetSync()
+                syncAppState()
+                fputs("[muesli-native] Google Calendar refresh token invalid, signed out\n", stderr)
             } catch {
                 fputs("[muesli-native] Google Calendar fetch failed: \(error)\n", stderr)
             }
@@ -552,16 +557,17 @@ final class MuesliController: NSObject {
 
     /// Check merged calendar events (EventKit + Google) for events starting within 5 minutes.
     /// Fires the meeting notification for events not yet notified.
+    /// Check Google Calendar events for upcoming meetings (EventKit events are handled
+    /// by CalendarMonitor.checkMeetings separately). Lets handleUpcomingMeeting decide
+    /// between notification vs auto-record.
     private func checkUpcomingCalendarNotifications() {
-        guard config.showMeetingDetectionNotification,
-              !config.autoRecordMeetings,
-              !isMeetingRecording(),
+        guard !isMeetingRecording(),
               !isStartingMeetingRecording else { return }
 
         let now = Date()
         let fiveMinutesFromNow = now.addingTimeInterval(5 * 60)
 
-        for event in appState.upcomingCalendarEvents {
+        for event in appState.upcomingCalendarEvents where event.source == .googleCalendar {
             guard !event.isAllDay else { continue }
             guard event.startDate > now && event.startDate <= fiveMinutesFromNow else { continue }
             guard !notifiedUpcomingEventIDs.contains(event.id) else { continue }
@@ -815,9 +821,8 @@ final class MuesliController: NSObject {
     }
 
     func createMeetingFromCalendarEvent(_ event: UnifiedCalendarEvent, folderID: Int64?) {
-        // Check for existing meeting with this calendar event ID to prevent duplicates
-        if let existing = appState.meetingRows.first(where: { $0.calendarEventID == event.id }) {
-            // Already exists — just move to the requested folder
+        // Check ALL folders for existing meeting with this calendar event ID
+        if let existing = try? dictationStore.meetingByCalendarEventID(event.id) {
             if let folderID {
                 try? dictationStore.moveMeeting(id: existing.id, toFolder: folderID)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -768,6 +768,17 @@ final class MuesliController: NSObject {
     }
 
     func createMeetingFromCalendarEvent(_ event: UnifiedCalendarEvent, folderID: Int64?) {
+        // Check for existing meeting with this calendar event ID to prevent duplicates
+        if let existing = appState.meetingRows.first(where: { $0.calendarEventID == event.id }) {
+            // Already exists — just move to the requested folder
+            if let folderID {
+                try? dictationStore.moveMeeting(id: existing.id, toFolder: folderID)
+            }
+            syncAppState()
+            fputs("[muesli-native] calendar event already exists as meeting \(existing.id), moved to folder\n", stderr)
+            return
+        }
+
         do {
             let meetingID = try dictationStore.insertMeeting(
                 title: event.title,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -523,6 +523,7 @@ final class MuesliController: NSObject {
         }
 
         appState.upcomingCalendarEvents = ekEvents
+        statusBarController?.updateMenuBarTitle()
     }
 
     func startCalendarRefreshTimer() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -501,6 +501,7 @@ final class MuesliController: NSObject {
 
     func signOutGoogleCalendar() {
         googleCalAuth.signOut()
+        googleCalClient.resetSync()
         syncAppState()
         Task { await refreshUpcomingCalendarEvents() }
     }
@@ -528,7 +529,7 @@ final class MuesliController: NSObject {
 
     func startCalendarRefreshTimer() {
         calendarRefreshTimer?.invalidate()
-        calendarRefreshTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
+        calendarRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 await self.refreshUpcomingCalendarEvents()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -83,6 +83,9 @@ final class MuesliController: NSObject {
     private let meetingNotification = MeetingNotificationController()
 
     private let chatGPTAuth = ChatGPTAuthManager.shared
+    private let googleCalAuth = GoogleCalendarAuthManager.shared
+    private let googleCalClient = GoogleCalendarClient()
+    private var calendarRefreshTimer: Timer?
 
     private var statusBarController: StatusBarController?
     private var historyWindowController: RecentHistoryWindowController?
@@ -204,6 +207,7 @@ final class MuesliController: NSObject {
             self?.handleUpcomingMeeting(event)
         }
         calendarMonitor.start()
+        startCalendarRefreshTimer()
 
         micActivityMonitor.calendarEventProvider = { [weak self] in
             self?.calendarMonitor.currentOrNearbyEvent()
@@ -341,6 +345,8 @@ final class MuesliController: NSObject {
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
+        appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
+        appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
     }
 
     func updateConfig(_ mutate: (inout AppConfig) -> Void) {
@@ -474,6 +480,52 @@ final class MuesliController: NSObject {
             selectMeetingSummaryBackend(.openAI)
         }
         syncAppState()
+    }
+
+    // MARK: - Google Calendar
+
+    func signInWithGoogleCalendar() async -> String? {
+        do {
+            try await googleCalAuth.signIn()
+            syncAppState()
+            Task { await refreshUpcomingCalendarEvents() }
+            return nil
+        } catch {
+            fputs("[muesli-native] Google Calendar sign-in failed: \(error)\n", stderr)
+            return error.localizedDescription
+        }
+    }
+
+    func signOutGoogleCalendar() {
+        googleCalAuth.signOut()
+        syncAppState()
+        Task { await refreshUpcomingCalendarEvents() }
+    }
+
+    func refreshUpcomingCalendarEvents() async {
+        var ekEvents = calendarMonitor.upcomingEvents(daysAhead: 7)
+
+        if googleCalAuth.isAuthenticated {
+            do {
+                let googleEvents = try await googleCalClient.fetchUpcomingEvents(daysAhead: 7)
+                ekEvents = GoogleCalendarClient.mergeEvents(eventKit: ekEvents, google: googleEvents)
+            } catch {
+                fputs("[muesli-native] Google Calendar fetch failed: \(error)\n", stderr)
+            }
+        }
+
+        appState.upcomingCalendarEvents = ekEvents
+    }
+
+    func startCalendarRefreshTimer() {
+        calendarRefreshTimer?.invalidate()
+        calendarRefreshTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                await self.refreshUpcomingCalendarEvents()
+            }
+        }
+        Task { await refreshUpcomingCalendarEvents() }
     }
 
     func addCustomWord(_ word: CustomWord) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -350,6 +350,7 @@ final class MuesliController: NSObject {
         appState.isMeetingRecording = isMeetingRecording()
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
+        appState.isGoogleCalendarVerified = googleCalAuth.isVerified
         appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -961,6 +961,11 @@ final class MuesliController: NSObject {
         }
     }
 
+    @objc func startMeetingFromCalendarMenuItem(_ sender: NSMenuItem) {
+        guard let title = sender.representedObject as? String else { return }
+        startMeetingRecording(title: title)
+    }
+
     func startMeetingRecording(title: String = "Meeting") {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
         isStartingMeetingRecording = true

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -112,6 +112,8 @@ final class MuesliController: NSObject {
     private var isStartingMeetingRecording = false
     private var currentMeetingDetection: MeetingDetection?
     private var presentedMeetingDetection: MeetingDetection?
+    private var meetingEndTimer: Timer?
+    private var activeMeetingCalendarEndDate: Date?
 
     init(runtime: RuntimePaths, dictationStore: DictationStore? = nil) {
         let loadedConfig = configStore.load()
@@ -1040,6 +1042,9 @@ final class MuesliController: NSObject {
 
     func stopMeetingRecording() {
         guard let activeMeetingSession else { return }
+        meetingEndTimer?.invalidate()
+        meetingEndTimer = nil
+        meetingNotification.close()
         indicator.setMeetingRecording(false, config: config)
         indicator.setTranscribingTitle("Transcribing", config: config)
         setState(.transcribing)
@@ -1577,8 +1582,14 @@ final class MuesliController: NSObject {
 
     private func handleUpcomingMeeting(_ event: UpcomingMeetingEvent) {
         fputs("[muesli-native] meeting soon: \(event.title)\n", stderr)
+
+        // Look up end date from unified calendar events
+        let calendarEndDate = appState.upcomingCalendarEvents
+            .first(where: { $0.id == event.id || $0.title == event.title })?.endDate
+
         if config.autoRecordMeetings, !isMeetingRecording() {
             startMeetingRecording(title: event.title)
+            scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
             return
         }
 
@@ -1603,6 +1614,7 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.startMeetingRecording(title: event.title)
+                self.scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
             },
             onDismiss: { [weak self] in
                 guard let self else { return }
@@ -1610,6 +1622,33 @@ final class MuesliController: NSObject {
                 self.micActivityMonitor.refreshState()
             }
         )
+    }
+
+    private func scheduleMeetingEndNotification(endDate: Date?, title: String) {
+        meetingEndTimer?.invalidate()
+        meetingEndTimer = nil
+
+        guard let endDate else { return }
+
+        let delay = endDate.timeIntervalSinceNow
+        guard delay > 0 else { return }
+
+        fputs("[muesli-native] meeting end notification scheduled in \(Int(delay))s for \"\(title)\"\n", stderr)
+        meetingEndTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            guard let self, self.isMeetingRecording() else { return }
+            DispatchQueue.main.async {
+                self.meetingNotification.show(
+                    title: "Meeting ended",
+                    subtitle: "\(title) · scheduled time is over",
+                    actionLabel: "Stop Recording",
+                    dismissAfter: 45,
+                    onStartRecording: { [weak self] in
+                        self?.stopMeetingRecording()
+                    },
+                    onDismiss: nil
+                )
+            }
+        }
     }
 
     func serializedCustomWords() -> [[String: Any]] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -361,6 +361,7 @@ final class MuesliController: NSObject {
         }) ?? .openAI
         statusBarController?.refresh()
         statusBarController?.refreshIcon()
+        indicator.refreshIcon()
         historyWindowController?.updateBackendLabel()
         if config.showFloatingIndicator {
             indicator.ensureVisible(config: config)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -139,7 +139,7 @@ struct OnboardingView: View {
         case 5:
             HStack(spacing: MuesliTheme.spacing12) {
                 Button("Skip") {
-                    finishOnboarding(withKey: false)
+                    finishOnboarding(withKey: true)
                 }
                 .buttonStyle(.plain)
                 .font(MuesliTheme.body())

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -725,6 +725,24 @@ struct OnboardingView: View {
                             .font(MuesliTheme.body())
                             .foregroundStyle(MuesliTheme.textSecondary)
                     }
+                } else if appState.isGoogleCalendarAvailable && !appState.isGoogleCalendarVerified {
+                    VStack(spacing: 6) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "calendar.badge.plus")
+                                .font(.system(size: 14))
+                            Text("Connect Google Calendar")
+                                .font(.system(size: 14, weight: .medium))
+                        }
+                        .foregroundStyle(.white.opacity(0.4))
+                        .padding(.horizontal, MuesliTheme.spacing16)
+                        .padding(.vertical, MuesliTheme.spacing8)
+                        .background(MuesliTheme.textTertiary.opacity(0.3))
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                        Text("Google OAuth verification pending")
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
                 } else if appState.isGoogleCalendarAvailable {
                     Button {
                         isSigningInGoogleCal = true

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -28,7 +28,12 @@ struct OnboardingView: View {
     @State private var isRecordingHotkey = false
     @State private var hotkeyEventMonitor: Any?
 
-    private let totalSteps = 5
+    // Google Calendar
+    @State private var isSigningInGoogleCal = false
+    @State private var googleCalSignInDone = false
+    @State private var googleCalSignInError: String?
+
+    private let totalSteps = 6
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,6 +44,7 @@ struct OnboardingView: View {
                 case 2: permissionsStep
                 case 3: hotkeyStep
                 case 4: meetingSummaryStep
+                case 5: googleCalendarStep
                 default: EmptyView()
                 }
             }
@@ -112,6 +118,27 @@ struct OnboardingView: View {
         case 4:
             HStack(spacing: MuesliTheme.spacing12) {
                 Button("Skip") {
+                    withAnimation(.easeInOut(duration: 0.2)) { currentStep = 5 }
+                }
+                .buttonStyle(.plain)
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .padding(.horizontal, MuesliTheme.spacing16)
+                .padding(.vertical, MuesliTheme.spacing8)
+                .background(MuesliTheme.surfacePrimary)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+
+                onboardingButton("Continue", enabled: true) {
+                    withAnimation(.easeInOut(duration: 0.2)) { currentStep = 5 }
+                }
+            }
+        case 5:
+            HStack(spacing: MuesliTheme.spacing12) {
+                Button("Skip") {
                     finishOnboarding(withKey: false)
                 }
                 .buttonStyle(.plain)
@@ -127,7 +154,7 @@ struct OnboardingView: View {
                 )
 
                 onboardingButton("Finish", enabled: true) {
-                    finishOnboarding(withKey: true)
+                    finishOnboarding(withKey: false)
                 }
             }
         default:
@@ -664,6 +691,84 @@ struct OnboardingView: View {
             }
         }
         withAnimation(.easeInOut(duration: 0.2)) { currentStep = 2 }
+    }
+
+    private var googleCalendarStep: some View {
+        VStack(spacing: MuesliTheme.spacing24) {
+            Spacer()
+
+            VStack(spacing: MuesliTheme.spacing8) {
+                Text("Google Calendar")
+                    .font(MuesliTheme.title1())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+
+                Text("Connect Google Calendar to see upcoming meetings.\nYou can set this up later in Settings.")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(spacing: MuesliTheme.spacing12) {
+                if googleCalSignInDone {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(MuesliTheme.success)
+                        Text("Google Calendar connected")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                    }
+                } else if isSigningInGoogleCal {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Connecting...")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+                } else if appState.isGoogleCalendarAvailable {
+                    Button {
+                        isSigningInGoogleCal = true
+                        googleCalSignInError = nil
+                        Task {
+                            let error = await controller.signInWithGoogleCalendar()
+                            isSigningInGoogleCal = false
+                            if let error {
+                                googleCalSignInError = error
+                            } else {
+                                googleCalSignInDone = true
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "calendar.badge.plus")
+                                .font(.system(size: 14))
+                            Text("Connect Google Calendar")
+                                .font(.system(size: 14, weight: .medium))
+                        }
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, MuesliTheme.spacing16)
+                        .padding(.vertical, MuesliTheme.spacing8)
+                        .background(MuesliTheme.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    }
+                    .buttonStyle(.plain)
+
+                    if let googleCalSignInError {
+                        Text(googleCalSignInError)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.red)
+                            .multilineTextAlignment(.center)
+                    }
+                } else {
+                    Text("Google Calendar credentials not configured.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, MuesliTheme.spacing32)
     }
 
     private func finishOnboarding(withKey: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -154,7 +154,7 @@ struct OnboardingView: View {
                 )
 
                 onboardingButton("Finish", enabled: true) {
-                    finishOnboarding(withKey: false)
+                    finishOnboarding(withKey: true)
                 }
             }
         default:

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -366,6 +366,12 @@ struct SettingsView: View {
                             controller.updateConfig { $0.soundEnabled = newValue }
                         }
                     }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Show next meeting in menu bar") {
+                        settingsSwitch(isOn: appState.config.showNextMeetingInMenuBar) { newValue in
+                            controller.updateConfig { $0.showNextMeetingInMenuBar = newValue }
+                        }
+                    }
                 }
 
                 settingsSection("Data") {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -39,6 +39,8 @@ struct SettingsView: View {
 
     @State private var chatGPTSignInError: String?
     @State private var isSigningInChatGPT = false
+    @State private var googleCalSignInError: String?
+    @State private var isSigningInGoogleCal = false
     @State private var pendingDataDestruction: PendingDataDestruction?
     @State private var recordingColorInput: String = ""
 
@@ -239,6 +241,75 @@ struct SettingsView: View {
                         ) { label in
                             guard let policy = recordingSavePolicy(for: label) else { return }
                             controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
+                        }
+                    }
+                }
+
+                if appState.isGoogleCalendarAvailable {
+                    settingsSection("Calendar") {
+                        settingsRow("Google Calendar") {
+                            if appState.isGoogleCalendarAuthenticated {
+                                Button {
+                                    controller.signOutGoogleCalendar()
+                                } label: {
+                                    HStack(spacing: 5) {
+                                        Image(systemName: "calendar")
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.white)
+                                        Text("Connected · Disconnect")
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.white)
+                                            .lineLimit(1)
+                                    }
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 4)
+                                    .background(MuesliTheme.success)
+                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                }
+                                .buttonStyle(.plain)
+                            } else if isSigningInGoogleCal {
+                                HStack(spacing: 6) {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                    Text("Connecting...")
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(MuesliTheme.textSecondary)
+                                }
+                            } else {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Button {
+                                        isSigningInGoogleCal = true
+                                        googleCalSignInError = nil
+                                        Task {
+                                            let error = await controller.signInWithGoogleCalendar()
+                                            isSigningInGoogleCal = false
+                                            googleCalSignInError = error
+                                        }
+                                    } label: {
+                                        HStack(spacing: 5) {
+                                            Image(systemName: "calendar.badge.plus")
+                                                .font(.system(size: 10))
+                                                .foregroundStyle(.white)
+                                            Text("Connect Google Calendar")
+                                                .font(.system(size: 11, weight: .medium))
+                                                .foregroundStyle(.white)
+                                                .lineLimit(1)
+                                        }
+                                        .padding(.horizontal, 10)
+                                        .padding(.vertical, 4)
+                                        .background(MuesliTheme.accent)
+                                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                    }
+                                    .buttonStyle(.plain)
+
+                                    if let googleCalSignInError {
+                                        Text(googleCalSignInError)
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.red)
+                                            .lineLimit(2)
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -278,6 +278,27 @@ struct SettingsView: View {
                                         .font(.system(size: 11))
                                         .foregroundStyle(MuesliTheme.textSecondary)
                                 }
+                            } else if !appState.isGoogleCalendarVerified {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack(spacing: 5) {
+                                        Image(systemName: "calendar.badge.plus")
+                                            .font(.system(size: 10))
+                                            .foregroundStyle(.white.opacity(0.4))
+                                        Text("Connect Google Calendar")
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.white.opacity(0.4))
+                                            .lineLimit(1)
+                                    }
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 4)
+                                    .background(MuesliTheme.textTertiary.opacity(0.3))
+                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                                    Text("Google OAuth verification pending")
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(MuesliTheme.textTertiary)
+                                }
                             } else {
                                 VStack(alignment: .leading, spacing: 4) {
                                     Button {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -116,6 +116,7 @@ struct SettingsView: View {
                                             .foregroundStyle(.white)
                                             .lineLimit(1)
                                     }
+                                    .frame(maxWidth: .infinity)
                                     .padding(.horizontal, 10)
                                     .padding(.vertical, 4)
                                     .background(MuesliTheme.success)
@@ -150,6 +151,7 @@ struct SettingsView: View {
                                                 .foregroundStyle(.white)
                                                 .lineLimit(1)
                                         }
+                                        .frame(maxWidth: .infinity)
                                         .padding(.horizontal, 10)
                                         .padding(.vertical, 4)
                                         .background(MuesliTheme.accent)
@@ -261,6 +263,7 @@ struct SettingsView: View {
                                             .foregroundStyle(.white)
                                             .lineLimit(1)
                                     }
+                                    .frame(maxWidth: .infinity)
                                     .padding(.horizontal, 10)
                                     .padding(.vertical, 4)
                                     .background(MuesliTheme.success)
@@ -295,6 +298,7 @@ struct SettingsView: View {
                                                 .foregroundStyle(.white)
                                                 .lineLimit(1)
                                         }
+                                        .frame(maxWidth: .infinity)
                                         .padding(.horizontal, 10)
                                         .padding(.vertical, 4)
                                         .background(MuesliTheme.accent)
@@ -463,16 +467,22 @@ struct SettingsView: View {
         }
     }
 
-    /// Standardized row: label on left, control on right, consistent 36pt height
+    /// Standardized row: label on left, control on right.
+    /// Controls share a fixed-width column so they all right-align consistently.
     @ViewBuilder
     private func settingsRow(_ label: String, @ViewBuilder control: () -> some View) -> some View {
-        HStack {
+        HStack(alignment: .center) {
             Text(label)
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textPrimary)
-            Spacer()
-            control()
-                .frame(width: controlWidth, alignment: .trailing)
+                .layoutPriority(1)
+            Spacer(minLength: 20)
+            ZStack(alignment: .trailing) {
+                // Invisible spacer forces the ZStack to exactly controlWidth
+                Color.clear.frame(width: controlWidth, height: 1)
+                control()
+                    .frame(maxWidth: controlWidth)
+            }
         }
         .frame(minHeight: 32)
     }
@@ -481,62 +491,56 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func settingsSwitch(isOn: Bool, onChange: @escaping (Bool) -> Void) -> some View {
-        Toggle("", isOn: Binding(get: { isOn }, set: { onChange($0) }))
-            .toggleStyle(.switch)
-            .tint(MuesliTheme.accent)
-            .labelsHidden()
+        HStack {
+            Spacer()
+            Toggle("", isOn: Binding(get: { isOn }, set: { onChange($0) }))
+                .toggleStyle(.switch)
+                .tint(MuesliTheme.accent)
+                .labelsHidden()
+        }
     }
 
     @ViewBuilder
     private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
-        Picker("", selection: Binding(get: { selection }, set: { onChange($0) })) {
-            ForEach(options, id: \.self) { Text($0).tag($0) }
-        }
-        .pickerStyle(.menu)
-        .frame(maxWidth: .infinity)
+        FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
+            .frame(height: 24)
     }
 
     @ViewBuilder
     private func meetingTemplateMenu(selectionID: String, onChange: @escaping (String) -> Void) -> some View {
-        Picker(
-            "",
-            selection: Binding(
-                get: { selectionID },
-                set: { onChange($0) }
-            )
-        ) {
-            Text(MeetingTemplates.auto.title)
-                .tag(MeetingTemplates.autoID)
-            Section("Built-in Templates") {
-                ForEach(controller.builtInMeetingTemplates()) { template in
-                    Text(template.title)
-                        .tag(template.id)
+        let allItems: [(id: String, label: String)] = {
+            var items: [(String, String)] = [(MeetingTemplates.autoID, MeetingTemplates.auto.title)]
+            items += controller.builtInMeetingTemplates().map { ($0.id, $0.title) }
+            items += controller.customMeetingTemplates().map { ($0.id, $0.name) }
+            return items
+        }()
+        let selectedLabel = allItems.first(where: { $0.id == selectionID })?.label ?? "Auto"
+        FixedWidthPopUp(
+            selection: selectedLabel,
+            options: allItems.map(\.label),
+            onChange: { label in
+                if let item = allItems.first(where: { $0.label == label }) {
+                    onChange(item.id)
                 }
             }
-
-            if !controller.customMeetingTemplates().isEmpty {
-                Section("Custom Templates") {
-                    ForEach(controller.customMeetingTemplates()) { template in
-                        Text(template.name)
-                            .tag(template.id)
-                    }
-                }
-            }
-        }
-        .pickerStyle(.menu)
-        .frame(maxWidth: .infinity)
+        )
+        .frame(height: 24)
     }
 
     @ViewBuilder
     private func settingsModelMenu(currentModel: String, presets: [SummaryModelPreset], onChange: @escaping (String) -> Void) -> some View {
-        Picker("", selection: Binding(
-            get: { currentModel.isEmpty ? (presets.first?.id ?? "") : currentModel },
-            set: { onChange($0 == presets.first?.id ? "" : $0) }
-        )) {
-            ForEach(presets, id: \.id) { Text($0.label).tag($0.id) }
-        }
-        .pickerStyle(.menu)
-        .frame(maxWidth: .infinity)
+        let effectiveModel = currentModel.isEmpty ? (presets.first?.id ?? "") : currentModel
+        let selectedLabel = presets.first(where: { $0.id == effectiveModel })?.label ?? presets.first?.label ?? ""
+        FixedWidthPopUp(
+            selection: selectedLabel,
+            options: presets.map(\.label),
+            onChange: { label in
+                if let preset = presets.first(where: { $0.label == label }) {
+                    onChange(preset.id == presets.first?.id ? "" : preset.id)
+                }
+            }
+        )
+        .frame(height: 24)
     }
 
     @ViewBuilder
@@ -560,6 +564,7 @@ struct SettingsView: View {
             Text(title)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(isDestructive ? MuesliTheme.recording : MuesliTheme.textPrimary)
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, MuesliTheme.spacing16)
                 .padding(.vertical, MuesliTheme.spacing8)
                 .background(isDestructive ? MuesliTheme.recording.opacity(0.1) : MuesliTheme.surfacePrimary)
@@ -617,6 +622,47 @@ class EditableNSSecureTextField: NSSecureTextField {
             }
         }
         return super.performKeyEquivalent(with: event)
+    }
+}
+
+/// NSPopUpButton wrapper that respects width constraints (SwiftUI Picker with .menu style ignores them).
+struct FixedWidthPopUp: NSViewRepresentable {
+    let selection: String
+    let options: [String]
+    let onChange: (String) -> Void
+
+    func makeNSView(context: Context) -> NSPopUpButton {
+        let button = NSPopUpButton(frame: .zero, pullsDown: false)
+        button.removeAllItems()
+        button.addItems(withTitles: options)
+        button.selectItem(withTitle: selection)
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.selectionChanged(_:))
+        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return button
+    }
+
+    func updateNSView(_ button: NSPopUpButton, context: Context) {
+        let currentTitles = button.itemTitles
+        if currentTitles != options {
+            button.removeAllItems()
+            button.addItems(withTitles: options)
+        }
+        if button.titleOfSelectedItem != selection {
+            button.selectItem(withTitle: selection)
+        }
+        context.coordinator.onChange = onChange
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(onChange: onChange) }
+
+    class Coordinator: NSObject {
+        var onChange: (String) -> Void
+        init(onChange: @escaping (String) -> Void) { self.onChange = onChange }
+        @objc func selectionChanged(_ sender: NSPopUpButton) {
+            if let title = sender.titleOfSelectedItem { onChange(title) }
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -524,10 +524,9 @@ struct SettingsView: View {
         FixedWidthPopUp(
             selection: selectedLabel,
             options: allItems.map(\.label),
-            onChange: { label in
-                if let item = allItems.first(where: { $0.label == label }) {
-                    onChange(item.id)
-                }
+            onSelectIndex: { index in
+                guard index >= 0 && index < allItems.count else { return }
+                onChange(allItems[index].id)
             }
         )
         .frame(height: 24)
@@ -540,10 +539,10 @@ struct SettingsView: View {
         FixedWidthPopUp(
             selection: selectedLabel,
             options: presets.map(\.label),
-            onChange: { label in
-                if let preset = presets.first(where: { $0.label == label }) {
-                    onChange(preset.id == presets.first?.id ? "" : preset.id)
-                }
+            onSelectIndex: { index in
+                guard index >= 0 && index < presets.count else { return }
+                let selectedId = presets[index].id
+                onChange(selectedId == presets.first?.id ? "" : selectedId)
             }
         )
         .frame(height: 24)
@@ -635,7 +634,23 @@ class EditableNSSecureTextField: NSSecureTextField {
 struct FixedWidthPopUp: NSViewRepresentable {
     let selection: String
     let options: [String]
-    let onChange: (String) -> Void
+    /// Reports the selected index, avoiding label collision issues.
+    let onSelectionIndex: (Int) -> Void
+
+    init(selection: String, options: [String], onChange: @escaping (String) -> Void) {
+        self.selection = selection
+        self.options = options
+        self.onSelectionIndex = { index in
+            guard index >= 0 && index < options.count else { return }
+            onChange(options[index])
+        }
+    }
+
+    init(selection: String, options: [String], onSelectIndex: @escaping (Int) -> Void) {
+        self.selection = selection
+        self.options = options
+        self.onSelectionIndex = onSelectIndex
+    }
 
     func makeNSView(context: Context) -> NSPopUpButton {
         let button = NSPopUpButton(frame: .zero, pullsDown: false)
@@ -658,16 +673,16 @@ struct FixedWidthPopUp: NSViewRepresentable {
         if button.titleOfSelectedItem != selection {
             button.selectItem(withTitle: selection)
         }
-        context.coordinator.onChange = onChange
+        context.coordinator.onSelectionIndex = onSelectionIndex
     }
 
-    func makeCoordinator() -> Coordinator { Coordinator(onChange: onChange) }
+    func makeCoordinator() -> Coordinator { Coordinator(onSelectionIndex: onSelectionIndex) }
 
     class Coordinator: NSObject {
-        var onChange: (String) -> Void
-        init(onChange: @escaping (String) -> Void) { self.onChange = onChange }
+        var onSelectionIndex: (Int) -> Void
+        init(onSelectionIndex: @escaping (Int) -> Void) { self.onSelectionIndex = onSelectionIndex }
         @objc func selectionChanged(_ sender: NSPopUpButton) {
-            if let title = sender.titleOfSelectedItem { onChange(title) }
+            onSelectionIndex(sender.indexOfSelectedItem)
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -25,6 +25,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     func refresh() {
         rebuildMenu()
+        updateMenuBarTitle()
     }
 
     func menuNeedsUpdate(_ menu: NSMenu) {
@@ -33,6 +34,33 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     func refreshIcon() {
         statusItem.button?.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon)
+        updateMenuBarTitle()
+    }
+
+    func updateMenuBarTitle() {
+        guard controller.config.showNextMeetingInMenuBar else {
+            statusItem.button?.title = ""
+            return
+        }
+
+        let now = Date()
+        let nextEvent = controller.appState.upcomingCalendarEvents
+            .filter { !$0.isAllDay && $0.startDate > now }
+            .first
+
+        if let event = nextEvent {
+            let minutesUntil = Int(ceil(event.startDate.timeIntervalSince(now) / 60))
+            let truncatedTitle = event.title.count > 20
+                ? String(event.title.prefix(18)) + "…"
+                : event.title
+            if minutesUntil <= 60 {
+                statusItem.button?.title = " \(truncatedTitle) · \(formatTimeUntil(minutesUntil))"
+            } else {
+                statusItem.button?.title = " \(truncatedTitle)"
+            }
+        } else {
+            statusItem.button?.title = ""
+        }
     }
 
     private func build() {
@@ -42,6 +70,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             button.toolTip = AppIdentity.displayName
         }
         rebuildMenu()
+        updateMenuBarTitle()
         statusItem.menu = menu
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -74,30 +74,6 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         menu.setSubmenu(recentMenu, for: recentItem)
         menu.addItem(recentItem)
 
-        let meetingItem = NSMenuItem(title: "Meeting Transcripts", action: nil, keyEquivalent: "")
-        let meetingMenu = NSMenu()
-        let meetingRows = controller.recentMeetings()
-        if meetingRows.isEmpty {
-            let empty = NSMenuItem(title: "No meetings yet", action: nil, keyEquivalent: "")
-            empty.isEnabled = false
-            meetingMenu.addItem(empty)
-        } else {
-            for row in meetingRows {
-                let title = controller.truncate(row.title, limit: 18)
-                let transcript = controller.truncate(row.rawTranscript, limit: 30)
-                let item = NSMenuItem(
-                    title: "\(title): \(transcript)",
-                    action: #selector(MuesliController.copyRecentMeeting(_:)),
-                    keyEquivalent: ""
-                )
-                item.target = controller
-                item.representedObject = row.rawTranscript
-                meetingMenu.addItem(item)
-            }
-        }
-        menu.setSubmenu(meetingMenu, for: meetingItem)
-        menu.addItem(meetingItem)
-
         let backendItem = NSMenuItem(title: "Transcription Backend", action: nil, keyEquivalent: "")
         let backendMenu = NSMenu()
         for option in BackendOption.downloaded {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -48,6 +48,13 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private func rebuildMenu() {
         menu.removeAllItems()
 
+        // Upcoming calendar events
+        let upcomingEvents = controller.appState.upcomingCalendarEvents.filter { !$0.isAllDay }
+        if !upcomingEvents.isEmpty {
+            addUpcomingEventsSection(upcomingEvents)
+            menu.addItem(.separator())
+        }
+
         menu.addItem(actionItem(title: "Open \(AppIdentity.displayName)", action: #selector(MuesliController.openHistoryWindow as (MuesliController) -> () -> Void)))
         let meetingTitle = controller.isMeetingRecording() ? "Stop Meeting Recording" : "Start Meeting Recording"
         menu.addItem(actionItem(title: meetingTitle, action: #selector(MuesliController.toggleMeetingRecording)))
@@ -108,6 +115,112 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         menu.addItem(statusLabel)
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Quit", action: #selector(MuesliController.quitApp)))
+    }
+
+    private func addUpcomingEventsSection(_ events: [UnifiedCalendarEvent]) {
+        let now = Date()
+        let calendar = Calendar.current
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH:mm"
+
+        // Group: next up (within 1 hour) vs today (rest of day)
+        var nextUpEvents: [UnifiedCalendarEvent] = []
+        var todayEvents: [UnifiedCalendarEvent] = []
+
+        for event in events {
+            guard event.startDate > now else { continue }
+            if calendar.isDateInToday(event.startDate) {
+                if event.startDate.timeIntervalSince(now) <= 3600 {
+                    nextUpEvents.append(event)
+                } else {
+                    todayEvents.append(event)
+                }
+            }
+        }
+
+        if !nextUpEvents.isEmpty {
+            let firstEvent = nextUpEvents[0]
+            let minutesUntil = Int(ceil(firstEvent.startDate.timeIntervalSince(now) / 60))
+            let header = NSMenuItem(title: "Starts in \(formatTimeUntil(minutesUntil))", action: nil, keyEquivalent: "")
+            header.isEnabled = false
+            let headerAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 11, weight: .medium),
+                .foregroundColor: NSColor.secondaryLabelColor,
+            ]
+            header.attributedTitle = NSAttributedString(string: "Starts in \(formatTimeUntil(minutesUntil))", attributes: headerAttrs)
+            menu.addItem(header)
+
+            for event in nextUpEvents {
+                let timeStr = "\(timeFormatter.string(from: event.startDate)) – \(timeFormatter.string(from: event.endDate))"
+                let item = NSMenuItem(
+                    title: "\(event.title)\n\(timeStr)",
+                    action: #selector(MuesliController.startMeetingFromCalendarMenuItem(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = controller
+                item.representedObject = event.title
+
+                let titleAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+                    .foregroundColor: NSColor.labelColor,
+                ]
+                let timeAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 11),
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                ]
+                let attributed = NSMutableAttributedString(string: event.title, attributes: titleAttrs)
+                attributed.append(NSAttributedString(string: "\n\(timeStr)", attributes: timeAttrs))
+                item.attributedTitle = attributed
+                menu.addItem(item)
+            }
+        }
+
+        if !todayEvents.isEmpty {
+            let header = NSMenuItem(title: "Today", action: nil, keyEquivalent: "")
+            header.isEnabled = false
+            let headerAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 11, weight: .medium),
+                .foregroundColor: NSColor.secondaryLabelColor,
+            ]
+            header.attributedTitle = NSAttributedString(string: "Today", attributes: headerAttrs)
+            menu.addItem(header)
+
+            for event in todayEvents.prefix(5) {
+                let timeStr = "\(timeFormatter.string(from: event.startDate)) – \(timeFormatter.string(from: event.endDate))"
+                let item = NSMenuItem(
+                    title: "\(event.title)\n\(timeStr)",
+                    action: #selector(MuesliController.startMeetingFromCalendarMenuItem(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = controller
+                item.representedObject = event.title
+
+                let titleAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+                    .foregroundColor: NSColor.labelColor,
+                ]
+                let timeAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 11),
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                ]
+                let attributed = NSMutableAttributedString(string: event.title, attributes: titleAttrs)
+                attributed.append(NSAttributedString(string: "\n\(timeStr)", attributes: timeAttrs))
+                item.attributedTitle = attributed
+                menu.addItem(item)
+            }
+        }
+    }
+
+    private func formatTimeUntil(_ minutes: Int) -> String {
+        if minutes < 60 {
+            return "\(minutes)m"
+        }
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+        if remainingMinutes == 0 {
+            return "\(hours)h"
+        }
+        return "\(hours)h \(remainingMinutes)m"
     }
 
     private func actionItem(title: String, action: Selector) -> NSMenuItem {

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -57,7 +57,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T15:00:00+05:30"],
         ]
 
-        let event = parseTestEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item)
         #expect(event != nil)
         #expect(event?.id == "event123")
         #expect(event?.title == "Sprint Planning")
@@ -74,7 +74,7 @@ struct GoogleCalendarTests {
             "end": ["date": "2026-04-11"],
         ]
 
-        let event = parseTestEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item)
         #expect(event != nil)
         #expect(event?.isAllDay == true)
         #expect(event?.title == "Company Holiday")
@@ -88,7 +88,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T15:00:00Z"],
         ]
 
-        #expect(parseTestEvent(item) == nil)
+        #expect(GoogleCalendarClient().parseEvent(item) == nil)
     }
 
     @Test("returns nil for event missing id")
@@ -99,7 +99,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T15:00:00Z"],
         ]
 
-        #expect(parseTestEvent(item) == nil)
+        #expect(GoogleCalendarClient().parseEvent(item) == nil)
     }
 
     // MARK: - Merge & dedup
@@ -168,46 +168,4 @@ struct GoogleCalendarTests {
         return f.date(from: iso)!
     }
 
-    /// Mirror of GoogleCalendarClient.parseEvent for testing without @MainActor
-    private func parseTestEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
-        guard let id = item["id"] as? String,
-              let summary = item["summary"] as? String else { return nil }
-
-        let startDict = item["start"] as? [String: Any] ?? [:]
-        let endDict = item["end"] as? [String: Any] ?? [:]
-
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime]
-        let dateOnlyFormatter = DateFormatter()
-        dateOnlyFormatter.dateFormat = "yyyy-MM-dd"
-        dateOnlyFormatter.timeZone = .current
-
-        let startDate: Date
-        let endDate: Date
-        let isAllDay: Bool
-
-        if let dateTimeStr = startDict["dateTime"] as? String,
-           let start = isoFormatter.date(from: dateTimeStr) {
-            startDate = start
-            isAllDay = false
-            if let endStr = endDict["dateTime"] as? String, let end = isoFormatter.date(from: endStr) {
-                endDate = end
-            } else {
-                endDate = start.addingTimeInterval(3600)
-            }
-        } else if let dateStr = startDict["date"] as? String,
-                  let start = dateOnlyFormatter.date(from: dateStr) {
-            startDate = start
-            isAllDay = true
-            if let endStr = endDict["date"] as? String, let end = dateOnlyFormatter.date(from: endStr) {
-                endDate = end
-            } else {
-                endDate = start.addingTimeInterval(86400)
-            }
-        } else {
-            return nil
-        }
-
-        return UnifiedCalendarEvent(id: id, title: summary, startDate: startDate, endDate: endDate, isAllDay: isAllDay, source: .googleCalendar)
-    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -1,0 +1,213 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Google Calendar integration")
+@MainActor
+struct GoogleCalendarTests {
+
+    // MARK: - Credentials parsing
+
+    @Test("loads credentials from valid JSON")
+    func loadsValidCredentials() throws {
+        let json = """
+        {"client_id": "test-id.apps.googleusercontent.com", "client_secret": "test-secret"}
+        """
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test-creds-\(UUID()).json")
+        try json.data(using: .utf8)!.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let data = try Data(contentsOf: url)
+        let parsed = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let clientId = parsed["client_id"] as? String
+        let clientSecret = parsed["client_secret"] as? String
+
+        #expect(clientId == "test-id.apps.googleusercontent.com")
+        #expect(clientSecret == "test-secret")
+    }
+
+    @Test("verified defaults to false when missing from JSON")
+    func verifiedDefaultsFalse() throws {
+        let json = """
+        {"client_id": "id", "client_secret": "secret"}
+        """
+        let parsed = try JSONSerialization.jsonObject(with: json.data(using: .utf8)!) as! [String: Any]
+        let verified = parsed["verified"] as? Bool ?? false
+        #expect(verified == false)
+    }
+
+    @Test("verified reads true from JSON")
+    func verifiedReadsTrue() throws {
+        let json = """
+        {"client_id": "id", "client_secret": "secret", "verified": true}
+        """
+        let parsed = try JSONSerialization.jsonObject(with: json.data(using: .utf8)!) as! [String: Any]
+        let verified = parsed["verified"] as? Bool ?? false
+        #expect(verified == true)
+    }
+
+    // MARK: - Event JSON parsing
+
+    @Test("parses timed event from Google Calendar API response")
+    func parsesTimedEvent() {
+        let item: [String: Any] = [
+            "id": "event123",
+            "summary": "Sprint Planning",
+            "start": ["dateTime": "2026-04-10T14:00:00+05:30"],
+            "end": ["dateTime": "2026-04-10T15:00:00+05:30"],
+        ]
+
+        let event = parseTestEvent(item)
+        #expect(event != nil)
+        #expect(event?.id == "event123")
+        #expect(event?.title == "Sprint Planning")
+        #expect(event?.isAllDay == false)
+        #expect(event?.source == .googleCalendar)
+    }
+
+    @Test("parses all-day event from Google Calendar API response")
+    func parsesAllDayEvent() {
+        let item: [String: Any] = [
+            "id": "allday1",
+            "summary": "Company Holiday",
+            "start": ["date": "2026-04-10"],
+            "end": ["date": "2026-04-11"],
+        ]
+
+        let event = parseTestEvent(item)
+        #expect(event != nil)
+        #expect(event?.isAllDay == true)
+        #expect(event?.title == "Company Holiday")
+    }
+
+    @Test("returns nil for event missing summary")
+    func returnsNilMissingSummary() {
+        let item: [String: Any] = [
+            "id": "no-title",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T15:00:00Z"],
+        ]
+
+        #expect(parseTestEvent(item) == nil)
+    }
+
+    @Test("returns nil for event missing id")
+    func returnsNilMissingId() {
+        let item: [String: Any] = [
+            "summary": "Test",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T15:00:00Z"],
+        ]
+
+        #expect(parseTestEvent(item) == nil)
+    }
+
+    // MARK: - Merge & dedup
+
+    @Test("merges EventKit and Google events without duplicates")
+    func mergesWithoutDuplicates() {
+        let ek = [
+            UnifiedCalendarEvent(id: "ek1", title: "Standup", startDate: date("2026-04-10T09:00:00Z"), endDate: date("2026-04-10T09:15:00Z"), isAllDay: false, source: .eventKit),
+        ]
+        let google = [
+            UnifiedCalendarEvent(id: "g1", title: "Design Review", startDate: date("2026-04-10T10:00:00Z"), endDate: date("2026-04-10T11:00:00Z"), isAllDay: false, source: .googleCalendar),
+        ]
+
+        let merged = GoogleCalendarClient.mergeEvents(eventKit: ek, google: google)
+        #expect(merged.count == 2)
+        #expect(merged[0].title == "Standup")
+        #expect(merged[1].title == "Design Review")
+    }
+
+    @Test("deduplicates events with same title and close start time")
+    func deduplicatesByTitleAndTime() {
+        let ek = [
+            UnifiedCalendarEvent(id: "ek1", title: "Sprint Planning", startDate: date("2026-04-10T14:00:00Z"), endDate: date("2026-04-10T15:00:00Z"), isAllDay: false, source: .eventKit),
+        ]
+        let google = [
+            UnifiedCalendarEvent(id: "g1", title: "Sprint Planning", startDate: date("2026-04-10T14:02:00Z"), endDate: date("2026-04-10T15:00:00Z"), isAllDay: false, source: .googleCalendar),
+        ]
+
+        let merged = GoogleCalendarClient.mergeEvents(eventKit: ek, google: google)
+        #expect(merged.count == 1)
+        #expect(merged[0].source == .eventKit)
+    }
+
+    @Test("keeps events with same title but different times")
+    func keepsSameTitleDifferentTimes() {
+        let ek = [
+            UnifiedCalendarEvent(id: "ek1", title: "Standup", startDate: date("2026-04-10T09:00:00Z"), endDate: date("2026-04-10T09:15:00Z"), isAllDay: false, source: .eventKit),
+        ]
+        let google = [
+            UnifiedCalendarEvent(id: "g1", title: "Standup", startDate: date("2026-04-11T09:00:00Z"), endDate: date("2026-04-11T09:15:00Z"), isAllDay: false, source: .googleCalendar),
+        ]
+
+        let merged = GoogleCalendarClient.mergeEvents(eventKit: ek, google: google)
+        #expect(merged.count == 2)
+    }
+
+    @Test("merged events are sorted by start date")
+    func mergedSortedByStartDate() {
+        let ek = [
+            UnifiedCalendarEvent(id: "ek1", title: "Late", startDate: date("2026-04-10T16:00:00Z"), endDate: date("2026-04-10T17:00:00Z"), isAllDay: false, source: .eventKit),
+        ]
+        let google = [
+            UnifiedCalendarEvent(id: "g1", title: "Early", startDate: date("2026-04-10T08:00:00Z"), endDate: date("2026-04-10T09:00:00Z"), isAllDay: false, source: .googleCalendar),
+        ]
+
+        let merged = GoogleCalendarClient.mergeEvents(eventKit: ek, google: google)
+        #expect(merged[0].title == "Early")
+        #expect(merged[1].title == "Late")
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: iso)!
+    }
+
+    /// Mirror of GoogleCalendarClient.parseEvent for testing without @MainActor
+    private func parseTestEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
+        guard let id = item["id"] as? String,
+              let summary = item["summary"] as? String else { return nil }
+
+        let startDict = item["start"] as? [String: Any] ?? [:]
+        let endDict = item["end"] as? [String: Any] ?? [:]
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        let dateOnlyFormatter = DateFormatter()
+        dateOnlyFormatter.dateFormat = "yyyy-MM-dd"
+        dateOnlyFormatter.timeZone = .current
+
+        let startDate: Date
+        let endDate: Date
+        let isAllDay: Bool
+
+        if let dateTimeStr = startDict["dateTime"] as? String,
+           let start = isoFormatter.date(from: dateTimeStr) {
+            startDate = start
+            isAllDay = false
+            if let endStr = endDict["dateTime"] as? String, let end = isoFormatter.date(from: endStr) {
+                endDate = end
+            } else {
+                endDate = start.addingTimeInterval(3600)
+            }
+        } else if let dateStr = startDict["date"] as? String,
+                  let start = dateOnlyFormatter.date(from: dateStr) {
+            startDate = start
+            isAllDay = true
+            if let endStr = endDict["date"] as? String, let end = dateOnlyFormatter.date(from: endStr) {
+                endDate = end
+            } else {
+                endDate = start.addingTimeInterval(86400)
+            }
+        } else {
+            return nil
+        }
+
+        return UnifiedCalendarEvent(id: id, title: summary, startDate: startDate, endDate: endDate, isAllDay: isAllDay, source: .googleCalendar)
+    }
+}


### PR DESCRIPTION
## Summary

- **Google Calendar OAuth**: Full OAuth 2.0 + PKCE flow for desktop apps, mirroring the existing ChatGPT auth pattern. Localhost callback on port 1456, file-based token storage with refresh support. Credentials loaded from app bundle (production) or `~/.config/muesli/google-oauth.json` (dev) — never committed to repo.
- **"Coming Up" section**: Shows upcoming calendar events in the Meetings browser, grouped by date. Merges events from both EventKit (local macOS calendar) and Google Calendar, deduplicating by title + time proximity.
- **Onboarding**: New step 5 (skippable) for Google Calendar connection
- **Settings**: Calendar section with connect/disconnect button

### Architecture

- `GoogleCalendarCredentials.swift` — loads client_id/secret from bundle or dev config
- `GoogleCalendarAuthManager.swift` — OAuth flow (NWListener, PKCE, token refresh)
- `GoogleCalendarClient.swift` — Google Calendar API client + `UnifiedCalendarEvent` shared model
- `CalendarMonitor.swift` — extended with `upcomingEvents()` for EventKit
- Calendar events refresh every 5 minutes via timer in MuesliController

### Credentials

OAuth client_id and client_secret are NOT in the repo. For development:
```json
// ~/.config/muesli/google-oauth.json
{"client_id": "...", "client_secret": "..."}
```
Production builds embed credentials in the app bundle via build script.

Google OAuth verification is pending — app is in testing mode. Once verified, the feature ships to all users.

## Test plan
- [ ] Create `~/.config/muesli/google-oauth.json` with GCP credentials
- [ ] Run onboarding (`--reset`) — verify Google Calendar step appears as step 5 (skippable)
- [ ] Connect Google Calendar from onboarding or Settings — browser opens, OAuth completes
- [ ] Navigate to Meetings tab — "Coming Up" section shows upcoming events
- [ ] Disconnect from Settings — section updates
- [ ] Verify EventKit-only path works (no Google credentials) — events from macOS Calendar appear
- [ ] Build without credentials file — feature disabled gracefully, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)