### PR TITLE
[codex] Harden Sparkle update flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,18 @@ jobs:
             FILES=$(git diff --name-only HEAD^1 HEAD -- \
               'native/' \
               'assets/' \
+              'docs/appcast.xml' \
               'scripts/build_native_app.sh' \
+              'scripts/verify_update_flow.sh' \
               'scripts/test_packaged_cli.sh' \
               '.github/workflows/ci.yml')
           else
             FILES=$(git diff --name-only HEAD~1 HEAD -- \
               'native/' \
               'assets/' \
+              'docs/appcast.xml' \
               'scripts/build_native_app.sh' \
+              'scripts/verify_update_flow.sh' \
               'scripts/test_packaged_cli.sh' \
               '.github/workflows/ci.yml')
           fi
@@ -92,20 +96,35 @@ jobs:
       - name: Verify packaged CLI bundle
         run: ./scripts/test_packaged_cli.sh
 
+  # Sparkle appcast/update metadata smoke test — catches broken release URLs,
+  # missing signatures, accidental delta entries, and malformed appcast XML.
+  update-flow:
+    needs: changes
+    if: needs.changes.outputs.native_or_packaging == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Verify Sparkle update metadata
+        run: ./scripts/verify_update_flow.sh --skip-dmg
+
   # Gate job — always runs, always reports a status
   # This is the only required check in branch protection
   ci-gate:
     if: always()
-    needs: [changes, build_release, test_shards, cli-smoke]
+    needs: [changes, build_release, test_shards, cli-smoke, update-flow]
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
           if [[ "${{ needs.build_release.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.test_shards.result }}" =~ ^(success|skipped)$ ]] && \
-             [[ "${{ needs.cli-smoke.result }}" =~ ^(success|skipped)$ ]]; then
-            echo "CI passed (build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }})"
+             [[ "${{ needs.cli-smoke.result }}" =~ ^(success|skipped)$ ]] && \
+             [[ "${{ needs.update-flow.result }}" =~ ^(success|skipped)$ ]]; then
+            echo "CI passed (build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
           else
-            echo "CI failed (build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }})"
+            echo "CI failed (build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
             exit 1
           fi

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -53,9 +53,10 @@ final class UpdateFailureGuidancePresenter: NSObject, SPUUpdaterDelegate {
         let nsError = error as NSError
         guard UpdateFailureGuidance.shouldShowFallback(for: nsError) else { return }
 
-        // Sparkle shows its own error alert first. Present this shortly after so
-        // users get a concrete recovery path instead of only the generic failure.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+        // Sparkle shows its own error alert first. Delay briefly so this
+        // recovery path appears after the generic updater failure alert.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 400_000_000)
             self?.showManualInstallGuidance()
         }
     }
