### PR TITLE
Improve meeting recording stability

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -43,6 +43,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         controller?.shutdown()
     }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard controller?.shouldTerminateApplication() != false else {
+            return .terminateCancel
+        }
+        return .terminateNow
+    }
 }
 
 @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -45,7 +45,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        guard controller?.shouldTerminateApplication() != false else {
+        if controller?.shouldTerminateApplication() == false {
             return .terminateCancel
         }
         return .terminateNow

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingTerminationPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingTerminationPolicy.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum MeetingTerminationState: Equatable {
+    case none
+    case starting
+    case recording
+    case processing
+}
+
+enum MeetingTerminationPolicy {
+    static func state(
+        isStarting: Bool,
+        hasActiveSession: Bool,
+        isRecording: Bool,
+        isStopping: Bool
+    ) -> MeetingTerminationState {
+        if isStopping {
+            return .processing
+        }
+        if isStarting {
+            return .starting
+        }
+        if hasActiveSession {
+            return isRecording ? .recording : .processing
+        }
+        return .none
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -120,6 +120,8 @@ final class MuesliController: NSObject {
     private var presentedMeetingDetection: MeetingDetection?
     private var meetingEndTimer: Timer?
     private var activeMeetingCalendarEndDate: Date?
+    private var meetingActivity: NSObjectProtocol?
+    private var isStoppingMeetingRecording = false
 
     init(runtime: RuntimePaths, dictationStore: DictationStore? = nil) {
         let loadedConfig = configStore.load()
@@ -307,6 +309,9 @@ final class MuesliController: NSObject {
         micActivityMonitor.stop()
         dismissPresentedMeetingDetection()
         meetingNotification.close()
+        activeMeetingSession?.discard()
+        activeMeetingSession = nil
+        endMeetingActivity()
         recorder.cancel()
         Task {
             await transcriptionCoordinator.shutdown()
@@ -848,9 +853,11 @@ final class MuesliController: NSObject {
                 let title = event.title
                 meetingStartingNowTimers[key]?.invalidate()
                 meetingStartingNowTimers[key] = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
-                    guard let self, !self.isMeetingRecording() else { return }
-                    self.meetingStartingNowTimers.removeValue(forKey: key)
-                    self.showMeetingStartingNowNotification(title: title, meetingURL: meetingURL, endDate: endDate)
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self, !self.isMeetingRecording() else { return }
+                        self.meetingStartingNowTimers.removeValue(forKey: key)
+                        self.showMeetingStartingNowNotification(title: title, meetingURL: meetingURL, endDate: endDate)
+                    }
                 }
             }
 
@@ -1358,7 +1365,53 @@ final class MuesliController: NSObject {
     }
 
     func isMeetingRecording() -> Bool {
-        activeMeetingSession?.isRecording == true
+        activeMeetingSession?.isRecording == true || isStoppingMeetingRecording
+    }
+
+    private var meetingTerminationState: MeetingTerminationState {
+        MeetingTerminationPolicy.state(
+            isStarting: isStartingMeetingRecording,
+            hasActiveSession: activeMeetingSession != nil,
+            isRecording: activeMeetingSession?.isRecording == true,
+            isStopping: isStoppingMeetingRecording
+        )
+    }
+
+    func shouldTerminateApplication() -> Bool {
+        let state = meetingTerminationState
+        guard state != .none else { return true }
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        switch state {
+        case .starting:
+            alert.messageText = "Meeting recording is starting"
+            alert.informativeText = "Quitting now will cancel the meeting recording before it has been saved."
+        case .recording:
+            alert.messageText = "Meeting recording in progress"
+            alert.informativeText = "Quitting now will stop the meeting recording and the current transcript may be lost. Stop the recording first if you want Muesli to save notes."
+        case .processing:
+            alert.messageText = "Meeting transcription in progress"
+            alert.informativeText = "Quitting now will interrupt transcription and the meeting notes may not be saved."
+        case .none:
+            return true
+        }
+        alert.addButton(withTitle: "Keep Muesli Running")
+        alert.addButton(withTitle: "Quit Anyway")
+
+        let response = alert.runModal()
+        guard response == .alertSecondButtonReturn else {
+            return false
+        }
+
+        activeMeetingSession?.discard()
+        activeMeetingSession = nil
+        isStartingMeetingRecording = false
+        isStoppingMeetingRecording = false
+        endMeetingActivity()
+        return true
     }
 
     @objc func toggleMeetingRecording() {
@@ -1377,6 +1430,7 @@ final class MuesliController: NSObject {
     func startMeetingRecording(title: String = "Meeting") {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
         isStartingMeetingRecording = true
+        beginMeetingActivity(reason: "Recording and transcribing a meeting")
         micActivityMonitor.suppressWhileActive()
         micActivityMonitor.refreshState()
         updateMeetingNotificationVisibility()
@@ -1394,6 +1448,7 @@ final class MuesliController: NSObject {
                 self.statusBarController?.setStatus("Idle")
                 self.statusBarController?.refresh()
                 self.setState(.idle)
+                self.endMeetingActivity()
 
                 let isSystemAudioError = error is CoreAudioSystemRecorder.RecorderError
                 let alert = NSAlert()
@@ -1506,6 +1561,8 @@ final class MuesliController: NSObject {
         }
         activeMeetingSession.discard()
         self.activeMeetingSession = nil
+        isStoppingMeetingRecording = false
+        endMeetingActivity()
         indicator.setMeetingRecording(false, config: config)
         micActivityMonitor.resumeAfterCooldown()
         micActivityMonitor.refreshState()
@@ -1516,12 +1573,14 @@ final class MuesliController: NSObject {
     }
 
     func stopMeetingRecording() {
+        guard !isStoppingMeetingRecording else { return }
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             indicator.setMeetingRecording(false, config: config)
             setState(.idle)
             return
         }
+        isStoppingMeetingRecording = true
         meetingEndTimer?.invalidate()
         meetingEndTimer = nil
         meetingNotification.close()
@@ -1565,6 +1624,8 @@ final class MuesliController: NSObject {
             }
             await MainActor.run {
                 self.activeMeetingSession = nil
+                self.isStoppingMeetingRecording = false
+                self.endMeetingActivity()
                 self.setState(.idle)
                 self.micActivityMonitor.resumeAfterCooldown()
                 self.micActivityMonitor.refreshState()
@@ -1775,6 +1836,24 @@ final class MuesliController: NSObject {
         if !isDictationTestMode {
             indicator.setState(state, config: config)
         }
+    }
+
+    private func beginMeetingActivity(reason: String) {
+        guard meetingActivity == nil else { return }
+        meetingActivity = ProcessInfo.processInfo.beginActivity(
+            options: [
+                .userInitiatedAllowingIdleSystemSleep,
+                .suddenTerminationDisabled,
+                .automaticTerminationDisabled,
+            ],
+            reason: reason
+        )
+    }
+
+    private func endMeetingActivity() {
+        guard let activity = meetingActivity else { return }
+        ProcessInfo.processInfo.endActivity(activity)
+        meetingActivity = nil
     }
 
     private func dismissPresentedMeetingDetection() {
@@ -2262,8 +2341,8 @@ final class MuesliController: NSObject {
         guard delay > 0 else { return }
 
         meetingEndTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
-            guard let self, self.isMeetingRecording() else { return }
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.isMeetingRecording() else { return }
                 self.meetingNotification.show(
                     title: "Meeting ended",
                     subtitle: "\(title) · scheduled time is over",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1379,25 +1379,29 @@ final class MuesliController: NSObject {
 
     func shouldTerminateApplication() -> Bool {
         let state = meetingTerminationState
-        guard state != .none else { return true }
+        let messageText: String
+        let informativeText: String
+
+        switch state {
+        case .none:
+            return true
+        case .starting:
+            messageText = "Meeting recording is starting"
+            informativeText = "Quitting now will cancel the meeting recording before it has been saved."
+        case .recording:
+            messageText = "Meeting recording in progress"
+            informativeText = "Quitting now will stop the meeting recording and the current transcript may be lost. Stop the recording first if you want Muesli to save notes."
+        case .processing:
+            messageText = "Meeting transcription in progress"
+            informativeText = "Quitting now will interrupt transcription and the meeting notes may not be saved."
+        }
 
         NSApp.activate(ignoringOtherApps: true)
 
         let alert = NSAlert()
         alert.alertStyle = .warning
-        switch state {
-        case .starting:
-            alert.messageText = "Meeting recording is starting"
-            alert.informativeText = "Quitting now will cancel the meeting recording before it has been saved."
-        case .recording:
-            alert.messageText = "Meeting recording in progress"
-            alert.informativeText = "Quitting now will stop the meeting recording and the current transcript may be lost. Stop the recording first if you want Muesli to save notes."
-        case .processing:
-            alert.messageText = "Meeting transcription in progress"
-            alert.informativeText = "Quitting now will interrupt transcription and the meeting notes may not be saved."
-        case .none:
-            return true
-        }
+        alert.messageText = messageText
+        alert.informativeText = informativeText
         alert.addButton(withTitle: "Keep Muesli Running")
         alert.addButton(withTitle: "Quit Anyway")
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1561,6 +1561,8 @@ final class MuesliController: NSObject {
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             indicator.setMeetingRecording(false, config: config)
+            isStoppingMeetingRecording = false
+            endMeetingActivity()
             setState(.idle)
             return
         }
@@ -1582,6 +1584,8 @@ final class MuesliController: NSObject {
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             indicator.setMeetingRecording(false, config: config)
+            isStoppingMeetingRecording = false
+            endMeetingActivity()
             setState(.idle)
             return
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1377,6 +1377,7 @@ final class MuesliController: NSObject {
         )
     }
 
+    @MainActor
     func shouldTerminateApplication() -> Bool {
         let state = meetingTerminationState
         let messageText: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -1,97 +1,206 @@
 import FluidAudio
 import Foundation
+import os
 
-/// Bridges real-time mic audio to VadManager's streaming API.
-/// Emits chunk boundary signals on speechEnd events for VAD-driven rotation.
+/// Bridges real-time meeting audio to VadManager's streaming API.
+///
+/// The key requirement here is single-flight state ownership: exactly one chunk
+/// may be processed against the mutable stream state at a time. Chunks can
+/// arrive faster than VAD inference finishes, so we queue them and drain
+/// serially rather than spawning overlapping Tasks that race the same state.
 final class StreamingVadController {
-    /// Called when VAD detects a natural speech boundary (rotation point).
+    /// Called when VAD detects a natural chunk boundary.
     var onChunkBoundary: (() -> Void)?
 
-    private let vadManager: VadManager
-    private var streamState: VadStreamState?
-    private var lastRotationTime: Date?
-    private var isActive = false
+    private struct State {
+        var isActive = false
+        var isDraining = false
+        var pendingChunks: [[Float]] = []
+        var streamState: VadStreamState?
+        var lastRotationTime: Date?
+    }
+
+    private let lock = OSAllocatedUnfairLock(initialState: State())
+    private let makeInitialState: @Sendable () async -> VadStreamState
+    private let processStreamChunk: @Sendable ([Float], VadStreamState) async throws -> VadStreamResult
+    private let logger = Logger(subsystem: "com.muesli.native", category: "StreamingVadController")
 
     /// Minimum chunk duration before allowing rotation (prevents rapid flipping).
-    private let minChunkDuration: TimeInterval = 3.0
+    private let minChunkDuration: TimeInterval
     /// Maximum chunk duration before forcing rotation (safety cap).
-    private let maxChunkDuration: TimeInterval = 60.0
-    /// Timer for max duration fallback.
+    private let maxChunkDuration: TimeInterval
     private var maxDurationTimer: Timer?
 
-    init(vadManager: VadManager) {
-        self.vadManager = vadManager
+    convenience init(vadManager: VadManager) {
+        self.init(
+            minChunkDuration: 3.0,
+            maxChunkDuration: 60.0,
+            makeInitialState: { await vadManager.makeStreamState() },
+            processStreamChunk: { samples, state in
+                try await vadManager.processStreamingChunk(samples, state: state)
+            }
+        )
+    }
+
+    internal init(
+        minChunkDuration: TimeInterval,
+        maxChunkDuration: TimeInterval,
+        makeInitialState: @escaping @Sendable () async -> VadStreamState,
+        processStreamChunk: @escaping @Sendable ([Float], VadStreamState) async throws -> VadStreamResult
+    ) {
+        self.minChunkDuration = minChunkDuration
+        self.maxChunkDuration = maxChunkDuration
+        self.makeInitialState = makeInitialState
+        self.processStreamChunk = processStreamChunk
     }
 
     func start() {
-        isActive = true
-        lastRotationTime = Date()
+        let shouldStart = lock.withLock { state in
+            guard !state.isActive else { return false }
+            state.isActive = true
+            state.isDraining = false
+            state.pendingChunks.removeAll(keepingCapacity: true)
+            state.streamState = nil
+            state.lastRotationTime = Date()
+            return true
+        }
+        guard shouldStart else { return }
 
-        // Initialize streaming state
-        Task {
-            streamState = await vadManager.makeStreamState()
+        Task { [weak self] in
+            guard let self else { return }
+            let initialState = await self.makeInitialState()
+            let shouldKickDrain = self.lock.withLock { state in
+                guard state.isActive else { return false }
+                state.streamState = initialState
+                return !state.pendingChunks.isEmpty
+            }
+            if shouldKickDrain {
+                self.startDrainIfNeeded()
+            }
         }
 
-        // Max duration fallback timer
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            self.maxDurationTimer?.invalidate()
             self.maxDurationTimer = Timer.scheduledTimer(withTimeInterval: self.maxChunkDuration, repeats: true) { [weak self] _ in
-                guard let self, self.isActive else { return }
-                fputs("[vad] max chunk duration reached, forcing rotation\n", stderr)
-                self.lastRotationTime = Date()
-                self.onChunkBoundary?()
+                self?.handleMaxDurationTimer()
             }
         }
     }
 
     func stop() {
-        isActive = false
+        lock.withLock { state in
+            state.isActive = false
+            state.pendingChunks.removeAll(keepingCapacity: false)
+            state.streamState = nil
+        }
         maxDurationTimer?.invalidate()
         maxDurationTimer = nil
-        streamState = nil
     }
 
-    /// Feed a chunk of Float audio samples (4096 samples = 256ms at 16kHz).
+    /// Feed a chunk of Float audio samples (typically 4096 samples = 256ms at 16kHz).
     func processAudio(_ samples: [Float]) {
-        guard isActive, let currentState = streamState else { return }
+        guard !samples.isEmpty else { return }
 
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let result = try await self.vadManager.processStreamingChunk(
-                    samples,
-                    state: currentState
-                )
-                self.streamState = result.state
+        let shouldStart = lock.withLock { state in
+            guard state.isActive else { return false }
+            state.pendingChunks.append(samples)
+            return state.streamState != nil && !state.isDraining
+        }
 
-                // Check for speech end event
-                if let event = result.event, event.kind == .speechEnd {
-                    let now = Date()
-                    let elapsed = now.timeIntervalSince(self.lastRotationTime ?? now)
-
-                    if elapsed >= self.minChunkDuration {
-                        fputs("[vad] speech end detected at \(String(format: "%.1f", elapsed))s, rotating chunk\n", stderr)
-                        self.lastRotationTime = now
-
-                        // Reset max duration timer
-                        DispatchQueue.main.async { [weak self] in
-                            self?.maxDurationTimer?.fireDate = Date().addingTimeInterval(self?.maxChunkDuration ?? 60)
-                        }
-
-                        self.onChunkBoundary?()
-                    }
-                }
-            } catch {
-                // VAD failure is non-critical — chunk will rotate on max duration fallback
-            }
+        if shouldStart {
+            startDrainIfNeeded()
         }
     }
 
-    /// Notify that a rotation just happened (e.g., from external trigger).
+    /// Notify that an external rotation just happened.
     func notifyRotation() {
-        lastRotationTime = Date()
+        lock.withLock { state in
+            state.lastRotationTime = Date()
+        }
         DispatchQueue.main.async { [weak self] in
             self?.maxDurationTimer?.fireDate = Date().addingTimeInterval(self?.maxChunkDuration ?? 60)
+        }
+    }
+
+    private func handleMaxDurationTimer() {
+        let shouldRotate = lock.withLock { state in
+            guard state.isActive else { return false }
+            let now = Date()
+            let elapsed = now.timeIntervalSince(state.lastRotationTime ?? now)
+            guard elapsed >= self.minChunkDuration else { return false }
+            state.lastRotationTime = now
+            return true
+        }
+        guard shouldRotate else { return }
+        fputs("[vad] max chunk duration reached, forcing rotation\n", stderr)
+        onChunkBoundary?()
+    }
+
+    private func startDrainIfNeeded() {
+        let shouldStart = lock.withLock { state in
+            guard state.isActive, state.streamState != nil, !state.isDraining else { return false }
+            guard !state.pendingChunks.isEmpty else { return false }
+            state.isDraining = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        Task { [weak self] in
+            await self?.drainQueue()
+        }
+    }
+
+    private func drainQueue() async {
+        while true {
+            let next: (chunk: [Float], streamState: VadStreamState)? = lock.withLock { state in
+                guard state.isActive else {
+                    state.isDraining = false
+                    state.pendingChunks.removeAll(keepingCapacity: false)
+                    return nil
+                }
+                guard let streamState = state.streamState else {
+                    state.isDraining = false
+                    return nil
+                }
+                guard !state.pendingChunks.isEmpty else {
+                    state.isDraining = false
+                    return nil
+                }
+                return (state.pendingChunks.removeFirst(), streamState)
+            }
+
+            guard let next else { return }
+
+            do {
+                let result = try await processStreamChunk(next.chunk, next.streamState)
+
+                let shouldRotate = lock.withLock { state in
+                    guard state.isActive else { return false }
+                    state.streamState = result.state
+
+                    guard let event = result.event, event.kind == .speechEnd else {
+                        return false
+                    }
+
+                    let now = Date()
+                    let elapsed = now.timeIntervalSince(state.lastRotationTime ?? now)
+                    guard elapsed >= self.minChunkDuration else { return false }
+                    state.lastRotationTime = now
+                    return true
+                }
+
+                if shouldRotate {
+                    fputs("[vad] speech end detected, rotating chunk\n", stderr)
+                    DispatchQueue.main.async { [weak self] in
+                        self?.maxDurationTimer?.fireDate = Date().addingTimeInterval(self?.maxChunkDuration ?? 60)
+                    }
+                    onChunkBoundary?()
+                }
+            } catch {
+                logger.error("streaming VAD chunk failed: \(String(describing: error), privacy: .public)")
+                fputs("[vad] streaming chunk failed: \(error)\n", stderr)
+            }
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -166,8 +166,10 @@ final class StreamingVadController {
         while true {
             let next: (generation: Int, chunk: [Float], streamState: VadStreamState)? = lock.withLock { state in
                 guard state.isActive, state.isDraining, state.drainerEpoch == drainerEpoch else {
-                    state.isDraining = false
-                    state.pendingChunks.removeAll(keepingCapacity: false)
+                    if !state.isActive {
+                        state.isDraining = false
+                        state.pendingChunks.removeAll(keepingCapacity: false)
+                    }
                     return nil
                 }
                 guard let streamState = state.streamState else {
@@ -206,8 +208,8 @@ final class StreamingVadController {
                     DispatchQueue.main.async { [weak self] in
                         guard let self else { return }
                         self.maxDurationTimer?.fireDate = Date().addingTimeInterval(self.maxChunkDuration)
+                        self.onChunkBoundary?()
                     }
-                    onChunkBoundary?()
                 }
             } catch {
                 logger.error("streaming VAD chunk failed: \(String(describing: error), privacy: .public)")

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -82,6 +82,7 @@ final class StreamingVadController {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.maxDurationTimer?.invalidate()
+            guard self.lock.withLock({ $0.isActive }) else { return }
             self.maxDurationTimer = Timer.scheduledTimer(withTimeInterval: self.maxChunkDuration, repeats: true) { [weak self] _ in
                 self?.handleMaxDurationTimer()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -14,6 +14,7 @@ final class StreamingVadController {
 
     private struct State {
         var generation = 0
+        var drainerEpoch = 0
         var isActive = false
         var isDraining = false
         var pendingChunks: [[Float]] = []
@@ -127,7 +128,8 @@ final class StreamingVadController {
             state.lastRotationTime = Date()
         }
         DispatchQueue.main.async { [weak self] in
-            self?.maxDurationTimer?.fireDate = Date().addingTimeInterval(self?.maxChunkDuration ?? 60)
+            guard let self else { return }
+            self.maxDurationTimer?.fireDate = Date().addingTimeInterval(self.maxChunkDuration)
         }
     }
 
@@ -146,23 +148,24 @@ final class StreamingVadController {
     }
 
     private func startDrainIfNeeded() {
-        let shouldStart = lock.withLock { state in
-            guard state.isActive, state.streamState != nil, !state.isDraining else { return false }
-            guard !state.pendingChunks.isEmpty else { return false }
+        let drainerEpoch = lock.withLock { state -> Int? in
+            guard state.isActive, state.streamState != nil, !state.isDraining else { return nil }
+            guard !state.pendingChunks.isEmpty else { return nil }
+            state.drainerEpoch += 1
             state.isDraining = true
-            return true
+            return state.drainerEpoch
         }
-        guard shouldStart else { return }
+        guard let drainerEpoch else { return }
 
         Task { [weak self] in
-            await self?.drainQueue()
+            await self?.drainQueue(drainerEpoch: drainerEpoch)
         }
     }
 
-    private func drainQueue() async {
+    private func drainQueue(drainerEpoch: Int) async {
         while true {
             let next: (generation: Int, chunk: [Float], streamState: VadStreamState)? = lock.withLock { state in
-                guard state.isActive else {
+                guard state.isActive, state.isDraining, state.drainerEpoch == drainerEpoch else {
                     state.isDraining = false
                     state.pendingChunks.removeAll(keepingCapacity: false)
                     return nil
@@ -201,7 +204,8 @@ final class StreamingVadController {
                 if shouldRotate {
                     fputs("[vad] speech end detected, rotating chunk\n", stderr)
                     DispatchQueue.main.async { [weak self] in
-                        self?.maxDurationTimer?.fireDate = Date().addingTimeInterval(self?.maxChunkDuration ?? 60)
+                        guard let self else { return }
+                        self.maxDurationTimer?.fireDate = Date().addingTimeInterval(self.maxChunkDuration)
                     }
                     onChunkBoundary?()
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -13,6 +13,7 @@ final class StreamingVadController {
     var onChunkBoundary: (() -> Void)?
 
     private struct State {
+        var generation = 0
         var isActive = false
         var isDraining = false
         var pendingChunks: [[Float]] = []
@@ -55,22 +56,23 @@ final class StreamingVadController {
     }
 
     func start() {
-        let shouldStart = lock.withLock { state in
-            guard !state.isActive else { return false }
+        let startGeneration = lock.withLock { state -> Int? in
+            guard !state.isActive else { return nil }
+            state.generation += 1
             state.isActive = true
             state.isDraining = false
             state.pendingChunks.removeAll(keepingCapacity: true)
             state.streamState = nil
             state.lastRotationTime = Date()
-            return true
+            return state.generation
         }
-        guard shouldStart else { return }
+        guard let startGeneration else { return }
 
         Task { [weak self] in
             guard let self else { return }
             let initialState = await self.makeInitialState()
             let shouldKickDrain = self.lock.withLock { state in
-                guard state.isActive else { return false }
+                guard state.isActive, state.generation == startGeneration else { return false }
                 state.streamState = initialState
                 return !state.pendingChunks.isEmpty
             }
@@ -82,7 +84,7 @@ final class StreamingVadController {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.maxDurationTimer?.invalidate()
-            guard self.lock.withLock({ $0.isActive }) else { return }
+            guard self.lock.withLock({ $0.isActive && $0.generation == startGeneration }) else { return }
             self.maxDurationTimer = Timer.scheduledTimer(withTimeInterval: self.maxChunkDuration, repeats: true) { [weak self] _ in
                 self?.handleMaxDurationTimer()
             }
@@ -90,13 +92,18 @@ final class StreamingVadController {
     }
 
     func stop() {
-        lock.withLock { state in
+        let stopGeneration = lock.withLock { state in
             state.isActive = false
             state.pendingChunks.removeAll(keepingCapacity: false)
             state.streamState = nil
+            return state.generation
         }
-        maxDurationTimer?.invalidate()
-        maxDurationTimer = nil
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard self.lock.withLock({ !$0.isActive && $0.generation == stopGeneration }) else { return }
+            self.maxDurationTimer?.invalidate()
+            self.maxDurationTimer = nil
+        }
     }
 
     /// Feed a chunk of Float audio samples (typically 4096 samples = 256ms at 16kHz).
@@ -154,7 +161,7 @@ final class StreamingVadController {
 
     private func drainQueue() async {
         while true {
-            let next: (chunk: [Float], streamState: VadStreamState)? = lock.withLock { state in
+            let next: (generation: Int, chunk: [Float], streamState: VadStreamState)? = lock.withLock { state in
                 guard state.isActive else {
                     state.isDraining = false
                     state.pendingChunks.removeAll(keepingCapacity: false)
@@ -168,7 +175,7 @@ final class StreamingVadController {
                     state.isDraining = false
                     return nil
                 }
-                return (state.pendingChunks.removeFirst(), streamState)
+                return (state.generation, state.pendingChunks.removeFirst(), streamState)
             }
 
             guard let next else { return }
@@ -177,7 +184,7 @@ final class StreamingVadController {
                 let result = try await processStreamChunk(next.chunk, next.streamState)
 
                 let shouldRotate = lock.withLock { state in
-                    guard state.isActive else { return false }
+                    guard state.isActive, state.generation == next.generation else { return false }
                     state.streamState = result.state
 
                     guard let event = result.event, event.kind == .speechEnd else {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingTerminationPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingTerminationPolicyTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting termination policy")
+struct MeetingTerminationPolicyTests {
+    @Test("allows termination when no meeting lifecycle is active")
+    func allowsIdleTermination() {
+        #expect(
+            MeetingTerminationPolicy.state(
+                isStarting: false,
+                hasActiveSession: false,
+                isRecording: false,
+                isStopping: false
+            ) == .none
+        )
+    }
+
+    @Test("warns while a meeting is starting")
+    func warnsDuringStart() {
+        #expect(
+            MeetingTerminationPolicy.state(
+                isStarting: true,
+                hasActiveSession: false,
+                isRecording: false,
+                isStopping: false
+            ) == .starting
+        )
+    }
+
+    @Test("warns while a meeting is recording")
+    func warnsDuringRecording() {
+        #expect(
+            MeetingTerminationPolicy.state(
+                isStarting: false,
+                hasActiveSession: true,
+                isRecording: true,
+                isStopping: false
+            ) == .recording
+        )
+    }
+
+    @Test("warns while a stopped meeting is still processing")
+    func warnsDuringProcessing() {
+        #expect(
+            MeetingTerminationPolicy.state(
+                isStarting: false,
+                hasActiveSession: true,
+                isRecording: false,
+                isStopping: true
+            ) == .processing
+        )
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingTerminationPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingTerminationPolicyTests.swift
@@ -62,4 +62,16 @@ struct MeetingTerminationPolicyTests {
             ) == .processing
         )
     }
+
+    @Test("warns while stopping even when session is already nil")
+    func warnsDuringStopWithNoSession() {
+        #expect(
+            MeetingTerminationPolicy.state(
+                isStarting: false,
+                hasActiveSession: false,
+                isRecording: false,
+                isStopping: true
+            ) == .processing
+        )
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingTerminationPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingTerminationPolicyTests.swift
@@ -39,6 +39,18 @@ struct MeetingTerminationPolicyTests {
         )
     }
 
+    @Test("warns while a session exists before recording state is visible")
+    func warnsForActiveSessionBeforeRecording() {
+        #expect(
+            MeetingTerminationPolicy.state(
+                isStarting: false,
+                hasActiveSession: true,
+                isRecording: false,
+                isStopping: false
+            ) == .processing
+        )
+    }
+
     @Test("warns while a stopped meeting is still processing")
     func warnsDuringProcessing() {
         #expect(

--- a/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
@@ -166,4 +166,42 @@ struct StreamingVadControllerTests {
         #expect(await probe.processedCount == 1)
         #expect(await probe.boundaryCount == 0)
     }
+
+    @Test("stale drainer does not clear restarted session queue")
+    func staleDrainerDoesNotClearRestartedSessionQueue() async throws {
+        let probe = StreamingVadTestProbe()
+        let controller = StreamingVadController(
+            minChunkDuration: 0,
+            maxChunkDuration: 3600,
+            makeInitialState: { VadStreamState.initial() },
+            processStreamChunk: { _, state in
+                await probe.processingStarted()
+                try? await Task.sleep(for: .milliseconds(120))
+                await probe.processingFinished()
+                return VadStreamResult(state: state, event: nil, probability: 0.0)
+            }
+        )
+
+        controller.start()
+        controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
+
+        let startedDeadline = ContinuousClock.now + .seconds(1)
+        while await probe.inFlightCount == 0, ContinuousClock.now < startedDeadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        controller.stop()
+        controller.start()
+        for _ in 0..<3 {
+            controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
+        }
+
+        let finishedDeadline = ContinuousClock.now + .seconds(2)
+        while await probe.processedCount < 4, ContinuousClock.now < finishedDeadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        controller.stop()
+
+        #expect(await probe.processedCount == 4)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
@@ -1,0 +1,125 @@
+import FluidAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+private actor StreamingVadTestProbe {
+    private(set) var processedCount = 0
+    private(set) var inFlightCount = 0
+    private(set) var maxConcurrentCount = 0
+    private(set) var boundaryCount = 0
+
+    func processingStarted() {
+        inFlightCount += 1
+        maxConcurrentCount = max(maxConcurrentCount, inFlightCount)
+    }
+
+    func processingFinished() {
+        inFlightCount = max(0, inFlightCount - 1)
+        processedCount += 1
+    }
+
+    func boundaryTriggered() {
+        boundaryCount += 1
+    }
+}
+
+@Suite("StreamingVadController")
+struct StreamingVadControllerTests {
+    @Test("serializes streaming VAD processing to a single in-flight chunk")
+    func serializesChunkProcessing() async throws {
+        let probe = StreamingVadTestProbe()
+        let controller = StreamingVadController(
+            minChunkDuration: 0,
+            maxChunkDuration: 3600,
+            makeInitialState: { VadStreamState.initial() },
+            processStreamChunk: { _, state in
+                await probe.processingStarted()
+                try? await Task.sleep(for: .milliseconds(25))
+                await probe.processingFinished()
+                return VadStreamResult(state: state, event: nil, probability: 0.0)
+            }
+        )
+
+        controller.start()
+        for _ in 0..<10 {
+            controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
+        }
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while await probe.processedCount < 10, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        controller.stop()
+
+        #expect(await probe.processedCount == 10)
+        #expect(await probe.maxConcurrentCount == 1)
+    }
+
+    @Test("buffers chunks that arrive before stream state initialization completes")
+    func buffersChunksBeforeStateReady() async throws {
+        let probe = StreamingVadTestProbe()
+        let controller = StreamingVadController(
+            minChunkDuration: 0,
+            maxChunkDuration: 3600,
+            makeInitialState: {
+                try? await Task.sleep(for: .milliseconds(120))
+                return VadStreamState.initial()
+            },
+            processStreamChunk: { _, state in
+                await probe.processingStarted()
+                try? await Task.sleep(for: .milliseconds(10))
+                await probe.processingFinished()
+                return VadStreamResult(state: state, event: nil, probability: 0.0)
+            }
+        )
+
+        controller.start()
+        for _ in 0..<3 {
+            controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
+        }
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while await probe.processedCount < 3, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        controller.stop()
+
+        #expect(await probe.processedCount == 3)
+        #expect(await probe.maxConcurrentCount == 1)
+    }
+
+    @Test("emits a chunk boundary when streaming VAD detects speech end")
+    func emitsChunkBoundaryOnSpeechEnd() async throws {
+        let probe = StreamingVadTestProbe()
+        let controller = StreamingVadController(
+            minChunkDuration: 0,
+            maxChunkDuration: 3600,
+            makeInitialState: { VadStreamState.initial() },
+            processStreamChunk: { _, state in
+                await probe.processingStarted()
+                await probe.processingFinished()
+                return VadStreamResult(
+                    state: state,
+                    event: VadStreamEvent(kind: .speechEnd, sampleIndex: VadManager.chunkSize),
+                    probability: 0.05
+                )
+            }
+        )
+
+        controller.onChunkBoundary = {
+            Task { await probe.boundaryTriggered() }
+        }
+
+        controller.start()
+        controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
+
+        let deadline = ContinuousClock.now + .seconds(1)
+        while await probe.boundaryCount < 1, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        controller.stop()
+
+        #expect(await probe.boundaryCount == 1)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
@@ -122,4 +122,48 @@ struct StreamingVadControllerTests {
 
         #expect(await probe.boundaryCount == 1)
     }
+
+    @Test("ignores stale VAD results after stop and restart")
+    func ignoresStaleResultsAfterRestart() async throws {
+        let probe = StreamingVadTestProbe()
+        let controller = StreamingVadController(
+            minChunkDuration: 0,
+            maxChunkDuration: 3600,
+            makeInitialState: { VadStreamState.initial() },
+            processStreamChunk: { _, state in
+                await probe.processingStarted()
+                try? await Task.sleep(for: .milliseconds(120))
+                await probe.processingFinished()
+                return VadStreamResult(
+                    state: state,
+                    event: VadStreamEvent(kind: .speechEnd, sampleIndex: VadManager.chunkSize),
+                    probability: 0.05
+                )
+            }
+        )
+
+        controller.onChunkBoundary = {
+            Task { await probe.boundaryTriggered() }
+        }
+
+        controller.start()
+        controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
+
+        let startedDeadline = ContinuousClock.now + .seconds(1)
+        while await probe.inFlightCount == 0, ContinuousClock.now < startedDeadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        controller.stop()
+        controller.start()
+
+        let finishedDeadline = ContinuousClock.now + .seconds(2)
+        while await probe.processedCount < 1, ContinuousClock.now < finishedDeadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        controller.stop()
+
+        #expect(await probe.processedCount == 1)
+        #expect(await probe.boundaryCount == 0)
+    }
 }


### PR DESCRIPTION
## Summary\n- prevent silent app termination while a meeting lifecycle is active\n- serialize streaming VAD chunk processing so only one streaming chunk is in flight at a time\n- add regression tests for meeting termination policy and streaming VAD controller behavior\n\n## Testing\n- swift test\n