### PR TITLE
[codex] Add meeting post-hook automation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingHookRunner.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingHookRunner.swift
@@ -106,7 +106,11 @@ final class MeetingHookRunner: MeetingHookDispatching {
         } catch {
             writeLog("stdin write failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
         }
-        try? inputPipe.fileHandleForWriting.close()
+        do {
+            try inputPipe.fileHandleForWriting.close()
+        } catch {
+            writeLog("stdin close failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
+        }
 
         let timeoutSeconds = max(config.meetingHookTimeoutSeconds, 1)
         writeLog("started: id=\(event.id) path=\(trimmedPath) timeout=\(timeoutSeconds)s")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingHookRunner.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingHookRunner.swift
@@ -13,8 +13,36 @@ struct MeetingHookEvent: Codable, Equatable {
     let completedAt: String
 }
 
+private final class BoundedOutputBuffer {
+    private let capacity: Int
+    private let queue = DispatchQueue(label: "com.muesli.native.meeting-hook-output-buffer")
+    private var data = Data()
+
+    init(capacity: Int) {
+        self.capacity = max(capacity, 1)
+    }
+
+    func append(_ chunk: Data) {
+        guard !chunk.isEmpty else { return }
+        queue.sync {
+            data.append(chunk)
+            if data.count > capacity {
+                data.removeFirst(data.count - capacity)
+            }
+        }
+    }
+
+    func stringValue() -> String? {
+        queue.sync {
+            guard !data.isEmpty else { return nil }
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+}
+
 final class MeetingHookRunner: MeetingHookDispatching {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingHook")
+    private static let maxLoggedStandardErrorBytes = 4096
 
     private let supportDirectory: URL
     private let fileManager: FileManager
@@ -82,7 +110,17 @@ final class MeetingHookRunner: MeetingHookDispatching {
         process.executableURL = URL(fileURLWithPath: trimmedPath)
         process.currentDirectoryURL = supportDirectory
         process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        let standardErrorPipe = Pipe()
+        let standardErrorBuffer = BoundedOutputBuffer(capacity: Self.maxLoggedStandardErrorBytes)
+        standardErrorPipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                return
+            }
+            standardErrorBuffer.append(chunk)
+        }
+        process.standardError = standardErrorPipe
 
         let inputPipe = Pipe()
         process.standardInput = inputPipe
@@ -97,34 +135,41 @@ final class MeetingHookRunner: MeetingHookDispatching {
         do {
             try process.run()
         } catch {
+            standardErrorPipe.fileHandleForReading.readabilityHandler = nil
             writeLog("launch failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
             return
-        }
-
-        do {
-            try inputPipe.fileHandleForWriting.write(contentsOf: payloadData)
-        } catch {
-            writeLog("stdin write failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
-        }
-        do {
-            try inputPipe.fileHandleForWriting.close()
-        } catch {
-            writeLog("stdin close failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
         }
 
         let timeoutSeconds = max(config.meetingHookTimeoutSeconds, 1)
         writeLog("started: id=\(event.id) path=\(trimmedPath) timeout=\(timeoutSeconds)s")
 
-        if terminationSemaphore.wait(timeout: .now() + .seconds(timeoutSeconds)) == .timedOut {
-            writeLog("timed out: id=\(event.id) path=\(trimmedPath) timeout=\(timeoutSeconds)s")
+        do {
+            try inputPipe.fileHandleForWriting.write(contentsOf: payloadData)
+        } catch {
+            writeLog("stdin write failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
+            closeInputPipe(inputPipe, event: event, path: trimmedPath)
+            standardErrorPipe.fileHandleForReading.readabilityHandler = nil
             terminate(process: process, semaphore: terminationSemaphore)
+            drainStandardError(from: standardErrorPipe, into: standardErrorBuffer)
             return
         }
+        closeInputPipe(inputPipe, event: event, path: trimmedPath)
+
+        if terminationSemaphore.wait(timeout: .now() + .seconds(timeoutSeconds)) == .timedOut {
+            standardErrorPipe.fileHandleForReading.readabilityHandler = nil
+            terminate(process: process, semaphore: terminationSemaphore)
+            drainStandardError(from: standardErrorPipe, into: standardErrorBuffer)
+            writeLog("timed out: id=\(event.id) path=\(trimmedPath) timeout=\(timeoutSeconds)s\(standardErrorSuffix(from: standardErrorBuffer))")
+            return
+        }
+
+        standardErrorPipe.fileHandleForReading.readabilityHandler = nil
+        drainStandardError(from: standardErrorPipe, into: standardErrorBuffer)
 
         if terminationStatus == 0 {
             writeLog("completed: id=\(event.id) path=\(trimmedPath) exit=0")
         } else {
-            writeLog("failed: id=\(event.id) path=\(trimmedPath) exit=\(terminationStatus)")
+            writeLog("failed: id=\(event.id) path=\(trimmedPath) exit=\(terminationStatus)\(standardErrorSuffix(from: standardErrorBuffer))")
         }
     }
 
@@ -135,6 +180,35 @@ final class MeetingHookRunner: MeetingHookDispatching {
             kill(process.processIdentifier, SIGKILL)
             _ = semaphore.wait(timeout: .now() + .seconds(1))
         }
+    }
+
+    private func closeInputPipe(_ inputPipe: Pipe, event: MeetingHookEvent, path: String) {
+        do {
+            try inputPipe.fileHandleForWriting.close()
+        } catch {
+            writeLog("stdin close failed: id=\(event.id) path=\(path) error=\(error.localizedDescription)")
+        }
+    }
+
+    private func drainStandardError(from pipe: Pipe, into buffer: BoundedOutputBuffer) {
+        do {
+            if let trailingData = try pipe.fileHandleForReading.readToEnd(), !trailingData.isEmpty {
+                buffer.append(trailingData)
+            }
+            try pipe.fileHandleForReading.close()
+        } catch {
+            writeLog("stderr capture failed: error=\(error.localizedDescription)")
+        }
+    }
+
+    private func standardErrorSuffix(from buffer: BoundedOutputBuffer) -> String {
+        guard let value = buffer.stringValue() else { return "" }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        let singleLine = trimmed
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return " stderr=\(singleLine)"
     }
 
     private func writeLog(_ message: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingHookRunner.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingHookRunner.swift
@@ -1,0 +1,161 @@
+import Foundation
+import os
+
+protocol MeetingHookDispatching {
+    func dispatchCompletedMeetingHook(meetingID: Int64, completedAt: Date, config: AppConfig)
+}
+
+struct MeetingHookEvent: Codable, Equatable {
+    let schemaVersion: Int
+    let event: String
+    let kind: String
+    let id: Int64
+    let completedAt: String
+}
+
+final class MeetingHookRunner: MeetingHookDispatching {
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingHook")
+
+    private let supportDirectory: URL
+    private let fileManager: FileManager
+    private let logQueue = DispatchQueue(label: "com.muesli.native.meeting-hook-log")
+    private let dateProvider: () -> Date
+
+    init(
+        supportDirectory: URL = AppIdentity.supportDirectoryURL,
+        fileManager: FileManager = .default,
+        dateProvider: @escaping () -> Date = Date.init
+    ) {
+        self.supportDirectory = supportDirectory
+        self.fileManager = fileManager
+        self.dateProvider = dateProvider
+    }
+
+    var logURL: URL {
+        supportDirectory.appendingPathComponent("meeting-hook.log")
+    }
+
+    func dispatchCompletedMeetingHook(meetingID: Int64, completedAt: Date, config: AppConfig) {
+        let event = MeetingHookEvent(
+            schemaVersion: 1,
+            event: "meeting.completed",
+            kind: "meeting",
+            id: meetingID,
+            completedAt: Self.iso8601Formatter.string(from: completedAt)
+        )
+
+        Task.detached(priority: .utility) { [self] in
+            executeIfConfigured(event: event, config: config)
+        }
+    }
+
+    func executeIfConfigured(event: MeetingHookEvent, config: AppConfig) {
+        guard config.meetingHookEnabled else { return }
+
+        let trimmedPath = config.meetingHookPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else {
+            writeLog("skipped: hook enabled but no executable path configured")
+            return
+        }
+        guard NSString(string: trimmedPath).isAbsolutePath else {
+            writeLog("skipped: hook path must be absolute path=\(trimmedPath)")
+            return
+        }
+        guard fileManager.fileExists(atPath: trimmedPath) else {
+            writeLog("launch failed: executable does not exist path=\(trimmedPath)")
+            return
+        }
+        guard fileManager.isExecutableFile(atPath: trimmedPath) else {
+            writeLog("launch failed: executable is not runnable path=\(trimmedPath)")
+            return
+        }
+
+        let payloadData: Data
+        do {
+            payloadData = try JSONEncoder().encode(event)
+        } catch {
+            writeLog("encoding failed: id=\(event.id) error=\(error.localizedDescription)")
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: trimmedPath)
+        process.currentDirectoryURL = supportDirectory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        let inputPipe = Pipe()
+        process.standardInput = inputPipe
+
+        let terminationSemaphore = DispatchSemaphore(value: 0)
+        var terminationStatus: Int32 = -1
+        process.terminationHandler = { terminatedProcess in
+            terminationStatus = terminatedProcess.terminationStatus
+            terminationSemaphore.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            writeLog("launch failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
+            return
+        }
+
+        do {
+            try inputPipe.fileHandleForWriting.write(contentsOf: payloadData)
+        } catch {
+            writeLog("stdin write failed: id=\(event.id) path=\(trimmedPath) error=\(error.localizedDescription)")
+        }
+        try? inputPipe.fileHandleForWriting.close()
+
+        let timeoutSeconds = max(config.meetingHookTimeoutSeconds, 1)
+        writeLog("started: id=\(event.id) path=\(trimmedPath) timeout=\(timeoutSeconds)s")
+
+        if terminationSemaphore.wait(timeout: .now() + .seconds(timeoutSeconds)) == .timedOut {
+            writeLog("timed out: id=\(event.id) path=\(trimmedPath) timeout=\(timeoutSeconds)s")
+            terminate(process: process, semaphore: terminationSemaphore)
+            return
+        }
+
+        if terminationStatus == 0 {
+            writeLog("completed: id=\(event.id) path=\(trimmedPath) exit=0")
+        } else {
+            writeLog("failed: id=\(event.id) path=\(trimmedPath) exit=\(terminationStatus)")
+        }
+    }
+
+    private func terminate(process: Process, semaphore: DispatchSemaphore) {
+        guard process.isRunning else { return }
+        process.terminate()
+        if semaphore.wait(timeout: .now() + .seconds(1)) == .timedOut, process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            _ = semaphore.wait(timeout: .now() + .seconds(1))
+        }
+    }
+
+    private func writeLog(_ message: String) {
+        let line = "[\(Self.iso8601Formatter.string(from: dateProvider()))] \(message)\n"
+        Self.logger.log("\(line, privacy: .public)")
+
+        logQueue.sync {
+            do {
+                try fileManager.createDirectory(at: supportDirectory, withIntermediateDirectories: true)
+                if !fileManager.fileExists(atPath: logURL.path) {
+                    fileManager.createFile(atPath: logURL.path, contents: nil)
+                }
+                let handle = try FileHandle(forWritingTo: logURL)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: Data(line.utf8))
+            } catch {
+                fputs("[meeting-hook] log write failed: \(error)\n", stderr)
+            }
+        }
+    }
+
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -453,6 +453,9 @@ struct AppConfig: Codable {
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     var enableScreenContext: Bool = false
     var useCoreAudioTap: Bool = true
+    var meetingHookEnabled: Bool = false
+    var meetingHookPath: String = ""
+    var meetingHookTimeoutSeconds: Int = 30
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -501,6 +504,9 @@ struct AppConfig: Codable {
         case postProcessorSystemPrompt = "post_processor_system_prompt"
         case enableScreenContext = "enable_screen_context"
         case useCoreAudioTap = "use_core_audio_tap"
+        case meetingHookEnabled = "meeting_hook_enabled"
+        case meetingHookPath = "meeting_hook_path"
+        case meetingHookTimeoutSeconds = "meeting_hook_timeout_seconds"
     }
 
     init() {}
@@ -555,6 +561,9 @@ struct AppConfig: Codable {
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap
+        meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled
+        meetingHookPath = (try? c.decode(String.self, forKey: .meetingHookPath)) ?? defaults.meetingHookPath
+        meetingHookTimeoutSeconds = (try? c.decode(Int.self, forKey: .meetingHookTimeoutSeconds)) ?? defaults.meetingHookTimeoutSeconds
     }
 
     var resolvedCohereLanguage: CohereTranscribeLanguage {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1743,7 +1743,7 @@ final class MuesliController: NSObject {
         let persistenceResult = try persistCompletedMeetingResult(result)
         meetingHookDispatcher.dispatchCompletedMeetingHook(
             meetingID: persistenceResult.meetingID,
-            completedAt: Date(),
+            completedAt: result.endTime,
             config: config
         )
         return persistenceResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -74,6 +74,7 @@ final class MuesliController: NSObject {
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
     private let dictationStore: DictationStore
+    private let meetingHookDispatcher: MeetingHookDispatching
     let transcriptionCoordinator = TranscriptionCoordinator()
     private let hotkeyMonitor = HotkeyMonitor()
     private let recorder = MicrophoneRecorder()
@@ -123,12 +124,17 @@ final class MuesliController: NSObject {
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
 
-    init(runtime: RuntimePaths, dictationStore: DictationStore? = nil) {
+    init(
+        runtime: RuntimePaths,
+        dictationStore: DictationStore? = nil,
+        meetingHookDispatcher: MeetingHookDispatching = MeetingHookRunner()
+    ) {
         let loadedConfig = configStore.load()
         self.runtime = runtime
         self.dictationStore = dictationStore ?? DictationStore(
             databaseURL: MuesliPaths.defaultDatabaseURL(appName: AppIdentity.supportDirectoryName)
         )
+        self.meetingHookDispatcher = meetingHookDispatcher
         self.config = loadedConfig
         if loadedConfig.recordingColorHex != "1e1e2e" {
             MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
@@ -1644,7 +1650,7 @@ final class MuesliController: NSObject {
                 await MainActor.run {
                     self.setMeetingProcessingStatus("Finalizing")
                 }
-                let persistenceResult = try self.persistCompletedMeetingResult(result)
+                let persistenceResult = try self.persistCompletedMeetingResultAndDispatchHook(result)
                 completedMeetingID = persistenceResult.meetingID
                 if let recordingSaveError = persistenceResult.recordingSaveError {
                     self.presentErrorAlert(title: "Meeting Recording", message: recordingSaveError.localizedDescription)
@@ -1731,6 +1737,16 @@ final class MuesliController: NSObject {
                 recordingSaveError: .failedToSaveRecording(underlying: error)
             )
         }
+    }
+
+    func persistCompletedMeetingResultAndDispatchHook(_ result: MeetingSessionResult) throws -> CompletedMeetingPersistenceResult {
+        let persistenceResult = try persistCompletedMeetingResult(result)
+        meetingHookDispatcher.dispatchCompletedMeetingHook(
+            meetingID: persistenceResult.meetingID,
+            completedAt: Date(),
+            config: config
+        )
+        return persistenceResult
     }
 
     private func persistMeetingRecordingIfNeeded(for result: MeetingSessionResult) throws -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1130,6 +1130,25 @@ struct SettingsView: View {
             )
             .help(appState.config.meetingHookPath.isEmpty ? "No hook script selected" : appState.config.meetingHookPath)
 
+            if !appState.config.meetingHookPath.isEmpty {
+                Button {
+                    controller.updateConfig { $0.meetingHookPath = "" }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("Clear hook script")
+            }
+
             Button {
                 pickMeetingHookFile()
             } label: {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -442,6 +442,38 @@ struct SettingsView: View {
                 }
             }
 
+            settingsSection("Advanced") {
+                settingsRow("Enable post-meeting hook") {
+                    settingsSwitch(isOn: appState.config.meetingHookEnabled) { newValue in
+                        controller.updateConfig { $0.meetingHookEnabled = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Hook script") {
+                    meetingHookPathPicker
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Timeout") {
+                    Stepper(
+                        value: Binding(
+                            get: { max(appState.config.meetingHookTimeoutSeconds, 1) },
+                            set: { newValue in
+                                controller.updateConfig { $0.meetingHookTimeoutSeconds = max(newValue, 1) }
+                            }
+                        ),
+                        in: 1...600
+                    ) {
+                        Text("\(max(appState.config.meetingHookTimeoutSeconds, 1)) seconds")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                    }
+                }
+                Text("Advanced: runs a user-supplied executable after each completed meeting. The executable receives JSON on stdin and must already be runnable on its own.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.horizontal, MuesliTheme.spacing16)
+            }
+
             if appState.isGoogleCalendarAvailable {
                 settingsSection("Calendar") {
                     settingsRow("Google Calendar") {
@@ -824,6 +856,47 @@ struct SettingsView: View {
         }
     }
 
+    private func pickMeetingHookFile() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a hook script"
+        panel.prompt = "Choose Script"
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.directoryURL = preferredMeetingHookDirectoryURL()
+
+        presentOpenPanel(panel) { url in
+            controller.updateConfig { $0.meetingHookPath = url.standardizedFileURL.path }
+        }
+    }
+
+    private func preferredMeetingHookDirectoryURL() -> URL {
+        let configuredPath = appState.config.meetingHookPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !configuredPath.isEmpty {
+            let configuredURL = URL(fileURLWithPath: configuredPath).standardizedFileURL
+            if FileManager.default.fileExists(atPath: configuredURL.path) {
+                return configuredURL.deletingLastPathComponent()
+            }
+            return configuredURL.deletingLastPathComponent()
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Desktop", isDirectory: true)
+    }
+
+    private func presentOpenPanel(_ panel: NSOpenPanel, onPick: @escaping (URL) -> Void) {
+        NSApp.activate()
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            panel.beginSheetModal(for: window) { response in
+                guard response == .OK, let url = panel.url else { return }
+                onPick(url)
+            }
+        } else {
+            panel.begin { response in
+                guard response == .OK, let url = panel.url else { return }
+                onPick(url)
+            }
+        }
+    }
+
     // MARK: - Permissions
 
     private var permissionsSection: some View {
@@ -1022,6 +1095,58 @@ struct SettingsView: View {
     private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
         FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
             .frame(height: 24)
+    }
+
+    @ViewBuilder
+    private var meetingHookPathPicker: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "doc.badge.gearshape")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+
+                if appState.config.meetingHookPath.isEmpty {
+                    Text("Choose a script…")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .lineLimit(1)
+                } else {
+                    Text(appState.config.meetingHookPath)
+                        .font(.system(size: 12))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+            .help(appState.config.meetingHookPath.isEmpty ? "No hook script selected" : appState.config.meetingHookPath)
+
+            Button {
+                pickMeetingHookFile()
+            } label: {
+                Image(systemName: "folder")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .help("Choose hook script")
+        }
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -874,10 +874,10 @@ struct SettingsView: View {
         let configuredPath = appState.config.meetingHookPath.trimmingCharacters(in: .whitespacesAndNewlines)
         if !configuredPath.isEmpty {
             let configuredURL = URL(fileURLWithPath: configuredPath).standardizedFileURL
-            if FileManager.default.fileExists(atPath: configuredURL.path) {
-                return configuredURL.deletingLastPathComponent()
+            let parentDirectory = configuredURL.deletingLastPathComponent()
+            if FileManager.default.fileExists(atPath: parentDirectory.path) {
+                return parentDirectory
             }
-            return configuredURL.deletingLastPathComponent()
         }
         return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Desktop", isDirectory: true)
     }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -33,6 +33,19 @@ struct MeetingHookIntegrationTests {
         #expect(invocation.meetingID > 0)
     }
 
+    @Test("completedAt uses the meeting end time")
+    func completedAtUsesMeetingEndTime() throws {
+        let store = try makeStore()
+        let spy = MeetingHookDispatcherSpy()
+        let controller = makeController(store: store, dispatcher: spy)
+        let result = makeMeetingResult()
+
+        _ = try controller.persistCompletedMeetingResultAndDispatchHook(result)
+
+        let invocation = try #require(spy.invocations.first)
+        #expect(invocation.completedAt == result.endTime)
+    }
+
     @Test("hook launch failure does not fail meeting persistence")
     func hookLaunchFailureDoesNotFailPersistence() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+import MuesliCore
+@testable import MuesliNativeApp
+
+@MainActor
+@Suite("Meeting hook integration")
+struct MeetingHookIntegrationTests {
+
+    @Test("meeting completion dispatches one hook event after persistence succeeds")
+    func dispatchesHookAfterPersistence() throws {
+        let store = try makeStore()
+        let spy = MeetingHookDispatcherSpy()
+        let controller = makeController(store: store, dispatcher: spy)
+
+        let persistence = try controller.persistCompletedMeetingResultAndDispatchHook(makeMeetingResult())
+
+        #expect(spy.invocations.count == 1)
+        #expect(spy.invocations.first?.meetingID == persistence.meetingID)
+        #expect(try store.meeting(id: persistence.meetingID) != nil)
+    }
+
+    @Test("persisted meeting id is sent to the hook dispatcher")
+    func persistedMeetingIDIsSentToHook() throws {
+        let store = try makeStore()
+        let spy = MeetingHookDispatcherSpy()
+        let controller = makeController(store: store, dispatcher: spy)
+
+        let persistence = try controller.persistCompletedMeetingResultAndDispatchHook(makeMeetingResult(calendarEventID: "event-123"))
+
+        let invocation = try #require(spy.invocations.first)
+        #expect(invocation.meetingID == persistence.meetingID)
+        #expect(invocation.meetingID > 0)
+    }
+
+    @Test("hook launch failure does not fail meeting persistence")
+    func hookLaunchFailureDoesNotFailPersistence() throws {
+        let store = try makeStore()
+        let supportDirectory = makeTemporaryDirectory()
+        let runner = MeetingHookRunner(supportDirectory: supportDirectory)
+        let controller = makeController(store: store, dispatcher: runner)
+        controller.updateConfig {
+            $0.meetingHookEnabled = true
+            $0.meetingHookPath = "/definitely/missing/hook.sh"
+            $0.meetingHookTimeoutSeconds = 1
+        }
+
+        let persistence = try controller.persistCompletedMeetingResultAndDispatchHook(makeMeetingResult())
+
+        #expect(try store.meeting(id: persistence.meetingID) != nil)
+    }
+
+    @Test("no hook runs when meeting persistence fails")
+    func noHookRunsWhenPersistenceFails() throws {
+        let store = try makeStore()
+        let spy = MeetingHookDispatcherSpy()
+        let controller = makeController(store: store, dispatcher: spy)
+        let now = Date()
+        try store.insertMeeting(
+            title: "Existing",
+            calendarEventID: "duplicate-event",
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "Existing transcript",
+            formattedNotes: "Existing notes",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+
+        #expect(throws: Error.self) {
+            try controller.persistCompletedMeetingResultAndDispatchHook(
+                makeMeetingResult(calendarEventID: "duplicate-event")
+            )
+        }
+        #expect(spy.invocations.isEmpty)
+    }
+
+    private func makeController(store: DictationStore, dispatcher: MeetingHookDispatching) -> MuesliController {
+        MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store,
+            meetingHookDispatcher: dispatcher
+        )
+    }
+
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-hook-integration-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-hook-support-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeMeetingResult(calendarEventID: String? = nil) -> MeetingSessionResult {
+        let start = Date(timeIntervalSince1970: 1_713_961_200)
+        let end = start.addingTimeInterval(300)
+        return MeetingSessionResult(
+            title: "Tim V1 Meeting",
+            calendarEventID: calendarEventID,
+            startTime: start,
+            endTime: end,
+            durationSeconds: end.timeIntervalSince(start),
+            rawTranscript: "Discussed action items and follow ups.",
+            formattedNotes: "## Summary\nReady for automation.",
+            retainedRecordingURL: nil,
+            retainedRecordingError: nil,
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+    }
+}
+
+private final class MeetingHookDispatcherSpy: MeetingHookDispatching {
+    struct Invocation {
+        let meetingID: Int64
+        let completedAt: Date
+        let config: AppConfig
+    }
+
+    private(set) var invocations: [Invocation] = []
+
+    func dispatchCompletedMeetingHook(meetingID: Int64, completedAt: Date, config: AppConfig) {
+        invocations.append(Invocation(meetingID: meetingID, completedAt: completedAt, config: config))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookRunnerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookRunnerTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("MeetingHookRunner")
+struct MeetingHookRunnerTests {
+
+    @Test("disabled hook is a no-op")
+    func disabledHookIsNoOp() async throws {
+        let directory = makeTemporaryDirectory()
+        let runner = MeetingHookRunner(supportDirectory: directory)
+        let event = makeEvent(id: 101)
+
+        await Task.detached {
+            runner.executeIfConfigured(event: event, config: AppConfig())
+        }.value
+
+        #expect(FileManager.default.fileExists(atPath: runner.logURL.path) == false)
+    }
+
+    @Test("empty path logs a skipped entry")
+    func emptyPathLogsSkippedEntry() async throws {
+        let directory = makeTemporaryDirectory()
+        let runner = MeetingHookRunner(supportDirectory: directory)
+        var config = AppConfig()
+        config.meetingHookEnabled = true
+
+        await Task.detached {
+            runner.executeIfConfigured(event: makeEvent(id: 102), config: config)
+        }.value
+
+        let log = try String(contentsOf: runner.logURL, encoding: .utf8)
+        #expect(log.contains("skipped: hook enabled but no executable path configured"))
+    }
+
+    @Test("valid executable receives stdin payload")
+    func validExecutableReceivesPayload() async throws {
+        let directory = makeTemporaryDirectory()
+        let outputURL = directory.appendingPathComponent("payload.json")
+        let scriptURL = try makeScript(
+            directory: directory,
+            name: "capture-payload.sh",
+            body: """
+            #!/bin/sh
+            cat > "\(outputURL.path)"
+            """
+        )
+        let runner = MeetingHookRunner(supportDirectory: directory)
+        var config = AppConfig()
+        config.meetingHookEnabled = true
+        config.meetingHookPath = scriptURL.path
+        config.meetingHookTimeoutSeconds = 5
+
+        await Task.detached {
+            runner.executeIfConfigured(event: makeEvent(id: 125), config: config)
+        }.value
+
+        let payload = try String(contentsOf: outputURL, encoding: .utf8)
+        #expect(payload.contains("\"event\":\"meeting.completed\""))
+        #expect(payload.contains("\"id\":125"))
+    }
+
+    @Test("timeout kills long running executable and logs timeout")
+    func timeoutLogsAndTerminatesProcess() async throws {
+        let directory = makeTemporaryDirectory()
+        let scriptURL = try makeScript(
+            directory: directory,
+            name: "sleep-forever.sh",
+            body: """
+            #!/bin/sh
+            sleep 10
+            """
+        )
+        let runner = MeetingHookRunner(supportDirectory: directory)
+        var config = AppConfig()
+        config.meetingHookEnabled = true
+        config.meetingHookPath = scriptURL.path
+        config.meetingHookTimeoutSeconds = 1
+
+        await Task.detached {
+            runner.executeIfConfigured(event: makeEvent(id: 201), config: config)
+        }.value
+
+        let log = try String(contentsOf: runner.logURL, encoding: .utf8)
+        #expect(log.contains("timed out: id=201"))
+    }
+
+    @Test("non-zero exit logs failure")
+    func nonZeroExitLogsFailure() async throws {
+        let directory = makeTemporaryDirectory()
+        let scriptURL = try makeScript(
+            directory: directory,
+            name: "fail.sh",
+            body: """
+            #!/bin/sh
+            exit 7
+            """
+        )
+        let runner = MeetingHookRunner(supportDirectory: directory)
+        var config = AppConfig()
+        config.meetingHookEnabled = true
+        config.meetingHookPath = scriptURL.path
+        config.meetingHookTimeoutSeconds = 5
+
+        await Task.detached {
+            runner.executeIfConfigured(event: makeEvent(id: 301), config: config)
+        }.value
+
+        let log = try String(contentsOf: runner.logURL, encoding: .utf8)
+        #expect(log.contains("failed: id=301"))
+        #expect(log.contains("exit=7"))
+    }
+
+    private func makeEvent(id: Int64) -> MeetingHookEvent {
+        MeetingHookEvent(
+            schemaVersion: 1,
+            event: "meeting.completed",
+            kind: "meeting",
+            id: id,
+            completedAt: "2026-04-24T12:34:56Z"
+        )
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-hook-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeScript(directory: URL, name: String, body: String) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try Data(body.utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookRunnerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookRunnerTests.swift
@@ -94,6 +94,7 @@ struct MeetingHookRunnerTests {
             name: "fail.sh",
             body: """
             #!/bin/sh
+            echo "hook stderr" >&2
             exit 7
             """
         )
@@ -110,6 +111,7 @@ struct MeetingHookRunnerTests {
         let log = try String(contentsOf: runner.logURL, encoding: .utf8)
         #expect(log.contains("failed: id=301"))
         #expect(log.contains("exit=7"))
+        #expect(log.contains("stderr=hook stderr"))
     }
 
     private func makeEvent(id: Int64) -> MeetingHookEvent {

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -260,6 +260,9 @@ struct AppConfigTests {
         #expect(config.hasCompletedOnboarding == false)
         #expect(config.userName.isEmpty)
         #expect(config.customMeetingTemplates.isEmpty)
+        #expect(config.meetingHookEnabled == false)
+        #expect(config.meetingHookPath.isEmpty)
+        #expect(config.meetingHookTimeoutSeconds == 30)
     }
 
     @Test("JSON encode/decode round-trip")
@@ -279,6 +282,9 @@ struct AppConfigTests {
                 icon: "dollarsign.circle"
             )
         ]
+        config.meetingHookEnabled = true
+        config.meetingHookPath = "/tmp/meeting-hook.sh"
+        config.meetingHookTimeoutSeconds = 45
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -292,6 +298,9 @@ struct AppConfigTests {
         #expect(decoded.customMeetingTemplates.count == 1)
         #expect(decoded.customMeetingTemplates.first?.name == "Customer Follow-Up")
         #expect(decoded.customMeetingTemplates.first?.icon == "dollarsign.circle")
+        #expect(decoded.meetingHookEnabled == true)
+        #expect(decoded.meetingHookPath == "/tmp/meeting-hook.sh")
+        #expect(decoded.meetingHookTimeoutSeconds == 45)
         #expect(decoded.meetingTranscriptionBackend == config.meetingTranscriptionBackend)
         #expect(decoded.indicatorAnchor == config.indicatorAnchor)
     }
@@ -313,6 +322,9 @@ struct AppConfigTests {
         #expect(json["default_meeting_template_id"] != nil)
         #expect(json["meeting_recording_save_policy"] != nil)
         #expect(json["custom_meeting_templates"] != nil)
+        #expect(json["meeting_hook_enabled"] != nil)
+        #expect(json["meeting_hook_path"] != nil)
+        #expect(json["meeting_hook_timeout_seconds"] != nil)
     }
 
     @Test("decodes with missing fields using defaults")
@@ -328,6 +340,9 @@ struct AppConfigTests {
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
         #expect(config.customMeetingTemplates.isEmpty)
+        #expect(config.meetingHookEnabled == false)
+        #expect(config.meetingHookPath.isEmpty)
+        #expect(config.meetingHookTimeoutSeconds == 30)
     }
 
     @Test("unsupported cohere language falls back to english")

--- a/scripts/test-meeting-hook.sh
+++ b/scripts/test-meeting-hook.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${MUESLI_HOOK_TEST_DIR:-$HOME/Desktop/MuesliHookTest}"
+mkdir -p "$OUTPUT_DIR"
+
+PAYLOAD_FILE="$(mktemp "$OUTPUT_DIR/payload.XXXXXX.json")"
+cat > "$PAYLOAD_FILE"
+
+PARSED_LINE="$(
+  python3 - "$PAYLOAD_FILE" <<'PY'
+import json
+import sys
+
+payload_path = sys.argv[1]
+with open(payload_path, "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+
+print(f"{payload.get('id', '')}\t{payload.get('completedAt', '')}")
+PY
+)"
+
+IFS=$'\t' read -r MEETING_ID COMPLETED_AT <<< "$PARSED_LINE"
+
+if [[ -z "$MEETING_ID" ]]; then
+  echo "Hook payload did not include a meeting id." >&2
+  exit 1
+fi
+
+if [[ -x "/Applications/MuesliDev.app/Contents/MacOS/muesli-cli" ]]; then
+  CLI_BIN="/Applications/MuesliDev.app/Contents/MacOS/muesli-cli"
+elif [[ -x "/Applications/Muesli.app/Contents/MacOS/muesli-cli" ]]; then
+  CLI_BIN="/Applications/Muesli.app/Contents/MacOS/muesli-cli"
+elif command -v muesli-cli >/dev/null 2>&1; then
+  CLI_BIN="$(command -v muesli-cli)"
+else
+  echo "Could not find muesli-cli." >&2
+  exit 1
+fi
+
+MEETING_JSON="$OUTPUT_DIR/meeting-$MEETING_ID.json"
+EVENT_JSON="$OUTPUT_DIR/last-event.json"
+SUMMARY_TXT="$OUTPUT_DIR/last-run.txt"
+
+cp "$PAYLOAD_FILE" "$EVENT_JSON"
+"$CLI_BIN" meetings get "$MEETING_ID" > "$MEETING_JSON"
+
+cat > "$SUMMARY_TXT" <<EOF
+Meeting hook test ran successfully.
+
+Meeting ID: $MEETING_ID
+Completed At: $COMPLETED_AT
+CLI: $CLI_BIN
+Payload: $EVENT_JSON
+Meeting JSON: $MEETING_JSON
+Ran At: $(date)
+EOF
+
+rm -f "$PAYLOAD_FILE"

--- a/scripts/test-meeting-hook.sh
+++ b/scripts/test-meeting-hook.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for test-meeting-hook.sh." >&2
+  exit 1
+fi
+
 OUTPUT_DIR="${MUESLI_HOOK_TEST_DIR:-$HOME/Desktop/MuesliHookTest}"
 mkdir -p "$OUTPUT_DIR"
 


### PR DESCRIPTION
## Summary
- add a meeting-only post-meeting hook that runs a user-selected executable after persistence
- add an Advanced meeting settings UI for enabling the hook, choosing the script, and setting timeout
- add a local test hook script plus focused config, runner, and integration coverage

## Why
Tim requested a post-transcription hook so downstream automations can react as soon as a meeting is ready without polling `muesli-cli`.

## Validation
- `swift test --package-path native/MuesliNative --filter AppConfig`
- `swift test --package-path native/MuesliNative --filter MeetingHookRunner`
- `swift test --package-path native/MuesliNative --filter MeetingHookIntegrationTests`
- rebuilt and signed `/Applications/MuesliDev.app` for manual verification

Closes #53.