@@ -93,7 +94,6 @@ enum UpdateFailureGuidance {
         guard error.domain == SUSparkleErrorDomain else { return false }
 
         let installStageCodes: Set<Int> = [
-            3002, // SUValidationError
             4000, // SUFileCopyFailure
             4001, // SUAuthenticationFailure
             4002, // SUMissingUpdateError

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -87,7 +87,7 @@ enum UpdateFailureGuidance {
     static let message = """
     Please quit Muesli, reopen it from Applications, and try the update once more.
 
-    If this keeps happening, download the latest DMG and replace Muesli manually. This usually means macOS blocked the local updater from replacing the app, not that the download failed.
+    If this keeps happening, download the latest DMG and replace Muesli manually. This can happen when the local updater cannot finish preparing or replacing the app.
     """
 
     static func shouldShowFallback(for error: NSError) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -8,6 +8,7 @@ import MuesliCore
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var controller: MuesliController?
     private(set) var updaterController: SPUStandardUpdaterController?
+    private let updateFailureGuidancePresenter = UpdateFailureGuidancePresenter()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let telemetryConfig = TelemetryDeck.Config(appID: "7F2B7846-1CB5-4FE6-8ABC-56F217B06A86")
@@ -16,7 +17,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: updateFailureGuidancePresenter,
             userDriverDelegate: nil
         )
 
@@ -41,5 +42,69 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         controller?.shutdown()
+    }
+}
+
+@MainActor
+final class UpdateFailureGuidancePresenter: NSObject, SPUUpdaterDelegate {
+    private var lastPresentedAt: Date?
+
+    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        let nsError = error as NSError
+        guard UpdateFailureGuidance.shouldShowFallback(for: nsError) else { return }
+
+        // Sparkle shows its own error alert first. Present this shortly after so
+        // users get a concrete recovery path instead of only the generic failure.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            self?.showManualInstallGuidance()
+        }
+    }
+
+    private func showManualInstallGuidance() {
+        if let lastPresentedAt, Date().timeIntervalSince(lastPresentedAt) < 60 {
+            return
+        }
+        lastPresentedAt = Date()
+
+        let alert = NSAlert()
+        alert.messageText = "Update did not finish"
+        alert.informativeText = UpdateFailureGuidance.message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Open Download Page")
+        alert.addButton(withTitle: "OK")
+
+        if alert.runModal() == .alertFirstButtonReturn,
+           let url = URL(string: UpdateFailureGuidance.downloadPageURLString) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+enum UpdateFailureGuidance {
+    static let downloadPageURLString = "https://phequals7.github.io/muesli/"
+
+    static let message = """
+    Please quit Muesli, reopen it from Applications, and try the update once more.
+
+    If this keeps happening, download the latest DMG and replace Muesli manually. This usually means macOS blocked the local updater from replacing the app, not that the download failed.
+    """
+
+    static func shouldShowFallback(for error: NSError) -> Bool {
+        guard error.domain == SUSparkleErrorDomain else { return false }
+
+        let installStageCodes: Set<Int> = [
+            3002, // SUValidationError
+            4000, // SUFileCopyFailure
+            4001, // SUAuthenticationFailure
+            4002, // SUMissingUpdateError
+            4003, // SUMissingInstallerToolError
+            4004, // SURelaunchError
+            4005, // SUInstallationError
+            4009, // SUNotValidUpdateError
+            4010, // SUAgentInvalidationError
+            4012, // SUInstallationWriteNoPermissionError
+        ]
+
+        return installStageCodes.contains(error.code)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -103,6 +103,7 @@ enum UpdateFailureGuidance {
             4009, // SUNotValidUpdateError
             4010, // SUAgentInvalidationError
             4012, // SUInstallationWriteNoPermissionError
+            4013, // SUInstallationTranslocationError
         ]
 
         return installStageCodes.contains(error.code)

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct UpdateFailureGuidanceTests {
     @Test(
         "shows fallback for Sparkle installation failures",
-        arguments: [4000, 4001, 4002, 4003, 4004, 4005, 4009, 4010, 4012]
+        arguments: [4000, 4001, 4002, 4003, 4004, 4005, 4009, 4010, 4012, 4013]
     )
     func showsFallbackForInstallationFailures(code: Int) {
         let error = NSError(domain: SUSparkleErrorDomain, code: code)

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Sparkle
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Update failure guidance")
+struct UpdateFailureGuidanceTests {
+    @Test("shows fallback for Sparkle installation failures")
+    func showsFallbackForInstallationFailures() {
+        let error = NSError(domain: SUSparkleErrorDomain, code: 4005)
+
+        #expect(UpdateFailureGuidance.shouldShowFallback(for: error))
+    }
+
+    @Test("does not show fallback for no update")
+    func hidesFallbackForNoUpdate() {
+        let error = NSError(domain: SUSparkleErrorDomain, code: 1001)
+
+        #expect(!UpdateFailureGuidance.shouldShowFallback(for: error))
+    }
+
+    @Test("does not show fallback for unrelated errors")
+    func hidesFallbackForUnrelatedErrors() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+
+        #expect(!UpdateFailureGuidance.shouldShowFallback(for: error))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -5,16 +5,22 @@ import Testing
 
 @Suite("Update failure guidance")
 struct UpdateFailureGuidanceTests {
-    @Test("shows fallback for Sparkle installation failures")
-    func showsFallbackForInstallationFailures() {
-        let error = NSError(domain: SUSparkleErrorDomain, code: 4005)
+    @Test(
+        "shows fallback for Sparkle installation failures",
+        arguments: [4000, 4001, 4002, 4003, 4004, 4005, 4009, 4010, 4012]
+    )
+    func showsFallbackForInstallationFailures(code: Int) {
+        let error = NSError(domain: SUSparkleErrorDomain, code: code)
 
         #expect(UpdateFailureGuidance.shouldShowFallback(for: error))
     }
 
-    @Test("does not show fallback for no update")
-    func hidesFallbackForNoUpdate() {
-        let error = NSError(domain: SUSparkleErrorDomain, code: 1001)
+    @Test(
+        "does not show fallback for non-install Sparkle errors",
+        arguments: [1001, 3001, 3002, 4011]
+    )
+    func hidesFallbackForNonInstallSparkleErrors(code: Int) {
+        let error = NSError(domain: SUSparkleErrorDomain, code: code)
 
         #expect(!UpdateFailureGuidance.shouldShowFallback(for: error))
     }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -17,7 +17,7 @@ struct UpdateFailureGuidanceTests {
 
     @Test(
         "does not show fallback for non-install Sparkle errors",
-        arguments: [1001, 3001, 3002, 4011]
+        arguments: [1001, 3001, 3002, 4006, 4007, 4008, 4011]
     )
     func hidesFallbackForNonInstallSparkleErrors(code: Int) {
         let error = NSError(domain: SUSparkleErrorDomain, code: code)

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -120,6 +120,11 @@ This checklist is for **verification** after the script runs, and for manual rec
 
 - [ ] **Update download link** in `docs/index.html` (both the `<a>` href and JSON-LD `downloadUrl`)
 
+- [ ] **Verify Sparkle update flow metadata and artifact:**
+  ```bash
+  scripts/verify_update_flow.sh --version X.Y.Z --dmg dist-release/Muesli-X.Y.Z.dmg --require-notarized
+  ```
+
 - [ ] **Push appcast + download link:**
   ```bash
   git add docs/appcast.xml docs/index.html

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -377,6 +377,12 @@ perl -0pi -e 's{^\h*<enclosure\b[^>]*\bsparkle:deltaFrom="[^"]*"[^>]*/>\n}{}mg' 
 sed -i '' "s|https://github.com/pHequals7/muesli/releases/download/[^\"]*\\.dmg|$DOWNLOAD_URL|g" "$ROOT/docs/index.html"
 sed -i '' "s|https://github.com/pHequals7/muesli/releases/download/.*\\.dmg|$DOWNLOAD_URL|g" "$ROOT/docs/llms.txt"
 
+echo "  Verifying Sparkle update flow metadata..."
+"$ROOT/scripts/verify_update_flow.sh" \
+  --version "$VERSION" \
+  --dmg "$DMG_PATH" \
+  --require-notarized
+
 git add docs/appcast.xml docs/index.html docs/llms.txt
 if git diff --cached --quiet; then
   echo "  No docs changes to commit."

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -22,6 +22,7 @@ case "${shard}" in
       MeetingChunkCollectorTests
       AppConfigTests
       CGPointCodableTests
+      UpdateFailureGuidanceTests
       WordCountTests
     )
     ;;

--- a/scripts/verify_update_flow.sh
+++ b/scripts/verify_update_flow.sh
@@ -64,7 +64,7 @@ if [[ ! -f "$APPCAST" ]]; then
   exit 1
 fi
 
-APPCAST_METADATA="$(python3 - "$APPCAST" "$VERSION" <<'PY'
+if ! APPCAST_METADATA="$(python3 - "$APPCAST" "$VERSION" <<'PY'
 import base64
 import re
 import shlex
@@ -110,6 +110,8 @@ if enclosure is None:
 url = enclosure.attrib.get("url", "")
 length = enclosure.attrib.get("length", "")
 signature = enclosure.attrib.get(f"{{{sparkle_ns}}}edSignature", "")
+if not signature:
+    raise SystemExit("ERROR: latest appcast enclosure is missing sparkle:edSignature")
 
 expected_url = f"https://github.com/pHequals7/muesli/releases/download/v{version}/Muesli-{version}.dmg"
 if url != expected_url:
@@ -152,7 +154,9 @@ for key, value in {
 }.items():
     print(f"{key}={shlex.quote(value)}")
 PY
-)"
+)"; then
+  exit 1
+fi
 # The Python emitter shell-quotes every value with shlex.quote before printing
 # KEY=value lines, so eval only imports validated scalar appcast metadata.
 eval "$APPCAST_METADATA"
@@ -214,6 +218,7 @@ if ! ATTACH_OUTPUT="$(hdiutil attach "$DMG_PATH" -nobrowse -readonly 2>"$HDIUTIL
 fi
 MOUNT_POINT="$(printf '%s\n' "$ATTACH_OUTPUT" | awk -F'\t' '/\/Volumes\// {print $NF; exit}')"
 if [[ -z "$MOUNT_POINT" ]]; then
+  cat "$HDIUTIL_ATTACH_LOG" >&2
   echo "ERROR: Could not mount DMG: $DMG_PATH" >&2
   exit 1
 fi
@@ -291,7 +296,11 @@ if ! APP_CODESIGN_RESULT="$(codesign --verify --deep --strict --verbose=2 "$APP_
 fi
 echo "App code signature OK."
 
-APP_SIGNATURE_DETAILS="$(codesign -dvvv "$APP_PATH" 2>&1)"
+if ! APP_SIGNATURE_DETAILS="$(codesign -dvvv "$APP_PATH" 2>&1)"; then
+  echo "$APP_SIGNATURE_DETAILS" >&2
+  echo "ERROR: codesign failed for app bundle; app may be unsigned." >&2
+  exit 1
+fi
 if ! echo "$APP_SIGNATURE_DETAILS" | grep -q "flags=.*runtime"; then
   echo "$APP_SIGNATURE_DETAILS" >&2
   echo "ERROR: app bundle is missing hardened runtime flag." >&2

--- a/scripts/verify_update_flow.sh
+++ b/scripts/verify_update_flow.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APPCAST="$ROOT/docs/appcast.xml"
+VERSION=""
+DMG_PATH=""
+SKIP_DMG=0
+REQUIRE_NOTARIZED=0
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/verify_update_flow.sh [options]
+
+Validates the Sparkle appcast and, when a DMG is available, the update artifact
+Sparkle will install.
+
+Options:
+  --version <version>       Require the latest appcast item to match this version.
+  --appcast <path>          Appcast XML path. Defaults to docs/appcast.xml.
+  --dmg <path>              DMG path. Defaults to dist-release/Muesli-<version>.dmg.
+  --skip-dmg                Only validate appcast metadata. Suitable for CI.
+  --require-notarized       Also require Gatekeeper/stapler checks for DMG and app.
+  -h, --help                Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      VERSION="${2:?missing value for --version}"
+      shift 2
+      ;;
+    --appcast)
+      APPCAST="${2:?missing value for --appcast}"
+      shift 2
+      ;;
+    --dmg)
+      DMG_PATH="${2:?missing value for --dmg}"
+      shift 2
+      ;;
+    --skip-dmg)
+      SKIP_DMG=1
+      shift
+      ;;
+    --require-notarized)
+      REQUIRE_NOTARIZED=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$APPCAST" ]]; then
+  echo "ERROR: appcast not found: $APPCAST" >&2
+  exit 1
+fi
+
+APPCAST_METADATA="$(python3 - "$APPCAST" "$VERSION" <<'PY'
+import base64
+import re
+import shlex
+import sys
+import xml.etree.ElementTree as ET
+
+appcast_path = sys.argv[1]
+expected_version = sys.argv[2]
+sparkle_ns = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+try:
+    tree = ET.parse(appcast_path)
+except ET.ParseError as exc:
+    raise SystemExit(f"ERROR: appcast XML is not well-formed: {exc}")
+
+root = tree.getroot()
+channel = root.find("channel")
+if channel is None:
+    raise SystemExit("ERROR: appcast is missing channel")
+
+items = channel.findall("item")
+if not items:
+    raise SystemExit("ERROR: appcast has no update items")
+
+latest = items[0]
+version = latest.findtext(f"{{{sparkle_ns}}}version")
+short_version = latest.findtext(f"{{{sparkle_ns}}}shortVersionString")
+enclosure = latest.find("enclosure")
+
+if not version:
+    raise SystemExit("ERROR: latest appcast item is missing sparkle:version")
+if not short_version:
+    raise SystemExit("ERROR: latest appcast item is missing sparkle:shortVersionString")
+if version != short_version:
+    raise SystemExit(f"ERROR: latest appcast version mismatch: {version} != {short_version}")
+if expected_version and version != expected_version:
+    raise SystemExit(f"ERROR: latest appcast version is {version}, expected {expected_version}")
+if enclosure is None:
+    raise SystemExit("ERROR: latest appcast item is missing enclosure")
+
+url = enclosure.attrib.get("url", "")
+length = enclosure.attrib.get("length", "")
+signature = enclosure.attrib.get(f"{{{sparkle_ns}}}edSignature", "")
+
+expected_url = f"https://github.com/pHequals7/muesli/releases/download/v{version}/Muesli-{version}.dmg"
+if url != expected_url:
+    raise SystemExit(f"ERROR: latest appcast URL is {url!r}, expected {expected_url!r}")
+
+try:
+    length_int = int(length)
+except ValueError:
+    raise SystemExit(f"ERROR: latest appcast enclosure length is not an integer: {length!r}")
+if length_int <= 0:
+    raise SystemExit("ERROR: latest appcast enclosure length must be positive")
+
+try:
+    decoded_signature = base64.b64decode(signature, validate=True)
+except Exception as exc:
+    raise SystemExit(f"ERROR: latest appcast edSignature is not valid base64: {exc}")
+if len(decoded_signature) != 64:
+    raise SystemExit(f"ERROR: latest appcast edSignature is {len(decoded_signature)} bytes, expected 64")
+
+delta_attr = f"{{{sparkle_ns}}}deltaFrom"
+delta_enclosures = [
+    node.attrib.get("url", "(missing url)")
+    for node in root.iter("enclosure")
+    if delta_attr in node.attrib
+]
+if delta_enclosures:
+    raise SystemExit(
+        "ERROR: appcast contains delta enclosures, but release deltas are not hosted: "
+        + ", ".join(delta_enclosures)
+    )
+
+if not re.fullmatch(r"[0-9][0-9A-Za-z.\-]*", version):
+    raise SystemExit(f"ERROR: unexpected version format: {version!r}")
+
+for key, value in {
+    "APPCAST_VERSION": version,
+    "APPCAST_URL": url,
+    "APPCAST_LENGTH": str(length_int),
+    "APPCAST_SIGNATURE": signature,
+}.items():
+    print(f"{key}={shlex.quote(value)}")
+PY
+)"
+eval "$APPCAST_METADATA"
+
+echo "Appcast OK: v${APPCAST_VERSION}"
+
+if [[ "$SKIP_DMG" == "1" ]]; then
+  echo "DMG checks skipped."
+  exit 0
+fi
+
+if [[ -z "$DMG_PATH" ]]; then
+  DMG_PATH="$ROOT/dist-release/Muesli-${APPCAST_VERSION}.dmg"
+fi
+
+if [[ ! -f "$DMG_PATH" ]]; then
+  echo "ERROR: DMG not found: $DMG_PATH" >&2
+  echo "       Use --skip-dmg for CI metadata-only validation." >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "ERROR: DMG validation requires macOS." >&2
+  exit 1
+fi
+
+file_size() {
+  stat -f '%z' "$1"
+}
+
+DMG_LENGTH="$(file_size "$DMG_PATH")"
+if [[ "$DMG_LENGTH" != "$APPCAST_LENGTH" ]]; then
+  echo "ERROR: DMG size $DMG_LENGTH does not match appcast length $APPCAST_LENGTH" >&2
+  exit 1
+fi
+echo "DMG length OK: $DMG_LENGTH bytes"
+
+MOUNT_POINT=""
+SWIFT_VERIFY_FILE=""
+cleanup() {
+  if [[ -n "$MOUNT_POINT" ]]; then
+    hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+  fi
+  if [[ -n "$SWIFT_VERIFY_FILE" && -f "$SWIFT_VERIFY_FILE" ]]; then
+    rm -f "$SWIFT_VERIFY_FILE"
+  fi
+}
+trap cleanup EXIT
+
+MOUNT_POINT="$(hdiutil attach "$DMG_PATH" -nobrowse -readonly 2>&1 | awk -F'\t' '/\/Volumes\// {print $NF; exit}')"
+if [[ -z "$MOUNT_POINT" ]]; then
+  echo "ERROR: Could not mount DMG: $DMG_PATH" >&2
+  exit 1
+fi
+
+APP_PATH="$MOUNT_POINT/Muesli.app"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "ERROR: mounted DMG does not contain Muesli.app" >&2
+  exit 1
+fi
+
+BUNDLE_SHORT_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+FEED_URL="$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$INFO_PLIST")"
+PUBLIC_ED_KEY="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$INFO_PLIST")"
+
+if [[ "$BUNDLE_SHORT_VERSION" != "$APPCAST_VERSION" || "$BUNDLE_VERSION" != "$APPCAST_VERSION" ]]; then
+  echo "ERROR: app bundle version ${BUNDLE_SHORT_VERSION}/${BUNDLE_VERSION} does not match appcast ${APPCAST_VERSION}" >&2
+  exit 1
+fi
+
+if [[ "$FEED_URL" != "https://pHequals7.github.io/muesli/appcast.xml" ]]; then
+  echo "ERROR: app bundle SUFeedURL is $FEED_URL" >&2
+  exit 1
+fi
+
+if [[ -z "$PUBLIC_ED_KEY" ]]; then
+  echo "ERROR: app bundle is missing SUPublicEDKey" >&2
+  exit 1
+fi
+echo "Bundle metadata OK."
+
+SWIFT_VERIFY_FILE="$(mktemp -t muesli-ed25519-verify.XXXXXX.swift)"
+cat > "$SWIFT_VERIFY_FILE" <<'SWIFT'
+import CryptoKit
+import Foundation
+
+guard CommandLine.arguments.count == 4 else {
+    fatalError("usage: verifier <public-key-base64> <signature-base64> <file>")
+}
+
+guard let publicKeyData = Data(base64Encoded: CommandLine.arguments[1]),
+      let signature = Data(base64Encoded: CommandLine.arguments[2]) else {
+    fatalError("invalid base64 input")
+}
+
+let fileURL = URL(fileURLWithPath: CommandLine.arguments[3])
+let payload = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKeyData)
+
+if !publicKey.isValidSignature(signature, for: payload) {
+    fputs("ERROR: appcast edSignature does not verify against app SUPublicEDKey\n", stderr)
+    exit(1)
+}
+SWIFT
+
+swift "$SWIFT_VERIFY_FILE" "$PUBLIC_ED_KEY" "$APPCAST_SIGNATURE" "$DMG_PATH"
+echo "Sparkle EdDSA signature OK."
+
+if ! APP_CODESIGN_RESULT="$(codesign --verify --deep --strict --verbose=2 "$APP_PATH" 2>&1)"; then
+  echo "$APP_CODESIGN_RESULT" >&2
+  exit 1
+fi
+echo "App code signature OK."
+
+DMG_FLAGS="$(codesign -dvvv "$DMG_PATH" 2>&1 || true)"
+if ! echo "$DMG_FLAGS" | grep -q "runtime"; then
+  echo "ERROR: DMG is missing hardened runtime flag." >&2
+  exit 1
+fi
+echo "DMG hardened runtime OK."
+
+if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
+  APP_SPCTL_RESULT="$(spctl -a -vv "$APP_PATH" 2>&1)"
+  echo "$APP_SPCTL_RESULT"
+  if ! echo "$APP_SPCTL_RESULT" | grep -q "accepted"; then
+    echo "ERROR: app inside DMG was rejected by Gatekeeper." >&2
+    exit 1
+  fi
+
+  APP_STAPLE_RESULT="$(xcrun stapler validate "$APP_PATH" 2>&1)"
+  echo "$APP_STAPLE_RESULT"
+  if ! echo "$APP_STAPLE_RESULT" | grep -q "worked"; then
+    echo "ERROR: app inside DMG does not have a valid staple." >&2
+    exit 1
+  fi
+
+  DMG_SPCTL_RESULT="$(spctl -a -vv -t open --context context:primary-signature "$DMG_PATH" 2>&1)"
+  echo "$DMG_SPCTL_RESULT"
+  if ! echo "$DMG_SPCTL_RESULT" | grep -q "accepted"; then
+    echo "ERROR: DMG was rejected by Gatekeeper." >&2
+    exit 1
+  fi
+
+  DMG_STAPLE_RESULT="$(xcrun stapler validate "$DMG_PATH" 2>&1)"
+  echo "$DMG_STAPLE_RESULT"
+  if ! echo "$DMG_STAPLE_RESULT" | grep -q "worked"; then
+    echo "ERROR: DMG does not have a valid staple." >&2
+    exit 1
+  fi
+  echo "Notarization/staple checks OK."
+fi
+
+echo "Update flow verification passed for v${APPCAST_VERSION}."

--- a/scripts/verify_update_flow.sh
+++ b/scripts/verify_update_flow.sh
@@ -315,7 +315,9 @@ fi
 echo "DMG code signature OK."
 
 if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
-  APP_SPCTL_RESULT="$(spctl -a -vv "$APP_PATH" 2>&1)"
+  if ! APP_SPCTL_RESULT="$(spctl -a -vv "$APP_PATH" 2>&1)"; then
+    :
+  fi
   echo "$APP_SPCTL_RESULT"
   if ! echo "$APP_SPCTL_RESULT" | grep -q "accepted"; then
     echo "ERROR: app inside DMG was rejected by Gatekeeper." >&2
@@ -328,7 +330,9 @@ if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
     exit 1
   fi
 
-  DMG_SPCTL_RESULT="$(spctl -a -vv -t open --context context:primary-signature "$DMG_PATH" 2>&1)"
+  if ! DMG_SPCTL_RESULT="$(spctl -a -vv -t open --context context:primary-signature "$DMG_PATH" 2>&1)"; then
+    :
+  fi
   echo "$DMG_SPCTL_RESULT"
   if ! echo "$DMG_SPCTL_RESULT" | grep -q "accepted"; then
     echo "ERROR: DMG was rejected by Gatekeeper." >&2

--- a/scripts/verify_update_flow.sh
+++ b/scripts/verify_update_flow.sh
@@ -98,6 +98,8 @@ if not version:
     raise SystemExit("ERROR: latest appcast item is missing sparkle:version")
 if not short_version:
     raise SystemExit("ERROR: latest appcast item is missing sparkle:shortVersionString")
+# Muesli deliberately uses the marketing version as CFBundleVersion too, so
+# The Sparkle appcast version and shortVersionString should remain identical.
 if version != short_version:
     raise SystemExit(f"ERROR: latest appcast version mismatch: {version} != {short_version}")
 if expected_version and version != expected_version:
@@ -151,6 +153,8 @@ for key, value in {
     print(f"{key}={shlex.quote(value)}")
 PY
 )"
+# The Python emitter shell-quotes every value with shlex.quote before printing
+# KEY=value lines, so eval only imports validated scalar appcast metadata.
 eval "$APPCAST_METADATA"
 
 echo "Appcast OK: v${APPCAST_VERSION}"
@@ -188,6 +192,7 @@ echo "DMG length OK: $DMG_LENGTH bytes"
 
 MOUNT_POINT=""
 SWIFT_VERIFY_FILE=""
+HDIUTIL_ATTACH_LOG=""
 cleanup() {
   if [[ -n "$MOUNT_POINT" ]]; then
     hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
@@ -195,10 +200,19 @@ cleanup() {
   if [[ -n "$SWIFT_VERIFY_FILE" && -f "$SWIFT_VERIFY_FILE" ]]; then
     rm -f "$SWIFT_VERIFY_FILE"
   fi
+  if [[ -n "$HDIUTIL_ATTACH_LOG" && -f "$HDIUTIL_ATTACH_LOG" ]]; then
+    rm -f "$HDIUTIL_ATTACH_LOG"
+  fi
 }
 trap cleanup EXIT
 
-MOUNT_POINT="$(hdiutil attach "$DMG_PATH" -nobrowse -readonly 2>&1 | awk -F'\t' '/\/Volumes\// {print $NF; exit}')"
+HDIUTIL_ATTACH_LOG="$(mktemp -t muesli-hdiutil-attach.XXXXXX.log)"
+if ! ATTACH_OUTPUT="$(hdiutil attach "$DMG_PATH" -nobrowse -readonly 2>"$HDIUTIL_ATTACH_LOG")"; then
+  cat "$HDIUTIL_ATTACH_LOG" >&2
+  echo "ERROR: Could not mount DMG: $DMG_PATH" >&2
+  exit 1
+fi
+MOUNT_POINT="$(printf '%s\n' "$ATTACH_OUTPUT" | awk -F'\t' '/\/Volumes\// {print $NF; exit}')"
 if [[ -z "$MOUNT_POINT" ]]; then
   echo "ERROR: Could not mount DMG: $DMG_PATH" >&2
   exit 1
@@ -237,18 +251,30 @@ cat > "$SWIFT_VERIFY_FILE" <<'SWIFT'
 import CryptoKit
 import Foundation
 
+func fail(_ message: String) -> Never {
+    fputs("ERROR: \(message)\n", stderr)
+    exit(1)
+}
+
 guard CommandLine.arguments.count == 4 else {
-    fatalError("usage: verifier <public-key-base64> <signature-base64> <file>")
+    fail("usage: verifier <public-key-base64> <signature-base64> <file>")
 }
 
 guard let publicKeyData = Data(base64Encoded: CommandLine.arguments[1]),
       let signature = Data(base64Encoded: CommandLine.arguments[2]) else {
-    fatalError("invalid base64 input")
+    fail("invalid base64 input")
 }
 
 let fileURL = URL(fileURLWithPath: CommandLine.arguments[3])
-let payload = try Data(contentsOf: fileURL, options: .mappedIfSafe)
-let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKeyData)
+let payload: Data
+let publicKey: Curve25519.Signing.PublicKey
+
+do {
+    payload = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+    publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: publicKeyData)
+} catch {
+    fail("\(error)")
+}
 
 if !publicKey.isValidSignature(signature, for: payload) {
     fputs("ERROR: appcast edSignature does not verify against app SUPublicEDKey\n", stderr)
@@ -265,12 +291,19 @@ if ! APP_CODESIGN_RESULT="$(codesign --verify --deep --strict --verbose=2 "$APP_
 fi
 echo "App code signature OK."
 
-DMG_FLAGS="$(codesign -dvvv "$DMG_PATH" 2>&1 || true)"
-if ! echo "$DMG_FLAGS" | grep -q "runtime"; then
-  echo "ERROR: DMG is missing hardened runtime flag." >&2
+APP_SIGNATURE_DETAILS="$(codesign -dvvv "$APP_PATH" 2>&1)"
+if ! echo "$APP_SIGNATURE_DETAILS" | grep -q "flags=.*runtime"; then
+  echo "$APP_SIGNATURE_DETAILS" >&2
+  echo "ERROR: app bundle is missing hardened runtime flag." >&2
   exit 1
 fi
-echo "DMG hardened runtime OK."
+echo "App hardened runtime OK."
+
+if ! DMG_CODESIGN_RESULT="$(codesign --verify --strict --verbose=2 "$DMG_PATH" 2>&1)"; then
+  echo "$DMG_CODESIGN_RESULT" >&2
+  exit 1
+fi
+echo "DMG code signature OK."
 
 if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
   APP_SPCTL_RESULT="$(spctl -a -vv "$APP_PATH" 2>&1)"
@@ -280,9 +313,8 @@ if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
     exit 1
   fi
 
-  APP_STAPLE_RESULT="$(xcrun stapler validate "$APP_PATH" 2>&1)"
-  echo "$APP_STAPLE_RESULT"
-  if ! echo "$APP_STAPLE_RESULT" | grep -q "worked"; then
+  echo "Validating app staple..."
+  if ! xcrun stapler validate "$APP_PATH"; then
     echo "ERROR: app inside DMG does not have a valid staple." >&2
     exit 1
   fi
@@ -294,9 +326,8 @@ if [[ "$REQUIRE_NOTARIZED" == "1" ]]; then
     exit 1
   fi
 
-  DMG_STAPLE_RESULT="$(xcrun stapler validate "$DMG_PATH" 2>&1)"
-  echo "$DMG_STAPLE_RESULT"
-  if ! echo "$DMG_STAPLE_RESULT" | grep -q "worked"; then
+  echo "Validating DMG staple..."
+  if ! xcrun stapler validate "$DMG_PATH"; then
     echo "ERROR: DMG does not have a valid staple." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Adds user-facing fallback guidance for Sparkle install-stage failures so users know to retry from Applications or manually install the latest DMG.
- Adds `scripts/verify_update_flow.sh` to validate Sparkle appcast metadata and, when available, the signed DMG artifact.
- Wires metadata-only update-flow validation into CI and full notarized artifact validation into the release pipeline.
- Documents the release verification command in the release checklist.

## Why

Users hitting Sparkle's generic “An error occurred while running the updater” alert had no actionable next step. The release metadata and artifact checks also lived as manual debugging steps, so broken appcast URLs, missing signatures, delta entries, or mismatched DMG metadata could slip through without a dedicated gate.

## Validation

- `swift test --package-path native/MuesliNative --filter UpdateFailureGuidanceTests`
- `./scripts/verify_update_flow.sh --skip-dmg`
- `./scripts/verify_update_flow.sh --version 0.6.1 --dmg dist-release/Muesli-0.6.1.dmg --require-notarized`
- `git diff --check`
