### PR TITLE
Prototype GGUF transcript post-processing for dictation

### DIFF
--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "llm.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eastriverlee/LLM.swift/",
+      "state" : {
+        "branch" : "main",
+        "revision" : "427f3b8957a40982500abc8d35ccff8b83ec56a4"
+      }
+    },
+    {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
@@ -106,6 +115,15 @@
       "state" : {
         "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
         "version" : "2.97.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -30,10 +30,9 @@
     {
       "identity" : "llm.swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/eastriverlee/LLM.swift/",
+      "location" : "https://github.com/obra/LLM.swift.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "427f3b8957a40982500abc8d35ccff8b83ec56a4"
+        "revision" : "f1e1e11982dbc59662be191b8bed408dfb48e9df"
       }
     },
     {

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.2"..<"0.13.0"),
         .package(url: "https://github.com/exPHAT/SwiftWhisper.git", branch: "master"),
-        .package(url: "https://github.com/eastriverlee/LLM.swift/", branch: "main"),
+        .package(url: "https://github.com/obra/LLM.swift.git", revision: "f1e1e11982dbc59662be191b8bed408dfb48e9df"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
         .package(url: "https://github.com/TelemetryDeck/SwiftSDK", from: "2.0.0"),
         .package(url: "https://github.com/MimicScribe/dtln-aec-coreml.git", from: "0.4.0-beta"),

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -15,6 +15,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.2"..<"0.13.0"),
         .package(url: "https://github.com/exPHAT/SwiftWhisper.git", branch: "master"),
+        // Ghost Pepper uses this LLM.swift fork for local Qwen cleanup. Before production, replace it with upstream
+        // eastriverlee/LLM.swift once explicit Qwen/ChatML template behavior is validated against our GGUF models.
         .package(url: "https://github.com/obra/LLM.swift.git", revision: "f1e1e11982dbc59662be191b8bed408dfb48e9df"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
         .package(url: "https://github.com/TelemetryDeck/SwiftSDK", from: "2.0.0"),

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.2"..<"0.13.0"),
         .package(url: "https://github.com/exPHAT/SwiftWhisper.git", branch: "master"),
+        .package(url: "https://github.com/eastriverlee/LLM.swift/", branch: "main"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
         .package(url: "https://github.com/TelemetryDeck/SwiftSDK", from: "2.0.0"),
         .package(url: "https://github.com/MimicScribe/dtln-aec-coreml.git", from: "0.4.0-beta"),
@@ -33,6 +34,7 @@ let package = Package(
             dependencies: [
                 "MuesliCore",
                 .product(name: "FluidAudio", package: "FluidAudio"),
+                .product(name: "LLM", package: "LLM.swift"),
                 .product(name: "SwiftWhisper", package: "SwiftWhisper"),
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "TelemetryDeck", package: "SwiftSDK"),

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -40,7 +40,7 @@ final class AppState {
     // Config-driven state
     var selectedBackend: BackendOption = .whisper
     var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .openAI
-    var activePostProcessor: PostProcessorOption = .finetunedV2
+    var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()
 
     // Live status

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -40,6 +40,7 @@ final class AppState {
     // Config-driven state
     var selectedBackend: BackendOption = .whisper
     var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .openAI
+    var activePostProcessor: PostProcessorOption = .finetunedV2
     var config: AppConfig = AppConfig()
 
     // Live status

--- a/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
@@ -46,5 +46,8 @@ func downloadWithRetry(
             lastError = error
         }
     }
-    throw DownloadError.retriesExhausted(url.lastPathComponent, lastError!)
+    let underlying = lastError ?? NSError(domain: "DownloadError", code: 0, userInfo: [
+        NSLocalizedDescriptionKey: "No download attempts were made",
+    ])
+    throw DownloadError.retriesExhausted(url.lastPathComponent, underlying)
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -132,16 +132,6 @@ final class MeetingSession {
         self.transcriptionCoordinator = transcriptionCoordinator
     }
 
-    private var serializedCustomWords: [[String: Any]] {
-        config.customWords.map { word in
-            var dict: [String: Any] = ["word": word.word]
-            if let replacement = word.replacement {
-                dict["replacement"] = replacement
-            }
-            return dict
-        }
-    }
-
     func start() async throws {
         let vadManager = await transcriptionCoordinator.getVadManager()
         let now = Date()
@@ -297,7 +287,7 @@ final class MeetingSession {
             let chunkDuration = lastSystemChunkTiming?.durationSeconds ?? 0
             fputs("[meeting] transcribing final system chunk (offset=\(String(format: "%.0f", chunkOffset))s)\n", stderr)
             do {
-                let result = try await transcriptionCoordinator.transcribeMeetingChunk(at: lastSystemChunkURL, backend: backend, customWords: serializedCustomWords)
+                let result = try await transcriptionCoordinator.transcribeMeetingChunk(at: lastSystemChunkURL, backend: backend)
                 let normalizedSegments = normalizeSystemTranscription(
                     result: result,
                     startTime: chunkOffset,
@@ -554,7 +544,7 @@ final class MeetingSession {
                 if Task.isCancelled {
                     return []
                 }
-                let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(at: chunkURL, backend: backend, customWords: self.serializedCustomWords)
+                let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(at: chunkURL, backend: backend)
                 if !result.text.isEmpty {
                     fputs("[meeting] system chunk transcribed: \"\(String(result.text.prefix(60)))...\"\n", stderr)
                     let normalizedSegments = self.normalizeSystemTranscription(
@@ -710,8 +700,7 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeetingChunk(
                 at: url,
-                backend: backend,
-                customWords: serializedCustomWords
+                backend: backend
             )
             if !result.text.isEmpty {
                 fputs("[meeting] mic chunk transcribed (raw): \"\(String(result.text.prefix(60)))...\"\n", stderr)
@@ -860,8 +849,7 @@ final class MeetingSession {
 
                     let result = try await transcriptionCoordinator.transcribeMeeting(
                         at: segmentURL,
-                        backend: backend,
-                        customWords: serializedCustomWords
+                        backend: backend
                     )
                     repairedSegments.append(contentsOf: MicTurnNormalizer.normalize(
                         result: result,
@@ -941,8 +929,7 @@ final class MeetingSession {
 
                     let result = try await transcriptionCoordinator.transcribeMeeting(
                         at: segmentURL,
-                        backend: backend,
-                        customWords: serializedCustomWords
+                        backend: backend
                     )
                     repairedSegments.append(contentsOf: normalizeSystemTranscription(
                         result: result,
@@ -972,8 +959,7 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeeting(
                 at: fullSessionMicURL,
-                backend: backend,
-                customWords: serializedCustomWords
+                backend: backend
             )
             return MicTurnNormalizer.normalize(
                 result: result,
@@ -994,8 +980,7 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeeting(
                 at: systemAudioURL,
-                backend: backend,
-                customWords: serializedCustomWords
+                backend: backend
             )
             return normalizeSystemTranscription(
                 result: result,

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -242,9 +242,9 @@ struct PostProcessorOption: Identifiable, Equatable {
     static let qwen35_0_8b = PostProcessorOption(
         id: "qwen35-0.8b",
         label: "Qwen3.5 0.8B",
-        sizeLabel: "~510 MB",
+        sizeLabel: "~533 MB",
         description: "Vanilla Qwen3.5-0.8B. Good for typo correction and filler removal. Spoken list formatting is unreliable.",
-        downloadURL: URL(string: "https://huggingface.co/Qwen/Qwen3.5-0.8B-Instruct-GGUF/resolve/main/Qwen3.5-0.8B-Instruct-Q4_K_M.gguf")!,
+        downloadURL: URL(string: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf")!,
         filename: "Qwen3.5-0.8B-Q4_K_M.gguf"
     )
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -206,6 +206,59 @@ struct MeetingSummaryBackendOption: Equatable {
     static let all: [MeetingSummaryBackendOption] = [.openAI, .openRouter, .chatGPT]
 }
 
+struct PostProcessorOption: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let sizeLabel: String
+    let description: String
+    let downloadURL: URL
+    let filename: String
+
+    var cacheDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/muesli/models/postproc-\(id)", isDirectory: true)
+    }
+
+    var modelURL: URL {
+        cacheDirectory.appendingPathComponent(filename)
+    }
+
+    var isDownloaded: Bool {
+        FileManager.default.fileExists(atPath: modelURL.path)
+    }
+
+    // Fine-tuned Qwen3-0.6B trained on Muesli dictation correction data.
+    // HF repo must be public (or token-gated) before distributing alpha builds.
+    static let finetunedV2 = PostProcessorOption(
+        id: "qwen3-postproc-v2",
+        label: "Post-Proc v2 (Finetuned)",
+        sizeLabel: "~390 MB",
+        description: "Fine-tuned on Muesli dictation data. Best for filler removal, deletion cues, and spoken list formatting.",
+        downloadURL: URL(string: "https://huggingface.co/phequals/qwen3-postproc-v2/resolve/main/qwen3-postproc-v2-q4_k_m.gguf")!,
+        filename: "qwen3-postproc-v2-q4_k_m.gguf"
+    )
+
+    // Vanilla Qwen3.5-0.8B. Stable for basic cleanup; does not reliably convert spoken list cues.
+    static let qwen35_0_8b = PostProcessorOption(
+        id: "qwen35-0.8b",
+        label: "Qwen3.5 0.8B",
+        sizeLabel: "~510 MB",
+        description: "Vanilla Qwen3.5-0.8B. Good for typo correction and filler removal. Spoken list formatting is unreliable.",
+        downloadURL: URL(string: "https://huggingface.co/Qwen/Qwen3.5-0.8B-Instruct-GGUF/resolve/main/Qwen3.5-0.8B-Instruct-Q4_K_M.gguf")!,
+        filename: "Qwen3.5-0.8B-Q4_K_M.gguf"
+    )
+
+    static let all: [PostProcessorOption] = [.finetunedV2, .qwen35_0_8b]
+
+    static let defaultSystemPrompt = """
+    Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.
+
+    You may: fix obvious misspellings, remove filler words (um, uh, like), apply 'scratch that' deletions, and format numbered or bullet lists when dictated.
+
+    Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.
+    """
+}
+
 struct CustomWord: Codable, Equatable, Identifiable {
     var id = UUID()
     var word: String
@@ -286,6 +339,8 @@ struct AppConfig: Codable {
     var maraudersMapCustomAudioPath: String?
     var hiddenCalendarEventIDs: [String] = []
     var enablePostProcessor: Bool = false
+    var activePostProcessorId: String = PostProcessorOption.finetunedV2.id
+    var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -326,6 +381,8 @@ struct AppConfig: Codable {
         case maraudersMapCustomAudioPath = "marauders_map_custom_audio_path"
         case hiddenCalendarEventIDs = "hidden_calendar_event_ids"
         case enablePostProcessor = "enable_post_processor"
+        case activePostProcessorId = "active_post_processor_id"
+        case postProcessorSystemPrompt = "post_processor_system_prompt"
     }
 
     init() {}
@@ -371,6 +428,8 @@ struct AppConfig: Codable {
         maraudersMapCustomAudioPath = try? c.decode(String.self, forKey: .maraudersMapCustomAudioPath)
         hiddenCalendarEventIDs = (try? c.decode([String].self, forKey: .hiddenCalendarEventIDs)) ?? defaults.hiddenCalendarEventIDs
         enablePostProcessor = (try? c.decode(Bool.self, forKey: .enablePostProcessor)) ?? defaults.enablePostProcessor
+        activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
+        postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -265,25 +265,45 @@ struct PostProcessorOption: Identifiable, Equatable {
         all.filter(\.isDownloaded)
     }
 
+    static var downloadedIDs: Set<String> {
+        Set(downloaded.map(\.id))
+    }
+
     static func resolve(id: String) -> PostProcessorOption {
         all.first { $0.id == id } ?? defaultOption
     }
 
-    static func firstDownloaded(
-        excluding excludedID: String? = nil,
-        downloadedIDs: Set<String> = Set(downloaded.map(\.id))
-    ) -> PostProcessorOption? {
+    static func firstDownloaded(excluding excludedID: String? = nil) -> PostProcessorOption? {
+        firstDownloaded(excluding: excludedID, downloadedIDs: downloadedIDs)
+    }
+
+    static func firstDownloaded(excluding excludedID: String? = nil, downloadedIDs: Set<String>) -> PostProcessorOption? {
         all.first { option in
             option.id != excludedID && downloadedIDs.contains(option.id)
         }
     }
 
-    static func resolveDownloaded(
-        id: String,
-        downloadedIDs: Set<String> = Set(downloaded.map(\.id))
-    ) -> PostProcessorOption? {
+    static func resolveDownloaded(id: String) -> PostProcessorOption? {
+        resolveDownloaded(id: id, downloadedIDs: downloadedIDs)
+    }
+
+    static func resolveDownloaded(id: String, downloadedIDs: Set<String>) -> PostProcessorOption? {
         let resolved = resolve(id: id)
         if downloadedIDs.contains(resolved.id) { return resolved }
+        return firstDownloaded(downloadedIDs: downloadedIDs)
+    }
+
+    static func runtimeOption(id: String) -> PostProcessorOption? {
+        runtimeOption(
+            id: id,
+            downloadedIDs: downloadedIDs,
+            hasDevOverride: Qwen3PostProcessorConfig.devOverrideURL() != nil
+        )
+    }
+
+    static func runtimeOption(id: String, downloadedIDs: Set<String>, hasDevOverride: Bool) -> PostProcessorOption? {
+        let configured = resolve(id: id)
+        if downloadedIDs.contains(configured.id) || hasDevOverride { return configured }
         return firstDownloaded(downloadedIDs: downloadedIDs)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -248,7 +248,17 @@ struct PostProcessorOption: Identifiable, Equatable {
         filename: "Qwen3.5-0.8B-Q4_K_M.gguf"
     )
 
-    static let all: [PostProcessorOption] = [.finetunedV2, .qwen35_0_8b]
+    // Fine-tuned Qwen3.5-0.8B v3 trained on Muesli dictation correction data.
+    static let finetunedV3 = PostProcessorOption(
+        id: "qwen35-postproc-v3",
+        label: "Post-Proc v3 (Finetuned)",
+        sizeLabel: "~505 MB",
+        description: "Fine-tuned Qwen3.5-0.8B on Muesli dictation data. Improved over v2 on filler removal, deletion cues, and spoken list formatting.",
+        downloadURL: URL(string: "https://huggingface.co/phequals/qwen35-postproc-v3-gguf/resolve/main/qwen35-postproc-v3-Q4_K_M.gguf")!,
+        filename: "qwen35-postproc-v3-Q4_K_M.gguf"
+    )
+
+    static let all: [PostProcessorOption] = [.finetunedV3, .finetunedV2, .qwen35_0_8b]
 
     static let defaultSystemPrompt = """
     Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -259,6 +259,33 @@ struct PostProcessorOption: Identifiable, Equatable {
     )
 
     static let all: [PostProcessorOption] = [.finetunedV3, .finetunedV2, .qwen35_0_8b]
+    static let defaultOption: PostProcessorOption = .finetunedV3
+
+    static var downloaded: [PostProcessorOption] {
+        all.filter(\.isDownloaded)
+    }
+
+    static func resolve(id: String) -> PostProcessorOption {
+        all.first { $0.id == id } ?? defaultOption
+    }
+
+    static func firstDownloaded(
+        excluding excludedID: String? = nil,
+        downloadedIDs: Set<String> = Set(downloaded.map(\.id))
+    ) -> PostProcessorOption? {
+        all.first { option in
+            option.id != excludedID && downloadedIDs.contains(option.id)
+        }
+    }
+
+    static func resolveDownloaded(
+        id: String,
+        downloadedIDs: Set<String> = Set(downloaded.map(\.id))
+    ) -> PostProcessorOption? {
+        let resolved = resolve(id: id)
+        if downloadedIDs.contains(resolved.id) { return resolved }
+        return firstDownloaded(downloadedIDs: downloadedIDs)
+    }
 
     static let defaultSystemPrompt = """
     Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.
@@ -349,7 +376,7 @@ struct AppConfig: Codable {
     var maraudersMapCustomAudioPath: String?
     var hiddenCalendarEventIDs: [String] = []
     var enablePostProcessor: Bool = false
-    var activePostProcessorId: String = PostProcessorOption.finetunedV2.id
+    var activePostProcessorId: String = PostProcessorOption.defaultOption.id
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
 
     enum CodingKeys: String, CodingKey {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -285,6 +285,7 @@ struct AppConfig: Codable {
     var maraudersMapAudioClip: String = "bbc_world_news"
     var maraudersMapCustomAudioPath: String?
     var hiddenCalendarEventIDs: [String] = []
+    var enablePostProcessor: Bool = false
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -324,6 +325,7 @@ struct AppConfig: Codable {
         case maraudersMapAudioClip = "marauders_map_audio_clip"
         case maraudersMapCustomAudioPath = "marauders_map_custom_audio_path"
         case hiddenCalendarEventIDs = "hidden_calendar_event_ids"
+        case enablePostProcessor = "enable_post_processor"
     }
 
     init() {}
@@ -368,6 +370,7 @@ struct AppConfig: Codable {
         maraudersMapAudioClip = (try? c.decode(String.self, forKey: .maraudersMapAudioClip)) ?? defaults.maraudersMapAudioClip
         maraudersMapCustomAudioPath = try? c.decode(String.self, forKey: .maraudersMapCustomAudioPath)
         hiddenCalendarEventIDs = (try? c.decode([String].self, forKey: .hiddenCalendarEventIDs)) ?? defaults.hiddenCalendarEventIDs
+        enablePostProcessor = (try? c.decode(Bool.self, forKey: .enablePostProcessor)) ?? defaults.enablePostProcessor
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -14,6 +14,15 @@ struct ModelsView: View {
     @State private var selectedWhisperModel: String
     @State private var showExperimental: Bool
 
+    // Post-processor state
+    @State private var downloadingPostProcModels: Set<String> = []
+    @State private var downloadProgressPostProc: [String: Double] = [:]
+    @State private var downloadedPostProcModels: Set<String> = []
+    @State private var downloadTasksPostProc: [String: Task<Void, Never>] = [:]
+    @State private var postProcModelToDelete: PostProcessorOption?
+    @State private var isEditingSystemPrompt: Bool = false
+    @State private var editedSystemPrompt: String
+
     init(appState: AppState, controller: MuesliController) {
         self.appState = appState
         self.controller = controller
@@ -22,6 +31,7 @@ struct ModelsView: View {
         _selectedParakeetModel = State(initialValue: BackendOption.parakeetFamily.contains(active) ? active.model : BackendOption.parakeetMultilingual.model)
         _selectedWhisperModel = State(initialValue: BackendOption.whisperFamily.contains(active) ? active.model : BackendOption.whisperSmall.model)
         _showExperimental = State(initialValue: false)
+        _editedSystemPrompt = State(initialValue: appState.config.postProcessorSystemPrompt)
     }
 
     var body: some View {
@@ -55,6 +65,8 @@ struct ModelsView: View {
 
                 experimentalSection
 
+                postProcessorSection
+
                 if !BackendOption.comingSoon.isEmpty {
                     VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                         Text("COMING SOON")
@@ -78,6 +90,7 @@ struct ModelsView: View {
         .background(MuesliTheme.backgroundBase)
         .onAppear {
             checkDownloadedModels()
+            checkDownloadedPostProcModels()
             syncSelectionsFromActiveBackend()
         }
         .onChange(of: appState.selectedBackend.model) { _, _ in
@@ -97,6 +110,24 @@ struct ModelsView: View {
                 guard let option = modelToDelete else { return }
                 deleteModel(option)
                 modelToDelete = nil
+            }
+        } message: {
+            Text("The downloaded model files will be removed from this Mac. You can download the model again later.")
+        }
+        .alert(
+            "Delete \"\(postProcModelToDelete?.label ?? "")\"?",
+            isPresented: Binding(
+                get: { postProcModelToDelete != nil },
+                set: { if !$0 { postProcModelToDelete = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                postProcModelToDelete = nil
+            }
+            Button("Delete", role: .destructive) {
+                guard let option = postProcModelToDelete else { return }
+                deletePostProcModel(option)
+                postProcModelToDelete = nil
             }
         } message: {
             Text("The downloaded model files will be removed from this Mac. You can download the model again later.")
@@ -146,6 +177,240 @@ struct ModelsView: View {
                         modelCard(option: option)
                     }
                 }
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private var postProcessorSection: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("POST-PROCESSING")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .textCase(.uppercase)
+                    .padding(.leading, 2)
+
+                Text("Optional LLM cleanup layer applied after transcription. Removes filler words, formats spoken lists, and corrects common dictation errors.")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .padding(.leading, 2)
+            }
+            .padding(.top, MuesliTheme.spacing8)
+
+            VStack(spacing: MuesliTheme.spacing12) {
+                ForEach(PostProcessorOption.all) { option in
+                    postProcModelCard(option)
+                }
+            }
+
+            systemPromptCard
+        }
+    }
+
+    private func postProcModelCard(_ option: PostProcessorOption) -> some View {
+        let isActive = appState.activePostProcessor.id == option.id
+        let isDownloaded = downloadedPostProcModels.contains(option.id)
+        let isDownloading = downloadingPostProcModels.contains(option.id)
+        let progress = downloadProgressPostProc[option.id] ?? 0
+
+        return VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        Text(option.label)
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+
+                        Text(option.sizeLabel)
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+
+                    Text(option.description)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+
+                Spacer()
+
+                if isActive {
+                    Text("Active")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.success)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(MuesliTheme.success.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                } else if isDownloaded {
+                    Text("Downloaded")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+            }
+
+            if isDownloading {
+                VStack(alignment: .leading, spacing: 4) {
+                    ProgressView(value: progress)
+                        .tint(MuesliTheme.accent)
+                    Text("\(Int(progress * 100))% downloading...")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+            }
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                if isDownloading {
+                    Button("Cancel") {
+                        cancelPostProcDownload(option)
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                } else if isDownloaded {
+                    if !isActive {
+                        Button("Set Active") {
+                            controller.selectPostProcessor(option)
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .padding(.horizontal, MuesliTheme.spacing12)
+                        .padding(.vertical, 4)
+                        .background(MuesliTheme.accentSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    }
+
+                    Button {
+                        postProcModelToDelete = option
+                    } label: {
+                        Image(systemName: "trash")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.red.opacity(0.6))
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Button("Download") {
+                        startPostProcDownload(option)
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.accentSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(isActive ? MuesliTheme.accent.opacity(0.5) : MuesliTheme.surfaceBorder, lineWidth: isActive ? 1.5 : 1)
+        )
+    }
+
+    private var systemPromptCard: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text("System Prompt")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Controls how the model cleans up transcriptions. Applies to the active post-processor model.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+                Spacer()
+                if !isEditingSystemPrompt {
+                    Button("Edit") {
+                        editedSystemPrompt = appState.config.postProcessorSystemPrompt
+                        isEditingSystemPrompt = true
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.accentSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+            }
+
+            if isEditingSystemPrompt {
+                TextEditor(text: $editedSystemPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .frame(minHeight: 120)
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+
+                HStack(spacing: MuesliTheme.spacing8) {
+                    Button("Save") {
+                        controller.updatePostProcessorSystemPrompt(editedSystemPrompt)
+                        isEditingSystemPrompt = false
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.accentSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                    Button("Cancel") {
+                        isEditingSystemPrompt = false
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                    Button("Reset to Default") {
+                        editedSystemPrompt = PostProcessorOption.defaultSystemPrompt
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+            } else {
+                Text(appState.config.postProcessorSystemPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(6)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
         }
         .padding(MuesliTheme.spacing16)
@@ -430,6 +695,91 @@ struct ModelsView: View {
                 .strokeBorder(MuesliTheme.surfaceBorder.opacity(0.5), lineWidth: 1)
         )
         .opacity(0.6)
+    }
+
+    // MARK: - Post-Processor Actions
+
+    private func startPostProcDownload(_ option: PostProcessorOption) {
+        withAnimation { downloadingPostProcModels.insert(option.id) }
+        downloadProgressPostProc[option.id] = 0.02
+
+        let task = Task {
+            let fm = FileManager.default
+            let tmpURL = option.cacheDirectory.appendingPathComponent(option.filename + ".tmp")
+            do {
+                try fm.createDirectory(at: option.cacheDirectory, withIntermediateDirectories: true)
+                fm.createFile(atPath: tmpURL.path, contents: nil)
+                let handle = try FileHandle(forWritingTo: tmpURL)
+                let (asyncBytes, response) = try await URLSession.shared.bytes(from: option.downloadURL)
+                let total = response.expectedContentLength
+                var received: Int64 = 0
+                var chunk = Data(capacity: 65536)
+                for try await byte in asyncBytes {
+                    guard !Task.isCancelled else { throw CancellationError() }
+                    chunk.append(byte)
+                    if chunk.count >= 65536 {
+                        try handle.write(contentsOf: chunk)
+                        received += Int64(chunk.count)
+                        chunk.removeAll(keepingCapacity: true)
+                        if total > 0 {
+                            let p = Double(received) / Double(total)
+                            await MainActor.run { downloadProgressPostProc[option.id] = max(p, 0.02) }
+                        }
+                    }
+                }
+                if !chunk.isEmpty { try handle.write(contentsOf: chunk) }
+                try handle.close()
+                if fm.fileExists(atPath: option.modelURL.path) { try fm.removeItem(at: option.modelURL) }
+                try fm.moveItem(at: tmpURL, to: option.modelURL)
+                await MainActor.run {
+                    withAnimation {
+                        downloadingPostProcModels.remove(option.id)
+                        downloadedPostProcModels.insert(option.id)
+                        downloadProgressPostProc.removeValue(forKey: option.id)
+                        downloadTasksPostProc.removeValue(forKey: option.id)
+                    }
+                }
+            } catch {
+                try? fm.removeItem(at: tmpURL)
+                await MainActor.run {
+                    withAnimation {
+                        downloadingPostProcModels.remove(option.id)
+                        downloadProgressPostProc.removeValue(forKey: option.id)
+                        downloadTasksPostProc.removeValue(forKey: option.id)
+                    }
+                }
+                if !(error is CancellationError) {
+                    fputs("[muesli-native] Post-processor download failed: \(error)\n", stderr)
+                }
+            }
+        }
+        downloadTasksPostProc[option.id] = task
+    }
+
+    private func cancelPostProcDownload(_ option: PostProcessorOption) {
+        downloadTasksPostProc[option.id]?.cancel()
+        withAnimation {
+            downloadingPostProcModels.remove(option.id)
+            downloadProgressPostProc.removeValue(forKey: option.id)
+            downloadTasksPostProc.removeValue(forKey: option.id)
+        }
+    }
+
+    private func deletePostProcModel(_ option: PostProcessorOption) {
+        if appState.activePostProcessor.id == option.id {
+            let fallback = PostProcessorOption.all.first { $0.id != option.id } ?? .finetunedV2
+            controller.selectPostProcessor(fallback)
+        }
+        try? FileManager.default.removeItem(at: option.cacheDirectory)
+        downloadedPostProcModels.remove(option.id)
+    }
+
+    private func checkDownloadedPostProcModels() {
+        for option in PostProcessorOption.all {
+            if option.isDownloaded {
+                downloadedPostProcModels.insert(option.id)
+            }
+        }
     }
 
     // MARK: - Actions

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -761,7 +761,10 @@ struct ModelsView: View {
                 lastError = error
             }
         }
-        throw DownloadError.retriesExhausted(option.filename, lastError!)
+        let underlying = lastError ?? NSError(domain: "PostProcDownload", code: 0, userInfo: [
+            NSLocalizedDescriptionKey: "No download attempts were made",
+        ])
+        throw DownloadError.retriesExhausted(option.filename, underlying)
     }
 
     private func downloadPostProcTempFile(_ option: PostProcessorOption) async throws -> URL {
@@ -771,14 +774,25 @@ struct ModelsView: View {
             }
         }
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        defer { session.finishTasksAndInvalidate() }
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                delegate.setContinuation(continuation)
-                session.downloadTask(with: option.downloadURL).resume()
+        let invalidator = URLSessionInvalidator()
+        do {
+            let downloadedURL = try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    delegate.setContinuation(continuation)
+                    session.downloadTask(with: option.downloadURL).resume()
+                }
+            } onCancel: {
+                invalidator.cancel(session)
             }
-        } onCancel: {
-            session.invalidateAndCancel()
+            invalidator.finish(session)
+            return downloadedURL
+        } catch {
+            if error is CancellationError {
+                invalidator.cancel(session)
+            } else {
+                invalidator.finish(session)
+            }
+            throw error
         }
     }
 
@@ -994,6 +1008,30 @@ struct ModelsView: View {
         default:
             return false
         }
+    }
+}
+
+private final class URLSessionInvalidator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didInvalidate = false
+
+    func finish(_ session: URLSession) {
+        invalidate(session, action: { $0.finishTasksAndInvalidate() })
+    }
+
+    func cancel(_ session: URLSession) {
+        invalidate(session, action: { $0.invalidateAndCancel() })
+    }
+
+    private func invalidate(_ session: URLSession, action: (URLSession) -> Void) {
+        lock.lock()
+        guard !didInvalidate else {
+            lock.unlock()
+            return
+        }
+        didInvalidate = true
+        lock.unlock()
+        action(session)
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -700,7 +700,7 @@ struct ModelsView: View {
     // MARK: - Post-Processor Actions
 
     private func startPostProcDownload(_ option: PostProcessorOption) {
-        withAnimation { downloadingPostProcModels.insert(option.id) }
+        withAnimation { _ = downloadingPostProcModels.insert(option.id) }
         downloadProgressPostProc[option.id] = 0.02
 
         let task = Task {
@@ -708,25 +708,7 @@ struct ModelsView: View {
             do {
                 try fm.createDirectory(at: option.cacheDirectory, withIntermediateDirectories: true)
 
-                let delegate = PostProcDownloadDelegate { progress in
-                    DispatchQueue.main.async {
-                        downloadProgressPostProc[option.id] = max(progress, 0.02)
-                    }
-                }
-                let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-
-                let tmpURL = try await withTaskCancellationHandler {
-                    try await withCheckedThrowingContinuation { continuation in
-                        delegate.setContinuation(continuation)
-                        session.downloadTask(with: option.downloadURL).resume()
-                    }
-                } onCancel: {
-                    session.invalidateAndCancel()
-                }
-                session.finishTasksAndInvalidate()
-
-                if fm.fileExists(atPath: option.modelURL.path) { try fm.removeItem(at: option.modelURL) }
-                try fm.moveItem(at: tmpURL, to: option.modelURL)
+                try await downloadPostProcModel(option)
 
                 await MainActor.run {
                     withAnimation {
@@ -734,6 +716,10 @@ struct ModelsView: View {
                         downloadedPostProcModels.insert(option.id)
                         downloadProgressPostProc.removeValue(forKey: option.id)
                         downloadTasksPostProc.removeValue(forKey: option.id)
+                    }
+                    if appState.config.enablePostProcessor && !appState.activePostProcessor.isDownloaded {
+                        controller.selectPostProcessor(option)
+                        controller.preloadExperimentalTranscriptionFeatures()
                     }
                 }
             } catch {
@@ -753,6 +739,70 @@ struct ModelsView: View {
         downloadTasksPostProc[option.id] = task
     }
 
+    private func downloadPostProcModel(_ option: PostProcessorOption, maxRetries: Int = 3) async throws {
+        var lastError: Error?
+        for attempt in 0..<maxRetries {
+            try Task.checkCancellation()
+            if attempt > 0 {
+                let delay = UInt64(pow(2.0, Double(attempt - 1))) * 1_000_000_000
+                try await Task.sleep(nanoseconds: delay)
+                fputs("[download] retry \(attempt)/\(maxRetries) for \(option.filename)\n", stderr)
+                await MainActor.run {
+                    downloadProgressPostProc[option.id] = 0.02
+                }
+            }
+            do {
+                let tmpURL = try await downloadPostProcTempFile(option)
+                try installPostProcModel(from: tmpURL, option: option)
+                return
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                lastError = error
+            }
+        }
+        throw DownloadError.retriesExhausted(option.filename, lastError!)
+    }
+
+    private func downloadPostProcTempFile(_ option: PostProcessorOption) async throws -> URL {
+        let delegate = PostProcDownloadDelegate { progress in
+            DispatchQueue.main.async {
+                downloadProgressPostProc[option.id] = max(progress, 0.02)
+            }
+        }
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                delegate.setContinuation(continuation)
+                session.downloadTask(with: option.downloadURL).resume()
+            }
+        } onCancel: {
+            session.invalidateAndCancel()
+        }
+    }
+
+    private func installPostProcModel(from tmpURL: URL, option: PostProcessorOption) throws {
+        let fm = FileManager.default
+        let stagingURL = option.cacheDirectory.appendingPathComponent(".\(option.filename).download")
+        defer {
+            try? fm.removeItem(at: tmpURL)
+            try? fm.removeItem(at: stagingURL)
+        }
+        try? fm.removeItem(at: stagingURL)
+        try fm.moveItem(at: tmpURL, to: stagingURL)
+        if fm.fileExists(atPath: option.modelURL.path) {
+            _ = try fm.replaceItemAt(
+                option.modelURL,
+                withItemAt: stagingURL,
+                backupItemName: nil,
+                options: []
+            )
+        } else {
+            try fm.moveItem(at: stagingURL, to: option.modelURL)
+        }
+    }
+
     private func cancelPostProcDownload(_ option: PostProcessorOption) {
         downloadTasksPostProc[option.id]?.cancel()
         withAnimation {
@@ -764,14 +814,19 @@ struct ModelsView: View {
 
     private func deletePostProcModel(_ option: PostProcessorOption) {
         if appState.activePostProcessor.id == option.id {
-            let fallback = PostProcessorOption.all.first { $0.id != option.id } ?? .finetunedV2
-            controller.selectPostProcessor(fallback)
+            let remainingDownloadedIDs = downloadedPostProcModels.subtracting([option.id])
+            if let fallback = PostProcessorOption.firstDownloaded(excluding: option.id, downloadedIDs: remainingDownloadedIDs) {
+                controller.selectPostProcessor(fallback)
+            } else {
+                controller.setPostProcessorEnabled(false)
+            }
         }
         try? FileManager.default.removeItem(at: option.cacheDirectory)
         downloadedPostProcModels.remove(option.id)
     }
 
     private func checkDownloadedPostProcModels() {
+        downloadedPostProcModels.removeAll()
         for option in PostProcessorOption.all {
             if option.isDownloaded {
                 downloadedPostProcModels.insert(option.id)
@@ -782,7 +837,7 @@ struct ModelsView: View {
     // MARK: - Actions
 
     private func startDownload(_ option: BackendOption) {
-        withAnimation { downloadingModels.insert(option.model) }
+        withAnimation { _ = downloadingModels.insert(option.model) }
         downloadProgress[option.model] = 0.05  // Show initial progress immediately
 
         let startTime = Date()
@@ -839,7 +894,7 @@ struct ModelsView: View {
         Task {
             await deleteModelFiles(option)
             await MainActor.run {
-                downloadedModels.remove(option.model)
+                _ = downloadedModels.remove(option.model)
             }
         }
     }
@@ -957,12 +1012,28 @@ private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelega
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-        // URLSession deletes the temp file after this returns — move it first.
-        let dest = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + ".gguf.tmp")
-        try? FileManager.default.moveItem(at: location, to: dest)
-        continuation?.resume(returning: dest)
-        continuation = nil
+        var dest: URL?
+        do {
+            if let response = downloadTask.response as? HTTPURLResponse,
+               !(200..<300).contains(response.statusCode) {
+                throw NSError(domain: "PostProcDownload", code: response.statusCode, userInfo: [
+                    NSLocalizedDescriptionKey: "Post-processor download failed with HTTP \(response.statusCode)",
+                ])
+            }
+
+            // URLSession deletes the temp file after this returns — move it first.
+            let movedURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString + ".gguf.tmp")
+            try FileManager.default.moveItem(at: location, to: movedURL)
+            dest = movedURL
+            try validateGGUFHeader(at: movedURL)
+            continuation?.resume(returning: movedURL)
+            continuation = nil
+        } catch {
+            if let dest { try? FileManager.default.removeItem(at: dest) }
+            continuation?.resume(throwing: error)
+            continuation = nil
+        }
     }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
@@ -976,5 +1047,16 @@ private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelega
         guard let error else { return }
         continuation?.resume(throwing: error)
         continuation = nil
+    }
+
+    private func validateGGUFHeader(at url: URL) throws {
+        let fh = try FileHandle(forReadingFrom: url)
+        defer { try? fh.close() }
+        let header = try fh.read(upToCount: 4) ?? Data()
+        guard header == Data([0x47, 0x47, 0x55, 0x46]) else {
+            throw NSError(domain: "PostProcDownload", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Downloaded post-processor file is not a GGUF model",
+            ])
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1001,6 +1001,7 @@ struct ModelsView: View {
 /// Uses OS-level buffered download task instead of byte-by-byte async iteration.
 private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
     private let onProgress: (Double) -> Void
+    private let lock = NSLock()
     private var continuation: CheckedContinuation<URL, Error>?
 
     init(onProgress: @escaping (Double) -> Void) {
@@ -1008,6 +1009,8 @@ private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelega
     }
 
     func setContinuation(_ c: CheckedContinuation<URL, Error>) {
+        lock.lock()
+        defer { lock.unlock() }
         continuation = c
     }
 
@@ -1027,12 +1030,10 @@ private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelega
             try FileManager.default.moveItem(at: location, to: movedURL)
             dest = movedURL
             try validateGGUFHeader(at: movedURL)
-            continuation?.resume(returning: movedURL)
-            continuation = nil
+            resumeOnce(.success(movedURL))
         } catch {
             if let dest { try? FileManager.default.removeItem(at: dest) }
-            continuation?.resume(throwing: error)
-            continuation = nil
+            resumeOnce(.failure(error))
         }
     }
 
@@ -1045,8 +1046,21 @@ private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelega
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard let error else { return }
-        continuation?.resume(throwing: error)
-        continuation = nil
+        resumeOnce(.failure(error))
+    }
+
+    private func resumeOnce(_ result: Result<URL, Error>) {
+        lock.lock()
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+
+        switch result {
+        case .success(let url):
+            continuation?.resume(returning: url)
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
     }
 
     private func validateGGUFHeader(at url: URL) throws {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -705,32 +705,29 @@ struct ModelsView: View {
 
         let task = Task {
             let fm = FileManager.default
-            let tmpURL = option.cacheDirectory.appendingPathComponent(option.filename + ".tmp")
             do {
                 try fm.createDirectory(at: option.cacheDirectory, withIntermediateDirectories: true)
-                fm.createFile(atPath: tmpURL.path, contents: nil)
-                let handle = try FileHandle(forWritingTo: tmpURL)
-                let (asyncBytes, response) = try await URLSession.shared.bytes(from: option.downloadURL)
-                let total = response.expectedContentLength
-                var received: Int64 = 0
-                var chunk = Data(capacity: 65536)
-                for try await byte in asyncBytes {
-                    guard !Task.isCancelled else { throw CancellationError() }
-                    chunk.append(byte)
-                    if chunk.count >= 65536 {
-                        try handle.write(contentsOf: chunk)
-                        received += Int64(chunk.count)
-                        chunk.removeAll(keepingCapacity: true)
-                        if total > 0 {
-                            let p = Double(received) / Double(total)
-                            await MainActor.run { downloadProgressPostProc[option.id] = max(p, 0.02) }
-                        }
+
+                let delegate = PostProcDownloadDelegate { progress in
+                    DispatchQueue.main.async {
+                        downloadProgressPostProc[option.id] = max(progress, 0.02)
                     }
                 }
-                if !chunk.isEmpty { try handle.write(contentsOf: chunk) }
-                try handle.close()
+                let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+
+                let tmpURL = try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        delegate.setContinuation(continuation)
+                        session.downloadTask(with: option.downloadURL).resume()
+                    }
+                } onCancel: {
+                    session.invalidateAndCancel()
+                }
+                session.finishTasksAndInvalidate()
+
                 if fm.fileExists(atPath: option.modelURL.path) { try fm.removeItem(at: option.modelURL) }
                 try fm.moveItem(at: tmpURL, to: option.modelURL)
+
                 await MainActor.run {
                     withAnimation {
                         downloadingPostProcModels.remove(option.id)
@@ -740,7 +737,6 @@ struct ModelsView: View {
                     }
                 }
             } catch {
-                try? fm.removeItem(at: tmpURL)
                 await MainActor.run {
                     withAnimation {
                         downloadingPostProcModels.remove(option.id)
@@ -748,7 +744,8 @@ struct ModelsView: View {
                         downloadTasksPostProc.removeValue(forKey: option.id)
                     }
                 }
-                if !(error is CancellationError) {
+                let isCancelled = error is CancellationError || (error as? URLError)?.code == .cancelled
+                if !isCancelled {
                     fputs("[muesli-native] Post-processor download failed: \(error)\n", stderr)
                 }
             }
@@ -942,5 +939,42 @@ struct ModelsView: View {
         default:
             return false
         }
+    }
+}
+
+/// URLSessionDownloadDelegate bridge for post-processor GGUF downloads.
+/// Uses OS-level buffered download task instead of byte-by-byte async iteration.
+private final class PostProcDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let onProgress: (Double) -> Void
+    private var continuation: CheckedContinuation<URL, Error>?
+
+    init(onProgress: @escaping (Double) -> Void) {
+        self.onProgress = onProgress
+    }
+
+    func setContinuation(_ c: CheckedContinuation<URL, Error>) {
+        continuation = c
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        // URLSession deletes the temp file after this returns — move it first.
+        let dest = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".gguf.tmp")
+        try? FileManager.default.moveItem(at: location, to: dest)
+        continuation?.resume(returning: dest)
+        continuation = nil
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        continuation?.resume(throwing: error)
+        continuation = nil
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -215,8 +215,8 @@ struct ModelsView: View {
     }
 
     private func postProcModelCard(_ option: PostProcessorOption) -> some View {
-        let isActive = appState.activePostProcessor.id == option.id
         let isDownloaded = downloadedPostProcModels.contains(option.id)
+        let isActive = appState.activePostProcessor.id == option.id && isDownloaded
         let isDownloading = downloadingPostProcModels.contains(option.id)
         let progress = downloadProgressPostProc[option.id] ?? 0
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -228,6 +228,13 @@ final class MuesliController: NSObject {
 
         Task { [weak self] in
             guard let self else { return }
+            if #available(macOS 15, *) {
+                let ppOption = PostProcessorOption.all.first { $0.id == self.config.activePostProcessorId } ?? .finetunedV2
+                await self.transcriptionCoordinator.setActivePostProcessor(
+                    option: ppOption,
+                    systemPrompt: self.config.postProcessorSystemPrompt
+                )
+            }
             await self.transcriptionCoordinator.preload(
                 backend: self.selectedBackend,
                 enablePostProcessor: self.config.enablePostProcessor
@@ -352,6 +359,7 @@ final class MuesliController: NSObject {
         appState.meetingStats = meetingStats()
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
+        appState.activePostProcessor = PostProcessorOption.all.first { $0.id == config.activePostProcessorId } ?? .finetunedV2
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
@@ -398,6 +406,13 @@ final class MuesliController: NSObject {
         }
         Task { [weak self] in
             guard let self else { return }
+            if #available(macOS 15, *) {
+                let ppOption = PostProcessorOption.all.first { $0.id == self.config.activePostProcessorId } ?? .finetunedV2
+                await self.transcriptionCoordinator.setActivePostProcessor(
+                    option: ppOption,
+                    systemPrompt: self.config.postProcessorSystemPrompt
+                )
+            }
             await self.transcriptionCoordinator.preload(
                 backend: option,
                 enablePostProcessor: self.config.enablePostProcessor
@@ -410,14 +425,50 @@ final class MuesliController: NSObject {
     }
 
     func preloadExperimentalTranscriptionFeatures() {
-        let backend = selectedBackend
         let enabled = config.enablePostProcessor
+        let ppId = config.activePostProcessorId
+        let ppPrompt = config.postProcessorSystemPrompt
         Task { [weak self] in
             guard let self else { return }
-            await self.transcriptionCoordinator.preload(
-                backend: backend,
-                enablePostProcessor: enabled
-            )
+            if #available(macOS 15, *) {
+                let ppOption = PostProcessorOption.all.first { $0.id == ppId } ?? .finetunedV2
+                await self.transcriptionCoordinator.setActivePostProcessor(
+                    option: ppOption,
+                    systemPrompt: ppPrompt
+                )
+            }
+            await self.transcriptionCoordinator.preloadPostProcessorIfNeeded(enabled: enabled)
+        }
+    }
+
+    func selectPostProcessor(_ option: PostProcessorOption) {
+        updateConfig { $0.activePostProcessorId = option.id }
+        appState.activePostProcessor = option
+        guard config.enablePostProcessor else { return }
+        let systemPrompt = config.postProcessorSystemPrompt
+        Task { [weak self] in
+            guard let self else { return }
+            if #available(macOS 15, *) {
+                await self.transcriptionCoordinator.setActivePostProcessor(
+                    option: option,
+                    systemPrompt: systemPrompt
+                )
+            }
+        }
+    }
+
+    func updatePostProcessorSystemPrompt(_ prompt: String) {
+        updateConfig { $0.postProcessorSystemPrompt = prompt }
+        let ppOption = PostProcessorOption.all.first { $0.id == config.activePostProcessorId } ?? .finetunedV2
+        guard config.enablePostProcessor else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            if #available(macOS 15, *) {
+                await self.transcriptionCoordinator.setActivePostProcessor(
+                    option: ppOption,
+                    systemPrompt: prompt
+                )
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -228,8 +228,9 @@ final class MuesliController: NSObject {
 
         Task { [weak self] in
             guard let self else { return }
+            let ppOption = self.runtimePostProcessorOption()
             if #available(macOS 15, *) {
-                if let ppOption = self.resolveRuntimePostProcessorOption() {
+                if let ppOption {
                     await self.transcriptionCoordinator.setActivePostProcessor(
                         option: ppOption,
                         systemPrompt: self.config.postProcessorSystemPrompt
@@ -238,7 +239,7 @@ final class MuesliController: NSObject {
             }
             await self.transcriptionCoordinator.preload(
                 backend: self.selectedBackend,
-                enablePostProcessor: self.isPostProcessorReady
+                enablePostProcessor: self.config.enablePostProcessor && ppOption != nil
             )
             await MainActor.run {
                 self.refreshUI()
@@ -407,8 +408,9 @@ final class MuesliController: NSObject {
         }
         Task { [weak self] in
             guard let self else { return }
+            let ppOption = self.runtimePostProcessorOption()
             if #available(macOS 15, *) {
-                if let ppOption = self.resolveRuntimePostProcessorOption() {
+                if let ppOption {
                     await self.transcriptionCoordinator.setActivePostProcessor(
                         option: ppOption,
                         systemPrompt: self.config.postProcessorSystemPrompt
@@ -417,7 +419,7 @@ final class MuesliController: NSObject {
             }
             await self.transcriptionCoordinator.preload(
                 backend: option,
-                enablePostProcessor: self.isPostProcessorReady
+                enablePostProcessor: self.config.enablePostProcessor && ppOption != nil
             )
             await MainActor.run {
                 self.statusBarController?.refresh()
@@ -427,12 +429,12 @@ final class MuesliController: NSObject {
     }
 
     var isPostProcessorReady: Bool {
-        config.enablePostProcessor && resolveRuntimePostProcessorOption() != nil
+        config.enablePostProcessor && runtimePostProcessorOption() != nil
     }
 
     @discardableResult
     private func normalizePostProcessorSelectionForAvailability() -> PostProcessorOption? {
-        guard let option = PostProcessorOption.resolveDownloaded(id: config.activePostProcessorId) else {
+        guard let option = runtimePostProcessorOption() else {
             appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
             return nil
         }
@@ -443,27 +445,25 @@ final class MuesliController: NSObject {
         return option
     }
 
-    private func resolveRuntimePostProcessorOption() -> PostProcessorOption? {
-        let configured = PostProcessorOption.resolve(id: config.activePostProcessorId)
-        if configured.isDownloaded || Qwen3PostProcessorConfig.devOverrideURL() != nil {
-            return configured
-        }
-        return normalizePostProcessorSelectionForAvailability()
+    private func runtimePostProcessorOption() -> PostProcessorOption? {
+        PostProcessorOption.runtimeOption(id: config.activePostProcessorId)
     }
 
     func setPostProcessorEnabled(_ enabled: Bool) {
-        if enabled, resolveRuntimePostProcessorOption() == nil {
-            updateConfig { $0.enablePostProcessor = false }
-            appState.selectedTab = .models
-            return
+        if enabled {
+            guard normalizePostProcessorSelectionForAvailability() != nil else {
+                updateConfig { $0.enablePostProcessor = false }
+                appState.selectedTab = .models
+                return
+            }
         }
         updateConfig { $0.enablePostProcessor = enabled }
         preloadExperimentalTranscriptionFeatures()
     }
 
     func preloadExperimentalTranscriptionFeatures() {
-        let enabled = isPostProcessorReady
-        let ppOption = resolveRuntimePostProcessorOption()
+        let ppOption = runtimePostProcessorOption()
+        let enabled = config.enablePostProcessor && ppOption != nil
         let ppPrompt = config.postProcessorSystemPrompt
         Task { [weak self] in
             guard let self else { return }
@@ -495,7 +495,7 @@ final class MuesliController: NSObject {
 
     func updatePostProcessorSystemPrompt(_ prompt: String) {
         updateConfig { $0.postProcessorSystemPrompt = prompt }
-        let ppOption = resolveRuntimePostProcessorOption()
+        let ppOption = runtimePostProcessorOption()
         guard config.enablePostProcessor else { return }
         Task { [weak self] in
             guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -229,15 +229,16 @@ final class MuesliController: NSObject {
         Task { [weak self] in
             guard let self else { return }
             if #available(macOS 15, *) {
-                let ppOption = PostProcessorOption.all.first { $0.id == self.config.activePostProcessorId } ?? .finetunedV2
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: ppOption,
-                    systemPrompt: self.config.postProcessorSystemPrompt
-                )
+                if let ppOption = self.resolveRuntimePostProcessorOption() {
+                    await self.transcriptionCoordinator.setActivePostProcessor(
+                        option: ppOption,
+                        systemPrompt: self.config.postProcessorSystemPrompt
+                    )
+                }
             }
             await self.transcriptionCoordinator.preload(
                 backend: self.selectedBackend,
-                enablePostProcessor: self.config.enablePostProcessor
+                enablePostProcessor: self.isPostProcessorReady
             )
             await MainActor.run {
                 self.refreshUI()
@@ -359,7 +360,7 @@ final class MuesliController: NSObject {
         appState.meetingStats = meetingStats()
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
-        appState.activePostProcessor = PostProcessorOption.all.first { $0.id == config.activePostProcessorId } ?? .finetunedV2
+        appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
@@ -407,15 +408,16 @@ final class MuesliController: NSObject {
         Task { [weak self] in
             guard let self else { return }
             if #available(macOS 15, *) {
-                let ppOption = PostProcessorOption.all.first { $0.id == self.config.activePostProcessorId } ?? .finetunedV2
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: ppOption,
-                    systemPrompt: self.config.postProcessorSystemPrompt
-                )
+                if let ppOption = self.resolveRuntimePostProcessorOption() {
+                    await self.transcriptionCoordinator.setActivePostProcessor(
+                        option: ppOption,
+                        systemPrompt: self.config.postProcessorSystemPrompt
+                    )
+                }
             }
             await self.transcriptionCoordinator.preload(
                 backend: option,
-                enablePostProcessor: self.config.enablePostProcessor
+                enablePostProcessor: self.isPostProcessorReady
             )
             await MainActor.run {
                 self.statusBarController?.refresh()
@@ -424,14 +426,46 @@ final class MuesliController: NSObject {
         }
     }
 
+    var isPostProcessorReady: Bool {
+        config.enablePostProcessor && resolveRuntimePostProcessorOption() != nil
+    }
+
+    @discardableResult
+    private func normalizePostProcessorSelectionForAvailability() -> PostProcessorOption? {
+        guard let option = PostProcessorOption.resolveDownloaded(id: config.activePostProcessorId) else {
+            appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
+            return nil
+        }
+        if config.activePostProcessorId != option.id {
+            updateConfig { $0.activePostProcessorId = option.id }
+        }
+        appState.activePostProcessor = option
+        return option
+    }
+
+    private func resolveRuntimePostProcessorOption() -> PostProcessorOption? {
+        let configured = PostProcessorOption.resolve(id: config.activePostProcessorId)
+        if configured.isDownloaded || Qwen3PostProcessorConfig.devOverrideURL() != nil {
+            return configured
+        }
+        return normalizePostProcessorSelectionForAvailability()
+    }
+
+    func setPostProcessorEnabled(_ enabled: Bool) {
+        updateConfig { $0.enablePostProcessor = enabled }
+        if enabled {
+            normalizePostProcessorSelectionForAvailability()
+        }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
     func preloadExperimentalTranscriptionFeatures() {
-        let enabled = config.enablePostProcessor
-        let ppId = config.activePostProcessorId
+        let enabled = isPostProcessorReady
+        let ppOption = resolveRuntimePostProcessorOption()
         let ppPrompt = config.postProcessorSystemPrompt
         Task { [weak self] in
             guard let self else { return }
-            if #available(macOS 15, *) {
-                let ppOption = PostProcessorOption.all.first { $0.id == ppId } ?? .finetunedV2
+            if let ppOption, #available(macOS 15, *) {
                 await self.transcriptionCoordinator.setActivePostProcessor(
                     option: ppOption,
                     systemPrompt: ppPrompt
@@ -459,11 +493,11 @@ final class MuesliController: NSObject {
 
     func updatePostProcessorSystemPrompt(_ prompt: String) {
         updateConfig { $0.postProcessorSystemPrompt = prompt }
-        let ppOption = PostProcessorOption.all.first { $0.id == config.activePostProcessorId } ?? .finetunedV2
+        let ppOption = resolveRuntimePostProcessorOption()
         guard config.enablePostProcessor else { return }
         Task { [weak self] in
             guard let self else { return }
-            if #available(macOS 15, *) {
+            if let ppOption, #available(macOS 15, *) {
                 await self.transcriptionCoordinator.setActivePostProcessor(
                     option: ppOption,
                     systemPrompt: prompt
@@ -689,7 +723,7 @@ final class MuesliController: NSObject {
         progress(0.0, "Downloading \(backend.label)...")
         await transcriptionCoordinator.preload(
             backend: backend,
-            enablePostProcessor: config.enablePostProcessor,
+            enablePostProcessor: isPostProcessorReady,
             progress: progress
         )
         progress(1.0, nil)
@@ -1641,7 +1675,7 @@ final class MuesliController: NSObject {
                 let result = try await self.transcriptionCoordinator.transcribeDictation(
                     at: wavURL,
                     backend: self.selectedBackend,
-                    enablePostProcessor: self.config.enablePostProcessor,
+                    enablePostProcessor: self.isPostProcessorReady,
                     customWords: self.serializedCustomWords()
                 )
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -228,7 +228,10 @@ final class MuesliController: NSObject {
 
         Task { [weak self] in
             guard let self else { return }
-            await self.transcriptionCoordinator.preload(backend: self.selectedBackend)
+            await self.transcriptionCoordinator.preload(
+                backend: self.selectedBackend,
+                enablePostProcessor: self.config.enablePostProcessor
+            )
             await MainActor.run {
                 self.refreshUI()
             }
@@ -395,11 +398,26 @@ final class MuesliController: NSObject {
         }
         Task { [weak self] in
             guard let self else { return }
-            await self.transcriptionCoordinator.preload(backend: option)
+            await self.transcriptionCoordinator.preload(
+                backend: option,
+                enablePostProcessor: self.config.enablePostProcessor
+            )
             await MainActor.run {
                 self.statusBarController?.refresh()
                 self.historyWindowController?.updateBackendLabel()
             }
+        }
+    }
+
+    func preloadExperimentalTranscriptionFeatures() {
+        let backend = selectedBackend
+        let enabled = config.enablePostProcessor
+        Task { [weak self] in
+            guard let self else { return }
+            await self.transcriptionCoordinator.preload(
+                backend: backend,
+                enablePostProcessor: enabled
+            )
         }
     }
 
@@ -618,7 +636,11 @@ final class MuesliController: NSObject {
 
     func downloadModelForOnboarding(_ backend: BackendOption, progress: @escaping (Double, String?) -> Void) async throws -> Bool {
         progress(0.0, "Downloading \(backend.label)...")
-        await transcriptionCoordinator.preload(backend: backend, progress: progress)
+        await transcriptionCoordinator.preload(
+            backend: backend,
+            enablePostProcessor: config.enablePostProcessor,
+            progress: progress
+        )
         progress(1.0, nil)
         return false
     }
@@ -1568,6 +1590,7 @@ final class MuesliController: NSObject {
                 let result = try await self.transcriptionCoordinator.transcribeDictation(
                     at: wavURL,
                     backend: self.selectedBackend,
+                    enablePostProcessor: self.config.enablePostProcessor,
                     customWords: self.serializedCustomWords()
                 )
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -452,10 +452,12 @@ final class MuesliController: NSObject {
     }
 
     func setPostProcessorEnabled(_ enabled: Bool) {
-        updateConfig { $0.enablePostProcessor = enabled }
-        if enabled {
-            normalizePostProcessorSelectionForAvailability()
+        if enabled, resolveRuntimePostProcessorOption() == nil {
+            updateConfig { $0.enablePostProcessor = false }
+            appState.selectedTab = .models
+            return
         }
+        updateConfig { $0.enablePostProcessor = enabled }
         preloadExperimentalTranscriptionFeatures()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -170,7 +170,7 @@ enum Qwen3PostProcessorOutputCleaner {
     }
 }
 
-private enum Qwen3PostProcessorConfig {
+enum Qwen3PostProcessorConfig {
     // Dev/Canary override — takes precedence over the UI-selected model when set.
     static let envOverride = "MUESLI_QWEN3_POSTPROC_GGUF"
     static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -127,8 +127,16 @@ enum Qwen3PostProcessorOutputCleaner {
         }
 
         let inputLength = max(input.trimmingCharacters(in: .whitespacesAndNewlines).count, 1)
-        // Cleanup should usually compress text. Treat large expansion as a hallucination signal.
-        return Double(trimmed.count) > Double(inputLength) * 2.0 && trimmed.count > 200
+        // Cleanup should usually compress text. Treat expansion as a hallucination signal,
+        // with a lower absolute floor for short dictations.
+        let expansion = Double(trimmed.count) / Double(inputLength)
+        if inputLength < 50 {
+            return expansion > 4.0 && trimmed.count > 80
+        }
+        if inputLength < 150 {
+            return expansion > 2.5 && trimmed.count > 150
+        }
+        return expansion > 2.0 && trimmed.count > 200
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -1,0 +1,273 @@
+import Foundation
+import LLM
+
+enum Qwen3PostProcessingHeuristics {
+    private static let formattingCues: [String] = [
+        "bullet point", "bullet points", "number one", "number two", "number three",
+        "new paragraph", "new line", "next line", "comma", "period", "full stop",
+        "question mark", "exclamation point", "colon", "semicolon", "open quote",
+        "close quote", "open parenthesis", "close parenthesis",
+    ]
+
+    private static let deletionCues: [String] = [
+        "scratch that", "delete that", "forget that", "never mind",
+    ]
+
+    static func shouldApply(to text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if FillerWordFilter.apply(trimmed) != trimmed { return true }
+        return containsDeletionCue(trimmed) || containsFormattingCue(trimmed)
+    }
+
+    static func triggerLabels(for text: String) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var labels: [String] = []
+        if FillerWordFilter.apply(trimmed) != trimmed {
+            labels.append("fillers")
+        }
+        if containsDeletionCue(trimmed) {
+            labels.append("deletion")
+        }
+        if containsFormattingCue(trimmed) {
+            labels.append("formatting")
+        }
+        return labels
+    }
+
+    static func containsDeletionCue(_ text: String) -> Bool {
+        containsPhrase(in: text, phrases: deletionCues)
+    }
+
+    static func containsFormattingCue(_ text: String) -> Bool {
+        containsPhrase(in: text, phrases: formattingCues)
+    }
+
+    private static func containsPhrase(in text: String, phrases: [String]) -> Bool {
+        let lower = text.lowercased()
+        return phrases.contains { lower.contains($0) }
+    }
+}
+
+enum Qwen3PostProcessorOutputCleaner {
+    static func clean(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        var result = text
+        result = result.replacingOccurrences(
+            of: #"<think>[\s\S]*?</think>"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"<\|im_(?:start|end)\|>"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"```[A-Za-z0-9_-]*\s*"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"```"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"^`+|`+$"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\[end of text\]"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?im)^\s*(?:[#>*-]+\s*)?(?:\*\*|__)?(?:transcription|cleaned transcription|output|response)(?:\*\*|__)?\s*:\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?im)^\s*(?:\*\*|__)([^*\n_]{1,80})(?:\*\*|__)\s*$"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\s{2,}"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\s+([,.;:!?])"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private enum Qwen3PostProcessorConfig {
+    static let envOverride = "MUESLI_QWEN3_POSTPROC_GGUF"
+    static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"
+    static let maxContextTokens: Int32 = 2048
+
+    static let systemPrompt = """
+    Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.
+
+    You may: fix obvious misspellings, remove filler words (um, uh, like), apply 'scratch that' deletions, and format numbered or bullet lists when dictated.
+
+    Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.
+    """
+
+    static let defaultCacheDirectory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".cache/muesli/models/qwen3-postproc-gguf", isDirectory: true)
+}
+
+private enum Qwen3PostProcessorModelStore {
+    static func resolvedModelURL() throws -> URL {
+        if let override = overrideModelURL() {
+            return override
+        }
+        if let cached = ggufURL(in: Qwen3PostProcessorConfig.defaultCacheDirectory) {
+            return cached
+        }
+        throw NSError(domain: "Qwen3PostProcessor", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Qwen3 post-processor GGUF not found. Set \(Qwen3PostProcessorConfig.envOverride) to a .gguf file or directory.",
+        ])
+    }
+
+    private static func overrideModelURL() -> URL? {
+        let env = ProcessInfo.processInfo.environment
+        if let raw = env[Qwen3PostProcessorConfig.envOverride], !raw.isEmpty {
+            return resolveOverride(raw)
+        }
+        if let raw = env[Qwen3PostProcessorConfig.legacyDirectoryEnvOverride], !raw.isEmpty {
+            return resolveOverride(raw)
+        }
+        return nil
+    }
+
+    private static func resolveOverride(_ raw: String) -> URL? {
+        let url = URL(fileURLWithPath: raw)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+        if isDirectory.boolValue {
+            return ggufURL(in: url)
+        }
+        return url.pathExtension.lowercased() == "gguf" ? url : nil
+    }
+
+    private static func ggufURL(in directory: URL) -> URL? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        for case let fileURL as URL in enumerator {
+            guard fileURL.pathExtension.lowercased() == "gguf" else { continue }
+            return fileURL
+        }
+        return nil
+    }
+}
+
+@available(macOS 15, *)
+private final class Qwen3PostProcessorManager {
+    private let modelURL: URL
+    private let template = Template.chatML(Qwen3PostProcessorConfig.systemPrompt)
+
+    init(modelURL: URL) {
+        self.modelURL = modelURL
+    }
+
+    func warm() throws {
+        _ = try makeBot()
+    }
+
+    func process(_ text: String) async throws -> String {
+        let bot = try makeBot()
+        let prompt = bot.preprocess(text, [], .suppressed)
+        let raw = await bot.getCompletion(from: prompt)
+        let cleaned = Qwen3PostProcessorOutputCleaner.clean(raw)
+        fputs("[muesli-native] Qwen3 GGUF prompt chars=\(prompt.count)\n", stderr)
+        fputs("[muesli-native] Qwen3 GGUF raw output: \(raw)\n", stderr)
+        fputs("[muesli-native] Qwen3 GGUF cleaned output: \(cleaned)\n", stderr)
+        return cleaned
+    }
+
+    private func makeBot() throws -> LLM {
+        guard let bot = LLM(
+            from: modelURL,
+            template: template,
+            seed: 7,
+            topK: 1,
+            topP: 1.0,
+            temp: 0.0,
+            repeatPenalty: 1.0,
+            repetitionLookback: 64,
+            historyLimit: 0,
+            maxTokenCount: Qwen3PostProcessorConfig.maxContextTokens
+        ) else {
+            throw NSError(domain: "Qwen3PostProcessor", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Failed to load Qwen3 GGUF model at \(modelURL.path)",
+            ])
+        }
+        return bot
+    }
+}
+
+@available(macOS 15, *)
+actor Qwen3PostProcessor {
+    private var manager: Qwen3PostProcessorManager?
+    private var loadTask: Task<Qwen3PostProcessorManager, Error>?
+
+    func prepare() async throws {
+        _ = try await loadManager()
+    }
+
+    func process(_ text: String) async throws -> String {
+        let manager = try await loadManager()
+        return try await manager.process(text)
+    }
+
+    func shutdown() {
+        manager = nil
+        loadTask?.cancel()
+        loadTask = nil
+    }
+
+    private func loadManager() async throws -> Qwen3PostProcessorManager {
+        if let manager {
+            return manager
+        }
+        if let loadTask {
+            return try await loadTask.value
+        }
+
+        let task = Task<Qwen3PostProcessorManager, Error> {
+            let modelURL = try Qwen3PostProcessorModelStore.resolvedModelURL()
+            let manager = Qwen3PostProcessorManager(modelURL: modelURL)
+            try manager.warm()
+            return manager
+        }
+        loadTask = task
+        do {
+            let loaded = try await task.value
+            manager = loaded
+            loadTask = nil
+            return loaded
+        } catch {
+            loadTask = nil
+            throw error
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -291,10 +291,17 @@ private actor Qwen3PostProcessorManager {
 
 @available(macOS 15, *)
 actor Qwen3PostProcessor {
+    private struct LoadTaskState {
+        let id = UUID()
+        let modelURL: URL
+        let systemPrompt: String
+        let task: Task<Qwen3PostProcessorManager, Error>
+    }
+
     private var modelURL: URL
     private var systemPrompt: String
     private var manager: Qwen3PostProcessorManager?
-    private var loadTask: Task<Qwen3PostProcessorManager, Error>?
+    private var loadTask: LoadTaskState?
 
     init(modelURL: URL, systemPrompt: String) {
         // Dev/Canary env-var override takes precedence.
@@ -310,7 +317,7 @@ actor Qwen3PostProcessor {
         self.modelURL = resolved
         self.systemPrompt = systemPrompt
         manager = nil
-        loadTask?.cancel()
+        loadTask?.task.cancel()
         loadTask = nil
     }
 
@@ -325,13 +332,13 @@ actor Qwen3PostProcessor {
 
     func shutdown() {
         manager = nil
-        loadTask?.cancel()
+        loadTask?.task.cancel()
         loadTask = nil
     }
 
     private func loadManager() async throws -> Qwen3PostProcessorManager {
         if let manager { return manager }
-        if let loadTask { return try await loadTask.value }
+        if let loadTask { return try await finishLoad(loadTask) }
 
         let url = self.modelURL
         let prompt = self.systemPrompt
@@ -345,14 +352,28 @@ actor Qwen3PostProcessor {
             try await manager.warm()
             return manager
         }
-        loadTask = task
+        let state = LoadTaskState(modelURL: url, systemPrompt: prompt, task: task)
+        loadTask = state
+        return try await finishLoad(state)
+    }
+
+    private func finishLoad(_ state: LoadTaskState) async throws -> Qwen3PostProcessorManager {
         do {
-            let loaded = try await task.value
+            let loaded = try await state.task.value
+            guard state.modelURL == modelURL, state.systemPrompt == systemPrompt else {
+                if loadTask?.id == state.id {
+                    loadTask = nil
+                }
+                return try await loadManager()
+            }
+            guard loadTask?.id == state.id else { throw CancellationError() }
             manager = loaded
             loadTask = nil
             return loaded
         } catch {
-            loadTask = nil
+            if loadTask?.id == state.id {
+                loadTask = nil
+            }
             throw error
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -1,6 +1,28 @@
 import Foundation
 import LLM
 
+enum Qwen3PostProcessorLogging {
+    private static let verboseEnv = "MUESLI_DEBUG_POSTPROC_LOGS"
+
+    static var isVerboseEnabled: Bool {
+        #if DEBUG
+        true
+        #else
+        let raw = ProcessInfo.processInfo.environment[verboseEnv]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "yes"
+        #endif
+    }
+
+    static func log(_ message: String) {
+        fputs("[muesli-native] \(message)\n", stderr)
+    }
+
+    static func logVerbose(_ message: @autoclosure () -> String) {
+        guard isVerboseEnabled else { return }
+        log(message())
+    }
+}
+
 enum Qwen3PostProcessingHeuristics {
     private static let formattingCues: [String] = [
         "bullet point", "bullet points", "number one", "number two", "number three",
@@ -62,6 +84,11 @@ enum Qwen3PostProcessorOutputCleaner {
             options: .regularExpression
         )
         result = result.replacingOccurrences(
+            of: #"(?is)<think\b[^>]*>[\s\S]*$"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
             of: #"<\|im_(?:start|end)\|>"#,
             with: " ",
             options: .regularExpression
@@ -92,6 +119,16 @@ enum Qwen3PostProcessorOutputCleaner {
             options: .regularExpression
         )
         result = result.replacingOccurrences(
+            of: #"(?im)^\s*when the speaker is dictating a numbered list or bullet list,\s*format each item on its own line\.?\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?im)^\s*if the speaker is dictating a list, such as saying ["“”]?first point["“”]?[,]?\s*["“”]?second point["“”]?[,]?\s*or ["“”]?bullet point["“”]?[,]?\s*format each item on its own line\.?\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
             of: #"(?im)^\s*(?:\*\*|__)([^*\n_]{1,80})(?:\*\*|__)\s*$"#,
             with: "$1",
             options: .regularExpression
@@ -108,106 +145,108 @@ enum Qwen3PostProcessorOutputCleaner {
         )
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    static func shouldFallbackToInput(cleaned: String, input: String) -> Bool {
+        let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+
+        let lower = trimmed.lowercased()
+        let assistantMarkers = [
+            "the user is asking",
+            "**analysis:**",
+            "analysis:",
+            "**action plan:**",
+            "action plan:",
+            "grammar/spelling:",
+            "meaning:",
+            "remove the filler word",
+        ]
+        if assistantMarkers.contains(where: { lower.contains($0) }) {
+            return true
+        }
+
+        let inputLength = max(input.trimmingCharacters(in: .whitespacesAndNewlines).count, 1)
+        return trimmed.count > inputLength * 4 && trimmed.count > 500
+    }
 }
 
 private enum Qwen3PostProcessorConfig {
+    // Dev/Canary override — takes precedence over the UI-selected model when set.
     static let envOverride = "MUESLI_QWEN3_POSTPROC_GGUF"
     static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"
-    static let maxContextTokens: Int32 = 2048
+    static let maxContextTokens: Int32 = 768
 
-    static let systemPrompt = """
-    Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.
-
-    You may: fix obvious misspellings, remove filler words (um, uh, like), apply 'scratch that' deletions, and format numbered or bullet lists when dictated.
-
-    Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.
-    """
-
-    static let defaultCacheDirectory = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".cache/muesli/models/qwen3-postproc-gguf", isDirectory: true)
-}
-
-private enum Qwen3PostProcessorModelStore {
-    static func resolvedModelURL() throws -> URL {
-        if let override = overrideModelURL() {
-            return override
-        }
-        if let cached = ggufURL(in: Qwen3PostProcessorConfig.defaultCacheDirectory) {
-            return cached
-        }
-        throw NSError(domain: "Qwen3PostProcessor", code: 1, userInfo: [
-            NSLocalizedDescriptionKey: "Qwen3 post-processor GGUF not found. Set \(Qwen3PostProcessorConfig.envOverride) to a .gguf file or directory.",
-        ])
+    static func formatInput(_ text: String) -> String {
+        """
+        <USER-INPUT>
+        \(text)
+        </USER-INPUT>
+        """
     }
 
-    private static func overrideModelURL() -> URL? {
+    /// Checks for a dev/Canary env-var override and returns the resolved GGUF URL if present.
+    static func devOverrideURL() -> URL? {
         let env = ProcessInfo.processInfo.environment
-        if let raw = env[Qwen3PostProcessorConfig.envOverride], !raw.isEmpty {
-            return resolveOverride(raw)
-        }
-        if let raw = env[Qwen3PostProcessorConfig.legacyDirectoryEnvOverride], !raw.isEmpty {
-            return resolveOverride(raw)
+        for key in [envOverride, legacyDirectoryEnvOverride] {
+            guard let raw = env[key], !raw.isEmpty else { continue }
+            let url = URL(fileURLWithPath: raw)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) else { continue }
+            if isDir.boolValue {
+                if let found = firstGGUF(in: url) { return found }
+            } else if url.pathExtension.lowercased() == "gguf" {
+                return url
+            }
         }
         return nil
     }
 
-    private static func resolveOverride(_ raw: String) -> URL? {
-        let url = URL(fileURLWithPath: raw)
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
-            return nil
-        }
-        if isDirectory.boolValue {
-            return ggufURL(in: url)
-        }
-        return url.pathExtension.lowercased() == "gguf" ? url : nil
-    }
-
-    private static func ggufURL(in directory: URL) -> URL? {
-        guard let enumerator = FileManager.default.enumerator(
-            at: directory,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return nil
-        }
-
-        for case let fileURL as URL in enumerator {
-            guard fileURL.pathExtension.lowercased() == "gguf" else { continue }
-            return fileURL
-        }
+    private static func firstGGUF(in directory: URL) -> URL? {
+        guard let e = FileManager.default.enumerator(
+            at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles]
+        ) else { return nil }
+        for case let f as URL in e where f.pathExtension.lowercased() == "gguf" { return f }
         return nil
     }
 }
 
 @available(macOS 15, *)
-private final class Qwen3PostProcessorManager {
+private actor Qwen3PostProcessorManager {
     private let modelURL: URL
-    private let template = Template.chatML(Qwen3PostProcessorConfig.systemPrompt)
+    private let systemPrompt: String
+    private var bot: LLM?
 
-    init(modelURL: URL) {
+    init(modelURL: URL, systemPrompt: String) {
         self.modelURL = modelURL
+        self.systemPrompt = systemPrompt
     }
 
     func warm() throws {
-        _ = try makeBot()
+        _ = try loadBot()
     }
 
     func process(_ text: String) async throws -> String {
-        let bot = try makeBot()
-        let prompt = bot.preprocess(text, [], .suppressed)
-        let raw = await bot.getCompletion(from: prompt)
+        let bot = try loadBot()
+        defer { bot.reset() }
+        let formattedInput = Qwen3PostProcessorConfig.formatInput(text)
+        bot.history = []
+        await bot.respond(to: formattedInput, thinking: .suppressed)
+        let raw = bot.output
         let cleaned = Qwen3PostProcessorOutputCleaner.clean(raw)
-        fputs("[muesli-native] Qwen3 GGUF prompt chars=\(prompt.count)\n", stderr)
-        fputs("[muesli-native] Qwen3 GGUF raw output: \(raw)\n", stderr)
-        fputs("[muesli-native] Qwen3 GGUF cleaned output: \(cleaned)\n", stderr)
+        Qwen3PostProcessorLogging.log("Qwen3 GGUF prompt chars=\(bot.preprocess(formattedInput, [], .suppressed).count)")
+        Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF raw output: \(raw)")
+        Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF cleaned output: \(cleaned)")
+        if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: cleaned, input: text) {
+            Qwen3PostProcessorLogging.log("Qwen3 GGUF output rejected; falling back to raw ASR transcript")
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         return cleaned
     }
 
-    private func makeBot() throws -> LLM {
-        guard let bot = LLM(
+    private func loadBot() throws -> LLM {
+        if let bot { return bot }
+        guard let loaded = LLM(
             from: modelURL,
-            template: template,
             seed: 7,
             topK: 1,
             topP: 1.0,
@@ -221,14 +260,36 @@ private final class Qwen3PostProcessorManager {
                 NSLocalizedDescriptionKey: "Failed to load Qwen3 GGUF model at \(modelURL.path)",
             ])
         }
-        return bot
+        loaded.useResolvedTemplate(systemPrompt: systemPrompt)
+        bot = loaded
+        return loaded
     }
 }
 
 @available(macOS 15, *)
 actor Qwen3PostProcessor {
+    private var modelURL: URL
+    private var systemPrompt: String
     private var manager: Qwen3PostProcessorManager?
     private var loadTask: Task<Qwen3PostProcessorManager, Error>?
+
+    init(modelURL: URL, systemPrompt: String) {
+        // Dev/Canary env-var override takes precedence.
+        self.modelURL = Qwen3PostProcessorConfig.devOverrideURL() ?? modelURL
+        self.systemPrompt = systemPrompt
+    }
+
+    /// Swap to a different model or system prompt. Discards the loaded manager so
+    /// the next `prepare()` or `process()` call reloads with the new config.
+    func reconfigure(modelURL: URL, systemPrompt: String) {
+        let resolved = Qwen3PostProcessorConfig.devOverrideURL() ?? modelURL
+        guard resolved != self.modelURL || systemPrompt != self.systemPrompt else { return }
+        self.modelURL = resolved
+        self.systemPrompt = systemPrompt
+        manager = nil
+        loadTask?.cancel()
+        loadTask = nil
+    }
 
     func prepare() async throws {
         _ = try await loadManager()
@@ -246,17 +307,19 @@ actor Qwen3PostProcessor {
     }
 
     private func loadManager() async throws -> Qwen3PostProcessorManager {
-        if let manager {
-            return manager
-        }
-        if let loadTask {
-            return try await loadTask.value
-        }
+        if let manager { return manager }
+        if let loadTask { return try await loadTask.value }
 
+        let url = self.modelURL
+        let prompt = self.systemPrompt
         let task = Task<Qwen3PostProcessorManager, Error> {
-            let modelURL = try Qwen3PostProcessorModelStore.resolvedModelURL()
-            let manager = Qwen3PostProcessorManager(modelURL: modelURL)
-            try manager.warm()
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw NSError(domain: "Qwen3PostProcessor", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Post-processor model not found at \(url.path). Download it from the Models tab.",
+                ])
+            }
+            let manager = Qwen3PostProcessorManager(modelURL: url, systemPrompt: prompt)
+            try await manager.warm()
             return manager
         }
         loadTask = task

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -127,6 +127,7 @@ enum Qwen3PostProcessorOutputCleaner {
         }
 
         let inputLength = max(input.trimmingCharacters(in: .whitespacesAndNewlines).count, 1)
+        // Cleanup should usually compress text. Treat large expansion as a hallucination signal.
         return Double(trimmed.count) > Double(inputLength) * 2.0 && trimmed.count > 200
     }
 }
@@ -190,6 +191,7 @@ private actor Qwen3PostProcessorManager {
     }
 
     func process(_ text: String) async throws -> String {
+        // Actors can re-enter while respond() awaits; serialize access to the cached mutable LLM.
         await acquireInferenceSlot()
         defer { releaseInferenceSlot() }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -173,13 +173,58 @@ enum Qwen3PostProcessorConfig {
     }
 }
 
+actor Qwen3InferenceGate {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var isProcessing = false
+    private var waiters: [Waiter] = []
+
+    func acquire() async throws {
+        try Task.checkCancellation()
+        if !isProcessing {
+            isProcessing = true
+            return
+        }
+
+        let id = UUID()
+        let acquired = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                waiters.append(Waiter(id: id, continuation: continuation))
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+        guard acquired else { throw CancellationError() }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            isProcessing = false
+            return
+        }
+
+        waiters.removeFirst().continuation.resume(returning: true)
+    }
+
+    func queuedWaiterCount() -> Int {
+        waiters.count
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        waiters.remove(at: index).continuation.resume(returning: false)
+    }
+}
+
 @available(macOS 15, *)
 private actor Qwen3PostProcessorManager {
     private let modelURL: URL
     private let systemPrompt: String
     private var bot: LLM?
-    private var isProcessing = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private let inferenceGate = Qwen3InferenceGate()
 
     init(modelURL: URL, systemPrompt: String) {
         self.modelURL = modelURL
@@ -192,43 +237,31 @@ private actor Qwen3PostProcessorManager {
 
     func process(_ text: String) async throws -> String {
         // Actors can re-enter while respond() awaits; serialize access to the cached mutable LLM.
-        await acquireInferenceSlot()
-        defer { releaseInferenceSlot() }
-
-        let bot = try loadBot()
-        defer { bot.reset() }
-        let formattedInput = Qwen3PostProcessorConfig.formatInput(text)
-        await bot.respond(to: formattedInput, thinking: .suppressed)
-        let raw = bot.output
-        let cleaned = Qwen3PostProcessorOutputCleaner.clean(raw)
-        Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF prompt chars=\(bot.preprocess(formattedInput, [], .suppressed).count)")
-        Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF raw output: \(raw)")
-        Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF cleaned output: \(cleaned)")
-        if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: cleaned, input: text) {
-            Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF output rejected; falling back to raw ASR transcript")
-            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        try await inferenceGate.acquire()
+        do {
+            try Task.checkCancellation()
+            let bot = try loadBot()
+            defer { bot.reset() }
+            let formattedInput = Qwen3PostProcessorConfig.formatInput(text)
+            await bot.respond(to: formattedInput, thinking: .suppressed)
+            let raw = bot.output
+            let cleaned = Qwen3PostProcessorOutputCleaner.clean(raw)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF prompt chars=\(bot.preprocess(formattedInput, [], .suppressed).count)")
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF raw output: \(raw)")
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF cleaned output: \(cleaned)")
+            let result: String
+            if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: cleaned, input: text) {
+                Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF output rejected; falling back to raw ASR transcript")
+                result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                result = cleaned
+            }
+            await inferenceGate.release()
+            return result
+        } catch {
+            await inferenceGate.release()
+            throw error
         }
-        return cleaned
-    }
-
-    private func acquireInferenceSlot() async {
-        if !isProcessing {
-            isProcessing = true
-            return
-        }
-
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
-        }
-    }
-
-    private func releaseInferenceSlot() {
-        if waiters.isEmpty {
-            isProcessing = false
-            return
-        }
-
-        waiters.removeFirst().resume()
     }
 
     private func loadBot() throws -> LLM {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -176,6 +176,8 @@ private actor Qwen3PostProcessorManager {
     private let modelURL: URL
     private let systemPrompt: String
     private var bot: LLM?
+    private var isProcessing = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
 
     init(modelURL: URL, systemPrompt: String) {
         self.modelURL = modelURL
@@ -187,6 +189,9 @@ private actor Qwen3PostProcessorManager {
     }
 
     func process(_ text: String) async throws -> String {
+        await acquireInferenceSlot()
+        defer { releaseInferenceSlot() }
+
         let bot = try loadBot()
         defer { bot.reset() }
         let formattedInput = Qwen3PostProcessorConfig.formatInput(text)
@@ -201,6 +206,26 @@ private actor Qwen3PostProcessorManager {
             return text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return cleaned
+    }
+
+    private func acquireInferenceSlot() async {
+        if !isProcessing {
+            isProcessing = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func releaseInferenceSlot() {
+        if waiters.isEmpty {
+            isProcessing = false
+            return
+        }
+
+        waiters.removeFirst().resume()
     }
 
     private func loadBot() throws -> LLM {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -3,14 +3,16 @@ import LLM
 
 enum Qwen3PostProcessorLogging {
     private static let verboseEnv = "MUESLI_DEBUG_POSTPROC_LOGS"
+    private static let pairLogEnv = "MUESLI_LOG_POSTPROC_PAIRS"
 
     static var isVerboseEnabled: Bool {
-        #if DEBUG
-        true
-        #else
         let raw = ProcessInfo.processInfo.environment[verboseEnv]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return raw == "1" || raw == "true" || raw == "yes"
-        #endif
+    }
+
+    static var isPairLoggingEnabled: Bool {
+        let raw = ProcessInfo.processInfo.environment[pairLogEnv]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "yes"
     }
 
     static func log(_ message: String) {
@@ -23,53 +25,14 @@ enum Qwen3PostProcessorLogging {
     }
 }
 
-enum Qwen3PostProcessingHeuristics {
-    private static let formattingCues: [String] = [
-        "bullet point", "bullet points", "number one", "number two", "number three",
-        "new paragraph", "new line", "next line", "comma", "period", "full stop",
-        "question mark", "exclamation point", "colon", "semicolon", "open quote",
-        "close quote", "open parenthesis", "close parenthesis",
-    ]
-
+enum Qwen3DeletionCueDetector {
     private static let deletionCues: [String] = [
         "scratch that", "delete that", "forget that", "never mind",
     ]
 
-    static func shouldApply(to text: String) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        if FillerWordFilter.apply(trimmed) != trimmed { return true }
-        return containsDeletionCue(trimmed) || containsFormattingCue(trimmed)
-    }
-
-    static func triggerLabels(for text: String) -> [String] {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-
-        var labels: [String] = []
-        if FillerWordFilter.apply(trimmed) != trimmed {
-            labels.append("fillers")
-        }
-        if containsDeletionCue(trimmed) {
-            labels.append("deletion")
-        }
-        if containsFormattingCue(trimmed) {
-            labels.append("formatting")
-        }
-        return labels
-    }
-
     static func containsDeletionCue(_ text: String) -> Bool {
-        containsPhrase(in: text, phrases: deletionCues)
-    }
-
-    static func containsFormattingCue(_ text: String) -> Bool {
-        containsPhrase(in: text, phrases: formattingCues)
-    }
-
-    private static func containsPhrase(in text: String, phrases: [String]) -> Bool {
         let lower = text.lowercased()
-        return phrases.contains { lower.contains($0) }
+        return deletionCues.contains { lower.contains($0) }
     }
 }
 
@@ -229,7 +192,6 @@ private actor Qwen3PostProcessorManager {
         let bot = try loadBot()
         defer { bot.reset() }
         let formattedInput = Qwen3PostProcessorConfig.formatInput(text)
-        bot.history = []
         await bot.respond(to: formattedInput, thinking: .suppressed)
         let raw = bot.output
         let cleaned = Qwen3PostProcessorOutputCleaner.clean(raw)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -251,8 +251,10 @@ private actor Qwen3PostProcessorManager {
             Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF cleaned output: \(cleaned)")
             let result: String
             if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: cleaned, input: text) {
-                Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF output rejected; falling back to raw ASR transcript")
-                result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF output rejected; falling back to deterministic cleanup")
+                throw NSError(domain: "Qwen3PostProcessor", code: 4, userInfo: [
+                    NSLocalizedDescriptionKey: "Qwen3 GGUF output was rejected by transcript safety checks",
+                ])
             } else {
                 result = cleaned
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -366,6 +366,7 @@ actor Qwen3PostProcessor {
                 }
                 return try await loadManager()
             }
+            if let manager { return manager }
             guard loadTask?.id == state.id else { throw CancellationError() }
             manager = loaded
             loadTask = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -134,6 +134,7 @@ enum Qwen3PostProcessorConfig {
     // Dev/Canary override — takes precedence over the UI-selected model when set.
     static let envOverride = "MUESLI_QWEN3_POSTPROC_GGUF"
     static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"
+    // Dictation-only cleanup cap. Keep bounded to avoid slow local inference; long dictations may be truncated by LLM.swift.
     static let maxContextTokens: Int32 = 768
 
     static func formatInput(_ text: String) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -78,6 +78,7 @@ enum Qwen3PostProcessorOutputCleaner {
             with: "",
             options: .regularExpression
         )
+        // Observed model leakage from earlier prompt variants. Keep narrow so normal transcript text is not rewritten.
         result = result.replacingOccurrences(
             of: #"(?im)^\s*when the speaker is dictating a numbered list or bullet list,\s*format each item on its own line\.?\s*"#,
             with: "",
@@ -126,7 +127,7 @@ enum Qwen3PostProcessorOutputCleaner {
         }
 
         let inputLength = max(input.trimmingCharacters(in: .whitespacesAndNewlines).count, 1)
-        return trimmed.count > inputLength * 4 && trimmed.count > 500
+        return Double(trimmed.count) > Double(inputLength) * 2.0 && trimmed.count > 200
     }
 }
 
@@ -135,7 +136,7 @@ enum Qwen3PostProcessorConfig {
     static let envOverride = "MUESLI_QWEN3_POSTPROC_GGUF"
     static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"
     // Dictation-only cleanup cap. Keep bounded to avoid slow local inference; long dictations may be truncated by LLM.swift.
-    static let maxContextTokens: Int32 = 768
+    static let maxContextTokens: Int32 = 1024
 
     static func formatInput(_ text: String) -> String {
         """

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -11,17 +11,14 @@ enum Qwen3PostProcessorLogging {
     }
 
     static var isPairLoggingEnabled: Bool {
+        guard isVerboseEnabled else { return false }
         let raw = ProcessInfo.processInfo.environment[pairLogEnv]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return raw == "1" || raw == "true" || raw == "yes"
     }
 
-    static func log(_ message: String) {
-        fputs("[muesli-native] \(message)\n", stderr)
-    }
-
     static func logVerbose(_ message: @autoclosure () -> String) {
         guard isVerboseEnabled else { return }
-        log(message())
+        fputs("[muesli-native] \(message())\n", stderr)
     }
 }
 
@@ -195,11 +192,11 @@ private actor Qwen3PostProcessorManager {
         await bot.respond(to: formattedInput, thinking: .suppressed)
         let raw = bot.output
         let cleaned = Qwen3PostProcessorOutputCleaner.clean(raw)
-        Qwen3PostProcessorLogging.log("Qwen3 GGUF prompt chars=\(bot.preprocess(formattedInput, [], .suppressed).count)")
+        Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF prompt chars=\(bot.preprocess(formattedInput, [], .suppressed).count)")
         Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF raw output: \(raw)")
         Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF cleaned output: \(cleaned)")
         if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: cleaned, input: text) {
-            Qwen3PostProcessorLogging.log("Qwen3 GGUF output rejected; falling back to raw ASR transcript")
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 GGUF output rejected; falling back to raw ASR transcript")
             return text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return cleaned

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -51,7 +51,7 @@ struct SettingsView: View {
     /// Downloaded backends, always including the currently active one so the picker never goes blank.
     private var availableBackendOptions: [BackendOption] {
         var options = BackendOption.downloaded
-        if !options.contains(where: { $0.backend == appState.selectedBackend.backend }) {
+        if !options.contains(where: { $0 == appState.selectedBackend }) {
             options.insert(appState.selectedBackend, at: 0)
         }
         return options
@@ -59,7 +59,7 @@ struct SettingsView: View {
 
     /// Post-processor models that have been downloaded to disk.
     private var downloadedPostProcOptions: [PostProcessorOption] {
-        PostProcessorOption.all.filter { $0.isDownloaded }
+        PostProcessorOption.downloaded
     }
 
     var body: some View {
@@ -104,8 +104,7 @@ struct SettingsView: View {
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("AI transcript cleanup") {
                         settingsSwitch(isOn: appState.config.enablePostProcessor) { newValue in
-                            controller.updateConfig { $0.enablePostProcessor = newValue }
-                            controller.preloadExperimentalTranscriptionFeatures()
+                            controller.setPostProcessorEnabled(newValue)
                         }
                     }
                     if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
@@ -122,6 +121,15 @@ struct SettingsView: View {
                                     controller.selectPostProcessor(option)
                                 }
                             }
+                        }
+                    } else if appState.config.enablePostProcessor {
+                        Divider().background(MuesliTheme.surfaceBorder)
+                        settingsRow("Cleanup model") {
+                            Text("Download a cleanup model in Models")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: controlWidth, alignment: .trailing)
                         }
                     }
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -87,6 +87,13 @@ struct SettingsView: View {
                             }
                         }
                     }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("AI transcript cleanup") {
+                        settingsSwitch(isOn: appState.config.enablePostProcessor) { newValue in
+                            controller.updateConfig { $0.enablePostProcessor = newValue }
+                            controller.preloadExperimentalTranscriptionFeatures()
+                        }
+                    }
                 }
 
                 settingsSection("Meetings") {
@@ -872,4 +879,3 @@ private extension NSColor {
         return String(format: "%02x%02x%02x", r, g, b)
     }
 }
-

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -48,6 +48,20 @@ struct SettingsView: View {
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
 
+    /// Downloaded backends, always including the currently active one so the picker never goes blank.
+    private var availableBackendOptions: [BackendOption] {
+        var options = BackendOption.downloaded
+        if !options.contains(where: { $0.backend == appState.selectedBackend.backend }) {
+            options.insert(appState.selectedBackend, at: 0)
+        }
+        return options
+    }
+
+    /// Post-processor models that have been downloaded to disk.
+    private var downloadedPostProcOptions: [PostProcessorOption] {
+        PostProcessorOption.all.filter { $0.isDownloaded }
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
@@ -80,9 +94,9 @@ struct SettingsView: View {
                     settingsRow("Backend") {
                         settingsMenu(
                             selection: appState.selectedBackend.label,
-                            options: BackendOption.all.map(\.label)
+                            options: availableBackendOptions.map(\.label)
                         ) { label in
-                            if let option = BackendOption.all.first(where: { $0.label == label }) {
+                            if let option = availableBackendOptions.first(where: { $0.label == label }) {
                                 controller.selectBackend(option)
                             }
                         }
@@ -92,6 +106,22 @@ struct SettingsView: View {
                         settingsSwitch(isOn: appState.config.enablePostProcessor) { newValue in
                             controller.updateConfig { $0.enablePostProcessor = newValue }
                             controller.preloadExperimentalTranscriptionFeatures()
+                        }
+                    }
+                    if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
+                        Divider().background(MuesliTheme.surfaceBorder)
+                        settingsRow("Cleanup model") {
+                            let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
+                                ? appState.activePostProcessor.label
+                                : (downloadedPostProcOptions.first?.label ?? "")
+                            settingsMenu(
+                                selection: selection,
+                                options: downloadedPostProcOptions.map(\.label)
+                            ) { label in
+                                if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
+                                    controller.selectPostProcessor(option)
+                                }
+                            }
                         }
                     }
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -44,18 +44,14 @@ struct SettingsView: View {
     @State private var pendingDataDestruction: PendingDataDestruction?
     @State private var recordingColorInput: String = ""
     @State private var isPreviewingClip = false
+    @State private var availableBackendOptions: [BackendOption] = []
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
 
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
 
-    /// Downloaded backends, always including the currently active one so the picker never goes blank.
-    private var availableBackendOptions: [BackendOption] {
-        var options = BackendOption.downloaded
-        if !options.contains(where: { $0 == appState.selectedBackend }) {
-            options.insert(appState.selectedBackend, at: 0)
-        }
-        return options
+    private var displayedBackendOptions: [BackendOption] {
+        availableBackendOptions.isEmpty ? [appState.selectedBackend] : availableBackendOptions
     }
 
     var body: some View {
@@ -90,9 +86,9 @@ struct SettingsView: View {
                     settingsRow("Backend") {
                         settingsMenu(
                             selection: appState.selectedBackend.label,
-                            options: availableBackendOptions.map(\.label)
+                            options: displayedBackendOptions.map(\.label)
                         ) { label in
-                            if let option = availableBackendOptions.first(where: { $0.label == label }) {
+                            if let option = displayedBackendOptions.first(where: { $0.label == label }) {
                                 controller.selectBackend(option)
                             }
                         }
@@ -521,12 +517,15 @@ struct SettingsView: View {
         }
         .background(MuesliTheme.backgroundBase)
         .onAppear {
-            refreshDownloadedPostProcOptions()
+            refreshDownloadedModelOptions()
         }
         .onChange(of: appState.selectedTab) { _, tab in
             if tab == .settings {
-                refreshDownloadedPostProcOptions()
+                refreshDownloadedModelOptions()
             }
+        }
+        .onChange(of: appState.selectedBackend) { _, _ in
+            refreshAvailableBackendOptions()
         }
         .alert(
             pendingDataDestruction?.title ?? "Confirm Destructive Action",
@@ -554,8 +553,17 @@ struct SettingsView: View {
         }
     }
 
-    private func refreshDownloadedPostProcOptions() {
+    private func refreshDownloadedModelOptions() {
+        refreshAvailableBackendOptions()
         downloadedPostProcOptions = PostProcessorOption.downloaded
+    }
+
+    private func refreshAvailableBackendOptions() {
+        var options = BackendOption.downloaded
+        if !options.contains(where: { $0 == appState.selectedBackend }) {
+            options.insert(appState.selectedBackend, at: 0)
+        }
+        availableBackendOptions = options
     }
 
     private static let accentPresets: [(hex: String, name: String)] = [

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -44,6 +44,7 @@ struct SettingsView: View {
     @State private var pendingDataDestruction: PendingDataDestruction?
     @State private var recordingColorInput: String = ""
     @State private var isPreviewingClip = false
+    @State private var downloadedPostProcOptions: [PostProcessorOption] = []
 
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
@@ -55,11 +56,6 @@ struct SettingsView: View {
             options.insert(appState.selectedBackend, at: 0)
         }
         return options
-    }
-
-    /// Post-processor models that have been downloaded to disk.
-    private var downloadedPostProcOptions: [PostProcessorOption] {
-        PostProcessorOption.downloaded
     }
 
     var body: some View {
@@ -524,6 +520,14 @@ struct SettingsView: View {
             .padding(MuesliTheme.spacing32)
         }
         .background(MuesliTheme.backgroundBase)
+        .onAppear {
+            refreshDownloadedPostProcOptions()
+        }
+        .onChange(of: appState.selectedTab) { _, tab in
+            if tab == .settings {
+                refreshDownloadedPostProcOptions()
+            }
+        }
         .alert(
             pendingDataDestruction?.title ?? "Confirm Destructive Action",
             isPresented: Binding(
@@ -548,6 +552,10 @@ struct SettingsView: View {
         } message: {
             Text(pendingDataDestruction?.message ?? "")
         }
+    }
+
+    private func refreshDownloadedPostProcOptions() {
+        downloadedPostProcOptions = PostProcessorOption.downloaded
     }
 
     private static let accentPresets: [(hex: String, name: String)] = [

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -239,6 +239,7 @@ actor TranscriptionCoordinator {
         enablePostProcessor: Bool = false,
         customWords: [[String: Any]] = []
     ) async throws -> SpeechTranscriptionResult {
+        // Qwen3 post-processing is intentionally dictation-only. Meeting transcription should keep raw backend/Parakeet output.
         // Cohere decodes hallucinated text from silence — skip if VAD detects no speech
         if backend.backend == "cohere", let vadManager {
             do {
@@ -269,14 +270,13 @@ actor TranscriptionCoordinator {
         return final
     }
 
-    func transcribeMeeting(at url: URL, backend: BackendOption, customWords: [[String: Any]] = []) async throws -> SpeechTranscriptionResult {
-        var result = try await route(url: url, backend: backend)
-        result = removeArtifacts(result)
-        result = removeFillers(result)
-        return applyCustomWords(result, customWords: customWords)
+    func transcribeMeeting(at url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
+        // Meeting transcription intentionally returns raw backend/Parakeet output. Do not run transcript cleanup here.
+        try await route(url: url, backend: backend)
     }
 
-    func transcribeMeetingChunk(at url: URL, backend: BackendOption, customWords: [[String: Any]] = []) async throws -> SpeechTranscriptionResult {
+    func transcribeMeetingChunk(at url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
+        // Meeting chunks intentionally return raw backend/Parakeet output for reconciliation. Do not run transcript cleanup here.
         // Run VAD to skip silent chunks (prevents hallucinations)
         if let vadManager {
             do {
@@ -290,10 +290,7 @@ actor TranscriptionCoordinator {
                 fputs("[muesli-native] VAD check failed, transcribing anyway: \(error)\n", stderr)
             }
         }
-        var result = try await route(url: url, backend: backend)
-        result = removeArtifacts(result)
-        result = removeFillers(result)
-        return applyCustomWords(result, customWords: customWords)
+        return try await route(url: url, backend: backend)
     }
 
     func diarizeSystemAudio(at url: URL) async throws -> DiarizationResult? {
@@ -385,6 +382,7 @@ actor TranscriptionCoordinator {
             logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
             return SpeechTranscriptionResult(
                 text: trimmed,
+                // Original ASR segments describe pre-cleanup text. Keep them only for debug diagnostics.
                 segments: Qwen3PostProcessorLogging.isVerboseEnabled && !trimmed.isEmpty ? result.segments : []
             )
         } catch {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -374,6 +374,8 @@ actor TranscriptionCoordinator {
         }
 
         do {
+            // The explicit toggle means "always try cleanup" for dictation.
+            // Trigger heuristics were removed; the only remaining heuristic here preserves deletion-cue empty output.
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor forced by toggle")
             let start = CFAbsoluteTimeGetCurrent()
             let processed = try await qwen3PostProcessor.process(result.text)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -55,12 +55,27 @@ actor TranscriptionCoordinator {
         return _canaryQwenTranscriber as! CanaryQwenTranscriber
     }
 
+    private var postProcessorModelURL: URL = PostProcessorOption.finetunedV2.modelURL
+    private var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
+
     @available(macOS 15, *)
     private var qwen3PostProcessor: Qwen3PostProcessor {
         if _qwen3PostProcessor == nil {
-            _qwen3PostProcessor = Qwen3PostProcessor()
+            _qwen3PostProcessor = Qwen3PostProcessor(
+                modelURL: postProcessorModelURL,
+                systemPrompt: postProcessorSystemPrompt
+            )
         }
         return _qwen3PostProcessor as! Qwen3PostProcessor
+    }
+
+    @available(macOS 15, *)
+    func setActivePostProcessor(option: PostProcessorOption, systemPrompt: String) async {
+        postProcessorModelURL = option.modelURL
+        postProcessorSystemPrompt = systemPrompt
+        if let existing = _qwen3PostProcessor as? Qwen3PostProcessor {
+            await existing.reconfigure(modelURL: option.modelURL, systemPrompt: systemPrompt)
+        }
     }
 
     @available(macOS 15, *)
@@ -165,7 +180,11 @@ actor TranscriptionCoordinator {
             fputs("[muesli-native] unknown backend: \(backend.backend)\n", stderr)
         }
 
-        if enablePostProcessor, #available(macOS 15, *) {
+        await preloadPostProcessorIfNeeded(enabled: enablePostProcessor)
+    }
+
+    func preloadPostProcessorIfNeeded(enabled: Bool) async {
+        if enabled, #available(macOS 15, *) {
             do {
                 try await qwen3PostProcessor.prepare()
             } catch {
@@ -314,7 +333,9 @@ actor TranscriptionCoordinator {
         }
 
         do {
-            fputs("[muesli-native] Qwen3 post-processor forced by toggle\n", stderr)
+            // Prototype mode intentionally runs cleanup on every dictation while the toggle is on.
+            // Keep the heuristics in place for a future smart-mode gate once prompt/model behavior stabilizes.
+            fputs("[muesli-native] Qwen3 post-processor forced by toggle (prototype mode)\n", stderr)
             let start = CFAbsoluteTimeGetCurrent()
             let processed = try await qwen3PostProcessor.process(result.text)
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
@@ -323,7 +344,8 @@ actor TranscriptionCoordinator {
                 fputs("[muesli-native] Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back\n", stderr)
                 return nil
             }
-            fputs("[muesli-native] Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms -> \(trimmed)\n", stderr)
+            fputs("[muesli-native] Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor final output: \(trimmed)")
             return SpeechTranscriptionResult(
                 text: trimmed,
                 segments: trimmed.isEmpty ? [] : result.segments

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -228,7 +228,7 @@ actor TranscriptionCoordinator {
             do {
                 try await qwen3PostProcessor.prepare()
             } catch {
-                fputs("[muesli-native] Qwen3 post-processor preload failed: \(error)\n", stderr)
+                Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor preload failed: \(error)")
             }
         }
     }
@@ -358,37 +358,37 @@ actor TranscriptionCoordinator {
         enabled: Bool
     ) async -> SpeechTranscriptionResult? {
         guard enabled else {
-            fputs("[muesli-native] Qwen3 post-processor disabled for dictation\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor disabled for dictation")
             return nil
         }
         guard !result.text.isEmpty else {
-            fputs("[muesli-native] Qwen3 post-processor skipped: empty transcript\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor skipped: empty transcript")
             return nil
         }
         guard #available(macOS 15, *) else {
-            fputs("[muesli-native] Qwen3 post-processor skipped: requires macOS 15+\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor skipped: requires macOS 15+")
             return nil
         }
 
         do {
-            fputs("[muesli-native] Qwen3 post-processor forced by toggle (prototype mode)\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor forced by toggle")
             let start = CFAbsoluteTimeGetCurrent()
             let processed = try await qwen3PostProcessor.process(result.text)
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
             let trimmed = processed.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
-                fputs("[muesli-native] Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back\n", stderr)
+                Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
                 return nil
             }
-            fputs("[muesli-native] Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor final output: \(trimmed)")
             logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
             return SpeechTranscriptionResult(
                 text: trimmed,
-                segments: trimmed.isEmpty ? [] : result.segments
+                segments: Qwen3PostProcessorLogging.isVerboseEnabled && !trimmed.isEmpty ? result.segments : []
             )
         } catch {
-            fputs("[muesli-native] Qwen3 post-processor failed, falling back: \(error)\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor failed, falling back: \(error)")
             return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -271,12 +271,12 @@ actor TranscriptionCoordinator {
     }
 
     func transcribeMeeting(at url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
-        // Meeting transcription intentionally returns raw backend/Parakeet output. Do not run transcript cleanup here.
-        try await route(url: url, backend: backend)
+        // Meetings intentionally skip Qwen/custom-word post-processing. Keep deterministic artifact/filler cleanup only.
+        cleanMeetingTranscript(try await route(url: url, backend: backend))
     }
 
     func transcribeMeetingChunk(at url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
-        // Meeting chunks intentionally return raw backend/Parakeet output for reconciliation. Do not run transcript cleanup here.
+        // Meeting chunks intentionally skip Qwen/custom-word post-processing for reconciliation.
         // Run VAD to skip silent chunks (prevents hallucinations)
         if let vadManager {
             do {
@@ -290,7 +290,7 @@ actor TranscriptionCoordinator {
                 fputs("[muesli-native] VAD check failed, transcribing anyway: \(error)\n", stderr)
             }
         }
-        return try await route(url: url, backend: backend)
+        return cleanMeetingTranscript(try await route(url: url, backend: backend))
     }
 
     func diarizeSystemAudio(at url: URL) async throws -> DiarizationResult? {
@@ -339,11 +339,15 @@ actor TranscriptionCoordinator {
         let filtered = removeFillers(result)
         let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
         if filtered.text != result.text {
-            fputs("[muesli-native] FillerWordFilter applied in \(String(format: "%.1f", elapsedMs))ms -> \(filtered.text)\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("FillerWordFilter applied in \(String(format: "%.1f", elapsedMs))ms -> \(filtered.text)")
         } else {
-            fputs("[muesli-native] FillerWordFilter skipped effective changes (\(String(format: "%.1f", elapsedMs))ms)\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("FillerWordFilter skipped effective changes (\(String(format: "%.1f", elapsedMs))ms)")
         }
         return filtered
+    }
+
+    private func cleanMeetingTranscript(_ result: SpeechTranscriptionResult) -> SpeechTranscriptionResult {
+        removeFillers(removeArtifacts(result))
     }
 
     private func removeArtifacts(_ result: SpeechTranscriptionResult) -> SpeechTranscriptionResult {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -55,9 +55,9 @@ actor TranscriptionCoordinator {
         return _canaryQwenTranscriber as! CanaryQwenTranscriber
     }
 
-    private var postProcessorModelURL: URL = PostProcessorOption.finetunedV2.modelURL
+    private var postProcessorModelURL: URL = PostProcessorOption.defaultOption.modelURL
     private var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
-    private var postProcessorModelId: String = PostProcessorOption.finetunedV2.id
+    private var postProcessorModelId: String = PostProcessorOption.defaultOption.id
 
     @available(macOS 15, *)
     private var qwen3PostProcessor: Qwen3PostProcessor {
@@ -80,25 +80,37 @@ actor TranscriptionCoordinator {
         }
     }
 
+    private struct PostProcPairLogEntry: Encodable {
+        let ts: String
+        let raw: String
+        let processed: String
+        let model: String
+        let asr: String
+    }
+
     private func logPostProcPair(raw: String, processed: String, asr: String) {
         let logURL = AppIdentity.supportDirectoryURL.appendingPathComponent("postproc-pairs.jsonl")
         let iso8601 = ISO8601DateFormatter()
         iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let ts = iso8601.string(from: Date())
-        func jsonEscape(_ s: String) -> String {
-            s.replacingOccurrences(of: "\\", with: "\\\\")
-             .replacingOccurrences(of: "\"", with: "\\\"")
-             .replacingOccurrences(of: "\n", with: "\\n")
-             .replacingOccurrences(of: "\r", with: "\\r")
-             .replacingOccurrences(of: "\t", with: "\\t")
-        }
-        let line = "{\"ts\":\"\(ts)\",\"raw\":\"\(jsonEscape(raw))\",\"processed\":\"\(jsonEscape(processed))\",\"model\":\"\(jsonEscape(postProcessorModelId))\",\"asr\":\"\(jsonEscape(asr))\"}\n"
-        guard let data = line.data(using: .utf8) else { return }
+        let entry = PostProcPairLogEntry(
+            ts: ts,
+            raw: raw,
+            processed: processed,
+            model: postProcessorModelId,
+            asr: asr
+        )
+        guard var data = try? JSONEncoder().encode(entry) else { return }
+        data.append(0x0A)
+        try? FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         if FileManager.default.fileExists(atPath: logURL.path) {
             if let fh = try? FileHandle(forWritingTo: logURL) {
+                defer { try? fh.close() }
                 fh.seekToEndOfFile()
                 fh.write(data)
-                try? fh.close()
             }
         } else {
             try? data.write(to: logURL, options: .atomic)
@@ -242,16 +254,16 @@ actor TranscriptionCoordinator {
         var result = try await route(url: url, backend: backend)
         result = removeArtifacts(result)
         if !result.text.isEmpty {
-            fputs("[muesli-native] Dictation raw transcript after artifact cleanup: \(result.text)\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Dictation raw transcript after artifact cleanup: \(result.text)")
         }
-        result = try await postProcessDictationIfNeeded(
+        result = await postProcessDictationIfNeeded(
             result,
             backend: backend,
             enabled: enablePostProcessor
         ) ?? removeFillersWithLogging(result)
         let final = applyCustomWords(result, customWords: customWords)
         if !final.text.isEmpty {
-            fputs("[muesli-native] Dictation final transcript: \(final.text)\n", stderr)
+            Qwen3PostProcessorLogging.logVerbose("Dictation final transcript: \(final.text)")
         }
         return final
     }
@@ -305,17 +317,15 @@ actor TranscriptionCoordinator {
         diarizerManager
     }
 
-    func shutdown() {
-        Task {
-            await fluidTranscriber.shutdown()
-            await whisperTranscriber.shutdown()
-            if #available(macOS 15, *) {
-                await nemotronTranscriber.shutdown()
-                await qwen3Transcriber.shutdown()
-                await qwen3PostProcessor.shutdown()
-                await canaryQwenTranscriber.shutdown()
-                await cohereTranscriber.shutdown()
-            }
+    func shutdown() async {
+        await fluidTranscriber.shutdown()
+        await whisperTranscriber.shutdown()
+        if #available(macOS 15, *) {
+            await nemotronTranscriber.shutdown()
+            await qwen3Transcriber.shutdown()
+            await qwen3PostProcessor.shutdown()
+            await canaryQwenTranscriber.shutdown()
+            await cohereTranscriber.shutdown()
         }
     }
 
@@ -345,7 +355,7 @@ actor TranscriptionCoordinator {
         _ result: SpeechTranscriptionResult,
         backend: BackendOption,
         enabled: Bool
-    ) async throws -> SpeechTranscriptionResult? {
+    ) async -> SpeechTranscriptionResult? {
         guard enabled else {
             fputs("[muesli-native] Qwen3 post-processor disabled for dictation\n", stderr)
             return nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -89,6 +89,7 @@ actor TranscriptionCoordinator {
     }
 
     private func logPostProcPair(raw: String, processed: String, asr: String) {
+        guard Qwen3PostProcessorLogging.isPairLoggingEnabled else { return }
         let logURL = AppIdentity.supportDirectoryURL.appendingPathComponent("postproc-pairs.jsonl")
         let iso8601 = ISO8601DateFormatter()
         iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -370,14 +371,12 @@ actor TranscriptionCoordinator {
         }
 
         do {
-            // Prototype mode intentionally runs cleanup on every dictation while the toggle is on.
-            // Keep the heuristics in place for a future smart-mode gate once prompt/model behavior stabilizes.
             fputs("[muesli-native] Qwen3 post-processor forced by toggle (prototype mode)\n", stderr)
             let start = CFAbsoluteTimeGetCurrent()
             let processed = try await qwen3PostProcessor.process(result.text)
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
             let trimmed = processed.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty, !Qwen3PostProcessingHeuristics.containsDeletionCue(result.text) {
+            if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
                 fputs("[muesli-native] Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back\n", stderr)
                 return nil
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -321,7 +321,9 @@ actor TranscriptionCoordinator {
         if #available(macOS 15, *) {
             await nemotronTranscriber.shutdown()
             await qwen3Transcriber.shutdown()
-            await qwen3PostProcessor.shutdown()
+            if let postProcessor = _qwen3PostProcessor as? Qwen3PostProcessor {
+                await postProcessor.shutdown()
+            }
             await canaryQwenTranscriber.shutdown()
             await cohereTranscriber.shutdown()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -18,6 +18,7 @@ actor TranscriptionCoordinator {
     private let whisperTranscriber = WhisperCppTranscriber()
     private var _nemotronTranscriber: Any?
     private var _qwen3Transcriber: Any?
+    private var _qwen3PostProcessor: Any?
     private var _canaryQwenTranscriber: Any?
     private var _cohereTranscriber: Any?
     private var vadManager: VadManager?
@@ -55,6 +56,14 @@ actor TranscriptionCoordinator {
     }
 
     @available(macOS 15, *)
+    private var qwen3PostProcessor: Qwen3PostProcessor {
+        if _qwen3PostProcessor == nil {
+            _qwen3PostProcessor = Qwen3PostProcessor()
+        }
+        return _qwen3PostProcessor as! Qwen3PostProcessor
+    }
+
+    @available(macOS 15, *)
     private var cohereTranscriber: CohereTranscribeTranscriber {
         if _cohereTranscriber == nil {
             _cohereTranscriber = CohereTranscribeTranscriber()
@@ -62,7 +71,11 @@ actor TranscriptionCoordinator {
         return _cohereTranscriber as! CohereTranscribeTranscriber
     }
 
-    func preload(backend: BackendOption, progress: ((Double, String?) -> Void)? = nil) async {
+    func preload(
+        backend: BackendOption,
+        enablePostProcessor: Bool = false,
+        progress: ((Double, String?) -> Void)? = nil
+    ) async {
         activeBackend = backend.backend
 
         // Initialize Silero VAD for meeting chunk silence detection
@@ -151,9 +164,22 @@ actor TranscriptionCoordinator {
         default:
             fputs("[muesli-native] unknown backend: \(backend.backend)\n", stderr)
         }
+
+        if enablePostProcessor, #available(macOS 15, *) {
+            do {
+                try await qwen3PostProcessor.prepare()
+            } catch {
+                fputs("[muesli-native] Qwen3 post-processor preload failed: \(error)\n", stderr)
+            }
+        }
     }
 
-    func transcribeDictation(at url: URL, backend: BackendOption, customWords: [[String: Any]] = []) async throws -> SpeechTranscriptionResult {
+    func transcribeDictation(
+        at url: URL,
+        backend: BackendOption,
+        enablePostProcessor: Bool = false,
+        customWords: [[String: Any]] = []
+    ) async throws -> SpeechTranscriptionResult {
         // Cohere decodes hallucinated text from silence — skip if VAD detects no speech
         if backend.backend == "cohere", let vadManager {
             do {
@@ -169,8 +195,19 @@ actor TranscriptionCoordinator {
         }
         var result = try await route(url: url, backend: backend)
         result = removeArtifacts(result)
-        result = removeFillers(result)
-        return applyCustomWords(result, customWords: customWords)
+        if !result.text.isEmpty {
+            fputs("[muesli-native] Dictation raw transcript after artifact cleanup: \(result.text)\n", stderr)
+        }
+        result = try await postProcessDictationIfNeeded(
+            result,
+            backend: backend,
+            enabled: enablePostProcessor
+        ) ?? removeFillersWithLogging(result)
+        let final = applyCustomWords(result, customWords: customWords)
+        if !final.text.isEmpty {
+            fputs("[muesli-native] Dictation final transcript: \(final.text)\n", stderr)
+        }
+        return final
     }
 
     func transcribeMeeting(at url: URL, backend: BackendOption, customWords: [[String: Any]] = []) async throws -> SpeechTranscriptionResult {
@@ -229,6 +266,7 @@ actor TranscriptionCoordinator {
             if #available(macOS 15, *) {
                 await nemotronTranscriber.shutdown()
                 await qwen3Transcriber.shutdown()
+                await qwen3PostProcessor.shutdown()
                 await canaryQwenTranscriber.shutdown()
                 await cohereTranscriber.shutdown()
             }
@@ -240,9 +278,60 @@ actor TranscriptionCoordinator {
         return SpeechTranscriptionResult(text: filtered, segments: result.segments)
     }
 
+    private func removeFillersWithLogging(_ result: SpeechTranscriptionResult) -> SpeechTranscriptionResult {
+        let start = CFAbsoluteTimeGetCurrent()
+        let filtered = removeFillers(result)
+        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        if filtered.text != result.text {
+            fputs("[muesli-native] FillerWordFilter applied in \(String(format: "%.1f", elapsedMs))ms -> \(filtered.text)\n", stderr)
+        } else {
+            fputs("[muesli-native] FillerWordFilter skipped effective changes (\(String(format: "%.1f", elapsedMs))ms)\n", stderr)
+        }
+        return filtered
+    }
+
     private func removeArtifacts(_ result: SpeechTranscriptionResult) -> SpeechTranscriptionResult {
         let filtered = TranscriptionEngineArtifactsFilter.apply(result.text)
         return SpeechTranscriptionResult(text: filtered, segments: filtered.isEmpty ? [] : result.segments)
+    }
+
+    private func postProcessDictationIfNeeded(
+        _ result: SpeechTranscriptionResult,
+        backend: BackendOption,
+        enabled: Bool
+    ) async throws -> SpeechTranscriptionResult? {
+        guard enabled else {
+            fputs("[muesli-native] Qwen3 post-processor disabled for dictation\n", stderr)
+            return nil
+        }
+        guard !result.text.isEmpty else {
+            fputs("[muesli-native] Qwen3 post-processor skipped: empty transcript\n", stderr)
+            return nil
+        }
+        guard #available(macOS 15, *) else {
+            fputs("[muesli-native] Qwen3 post-processor skipped: requires macOS 15+\n", stderr)
+            return nil
+        }
+
+        do {
+            fputs("[muesli-native] Qwen3 post-processor forced by toggle\n", stderr)
+            let start = CFAbsoluteTimeGetCurrent()
+            let processed = try await qwen3PostProcessor.process(result.text)
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            let trimmed = processed.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty, !Qwen3PostProcessingHeuristics.containsDeletionCue(result.text) {
+                fputs("[muesli-native] Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back\n", stderr)
+                return nil
+            }
+            fputs("[muesli-native] Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms -> \(trimmed)\n", stderr)
+            return SpeechTranscriptionResult(
+                text: trimmed,
+                segments: trimmed.isEmpty ? [] : result.segments
+            )
+        } catch {
+            fputs("[muesli-native] Qwen3 post-processor failed, falling back: \(error)\n", stderr)
+            return nil
+        }
     }
 
     private func applyCustomWords(_ result: SpeechTranscriptionResult, customWords: [[String: Any]]) -> SpeechTranscriptionResult {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -57,6 +57,7 @@ actor TranscriptionCoordinator {
 
     private var postProcessorModelURL: URL = PostProcessorOption.finetunedV2.modelURL
     private var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
+    private var postProcessorModelId: String = PostProcessorOption.finetunedV2.id
 
     @available(macOS 15, *)
     private var qwen3PostProcessor: Qwen3PostProcessor {
@@ -73,8 +74,34 @@ actor TranscriptionCoordinator {
     func setActivePostProcessor(option: PostProcessorOption, systemPrompt: String) async {
         postProcessorModelURL = option.modelURL
         postProcessorSystemPrompt = systemPrompt
+        postProcessorModelId = option.id
         if let existing = _qwen3PostProcessor as? Qwen3PostProcessor {
             await existing.reconfigure(modelURL: option.modelURL, systemPrompt: systemPrompt)
+        }
+    }
+
+    private func logPostProcPair(raw: String, processed: String, asr: String) {
+        let logURL = AppIdentity.supportDirectoryURL.appendingPathComponent("postproc-pairs.jsonl")
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let ts = iso8601.string(from: Date())
+        func jsonEscape(_ s: String) -> String {
+            s.replacingOccurrences(of: "\\", with: "\\\\")
+             .replacingOccurrences(of: "\"", with: "\\\"")
+             .replacingOccurrences(of: "\n", with: "\\n")
+             .replacingOccurrences(of: "\r", with: "\\r")
+             .replacingOccurrences(of: "\t", with: "\\t")
+        }
+        let line = "{\"ts\":\"\(ts)\",\"raw\":\"\(jsonEscape(raw))\",\"processed\":\"\(jsonEscape(processed))\",\"model\":\"\(jsonEscape(postProcessorModelId))\",\"asr\":\"\(jsonEscape(asr))\"}\n"
+        guard let data = line.data(using: .utf8) else { return }
+        if FileManager.default.fileExists(atPath: logURL.path) {
+            if let fh = try? FileHandle(forWritingTo: logURL) {
+                fh.seekToEndOfFile()
+                fh.write(data)
+                try? fh.close()
+            }
+        } else {
+            try? data.write(to: logURL, options: .atomic)
         }
     }
 
@@ -346,6 +373,7 @@ actor TranscriptionCoordinator {
             }
             fputs("[muesli-native] Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))\n", stderr)
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor final output: \(trimmed)")
+            logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
             return SpeechTranscriptionResult(
                 text: trimmed,
                 segments: trimmed.isEmpty ? [] : result.segments

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -84,6 +84,77 @@ struct BackendOptionTests {
     }
 }
 
+@Suite("PostProcessorOption")
+struct PostProcessorOptionTests {
+
+    @Test("all options have unique ids")
+    func uniqueIDs() {
+        let ids = PostProcessorOption.all.map(\.id)
+        #expect(Set(ids).count == ids.count, "Duplicate id in PostProcessorOption.all")
+    }
+
+    @Test("all options have unique filenames")
+    func uniqueFilenames() {
+        let filenames = PostProcessorOption.all.map(\.filename)
+        #expect(Set(filenames).count == filenames.count, "Duplicate filename in PostProcessorOption.all")
+    }
+
+    @Test("all options use HTTPS GGUF downloads")
+    func validDownloadMetadata() {
+        for option in PostProcessorOption.all {
+            #expect(option.downloadURL.scheme == "https", "Non-HTTPS download URL for \(option.id)")
+            #expect(option.filename.lowercased().hasSuffix(".gguf"), "Non-GGUF filename for \(option.id)")
+            #expect(!option.label.isEmpty, "Empty label for \(option.id)")
+            #expect(!option.description.isEmpty, "Empty description for \(option.id)")
+            #expect(!option.sizeLabel.isEmpty, "Empty size label for \(option.id)")
+        }
+    }
+
+    @Test("default option is first and matches config default")
+    func defaultOption() {
+        #expect(PostProcessorOption.all.first == PostProcessorOption.defaultOption)
+        #expect(AppConfig().activePostProcessorId == PostProcessorOption.defaultOption.id)
+    }
+
+    @Test("unknown ids resolve to default")
+    func unknownIDResolvesToDefault() {
+        #expect(PostProcessorOption.resolve(id: "missing") == PostProcessorOption.defaultOption)
+    }
+
+    @Test("resolveDownloaded prefers selected downloaded option")
+    func resolveDownloadedPrefersSelected() {
+        let downloadedIDs: Set<String> = [
+            PostProcessorOption.finetunedV2.id,
+            PostProcessorOption.qwen35_0_8b.id,
+        ]
+        #expect(PostProcessorOption.resolveDownloaded(
+            id: PostProcessorOption.qwen35_0_8b.id,
+            downloadedIDs: downloadedIDs
+        ) == PostProcessorOption.qwen35_0_8b)
+    }
+
+    @Test("resolveDownloaded falls back to first downloaded option")
+    func resolveDownloadedFallsBack() {
+        let downloadedIDs: Set<String> = [PostProcessorOption.finetunedV2.id]
+        #expect(PostProcessorOption.resolveDownloaded(
+            id: PostProcessorOption.finetunedV3.id,
+            downloadedIDs: downloadedIDs
+        ) == PostProcessorOption.finetunedV2)
+    }
+
+    @Test("firstDownloaded respects deletion exclusion")
+    func firstDownloadedExcludingDeleted() {
+        let downloadedIDs: Set<String> = [
+            PostProcessorOption.finetunedV3.id,
+            PostProcessorOption.finetunedV2.id,
+        ]
+        #expect(PostProcessorOption.firstDownloaded(
+            excluding: PostProcessorOption.finetunedV3.id,
+            downloadedIDs: downloadedIDs
+        ) == PostProcessorOption.finetunedV2)
+    }
+}
+
 @Suite("SummaryModelPreset")
 struct SummaryModelPresetTests {
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -142,6 +142,47 @@ struct PostProcessorOptionTests {
         ) == PostProcessorOption.finetunedV2)
     }
 
+    @Test("runtimeOption prefers selected downloaded option")
+    func runtimeOptionPrefersSelectedDownloadedOption() {
+        let downloadedIDs: Set<String> = [
+            PostProcessorOption.finetunedV2.id,
+            PostProcessorOption.qwen35_0_8b.id,
+        ]
+        #expect(PostProcessorOption.runtimeOption(
+            id: PostProcessorOption.qwen35_0_8b.id,
+            downloadedIDs: downloadedIDs,
+            hasDevOverride: false
+        ) == PostProcessorOption.qwen35_0_8b)
+    }
+
+    @Test("runtimeOption falls back to first downloaded option")
+    func runtimeOptionFallsBackToFirstDownloadedOption() {
+        let downloadedIDs: Set<String> = [PostProcessorOption.finetunedV2.id]
+        #expect(PostProcessorOption.runtimeOption(
+            id: PostProcessorOption.finetunedV3.id,
+            downloadedIDs: downloadedIDs,
+            hasDevOverride: false
+        ) == PostProcessorOption.finetunedV2)
+    }
+
+    @Test("runtimeOption accepts configured option with dev override")
+    func runtimeOptionAcceptsConfiguredOptionWithDevOverride() {
+        #expect(PostProcessorOption.runtimeOption(
+            id: PostProcessorOption.finetunedV3.id,
+            downloadedIDs: [],
+            hasDevOverride: true
+        ) == PostProcessorOption.finetunedV3)
+    }
+
+    @Test("runtimeOption returns nil without a download or dev override")
+    func runtimeOptionReturnsNilWithoutDownloadOrDevOverride() {
+        #expect(PostProcessorOption.runtimeOption(
+            id: PostProcessorOption.finetunedV3.id,
+            downloadedIDs: [],
+            hasDevOverride: false
+        ) == nil)
+    }
+
     @Test("firstDownloaded respects deletion exclusion")
     func firstDownloadedExcludingDeleted() {
         let downloadedIDs: Set<String> = [

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -51,6 +51,28 @@ struct FloatingIndicatorVisibilityTests {
         let config = try JSONDecoder().decode(AppConfig.self, from: json.data(using: .utf8)!)
         #expect(config.showFloatingIndicator == false)
     }
+
+    @Test("post processor defaults to disabled")
+    func postProcessorDisabledByDefault() {
+        let config = AppConfig()
+        #expect(config.enablePostProcessor == false)
+    }
+
+    @Test("post processor persists through JSON round-trip")
+    func postProcessorRoundTrip() throws {
+        var config = AppConfig()
+        config.enablePostProcessor = true
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.enablePostProcessor == true)
+    }
+
+    @Test("post processor decodes from snake_case JSON")
+    func postProcessorSnakeCaseDecode() throws {
+        let json = #"{"enable_post_processor": true}"#
+        let config = try JSONDecoder().decode(AppConfig.self, from: json.data(using: .utf8)!)
+        #expect(config.enablePostProcessor == true)
+    }
 }
 
 // MARK: - Unified indicator frame sizes

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -58,13 +58,21 @@ struct FloatingIndicatorVisibilityTests {
         #expect(config.enablePostProcessor == false)
     }
 
+    @Test("post processor defaults to v3 model")
+    func postProcessorDefaultModel() {
+        let config = AppConfig()
+        #expect(config.activePostProcessorId == PostProcessorOption.defaultOption.id)
+    }
+
     @Test("post processor persists through JSON round-trip")
     func postProcessorRoundTrip() throws {
         var config = AppConfig()
         config.enablePostProcessor = true
+        config.activePostProcessorId = PostProcessorOption.finetunedV2.id
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.enablePostProcessor == true)
+        #expect(decoded.activePostProcessorId == PostProcessorOption.finetunedV2.id)
     }
 
     @Test("post processor decodes from snake_case JSON")

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -288,4 +288,13 @@ struct Qwen3PostProcessingOutputCleanerTests {
             input: input
         ))
     }
+
+    @Test("rejects short-input hallucination expansion")
+    func rejectsShortInputHallucinationExpansion() {
+        let cleaned = String(repeating: "This unrelated response should not replace a short dictation. ", count: 3)
+        #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: cleaned,
+            input: "um yeah"
+        ))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -186,3 +186,43 @@ struct TranscriptionEngineArtifactsFilterTests {
         #expect(TranscriptionEngineArtifactsFilter.apply(text) == "")
     }
 }
+
+@Suite("Qwen3 post-processing heuristics")
+struct Qwen3PostProcessingHeuristicsTests {
+
+    @Test("runs when filler cleanup would change text")
+    func fillerTrigger() {
+        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "um I think we should go") == true)
+    }
+
+    @Test("runs when scratch-that cue is present")
+    func deletionTrigger() {
+        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "Call Sarah scratch that call James") == true)
+    }
+
+    @Test("runs when formatting cue is present")
+    func formattingTrigger() {
+        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "bullet point ship the fix") == true)
+    }
+
+    @Test("skips clean text with no cues")
+    func cleanTextSkips() {
+        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "The quarterly revenue grew twelve percent.") == false)
+    }
+}
+
+@Suite("Qwen3 post-processing output cleanup")
+struct Qwen3PostProcessingOutputCleanerTests {
+
+    @Test("removes think tags")
+    func stripsThinkTags() {
+        let raw = "<think>reasoning</think>Clean transcript"
+        #expect(Qwen3PostProcessorOutputCleaner.clean(raw) == "Clean transcript")
+    }
+
+    @Test("removes chat markup")
+    func stripsChatMarkup() {
+        let raw = "<|im_start|>assistant Hello world <|im_end|>"
+        #expect(Qwen3PostProcessorOutputCleaner.clean(raw) == "assistant Hello world")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -225,4 +225,39 @@ struct Qwen3PostProcessingOutputCleanerTests {
         let raw = "<|im_start|>assistant Hello world <|im_end|>"
         #expect(Qwen3PostProcessorOutputCleaner.clean(raw) == "assistant Hello world")
     }
+
+    @Test("removes leaked list-formatting instruction")
+    func stripsLeakedPromptInstruction() {
+        let raw = """
+        If the speaker is dictating a list, such as saying "first point", "second point", or "bullet point", format each item on its own line.
+        First point is ship it
+        """
+        #expect(Qwen3PostProcessorOutputCleaner.clean(raw) == "First point is ship it")
+    }
+
+    @Test("rejects assistant-style analysis output")
+    func rejectsAssistantStyleAnalysisOutput() {
+        let cleaned = """
+        The user is asking about the system prompt.
+
+        Analysis:
+        This is a question.
+
+        Action Plan:
+        1. Answer the question.
+        """
+        #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: cleaned,
+            input: "What is the system prompt?"
+        ))
+    }
+
+    @Test("rejects runaway output")
+    func rejectsRunawayOutput() {
+        let cleaned = String(repeating: "Remove the filler word like. ", count: 40)
+        #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: cleaned,
+            input: "What is the system prompt?"
+        ))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -187,30 +187,6 @@ struct TranscriptionEngineArtifactsFilterTests {
     }
 }
 
-@Suite("Qwen3 post-processing heuristics")
-struct Qwen3PostProcessingHeuristicsTests {
-
-    @Test("runs when filler cleanup would change text")
-    func fillerTrigger() {
-        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "um I think we should go") == true)
-    }
-
-    @Test("runs when scratch-that cue is present")
-    func deletionTrigger() {
-        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "Call Sarah scratch that call James") == true)
-    }
-
-    @Test("runs when formatting cue is present")
-    func formattingTrigger() {
-        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "bullet point ship the fix") == true)
-    }
-
-    @Test("skips clean text with no cues")
-    func cleanTextSkips() {
-        #expect(Qwen3PostProcessingHeuristics.shouldApply(to: "The quarterly revenue grew twelve percent.") == false)
-    }
-}
-
 @Suite("Qwen3 post-processing output cleanup")
 struct Qwen3PostProcessingOutputCleanerTests {
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -39,6 +39,48 @@ struct SpeechTranscriptionResultTests {
     }
 }
 
+@Suite("Qwen3 inference gate")
+struct Qwen3InferenceGateTests {
+
+    @Test("cancelled waiter is removed before next slot")
+    func cancelledWaiterDoesNotConsumeSlot() async throws {
+        let gate = Qwen3InferenceGate()
+        try await gate.acquire()
+
+        let cancelled = Task {
+            try await gate.acquire()
+            await gate.release()
+            return true
+        }
+
+        try await Task.sleep(for: .milliseconds(10))
+        #expect(await gate.queuedWaiterCount() == 1)
+
+        cancelled.cancel()
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(await gate.queuedWaiterCount() == 0)
+
+        let next = Task {
+            try await gate.acquire()
+            await gate.release()
+            return true
+        }
+
+        try await Task.sleep(for: .milliseconds(10))
+        await gate.release()
+        #expect(try await next.value)
+
+        do {
+            _ = try await cancelled.value
+            Issue.record("Cancelled waiter unexpectedly acquired the inference slot")
+        } catch is CancellationError {
+            // Expected path.
+        } catch {
+            Issue.record("Cancelled waiter failed with unexpected error: \(error)")
+        }
+    }
+}
+
 @Suite("TranscriptionCoordinator routing")
 struct TranscriptionCoordinatorTests {
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -236,4 +236,14 @@ struct Qwen3PostProcessingOutputCleanerTests {
             input: "What is the system prompt?"
         ))
     }
+
+    @Test("rejects oversized cleanup output")
+    func rejectsOversizedCleanupOutput() {
+        let input = String(repeating: "Please ship this note. ", count: 10)
+        let cleaned = String(repeating: "Please ship this note with unrelated additions. ", count: 12)
+        #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: cleaned,
+            input: input
+        ))
+    }
 }

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -88,9 +88,9 @@ cat > "$STAGED_APP_DIR/Contents/Info.plist" <<PLIST
   <key>CFBundleIdentifier</key>
   <string>$BUNDLE_ID</string>
   <key>CFBundleVersion</key>
-  <string>0.5.5</string>
+  <string>${MUESLI_BUILD_VERSION:-0.5.5}</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.5.5</string>
+  <string>${MUESLI_BUILD_VERSION:-0.5.5}</string>
   <key>CFBundleExecutable</key>
   <string>$APP_EXECUTABLE_NAME</string>
   <key>CFBundlePackageType</key>

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -54,11 +54,11 @@ chmod +x "$STAGED_APP_DIR/Contents/MacOS/$APP_EXECUTABLE_NAME"
 cp "$CLI_BIN" "$STAGED_APP_DIR/Contents/MacOS/$CLI_BINARY"
 chmod +x "$STAGED_APP_DIR/Contents/MacOS/$CLI_BINARY"
 
-# Bundle Sparkle framework (rpath is @loader_path, so it goes next to the binary)
-SPARKLE_FW="$BIN_DIR/Sparkle.framework"
-if [[ -d "$SPARKLE_FW" ]]; then
-  ditto "$SPARKLE_FW" "$STAGED_APP_DIR/Contents/MacOS/Sparkle.framework"
-fi
+# Bundle SwiftPM-linked frameworks (rpath is @loader_path, so they go next to the binary)
+for framework in "$BIN_DIR"/*.framework; do
+  [[ -d "$framework" ]] || continue
+  ditto "$framework" "$STAGED_APP_DIR/Contents/MacOS/$(basename "$framework")"
+done
 
 # Bundle SPM resource bundles (CoreML models, privacy manifests, etc.)
 for bundle in "$BIN_DIR"/*.bundle; do
@@ -134,31 +134,29 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
     exit 1
   fi
 
-  # Sign all nested binaries inside Sparkle framework (required for notarization)
-  if [[ -d "$APP_DIR/Contents/MacOS/Sparkle.framework" ]]; then
-    # Deep-sign every executable inside Sparkle (Updater.app, Autoupdate, XPC services)
-    find "$APP_DIR/Contents/MacOS/Sparkle.framework" -type f -perm +111 | while read -r binary; do
-      # Skip non-Mach-O files (e.g., shell scripts, plists)
-      if file "$binary" | grep -q "Mach-O"; then
+  # Sign all bundled frameworks, including nested Sparkle executables.
+  find "$APP_DIR/Contents/MacOS" -maxdepth 1 -name "*.framework" -type d | while read -r framework; do
+    if [[ "$(basename "$framework")" == "Sparkle.framework" ]]; then
+      find "$framework" -type f -perm +111 | while read -r binary; do
+        if file "$binary" | grep -q "Mach-O"; then
+          codesign --force --options runtime --timestamp \
+            --sign "$SIGN_IDENTITY" "$binary"
+        fi
+      done
+      find "$framework" -name "*.xpc" -type d | while read -r xpc; do
         codesign --force --options runtime --timestamp \
-          --sign "$SIGN_IDENTITY" "$binary"
-      fi
-    done
-    # Sign the XPC bundles
-    find "$APP_DIR/Contents/MacOS/Sparkle.framework" -name "*.xpc" -type d | while read -r xpc; do
-      codesign --force --options runtime --timestamp \
-        --sign "$SIGN_IDENTITY" "$xpc"
-    done
-    # Sign the Updater.app bundle
-    find "$APP_DIR/Contents/MacOS/Sparkle.framework" -name "*.app" -type d | while read -r app; do
-      codesign --force --options runtime --timestamp \
-        --sign "$SIGN_IDENTITY" "$app"
-    done
-    # Sign the framework bundle itself
+          --sign "$SIGN_IDENTITY" "$xpc"
+      done
+      find "$framework" -name "*.app" -type d | while read -r app; do
+        codesign --force --options runtime --timestamp \
+          --sign "$SIGN_IDENTITY" "$app"
+      done
+    fi
+
     codesign --force --options runtime --timestamp \
       --sign "$SIGN_IDENTITY" \
-      "$APP_DIR/Contents/MacOS/Sparkle.framework"
-  fi
+      "$framework"
+  done
 
   codesign --force --options runtime --timestamp \
     --sign "$SIGN_IDENTITY" \

--- a/scripts/canary-test.sh
+++ b/scripts/canary-test.sh
@@ -20,6 +20,8 @@ CANARY_APP="${MUESLI_CANARY_APP_PATH:-/Applications/MuesliCanary.app}"
 CANARY_MODEL_CACHE="${MUESLI_CANARY_CACHE_DIR:-$HOME/.cache/muesli/models/canary-qwen-2.5b-coreml-int8}"
 STT_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/stt-quantize-coreml"
 STT_ROOT="${MUESLI_CANARY_STT_ROOT:-$STT_ROOT_DEFAULT}"
+POSTPROC_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/qwen3-finetune-asr/export/gguf/20260410-050118-q4_k_m/qwen3-postproc-v2-q4_k_m.gguf"
+POSTPROC_ROOT="${MUESLI_CANARY_POSTPROC_ROOT:-$POSTPROC_ROOT_DEFAULT}"
 
 CLEAN=0
 RESET=0
@@ -101,6 +103,27 @@ seed_local_models() {
   log "Seeded Canary model cache at: $CANARY_MODEL_CACHE"
 }
 
+configure_postproc_override() {
+  local resolved="$POSTPROC_ROOT"
+  if [[ -d "$resolved" ]]; then
+    local first_gguf
+    first_gguf="$(find "$resolved" -type f -name '*.gguf' | head -n 1 || true)"
+    if [[ -n "$first_gguf" ]]; then
+      resolved="$first_gguf"
+    fi
+  fi
+
+  if [[ -f "$resolved" && "$resolved" == *.gguf ]]; then
+    launchctl setenv MUESLI_QWEN3_POSTPROC_GGUF "$resolved"
+    launchctl unsetenv MUESLI_QWEN3_POSTPROC_DIR 2>/dev/null || true
+    log "Set Qwen3 GGUF post-processor override: $resolved"
+  else
+    launchctl unsetenv MUESLI_QWEN3_POSTPROC_GGUF 2>/dev/null || true
+    launchctl unsetenv MUESLI_QWEN3_POSTPROC_DIR 2>/dev/null || true
+    log "Qwen3 GGUF post-processor asset not found at: $resolved"
+  fi
+}
+
 pkill -f "MuesliCanary.app" 2>/dev/null || true
 sleep 0.5
 
@@ -124,6 +147,8 @@ fi
 if [[ "$SEED" -eq 1 ]]; then
   seed_local_models
 fi
+
+configure_postproc_override
 
 log "Building MuesliCanary (debug, signed)..."
 MUESLI_APP_NAME=MuesliCanary \

--- a/scripts/canary-test.sh
+++ b/scripts/canary-test.sh
@@ -20,8 +20,7 @@ CANARY_APP="${MUESLI_CANARY_APP_PATH:-/Applications/MuesliCanary.app}"
 CANARY_MODEL_CACHE="${MUESLI_CANARY_CACHE_DIR:-$HOME/.cache/muesli/models/canary-qwen-2.5b-coreml-int8}"
 STT_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/stt-quantize-coreml"
 STT_ROOT="${MUESLI_CANARY_STT_ROOT:-$STT_ROOT_DEFAULT}"
-POSTPROC_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/qwen3-finetune-asr/export/gguf/20260410-050118-q4_k_m/qwen3-postproc-v2-q4_k_m.gguf"
-POSTPROC_ROOT="${MUESLI_CANARY_POSTPROC_ROOT:-$POSTPROC_ROOT_DEFAULT}"
+POSTPROC_ROOT="${MUESLI_CANARY_POSTPROC_ROOT:-}"
 
 CLEAN=0
 RESET=0
@@ -105,6 +104,13 @@ seed_local_models() {
 
 configure_postproc_override() {
   local resolved="$POSTPROC_ROOT"
+  if [[ -z "$resolved" ]]; then
+    launchctl unsetenv MUESLI_QWEN3_POSTPROC_GGUF 2>/dev/null || true
+    launchctl unsetenv MUESLI_QWEN3_POSTPROC_DIR 2>/dev/null || true
+    log "Skipping Qwen3 GGUF post-processor override; set MUESLI_CANARY_POSTPROC_ROOT to a local .gguf file or directory"
+    return
+  fi
+
   if [[ -d "$resolved" ]]; then
     local first_gguf
     first_gguf="$(find "$resolved" -type f -name '*.gguf' | head -n 1 || true)"

--- a/scripts/canary-test.sh
+++ b/scripts/canary-test.sh
@@ -113,7 +113,7 @@ configure_postproc_override() {
 
   if [[ -d "$resolved" ]]; then
     local first_gguf
-    first_gguf="$(find "$resolved" -type f -name '*.gguf' | head -n 1 || true)"
+    first_gguf="$(find "$resolved" -maxdepth 3 -type f -name '*.gguf' | head -n 1 || true)"
     if [[ -n "$first_gguf" ]]; then
       resolved="$first_gguf"
     fi

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -125,7 +125,7 @@ echo "y" | MUESLI_BUILD_VERSION="$VERSION" \
   MUESLI_BUNDLE_ID=com.muesli.canary \
   MUESLI_DISPLAY_NAME=MuesliCanary \
   MUESLI_SUPPORT_DIR_NAME=MuesliCanary \
-  "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
+  "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
 
 FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -26,7 +26,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
-APP_DIR="/Applications/Muesli.app"
+APP_DIR="/Applications/MuesliCanary.app"
 OUTPUT_DIR="$ROOT/dist-release"
 HOSTED_MOUNT_POINT=""
 VERIFY_DIR=""
@@ -84,29 +84,31 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 
 TAG="v${VERSION}"
-RELEASE_TITLE="Muesli ${VERSION}"
-DMG_PATH="$OUTPUT_DIR/Muesli-${VERSION}.dmg"
+RELEASE_TITLE="MuesliCanary ${VERSION}"
+DMG_PATH="$OUTPUT_DIR/MuesliCanary-${VERSION}.dmg"
 
 RELEASE_NOTES="$(cat <<EOF
-## Muesli ${VERSION}
+## MuesliCanary ${VERSION}
 
 Alpha build — signed and notarized, but not yet stable.
+Installs as **MuesliCanary** alongside your existing Muesli install.
 
 ### Install
-1. Download \`Muesli-${VERSION}.dmg\`
-2. Open the DMG and drag Muesli to Applications (replaces existing install)
-3. Launch from Applications
+1. Download \`MuesliCanary-${VERSION}.dmg\`
+2. Open the DMG and drag MuesliCanary to Applications
+3. Launch MuesliCanary from Applications
 
-### Update path
-Sparkle in this build points to the stable update feed. When the next stable
-release ships, this app will auto-update to it via the in-app updater.
+### Notes
+- Stores data separately in \`~/Library/Application Support/MuesliCanary/\`
+- Raw ASR + post-processed pairs logged to \`MuesliCanary/postproc-pairs.jsonl\`
+- Sparkle points to the stable update feed — auto-updates to next stable release
 
 ### Not linked from the main site
 Download from [GitHub Releases](https://github.com/pHequals7/muesli/releases).
 EOF
 )"
 
-echo "=== Muesli Alpha v${VERSION} ==="
+echo "=== MuesliCanary Alpha v${VERSION} ==="
 echo ""
 
 mkdir -p "$OUTPUT_DIR"
@@ -118,7 +120,12 @@ echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/10] Building and signing (version: ${VERSION})..."
-echo "y" | MUESLI_BUILD_VERSION="$VERSION" "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
+echo "y" | MUESLI_BUILD_VERSION="$VERSION" \
+  MUESLI_APP_NAME=MuesliCanary \
+  MUESLI_BUNDLE_ID=com.muesli.canary \
+  MUESLI_DISPLAY_NAME=MuesliCanary \
+  MUESLI_SUPPORT_DIR_NAME=MuesliCanary \
+  "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
 echo "  Installed to $APP_DIR"
 
 FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')
@@ -126,7 +133,7 @@ echo "  Signature: $FLAGS"
 
 # --- Step 3: Notarize app bundle ---
 echo "[3/10] Notarizing app bundle (this may take several minutes)..."
-APP_ZIP="$OUTPUT_DIR/Muesli-app-${VERSION}.zip"
+APP_ZIP="$OUTPUT_DIR/MuesliCanary-app-${VERSION}.zip"
 ditto -c -k --keepParent "$APP_DIR" "$APP_ZIP"
 NOTARY_OUTPUT=$(xcrun notarytool submit "$APP_ZIP" \
   --keychain-profile "$PROFILE_NAME" \
@@ -151,7 +158,7 @@ echo "  App stapled."
 echo "[5/10] Creating DMG from stapled app..."
 "$ROOT/scripts/create_dmg.sh" "$APP_DIR" "$OUTPUT_DIR"
 # create_dmg.sh reads CFBundleShortVersionString from the app, so the DMG is
-# already named Muesli-{VERSION}.dmg — no rename needed.
+# already named MuesliCanary-{VERSION}.dmg — no rename needed.
 
 # --- Step 6: Notarize DMG ---
 echo "[6/10] Notarizing DMG..."
@@ -178,8 +185,8 @@ if [[ -z "$MOUNT_POINT" ]]; then
   exit 1
 fi
 
-SPCTL_RESULT=$(spctl -a -vv "$MOUNT_POINT/Muesli.app" 2>&1)
-STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/Muesli.app" 2>&1)
+SPCTL_RESULT=$(spctl -a -vv "$MOUNT_POINT/MuesliCanary.app" 2>&1)
+STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/MuesliCanary.app" 2>&1)
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
 
 if ! echo "$SPCTL_RESULT" | grep -q "accepted"; then
@@ -229,10 +236,10 @@ echo "  Draft prerelease: $DRAFT_URL"
 # --- Step 10: Verify hosted asset + publish ---
 echo "[10/10] Verifying hosted DMG and publishing..."
 VERIFY_DIR=$(mktemp -d)
-HOSTED_DMG="$VERIFY_DIR/Muesli-${VERSION}.dmg"
+HOSTED_DMG="$VERIFY_DIR/MuesliCanary-${VERSION}.dmg"
 
 gh release download "$TAG" \
-  -p "Muesli-${VERSION}.dmg" \
+  -p "MuesliCanary-${VERSION}.dmg" \
   -D "$VERIFY_DIR" \
   --clobber >/dev/null
 
@@ -259,7 +266,7 @@ if ! echo "$HOSTED_STAPLE" | grep -q "worked"; then
 fi
 
 HOSTED_MOUNT_POINT=$(hdiutil attach "$HOSTED_DMG" -nobrowse 2>&1 | grep "/Volumes" | awk -F'\t' '{print $NF}')
-HOSTED_APP_SPCTL=$(spctl -a -vv "$HOSTED_MOUNT_POINT/Muesli.app" 2>&1)
+HOSTED_APP_SPCTL=$(spctl -a -vv "$HOSTED_MOUNT_POINT/MuesliCanary.app" 2>&1)
 hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
 HOSTED_MOUNT_POINT=""
 

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Alpha release pipeline — signed, notarized, GitHub prerelease.
+#
+# What this does:
+#   - Builds and signs with the same Developer ID as stable releases
+#   - Notarizes + staples both the app bundle and the DMG
+#   - Creates a GitHub prerelease tagged v{VERSION}-alpha.N
+#   - Verifies the hosted asset matches the local artifact
+#
+# What this does NOT do (intentional):
+#   - Does not update docs/appcast.xml (stable Sparkle feed is untouched)
+#   - Does not update docs/index.html or docs/llms.txt (site stays on stable)
+#   - Does not update the Homebrew tap
+#   - Does not commit or push to main
+#
+# Sparkle in alpha builds points to the stable appcast.xml. When the next
+# stable release ships, alpha testers auto-update to it via the in-app updater.
+#
+# Usage: ./scripts/release-alpha.sh [version]
+#   e.g.: ./scripts/release-alpha.sh 0.5.6-alpha.1
+#   If no version given, auto-increments from the current stable base.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
+SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
+APP_DIR="/Applications/Muesli.app"
+OUTPUT_DIR="$ROOT/dist-release"
+HOSTED_MOUNT_POINT=""
+VERIFY_DIR=""
+
+cleanup() {
+  if [[ -n "$HOSTED_MOUNT_POINT" ]]; then
+    hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null || true
+  fi
+  if [[ -n "$VERIFY_DIR" && -d "$VERIFY_DIR" ]]; then
+    rm -rf "$VERIFY_DIR"
+  fi
+}
+
+trap cleanup EXIT
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  # Derive base from latest stable: bump patch by 1
+  LATEST_STABLE=$(gh release list --limit 20 --json tagName,isPrerelease \
+    -q '[.[] | select(.isPrerelease == false)] | .[0].tagName' 2>/dev/null || echo "")
+
+  if [[ -z "$LATEST_STABLE" ]]; then
+    echo "ERROR: Could not determine latest stable release from GitHub." >&2
+    exit 1
+  fi
+
+  LATEST_STABLE_VERSION="${LATEST_STABLE#v}"
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_STABLE_VERSION"
+  PATCH="${PATCH%%[-+]*}"
+  NEXT_PATCH=$((PATCH + 1))
+  BASE="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+  # Find the highest existing alpha.N for this base
+  LATEST_N=$(gh release list --limit 100 --json tagName,isPrerelease \
+    -q "[.[] | select(.isPrerelease == true) | .tagName \
+        | select(startswith(\"v${BASE}-alpha.\")) \
+        | ltrimstr(\"v${BASE}-alpha.\") \
+        | tonumber] | max // 0" 2>/dev/null || echo "0")
+
+  NEXT_N=$((LATEST_N + 1))
+  VERSION="${BASE}-alpha.${NEXT_N}"
+
+  echo "Latest stable:  ${LATEST_STABLE}"
+  echo "Proposed alpha: v${VERSION}"
+  echo ""
+  read -p "Release as v${VERSION}? [Y/n] " confirm
+  if [[ "$confirm" == "n" || "$confirm" == "N" ]]; then
+    read -p "Enter version: " VERSION
+  fi
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "ERROR: Working tree must be clean before running the release pipeline." >&2
+  exit 1
+fi
+
+TAG="v${VERSION}"
+RELEASE_TITLE="Muesli ${VERSION}"
+DMG_PATH="$OUTPUT_DIR/Muesli-${VERSION}.dmg"
+
+RELEASE_NOTES="$(cat <<EOF
+## Muesli ${VERSION}
+
+Alpha build — signed and notarized, but not yet stable.
+
+### Install
+1. Download \`Muesli-${VERSION}.dmg\`
+2. Open the DMG and drag Muesli to Applications (replaces existing install)
+3. Launch from Applications
+
+### Update path
+Sparkle in this build points to the stable update feed. When the next stable
+release ships, this app will auto-update to it via the in-app updater.
+
+### Not linked from the main site
+Download from [GitHub Releases](https://github.com/pHequals7/muesli/releases).
+EOF
+)"
+
+echo "=== Muesli Alpha v${VERSION} ==="
+echo ""
+
+mkdir -p "$OUTPUT_DIR"
+
+# --- Step 1: Run tests ---
+echo "[1/10] Running tests..."
+swift test --package-path "$ROOT/native/MuesliNative"
+echo "  Tests passed."
+
+# --- Step 2: Build and sign ---
+echo "[2/10] Building and signing (version: ${VERSION})..."
+echo "y" | MUESLI_BUILD_VERSION="$VERSION" "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
+echo "  Installed to $APP_DIR"
+
+FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')
+echo "  Signature: $FLAGS"
+
+# --- Step 3: Notarize app bundle ---
+echo "[3/10] Notarizing app bundle (this may take several minutes)..."
+APP_ZIP="$OUTPUT_DIR/Muesli-app-${VERSION}.zip"
+ditto -c -k --keepParent "$APP_DIR" "$APP_ZIP"
+NOTARY_OUTPUT=$(xcrun notarytool submit "$APP_ZIP" \
+  --keychain-profile "$PROFILE_NAME" \
+  --wait 2>&1)
+echo "$NOTARY_OUTPUT"
+rm -f "$APP_ZIP"
+
+if ! echo "$NOTARY_OUTPUT" | grep -q "status: Accepted"; then
+  echo "  App notarization FAILED. Fetching log..."
+  SUBMISSION_ID=$(echo "$NOTARY_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
+  xcrun notarytool log "$SUBMISSION_ID" --keychain-profile "$PROFILE_NAME" 2>&1
+  exit 1
+fi
+echo "  App notarization accepted."
+
+# --- Step 4: Staple app bundle ---
+echo "[4/10] Stapling app bundle..."
+xcrun stapler staple "$APP_DIR"
+echo "  App stapled."
+
+# --- Step 5: Create DMG from stapled app ---
+echo "[5/10] Creating DMG from stapled app..."
+"$ROOT/scripts/create_dmg.sh" "$APP_DIR" "$OUTPUT_DIR"
+# create_dmg.sh reads CFBundleShortVersionString from the app, so the DMG is
+# already named Muesli-{VERSION}.dmg — no rename needed.
+
+# --- Step 6: Notarize DMG ---
+echo "[6/10] Notarizing DMG..."
+NOTARY_OUTPUT=$(xcrun notarytool submit "$DMG_PATH" \
+  --keychain-profile "$PROFILE_NAME" \
+  --wait 2>&1)
+echo "$NOTARY_OUTPUT"
+
+if ! echo "$NOTARY_OUTPUT" | grep -q "status: Accepted"; then
+  echo "  DMG notarization FAILED. Fetching log..."
+  SUBMISSION_ID=$(echo "$NOTARY_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
+  xcrun notarytool log "$SUBMISSION_ID" --keychain-profile "$PROFILE_NAME" 2>&1
+  exit 1
+fi
+echo "  DMG notarization accepted."
+
+# --- Step 7: Staple + verify DMG ---
+echo "[7/10] Stapling and verifying DMG..."
+xcrun stapler staple "$DMG_PATH"
+
+MOUNT_POINT=$(hdiutil attach "$DMG_PATH" -nobrowse 2>&1 | grep "/Volumes" | awk -F'\t' '{print $NF}')
+if [[ -z "$MOUNT_POINT" ]]; then
+  echo "ERROR: Could not mount DMG for verification." >&2
+  exit 1
+fi
+
+SPCTL_RESULT=$(spctl -a -vv "$MOUNT_POINT/Muesli.app" 2>&1)
+STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/Muesli.app" 2>&1)
+hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
+
+if ! echo "$SPCTL_RESULT" | grep -q "accepted"; then
+  echo "  RELEASE ABORTED: App inside DMG rejected by Gatekeeper."
+  exit 1
+fi
+if ! echo "$STAPLE_RESULT" | grep -q "worked"; then
+  echo "  RELEASE ABORTED: App inside DMG missing valid staple."
+  exit 1
+fi
+
+DMG_FLAGS=$(codesign -dvvv "$DMG_PATH" 2>&1)
+if ! echo "$DMG_FLAGS" | grep -q "runtime"; then
+  echo "  RELEASE ABORTED: DMG missing hardened runtime flag."
+  exit 1
+fi
+echo "  Gatekeeper, staple, and hardened runtime verified."
+
+# --- Step 8: Tag ---
+echo "[8/10] Tagging..."
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "ERROR: Local tag ${TAG} already exists." >&2
+  exit 1
+fi
+if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+  echo "ERROR: Remote tag ${TAG} already exists." >&2
+  exit 1
+fi
+
+git tag -a "$TAG" -m "Alpha release ${VERSION}"
+git push origin "$TAG"
+echo "  Pushed tag $TAG (pointing at current main HEAD — no commit to main)."
+
+# --- Step 9: Create draft GitHub prerelease + upload DMG ---
+echo "[9/10] Creating draft GitHub prerelease..."
+gh release create "$TAG" \
+  --draft \
+  --prerelease \
+  --verify-tag \
+  --title "$RELEASE_TITLE" \
+  --notes "$RELEASE_NOTES" \
+  "$DMG_PATH"
+
+DRAFT_URL=$(gh release view "$TAG" --json url -q .url)
+echo "  Draft prerelease: $DRAFT_URL"
+
+# --- Step 10: Verify hosted asset + publish ---
+echo "[10/10] Verifying hosted DMG and publishing..."
+VERIFY_DIR=$(mktemp -d)
+HOSTED_DMG="$VERIFY_DIR/Muesli-${VERSION}.dmg"
+
+gh release download "$TAG" \
+  -p "Muesli-${VERSION}.dmg" \
+  -D "$VERIFY_DIR" \
+  --clobber >/dev/null
+
+LOCAL_SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+HOSTED_SHA=$(shasum -a 256 "$HOSTED_DMG" | awk '{print $1}')
+echo "  Local SHA256:  $LOCAL_SHA"
+echo "  Hosted SHA256: $HOSTED_SHA"
+
+if [[ "$LOCAL_SHA" != "$HOSTED_SHA" ]]; then
+  echo "  RELEASE ABORTED: Hosted DMG SHA256 mismatch."
+  exit 1
+fi
+
+HOSTED_SPCTL=$(spctl -a -vv -t open --context context:primary-signature "$HOSTED_DMG" 2>&1)
+HOSTED_STAPLE=$(xcrun stapler validate "$HOSTED_DMG" 2>&1)
+
+if ! echo "$HOSTED_SPCTL" | grep -q "accepted"; then
+  echo "  RELEASE ABORTED: Hosted DMG rejected by Gatekeeper."
+  exit 1
+fi
+if ! echo "$HOSTED_STAPLE" | grep -q "worked"; then
+  echo "  RELEASE ABORTED: Hosted DMG missing valid staple."
+  exit 1
+fi
+
+HOSTED_MOUNT_POINT=$(hdiutil attach "$HOSTED_DMG" -nobrowse 2>&1 | grep "/Volumes" | awk -F'\t' '{print $NF}')
+HOSTED_APP_SPCTL=$(spctl -a -vv "$HOSTED_MOUNT_POINT/Muesli.app" 2>&1)
+hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
+HOSTED_MOUNT_POINT=""
+
+if ! echo "$HOSTED_APP_SPCTL" | grep -q "accepted"; then
+  echo "  RELEASE ABORTED: App inside hosted DMG rejected by Gatekeeper."
+  exit 1
+fi
+echo "  Hosted asset verified."
+
+gh release edit "$TAG" \
+  --draft=false \
+  --title "$RELEASE_TITLE" \
+  --notes "$RELEASE_NOTES"
+
+RELEASE_URL=$(gh release view "$TAG" --json url -q .url)
+
+echo ""
+echo "=== Alpha release complete ==="
+echo "  Version:  ${VERSION}"
+echo "  Tag:      ${TAG} (no commit pushed to main)"
+echo "  DMG:      $DMG_PATH"
+echo "  Release:  $RELEASE_URL"
+echo "  Sparkle:  stable appcast (alpha testers auto-update to next stable)"
+echo "  Site:     unchanged (freedspeech.xyz stays on stable)"


### PR DESCRIPTION
## Summary
- add an opt-in Qwen post-processing path for dictation transcripts
- switch the experimental runtime from the earlier CoreML prototype to a local GGUF + `LLM.swift` integration
- bundle `llama.framework` into the native app and update Canary launch helpers for local GGUF testing
- add config, settings wiring, and tests around the post-processing toggle and output cleanup

## Notes
- this is a prototype branch for evaluation and iteration, not a production-ready implementation yet
- current behavior is promising for filler cleanup and explicit formatting instructions, but implicit spoken list conversion is still not reliable enough
- runtime prompt and output cleaning were tightened to suppress markdown and duplicated wrapper artifacts during testing

## Validation
- `swift build` in `native/MuesliNative`
- manual `MuesliCanary` smoke tests with local GGUF override and terminal stderr logging

Refs #10
