### PR TITLE
Fix meeting startup crash and harden system audio permission flow

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -416,18 +416,30 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     /// starting a CoreAudio tap recording. Per Apple docs, the system prompts
     /// "the first time you start recording from an aggregate device that
     /// contains a tap" — but only if `NSAudioCaptureUsageDescription` is in
-    /// Info.plist. Waits up to 10s for the user to respond to the dialog.
-    static func requestSystemAudioAccess() async {
+    /// Info.plist. Polls for permission for a short period so first-run users
+    /// have time to respond before we fall back to Settings.
+    @discardableResult
+    static func requestSystemAudioAccess(timeout: Duration = .seconds(12)) async -> Bool {
         let recorder = CoreAudioSystemRecorder()
+        let pollInterval = Duration.milliseconds(300)
         do {
             try await recorder.start()
-            // Wait long enough for the user to interact with the permission dialog.
-            // The dialog blocks audio capture until dismissed.
-            try? await Task.sleep(for: .seconds(3))
         } catch {
             fputs("[system-audio] permission request failed: \(error)\n", stderr)
         }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if checkSystemAudioPermission() {
+                _ = recorder.stop()
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+
         _ = recorder.stop()
+        return checkSystemAudioPermission()
     }
 
     /// Open System Settings to the Screen & System Audio pane where the user

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -1,6 +1,46 @@
 import DTLNAecCoreML
-import DTLNAec512
 import Foundation
+
+enum MeetingAecModelBundle {
+    static let bundleName = "DTLNAecCoreML_DTLNAec512.bundle"
+
+    static func resolve(
+        mainBundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) throws -> Bundle {
+        let candidates = candidateURLs(mainBundle: mainBundle)
+
+        for url in candidates {
+            var isDirectory = ObjCBool(false)
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+                continue
+            }
+            if let bundle = Bundle(url: url) {
+                return bundle
+            }
+        }
+
+        let searched = candidates.map(\.path).joined(separator: ", ")
+        throw NSError(
+            domain: "MeetingAecModelBundle",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate \(bundleName) in: \(searched)"]
+        )
+    }
+
+    static func candidateURLs(mainBundle: Bundle = .main) -> [URL] {
+        let rawCandidates = [
+            mainBundle.resourceURL?.appendingPathComponent(bundleName, isDirectory: true),
+            mainBundle.bundleURL.appendingPathComponent(bundleName, isDirectory: true),
+            mainBundle.executableURL?.deletingLastPathComponent().appendingPathComponent(bundleName, isDirectory: true),
+        ].compactMap { $0 }
+
+        var seen = Set<String>()
+        return rawCandidates.filter { url in
+            seen.insert(url.standardizedFileURL.path).inserted
+        }
+    }
+}
 
 final class MeetingNeuralAec {
     private var processor: DTLNAecEchoProcessor?
@@ -21,7 +61,7 @@ final class MeetingNeuralAec {
         guard !isLoaded else { return }
         let proc = DTLNAecEchoProcessor(modelSize: .large)
         do {
-            try await proc.loadModelsAsync(from: DTLNAec512.bundle)
+            try await proc.loadModelsAsync(from: MeetingAecModelBundle.resolve())
             processor = proc
             isLoaded = true
             fputs("[meeting-aec] DTLN-aec model preloaded\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1429,11 +1429,13 @@ final class MuesliController: NSObject {
                 statusBarController?.refresh()
                 return
             } catch {
-                guard shouldRetryAfterPermissionRequest, error is CoreAudioSystemRecorder.RecorderError else {
+                guard shouldRetryAfterPermissionRequest,
+                      case .tapCreationFailed = error as? CoreAudioSystemRecorder.RecorderError else {
                     throw error
                 }
 
                 shouldRetryAfterPermissionRequest = false
+                meetingSession.discard()
                 statusBarController?.setStatus("Requesting system audio permission...")
                 statusBarController?.refresh()
                 let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1366,30 +1366,13 @@ final class MuesliController: NSObject {
         micActivityMonitor.suppressWhileActive()
         micActivityMonitor.refreshState()
         updateMeetingNotificationVisibility()
-        let meetingSession = MeetingSession(
-            title: title,
-            calendarEventID: nil,
-            backend: selectedMeetingTranscriptionBackend,
-            runtime: runtime,
-            config: config,
-            transcriptionCoordinator: transcriptionCoordinator
-        )
         statusBarController?.setStatus("Starting meeting: \(title)")
         statusBarController?.refresh()
 
         Task { [weak self] in
             guard let self else { return }
             do {
-                try await meetingSession.start()
-                self.activeMeetingSession = meetingSession
-                self.micActivityMonitor.suppressWhileActive()
-                self.micActivityMonitor.refreshState()
-                self.statusBarController?.setStatus("Meeting: \(title)")
-                self.indicator.powerProvider = { [weak meetingSession] in
-                    meetingSession?.currentPower() ?? -160
-                }
-                self.indicator.setMeetingRecording(true, config: self.config)
-                self.statusBarController?.refresh()
+                try await self.startMeetingRecordingWithSystemAudioRecovery(title: title)
             } catch {
                 fputs("[muesli-native] failed to start meeting: \(error)\n", stderr)
                 self.micActivityMonitor.resumeAfterCooldown()
@@ -1417,6 +1400,50 @@ final class MuesliController: NSObject {
             }
             self.isStartingMeetingRecording = false
             self.updateMeetingNotificationVisibility()
+        }
+    }
+
+    private func startMeetingRecordingWithSystemAudioRecovery(title: String) async throws {
+        var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
+
+        while true {
+            let meetingSession = MeetingSession(
+                title: title,
+                calendarEventID: nil,
+                backend: selectedMeetingTranscriptionBackend,
+                runtime: runtime,
+                config: config,
+                transcriptionCoordinator: transcriptionCoordinator
+            )
+
+            do {
+                try await meetingSession.start()
+                activeMeetingSession = meetingSession
+                micActivityMonitor.suppressWhileActive()
+                micActivityMonitor.refreshState()
+                statusBarController?.setStatus("Meeting: \(title)")
+                indicator.powerProvider = { [weak meetingSession] in
+                    meetingSession?.currentPower() ?? -160
+                }
+                indicator.setMeetingRecording(true, config: config)
+                statusBarController?.refresh()
+                return
+            } catch {
+                guard shouldRetryAfterPermissionRequest, error is CoreAudioSystemRecorder.RecorderError else {
+                    throw error
+                }
+
+                shouldRetryAfterPermissionRequest = false
+                statusBarController?.setStatus("Requesting system audio permission...")
+                statusBarController?.refresh()
+                let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
+                if granted {
+                    statusBarController?.setStatus("Retrying meeting start...")
+                    statusBarController?.refresh()
+                    continue
+                }
+                throw error
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -23,7 +23,6 @@ struct OnboardingView: View {
     @State private var screenRecordingGranted = false
     @State private var systemAudioGranted = false
     @State private var permissionPollTimer: Timer?
-    @State private var isCheckingSystemAudioPermission = false
     @State private var grantingPermissionName: String?
     @State private var recentlyGrantedPermissionName: String?
 
@@ -67,7 +66,7 @@ struct OnboardingView: View {
         let initialAccessibilityGranted = AXIsProcessTrusted()
         let initialInputMonitoringGranted = CGPreflightListenEventAccess()
         let initialScreenRecordingGranted = CGPreflightScreenCaptureAccess()
-        let initialSystemAudioGranted = initialSystemAudioRequested || CoreAudioSystemRecorder.checkSystemAudioPermission()
+        let initialSystemAudioGranted = initialSystemAudioRequested
         let initialPermissionsGranted = initialMicGranted
             && initialAccessibilityGranted
             && initialInputMonitoringGranted
@@ -397,8 +396,14 @@ struct OnboardingView: View {
         if appState.config.useCoreAudioTap {
             steps.append(("speaker.wave.2.fill", "System Audio", "Capture meeting audio from other participants", systemAudioGranted, {
                 Task {
-                    await CoreAudioSystemRecorder.requestSystemAudioAccess()
-                    await resolveSystemAudioPermissionAfterRequest()
+                    let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
+                    await MainActor.run {
+                        self.systemAudioGranted = granted
+                        if granted {
+                            self.notePermissionGranted("System Audio")
+                        }
+                        self.saveProgress(atStep: self.currentStep)
+                    }
                 }
             }))
             steps.append(("rectangle.dashed.badge.record", "Screen Recording", "Capture screen content for richer meeting context", screenRecordingGranted, {
@@ -614,41 +619,9 @@ struct OnboardingView: View {
         accessibilityGranted = AXIsProcessTrusted()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
-        refreshSystemAudioPermissionIfNeeded()
 
         if let grantingPermissionName, isPermissionGranted(named: grantingPermissionName) {
             notePermissionGranted(grantingPermissionName)
-        }
-    }
-
-    private func refreshSystemAudioPermissionIfNeeded() {
-        guard appState.config.useCoreAudioTap, !isCheckingSystemAudioPermission else { return }
-        isCheckingSystemAudioPermission = true
-
-        Task {
-            let granted = await Task.detached(priority: .utility) {
-                CoreAudioSystemRecorder.checkSystemAudioPermission()
-            }.value
-            await MainActor.run {
-                self.systemAudioGranted = granted
-                self.isCheckingSystemAudioPermission = false
-                if let grantingPermissionName, self.isPermissionGranted(named: grantingPermissionName) {
-                    self.notePermissionGranted(grantingPermissionName)
-                }
-            }
-        }
-    }
-
-    private func resolveSystemAudioPermissionAfterRequest() async {
-        let granted = await Task.detached(priority: .utility) {
-            CoreAudioSystemRecorder.checkSystemAudioPermission()
-        }.value
-        await MainActor.run {
-            self.systemAudioGranted = granted
-            if granted {
-                self.notePermissionGranted("System Audio")
-            }
-            self.saveProgress(atStep: self.currentStep)
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
@@ -7,7 +7,9 @@ struct MeetingNeuralAecTests {
 
     @Test("bundle candidates prefer Contents/Resources in packaged apps")
     func candidateURLsPreferResourceDirectory() throws {
-        let appBundle = try makeTemporaryAppBundle()
+        let fixture = try makeTemporaryAppBundle()
+        defer { fixture.cleanup() }
+        let appBundle = fixture.bundle
         let candidates = MeetingAecModelBundle.candidateURLs(mainBundle: appBundle)
 
         #expect(candidates.count >= 2)
@@ -19,7 +21,9 @@ struct MeetingNeuralAecTests {
 
     @Test("resolver loads packaged app bundle from Contents/Resources")
     func resolverLoadsResourceBundle() throws {
-        let appBundle = try makeTemporaryAppBundle()
+        let fixture = try makeTemporaryAppBundle()
+        defer { fixture.cleanup() }
+        let appBundle = fixture.bundle
         let resourceBundleURL = try createResourceBundle(
             at: appBundle.resourceURL!.appendingPathComponent(MeetingAecModelBundle.bundleName, isDirectory: true)
         )
@@ -31,7 +35,9 @@ struct MeetingNeuralAecTests {
 
     @Test("resolver falls back to app-root bundle when needed")
     func resolverFallsBackToBundleRoot() throws {
-        let appBundle = try makeTemporaryAppBundle()
+        let fixture = try makeTemporaryAppBundle()
+        defer { fixture.cleanup() }
+        let appBundle = fixture.bundle
         let rootBundleURL = try createResourceBundle(
             at: appBundle.bundleURL.appendingPathComponent(MeetingAecModelBundle.bundleName, isDirectory: true)
         )
@@ -41,7 +47,7 @@ struct MeetingNeuralAecTests {
         #expect(resolved.bundleURL.standardizedFileURL == rootBundleURL.standardizedFileURL)
     }
 
-    private func makeTemporaryAppBundle() throws -> Bundle {
+    private func makeTemporaryAppBundle() throws -> TemporaryAppBundle {
         let appURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("meeting-aec-\(UUID().uuidString)", isDirectory: true)
             .appendingPathExtension("app")
@@ -71,12 +77,22 @@ struct MeetingNeuralAecTests {
         """
         try plist.write(to: contentsURL.appendingPathComponent("Info.plist"), atomically: true, encoding: .utf8)
 
-        return try #require(Bundle(url: appURL))
+        let bundle = try #require(Bundle(url: appURL))
+        return TemporaryAppBundle(url: appURL, bundle: bundle)
     }
 
     private func createResourceBundle(at url: URL) throws -> URL {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         try "{}".write(to: url.appendingPathComponent("Manifest.json"), atomically: true, encoding: .utf8)
         return url
+    }
+}
+
+private struct TemporaryAppBundle {
+    let url: URL
+    let bundle: Bundle
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: url)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingNeuralAec")
+struct MeetingNeuralAecTests {
+
+    @Test("bundle candidates prefer Contents/Resources in packaged apps")
+    func candidateURLsPreferResourceDirectory() throws {
+        let appBundle = try makeTemporaryAppBundle()
+        let candidates = MeetingAecModelBundle.candidateURLs(mainBundle: appBundle)
+
+        #expect(candidates.count >= 2)
+        #expect(candidates[0].path == appBundle.resourceURL?
+            .appendingPathComponent(MeetingAecModelBundle.bundleName, isDirectory: true).path)
+        #expect(candidates[1].path == appBundle.bundleURL
+            .appendingPathComponent(MeetingAecModelBundle.bundleName, isDirectory: true).path)
+    }
+
+    @Test("resolver loads packaged app bundle from Contents/Resources")
+    func resolverLoadsResourceBundle() throws {
+        let appBundle = try makeTemporaryAppBundle()
+        let resourceBundleURL = try createResourceBundle(
+            at: appBundle.resourceURL!.appendingPathComponent(MeetingAecModelBundle.bundleName, isDirectory: true)
+        )
+
+        let resolved = try MeetingAecModelBundle.resolve(mainBundle: appBundle)
+
+        #expect(resolved.bundleURL.standardizedFileURL == resourceBundleURL.standardizedFileURL)
+    }
+
+    @Test("resolver falls back to app-root bundle when needed")
+    func resolverFallsBackToBundleRoot() throws {
+        let appBundle = try makeTemporaryAppBundle()
+        let rootBundleURL = try createResourceBundle(
+            at: appBundle.bundleURL.appendingPathComponent(MeetingAecModelBundle.bundleName, isDirectory: true)
+        )
+
+        let resolved = try MeetingAecModelBundle.resolve(mainBundle: appBundle)
+
+        #expect(resolved.bundleURL.standardizedFileURL == rootBundleURL.standardizedFileURL)
+    }
+
+    private func makeTemporaryAppBundle() throws -> Bundle {
+        let appURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-aec-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathExtension("app")
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let macOSURL = contentsURL.appendingPathComponent("MacOS", isDirectory: true)
+        let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: macOSURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+        try Data().write(to: macOSURL.appendingPathComponent("TestApp"))
+
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>CFBundlePackageType</key>
+          <string>APPL</string>
+          <key>CFBundleExecutable</key>
+          <string>TestApp</string>
+          <key>CFBundleIdentifier</key>
+          <string>com.muesli.tests.MeetingAec</string>
+          <key>CFBundleName</key>
+          <string>TestApp</string>
+        </dict>
+        </plist>
+        """
+        try plist.write(to: contentsURL.appendingPathComponent("Info.plist"), atomically: true, encoding: .utf8)
+
+        return try #require(Bundle(url: appURL))
+    }
+
+    private func createResourceBundle(at url: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try "{}".write(to: url.appendingPathComponent("Manifest.json"), atomically: true, encoding: .utf8)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary
- fix packaged meeting startup by resolving the DTLN AEC bundle from the app resource directory instead of relying on SwiftPM's generated bundle accessor
- retry meeting start once after explicitly requesting system audio permission when CoreAudio tap startup fails
- harden onboarding so system audio is only marked granted after the explicit permission request succeeds
- add focused tests for the meeting AEC bundle resolver

## Validation
- swift test --package-path native/MuesliNative
- swift test --package-path native/MuesliNative --filter PasteControllerTests
- rebuilt signed MuesliDev and validated local + cross-user packaged meeting recording flows

Closes #58