### PR TITLE
Add QoL settings tabs, dictionary thresholds, and split meeting transcription

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -39,6 +39,7 @@ final class AppState {
 
     // Config-driven state
     var selectedBackend: BackendOption = .whisper
+    var selectedMeetingTranscriptionBackend: BackendOption = .whisper
     var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .openAI
     var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()

--- a/native/MuesliNative/Sources/MuesliNativeApp/CustomWordMatcher.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CustomWordMatcher.swift
@@ -6,19 +6,22 @@ import MuesliCore
 ///
 /// Matching stages (first match wins):
 /// 1. Exact case-insensitive match
-/// 2. Jaro-Winkler similarity > 0.85
+/// 2. Jaro-Winkler similarity >= the entry's configured threshold
 struct CustomWordMatcher {
 
     struct Entry {
         let word: String
         let replacement: String
+        let matchingThreshold: Double
     }
 
     /// Apply custom word replacements to transcribed text.
     static func apply(text: String, customWords: [CustomWord]) -> String {
         guard !text.isEmpty, !customWords.isEmpty else { return text }
 
-        let entries = customWords.map { Entry(word: $0.word, replacement: $0.targetWord) }
+        let entries = customWords.map {
+            Entry(word: $0.word, replacement: $0.targetWord, matchingThreshold: $0.matchingThreshold)
+        }
         let words = text.components(separatedBy: " ")
         var result: [String] = []
 
@@ -48,7 +51,7 @@ struct CustomWordMatcher {
 
                 // Stage 2: Jaro-Winkler similarity
                 let score = jaroWinklerSimilarity(wordLower, targetLower)
-                if score > 0.85 && score > bestScore {
+                if score >= entry.matchingThreshold && score > bestScore {
                     bestScore = score
                     bestMatch = entry.replacement
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -4,9 +4,11 @@ import MuesliCore
 struct DictionaryView: View {
     let appState: AppState
     let controller: MuesliController
+
     @State private var isAdding = false
     @State private var newWord = ""
     @State private var newReplacement = ""
+    @State private var newThreshold = 0.85
 
     var body: some View {
         ScrollView {
@@ -31,6 +33,7 @@ struct DictionaryView: View {
                     isAdding = true
                     newWord = ""
                     newReplacement = ""
+                    newThreshold = 0.85
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "plus")
@@ -50,7 +53,7 @@ struct DictionaryView: View {
                 }
                 .buttonStyle(.plain)
             }
-            Text("Add custom words to improve transcription accuracy for names, brands, and domain terms.")
+            Text("Add custom words for names, brands, and domain terms, and tune how aggressively each entry should fuzzy-match transcription errors.")
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
@@ -67,7 +70,7 @@ struct DictionaryView: View {
                 emptyState
             } else {
                 ForEach(appState.config.customWords) { word in
-                    wordRow(word)
+                    DictionaryWordEditorRow(word: word, controller: controller)
                     Divider().background(MuesliTheme.surfaceBorder)
                 }
             }
@@ -88,7 +91,7 @@ struct DictionaryView: View {
             Text("No custom words yet")
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textSecondary)
-            Text("Add words that Whisper frequently gets wrong")
+            Text("Add words that transcription frequently gets wrong")
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textTertiary)
         }
@@ -96,83 +99,155 @@ struct DictionaryView: View {
         .padding(MuesliTheme.spacing32)
     }
 
-    private func wordRow(_ word: CustomWord) -> some View {
-        HStack {
-            if let replacement = word.replacement, !replacement.isEmpty {
-                Text(word.word)
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                Image(systemName: "arrow.right")
-                    .font(.system(size: 10))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                Text(replacement)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(MuesliTheme.textPrimary)
-            } else {
-                Text(word.word)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(MuesliTheme.textPrimary)
-            }
-            Spacer()
-            Button {
-                controller.removeCustomWord(id: word.id)
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 14))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, MuesliTheme.spacing16)
-        .padding(.vertical, MuesliTheme.spacing12)
-    }
-
     private var addWordRow: some View {
-        HStack(spacing: MuesliTheme.spacing8) {
-            TextField("Word", text: $newWord)
-                .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: 180)
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                TextField("Word", text: $newWord)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Replace with (optional)", text: $newReplacement)
+                    .textFieldStyle(.roundedBorder)
+            }
 
-            Text("→")
-                .font(MuesliTheme.body())
+            thresholdEditorRow(
+                threshold: $newThreshold,
+                label: "Matching threshold"
+            )
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    isAdding = false
+                    newWord = ""
+                    newReplacement = ""
+                    newThreshold = 0.85
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
                 .foregroundStyle(MuesliTheme.textTertiary)
 
-            TextField("Replace with (optional)", text: $newReplacement)
-                .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: 200)
-
-            Button {
-                let trimmed = newWord.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-                let replacement = newReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
-                let word = CustomWord(
-                    word: trimmed,
-                    replacement: replacement.isEmpty ? nil : replacement
-                )
-                controller.addCustomWord(word)
-                newWord = ""
-                newReplacement = ""
-                isAdding = false
-            } label: {
-                Text("Add")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuesliTheme.accent)
+                Button("Add") {
+                    let trimmedWord = newWord.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmedWord.isEmpty else { return }
+                    let replacement = newReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
+                    controller.addCustomWord(
+                        CustomWord(
+                            word: trimmedWord,
+                            replacement: replacement.isEmpty ? nil : replacement,
+                            matchingThreshold: newThreshold
+                        )
+                    )
+                    isAdding = false
+                    newWord = ""
+                    newReplacement = ""
+                    newThreshold = 0.85
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MuesliTheme.accent)
+                .disabled(newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
-            .buttonStyle(.plain)
-            .disabled(newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-            Button {
-                isAdding = false
-                newWord = ""
-                newReplacement = ""
-            } label: {
-                Text("Cancel")
-                    .font(.system(size: 12))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-            }
-            .buttonStyle(.plain)
         }
-        .padding(.horizontal, MuesliTheme.spacing16)
-        .padding(.vertical, MuesliTheme.spacing12)
+        .padding(MuesliTheme.spacing16)
+    }
+
+    @ViewBuilder
+    private func thresholdEditorRow(threshold: Binding<Double>, label: String) -> some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            Text(label)
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            Slider(value: threshold, in: 0.70...0.95, step: 0.01)
+                .tint(MuesliTheme.accent)
+            Text(threshold.wrappedValue.formattedThreshold)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 36, alignment: .trailing)
+        }
+    }
+}
+
+private struct DictionaryWordEditorRow: View {
+    let word: CustomWord
+    let controller: MuesliController
+
+    @State private var draftWord: String
+    @State private var draftReplacement: String
+    @State private var draftThreshold: Double
+
+    init(word: CustomWord, controller: MuesliController) {
+        self.word = word
+        self.controller = controller
+        _draftWord = State(initialValue: word.word)
+        _draftReplacement = State(initialValue: word.replacement ?? "")
+        _draftThreshold = State(initialValue: word.matchingThreshold)
+    }
+
+    private var trimmedWord: String {
+        draftWord.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedReplacement: String {
+        draftReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var hasChanges: Bool {
+        trimmedWord != word.word
+            || (trimmedReplacement.isEmpty ? nil : trimmedReplacement) != word.replacement
+            || abs(draftThreshold - word.matchingThreshold) > 0.000_1
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                TextField("Word", text: $draftWord)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Replace with (optional)", text: $draftReplacement)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            HStack(spacing: MuesliTheme.spacing12) {
+                Text("Matching threshold")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                Slider(value: $draftThreshold, in: 0.70...0.95, step: 0.01)
+                    .tint(MuesliTheme.accent)
+                Text(draftThreshold.formattedThreshold)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .frame(width: 36, alignment: .trailing)
+            }
+
+            HStack {
+                Spacer()
+                Button("Delete") {
+                    controller.removeCustomWord(id: word.id)
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(MuesliTheme.recording)
+
+                Button("Save") {
+                    controller.updateCustomWord(
+                        CustomWord(
+                            id: word.id,
+                            word: trimmedWord,
+                            replacement: trimmedReplacement.isEmpty ? nil : trimmedReplacement,
+                            matchingThreshold: draftThreshold
+                        )
+                    )
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MuesliTheme.accent)
+                .disabled(trimmedWord.isEmpty || !hasChanges)
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+    }
+}
+
+private extension Double {
+    var formattedThreshold: String {
+        String(format: "%.2f", self)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -193,7 +193,7 @@ private struct DictionaryWordEditorRow: View {
     private var hasChanges: Bool {
         trimmedWord != word.word
             || (trimmedReplacement.isEmpty ? nil : trimmedReplacement) != word.replacement
-            || abs(draftThreshold - word.matchingThreshold) > 0.000_1
+            || abs(draftThreshold - word.matchingThreshold) > 0.001
     }
 
     var body: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -94,6 +94,7 @@ final class FloatingIndicatorController {
     var onStopMeeting: (() -> Void)?
     var onDiscardMeeting: (() -> Void)?
     var onCancelToggleDictation: (() -> Void)?
+    var onPositionSaved: ((CGPoint) -> Void)?
     var isToggleDictation = false
     private var stopLayer: CALayer?
     private var transcribingTitle = "Transcribing"
@@ -165,8 +166,10 @@ final class FloatingIndicatorController {
         guard let frame = panel?.frame else { return }
         let center = CGPoint(x: frame.midX, y: frame.midY)
         var config = configStore.load()
+        config.indicatorAnchor = .custom
         config.indicatorOrigin = CGPointCodable(x: center.x, y: center.y)
         configStore.save(config)
+        onPositionSaved?(center)
     }
 
     func setToggleDictation(_ active: Bool, config: AppConfig) {
@@ -505,7 +508,6 @@ final class FloatingIndicatorController {
 
     private func applyGlassState(_ state: DictationState, frameSize: NSSize) {
         let config = configStore.load()
-        let isIdle = (state == .idle)
         let radius = frameSize.height / 2
         let themeHex = config.recordingColorHex
 
@@ -687,10 +689,38 @@ final class FloatingIndicatorController {
     }
 
     static func defaultIndicatorCenter(in visibleFrame: NSRect, idleSize: NSSize = NSSize(width: 44, height: 28)) -> CGPoint {
-        CGPoint(
-            x: visibleFrame.maxX - idleSize.width / 2 - 8,
-            y: visibleFrame.midY
-        )
+        anchorCenter(.midTrailing, in: visibleFrame, size: idleSize)
+    }
+
+    static func anchorCenter(_ anchor: IndicatorAnchor, in visibleFrame: NSRect, size: NSSize) -> CGPoint {
+        let inset: CGFloat = 8
+        let leadingX = visibleFrame.minX + size.width / 2 + inset
+        let centerX = visibleFrame.midX
+        let trailingX = visibleFrame.maxX - size.width / 2 - inset
+        let topY = visibleFrame.maxY - size.height / 2 - inset
+        let midY = visibleFrame.midY
+        let bottomY = visibleFrame.minY + size.height / 2 + inset
+
+        switch anchor {
+        case .topLeading:
+            return CGPoint(x: leadingX, y: topY)
+        case .topCenter:
+            return CGPoint(x: centerX, y: topY)
+        case .topTrailing:
+            return CGPoint(x: trailingX, y: topY)
+        case .midLeading:
+            return CGPoint(x: leadingX, y: midY)
+        case .midTrailing:
+            return CGPoint(x: trailingX, y: midY)
+        case .bottomLeading:
+            return CGPoint(x: leadingX, y: bottomY)
+        case .bottomCenter:
+            return CGPoint(x: centerX, y: bottomY)
+        case .bottomTrailing:
+            return CGPoint(x: trailingX, y: bottomY)
+        case .custom:
+            return defaultIndicatorCenter(in: visibleFrame, idleSize: size)
+        }
     }
 
     static func isUsableIndicatorCenter(
@@ -716,16 +746,26 @@ final class FloatingIndicatorController {
         }
 
         // Use the pill's current on-screen center if it exists, so state
-        // transitions resize around the current position rather than jumping.
-        // Saved config is only used for initial panel creation.
+        // transitions resize around the current position rather than jumping
+        // for custom placement. Preset anchors always resolve from config so
+        // changing the setting snaps immediately to the chosen anchor.
         let center: CGPoint
-        if let currentFrame = panel?.frame, currentFrame.width > 0 {
+        if config.indicatorAnchor == .custom,
+           let currentFrame = panel?.frame,
+           currentFrame.width > 0 {
             center = CGPoint(x: currentFrame.midX, y: currentFrame.midY)
-        } else if let saved = config.indicatorOrigin,
-                  Self.isUsableIndicatorCenter(CGPoint(x: saved.x, y: saved.y), in: screen, size: size) {
-            center = CGPoint(x: saved.x, y: saved.y)
         } else {
-            center = Self.defaultIndicatorCenter(in: screen)
+            switch config.indicatorAnchor {
+            case .custom:
+                if let saved = config.indicatorOrigin,
+                   Self.isUsableIndicatorCenter(CGPoint(x: saved.x, y: saved.y), in: screen, size: size) {
+                    center = CGPoint(x: saved.x, y: saved.y)
+                } else {
+                    center = Self.defaultIndicatorCenter(in: screen, idleSize: size)
+                }
+            default:
+                center = Self.anchorCenter(config.indicatorAnchor, in: screen, size: size)
+            }
         }
 
         let x = min(max(center.x - size.width / 2, screen.minX), screen.maxX - size.width)

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -165,10 +165,6 @@ final class FloatingIndicatorController {
     func savePosition() {
         guard let frame = panel?.frame else { return }
         let center = CGPoint(x: frame.midX, y: frame.midY)
-        var config = configStore.load()
-        config.indicatorAnchor = .custom
-        config.indicatorOrigin = CGPointCodable(x: center.x, y: center.y)
-        configStore.save(config)
         onPositionSaved?(center)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -320,6 +320,29 @@ struct CustomWord: Codable, Equatable, Identifiable {
     var id = UUID()
     var word: String
     var replacement: String?
+    var matchingThreshold: Double = 0.85
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case word
+        case replacement
+        case matchingThreshold = "matching_threshold"
+    }
+
+    init(id: UUID = UUID(), word: String, replacement: String?, matchingThreshold: Double = 0.85) {
+        self.id = id
+        self.word = word
+        self.replacement = replacement
+        self.matchingThreshold = matchingThreshold
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = (try? c.decode(UUID.self, forKey: .id)) ?? UUID()
+        word = try c.decode(String.self, forKey: .word)
+        replacement = try c.decodeIfPresent(String.self, forKey: .replacement)
+        matchingThreshold = try c.decodeIfPresent(Double.self, forKey: .matchingThreshold) ?? 0.85
+    }
 
     var displayLabel: String {
         if let replacement, !replacement.isEmpty {
@@ -330,6 +353,32 @@ struct CustomWord: Codable, Equatable, Identifiable {
 
     var targetWord: String {
         replacement ?? word
+    }
+}
+
+enum IndicatorAnchor: String, Codable, CaseIterable {
+    case topLeading = "top_leading"
+    case topCenter = "top_center"
+    case topTrailing = "top_trailing"
+    case midLeading = "mid_leading"
+    case midTrailing = "mid_trailing"
+    case bottomLeading = "bottom_leading"
+    case bottomCenter = "bottom_center"
+    case bottomTrailing = "bottom_trailing"
+    case custom = "custom"
+
+    var label: String {
+        switch self {
+        case .topLeading: return "Top Left"
+        case .topCenter: return "Top Center"
+        case .topTrailing: return "Top Right"
+        case .midLeading: return "Middle Left"
+        case .midTrailing: return "Middle Right"
+        case .bottomLeading: return "Bottom Left"
+        case .bottomCenter: return "Bottom Center"
+        case .bottomTrailing: return "Bottom Right"
+        case .custom: return "Custom"
+        }
     }
 }
 
@@ -359,6 +408,8 @@ struct AppConfig: Codable {
     var dictationHotkey: HotkeyConfig = .default
     var sttBackend: String = BackendOption.whisper.backend
     var sttModel: String = BackendOption.whisper.model
+    var meetingTranscriptionBackend: String = BackendOption.whisper.backend
+    var meetingTranscriptionModel: String = BackendOption.whisper.model
     var meetingSummaryBackend: String = MeetingSummaryBackendOption.openAI.backend
     var defaultMeetingTemplateID: String = MeetingTemplates.autoID
     var whisperModel: String = BackendOption.whisper.model
@@ -371,6 +422,7 @@ struct AppConfig: Codable {
     var launchAtLogin: Bool = false
     var openDashboardOnLaunch: Bool = true
     var showFloatingIndicator: Bool = true
+    var indicatorAnchor: IndicatorAnchor = .midTrailing
     var dashboardWindowFrame: WindowFrame? = nil
     var indicatorOrigin: CGPointCodable? = nil
     var openAIAPIKey: String = ""
@@ -405,6 +457,8 @@ struct AppConfig: Codable {
         case dictationHotkey = "dictation_hotkey"
         case sttBackend = "stt_backend"
         case sttModel = "stt_model"
+        case meetingTranscriptionBackend = "meeting_transcription_backend"
+        case meetingTranscriptionModel = "meeting_transcription_model"
         case meetingSummaryBackend = "meeting_summary_backend"
         case defaultMeetingTemplateID = "default_meeting_template_id"
         case whisperModel = "whisper_model"
@@ -417,6 +471,7 @@ struct AppConfig: Codable {
         case launchAtLogin = "launch_at_login"
         case openDashboardOnLaunch = "open_dashboard_on_launch"
         case showFloatingIndicator = "show_floating_indicator"
+        case indicatorAnchor = "indicator_anchor"
         case dashboardWindowFrame = "dashboard_window_frame"
         case indicatorOrigin = "indicator_origin"
         case openAIAPIKey = "openai_api_key"
@@ -454,6 +509,8 @@ struct AppConfig: Codable {
         dictationHotkey = (try? c.decode(HotkeyConfig.self, forKey: .dictationHotkey)) ?? defaults.dictationHotkey
         sttBackend = (try? c.decode(String.self, forKey: .sttBackend)) ?? defaults.sttBackend
         sttModel = (try? c.decode(String.self, forKey: .sttModel)) ?? defaults.sttModel
+        meetingTranscriptionBackend = (try? c.decode(String.self, forKey: .meetingTranscriptionBackend)) ?? sttBackend
+        meetingTranscriptionModel = (try? c.decode(String.self, forKey: .meetingTranscriptionModel)) ?? sttModel
         meetingSummaryBackend = (try? c.decode(String.self, forKey: .meetingSummaryBackend)) ?? defaults.meetingSummaryBackend
         defaultMeetingTemplateID = (try? c.decode(String.self, forKey: .defaultMeetingTemplateID)) ?? defaults.defaultMeetingTemplateID
         whisperModel = (try? c.decode(String.self, forKey: .whisperModel)) ?? defaults.whisperModel
@@ -466,6 +523,8 @@ struct AppConfig: Codable {
         launchAtLogin = (try? c.decode(Bool.self, forKey: .launchAtLogin)) ?? defaults.launchAtLogin
         openDashboardOnLaunch = (try? c.decode(Bool.self, forKey: .openDashboardOnLaunch)) ?? defaults.openDashboardOnLaunch
         showFloatingIndicator = (try? c.decode(Bool.self, forKey: .showFloatingIndicator)) ?? defaults.showFloatingIndicator
+        indicatorAnchor = (try? c.decode(IndicatorAnchor.self, forKey: .indicatorAnchor))
+            ?? ((try? c.decodeIfPresent(CGPointCodable.self, forKey: .indicatorOrigin)) != nil ? .custom : .midTrailing)
         dashboardWindowFrame = try? c.decode(WindowFrame.self, forKey: .dashboardWindowFrame)
         indicatorOrigin = try? c.decode(CGPointCodable.self, forKey: .indicatorOrigin)
         openAIAPIKey = (try? c.decode(String.self, forKey: .openAIAPIKey)) ?? defaults.openAIAPIKey

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -92,14 +92,6 @@ struct BackendOption: Equatable {
         .whisperSmall, .whisperMedium, .whisperLargeTurbo,
     ]
 
-    static let experimental: [BackendOption] = [
-        .qwen3Asr, .canaryQwen, .nemotronStreaming,
-    ]
-
-    /// Models available for download and use.
-    static let all: [BackendOption] = parakeetFamily + [.cohereTranscribe] + whisperFamily + experimental
-    
-
     static let qwen3Asr = BackendOption(
         backend: "qwen",
         model: "FluidInference/qwen3-asr-0.6b-coreml",
@@ -108,6 +100,13 @@ struct BackendOption: Equatable {
         description: "Multilingual, 52 languages. Slower than Parakeet (~2-3s). First use takes ~30s to warm up.",
         recommended: false
     )
+
+    static let experimental: [BackendOption] = [
+        .qwen3Asr, .canaryQwen, .nemotronStreaming,
+    ]
+
+    /// Models available for download and use.
+    static let all: [BackendOption] = parakeetFamily + [.cohereTranscribe] + whisperFamily + experimental
 
     /// Models coming soon — shown greyed out in the Models tab.
     static let comingSoon: [BackendOption] = []
@@ -333,7 +332,7 @@ struct CustomWord: Codable, Equatable, Identifiable {
         self.id = id
         self.word = word
         self.replacement = replacement
-        self.matchingThreshold = matchingThreshold
+        self.matchingThreshold = Self.clampedThreshold(matchingThreshold)
     }
 
     init(from decoder: Decoder) throws {
@@ -341,7 +340,7 @@ struct CustomWord: Codable, Equatable, Identifiable {
         id = (try? c.decode(UUID.self, forKey: .id)) ?? UUID()
         word = try c.decode(String.self, forKey: .word)
         replacement = try c.decodeIfPresent(String.self, forKey: .replacement)
-        matchingThreshold = try c.decodeIfPresent(Double.self, forKey: .matchingThreshold) ?? 0.85
+        matchingThreshold = Self.clampedThreshold(try c.decodeIfPresent(Double.self, forKey: .matchingThreshold) ?? 0.85)
     }
 
     var displayLabel: String {
@@ -353,6 +352,10 @@ struct CustomWord: Codable, Equatable, Identifiable {
 
     var targetWord: String {
         replacement ?? word
+    }
+
+    private static func clampedThreshold(_ value: Double) -> Double {
+        min(max(value, 0.70), 0.95)
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -101,6 +101,7 @@ final class MuesliController: NSObject {
 
     private(set) var config: AppConfig
     private(set) var selectedBackend: BackendOption
+    private(set) var selectedMeetingTranscriptionBackend: BackendOption
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
     private var activeMeetingSession: MeetingSession?
     private var dictationStartedAt: Date?
@@ -131,6 +132,9 @@ final class MuesliController: NSObject {
         self.selectedBackend = BackendOption.all.first(where: {
             $0.backend == loadedConfig.sttBackend && $0.model == loadedConfig.sttModel
         }) ?? .whisper
+        self.selectedMeetingTranscriptionBackend = BackendOption.all.first(where: {
+            $0.backend == loadedConfig.meetingTranscriptionBackend && $0.model == loadedConfig.meetingTranscriptionModel
+        }) ?? self.selectedBackend
         self.selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == loadedConfig.meetingSummaryBackend
         }) ?? .openAI
@@ -186,6 +190,12 @@ final class MuesliController: NSObject {
             self?.handleCancel()
             self?.indicator.isToggleDictation = false
             self?.hotkeyMonitor.cancelToggleMode()
+        }
+        indicator.onPositionSaved = { [weak self] center in
+            self?.updateConfig {
+                $0.indicatorAnchor = .custom
+                $0.indicatorOrigin = CGPointCodable(x: center.x, y: center.y)
+            }
         }
         workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
@@ -384,6 +394,7 @@ final class MuesliController: NSObject {
         appState.dictationStats = dictationStats()
         appState.meetingStats = meetingStats()
         appState.selectedBackend = selectedBackend
+        appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
         appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
         appState.config = config
@@ -406,6 +417,9 @@ final class MuesliController: NSObject {
         selectedBackend = BackendOption.all.first(where: {
             $0.backend == config.sttBackend && $0.model == config.sttModel
         }) ?? .whisper
+        selectedMeetingTranscriptionBackend = BackendOption.all.first(where: {
+            $0.backend == config.meetingTranscriptionBackend && $0.model == config.meetingTranscriptionModel
+        }) ?? selectedBackend
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == config.meetingSummaryBackend
         }) ?? .openAI
@@ -419,6 +433,7 @@ final class MuesliController: NSObject {
             indicator.closeIfIdle()
         }
         appState.selectedBackend = selectedBackend
+        appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
@@ -448,6 +463,20 @@ final class MuesliController: NSObject {
             await MainActor.run {
                 self.statusBarController?.refresh()
                 self.historyWindowController?.updateBackendLabel()
+            }
+        }
+    }
+
+    func selectMeetingTranscriptionBackend(_ option: BackendOption) {
+        updateConfig {
+            $0.meetingTranscriptionBackend = option.backend
+            $0.meetingTranscriptionModel = option.model
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            await self.transcriptionCoordinator.preload(backend: option, enablePostProcessor: false)
+            await MainActor.run {
+                self.statusBarController?.refresh()
             }
         }
     }
@@ -727,6 +756,13 @@ final class MuesliController: NSObject {
         updateConfig { $0.customWords.append(word) }
     }
 
+    func updateCustomWord(_ word: CustomWord) {
+        updateConfig { config in
+            guard let index = config.customWords.firstIndex(where: { $0.id == word.id }) else { return }
+            config.customWords[index] = word
+        }
+    }
+
     func removeCustomWord(id: UUID) {
         updateConfig { $0.customWords.removeAll { $0.id == id } }
     }
@@ -811,6 +847,8 @@ final class MuesliController: NSObject {
             config.userName = userName
             config.sttBackend = backend.backend
             config.sttModel = backend.model
+            config.meetingTranscriptionBackend = backend.backend
+            config.meetingTranscriptionModel = backend.model
             config.dictationHotkey = hotkey
             if let summaryBackend {
                 config.meetingSummaryBackend = summaryBackend.backend
@@ -1194,7 +1232,7 @@ final class MuesliController: NSObject {
         let meetingSession = MeetingSession(
             title: title,
             calendarEventID: nil,
-            backend: selectedBackend,
+            backend: selectedMeetingTranscriptionBackend,
             runtime: runtime,
             config: config,
             transcriptionCoordinator: transcriptionCoordinator
@@ -1999,6 +2037,7 @@ final class MuesliController: NSObject {
             if let replacement = word.replacement {
                 dict["replacement"] = replacement
             }
+            dict["matchingThreshold"] = word.matchingThreshold
             return dict
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -262,6 +262,12 @@ final class MuesliController: NSObject {
                 backend: self.selectedBackend,
                 enablePostProcessor: self.config.enablePostProcessor && ppOption != nil
             )
+            if self.selectedMeetingTranscriptionBackend != self.selectedBackend {
+                await self.transcriptionCoordinator.preload(
+                    backend: self.selectedMeetingTranscriptionBackend,
+                    enablePostProcessor: false
+                )
+            }
             await MainActor.run {
                 self.refreshUI()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -35,6 +35,24 @@ struct SettingsView: View {
         }
     }
 
+    private enum SettingsPane: String, CaseIterable, Identifiable {
+        case general
+        case dictation
+        case meetings
+        case appearance
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .general: return "General"
+            case .dictation: return "Dictation"
+            case .meetings: return "Meetings"
+            case .appearance: return "Appearance"
+            }
+        }
+    }
+
     let appState: AppState
     let controller: MuesliController
 
@@ -43,9 +61,9 @@ struct SettingsView: View {
     @State private var googleCalSignInError: String?
     @State private var isSigningInGoogleCal = false
     @State private var pendingDataDestruction: PendingDataDestruction?
-    @State private var recordingColorInput: String = ""
     @State private var isPreviewingClip = false
-    @State private var availableBackendOptions: [BackendOption] = []
+    @State private var selectedPane: SettingsPane = .general
+    @State private var downloadedBackendOptions: [BackendOption] = []
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
     @State private var permissionPollTimer: Timer?
     @State private var micGranted = false
@@ -58,8 +76,12 @@ struct SettingsView: View {
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
 
-    private var displayedBackendOptions: [BackendOption] {
-        availableBackendOptions.isEmpty ? [appState.selectedBackend] : availableBackendOptions
+    private var dictationBackendOptions: [BackendOption] {
+        backendOptions(including: appState.selectedBackend)
+    }
+
+    private var meetingBackendOptions: [BackendOption] {
+        backendOptions(including: appState.selectedMeetingTranscriptionBackend)
     }
 
     var body: some View {
@@ -69,471 +91,8 @@ struct SettingsView: View {
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
-                settingsSection("General") {
-                    settingsRow("Launch at login") {
-                        settingsSwitch(isOn: appState.config.launchAtLogin) { newValue in
-                            controller.updateConfig { $0.launchAtLogin = newValue }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Open dashboard on launch") {
-                        settingsSwitch(isOn: appState.config.openDashboardOnLaunch) { newValue in
-                            controller.updateConfig { $0.openDashboardOnLaunch = newValue }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Show floating indicator") {
-                        settingsSwitch(isOn: appState.config.showFloatingIndicator) { newValue in
-                            controller.updateConfig { $0.showFloatingIndicator = newValue }
-                            controller.refreshIndicatorVisibility()
-                        }
-                    }
-                }
-
-                permissionsSection
-
-                settingsSection("Transcription") {
-                    settingsRow("Backend") {
-                        settingsMenu(
-                            selection: appState.selectedBackend.label,
-                            options: displayedBackendOptions.map(\.label)
-                        ) { label in
-                            if let option = displayedBackendOptions.first(where: { $0.label == label }) {
-                                controller.selectBackend(option)
-                            }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("AI transcript cleanup") {
-                        settingsSwitch(isOn: appState.config.enablePostProcessor) { newValue in
-                            controller.setPostProcessorEnabled(newValue)
-                        }
-                    }
-                    if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
-                        Divider().background(MuesliTheme.surfaceBorder)
-                        settingsRow("Cleanup model") {
-                            let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
-                                ? appState.activePostProcessor.label
-                                : (downloadedPostProcOptions.first?.label ?? "")
-                            settingsMenu(
-                                selection: selection,
-                                options: downloadedPostProcOptions.map(\.label)
-                            ) { label in
-                                if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
-                                    controller.selectPostProcessor(option)
-                                }
-                            }
-                        }
-                    } else if appState.config.enablePostProcessor {
-                        Divider().background(MuesliTheme.surfaceBorder)
-                        settingsRow("Cleanup model") {
-                            Text("Download a cleanup model in Models")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(MuesliTheme.textTertiary)
-                                .multilineTextAlignment(.trailing)
-                                .frame(width: controlWidth, alignment: .trailing)
-                        }
-                    }
-                }
-
-                settingsSection("Context") {
-                    settingsRow("Screen context") {
-                        settingsSwitch(isOn: appState.config.enableScreenContext) { newValue in
-                            controller.updateConfig { $0.enableScreenContext = newValue }
-                        }
-                    }
-                    Text("Reads app name and nearby text via the Accessibility API to improve dictation formatting and meeting summaries. No screenshots. All processing stays on-device.")
-                        .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                        .padding(.horizontal, MuesliTheme.spacing16)
-                }
-
-                settingsSection("Meetings") {
-                    settingsRow("Summary backend") {
-                        settingsMenu(
-                            selection: appState.selectedMeetingSummaryBackend.label,
-                            options: MeetingSummaryBackendOption.all.map(\.label)
-                        ) { label in
-                            if let option = MeetingSummaryBackendOption.all.first(where: { $0.label == label }) {
-                                controller.selectMeetingSummaryBackend(option)
-                            }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-
-                    if appState.selectedMeetingSummaryBackend == .chatGPT {
-                        settingsRow("Account") {
-                            if appState.isChatGPTAuthenticated {
-                                Button {
-                                    controller.signOutChatGPT()
-                                } label: {
-                                    HStack(spacing: 5) {
-                                        OpenAILogoShape()
-                                            .fill(.white)
-                                            .frame(width: 10, height: 10)
-                                        Text("Signed in · Sign Out")
-                                            .font(.system(size: 11, weight: .medium))
-                                            .foregroundStyle(.white)
-                                            .lineLimit(1)
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 4)
-                                    .background(MuesliTheme.success)
-                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                }
-                                .buttonStyle(.plain)
-                            } else if isSigningInChatGPT {
-                                HStack(spacing: 6) {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                    Text("Signing in...")
-                                        .font(.system(size: 11))
-                                        .foregroundStyle(MuesliTheme.textSecondary)
-                                }
-                            } else {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Button {
-                                        isSigningInChatGPT = true
-                                        chatGPTSignInError = nil
-                                        Task {
-                                            let error = await controller.signInWithChatGPT()
-                                            isSigningInChatGPT = false
-                                            chatGPTSignInError = error
-                                        }
-                                    } label: {
-                                        HStack(spacing: 5) {
-                                            OpenAILogoShape()
-                                                .fill(.white)
-                                                .frame(width: 10, height: 10)
-                                            Text("Sign in with ChatGPT")
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundStyle(.white)
-                                                .lineLimit(1)
-                                        }
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.horizontal, 10)
-                                        .padding(.vertical, 4)
-                                        .background(MuesliTheme.accent)
-                                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                    }
-                                    .buttonStyle(.plain)
-
-                                    if let chatGPTSignInError {
-                                        Text(chatGPTSignInError)
-                                            .font(.system(size: 10))
-                                            .foregroundStyle(.red)
-                                            .lineLimit(2)
-                                    }
-                                }
-                            }
-                        }
-                        Divider().background(MuesliTheme.surfaceBorder)
-                        settingsRow("Model") {
-                            settingsModelMenu(
-                                currentModel: appState.config.chatGPTModel,
-                                presets: SummaryModelPreset.chatGPTModels
-                            ) { val in controller.updateConfig { $0.chatGPTModel = val } }
-                        }
-                    } else if appState.selectedMeetingSummaryBackend == .openAI {
-                        settingsRow("API Key") {
-                            PastableSecureField(
-                                text: appState.config.openAIAPIKey,
-                                placeholder: "sk-...",
-                                onChange: { val in controller.updateConfig { $0.openAIAPIKey = val } }
-                            )
-                            .frame(height: 22)
-                        }
-                        Divider().background(MuesliTheme.surfaceBorder)
-                        settingsRow("Model") {
-                            settingsModelMenu(
-                                currentModel: appState.config.openAIModel,
-                                presets: SummaryModelPreset.openAIModels
-                            ) { val in controller.updateConfig { $0.openAIModel = val } }
-                        }
-                        keyStatusRow(key: appState.config.openAIAPIKey)
-                    } else {
-                        settingsRow("API Key") {
-                            PastableSecureField(
-                                text: appState.config.openRouterAPIKey,
-                                placeholder: "sk-or-...",
-                                onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
-                            )
-                            .frame(height: 22)
-                        }
-                        Divider().background(MuesliTheme.surfaceBorder)
-                        settingsRow("Model") {
-                            settingsModelMenu(
-                                currentModel: appState.config.openRouterModel,
-                                presets: SummaryModelPreset.openRouterModels
-                            ) { val in controller.updateConfig { $0.openRouterModel = val } }
-                        }
-                        keyStatusRow(key: appState.config.openRouterAPIKey)
-                    }
-
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Default template") {
-                        meetingTemplateMenu(selectionID: appState.config.defaultMeetingTemplateID) { id in
-                            controller.updateDefaultMeetingTemplate(id: id)
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Templates") {
-                        actionButton("Manage Templates…") {
-                            controller.showMeetingTemplatesManager()
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Auto-record calendar meetings") {
-                        settingsSwitch(isOn: appState.config.autoRecordMeetings) { newValue in
-                            controller.updateConfig { $0.autoRecordMeetings = newValue }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Notify when meeting detected") {
-                        settingsSwitch(isOn: appState.config.showMeetingDetectionNotification) { newValue in
-                            controller.updateConfig { $0.showMeetingDetectionNotification = newValue }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Save meeting recording") {
-                        settingsMenu(
-                            selection: recordingSaveLabel(for: appState.config.meetingRecordingSavePolicy),
-                            options: MeetingRecordingSavePolicy.allCases.map(recordingSaveLabel(for:))
-                        ) { label in
-                            guard let policy = recordingSavePolicy(for: label) else { return }
-                            controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
-                        }
-                    }
-                }
-
-                if appState.isGoogleCalendarAvailable {
-                    settingsSection("Calendar") {
-                        settingsRow("Google Calendar") {
-                            if appState.isGoogleCalendarAuthenticated {
-                                Button {
-                                    controller.signOutGoogleCalendar()
-                                } label: {
-                                    HStack(spacing: 5) {
-                                        Image(systemName: "calendar")
-                                            .font(.system(size: 10))
-                                            .foregroundStyle(.white)
-                                        Text("Connected · Disconnect")
-                                            .font(.system(size: 11, weight: .medium))
-                                            .foregroundStyle(.white)
-                                            .lineLimit(1)
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 4)
-                                    .background(MuesliTheme.success)
-                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                }
-                                .buttonStyle(.plain)
-                            } else if isSigningInGoogleCal {
-                                HStack(spacing: 6) {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                    Text("Connecting...")
-                                        .font(.system(size: 11))
-                                        .foregroundStyle(MuesliTheme.textSecondary)
-                                }
-                            } else if !appState.isGoogleCalendarVerified {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    HStack(spacing: 5) {
-                                        Image(systemName: "calendar.badge.plus")
-                                            .font(.system(size: 10))
-                                            .foregroundStyle(.white.opacity(0.4))
-                                        Text("Connect Google Calendar")
-                                            .font(.system(size: 11, weight: .medium))
-                                            .foregroundStyle(.white.opacity(0.4))
-                                            .lineLimit(1)
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 4)
-                                    .background(MuesliTheme.textTertiary.opacity(0.3))
-                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-
-                                    Text("Google OAuth verification pending")
-                                        .font(.system(size: 10))
-                                        .foregroundStyle(MuesliTheme.textTertiary)
-                                }
-                            } else {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Button {
-                                        isSigningInGoogleCal = true
-                                        googleCalSignInError = nil
-                                        Task {
-                                            let error = await controller.signInWithGoogleCalendar()
-                                            isSigningInGoogleCal = false
-                                            googleCalSignInError = error
-                                        }
-                                    } label: {
-                                        HStack(spacing: 5) {
-                                            Image(systemName: "calendar.badge.plus")
-                                                .font(.system(size: 10))
-                                                .foregroundStyle(.white)
-                                            Text("Connect Google Calendar")
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundStyle(.white)
-                                                .lineLimit(1)
-                                        }
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.horizontal, 10)
-                                        .padding(.vertical, 4)
-                                        .background(MuesliTheme.accent)
-                                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                    }
-                                    .buttonStyle(.plain)
-
-                                    if let googleCalSignInError {
-                                        Text(googleCalSignInError)
-                                            .font(.system(size: 10))
-                                            .foregroundStyle(.red)
-                                            .lineLimit(2)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                settingsSection("Appearance") {
-                    settingsRow("Menu bar icon") {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 4) {
-                                ForEach(MenuBarIconRenderer.options, id: \.id) { option in
-                                    let isSelected = appState.config.menuBarIcon == option.id
-                                    Button {
-                                        controller.updateConfig { $0.menuBarIcon = option.id }
-                                    } label: {
-                                        Group {
-                                            if option.id == "muesli",
-                                               let img = MenuBarIconRenderer.make(choice: "muesli") {
-                                                Image(nsImage: img)
-                                                    .resizable()
-                                                    .scaledToFit()
-                                                    .frame(width: 14, height: 14)
-                                            } else {
-                                                Image(systemName: option.id)
-                                                    .font(.system(size: 12))
-                                            }
-                                        }
-                                        .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
-                                        .frame(width: 26, height: 26)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 5)
-                                                .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
-                                        )
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 5)
-                                                .strokeBorder(Color.white.opacity(isSelected ? 0.3 : 0.08), lineWidth: 1)
-                                        )
-                                    }
-                                    .buttonStyle(.plain)
-                                    .help(option.label)
-                                }
-                            }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Accent color") {
-                        glassTintPicker
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Play sound effects") {
-                        settingsSwitch(isOn: appState.config.soundEnabled) { newValue in
-                            controller.updateConfig { $0.soundEnabled = newValue }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Show next meeting in menu bar") {
-                        settingsSwitch(isOn: appState.config.showNextMeetingInMenuBar) { newValue in
-                            controller.updateConfig { $0.showNextMeetingInMenuBar = newValue }
-                        }
-                    }
-                }
-
-                if appState.config.maraudersMapUnlocked {
-                    settingsSection("Marauder\u{2019}s Map") {
-                        settingsRow("Meeting countdown audio") {
-                            HStack(spacing: MuesliTheme.spacing8) {
-                                settingsMenu(
-                                    selection: SoundController.labelForClip(
-                                        id: appState.config.maraudersMapAudioClip,
-                                        customPath: appState.config.maraudersMapCustomAudioPath
-                                    ),
-                                    options: SoundController.maraudersMapClipLabels
-                                ) { label in
-                                    if label == "Custom\u{2026}" {
-                                        pickCustomAudioFile()
-                                    } else if let preset = SoundController.maraudersMapPresets
-                                        .first(where: { $0.label == label }) {
-                                        SoundController.stopMaraudersMapClip()
-                                        isPreviewingClip = false
-                                        controller.updateConfig {
-                                            $0.maraudersMapAudioClip = preset.id
-                                            $0.maraudersMapCustomAudioPath = nil
-                                        }
-                                        controller.updateMaraudersMapAudioClip()
-                                    }
-                                }
-                                Button {
-                                    if isPreviewingClip {
-                                        SoundController.stopMaraudersMapClip()
-                                        isPreviewingClip = false
-                                    } else {
-                                        SoundController.playMaraudersMapClip(
-                                            id: appState.config.maraudersMapAudioClip,
-                                            customPath: appState.config.maraudersMapCustomAudioPath
-                                        ) {
-                                            isPreviewingClip = false
-                                        }
-                                        isPreviewingClip = true
-                                    }
-                                } label: {
-                                    Image(systemName: isPreviewingClip ? "stop.fill" : "play.fill")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(MuesliTheme.textSecondary)
-                                        .frame(width: 24, height: 24)
-                                }
-                                .buttonStyle(.plain)
-                                .contentShape(Rectangle())
-                            }
-                        }
-                        Divider().background(MuesliTheme.surfaceBorder)
-                        settingsRow("") {
-                            Button {
-                                SoundController.stopMaraudersMapClip()
-                                isPreviewingClip = false
-                                controller.resetMaraudersMap()
-                            } label: {
-                                Text("Mischief Managed")
-                                    .font(.system(size: 11))
-                                    .foregroundColor(MuesliTheme.textSecondary)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                    .onDisappear {
-                        SoundController.stopMaraudersMapClip()
-                        isPreviewingClip = false
-                    }
-                }
-
-                settingsSection("Data") {
-                    HStack(spacing: MuesliTheme.spacing12) {
-                        actionButton("Clear dictation history", role: .destructive) {
-                            pendingDataDestruction = .dictations
-                        }
-                        actionButton("Clear meeting history", role: .destructive) {
-                            pendingDataDestruction = .meetings
-                        }
-                        .disabled(controller.isMeetingRecording())
-                        .help("Stop the current meeting recording before clearing meeting history.")
-                    }
-                }
+                settingsPanePicker
+                paneContent
             }
             .padding(MuesliTheme.spacing32)
         }
@@ -543,6 +102,8 @@ struct SettingsView: View {
             startPermissionPolling()
         }
         .onDisappear {
+            SoundController.stopMaraudersMapClip()
+            isPreviewingClip = false
             stopPermissionPolling()
         }
         .onChange(of: appState.selectedTab) { _, tab in
@@ -552,7 +113,10 @@ struct SettingsView: View {
             }
         }
         .onChange(of: appState.selectedBackend) { _, _ in
-            refreshAvailableBackendOptions()
+            refreshDownloadedModelOptions()
+        }
+        .onChange(of: appState.selectedMeetingTranscriptionBackend) { _, _ in
+            refreshDownloadedModelOptions()
         }
         .alert(
             pendingDataDestruction?.title ?? "Confirm Destructive Action",
@@ -581,16 +145,16 @@ struct SettingsView: View {
     }
 
     private func refreshDownloadedModelOptions() {
-        refreshAvailableBackendOptions()
+        downloadedBackendOptions = BackendOption.downloaded
         downloadedPostProcOptions = PostProcessorOption.downloaded
     }
 
-    private func refreshAvailableBackendOptions() {
-        var options = BackendOption.downloaded
-        if !options.contains(where: { $0 == appState.selectedBackend }) {
-            options.insert(appState.selectedBackend, at: 0)
+    private func backendOptions(including selection: BackendOption) -> [BackendOption] {
+        var options = downloadedBackendOptions
+        if !options.contains(where: { $0 == selection }) {
+            options.insert(selection, at: 0)
         }
-        availableBackendOptions = options
+        return options
     }
 
     private static let accentPresets: [(hex: String, name: String)] = [
@@ -602,6 +166,332 @@ struct SettingsView: View {
         ("ec4899", "Pink"),
         ("1e1e2e", "Dark"),
     ]
+
+    private var settingsPanePicker: some View {
+        HStack {
+            Spacer()
+            Picker("", selection: $selectedPane) {
+                ForEach(SettingsPane.allCases) { pane in
+                    Text(pane.title).tag(pane)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .frame(width: 560)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var paneContent: some View {
+        switch selectedPane {
+        case .general:
+            generalSettingsPane
+        case .dictation:
+            dictationSettingsPane
+        case .meetings:
+            meetingsSettingsPane
+        case .appearance:
+            appearanceSettingsPane
+        }
+    }
+
+    private var generalSettingsPane: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            settingsSection("General") {
+                settingsRow("Launch at login") {
+                    settingsSwitch(isOn: appState.config.launchAtLogin) { newValue in
+                        controller.updateConfig { $0.launchAtLogin = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Open dashboard on launch") {
+                    settingsSwitch(isOn: appState.config.openDashboardOnLaunch) { newValue in
+                        controller.updateConfig { $0.openDashboardOnLaunch = newValue }
+                    }
+                }
+            }
+
+            permissionsSection
+
+            settingsSection("Data") {
+                HStack(spacing: MuesliTheme.spacing12) {
+                    actionButton("Clear dictation history", role: .destructive) {
+                        pendingDataDestruction = .dictations
+                    }
+                    actionButton("Clear meeting history", role: .destructive) {
+                        pendingDataDestruction = .meetings
+                    }
+                    .disabled(controller.isMeetingRecording())
+                    .help("Stop the current meeting recording before clearing meeting history.")
+                }
+            }
+        }
+    }
+
+    private var dictationSettingsPane: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            settingsSection("Transcription") {
+                settingsRow("Dictation model") {
+                    settingsMenu(
+                        selection: appState.selectedBackend.label,
+                        options: dictationBackendOptions.map(\.label)
+                    ) { label in
+                        if let option = dictationBackendOptions.first(where: { $0.label == label }) {
+                            controller.selectBackend(option)
+                        }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("AI transcript cleanup") {
+                    settingsSwitch(isOn: appState.config.enablePostProcessor) { newValue in
+                        controller.setPostProcessorEnabled(newValue)
+                    }
+                }
+                if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Cleanup model") {
+                        let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
+                            ? appState.activePostProcessor.label
+                            : (downloadedPostProcOptions.first?.label ?? "")
+                        settingsMenu(
+                            selection: selection,
+                            options: downloadedPostProcOptions.map(\.label)
+                        ) { label in
+                            if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
+                                controller.selectPostProcessor(option)
+                            }
+                        }
+                    }
+                } else if appState.config.enablePostProcessor {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Cleanup model") {
+                        Text("Download a cleanup model in Models")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: controlWidth, alignment: .trailing)
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("App context") {
+                    settingsSwitch(isOn: appState.config.enableScreenContext) { newValue in
+                        controller.updateConfig { $0.enableScreenContext = newValue }
+                    }
+                }
+                Text("Uses nearby app text for dictation cleanup and also feeds meeting summaries. All processing stays on-device.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.horizontal, MuesliTheme.spacing16)
+            }
+        }
+    }
+
+    private var meetingsSettingsPane: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            settingsSection("Meeting Transcription") {
+                settingsRow("Meeting model") {
+                    settingsMenu(
+                        selection: appState.selectedMeetingTranscriptionBackend.label,
+                        options: meetingBackendOptions.map(\.label)
+                    ) { label in
+                        if let option = meetingBackendOptions.first(where: { $0.label == label }) {
+                            controller.selectMeetingTranscriptionBackend(option)
+                        }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Meeting context") {
+                    settingsSwitch(isOn: appState.config.enableScreenContext) { newValue in
+                        controller.updateConfig { $0.enableScreenContext = newValue }
+                    }
+                }
+                Text("Reads app name, nearby text, and OCR context when available to enrich meeting summaries. This shared setting also assists dictation cleanup.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.horizontal, MuesliTheme.spacing16)
+            }
+
+            settingsSection("Meeting Summaries") {
+                settingsRow("Summary backend") {
+                    settingsMenu(
+                        selection: appState.selectedMeetingSummaryBackend.label,
+                        options: MeetingSummaryBackendOption.all.map(\.label)
+                    ) { label in
+                        if let option = MeetingSummaryBackendOption.all.first(where: { $0.label == label }) {
+                            controller.selectMeetingSummaryBackend(option)
+                        }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+
+                if appState.selectedMeetingSummaryBackend == .chatGPT {
+                    settingsRow("Account") {
+                        chatGPTAccountControl
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model") {
+                        settingsModelMenu(
+                            currentModel: appState.config.chatGPTModel,
+                            presets: SummaryModelPreset.chatGPTModels
+                        ) { val in controller.updateConfig { $0.chatGPTModel = val } }
+                    }
+                } else if appState.selectedMeetingSummaryBackend == .openAI {
+                    settingsRow("API Key") {
+                        PastableSecureField(
+                            text: appState.config.openAIAPIKey,
+                            placeholder: "sk-...",
+                            onChange: { val in controller.updateConfig { $0.openAIAPIKey = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model") {
+                        settingsModelMenu(
+                            currentModel: appState.config.openAIModel,
+                            presets: SummaryModelPreset.openAIModels
+                        ) { val in controller.updateConfig { $0.openAIModel = val } }
+                    }
+                    keyStatusRow(key: appState.config.openAIAPIKey)
+                } else {
+                    settingsRow("API Key") {
+                        PastableSecureField(
+                            text: appState.config.openRouterAPIKey,
+                            placeholder: "sk-or-...",
+                            onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model") {
+                        settingsModelMenu(
+                            currentModel: appState.config.openRouterModel,
+                            presets: SummaryModelPreset.openRouterModels
+                        ) { val in controller.updateConfig { $0.openRouterModel = val } }
+                    }
+                    keyStatusRow(key: appState.config.openRouterAPIKey)
+                }
+
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Default template") {
+                    meetingTemplateMenu(selectionID: appState.config.defaultMeetingTemplateID) { id in
+                        controller.updateDefaultMeetingTemplate(id: id)
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Templates") {
+                    actionButton("Manage Templates…") {
+                        controller.showMeetingTemplatesManager()
+                    }
+                }
+            }
+
+            settingsSection("Recording") {
+                settingsRow("Auto-record calendar meetings") {
+                    settingsSwitch(isOn: appState.config.autoRecordMeetings) { newValue in
+                        controller.updateConfig { $0.autoRecordMeetings = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Notify when meeting detected") {
+                    settingsSwitch(isOn: appState.config.showMeetingDetectionNotification) { newValue in
+                        controller.updateConfig { $0.showMeetingDetectionNotification = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Save meeting recording") {
+                    settingsMenu(
+                        selection: recordingSaveLabel(for: appState.config.meetingRecordingSavePolicy),
+                        options: MeetingRecordingSavePolicy.allCases.map(recordingSaveLabel(for:))
+                    ) { label in
+                        guard let policy = recordingSavePolicy(for: label) else { return }
+                        controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
+                    }
+                }
+            }
+
+            if appState.isGoogleCalendarAvailable {
+                settingsSection("Calendar") {
+                    settingsRow("Google Calendar") {
+                        googleCalendarControl
+                    }
+                }
+            }
+        }
+    }
+
+    private var appearanceSettingsPane: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            settingsSection("Floating Indicator") {
+                settingsRow("Show floating indicator") {
+                    settingsSwitch(isOn: appState.config.showFloatingIndicator) { newValue in
+                        controller.updateConfig { $0.showFloatingIndicator = newValue }
+                        controller.refreshIndicatorVisibility()
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Indicator position") {
+                    settingsMenu(
+                        selection: appState.config.indicatorAnchor.label,
+                        options: IndicatorAnchor.allCases.map(\.label)
+                    ) { label in
+                        guard let anchor = IndicatorAnchor.allCases.first(where: { $0.label == label }) else { return }
+                        controller.updateConfig { $0.indicatorAnchor = anchor }
+                        controller.refreshIndicatorVisibility()
+                    }
+                }
+            }
+
+            settingsSection("Appearance") {
+                settingsRow("Dark mode") {
+                    settingsSwitch(isOn: appState.config.darkMode) { newValue in
+                        controller.updateConfig { $0.darkMode = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Menu bar icon") {
+                    menuBarIconPicker
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Accent color") {
+                    glassTintPicker
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Play sound effects") {
+                    settingsSwitch(isOn: appState.config.soundEnabled) { newValue in
+                        controller.updateConfig { $0.soundEnabled = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Show next meeting in menu bar") {
+                    settingsSwitch(isOn: appState.config.showNextMeetingInMenuBar) { newValue in
+                        controller.updateConfig { $0.showNextMeetingInMenuBar = newValue }
+                    }
+                }
+            }
+
+            if appState.config.maraudersMapUnlocked {
+                settingsSection("Marauder\u{2019}s Map") {
+                    settingsRow("Meeting countdown audio") {
+                        maraudersMapControl
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("") {
+                        Button {
+                            SoundController.stopMaraudersMapClip()
+                            isPreviewingClip = false
+                            controller.resetMaraudersMap()
+                        } label: {
+                            Text("Mischief Managed")
+                                .font(.system(size: 11))
+                                .foregroundColor(MuesliTheme.textSecondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
 
     private var glassTintPicker: some View {
         HStack(spacing: 6) {
@@ -623,6 +513,247 @@ struct SettingsView: View {
                 .buttonStyle(.plain)
                 .help(preset.name)
             }
+        }
+    }
+
+    private var menuBarIconPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                ForEach(MenuBarIconRenderer.options, id: \.id) { option in
+                    let isSelected = appState.config.menuBarIcon == option.id
+                    Button {
+                        controller.updateConfig { $0.menuBarIcon = option.id }
+                    } label: {
+                        Group {
+                            if option.id == "muesli",
+                               let img = MenuBarIconRenderer.make(choice: "muesli") {
+                                Image(nsImage: img)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 14, height: 14)
+                            } else {
+                                Image(systemName: option.id)
+                                    .font(.system(size: 12))
+                            }
+                        }
+                        .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                        .frame(width: 26, height: 26)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .strokeBorder(Color.white.opacity(isSelected ? 0.3 : 0.08), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .help(option.label)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var chatGPTAccountControl: some View {
+        if appState.isChatGPTAuthenticated {
+            Button {
+                controller.signOutChatGPT()
+            } label: {
+                HStack(spacing: 5) {
+                    OpenAILogoShape()
+                        .fill(.white)
+                        .frame(width: 10, height: 10)
+                    Text("Signed in · Sign Out")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(MuesliTheme.success)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+        } else if isSigningInChatGPT {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Signing in...")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                Button {
+                    isSigningInChatGPT = true
+                    chatGPTSignInError = nil
+                    Task {
+                        let error = await controller.signInWithChatGPT()
+                        isSigningInChatGPT = false
+                        chatGPTSignInError = error
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        OpenAILogoShape()
+                            .fill(.white)
+                            .frame(width: 10, height: 10)
+                        Text("Sign in with ChatGPT")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.accent)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+
+                if let chatGPTSignInError {
+                    Text(chatGPTSignInError)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var googleCalendarControl: some View {
+        if appState.isGoogleCalendarAuthenticated {
+            Button {
+                controller.signOutGoogleCalendar()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "calendar")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white)
+                    Text("Connected · Disconnect")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(MuesliTheme.success)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+        } else if isSigningInGoogleCal {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Connecting...")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+        } else if !appState.isGoogleCalendarVerified {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 5) {
+                    Image(systemName: "calendar.badge.plus")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white.opacity(0.4))
+                    Text("Connect Google Calendar")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(MuesliTheme.textTertiary.opacity(0.3))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                Text("Google OAuth verification pending")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                Button {
+                    isSigningInGoogleCal = true
+                    googleCalSignInError = nil
+                    Task {
+                        let error = await controller.signInWithGoogleCalendar()
+                        isSigningInGoogleCal = false
+                        googleCalSignInError = error
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "calendar.badge.plus")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.white)
+                        Text("Connect Google Calendar")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(MuesliTheme.accent)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+
+                if let googleCalSignInError {
+                    Text(googleCalSignInError)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+
+    private var maraudersMapControl: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            settingsMenu(
+                selection: SoundController.labelForClip(
+                    id: appState.config.maraudersMapAudioClip,
+                    customPath: appState.config.maraudersMapCustomAudioPath
+                ),
+                options: SoundController.maraudersMapClipLabels
+            ) { label in
+                if label == "Custom\u{2026}" {
+                    pickCustomAudioFile()
+                } else if let preset = SoundController.maraudersMapPresets
+                    .first(where: { $0.label == label }) {
+                    SoundController.stopMaraudersMapClip()
+                    isPreviewingClip = false
+                    controller.updateConfig {
+                        $0.maraudersMapAudioClip = preset.id
+                        $0.maraudersMapCustomAudioPath = nil
+                    }
+                    controller.updateMaraudersMapAudioClip()
+                }
+            }
+            Button {
+                if isPreviewingClip {
+                    SoundController.stopMaraudersMapClip()
+                    isPreviewingClip = false
+                } else {
+                    SoundController.playMaraudersMapClip(
+                        id: appState.config.maraudersMapAudioClip,
+                        customPath: appState.config.maraudersMapCustomAudioPath
+                    ) {
+                        isPreviewingClip = false
+                    }
+                    isPreviewingClip = true
+                }
+            } label: {
+                Image(systemName: isPreviewingClip ? "stop.fill" : "play.fill")
+                    .font(.system(size: 11))
+                    .foregroundColor(MuesliTheme.textSecondary)
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -167,6 +167,9 @@ struct SettingsView: View {
         ("1e1e2e", "Dark"),
     ]
 
+    private let sharedContextDescription =
+        "Uses nearby app text for dictation cleanup and meeting summaries, plus OCR context for meetings when available. All processing stays on-device."
+
     private var settingsPanePicker: some View {
         HStack {
             Spacer()
@@ -279,7 +282,7 @@ struct SettingsView: View {
                         controller.updateConfig { $0.enableScreenContext = newValue }
                     }
                 }
-                Text("Uses nearby app text for dictation cleanup and also feeds meeting summaries. All processing stays on-device.")
+                Text(sharedContextDescription)
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .padding(.horizontal, MuesliTheme.spacing16)
@@ -306,7 +309,7 @@ struct SettingsView: View {
                         controller.updateConfig { $0.enableScreenContext = newValue }
                     }
                 }
-                Text("Reads app name, nearby text, and OCR context when available to enrich meeting summaries. This shared setting also assists dictation cleanup.")
+                Text(sharedContextDescription)
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .padding(.horizontal, MuesliTheme.spacing16)
@@ -433,7 +436,7 @@ struct SettingsView: View {
                 settingsRow("Indicator position") {
                     settingsMenu(
                         selection: appState.config.indicatorAnchor.label,
-                        options: IndicatorAnchor.allCases.map(\.label)
+                        options: IndicatorAnchor.allCases.filter { $0 != .custom }.map(\.label)
                     ) { label in
                         guard let anchor = IndicatorAnchor.allCases.first(where: { $0.label == label }) else { return }
                         controller.updateConfig { $0.indicatorAnchor = anchor }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -169,6 +169,7 @@ struct SettingsView: View {
 
     private let sharedContextDescription =
         "Uses nearby app text for dictation cleanup and meeting summaries, plus OCR context for meetings when available. All processing stays on-device."
+    private let customIndicatorPositionLabel = "Custom (drag to reposition)"
 
     private var settingsPanePicker: some View {
         HStack {
@@ -434,10 +435,15 @@ struct SettingsView: View {
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Indicator position") {
+                    let isCustom = appState.config.indicatorAnchor == .custom
+                    let selection = isCustom ? customIndicatorPositionLabel : appState.config.indicatorAnchor.label
+                    let options = (isCustom ? [customIndicatorPositionLabel] : [])
+                        + IndicatorAnchor.allCases.filter { $0 != .custom }.map(\.label)
                     settingsMenu(
-                        selection: appState.config.indicatorAnchor.label,
-                        options: IndicatorAnchor.allCases.filter { $0 != .custom }.map(\.label)
+                        selection: selection,
+                        options: options
                     ) { label in
+                        if label == customIndicatorPositionLabel { return }
                         guard let anchor = IndicatorAnchor.allCases.first(where: { $0.label == label }) else { return }
                         controller.updateConfig { $0.indicatorAnchor = anchor }
                         controller.refreshIndicatorVisibility()

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -406,7 +406,8 @@ actor TranscriptionCoordinator {
         guard !customWords.isEmpty, !result.text.isEmpty else { return result }
         let entries = customWords.compactMap { dict -> CustomWord? in
             guard let word = dict["word"] as? String else { return nil }
-            return CustomWord(word: word, replacement: dict["replacement"] as? String)
+            let threshold = dict["matchingThreshold"] as? Double ?? 0.85
+            return CustomWord(word: word, replacement: dict["replacement"] as? String, matchingThreshold: threshold)
         }
         guard !entries.isEmpty else { return result }
         let correctedText = CustomWordMatcher.apply(text: result.text, customWords: entries)

--- a/native/MuesliNative/Tests/MuesliTests/CustomWordMatcherTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CustomWordMatcherTests.swift
@@ -111,4 +111,18 @@ struct CustomWordMatcherApplyTests {
         // "museli" fuzzy matches "muesli", replacement is nil so uses word "muesli"
         #expect(result == "I love muesli")
     }
+
+    @Test("per-word lower threshold allows aggressive fuzzy correction")
+    func lowerThresholdAllowsCorrection() {
+        let words = [CustomWord(word: "Caivex", replacement: "Caivex", matchingThreshold: 0.70)]
+        let result = CustomWordMatcher.apply(text: "talk to Kvex tomorrow", customWords: words)
+        #expect(result == "talk to Caivex tomorrow")
+    }
+
+    @Test("higher threshold blocks over-eager fuzzy correction")
+    func higherThresholdPreventsCorrection() {
+        let words = [CustomWord(word: "Caivex", replacement: "Caivex", matchingThreshold: 0.92)]
+        let result = CustomWordMatcher.apply(text: "talk to Kvex tomorrow", customWords: words)
+        #expect(result == "talk to Kvex tomorrow")
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -224,6 +224,19 @@ struct MeetingsNavigationTests {
         #expect(controller.config.customMeetingTemplates.isEmpty)
     }
 
+    @Test("meeting transcription backend selection is independent from dictation backend")
+    func meetingTranscriptionBackendSelectionIsIndependent() {
+        let controller = makeController()
+
+        controller.selectBackend(.parakeetEnglish)
+        controller.selectMeetingTranscriptionBackend(.whisperLargeTurbo)
+
+        #expect(controller.appState.selectedBackend == .parakeetEnglish)
+        #expect(controller.appState.selectedMeetingTranscriptionBackend == .whisperLargeTurbo)
+        #expect(controller.appState.config.sttModel == BackendOption.parakeetEnglish.model)
+        #expect(controller.appState.config.meetingTranscriptionModel == BackendOption.whisperLargeTurbo.model)
+    }
+
     private func makeMeeting(id: Int64, title: String) -> MeetingRecord {
         MeetingRecord(
             id: id,

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -244,6 +244,8 @@ struct AppConfigTests {
         let config = AppConfig()
         #expect(config.sttBackend == BackendOption.whisper.backend)
         #expect(config.sttModel == BackendOption.whisper.model)
+        #expect(config.meetingTranscriptionBackend == BackendOption.whisper.backend)
+        #expect(config.meetingTranscriptionModel == BackendOption.whisper.model)
         #expect(config.meetingSummaryBackend == "openai")
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
@@ -251,6 +253,7 @@ struct AppConfigTests {
         #expect(config.openRouterAPIKey.isEmpty)
         #expect(config.dictationHotkey == .default)
         #expect(config.showFloatingIndicator == true)
+        #expect(config.indicatorAnchor == .midTrailing)
         #expect(config.hasCompletedOnboarding == false)
         #expect(config.userName.isEmpty)
         #expect(config.customMeetingTemplates.isEmpty)
@@ -284,6 +287,8 @@ struct AppConfigTests {
         #expect(decoded.customMeetingTemplates.count == 1)
         #expect(decoded.customMeetingTemplates.first?.name == "Customer Follow-Up")
         #expect(decoded.customMeetingTemplates.first?.icon == "dollarsign.circle")
+        #expect(decoded.meetingTranscriptionBackend == config.meetingTranscriptionBackend)
+        #expect(decoded.indicatorAnchor == config.indicatorAnchor)
     }
 
     @Test("JSON coding keys use snake_case")
@@ -294,6 +299,9 @@ struct AppConfigTests {
 
         #expect(json["stt_backend"] != nil)
         #expect(json["stt_model"] != nil)
+        #expect(json["meeting_transcription_backend"] != nil)
+        #expect(json["meeting_transcription_model"] != nil)
+        #expect(json["indicator_anchor"] != nil)
         #expect(json["has_completed_onboarding"] != nil)
         #expect(json["user_name"] != nil)
         #expect(json["default_meeting_template_id"] != nil)
@@ -313,6 +321,52 @@ struct AppConfigTests {
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
         #expect(config.customMeetingTemplates.isEmpty)
+    }
+
+    @Test("meeting transcription falls back to dictation model when missing")
+    func meetingTranscriptionFallsBackToDictationModel() throws {
+        let json = """
+        {
+          "stt_backend": "whisper",
+          "stt_model": "ggml-medium.en"
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.meetingTranscriptionBackend == "whisper")
+        #expect(config.meetingTranscriptionModel == "ggml-medium.en")
+    }
+
+    @Test("indicator anchor falls back to custom when legacy origin exists")
+    func indicatorAnchorFallsBackToCustomForLegacyOrigin() throws {
+        let json = """
+        {
+          "indicator_origin": [640, 320]
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.indicatorAnchor == .custom)
+        #expect(config.indicatorOrigin?.x == 640)
+        #expect(config.indicatorOrigin?.y == 320)
+    }
+
+    @Test("custom words decode missing threshold with default")
+    func customWordsDecodeMissingThresholdWithDefault() throws {
+        let json = """
+        {
+          "custom_words": [
+            {
+              "id": "67A2A4E9-E707-4A65-B690-124AFA4F0C18",
+              "word": "muesli",
+              "replacement": "Muesli"
+            }
+          ]
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(config.customWords.count == 1)
+        #expect(config.customWords[0].matchingThreshold == 0.85)
     }
 
     @Test("custom templates decode missing icon with fallback")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -60,9 +60,10 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.whisperSmall))
         #expect(BackendOption.all.contains(.whisperMedium))
         #expect(BackendOption.all.contains(.whisperLargeTurbo))
+        #expect(BackendOption.all.contains(.qwen3Asr))
         #expect(BackendOption.all.contains(.canaryQwen))
         #expect(BackendOption.all.contains(.cohereTranscribe))
-        #expect(BackendOption.all.count == 9)
+        #expect(BackendOption.all.contains(.nemotronStreaming))
     }
 
     @Test("Cohere uses cohere backend")
@@ -367,6 +368,28 @@ struct AppConfigTests {
         let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
         #expect(config.customWords.count == 1)
         #expect(config.customWords[0].matchingThreshold == 0.85)
+    }
+
+    @Test("custom words clamp thresholds into the supported UI range")
+    func customWordsClampThresholdsIntoSupportedRange() throws {
+        let json = """
+        {
+          "custom_words": [
+            {
+              "word": "aggressive",
+              "matching_threshold": 0.1
+            },
+            {
+              "word": "strict",
+              "matching_threshold": 1.4
+            }
+          ]
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(config.customWords.count == 2)
+        #expect(config.customWords[0].matchingThreshold == 0.70)
+        #expect(config.customWords[1].matchingThreshold == 0.95)
     }
 
     @Test("custom templates decode missing icon with fallback")

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -127,6 +127,22 @@ struct IndicatorFrameSizeTests {
             CGPoint(x: 1270, y: 450)
         )
     }
+
+    @Test("anchor centers respect fixed screen insets")
+    @MainActor
+    func anchorCentersUseExpectedInsets() {
+        let visibleFrame = NSRect(x: 100, y: 50, width: 1200, height: 800)
+        let size = NSSize(width: 44, height: 28)
+
+        #expect(
+            FloatingIndicatorController.anchorCenter(.topLeading, in: visibleFrame, size: size) ==
+            CGPoint(x: 130, y: 828)
+        )
+        #expect(
+            FloatingIndicatorController.anchorCenter(.bottomCenter, in: visibleFrame, size: size) ==
+            CGPoint(x: 700, y: 72)
+        )
+    }
 }
 
 // MARK: - OpenAI Logo Shape


### PR DESCRIPTION
## Summary
- add per-word dictionary matching thresholds with inline editing
- split dictation and meeting transcription backend/model selection
- add floating indicator anchor presets plus persisted custom drag placement
- reorganize Settings into General, Dictation, Meetings, and Appearance panes

## Testing
- swift build --package-path native/MuesliNative -c debug --product MuesliNativeApp
- swift test --package-path native/MuesliNative
- rebuilt and visually verified /Applications/MuesliDev.app