### PR TITLE
[codex] Expose Cohere language setting

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/CohereTranscribeBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CohereTranscribeBackend.swift
@@ -117,6 +117,92 @@ enum CohereTranscribeUtils {
 
 // MARK: - Configuration
 
+enum CohereTranscribeLanguage: String, CaseIterable, Codable, Sendable {
+    case english = "en"
+    case french = "fr"
+    case german = "de"
+    case spanish = "es"
+    case italian = "it"
+    case portuguese = "pt"
+    case dutch = "nl"
+    case polish = "pl"
+    case greek = "el"
+    case arabic = "ar"
+    case japanese = "ja"
+    case chinese = "zh"
+    case vietnamese = "vi"
+    case korean = "ko"
+
+    static let defaultLanguage: Self = .english
+
+    var label: String {
+        switch self {
+        case .english: return "English"
+        case .french: return "French"
+        case .german: return "German"
+        case .spanish: return "Spanish"
+        case .italian: return "Italian"
+        case .portuguese: return "Portuguese"
+        case .dutch: return "Dutch"
+        case .polish: return "Polish"
+        case .greek: return "Greek"
+        case .arabic: return "Arabic"
+        case .japanese: return "Japanese"
+        case .chinese: return "Chinese"
+        case .vietnamese: return "Vietnamese"
+        case .korean: return "Korean"
+        }
+    }
+
+    var promptTokenId: Int32 {
+        switch self {
+        case .english: return 62
+        case .french: return 69
+        case .german: return 76
+        case .spanish: return 169
+        case .italian: return 97
+        case .portuguese: return 149
+        case .dutch: return 60
+        case .polish: return 148
+        case .greek: return 77
+        case .arabic: return 28
+        case .japanese: return 98
+        case .chinese: return 50
+        case .vietnamese: return 194
+        case .korean: return 110
+        }
+    }
+
+    var promptIds: [Int32] {
+        [
+            CohereTranscribeConfig.promptPrefixTokenId,
+            CohereTranscribeConfig.startOfContextTokenId,
+            CohereTranscribeConfig.startOfTranscriptTokenId,
+            CohereTranscribeConfig.undefinedEmotionTokenId,
+            promptTokenId,
+            promptTokenId,
+            CohereTranscribeConfig.punctuationTokenId,
+            CohereTranscribeConfig.noInverseTextNormalizationTokenId,
+            CohereTranscribeConfig.noTimestampTokenId,
+            CohereTranscribeConfig.noDiarizationTokenId,
+        ]
+    }
+
+    static func resolved(_ rawValue: String?) -> Self {
+        let normalized = rawValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard let normalized, let language = Self(rawValue: normalized) else {
+            return defaultLanguage
+        }
+        return language
+    }
+
+    static func resolvedCode(_ rawValue: String?) -> String {
+        resolved(rawValue).rawValue
+    }
+}
+
 private enum CohereTranscribeConfig {
     static let repoId = "phequals/cohere-transcribe-coreml-mixed-precision"
     static let envOverride = "MUESLI_COHERE_MODEL_DIR"
@@ -130,11 +216,17 @@ private enum CohereTranscribeConfig {
 
     static let melLength = 3500
     static let encLen = 438
-    static let prefillLen = 10
+    static let promptPrefixTokenId: Int32 = 13764
+    static let startOfContextTokenId: Int32 = 7
+    static let startOfTranscriptTokenId: Int32 = 4
+    static let undefinedEmotionTokenId: Int32 = 16
+    static let punctuationTokenId: Int32 = 5
+    static let noInverseTextNormalizationTokenId: Int32 = 9
+    static let noTimestampTokenId: Int32 = 11
+    static let noDiarizationTokenId: Int32 = 13
     static let maxSeqLen = 512
     static let vocabSize = 16384
     static let eosTokenId = 3 // <|endoftext|>
-    static let promptIds: [Int32] = [13764, 7, 4, 16, 62, 62, 5, 9, 11, 13]
 
     // Mel spectrogram parameters
     static let sampleRate = 16_000
@@ -762,7 +854,10 @@ private final class CohereTranscribeManager {
         return mask
     }
 
-    func transcribe(audioSamples: [Float]) async throws -> (text: String, profile: CohereProfilingSummary) {
+    func transcribe(
+        audioSamples: [Float],
+        language: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage
+    ) async throws -> (text: String, profile: CohereProfilingSummary) {
         let start = CFAbsoluteTimeGetCurrent()
         let duration = Double(audioSamples.count) / Double(CohereTranscribeConfig.sampleRate)
         var profile = CohereProfilingSummary(audioDurationS: duration)
@@ -781,7 +876,11 @@ private final class CohereTranscribeManager {
             let melStart = CFAbsoluteTimeGetCurrent()
             let (chunkMel, realFrameCount) = models.melExtractor.compute(audio: chunkSamples)
             totalMelMs += (CFAbsoluteTimeGetCurrent() - melStart) * 1000
-            let result = try transcribeChunk(mel: chunkMel, realMelFrames: realFrameCount)
+            let result = try transcribeChunk(
+                mel: chunkMel,
+                realMelFrames: realFrameCount,
+                language: language
+            )
             if !result.transcript.isEmpty {
                 transcripts.append(result.transcript)
             }
@@ -806,11 +905,17 @@ private final class CohereTranscribeManager {
         return (merged, profile)
     }
 
-    private func transcribeChunk(mel: [Float], realMelFrames: Int) throws -> (transcript: String, generatedTokenCount: Int, timing: CohereTimingBreakdown) {
+    private func transcribeChunk(
+        mel: [Float],
+        realMelFrames: Int,
+        language: CohereTranscribeLanguage
+    ) throws -> (transcript: String, generatedTokenCount: Int, timing: CohereTimingBreakdown) {
         var timing = CohereTimingBreakdown()
         let melLength = CohereTranscribeConfig.melLength
         let nMels = CohereTranscribeConfig.nMels
         let encLen = CohereTranscribeConfig.encLen
+        let promptIds = language.promptIds
+        let promptLength = promptIds.count
 
         // Build mel MLMultiArray [1, 128, 3500] — mel is flat [nMels * melLength], already normalized & zero-padded
         let melArray = try MLMultiArray(shape: [1, NSNumber(value: nMels), NSNumber(value: melLength)], dataType: .float32)
@@ -849,9 +954,9 @@ private final class CohereTranscribeManager {
 
         // Prefill — pass encoder_mask so cross-attention ignores padded positions
         let prefillStart = CFAbsoluteTimeGetCurrent()
-        let promptArray = try MLMultiArray(shape: [1, NSNumber(value: CohereTranscribeConfig.prefillLen)], dataType: .int32)
-        let promptPtr = promptArray.dataPointer.bindMemory(to: Int32.self, capacity: CohereTranscribeConfig.prefillLen)
-        for (i, id) in CohereTranscribeConfig.promptIds.enumerated() {
+        let promptArray = try MLMultiArray(shape: [1, NSNumber(value: promptLength)], dataType: .int32)
+        let promptPtr = promptArray.dataPointer.bindMemory(to: Int32.self, capacity: promptLength)
+        for (i, id) in promptIds.enumerated() {
             promptPtr[i] = id
         }
 
@@ -874,9 +979,9 @@ private final class CohereTranscribeManager {
         timing.prefillMs = (CFAbsoluteTimeGetCurrent() - prefillStart) * 1000
 
         // Argmax on last position of prefill logits
-        var nextToken = argmaxLastPosition(logits: prefillLogits, seqLen: CohereTranscribeConfig.prefillLen)
+        var nextToken = argmaxLastPosition(logits: prefillLogits, seqLen: promptLength)
         var generatedIds: [Int] = []
-        var currentPosition = CohereTranscribeConfig.prefillLen
+        var currentPosition = promptLength
 
         // Autoregressive decode — encoder_mask passed each step for cross-attention masking
         let decodeStart = CFAbsoluteTimeGetCurrent()
@@ -886,8 +991,8 @@ private final class CohereTranscribeManager {
         // with minimum 15. The CoreML encoder can't do internal length masking, so the
         // decoder doesn't get a clean EOS signal — this caps hallucination/repetition.
         let maxNewTokens = models.encoderUsesDynamicLength
-            ? (CohereTranscribeConfig.maxSeqLen - CohereTranscribeConfig.prefillLen)
-            : min(CohereTranscribeConfig.maxSeqLen - CohereTranscribeConfig.prefillLen, tokenBudget)
+            ? (CohereTranscribeConfig.maxSeqLen - promptLength)
+            : min(CohereTranscribeConfig.maxSeqLen - promptLength, tokenBudget)
         let tokenIdArray = try MLMultiArray(shape: [1, 1], dataType: .int32)
         let tokenIdPtr = tokenIdArray.dataPointer.bindMemory(to: Int32.self, capacity: 1)
 
@@ -1099,7 +1204,10 @@ actor CohereTranscribeTranscriber {
         scheduleWarmupIfNeeded()
     }
 
-    func transcribe(wavURL: URL) async throws -> (text: String, processingTime: Double, profile: CohereProfilingSummary) {
+    func transcribe(
+        wavURL: URL,
+        language: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage
+    ) async throws -> (text: String, processingTime: Double, profile: CohereProfilingSummary) {
         try await loadModels()
         if let warmupTask {
             CohereProfilingLog.write("[cohere] waiting for background warmup to finish before dictation...")
@@ -1111,7 +1219,7 @@ actor CohereTranscribeTranscriber {
         let resampleStart = CFAbsoluteTimeGetCurrent()
         let samples = try converter.resampleAudioFile(wavURL)
         let resampleMs = (CFAbsoluteTimeGetCurrent() - resampleStart) * 1000
-        let inference = try await manager.transcribe(audioSamples: samples)
+        let inference = try await manager.transcribe(audioSamples: samples, language: language)
         let processingTime = CFAbsoluteTimeGetCurrent() - start
         var profile = inference.profile
         profile.resampleMs = resampleMs

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -300,7 +300,11 @@ final class MeetingSession {
             let chunkDuration = lastSystemChunkTiming?.durationSeconds ?? 0
             fputs("[meeting] transcribing final system chunk (offset=\(String(format: "%.0f", chunkOffset))s)\n", stderr)
             do {
-                let result = try await transcriptionCoordinator.transcribeMeetingChunk(at: lastSystemChunkURL, backend: backend)
+                let result = try await transcriptionCoordinator.transcribeMeetingChunk(
+                    at: lastSystemChunkURL,
+                    backend: backend,
+                    cohereLanguage: config.resolvedCohereLanguage
+                )
                 let normalizedSegments = normalizeSystemTranscription(
                     result: result,
                     startTime: chunkOffset,
@@ -561,7 +565,11 @@ final class MeetingSession {
                 if Task.isCancelled {
                     return []
                 }
-                let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(at: chunkURL, backend: backend)
+                let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(
+                    at: chunkURL,
+                    backend: backend,
+                    cohereLanguage: config.resolvedCohereLanguage
+                )
                 if !result.text.isEmpty {
                     fputs("[meeting] system chunk transcribed: \"\(String(result.text.prefix(60)))...\"\n", stderr)
                     let normalizedSegments = self.normalizeSystemTranscription(
@@ -717,7 +725,8 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeetingChunk(
                 at: url,
-                backend: backend
+                backend: backend,
+                cohereLanguage: config.resolvedCohereLanguage
             )
             if !result.text.isEmpty {
                 fputs("[meeting] mic chunk transcribed (raw): \"\(String(result.text.prefix(60)))...\"\n", stderr)
@@ -866,7 +875,8 @@ final class MeetingSession {
 
                     let result = try await transcriptionCoordinator.transcribeMeeting(
                         at: segmentURL,
-                        backend: backend
+                        backend: backend,
+                        cohereLanguage: config.resolvedCohereLanguage
                     )
                     repairedSegments.append(contentsOf: MicTurnNormalizer.normalize(
                         result: result,
@@ -946,7 +956,8 @@ final class MeetingSession {
 
                     let result = try await transcriptionCoordinator.transcribeMeeting(
                         at: segmentURL,
-                        backend: backend
+                        backend: backend,
+                        cohereLanguage: config.resolvedCohereLanguage
                     )
                     repairedSegments.append(contentsOf: normalizeSystemTranscription(
                         result: result,
@@ -976,7 +987,8 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeeting(
                 at: fullSessionMicURL,
-                backend: backend
+                backend: backend,
+                cohereLanguage: config.resolvedCohereLanguage
             )
             return MicTurnNormalizer.normalize(
                 result: result,
@@ -997,7 +1009,8 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeeting(
                 at: systemAudioURL,
-                backend: backend
+                backend: backend,
+                cohereLanguage: config.resolvedCohereLanguage
             )
             return normalizeSystemTranscription(
                 result: result,

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -77,7 +77,7 @@ struct BackendOption: Equatable {
         model: "phequals/cohere-transcribe-coreml-mixed-precision",
         label: "Cohere Transcribe",
         sizeLabel: "~3.8 GB",
-        description: "Mixed precision (FP16 encoder + INT8 decoder). English. High accuracy (#1 Open ASR Leaderboard). Final transcript after stop. May decode hallucinated text during silence — use in quiet environments or with VAD.",
+        description: "Mixed precision (FP16 encoder + INT8 decoder). 14 languages. High accuracy (#1 Open ASR Leaderboard). Final transcript after stop. May decode hallucinated text during silence — use in quiet environments or with VAD.",
         recommended: false
     )
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -408,6 +408,7 @@ struct AppConfig: Codable {
     var dictationHotkey: HotkeyConfig = .default
     var sttBackend: String = BackendOption.whisper.backend
     var sttModel: String = BackendOption.whisper.model
+    var cohereLanguage: String = CohereTranscribeLanguage.defaultLanguage.rawValue
     var meetingTranscriptionBackend: String = BackendOption.whisper.backend
     var meetingTranscriptionModel: String = BackendOption.whisper.model
     var meetingSummaryBackend: String = MeetingSummaryBackendOption.openAI.backend
@@ -457,6 +458,7 @@ struct AppConfig: Codable {
         case dictationHotkey = "dictation_hotkey"
         case sttBackend = "stt_backend"
         case sttModel = "stt_model"
+        case cohereLanguage = "cohere_language"
         case meetingTranscriptionBackend = "meeting_transcription_backend"
         case meetingTranscriptionModel = "meeting_transcription_model"
         case meetingSummaryBackend = "meeting_summary_backend"
@@ -509,6 +511,7 @@ struct AppConfig: Codable {
         dictationHotkey = (try? c.decode(HotkeyConfig.self, forKey: .dictationHotkey)) ?? defaults.dictationHotkey
         sttBackend = (try? c.decode(String.self, forKey: .sttBackend)) ?? defaults.sttBackend
         sttModel = (try? c.decode(String.self, forKey: .sttModel)) ?? defaults.sttModel
+        cohereLanguage = CohereTranscribeLanguage.resolvedCode(try? c.decode(String.self, forKey: .cohereLanguage))
         meetingTranscriptionBackend = (try? c.decode(String.self, forKey: .meetingTranscriptionBackend)) ?? sttBackend
         meetingTranscriptionModel = (try? c.decode(String.self, forKey: .meetingTranscriptionModel)) ?? sttModel
         meetingSummaryBackend = (try? c.decode(String.self, forKey: .meetingSummaryBackend)) ?? defaults.meetingSummaryBackend
@@ -552,6 +555,10 @@ struct AppConfig: Codable {
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap
+    }
+
+    var resolvedCohereLanguage: CohereTranscribeLanguage {
+        CohereTranscribeLanguage.resolved(cohereLanguage)
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -190,6 +190,13 @@ struct ModelsView: View {
         )
     }
 
+    private var cohereLanguageSelection: Binding<CohereTranscribeLanguage> {
+        Binding(
+            get: { appState.config.resolvedCohereLanguage },
+            set: { controller.selectCohereLanguage($0) }
+        )
+    }
+
     private var postProcessorSection: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
@@ -665,6 +672,24 @@ struct ModelsView: View {
                         .padding(.vertical, 3)
                         .background(MuesliTheme.surfacePrimary)
                         .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+            }
+
+            if option.backend == BackendOption.cohereTranscribe.backend {
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    Text("Language")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 64, alignment: .leading)
+
+                    Picker("", selection: cohereLanguageSelection) {
+                        ForEach(CohereTranscribeLanguage.allCases, id: \.self) { language in
+                            Text(language.label).tag(language)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: 220, alignment: .leading)
                 }
             }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -528,6 +528,12 @@ final class MuesliController: NSObject {
         }
     }
 
+    func selectCohereLanguage(_ language: CohereTranscribeLanguage) {
+        updateConfig {
+            $0.cohereLanguage = language.rawValue
+        }
+    }
+
     var isPostProcessorReady: Bool {
         config.enablePostProcessor && runtimePostProcessorOption() != nil
     }
@@ -978,12 +984,20 @@ final class MuesliController: NSObject {
         progress(1.0, nil)
     }
 
-    func completeOnboarding(userName: String, backend: BackendOption, hotkey: HotkeyConfig, summaryBackend: MeetingSummaryBackendOption?, apiKey: String?) {
+    func completeOnboarding(
+        userName: String,
+        backend: BackendOption,
+        cohereLanguage: CohereTranscribeLanguage,
+        hotkey: HotkeyConfig,
+        summaryBackend: MeetingSummaryBackendOption?,
+        apiKey: String?
+    ) {
         updateConfig { config in
             config.hasCompletedOnboarding = true
             config.userName = userName
             config.sttBackend = backend.backend
             config.sttModel = backend.model
+            config.cohereLanguage = cohereLanguage.rawValue
             config.meetingTranscriptionBackend = backend.backend
             config.meetingTranscriptionModel = backend.model
             config.dictationHotkey = hotkey
@@ -2041,6 +2055,7 @@ final class MuesliController: NSObject {
                 let result = try await self.transcriptionCoordinator.transcribeDictation(
                     at: wavURL,
                     backend: self.selectedBackend,
+                    cohereLanguage: self.config.resolvedCohereLanguage,
                     enablePostProcessor: self.isPostProcessorReady,
                     customWords: self.serializedCustomWords(),
                     appContext: self.capturedDictationContext.map { DictationContextCapture.formatForPrompt($0) }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 struct OnboardingProgress: Codable {
-    static let currentSchemaVersion = 2
+    static let currentSchemaVersion = 3
 
     var schemaVersion: Int = currentSchemaVersion
     var currentStep: Int
     var userName: String
     var selectedBackendKey: String
     var selectedModelKey: String
+    var selectedCohereLanguageCode: String
     var hotkeyKeyCode: UInt16
     var hotkeyLabel: String
     var systemAudioRequested: Bool = false
@@ -18,6 +19,7 @@ struct OnboardingProgress: Codable {
         userName: String,
         selectedBackendKey: String,
         selectedModelKey: String,
+        selectedCohereLanguageCode: String = CohereTranscribeLanguage.defaultLanguage.rawValue,
         hotkeyKeyCode: UInt16,
         hotkeyLabel: String,
         systemAudioRequested: Bool = false
@@ -27,6 +29,7 @@ struct OnboardingProgress: Codable {
         self.userName = userName
         self.selectedBackendKey = selectedBackendKey
         self.selectedModelKey = selectedModelKey
+        self.selectedCohereLanguageCode = CohereTranscribeLanguage.resolvedCode(selectedCohereLanguageCode)
         self.hotkeyKeyCode = hotkeyKeyCode
         self.hotkeyLabel = hotkeyLabel
         self.systemAudioRequested = systemAudioRequested
@@ -39,6 +42,9 @@ struct OnboardingProgress: Codable {
         userName = try c.decode(String.self, forKey: .userName)
         selectedBackendKey = try c.decode(String.self, forKey: .selectedBackendKey)
         selectedModelKey = try c.decode(String.self, forKey: .selectedModelKey)
+        selectedCohereLanguageCode = CohereTranscribeLanguage.resolvedCode(
+            try c.decodeIfPresent(String.self, forKey: .selectedCohereLanguageCode)
+        )
         hotkeyKeyCode = try c.decode(UInt16.self, forKey: .hotkeyKeyCode)
         hotkeyLabel = try c.decode(String.self, forKey: .hotkeyLabel)
         systemAudioRequested = try c.decodeIfPresent(Bool.self, forKey: .systemAudioRequested) ?? false

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -10,6 +10,7 @@ struct OnboardingView: View {
     @State private var currentStep: Int
     @State private var userName: String
     @State private var selectedBackend: BackendOption
+    @State private var selectedCohereLanguage: CohereTranscribeLanguage
     @State private var summaryBackend: MeetingSummaryBackendOption = .openRouter
     @State private var apiKey = ""
     @State private var isSigningInChatGPT = false
@@ -55,6 +56,7 @@ struct OnboardingView: View {
         initialStep: Int = 0,
         initialUserName: String = "",
         initialBackend: BackendOption = .parakeetMultilingual,
+        initialCohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
         initialHotkey: HotkeyConfig = .default,
         initialSystemAudioRequested: Bool = false
     ) {
@@ -79,6 +81,7 @@ struct OnboardingView: View {
         _currentStep = State(initialValue: effectiveInitialStep)
         _userName = State(initialValue: initialUserName)
         _selectedBackend = State(initialValue: initialBackend)
+        _selectedCohereLanguage = State(initialValue: initialCohereLanguage)
         _selectedHotkey = State(initialValue: initialHotkey)
         _micGranted = State(initialValue: initialMicGranted)
         _accessibilityGranted = State(initialValue: initialAccessibilityGranted)
@@ -152,6 +155,12 @@ struct OnboardingView: View {
             saveProgress(atStep: step)
         }
         .onChange(of: userName) { _, _ in
+            saveProgress(atStep: currentStep)
+        }
+        .onChange(of: selectedBackend) { _, _ in
+            saveProgress(atStep: currentStep)
+        }
+        .onChange(of: selectedCohereLanguage) { _, _ in
             saveProgress(atStep: currentStep)
         }
     }
@@ -313,12 +322,46 @@ struct OnboardingView: View {
                             modelCard(option: option)
                         }
                     }
+
+                    if selectedBackend.backend == BackendOption.cohereTranscribe.backend {
+                        cohereLanguageCard
+                    }
                 }
                 .padding(.horizontal, MuesliTheme.spacing32)
             }
 
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var cohereLanguageCard: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Text("Cohere language")
+                .font(MuesliTheme.headline())
+                .foregroundStyle(MuesliTheme.textPrimary)
+
+            Text("Cohere does not auto-detect language, so pick the language you want it to transcribe.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+
+            FixedWidthPopUp(
+                selection: selectedCohereLanguage.label,
+                options: CohereTranscribeLanguage.allCases.map(\.label)
+            ) { label in
+                guard let language = CohereTranscribeLanguage.allCases.first(where: { $0.label == label }) else { return }
+                selectedCohereLanguage = language
+            }
+            .frame(height: 24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+        .padding(.top, MuesliTheme.spacing8)
     }
 
     private func modelCard(option: BackendOption) -> some View {
@@ -666,6 +709,7 @@ struct OnboardingView: View {
             userName: userName,
             selectedBackendKey: selectedBackend.backend,
             selectedModelKey: selectedBackend.model,
+            selectedCohereLanguageCode: selectedCohereLanguage.rawValue,
             hotkeyKeyCode: selectedHotkey.keyCode,
             hotkeyLabel: selectedHotkey.label,
             systemAudioRequested: systemAudioGranted
@@ -1169,6 +1213,7 @@ struct OnboardingView: View {
         controller.completeOnboarding(
             userName: userName.trimmingCharacters(in: .whitespaces),
             backend: selectedBackend,
+            cohereLanguage: selectedCohereLanguage,
             hotkey: selectedHotkey,
             summaryBackend: summaryBackend,
             apiKey: withKey ? apiKey : nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -45,6 +45,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
             let backend = BackendOption.all.first(where: {
                 $0.backend == progress.selectedBackendKey && $0.model == progress.selectedModelKey
             }) ?? .parakeetMultilingual
+            let cohereLanguage = CohereTranscribeLanguage.resolved(progress.selectedCohereLanguageCode)
             let hotkey = HotkeyConfig(keyCode: progress.hotkeyKeyCode, label: progress.hotkeyLabel)
             rootView = OnboardingView(
                 controller: controller,
@@ -52,13 +53,15 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
                 initialStep: progress.currentStep,
                 initialUserName: progress.userName,
                 initialBackend: backend,
+                initialCohereLanguage: cohereLanguage,
                 initialHotkey: hotkey,
                 initialSystemAudioRequested: progress.systemAudioRequested
             )
         } else {
             rootView = OnboardingView(
                 controller: controller,
-                appState: controller.appState
+                appState: controller.appState,
+                initialCohereLanguage: controller.config.resolvedCohereLanguage
             )
         }
         window.contentView = NSHostingView(rootView: rootView)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -84,6 +84,10 @@ struct SettingsView: View {
         backendOptions(including: appState.selectedMeetingTranscriptionBackend)
     }
 
+    private var selectedCohereLanguage: CohereTranscribeLanguage {
+        appState.config.resolvedCohereLanguage
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
@@ -246,6 +250,18 @@ struct SettingsView: View {
                         }
                     }
                 }
+                if appState.selectedBackend.backend == BackendOption.cohereTranscribe.backend {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Cohere language") {
+                        settingsMenu(
+                            selection: selectedCohereLanguage.label,
+                            options: CohereTranscribeLanguage.allCases.map(\.label)
+                        ) { label in
+                            guard let language = CohereTranscribeLanguage.allCases.first(where: { $0.label == label }) else { return }
+                            controller.selectCohereLanguage(language)
+                        }
+                    }
+                }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("AI transcript cleanup") {
                     settingsSwitch(isOn: appState.config.enablePostProcessor) { newValue in
@@ -301,6 +317,18 @@ struct SettingsView: View {
                     ) { label in
                         if let option = meetingBackendOptions.first(where: { $0.label == label }) {
                             controller.selectMeetingTranscriptionBackend(option)
+                        }
+                    }
+                }
+                if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Cohere language") {
+                        settingsMenu(
+                            selection: selectedCohereLanguage.label,
+                            options: CohereTranscribeLanguage.allCases.map(\.label)
+                        ) { label in
+                            guard let language = CohereTranscribeLanguage.allCases.first(where: { $0.label == label }) else { return }
+                            controller.selectCohereLanguage(language)
                         }
                     }
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -242,6 +242,7 @@ actor TranscriptionCoordinator {
     func transcribeDictation(
         at url: URL,
         backend: BackendOption,
+        cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
         enablePostProcessor: Bool = false,
         customWords: [[String: Any]] = [],
         appContext: String? = nil
@@ -260,7 +261,7 @@ actor TranscriptionCoordinator {
                 fputs("[muesli-native] VAD check failed, transcribing anyway: \(error)\n", stderr)
             }
         }
-        var result = try await route(url: url, backend: backend)
+        var result = try await route(url: url, backend: backend, cohereLanguage: cohereLanguage)
         result = removeArtifacts(result)
         if !result.text.isEmpty {
             Qwen3PostProcessorLogging.logVerbose("Dictation raw transcript after artifact cleanup: \(result.text)")
@@ -278,12 +279,20 @@ actor TranscriptionCoordinator {
         return final
     }
 
-    func transcribeMeeting(at url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
+    func transcribeMeeting(
+        at url: URL,
+        backend: BackendOption,
+        cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage
+    ) async throws -> SpeechTranscriptionResult {
         // Meetings intentionally skip Qwen/custom-word post-processing. Keep deterministic artifact/filler cleanup only.
-        cleanMeetingTranscript(try await route(url: url, backend: backend))
+        cleanMeetingTranscript(try await route(url: url, backend: backend, cohereLanguage: cohereLanguage))
     }
 
-    func transcribeMeetingChunk(at url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
+    func transcribeMeetingChunk(
+        at url: URL,
+        backend: BackendOption,
+        cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage
+    ) async throws -> SpeechTranscriptionResult {
         // Meeting chunks intentionally skip Qwen/custom-word post-processing for reconciliation.
         // Run VAD to skip silent chunks (prevents hallucinations)
         if let vadManager {
@@ -298,7 +307,7 @@ actor TranscriptionCoordinator {
                 fputs("[muesli-native] VAD check failed, transcribing anyway: \(error)\n", stderr)
             }
         }
-        return cleanMeetingTranscript(try await route(url: url, backend: backend))
+        return cleanMeetingTranscript(try await route(url: url, backend: backend, cohereLanguage: cohereLanguage))
     }
 
     func diarizeSystemAudio(at url: URL) async throws -> DiarizationResult? {
@@ -420,7 +429,11 @@ actor TranscriptionCoordinator {
         return SpeechTranscriptionResult(text: correctedText, segments: result.segments)
     }
 
-    private func route(url: URL, backend: BackendOption) async throws -> SpeechTranscriptionResult {
+    private func route(
+        url: URL,
+        backend: BackendOption,
+        cohereLanguage: CohereTranscribeLanguage
+    ) async throws -> SpeechTranscriptionResult {
         switch backend.backend {
         case "whisper":
             return try await transcribeWithWhisperKit(url: url)
@@ -431,7 +444,7 @@ actor TranscriptionCoordinator {
         case "canary":
             return try await transcribeWithCanaryQwen(url: url)
         case "cohere":
-            return try await transcribeWithCohere(url: url)
+            return try await transcribeWithCohere(url: url, language: cohereLanguage)
         default:
             return try await transcribeWithFluidAudio(url: url)
         }
@@ -505,10 +518,13 @@ actor TranscriptionCoordinator {
 
     // MARK: - Cohere Transcribe (CoreML)
 
-    private func transcribeWithCohere(url: URL) async throws -> SpeechTranscriptionResult {
+    private func transcribeWithCohere(
+        url: URL,
+        language: CohereTranscribeLanguage
+    ) async throws -> SpeechTranscriptionResult {
         if #available(macOS 15, *) {
             fputs("[muesli-native] transcribing with Cohere Transcribe: \(url.lastPathComponent)\n", stderr)
-            let result = try await cohereTranscriber.transcribe(wavURL: url)
+            let result = try await cohereTranscriber.transcribe(wavURL: url, language: language)
             fputs("[muesli-native] Cohere Transcribe result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             return SpeechTranscriptionResult(

--- a/native/MuesliNative/Tests/MuesliTests/ConfigStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ConfigStoreTests.swift
@@ -25,6 +25,7 @@ struct ConfigStoreTests {
         config.openAIModel = "gpt-5.4-pro"
         config.openRouterAPIKey = "sk-or-test-roundtrip"
         config.openRouterModel = "nvidia/nemotron-3-super-120b-a12b:free"
+        config.cohereLanguage = CohereTranscribeLanguage.german.rawValue
         config.meetingSummaryBackend = "openrouter"
         store.save(config)
 
@@ -33,6 +34,7 @@ struct ConfigStoreTests {
         #expect(loaded.openAIModel == "gpt-5.4-pro")
         #expect(loaded.openRouterAPIKey == "sk-or-test-roundtrip")
         #expect(loaded.openRouterModel == "nvidia/nemotron-3-super-120b-a12b:free")
+        #expect(loaded.cohereLanguage == CohereTranscribeLanguage.german.rawValue)
         #expect(loaded.meetingSummaryBackend == "openrouter")
 
         // Restore original

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -343,6 +343,19 @@ struct AppConfigTests {
         #expect(config.resolvedCohereLanguage == .english)
     }
 
+    @Test("cohere language codes are normalized case-insensitively")
+    func cohereLanguageCodesNormalizeCaseInsensitively() throws {
+        let json = """
+        {
+          "cohere_language": " Fr "
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.cohereLanguage == CohereTranscribeLanguage.french.rawValue)
+        #expect(config.resolvedCohereLanguage == .french)
+    }
+
     @Test("meeting transcription falls back to dictation model when missing")
     func meetingTranscriptionFallsBackToDictationModel() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -246,6 +246,7 @@ struct AppConfigTests {
         let config = AppConfig()
         #expect(config.sttBackend == BackendOption.whisper.backend)
         #expect(config.sttModel == BackendOption.whisper.model)
+        #expect(config.cohereLanguage == CohereTranscribeLanguage.defaultLanguage.rawValue)
         #expect(config.meetingTranscriptionBackend == BackendOption.whisper.backend)
         #expect(config.meetingTranscriptionModel == BackendOption.whisper.model)
         #expect(config.meetingSummaryBackend == "openai")
@@ -267,6 +268,7 @@ struct AppConfigTests {
         config.openAIAPIKey = "sk-test-key-123"
         config.userName = "Test User"
         config.hasCompletedOnboarding = true
+        config.cohereLanguage = CohereTranscribeLanguage.german.rawValue
         config.defaultMeetingTemplateID = "weekly-team-meeting"
         config.meetingRecordingSavePolicy = .always
         config.customMeetingTemplates = [
@@ -284,6 +286,7 @@ struct AppConfigTests {
         #expect(decoded.openAIAPIKey == "sk-test-key-123")
         #expect(decoded.userName == "Test User")
         #expect(decoded.hasCompletedOnboarding == true)
+        #expect(decoded.cohereLanguage == CohereTranscribeLanguage.german.rawValue)
         #expect(decoded.defaultMeetingTemplateID == "weekly-team-meeting")
         #expect(decoded.meetingRecordingSavePolicy == .always)
         #expect(decoded.customMeetingTemplates.count == 1)
@@ -301,6 +304,7 @@ struct AppConfigTests {
 
         #expect(json["stt_backend"] != nil)
         #expect(json["stt_model"] != nil)
+        #expect(json["cohere_language"] != nil)
         #expect(json["meeting_transcription_backend"] != nil)
         #expect(json["meeting_transcription_model"] != nil)
         #expect(json["indicator_anchor"] != nil)
@@ -319,10 +323,24 @@ struct AppConfigTests {
 
         #expect(config.openAIAPIKey.isEmpty)
         #expect(config.showFloatingIndicator == true)
+        #expect(config.resolvedCohereLanguage == .english)
         #expect(config.hasCompletedOnboarding == false)
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
         #expect(config.customMeetingTemplates.isEmpty)
+    }
+
+    @Test("unsupported cohere language falls back to english")
+    func unsupportedCohereLanguageFallsBackToEnglish() throws {
+        let json = """
+        {
+          "cohere_language": "xx"
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.cohereLanguage == CohereTranscribeLanguage.english.rawValue)
+        #expect(config.resolvedCohereLanguage == .english)
     }
 
     @Test("meeting transcription falls back to dictation model when missing")

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("OnboardingProgress")
+struct OnboardingProgressTests {
+
+    @Test("missing Cohere language defaults to english")
+    func missingCohereLanguageDefaultsToEnglish() throws {
+        let json = """
+        {
+          "schemaVersion": 2,
+          "currentStep": 3,
+          "userName": "Test User",
+          "selectedBackendKey": "cohere",
+          "selectedModelKey": "phequals/cohere-transcribe-coreml-mixed-precision",
+          "hotkeyKeyCode": 55,
+          "hotkeyLabel": "Left Cmd",
+          "systemAudioRequested": true
+        }
+        """
+
+        let progress = try JSONDecoder().decode(OnboardingProgress.self, from: Data(json.utf8))
+
+        #expect(progress.selectedCohereLanguageCode == CohereTranscribeLanguage.english.rawValue)
+    }
+
+    @Test("unsupported Cohere language is normalized")
+    func unsupportedCohereLanguageFallsBackToEnglish() throws {
+        let json = """
+        {
+          "schemaVersion": 3,
+          "currentStep": 1,
+          "userName": "Test User",
+          "selectedBackendKey": "cohere",
+          "selectedModelKey": "phequals/cohere-transcribe-coreml-mixed-precision",
+          "selectedCohereLanguageCode": "xx",
+          "hotkeyKeyCode": 55,
+          "hotkeyLabel": "Left Cmd"
+        }
+        """
+
+        let progress = try JSONDecoder().decode(OnboardingProgress.self, from: Data(json.utf8))
+
+        #expect(progress.selectedCohereLanguageCode == CohereTranscribeLanguage.english.rawValue)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -97,6 +97,30 @@ struct TranscriptionCoordinatorTests {
     }
 }
 
+@Suite("CohereTranscribeLanguage")
+struct CohereTranscribeLanguageTests {
+
+    @Test("english prompt ids match the current default prompt")
+    func englishPromptIds() {
+        #expect(
+            CohereTranscribeLanguage.english.promptIds == [13764, 7, 4, 16, 62, 62, 5, 9, 11, 13]
+        )
+    }
+
+    @Test("german prompt ids swap in the german language token")
+    func germanPromptIds() {
+        #expect(
+            CohereTranscribeLanguage.german.promptIds == [13764, 7, 4, 16, 76, 76, 5, 9, 11, 13]
+        )
+    }
+
+    @Test("unset and unsupported codes fall back to english")
+    func resolvedFallbacks() {
+        #expect(CohereTranscribeLanguage.resolved(nil) == .english)
+        #expect(CohereTranscribeLanguage.resolved("xx") == .english)
+    }
+}
+
 @Suite("CohereTranscribeUtils")
 struct CohereTranscribeUtilsTests {
 


### PR DESCRIPTION
## Summary
- expose a persisted Cohere transcription language setting in app config and onboarding progress
- thread the selected Cohere language through dictation and meeting transcription paths
- add the Cohere language picker in onboarding, Settings, and the Models tab when Cohere is active
- normalize unset or unsupported language codes back to English and cover that behavior with focused regression tests

## Why
Issue #49 needs Cohere's language-conditioned prompt tokens to be user-selectable instead of hardcoded to English, while keeping onboarding, persistence, and existing fallback behavior correct.

## User impact
Users can now choose a supported Cohere language once and have that selection apply consistently across onboarding, model selection, dictation, and meetings.

## Validation
- `swift test --filter 'MeetingsNavigationTests|TranscriptionCoordinatorTests|CohereTranscribeUtilsTests|AppConfigTests|ConfigStoreTests|OnboardingProgressTests|CohereTranscribeLanguageTests'`
- `swift test --filter 'ConfigStoreTests|ModelsTests|TranscriptionRuntimeTests|OnboardingProgressTests'`
- `./scripts/dev-test.sh`
