### PR TITLE
Overhaul onboarding: real permissions, app restart, dictation test

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -764,10 +764,13 @@ final class MuesliController: NSObject {
     /// The floating indicator and sounds are suppressed during test mode.
     var dictationTestCallback: ((String) -> Void)?
     var dictationTestRecordingStarted: (() -> Void)?
+    private var dictationTestTask: Task<Void, Never>?
 
     var isDictationTestMode: Bool { dictationTestCallback != nil }
 
     func cancelTestDictation() {
+        dictationTestTask?.cancel()
+        dictationTestTask = nil
         recorder.cancel()
         setState(.idle)
     }
@@ -1745,7 +1748,8 @@ final class MuesliController: NSObject {
         }
 
         setState(.transcribing)
-        Task { [weak self] in
+        let isTestMode = isDictationTestMode
+        let task = Task { [weak self] in
             guard let self else { return }
             defer {
                 try? FileManager.default.removeItem(at: wavURL)
@@ -1758,10 +1762,12 @@ final class MuesliController: NSObject {
                     enablePostProcessor: self.isPostProcessorReady,
                     customWords: self.serializedCustomWords()
                 )
+                // Drop result if test was cancelled (user navigated away)
+                try Task.checkCancellation()
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
 
                 // Test mode: route result to callback, skip history/paste
-                if self.isDictationTestMode {
+                if isTestMode {
                     await MainActor.run {
                         self.dictationTestCallback?(text)
                         self.setState(.idle)
@@ -1797,6 +1803,9 @@ final class MuesliController: NSObject {
                         "paste_method": "clipboard_restore",
                     ])
                 }
+            } catch is CancellationError {
+                fputs("[muesli-native] test dictation cancelled\n", stderr)
+                await MainActor.run { self.setState(.idle) }
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
                 await MainActor.run {
@@ -1807,6 +1816,7 @@ final class MuesliController: NSObject {
                 }
             }
         }
+        if isTestMode { dictationTestTask = task }
     }
 
     // MARK: - Marauder's Map

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -808,6 +808,7 @@ final class MuesliController: NSObject {
         // Start monitors that were deferred during onboarding
         calendarMonitor.start()
         startCalendarRefreshTimer()
+        if config.maraudersMapUnlocked { startMaraudersMapMonitoring() }
         micActivityMonitor.start()
 
         onboardingWindowController?.close()
@@ -1727,6 +1728,9 @@ final class MuesliController: NSObject {
         if duration < 0.3 {
             fputs("[muesli-native] discarded short recording\n", stderr)
             try? FileManager.default.removeItem(at: wavURL)
+            if isDictationTestMode {
+                dictationTestCallback?("")
+            }
             setState(.idle)
             return
         }
@@ -1746,6 +1750,16 @@ final class MuesliController: NSObject {
                     customWords: self.serializedCustomWords()
                 )
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                // Test mode: route result to callback, skip history/paste
+                if self.isDictationTestMode {
+                    await MainActor.run {
+                        self.dictationTestCallback?(text)
+                        self.setState(.idle)
+                    }
+                    return
+                }
+
                 if !self.config.maraudersMapUnlocked {
                     await MainActor.run { self.checkMaraudersMapActivation(text) }
                 }
@@ -1762,11 +1776,6 @@ final class MuesliController: NSObject {
                     endedAt: Date()
                 )
                 await MainActor.run {
-                    if let testCallback = self.dictationTestCallback {
-                        testCallback(text)
-                        self.setState(.idle)
-                        return
-                    }
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()
@@ -1782,6 +1791,9 @@ final class MuesliController: NSObject {
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
                 await MainActor.run {
+                    if self.isDictationTestMode {
+                        self.dictationTestCallback?("")
+                    }
                     self.setState(.idle)
                 }
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -753,7 +753,7 @@ final class MuesliController: NSObject {
                 fputs("[muesli-native] relaunch failed: \(error)\n", stderr)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                exit(0)
+                NSApp.terminate(nil)
             }
         }
     }
@@ -767,11 +767,11 @@ final class MuesliController: NSObject {
 
     var isDictationTestMode: Bool { dictationTestCallback != nil }
 
-    func configureHotkeyForTest(keyCode: UInt16) {
-        hotkeyMonitor.configure(keyCode: keyCode)
+    func stopHotkeyMonitor() {
+        hotkeyMonitor.stop()
     }
 
-    func downloadModelForOnboarding(_ backend: BackendOption, progress: @escaping (Double, String?) -> Void) async throws -> Bool {
+    func downloadModelForOnboarding(_ backend: BackendOption, progress: @escaping (Double, String?) -> Void) async throws {
         progress(0.0, "Downloading \(backend.label)...")
         await transcriptionCoordinator.preload(
             backend: backend,
@@ -779,7 +779,6 @@ final class MuesliController: NSObject {
             progress: progress
         )
         progress(1.0, nil)
-        return false
     }
 
     func completeOnboarding(userName: String, backend: BackendOption, hotkey: HotkeyConfig, summaryBackend: MeetingSummaryBackendOption?, apiKey: String?) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -154,7 +154,6 @@ final class MuesliController: NSObject {
             logDescription: "leftover temp meeting recording files"
         )
 
-        hotkeyMonitor.targetKeyCode = config.dictationHotkey.keyCode
         hotkeyMonitor.onPrepare = { [weak self] in self?.handlePrepare() }
         hotkeyMonitor.onStart = { [weak self] in self?.handleStart() }
         hotkeyMonitor.onStop = { [weak self] in self?.handleStop() }
@@ -162,7 +161,12 @@ final class MuesliController: NSObject {
         hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
-        hotkeyMonitor.start()
+
+        // Defer permission-triggering monitors until after onboarding
+        if config.hasCompletedOnboarding {
+            hotkeyMonitor.targetKeyCode = config.dictationHotkey.keyCode
+            hotkeyMonitor.start()
+        }
         indicator.hotkeyLabel = config.dictationHotkey.label
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
@@ -212,10 +216,6 @@ final class MuesliController: NSObject {
         calendarMonitor.onMeetingSoon = { [weak self] event in
             self?.handleUpcomingMeeting(event)
         }
-        calendarMonitor.start()
-        startCalendarRefreshTimer()
-        if config.maraudersMapUnlocked { startMaraudersMapMonitoring() }
-
         micActivityMonitor.calendarEventProvider = { [weak self] in
             self?.calendarMonitor.currentOrNearbyEvent()
         }
@@ -224,7 +224,14 @@ final class MuesliController: NSObject {
             self.currentMeetingDetection = detection
             self.updateMeetingNotificationVisibility()
         }
-        micActivityMonitor.start()
+
+        // Defer permission-triggering monitors until after onboarding
+        if config.hasCompletedOnboarding {
+            calendarMonitor.start()
+            startCalendarRefreshTimer()
+            if config.maraudersMapUnlocked { startMaraudersMapMonitoring() }
+            micActivityMonitor.start()
+        }
 
         Task { [weak self] in
             guard let self else { return }
@@ -247,7 +254,14 @@ final class MuesliController: NSObject {
         }
 
         if !config.hasCompletedOnboarding {
-            showOnboarding()
+            if let progress = OnboardingProgress.load() {
+                // Configure and start hotkey for the dictation test step
+                hotkeyMonitor.targetKeyCode = progress.hotkeyKeyCode
+                hotkeyMonitor.start()
+                showOnboarding(resumeFrom: progress)
+            } else {
+                showOnboarding()
+            }
         } else if config.openDashboardOnLaunch {
             openHistoryWindow()
         }
@@ -715,10 +729,40 @@ final class MuesliController: NSObject {
 
     // MARK: - Onboarding
 
-    func showOnboarding() {
-        let wc = OnboardingWindowController(controller: self)
+    func showOnboarding(resumeFrom progress: OnboardingProgress? = nil) {
+        let wc = OnboardingWindowController(controller: self, resumeProgress: progress)
         self.onboardingWindowController = wc
         wc.show()
+    }
+
+    func relaunchApp() {
+        let bundlePath = Bundle.main.bundleURL.path
+        // Defer to next run-loop to escape any SwiftUI animation context
+        DispatchQueue.main.async {
+            // Launch a shell that waits for this process to die, then opens the app
+            let script = "sleep 1; open \"\(bundlePath)\""
+            let shell = Process()
+            shell.executableURL = URL(fileURLWithPath: "/bin/sh")
+            shell.arguments = ["-c", script]
+            try? shell.run()
+            // Give the shell a moment to start, then exit
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                exit(0)
+            }
+        }
+    }
+
+    // MARK: - Dictation Test Mode (onboarding)
+
+    /// When set, handleStop routes transcribed text to this callback instead of pasting.
+    /// The floating indicator and sounds are suppressed during test mode.
+    var dictationTestCallback: ((String) -> Void)?
+    var dictationTestRecordingStarted: (() -> Void)?
+
+    var isDictationTestMode: Bool { dictationTestCallback != nil }
+
+    func configureHotkeyForTest(keyCode: UInt16) {
+        hotkeyMonitor.configure(keyCode: keyCode)
     }
 
     func downloadModelForOnboarding(_ backend: BackendOption, progress: @escaping (Double, String?) -> Void) async throws -> Bool {
@@ -753,6 +797,14 @@ final class MuesliController: NSObject {
         }
         selectBackend(backend)
         hotkeyMonitor.configure(keyCode: hotkey.keyCode)
+        dictationTestCallback = nil
+        dictationTestRecordingStarted = nil
+
+        // Start monitors that were deferred during onboarding
+        calendarMonitor.start()
+        startCalendarRefreshTimer()
+        micActivityMonitor.start()
+
         onboardingWindowController?.close()
         onboardingWindowController = nil
         openHistoryWindow()
@@ -1423,7 +1475,9 @@ final class MuesliController: NSObject {
         case .transcribing: status = "Transcribing"
         }
         statusBarController?.setStatus(status)
-        indicator.setState(state, config: config)
+        if !isDictationTestMode {
+            indicator.setState(state, config: config)
+        }
     }
 
     private func dismissPresentedMeetingDetection() {
@@ -1516,11 +1570,16 @@ final class MuesliController: NSObject {
         do {
             try recorder.start()
             dictationStartedAt = Date()
-            indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
+            if !isDictationTestMode {
+                indicator.powerProvider = { [weak self] in
+                    self?.recorder.currentPower() ?? -160
+                }
             }
             setState(.recording)
-            SoundController.playDictationStart(enabled: config.soundEnabled)
+            if isDictationTestMode {
+                dictationTestRecordingStarted?()
+            }
+            SoundController.playDictationStart(enabled: config.soundEnabled && !isDictationTestMode)
         } catch {
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
             setState(.idle)
@@ -1698,6 +1757,11 @@ final class MuesliController: NSObject {
                     endedAt: Date()
                 )
                 await MainActor.run {
+                    if let testCallback = self.dictationTestCallback {
+                        testCallback(text)
+                        self.setState(.idle)
+                        return
+                    }
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -808,7 +808,6 @@ final class MuesliController: NSObject {
         // Start monitors that were deferred during onboarding
         calendarMonitor.start()
         startCalendarRefreshTimer()
-        if config.maraudersMapUnlocked { startMaraudersMapMonitoring() }
         micActivityMonitor.start()
 
         onboardingWindowController?.close()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -255,9 +255,11 @@ final class MuesliController: NSObject {
 
         if !config.hasCompletedOnboarding {
             if let progress = OnboardingProgress.load() {
-                // Configure and start hotkey for the dictation test step
-                hotkeyMonitor.targetKeyCode = progress.hotkeyKeyCode
-                hotkeyMonitor.start()
+                // Only start hotkey monitor when resuming at/past the dictation test step
+                if progress.currentStep >= OnboardingView.dictationTestStep {
+                    hotkeyMonitor.targetKeyCode = progress.hotkeyKeyCode
+                    hotkeyMonitor.start()
+                }
                 showOnboarding(resumeFrom: progress)
             } else {
                 showOnboarding()
@@ -739,13 +741,17 @@ final class MuesliController: NSObject {
         let bundlePath = Bundle.main.bundleURL.path
         // Defer to next run-loop to escape any SwiftUI animation context
         DispatchQueue.main.async {
-            // Launch a shell that waits for this process to die, then opens the app
-            let script = "sleep 1; open \"\(bundlePath)\""
+            // Launch a detached process that waits for us to die, then reopens the app.
+            // Uses /bin/sh only for the sleep; the path is passed as a positional arg
+            // to avoid shell interpolation of special characters.
             let shell = Process()
             shell.executableURL = URL(fileURLWithPath: "/bin/sh")
-            shell.arguments = ["-c", script]
-            try? shell.run()
-            // Give the shell a moment to start, then exit
+            shell.arguments = ["-c", "sleep 1; open -- \"$1\"", "--", bundlePath]
+            do {
+                try shell.run()
+            } catch {
+                fputs("[muesli-native] relaunch failed: \(error)\n", stderr)
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 exit(0)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -767,6 +767,10 @@ final class MuesliController: NSObject {
 
     var isDictationTestMode: Bool { dictationTestCallback != nil }
 
+    func startHotkeyMonitor() {
+        hotkeyMonitor.start()
+    }
+
     func stopHotkeyMonitor() {
         hotkeyMonitor.stop()
     }
@@ -802,6 +806,7 @@ final class MuesliController: NSObject {
         }
         selectBackend(backend)
         hotkeyMonitor.configure(keyCode: hotkey.keyCode)
+        hotkeyMonitor.start()
         dictationTestCallback = nil
         dictationTestRecordingStarted = nil
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -767,6 +767,11 @@ final class MuesliController: NSObject {
 
     var isDictationTestMode: Bool { dictationTestCallback != nil }
 
+    func cancelTestDictation() {
+        recorder.cancel()
+        setState(.idle)
+    }
+
     func startHotkeyMonitor() {
         hotkeyMonitor.start()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct OnboardingProgress: Codable {
+    var currentStep: Int
+    var userName: String
+    var selectedBackendKey: String
+    var selectedModelKey: String
+    var hotkeyKeyCode: UInt16
+    var hotkeyLabel: String
+
+    private static var fileURL: URL {
+        AppIdentity.supportDirectoryURL.appendingPathComponent("onboarding-progress.json")
+    }
+
+    static func save(_ progress: OnboardingProgress) {
+        do {
+            let dir = AppIdentity.supportDirectoryURL
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(progress)
+            try data.write(to: fileURL, options: [.atomic])
+        } catch {
+            fputs("[muesli-native] failed to save onboarding progress: \(error)\n", stderr)
+        }
+    }
+
+    static func load() -> OnboardingProgress? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode(OnboardingProgress.self, from: data)
+    }
+
+    static func clear() {
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 struct OnboardingProgress: Codable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int = currentSchemaVersion
     var currentStep: Int
     var userName: String
     var selectedBackendKey: String
@@ -25,7 +28,16 @@ struct OnboardingProgress: Codable {
 
     static func load() -> OnboardingProgress? {
         guard let data = try? Data(contentsOf: fileURL) else { return nil }
-        return try? JSONDecoder().decode(OnboardingProgress.self, from: data)
+        guard let progress = try? JSONDecoder().decode(OnboardingProgress.self, from: data) else {
+            // Stale or incompatible schema — discard and start fresh
+            clear()
+            return nil
+        }
+        guard progress.schemaVersion == currentSchemaVersion else {
+            clear()
+            return nil
+        }
+        return progress
     }
 
     static func clear() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -7,33 +7,57 @@ struct OnboardingView: View {
     let controller: MuesliController
     let appState: AppState
 
-    @State private var currentStep = 0
-    @State private var userName = ""
-    @State private var selectedBackend: BackendOption = .parakeetMultilingual
+    @State private var currentStep: Int
+    @State private var userName: String
+    @State private var selectedBackend: BackendOption
     @State private var summaryBackend: MeetingSummaryBackendOption = .openRouter
     @State private var apiKey = ""
     @State private var isSigningInChatGPT = false
     @State private var chatGPTSignInDone = false
     @State private var chatGPTSignInError: String?
 
-    // Permission states — pre-filled from OS on appear, then set to true after delay on Grant click
+    // Permission states — polled from OS every second
     @State private var micGranted = false
     @State private var accessibilityGranted = false
     @State private var inputMonitoringGranted = false
     @State private var screenRecordingGranted = false
-    @State private var pendingPermissions: Set<String> = []
+    @State private var permissionPollTimer: Timer?
+    @State private var showRestartBanner = false
 
     // Hotkey recorder
-    @State private var selectedHotkey: HotkeyConfig = .default
+    @State private var selectedHotkey: HotkeyConfig
     @State private var isRecordingHotkey = false
     @State private var hotkeyEventMonitor: Any?
+
+    // Dictation test
+    @State private var isDictationTesting = false
+    @State private var dictationTestResult: String?
+    @State private var dictationTestError: String?
+    @State private var isModelStillDownloading = false
+    @State private var modelPollTimer: Timer?
 
     // Google Calendar
     @State private var isSigningInGoogleCal = false
     @State private var googleCalSignInDone = false
     @State private var googleCalSignInError: String?
 
-    private let totalSteps = 6
+    private let totalSteps = 7
+
+    init(
+        controller: MuesliController,
+        appState: AppState,
+        initialStep: Int = 0,
+        initialUserName: String = "",
+        initialBackend: BackendOption = .parakeetMultilingual,
+        initialHotkey: HotkeyConfig = .default
+    ) {
+        self.controller = controller
+        self.appState = appState
+        _currentStep = State(initialValue: initialStep)
+        _userName = State(initialValue: initialUserName)
+        _selectedBackend = State(initialValue: initialBackend)
+        _selectedHotkey = State(initialValue: initialHotkey)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -43,8 +67,9 @@ struct OnboardingView: View {
                 case 1: modelStep
                 case 2: permissionsStep
                 case 3: hotkeyStep
-                case 4: meetingSummaryStep
-                case 5: googleCalendarStep
+                case 4: dictationTestStep
+                case 5: meetingSummaryStep
+                case 6: googleCalendarStep
                 default: EmptyView()
                 }
             }
@@ -92,6 +117,9 @@ struct OnboardingView: View {
         }
         .background(MuesliTheme.backgroundBase)
         .preferredColorScheme(.dark)
+        .onChange(of: currentStep) { _, step in
+            if step > 0 { saveProgress() }
+        }
     }
 
     // MARK: - Primary Button
@@ -113,46 +141,25 @@ struct OnboardingView: View {
             }
         case 3:
             onboardingButton("Continue", enabled: true) {
-                withAnimation(.easeInOut(duration: 0.2)) { currentStep = 4 }
+                saveProgressAndRestart()
             }
         case 4:
             HStack(spacing: MuesliTheme.spacing12) {
-                Button("Skip") {
-                    withAnimation(.easeInOut(duration: 0.2)) { currentStep = 5 }
-                }
-                .buttonStyle(.plain)
-                .font(MuesliTheme.body())
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .padding(.horizontal, MuesliTheme.spacing16)
-                .padding(.vertical, MuesliTheme.spacing8)
-                .background(MuesliTheme.surfacePrimary)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                )
-
-                onboardingButton("Continue", enabled: true) {
+                skipButton { withAnimation(.easeInOut(duration: 0.2)) { currentStep = 5 } }
+                onboardingButton("Continue", enabled: dictationTestResult != nil) {
                     withAnimation(.easeInOut(duration: 0.2)) { currentStep = 5 }
                 }
             }
         case 5:
             HStack(spacing: MuesliTheme.spacing12) {
-                Button("Skip") {
-                    finishOnboarding(withKey: true)
+                skipButton { withAnimation(.easeInOut(duration: 0.2)) { currentStep = 6 } }
+                onboardingButton("Continue", enabled: true) {
+                    withAnimation(.easeInOut(duration: 0.2)) { currentStep = 6 }
                 }
-                .buttonStyle(.plain)
-                .font(MuesliTheme.body())
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .padding(.horizontal, MuesliTheme.spacing16)
-                .padding(.vertical, MuesliTheme.spacing8)
-                .background(MuesliTheme.surfacePrimary)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                )
-
+            }
+        case 6:
+            HStack(spacing: MuesliTheme.spacing12) {
+                skipButton { finishOnboarding(withKey: true) }
                 onboardingButton("Finish", enabled: true) {
                     finishOnboarding(withKey: true)
                 }
@@ -175,6 +182,22 @@ struct OnboardingView: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+    }
+
+    @ViewBuilder
+    private func skipButton(action: @escaping () -> Void) -> some View {
+        Button("Skip", action: action)
+            .buttonStyle(.plain)
+            .font(MuesliTheme.body())
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.horizontal, MuesliTheme.spacing16)
+            .padding(.vertical, MuesliTheme.spacing8)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
     }
 
     // MARK: - Step 1: Welcome
@@ -211,6 +234,8 @@ struct OnboardingView: View {
         .frame(maxWidth: .infinity)
     }
 
+    @State private var showMoreModels = false
+
     // MARK: - Step 2: Model Selection
 
     private var modelStep: some View {
@@ -220,7 +245,7 @@ struct OnboardingView: View {
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
-                Text("Pick a model to get started. You can download more from the Models tab later.")
+                Text("We recommend Parakeet v3 for the best experience.\nYou can download more models later.")
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .multilineTextAlignment(.center)
@@ -229,8 +254,28 @@ struct OnboardingView: View {
 
             ScrollView {
                 VStack(spacing: MuesliTheme.spacing8) {
-                    ForEach(BackendOption.all, id: \.model) { option in
-                        modelCard(option: option)
+                    modelCard(option: .parakeetMultilingual)
+
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showMoreModels.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text("Other models")
+                                .font(MuesliTheme.caption())
+                            Image(systemName: showMoreModels ? "chevron.up" : "chevron.down")
+                                .font(.system(size: 9, weight: .semibold))
+                        }
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, MuesliTheme.spacing4)
+
+                    if showMoreModels {
+                        ForEach(BackendOption.all.filter { !$0.recommended }, id: \.model) { option in
+                            modelCard(option: option)
+                        }
                     }
                 }
                 .padding(.horizontal, MuesliTheme.spacing32)
@@ -313,10 +358,8 @@ struct OnboardingView: View {
                     name: "Microphone",
                     description: "Record audio for dictation and meetings",
                     granted: micGranted,
-                    pending: pendingPermissions.contains("mic"),
                     action: {
                         AVCaptureDevice.requestAccess(for: .audio) { _ in }
-                        grantAfterDelay("mic") { micGranted = true }
                     }
                 )
                 Divider().background(MuesliTheme.surfaceBorder)
@@ -325,10 +368,10 @@ struct OnboardingView: View {
                     name: "Accessibility",
                     description: "Paste transcribed text into other apps",
                     granted: accessibilityGranted,
-                    pending: pendingPermissions.contains("accessibility"),
                     action: {
-                        openSystemSettings("Privacy_Accessibility")
-                        grantAfterDelay("accessibility") { accessibilityGranted = true }
+                        // Triggers system dialog that auto-adds the app to the list
+                        let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+                        AXIsProcessTrustedWithOptions(opts)
                     }
                 )
                 Divider().background(MuesliTheme.surfaceBorder)
@@ -337,16 +380,8 @@ struct OnboardingView: View {
                     name: "Input Monitoring",
                     description: "Detect hotkey for push-to-talk dictation",
                     granted: inputMonitoringGranted,
-                    pending: pendingPermissions.contains("input"),
                     action: {
-                        if !CGPreflightListenEventAccess() {
-                            CGRequestListenEventAccess()
-                        }
-                        // Delay opening Settings to avoid race with permission dialog
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                            openSystemSettings("Privacy_ListenEvent")
-                        }
-                        grantAfterDelay("input") { inputMonitoringGranted = true }
+                        CGRequestListenEventAccess()
                     }
                 )
                 Divider().background(MuesliTheme.surfaceBorder)
@@ -355,10 +390,8 @@ struct OnboardingView: View {
                     name: "Screen Recording",
                     description: "Capture system audio during meetings",
                     granted: screenRecordingGranted,
-                    pending: pendingPermissions.contains("screen"),
                     action: {
-                        openSystemSettings("Privacy_ScreenCapture")
-                        grantAfterDelay("screen") { screenRecordingGranted = true }
+                        CGRequestScreenCaptureAccess()
                     }
                 )
             }
@@ -370,18 +403,32 @@ struct OnboardingView: View {
             )
             .frame(width: 460)
 
-            Text("Make sure to toggle on permissions in System Settings when prompted.")
-                .font(MuesliTheme.caption())
-                .foregroundStyle(MuesliTheme.textTertiary)
-                .multilineTextAlignment(.center)
+            VStack(spacing: 4) {
+                Text("A macOS prompt will appear for each permission. Just click Allow.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .multilineTextAlignment(.center)
+
+                if !allPermissionsGranted {
+                    Button {
+                        openSystemSettings("Privacy_Accessibility")
+                    } label: {
+                        Text("Not seeing a prompt? Open System Settings manually")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuesliTheme.accent)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
 
             Spacer()
         }
         .frame(maxWidth: .infinity)
-        .onAppear { refreshPermissions() }
+        .onAppear { startPermissionPolling() }
+        .onDisappear { stopPermissionPolling() }
     }
 
-    private func permissionRow(icon: String, name: String, description: String, granted: Bool, pending: Bool, action: @escaping () -> Void) -> some View {
+    private func permissionRow(icon: String, name: String, description: String, granted: Bool, action: @escaping () -> Void) -> some View {
         HStack(spacing: MuesliTheme.spacing12) {
             Image(systemName: icon)
                 .font(.system(size: 16, weight: .medium))
@@ -404,10 +451,6 @@ struct OnboardingView: View {
                     .font(.system(size: 18))
                     .foregroundStyle(MuesliTheme.success)
                     .transition(.scale.combined(with: .opacity))
-            } else if pending {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(width: 18, height: 18)
             } else {
                 Button("Grant") {
                     action()
@@ -426,14 +469,28 @@ struct OnboardingView: View {
         .animation(.easeInOut(duration: 0.25), value: granted)
     }
 
-    private func grantAfterDelay(_ key: String, grant: @escaping () -> Void) {
-        pendingPermissions.insert(key)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            withAnimation {
-                pendingPermissions.remove(key)
-                grant()
+    private var allPermissionsGranted: Bool {
+        micGranted && accessibilityGranted && inputMonitoringGranted && screenRecordingGranted
+    }
+
+    private func startPermissionPolling() {
+        refreshPermissions()
+        permissionPollTimer?.invalidate()
+        permissionPollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            DispatchQueue.main.async {
+                let wasAccessibilityGranted = accessibilityGranted
+                withAnimation { refreshPermissions() }
+                // Show restart banner if Accessibility was just granted but CGEvent creation fails
+                if accessibilityGranted && !wasAccessibilityGranted && !accessibilityActuallyWorks {
+                    withAnimation { showRestartBanner = true }
+                }
             }
         }
+    }
+
+    private func stopPermissionPolling() {
+        permissionPollTimer?.invalidate()
+        permissionPollTimer = nil
     }
 
     private func refreshPermissions() {
@@ -441,6 +498,32 @@ struct OnboardingView: View {
         accessibilityGranted = AXIsProcessTrusted()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
+    }
+
+    private var accessibilityActuallyWorks: Bool {
+        guard AXIsProcessTrusted() else { return false }
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let _ = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) else {
+            return false
+        }
+        return true
+    }
+
+    private func saveProgress(atStep step: Int? = nil) {
+        let progress = OnboardingProgress(
+            currentStep: step ?? currentStep,
+            userName: userName,
+            selectedBackendKey: selectedBackend.backend,
+            selectedModelKey: selectedBackend.model,
+            hotkeyKeyCode: selectedHotkey.keyCode,
+            hotkeyLabel: selectedHotkey.label
+        )
+        OnboardingProgress.save(progress)
+    }
+
+    private func saveProgressAndRestart() {
+        saveProgress(atStep: 4) // Resume at dictation test after restart
+        controller.relaunchApp()
     }
 
     private func openSystemSettings(_ pane: String) {
@@ -533,7 +616,129 @@ struct OnboardingView: View {
         }
     }
 
-    // MARK: - Step 5: Meeting Summaries
+    // MARK: - Step 5: Dictation Test
+
+    private var dictationTestStep: some View {
+        VStack(spacing: MuesliTheme.spacing24) {
+            Spacer()
+
+            VStack(spacing: MuesliTheme.spacing8) {
+                Text("Test Dictation")
+                    .font(MuesliTheme.title1())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+
+                Text("Hold **\(selectedHotkey.label)** and say something, then release.\nYour words should appear below.")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+
+                Text("Try saying: \"testing this one out\"")
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .padding(.top, 2)
+            }
+
+            if isModelStillDownloading {
+                VStack(spacing: MuesliTheme.spacing8) {
+                    ProgressView()
+                        .controlSize(.regular)
+                    Text("Waiting for model download to finish...")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+            } else {
+                VStack(spacing: MuesliTheme.spacing16) {
+                    Text(dictationTestResult ?? "Your transcription will appear here...")
+                        .font(dictationTestResult != nil ? .system(size: 14, design: .monospaced) : .system(size: 13, design: .rounded))
+                        .foregroundStyle(dictationTestResult != nil ? MuesliTheme.textPrimary : MuesliTheme.textTertiary)
+                        .italic(dictationTestResult == nil)
+                        .frame(maxWidth: 400, minHeight: 60, alignment: .topLeading)
+                        .padding(MuesliTheme.spacing16)
+                        .background(MuesliTheme.backgroundRaised)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                                .strokeBorder(dictationTestResult != nil ? MuesliTheme.success.opacity(0.5) : MuesliTheme.surfaceBorder, lineWidth: 1)
+                        )
+
+                    if isDictationTesting {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Listening... release \(selectedHotkey.label) when done")
+                                .font(MuesliTheme.caption())
+                                .foregroundStyle(MuesliTheme.textSecondary)
+                        }
+                    } else if dictationTestResult == nil {
+                        HStack(spacing: 6) {
+                            Image(systemName: "keyboard")
+                                .font(.system(size: 14))
+                            Text("Hold \(selectedHotkey.label) to start")
+                                .font(MuesliTheme.body())
+                        }
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+
+                    if let dictationTestError {
+                        Text(dictationTestError)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+
+                    if dictationTestResult != nil {
+                        HStack(spacing: 6) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(MuesliTheme.success)
+                            Text("Dictation is working!")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.success)
+                        }
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .onAppear {
+            checkModelDownloadStatus()
+            controller.dictationTestRecordingStarted = {
+                withAnimation { isDictationTesting = true }
+                dictationTestError = nil
+            }
+            controller.dictationTestCallback = { text in
+                if text.isEmpty {
+                    dictationTestError = "No speech detected. Try again."
+                } else {
+                    withAnimation { dictationTestResult = text }
+                }
+                isDictationTesting = false
+            }
+        }
+        .onDisappear {
+            modelPollTimer?.invalidate()
+            modelPollTimer = nil
+            controller.dictationTestCallback = nil
+            controller.dictationTestRecordingStarted = nil
+        }
+    }
+
+    private func checkModelDownloadStatus() {
+        isModelStillDownloading = !selectedBackend.isDownloaded
+        guard isModelStillDownloading else { return }
+        modelPollTimer?.invalidate()
+        modelPollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { timer in
+            DispatchQueue.main.async {
+                if selectedBackend.isDownloaded {
+                    withAnimation { isModelStillDownloading = false }
+                    timer.invalidate()
+                }
+            }
+        }
+    }
+
+    // MARK: - Step 6: Meeting Summaries
 
     private var meetingSummaryStep: some View {
         VStack(spacing: MuesliTheme.spacing24) {
@@ -790,6 +995,7 @@ struct OnboardingView: View {
     }
 
     private func finishOnboarding(withKey: Bool) {
+        OnboardingProgress.clear()
         controller.completeOnboarding(
             userName: userName.trimmingCharacters(in: .whitespaces),
             backend: selectedBackend,

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -412,7 +412,12 @@ struct OnboardingView: View {
 
                 if !allPermissionsGranted {
                     Button {
-                        openSystemSettings("Privacy_Accessibility")
+                        let pane: String
+                        if !micGranted { pane = "Privacy_Microphone" }
+                        else if !accessibilityGranted { pane = "Privacy_Accessibility" }
+                        else if !inputMonitoringGranted { pane = "Privacy_ListenEvent" }
+                        else { pane = "Privacy_ScreenCapture" }
+                        openSystemSettings(pane)
                     } label: {
                         Text("Not seeing a prompt? Open System Settings manually")
                             .font(.system(size: 11))
@@ -706,6 +711,10 @@ struct OnboardingView: View {
             modelPollTimer = nil
             controller.dictationTestCallback = nil
             controller.dictationTestRecordingStarted = nil
+            // Stop hotkey monitor if going back to prevent real dictation on step 3
+            if currentStep < Self.dictationTestStep {
+                controller.stopHotkeyMonitor()
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -162,7 +162,7 @@ struct OnboardingView: View {
             }
         case 6:
             HStack(spacing: MuesliTheme.spacing12) {
-                skipButton { finishOnboarding(withKey: true) }
+                skipButton { finishOnboarding(withKey: false) }
                 onboardingButton("Finish", enabled: true) {
                     finishOnboarding(withKey: true)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -22,12 +22,14 @@ struct OnboardingView: View {
     @State private var inputMonitoringGranted = false
     @State private var screenRecordingGranted = false
     @State private var permissionPollTimer: Timer?
-    @State private var showRestartBanner = false
 
     // Hotkey recorder
     @State private var selectedHotkey: HotkeyConfig
     @State private var isRecordingHotkey = false
     @State private var hotkeyEventMonitor: Any?
+
+    // Model selection
+    @State private var showMoreModels = false
 
     // Dictation test
     @State private var isDictationTesting = false
@@ -42,6 +44,7 @@ struct OnboardingView: View {
     @State private var googleCalSignInError: String?
 
     private let totalSteps = 7
+    static let dictationTestStep = 4
 
     init(
         controller: MuesliController,
@@ -233,8 +236,6 @@ struct OnboardingView: View {
         }
         .frame(maxWidth: .infinity)
     }
-
-    @State private var showMoreModels = false
 
     // MARK: - Step 2: Model Selection
 
@@ -477,14 +478,7 @@ struct OnboardingView: View {
         refreshPermissions()
         permissionPollTimer?.invalidate()
         permissionPollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            DispatchQueue.main.async {
-                let wasAccessibilityGranted = accessibilityGranted
-                withAnimation { refreshPermissions() }
-                // Show restart banner if Accessibility was just granted but CGEvent creation fails
-                if accessibilityGranted && !wasAccessibilityGranted && !accessibilityActuallyWorks {
-                    withAnimation { showRestartBanner = true }
-                }
-            }
+            withAnimation { refreshPermissions() }
         }
     }
 
@@ -500,15 +494,6 @@ struct OnboardingView: View {
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
     }
 
-    private var accessibilityActuallyWorks: Bool {
-        guard AXIsProcessTrusted() else { return false }
-        guard let source = CGEventSource(stateID: .combinedSessionState),
-              let _ = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) else {
-            return false
-        }
-        return true
-    }
-
     private func saveProgress(atStep step: Int? = nil) {
         let progress = OnboardingProgress(
             currentStep: step ?? currentStep,
@@ -522,7 +507,7 @@ struct OnboardingView: View {
     }
 
     private func saveProgressAndRestart() {
-        saveProgress(atStep: 4) // Resume at dictation test after restart
+        saveProgress(atStep: Self.dictationTestStep)
         controller.relaunchApp()
     }
 
@@ -729,11 +714,9 @@ struct OnboardingView: View {
         guard isModelStillDownloading else { return }
         modelPollTimer?.invalidate()
         modelPollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { timer in
-            DispatchQueue.main.async {
-                if selectedBackend.isDownloaded {
-                    withAnimation { isModelStillDownloading = false }
-                    timer.invalidate()
-                }
+            if selectedBackend.isDownloaded {
+                withAnimation { isModelStillDownloading = false }
+                timer.invalidate()
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -162,7 +162,7 @@ struct OnboardingView: View {
             }
         case 6:
             HStack(spacing: MuesliTheme.spacing12) {
-                skipButton { finishOnboarding(withKey: false) }
+                skipButton { finishOnboarding(withKey: true) }
                 onboardingButton("Finish", enabled: true) {
                     finishOnboarding(withKey: true)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -711,10 +711,8 @@ struct OnboardingView: View {
             modelPollTimer = nil
             controller.dictationTestCallback = nil
             controller.dictationTestRecordingStarted = nil
-            // Stop hotkey monitor if going back to prevent real dictation on step 3
-            if currentStep < Self.dictationTestStep {
-                controller.stopHotkeyMonitor()
-            }
+            // Stop hotkey monitor when leaving dictation test to prevent real dictation
+            controller.stopHotkeyMonitor()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -482,9 +482,11 @@ struct OnboardingView: View {
     private func startPermissionPolling() {
         refreshPermissions()
         permissionPollTimer?.invalidate()
-        permissionPollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             withAnimation { refreshPermissions() }
         }
+        RunLoop.main.add(timer, forMode: .common)
+        permissionPollTimer = timer
     }
 
     private func stopPermissionPolling() {
@@ -710,6 +712,9 @@ struct OnboardingView: View {
         .onDisappear {
             modelPollTimer?.invalidate()
             modelPollTimer = nil
+            // Cancel any in-flight recording before clearing callbacks to prevent
+            // the transcription Task from falling through to the production paste path
+            controller.cancelTestDictation()
             controller.dictationTestCallback = nil
             controller.dictationTestRecordingStarted = nil
             // Stop hotkey monitor when leaving dictation test to prevent real dictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -693,6 +693,7 @@ struct OnboardingView: View {
         .frame(maxWidth: .infinity)
         .onAppear {
             checkModelDownloadStatus()
+            controller.startHotkeyMonitor()
             controller.dictationTestRecordingStarted = {
                 withAnimation { isDictationTesting = true }
                 dictationTestError = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -5,10 +5,12 @@ import MuesliCore
 @MainActor
 final class OnboardingWindowController: NSObject, NSWindowDelegate {
     private let controller: MuesliController
+    private let resumeProgress: OnboardingProgress?
     private var window: NSWindow?
 
-    init(controller: MuesliController) {
+    init(controller: MuesliController, resumeProgress: OnboardingProgress? = nil) {
         self.controller = controller
+        self.resumeProgress = resumeProgress
         super.init()
     }
 
@@ -16,7 +18,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         if window == nil { buildWindow() }
         window?.makeKeyAndOrderFront(nil)
         window?.center()
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        NSApplication.shared.activate()
     }
 
     func close() {
@@ -38,7 +40,26 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         window.titleVisibility = .hidden
         window.backgroundColor = NSColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1)
 
-        let rootView = OnboardingView(controller: controller, appState: controller.appState)
+        let rootView: OnboardingView
+        if let progress = resumeProgress {
+            let backend = BackendOption.all.first(where: {
+                $0.backend == progress.selectedBackendKey && $0.model == progress.selectedModelKey
+            }) ?? .parakeetMultilingual
+            let hotkey = HotkeyConfig(keyCode: progress.hotkeyKeyCode, label: progress.hotkeyLabel)
+            rootView = OnboardingView(
+                controller: controller,
+                appState: controller.appState,
+                initialStep: progress.currentStep,
+                initialUserName: progress.userName,
+                initialBackend: backend,
+                initialHotkey: hotkey
+            )
+        } else {
+            rootView = OnboardingView(
+                controller: controller,
+                appState: controller.appState
+            )
+        }
         window.contentView = NSHostingView(rootView: rootView)
         self.window = window
     }


### PR DESCRIPTION
## Summary

Fixes #13

- Addresses the #1 user complaint from launch: dictation not pasting after onboarding because Accessibility permission requires an app restart
- Replaces fake 1.5s permission timers with real OS polling (1-second interval)
- Uses proper macOS permission APIs (`AXIsProcessTrustedWithOptions`, `CGRequestScreenCaptureAccess`) that trigger native prompts and auto-add the app to TCC lists
- Defers hotkey, calendar, and mic monitors until after onboarding — no more surprise permission prompts on launch
- Auto-restarts app after hotkey configuration so Accessibility takes effect before dictation test
- New dictation test step: user holds their configured hotkey, speaks, and verifies transcription appears — proves the full pipeline works before proceeding
- Onboarding progress saved on every step transition — survives manual quit or crash
- Model selection simplified: Parakeet v3 shown by default, others behind collapsible toggle

New flow: Welcome → Model → Permissions → Hotkey → [restart] → Dictation Test → Meeting Summaries → Google Calendar

## Test plan
- [x] 381 tests passing
- [x] Manually tested full onboarding flow with fresh permission reset
- [x] Verified app restart works reliably after hotkey step
- [x] Verified dictation test captures speech via hold-to-talk hotkey
- [x] Verified progress persists across manual quit and resume
- [x] Verified no premature permission prompts on app launch during onboarding
- [ ] Test on fresh macOS user account (no prior TCC entries)


🤖 Generated with [Claude Code](https://claude.com/claude-code)