### PR TITLE
Replace SwiftWhisper with WhisperKit (CoreML/ANE)

### DIFF
--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -85,8 +85,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "bb4ba815dab96d4edc1e0b86d7b9acf9ff973a84",
-        "version" : "4.3.1"
+        "revision" : "476538ccb827f2dd18efc5de754cc87d77127a47",
+        "version" : "4.4.0"
       }
     },
     {
@@ -112,8 +112,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
-        "version" : "2.97.1"
+        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
+        "version" : "2.98.0"
       }
     },
     {
@@ -153,12 +153,12 @@
       }
     },
     {
-      "identity" : "swiftwhisper",
+      "identity" : "whisperkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/exPHAT/SwiftWhisper.git",
+      "location" : "https://github.com/argmaxinc/WhisperKit.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "c340197966ebd264f3135d3955874b40f8ed58bc"
+        "branch" : "main",
+        "revision" : "80d96762fa727f816ffceab76a6529cd12c2726f"
       }
     },
     {

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.6"..<"0.13.0"),
-        .package(url: "https://github.com/argmaxinc/WhisperKit.git", branch: "main"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit.git", branch: "main"), // TODO: pin to tagged release once one ships post-PR #455 (swift-transformers removal)
         // Ghost Pepper uses this LLM.swift fork for local Qwen cleanup. Before production, replace it with upstream
         // eastriverlee/LLM.swift once explicit Qwen/ChatML template behavior is validated against our GGUF models.
         .package(url: "https://github.com/obra/LLM.swift.git", revision: "f1e1e11982dbc59662be191b8bed408dfb48e9df"),

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.2"..<"0.13.0"),
-        .package(url: "https://github.com/exPHAT/SwiftWhisper.git", branch: "master"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.6"..<"0.13.0"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit.git", branch: "main"),
         // Ghost Pepper uses this LLM.swift fork for local Qwen cleanup. Before production, replace it with upstream
         // eastriverlee/LLM.swift once explicit Qwen/ChatML template behavior is validated against our GGUF models.
         .package(url: "https://github.com/obra/LLM.swift.git", revision: "f1e1e11982dbc59662be191b8bed408dfb48e9df"),
@@ -37,7 +37,7 @@ let package = Package(
                 "MuesliCore",
                 .product(name: "FluidAudio", package: "FluidAudio"),
                 .product(name: "LLM", package: "LLM.swift"),
-                .product(name: "SwiftWhisper", package: "SwiftWhisper"),
+                .product(name: "WhisperKit", package: "WhisperKit"),
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "TelemetryDeck", package: "SwiftSDK"),
                 .product(name: "DTLNAecCoreML", package: "dtln-aec-coreml"),

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -459,7 +459,10 @@ final class FloatingIndicatorController {
         isShowingLoading = false
         loadingSpinner?.stopAnimation(nil)
         loadingSpinner?.isHidden = true
-        setState(.idle, config: configStore.load())
+        // Only reset to idle if no dictation started during the warmup window
+        if state == .idle || state == .preparing {
+            setState(.idle, config: configStore.load())
+        }
     }
 
     func setHovered(_ hovered: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -98,6 +98,8 @@ final class FloatingIndicatorController {
     var isToggleDictation = false
     private var stopLayer: CALayer?
     private var transcribingTitle = "Transcribing"
+    private var loadingSpinner: NSProgressIndicator?
+    private var isShowingLoading = false
     var hotkeyLabel: String = "Left Cmd"
 
     init(configStore: ConfigStore) {
@@ -376,6 +378,88 @@ final class FloatingIndicatorController {
             guard let self, self.state == .idle else { return }
             self.setState(.idle, config: self.configStore.load())
         }
+    }
+
+    func showLoading(_ message: String) {
+        let config = configStore.load()
+        if panel == nil { createPanel(config: config) }
+        guard let panel, let contentView, let textLabel else { return }
+
+        isShowingLoading = true
+        let loadingSize = NSSize(width: 180, height: 36)
+        let center = CGPoint(x: panel.frame.midX, y: panel.frame.midY)
+        guard let screen = NSScreen.main?.visibleFrame else { return }
+        let x = min(max(center.x - loadingSize.width / 2, screen.minX), screen.maxX - loadingSize.width)
+        let y = min(max(center.y - loadingSize.height / 2, screen.minY), screen.maxY - loadingSize.height)
+        let targetFrame = NSRect(x: x, y: y, width: loadingSize.width, height: loadingSize.height)
+
+        // Create spinner if needed
+        if loadingSpinner == nil {
+            let spinner = NSProgressIndicator()
+            spinner.style = .spinning
+            spinner.controlSize = .small
+            spinner.isIndeterminate = true
+            spinner.appearance = NSAppearance(named: .darkAqua)
+            contentView.addSubview(spinner)
+            loadingSpinner = spinner
+        }
+
+        let spinnerSize: CGFloat = 16
+        let gap: CGFloat = 8
+        let attrs: [NSAttributedString.Key: Any] = [.font: NSFont.systemFont(ofSize: 11, weight: .medium)]
+        let textW = ceil((message as NSString).size(withAttributes: attrs).width) + 2
+        let totalW = spinnerSize + gap + textW
+        let startX = (loadingSize.width - totalW) / 2
+
+        micIconView?.isHidden = true
+        wandIconView?.isHidden = true
+        iconLabel?.isHidden = true
+        glassView?.isHidden = false
+        tintLayer?.isHidden = false
+        tintLayer?.backgroundColor = NSColor.colorWith(hexString: "1e1e2e", alpha: 0.72).cgColor
+        tintLayer?.frame = CGRect(origin: .zero, size: loadingSize)
+        tintLayer?.cornerRadius = loadingSize.height / 2
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            context.allowsImplicitAnimation = true
+
+            panel.animator().setFrame(targetFrame, display: true)
+            panel.animator().alphaValue = 1.0
+            contentView.animator().frame = NSRect(origin: .zero, size: loadingSize)
+            contentView.layer?.cornerRadius = loadingSize.height / 2
+            contentView.layer?.backgroundColor = NSColor.clear.cgColor
+            contentView.layer?.borderWidth = 1.0
+            contentView.layer?.borderColor = NSColor.colorWith(hex: 0xFFFFFF, alpha: 0.16).cgColor
+
+            loadingSpinner?.frame = NSRect(
+                x: startX, y: (loadingSize.height - spinnerSize) / 2,
+                width: spinnerSize, height: spinnerSize
+            )
+            loadingSpinner?.isHidden = false
+            loadingSpinner?.startAnimation(nil)
+
+            textLabel.stringValue = message
+            textLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+            textLabel.textColor = NSColor.colorWith(hex: 0xFFFFFF, alpha: 0.82)
+            textLabel.frame = NSRect(
+                x: startX + spinnerSize + gap,
+                y: (loadingSize.height - 14) / 2,
+                width: textW, height: 14
+            )
+            textLabel.isHidden = false
+            textLabel.animator().alphaValue = 1
+        }
+        panel.orderFrontRegardless()
+    }
+
+    func hideLoading() {
+        guard isShowingLoading else { return }
+        isShowingLoading = false
+        loadingSpinner?.stopAnimation(nil)
+        loadingSpinner?.isHidden = true
+        setState(.idle, config: configStore.load())
     }
 
     func setHovered(_ hovered: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -29,28 +29,28 @@ struct BackendOption: Equatable {
 
     static let whisperSmall = BackendOption(
         backend: "whisper",
-        model: "ggml-small.en-q5_1",
+        model: "small.en",
         label: "Whisper Small",
-        sizeLabel: "~190 MB",
-        description: "Fast, English-optimized. Quantized for smaller download.",
+        sizeLabel: "~250 MB",
+        description: "Fast, English-optimized. Runs on Apple Neural Engine via CoreML.",
         recommended: false
     )
 
     static let whisperMedium = BackendOption(
         backend: "whisper",
-        model: "ggml-medium.en",
+        model: "medium.en",
         label: "Whisper Medium",
         sizeLabel: "~1.5 GB",
-        description: "Better accuracy, English-only. Good balance of speed and quality.",
+        description: "Better accuracy, English-only. Runs on Apple Neural Engine via CoreML.",
         recommended: false
     )
 
     static let whisperLargeTurbo = BackendOption(
         backend: "whisper",
-        model: "ggml-large-v3-turbo-q5_0",
+        model: "large-v3-v20240930_626MB",
         label: "Whisper Large Turbo",
-        sizeLabel: "~600 MB",
-        description: "Highest accuracy, multilingual. Quantized for faster inference.",
+        sizeLabel: "~626 MB",
+        description: "Highest accuracy, multilingual. Quantized CoreML for faster inference.",
         recommended: false
     )
 
@@ -121,10 +121,7 @@ struct BackendOption: Equatable {
         let fm = FileManager.default
         switch backend {
         case "whisper":
-            let filename = model.hasSuffix(".bin") ? model : "\(model).bin"
-            let path = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent(".cache/muesli/models/\(filename)")
-            return fm.fileExists(atPath: path.path)
+            return WhisperKitTranscriber.isModelDownloaded(model)
         case "fluidaudio":
             let supportDir = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent("Library/Application Support/FluidAudio/Models")

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -917,10 +917,7 @@ struct ModelsView: View {
         let fm = FileManager.default
         switch option.backend {
         case "whisper":
-            let filename = option.model.hasSuffix(".bin") ? option.model : "\(option.model).bin"
-            let path = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent(".cache/muesli/models/\(filename)")
-            try? fm.removeItem(at: path)
+            WhisperKitTranscriber.deleteModel(option.model)
         case "nemotron":
             let path = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/muesli/models/nemotron-560ms")
@@ -977,10 +974,7 @@ struct ModelsView: View {
     private func isModelDownloaded(_ option: BackendOption, fm: FileManager) -> Bool {
         switch option.backend {
         case "whisper":
-            let filename = option.model.hasSuffix(".bin") ? option.model : "\(option.model).bin"
-            let path = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent(".cache/muesli/models/\(filename)")
-            return fm.fileExists(atPath: path.path)
+            return WhisperKitTranscriber.isModelDownloaded(option.model)
         case "nemotron":
             let path = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/muesli/models/nemotron-560ms/encoder/encoder_int8.mlmodelc")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -453,8 +453,11 @@ final class MuesliController: NSObject {
         }
         Task { [weak self] in
             guard let self else { return }
-            await MainActor.run {
-                self.indicator.showLoading("Warming up...")
+            let needsWarmup = option.backend == "whisper"
+            if needsWarmup {
+                await MainActor.run {
+                    self.indicator.showLoading("Warming up...")
+                }
             }
             let ppOption = self.runtimePostProcessorOption()
             if #available(macOS 15, *) {
@@ -470,7 +473,9 @@ final class MuesliController: NSObject {
                 enablePostProcessor: self.config.enablePostProcessor && ppOption != nil
             )
             await MainActor.run {
-                self.indicator.hideLoading()
+                if needsWarmup {
+                    self.indicator.hideLoading()
+                }
                 self.statusBarController?.refresh()
                 self.historyWindowController?.updateBackendLabel()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -453,6 +453,9 @@ final class MuesliController: NSObject {
         }
         Task { [weak self] in
             guard let self else { return }
+            await MainActor.run {
+                self.statusBarController?.setStatus("Loading \(option.label)...")
+            }
             let ppOption = self.runtimePostProcessorOption()
             if #available(macOS 15, *) {
                 if let ppOption {
@@ -467,6 +470,7 @@ final class MuesliController: NSObject {
                 enablePostProcessor: self.config.enablePostProcessor && ppOption != nil
             )
             await MainActor.run {
+                self.statusBarController?.setStatus("Idle")
                 self.statusBarController?.refresh()
                 self.historyWindowController?.updateBackendLabel()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -454,7 +454,7 @@ final class MuesliController: NSObject {
         Task { [weak self] in
             guard let self else { return }
             await MainActor.run {
-                self.statusBarController?.setStatus("Loading \(option.label)...")
+                self.indicator.showLoading("Warming up...")
             }
             let ppOption = self.runtimePostProcessorOption()
             if #available(macOS 15, *) {
@@ -470,7 +470,7 @@ final class MuesliController: NSObject {
                 enablePostProcessor: self.config.enablePostProcessor && ppOption != nil
             )
             await MainActor.run {
-                self.statusBarController?.setStatus("Idle")
+                self.indicator.hideLoading()
                 self.statusBarController?.refresh()
                 self.historyWindowController?.updateBackendLabel()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -167,8 +167,13 @@ actor TranscriptionCoordinator {
         case "whisper":
             do {
                 try await whisperTranscriber.loadModel(modelName: backend.model, progress: progress)
+                // Warmup ANE/GPU so first dictation doesn't pay CoreML compilation cost
+                fputs("[muesli-native] WhisperKit warmup: running silent audio for CoreML compilation...\n", stderr)
+                progress?(0.95, "Warming up model...")
+                try await whisperTranscriber.warmup()
+                fputs("[muesli-native] WhisperKit warmup complete\n", stderr)
             } catch {
-                fputs("[muesli-native] whisper.cpp preload failed: \(error)\n", stderr)
+                fputs("[muesli-native] WhisperKit preload failed: \(error)\n", stderr)
             }
         case "nemotron":
             if #available(macOS 15, *) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -15,7 +15,7 @@ struct SpeechTranscriptionResult: Sendable {
 
 actor TranscriptionCoordinator {
     private let fluidTranscriber = FluidAudioTranscriber()
-    private let whisperTranscriber = WhisperCppTranscriber()
+    private let whisperTranscriber = WhisperKitTranscriber()
     private var _nemotronTranscriber: Any?
     private var _qwen3Transcriber: Any?
     private var _qwen3PostProcessor: Any?
@@ -417,7 +417,7 @@ actor TranscriptionCoordinator {
     private func route(url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
         switch backend.backend {
         case "whisper":
-            return try await transcribeWithWhisperCpp(url: url)
+            return try await transcribeWithWhisperKit(url: url)
         case "nemotron":
             return try await transcribeWithNemotron(url: url)
         case "qwen":
@@ -447,12 +447,12 @@ actor TranscriptionCoordinator {
         )
     }
 
-    // MARK: - whisper.cpp (Whisper on Metal/CPU)
+    // MARK: - WhisperKit (Whisper on ANE/GPU via CoreML)
 
-    private func transcribeWithWhisperCpp(url: URL) async throws -> SpeechTranscriptionResult {
-        fputs("[muesli-native] transcribing with whisper.cpp: \(url.lastPathComponent)\n", stderr)
+    private func transcribeWithWhisperKit(url: URL) async throws -> SpeechTranscriptionResult {
+        fputs("[muesli-native] transcribing with WhisperKit: \(url.lastPathComponent)\n", stderr)
         let result = try await whisperTranscriber.transcribe(wavURL: url)
-        fputs("[muesli-native] whisper.cpp result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
+        fputs("[muesli-native] WhisperKit result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
         let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
         return SpeechTranscriptionResult(
             text: text,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -169,9 +169,10 @@ actor TranscriptionCoordinator {
                 try await whisperTranscriber.loadModel(modelName: backend.model, progress: progress)
                 // Warmup ANE/GPU so first dictation doesn't pay CoreML compilation cost
                 fputs("[muesli-native] WhisperKit warmup: running silent audio for CoreML compilation...\n", stderr)
-                progress?(0.95, "Warming up model...")
+                progress?(0.9, "Warming up model...")
                 try await whisperTranscriber.warmup()
                 fputs("[muesli-native] WhisperKit warmup complete\n", stderr)
+                progress?(1.0, nil)
             } catch {
                 fputs("[muesli-native] WhisperKit preload failed: \(error)\n", stderr)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -34,11 +34,10 @@ actor WhisperKitTranscriber {
             )
         )
 
-        progress?(0.5, "Loading \(modelName)...")
+        progress?(0.5, "Downloading \(modelName) (may take a few minutes)...")
         whisperKit = try await WhisperKit(config)
         loadedModel = modelName
         fputs("[whisperkit] model ready: \(modelName)\n", stderr)
-        progress?(1.0, nil)
     }
 
     /// Transcribe a 16kHz mono WAV file.

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -1,151 +1,98 @@
 import Foundation
-import SwiftWhisper
+import WhisperKit
 import MuesliCore
 
-/// Native Swift transcription backend using whisper.cpp via SwiftWhisper.
-/// Runs Whisper models on CPU + Metal GPU.
-actor WhisperCppTranscriber {
-    private var whisper: Whisper?
-    private var loadedModelPath: String?
+/// Native Swift transcription backend using WhisperKit (CoreML on ANE/GPU).
+actor WhisperKitTranscriber {
+    private var whisperKit: WhisperKit?
+    private var loadedModel: String?
 
     enum TranscriberError: Error, LocalizedError {
         case notLoaded
-        case modelDownloadFailed(String)
-        case audioLoadFailed(String)
+        case transcriptionFailed(String)
 
         var errorDescription: String? {
             switch self {
-            case .notLoaded: return "Whisper model not loaded."
-            case .modelDownloadFailed(let msg): return "Model download failed: \(msg)"
-            case .audioLoadFailed(let msg): return "Audio load failed: \(msg)"
+            case .notLoaded: return "WhisperKit model not loaded."
+            case .transcriptionFailed(let msg): return "Transcription failed: \(msg)"
             }
         }
     }
 
-    /// Load a ggml model file. Downloads from HuggingFace if not cached.
+    /// Load a WhisperKit CoreML model. Downloads from HuggingFace if not cached.
     func loadModel(modelName: String, progress: ((Double, String?) -> Void)? = nil) async throws {
-        let modelPath = try await ensureModelDownloaded(modelName: modelName, progress: progress)
-        if loadedModelPath == modelPath, whisper != nil { return }
+        if loadedModel == modelName, whisperKit != nil { return }
 
-        // Validate file size — ggml models are at least 10MB
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: modelPath)[.size] as? Int) ?? 0
-        if fileSize < 10_000_000 {
-            // Corrupted/incomplete download — delete and throw
-            try? FileManager.default.removeItem(atPath: modelPath)
-            throw TranscriberError.modelDownloadFailed("Downloaded file is too small (\(fileSize) bytes), likely corrupted. Deleted — try again.")
-        }
+        fputs("[whisperkit] loading model: \(modelName)...\n", stderr)
+        progress?(0.1, "Preparing \(modelName)...")
 
-        fputs("[whisper.cpp] loading model: \(modelName) (\(fileSize / 1_000_000)MB)...\n", stderr)
-        progress?(0.95, "Loading model...")
-        let modelURL = URL(fileURLWithPath: modelPath)
-        whisper = Whisper(fromFileURL: modelURL)
-        loadedModelPath = modelPath
-        fputs("[whisper.cpp] model ready\n", stderr)
+        let config = WhisperKitConfig(
+            model: modelName,
+            computeOptions: ModelComputeOptions(
+                audioEncoderCompute: .cpuAndNeuralEngine,
+                textDecoderCompute: .cpuAndNeuralEngine
+            )
+        )
+
+        progress?(0.5, "Loading \(modelName)...")
+        whisperKit = try await WhisperKit(config)
+        loadedModel = modelName
+        fputs("[whisperkit] model ready: \(modelName)\n", stderr)
+        progress?(1.0, nil)
     }
 
     /// Transcribe a 16kHz mono WAV file.
     func transcribe(wavURL: URL) async throws -> (text: String, processingTime: Double) {
-        guard let whisper else { throw TranscriberError.notLoaded }
+        guard let whisperKit else { throw TranscriberError.notLoaded }
 
-        let audioFrames = try loadWavAsFloats(url: wavURL)
         let start = CFAbsoluteTimeGetCurrent()
-        let segments = try await whisper.transcribe(audioFrames: audioFrames)
+        let results = try await whisperKit.transcribe(audioPath: wavURL.path)
         let elapsed = CFAbsoluteTimeGetCurrent() - start
 
-        let text = segments.map(\.text).joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = results.map(\.text).joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         return (text: text, processingTime: elapsed)
     }
 
     func shutdown() {
-        whisper = nil
-        loadedModelPath = nil
+        whisperKit = nil
+        loadedModel = nil
     }
 
-    // MARK: - Model Download
+    // MARK: - Model Storage
 
-    private static let modelsDir: URL = {
-        let dir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache/muesli/models", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }()
-
-    private static let modelURLs: [String: String] = [
-        "ggml-small.en": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin",
-        "ggml-small.en-q5_1": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q5_1.bin",
-        "ggml-medium.en": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin",
-        "ggml-large-v3-turbo": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
-        "ggml-large-v3-turbo-q5_0": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
-    ]
-
-    private func ensureModelDownloaded(modelName: String, progress: ((Double, String?) -> Void)? = nil) async throws -> String {
-        let filename = modelName.hasSuffix(".bin") ? modelName : "\(modelName).bin"
-        let localPath = Self.modelsDir.appendingPathComponent(filename)
-
-        if FileManager.default.fileExists(atPath: localPath.path) {
-            return localPath.path
+    /// WhisperKit stores models under ~/Documents/huggingface/ by default.
+    /// Check if a model variant directory exists.
+    static func isModelDownloaded(_ modelName: String) -> Bool {
+        let fm = FileManager.default
+        let base = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
+        // WhisperKit uses snapshot directories — check if any snapshot contains our model folder
+        guard let snapshots = try? fm.contentsOfDirectory(at: base, includingPropertiesForKeys: nil) else {
+            return false
         }
-
-        guard let urlString = Self.modelURLs[modelName.replacingOccurrences(of: ".bin", with: "")],
-              let url = URL(string: urlString) else {
-            throw TranscriberError.modelDownloadFailed("Unknown model: \(modelName)")
-        }
-
-        fputs("[whisper.cpp] downloading \(modelName) from HuggingFace...\n", stderr)
-        progress?(0.0, "Downloading \(modelName)...")
-
-        let delegate = DownloadProgressDelegate { fraction in
-            progress?(fraction * 0.9, "Downloading \(modelName)...")  // Reserve 10% for loading
-        }
-        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        try await downloadWithRetry(from: url, to: localPath, session: session)
-        fputs("[whisper.cpp] download complete: \(localPath.path)\n", stderr)
-        return localPath.path
-    }
-
-    // MARK: - Audio Loading
-
-    private func loadWavAsFloats(url: URL) throws -> [Float] {
-        let data = try Data(contentsOf: url)
-        // Skip 44-byte WAV header, read 16-bit PCM samples
-        guard data.count > 44 else {
-            throw TranscriberError.audioLoadFailed("WAV file too small")
-        }
-
-        let pcmData = data.dropFirst(44)
-        let sampleCount = pcmData.count / 2
-        var floats = [Float](repeating: 0, count: sampleCount)
-
-        pcmData.withUnsafeBytes { raw in
-            let int16Buffer = raw.bindMemory(to: Int16.self)
-            for i in 0..<sampleCount {
-                floats[i] = Float(int16Buffer[i]) / 32767.0
+        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
+        for snapshot in snapshots {
+            let modelDir = snapshot.appendingPathComponent(fullName)
+            if fm.fileExists(atPath: modelDir.path) {
+                return true
             }
         }
-
-        return floats
-    }
-}
-
-// MARK: - Download Progress Delegate
-
-private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
-    let onProgress: @Sendable (Double) -> Void
-
-    init(onProgress: @escaping @Sendable (Double) -> Void) {
-        self.onProgress = onProgress
+        return false
     }
 
-    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
-                    didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
-                    totalBytesExpectedToWrite: Int64) {
-        guard totalBytesExpectedToWrite > 0 else { return }
-        let fraction = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
-        onProgress(fraction)
-    }
-
-    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
-                    didFinishDownloadingTo location: URL) {
-        // Handled by the async download call
+    /// Delete cached model files for a WhisperKit model variant.
+    static func deleteModel(_ modelName: String) {
+        let fm = FileManager.default
+        let base = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
+        guard let snapshots = try? fm.contentsOfDirectory(at: base, includingPropertiesForKeys: nil) else {
+            return
+        }
+        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
+        for snapshot in snapshots {
+            let modelDir = snapshot.appendingPathComponent(fullName)
+            try? fm.removeItem(at: modelDir)
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -54,6 +54,17 @@ actor WhisperKitTranscriber {
         return (text: text, processingTime: elapsed)
     }
 
+    /// Run a short silent transcription to trigger CoreML compilation.
+    /// First-run compilation takes 10-30s; subsequent loads are instant.
+    func warmup() async throws {
+        guard let whisperKit else { return }
+        let silence = [Float](repeating: 0, count: 16000) // 1 second of silence at 16kHz
+        let start = CFAbsoluteTimeGetCurrent()
+        let _: [TranscriptionResult] = try await whisperKit.transcribe(audioArray: silence)
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        fputs("[whisperkit] warmup transcription took \(String(format: "%.1f", elapsed))s\n", stderr)
+    }
+
     func shutdown() {
         whisperKit = nil
         loadedModel = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -72,38 +72,22 @@ actor WhisperKitTranscriber {
 
     // MARK: - Model Storage
 
-    /// WhisperKit stores models under ~/Documents/huggingface/ by default.
-    /// Check if a model variant directory exists.
+    /// WhisperKit stores models under ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/.
+    /// Each model variant is a direct subdirectory (e.g. openai_whisper-small.en/).
     static func isModelDownloaded(_ modelName: String) -> Bool {
         let fm = FileManager.default
-        let base = fm.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
-        // WhisperKit uses snapshot directories — check if any snapshot contains our model folder
-        guard let snapshots = try? fm.contentsOfDirectory(at: base, includingPropertiesForKeys: nil) else {
-            return false
-        }
         let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        for snapshot in snapshots {
-            let modelDir = snapshot.appendingPathComponent(fullName)
-            if fm.fileExists(atPath: modelDir.path) {
-                return true
-            }
-        }
-        return false
+        let modelDir = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
+        return fm.fileExists(atPath: modelDir.path)
     }
 
     /// Delete cached model files for a WhisperKit model variant.
     static func deleteModel(_ modelName: String) {
         let fm = FileManager.default
-        let base = fm.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml")
-        guard let snapshots = try? fm.contentsOfDirectory(at: base, includingPropertiesForKeys: nil) else {
-            return
-        }
         let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        for snapshot in snapshots {
-            let modelDir = snapshot.appendingPathComponent(fullName)
-            try? fm.removeItem(at: modelDir)
-        }
+        let modelDir = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
+        try? fm.removeItem(at: modelDir)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -3,26 +3,24 @@ import Foundation
 import MuesliCore
 @testable import MuesliNativeApp
 
-@Suite("WhisperCppTranscriber")
-struct WhisperCppTranscriberTests {
+@Suite("WhisperKitTranscriber")
+struct WhisperKitTranscriberTests {
 
-    @Test("known model URLs are valid")
-    func modelURLsValid() {
-        // Verify the static model URL map has correct HuggingFace URLs
-        let knownModels = ["ggml-small.en", "ggml-small.en-q5_0", "ggml-medium.en", "ggml-large-v3-turbo", "ggml-large-v3-turbo-q5_0"]
-        for model in knownModels {
-            let option = BackendOption.all.first { $0.model == model || $0.model == "\(model).bin" }
-            if let option {
-                #expect(option.backend == "whisper", "\(model) should use whisper backend")
-            }
+    @Test("whisper models use whisper backend")
+    func whisperModelsBackend() {
+        let whisperOptions = BackendOption.all.filter { $0.backend == "whisper" }
+        for option in whisperOptions {
+            #expect(option.backend == "whisper", "\(option.label) should use whisper backend")
         }
     }
 
-    @Test("whisper models have ggml prefix")
-    func whisperModelsGgmlPrefix() {
+    @Test("whisper models use WhisperKit variant names")
+    func whisperModelsVariantNames() {
         let whisperOptions = BackendOption.all.filter { $0.backend == "whisper" }
         for option in whisperOptions {
-            #expect(option.model.hasPrefix("ggml-"), "\(option.label) model should start with ggml-")
+            // WhisperKit models should NOT have ggml- prefix (that was the old SwiftWhisper format)
+            #expect(!option.model.hasPrefix("ggml-"), "\(option.label) should not use ggml- prefix")
+            #expect(!option.model.hasSuffix(".bin"), "\(option.label) should not use .bin suffix")
         }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -77,11 +77,12 @@ struct BackendOptionTests {
         #expect(!BackendOption.experimental.contains(.cohereTranscribe))
     }
 
-    @Test("Whisper models reference ggml format")
-    func whisperGgmlModels() {
-        #expect(BackendOption.whisperSmall.model.hasPrefix("ggml-"))
-        #expect(BackendOption.whisperMedium.model.hasPrefix("ggml-"))
-        #expect(BackendOption.whisperLargeTurbo.model.hasPrefix("ggml-"))
+    @Test("Whisper models use WhisperKit CoreML identifiers")
+    func whisperKitModels() {
+        // WhisperKit models use short variant names, not ggml- prefixed binaries
+        #expect(BackendOption.whisperSmall.model == "small.en")
+        #expect(BackendOption.whisperMedium.model == "medium.en")
+        #expect(BackendOption.whisperLargeTurbo.model.contains("large"))
     }
 }
 


### PR DESCRIPTION
## Summary

- **Replace SwiftWhisper (whisper.cpp v1.4.2, CPU-only) with WhisperKit (CoreML on ANE/GPU)** for the Whisper transcription backend
- Whisper Small dictation should drop from **5-6s → sub-1s** by running on Apple Neural Engine instead of CPU
- Models switch from GGML `.bin` files to pre-converted CoreML packages from `argmaxinc/whisperkit-coreml` on HuggingFace
- FluidAudio pinned to ≥0.12.6 to fix strict concurrency build errors (0.12.4 had `SendingRisksDataRace` errors)
- WhisperKit uses `main` branch (post-PR #455 which removed `swift-transformers` dep that conflicted with FluidAudio)

## Files changed

| File | Change |
|---|---|
| `Package.swift` | SwiftWhisper → WhisperKit dependency |
| `WhisperCppBackend.swift` | Full rewrite: `WhisperKitTranscriber` actor using WhisperKit API |
| `Models.swift` | Model IDs: `ggml-small.en-q5_1` → `small.en`, etc. Updated `isDownloaded` |
| `TranscriptionRuntime.swift` | Route to `WhisperKitTranscriber`, updated log labels |
| `ModelsView.swift` | Updated delete/download-check for WhisperKit storage paths |
| `BackendTests.swift` | Updated to verify WhisperKit format (no ggml- prefix) |
| `ModelsTests.swift` | Updated model ID assertions |

## Known considerations

- **First-run CoreML compilation warmup**: WhisperKit compiles CoreML models to device-specific code on first load (~10-30s). Subsequent loads are instant. Consider surfacing this in onboarding if Whisper is selected.
- **WhisperKit on `main` branch**: Using branch ref until a tagged release includes the `swift-transformers` removal (PR #455). Should pin to a release version once available.
- **Model storage**: WhisperKit stores models under `~/Documents/huggingface/` instead of `~/.cache/muesli/models/`. Old GGML models in the cache are orphaned (users can delete manually).

## Test plan

- [x] `swift build` — compiles clean (0 errors)
- [x] `swift test` — 382 tests in 65 suites pass
- [ ] Manual test: select Whisper Small in MuesliDev, dictate, verify sub-1s latency
- [ ] Manual test: model download flow works via Models tab
- [ ] Manual test: delete model, verify re-download works
- [ ] Test with Whisper Large Turbo variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)