### PR TITLE
Wire Sparkle updates into About

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+    <channel>
+        <title>Muesli Preprod</title>
+        <description>Muesli pre-production update feed</description>
+        <language>en</language>
+        <!-- Items are added by scripts/release-preprod.sh -->
+    </channel>
+</rss>

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import MuesliCore
 
 struct AboutView: View {
+    let appState: AppState
     let controller: MuesliController
 
     private let githubURL = "https://github.com/pHequals7/muesli"
@@ -23,6 +24,10 @@ struct AboutView: View {
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
+                if let banner = updateBanner {
+                    updateBannerView(banner)
+                }
+
                 // MARK: - App Info
                 sectionHeader("App Info")
                 aboutCard {
@@ -36,7 +41,7 @@ struct AboutView: View {
 
                     aboutRow("Check for Updates") {
                         actionButton("Check Now", icon: "arrow.triangle.2.circlepath") {
-                            // TODO: Wire to Sparkle SPUStandardUpdaterController
+                            controller.checkForUpdates()
                         }
                     }
                 }
@@ -114,6 +119,9 @@ struct AboutView: View {
             .padding(MuesliTheme.spacing32)
         }
         .background(MuesliTheme.backgroundBase)
+        .task {
+            controller.refreshUpdateInformation()
+        }
     }
 
     // MARK: - Components
@@ -138,6 +146,104 @@ struct AboutView: View {
         .overlay(
             RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private struct UpdateBanner {
+        let icon: String
+        let title: String
+        let message: String
+        let tint: Color
+        let actionTitle: String?
+    }
+
+    private var updateBanner: UpdateBanner? {
+        switch appState.sparkleUpdateStatus {
+        case .idle:
+            return nil
+        case .checking:
+            return UpdateBanner(
+                icon: "arrow.triangle.2.circlepath",
+                title: "Checking for updates",
+                message: "Muesli is checking the appcast for the latest version.",
+                tint: MuesliTheme.transcribing,
+                actionTitle: nil
+            )
+        case .available(let version):
+            return UpdateBanner(
+                icon: "exclamationmark.triangle.fill",
+                title: "Muesli \(version) is available",
+                message: "An update is available. Start the updater to download and install it.",
+                tint: MuesliTheme.transcribing,
+                actionTitle: "Install Update"
+            )
+        case .downloaded(let version):
+            return UpdateBanner(
+                icon: "exclamationmark.triangle.fill",
+                title: "Muesli \(version) is ready to install",
+                message: "The update has been downloaded and is waiting for you to finish installation.",
+                tint: MuesliTheme.transcribing,
+                actionTitle: "Install Update"
+            )
+        case .installing(let version):
+            return UpdateBanner(
+                icon: "arrow.down.circle.fill",
+                title: "Installing Muesli \(version)",
+                message: "Sparkle is preparing the update. Muesli may relaunch when installation finishes.",
+                tint: MuesliTheme.transcribing,
+                actionTitle: nil
+            )
+        case .upToDate:
+            return UpdateBanner(
+                icon: "checkmark.circle.fill",
+                title: "Muesli is up to date",
+                message: "No newer version was found in the appcast.",
+                tint: MuesliTheme.success,
+                actionTitle: nil
+            )
+        case .failed(let message):
+            return UpdateBanner(
+                icon: "xmark.octagon.fill",
+                title: "Update check failed",
+                message: message,
+                tint: MuesliTheme.recording,
+                actionTitle: "Try Again"
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func updateBannerView(_ banner: UpdateBanner) -> some View {
+        HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+            Image(systemName: banner.icon)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(banner.tint)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text(banner.title)
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(banner.message)
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: MuesliTheme.spacing16)
+
+            if let actionTitle = banner.actionTitle {
+                actionButton(actionTitle, icon: "arrow.down.circle") {
+                    controller.checkForUpdates()
+                }
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(banner.tint.opacity(0.14))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(banner.tint.opacity(0.45), lineWidth: 1)
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -181,9 +181,9 @@ struct AboutView: View {
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is ready to install",
-                message: "The update has been downloaded and is waiting for you to finish installation.",
+                message: "Quit and reopen Muesli to finish installing the update.",
                 tint: MuesliTheme.transcribing,
-                actionTitle: "Install Update"
+                actionTitle: nil
             )
         case .installing(let version):
             return UpdateBanner(

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -201,6 +201,14 @@ struct AboutView: View {
                 tint: MuesliTheme.success,
                 actionTitle: nil
             )
+        case .disabled(let message):
+            return UpdateBanner(
+                icon: "minus.circle.fill",
+                title: "Updates are disabled",
+                message: message,
+                tint: MuesliTheme.textTertiary,
+                actionTitle: nil
+            )
         case .failed(let message):
             return UpdateBanner(
                 icon: "xmark.octagon.fill",

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -8,7 +8,7 @@ import MuesliCore
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var controller: MuesliController?
     private(set) var updaterController: SPUStandardUpdaterController?
-    private let updateFailureGuidancePresenter = UpdateFailureGuidancePresenter()
+    private let sparkleUpdateDelegate = SparkleUpdateDelegate()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let telemetryConfig = TelemetryDeck.Config(appID: "7F2B7846-1CB5-4FE6-8ABC-56F217B06A86")
@@ -17,7 +17,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: updateFailureGuidancePresenter,
+            updaterDelegate: sparkleUpdateDelegate,
             userDriverDelegate: nil
         )
 
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             let controller = MuesliController(runtime: runtime)
             controller.updaterController = updaterController
+            sparkleUpdateDelegate.appState = controller.appState
             self.controller = controller
             controller.start()
         } catch {
@@ -53,11 +54,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 @MainActor
-final class UpdateFailureGuidancePresenter: NSObject, SPUUpdaterDelegate {
+final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
+    weak var appState: AppState?
     private var lastPresentedAt: Date?
+
+    func updater(_ updater: SPUUpdater, mayPerform updateCheck: SPUUpdateCheck) throws {
+        appState?.sparkleUpdateStatus = .checking
+    }
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+        appState?.sparkleUpdateStatus = .upToDate
+    }
+
+    func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+        appState?.sparkleUpdateStatus = .downloaded(version: item.displayVersionString)
+    }
+
+    func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        appState?.sparkleUpdateStatus = .installing(version: item.displayVersionString)
+    }
+
+    func updater(_ updater: SPUUpdater, userDidMake choice: SPUUserUpdateChoice, forUpdate item: SUAppcastItem, state: SPUUserUpdateState) {
+        switch choice {
+        case .install:
+            appState?.sparkleUpdateStatus = .installing(version: item.displayVersionString)
+        case .dismiss where state.stage == .downloaded:
+            appState?.sparkleUpdateStatus = .downloaded(version: item.displayVersionString)
+        case .dismiss:
+            appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
+        case .skip:
+            appState?.sparkleUpdateStatus = .idle
+        @unknown default:
+            appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
+        }
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+    ) -> Bool {
+        appState?.sparkleUpdateStatus = .downloaded(version: item.displayVersionString)
+        return false
+    }
 
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
         let nsError = error as NSError
+        appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
         guard UpdateFailureGuidance.shouldShowFallback(for: nsError) else { return }
 
         // Sparkle shows its own error alert first. Delay briefly so this
@@ -66,6 +113,10 @@ final class UpdateFailureGuidancePresenter: NSObject, SPUUpdaterDelegate {
             try? await Task.sleep(nanoseconds: 400_000_000)
             self?.showManualInstallGuidance()
         }
+    }
+
+    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: Error?) {
+        appState?.sparkleLastCheckedAt = Date()
     }
 
     private func showManualInstallGuidance() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -15,14 +15,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TelemetryDeck.initialize(config: telemetryConfig)
         TelemetryDeck.signal("app.launched")
 
-        if Self.hasConfiguredSparkleFeed {
-            updaterController = SPUStandardUpdaterController(
-                startingUpdater: true,
-                updaterDelegate: sparkleUpdateDelegate,
-                userDriverDelegate: nil
-            )
-        }
-
         do {
             let runtime = try RuntimePaths.resolve()
             AppFonts.registerIfNeeded(runtime: runtime)
@@ -30,8 +22,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSApplication.shared.applicationIconImage = image
             }
             let controller = MuesliController(runtime: runtime)
-            controller.updaterController = updaterController
             sparkleUpdateDelegate.appState = controller.appState
+            if Self.hasConfiguredSparkleFeed {
+                let updaterController = SPUStandardUpdaterController(
+                    startingUpdater: true,
+                    updaterDelegate: sparkleUpdateDelegate,
+                    userDriverDelegate: nil
+                )
+                controller.updaterController = updaterController
+                self.updaterController = updaterController
+            }
             self.controller = controller
             controller.start()
         } catch {
@@ -100,15 +100,6 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
         @unknown default:
             appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
         }
-    }
-
-    func updater(
-        _ updater: SPUUpdater,
-        willInstallUpdateOnQuit item: SUAppcastItem,
-        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
-    ) -> Bool {
-        appState?.sparkleUpdateStatus = .downloaded(version: item.displayVersionString)
-        return false
     }
 
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -15,11 +15,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TelemetryDeck.initialize(config: telemetryConfig)
         TelemetryDeck.signal("app.launched")
 
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: sparkleUpdateDelegate,
-            userDriverDelegate: nil
-        )
+        if Self.hasConfiguredSparkleFeed {
+            updaterController = SPUStandardUpdaterController(
+                startingUpdater: true,
+                updaterDelegate: sparkleUpdateDelegate,
+                userDriverDelegate: nil
+            )
+        }
 
         do {
             let runtime = try RuntimePaths.resolve()
@@ -50,6 +52,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateCancel
         }
         return .terminateNow
+    }
+
+    private static var hasConfiguredSparkleFeed: Bool {
+        guard let feedURL = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String else {
+            return false
+        }
+        return !feedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -64,6 +64,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 @MainActor
 final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
+    private static let noUpdateErrorCode = 1001
+
     weak var appState: AppState?
     private var lastPresentedAt: Date?
 
@@ -76,7 +78,13 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
-        appState?.sparkleUpdateStatus = .upToDate
+        let nsError = error as NSError
+        if nsError.domain == SUSparkleErrorDomain,
+           nsError.code == Self.noUpdateErrorCode {
+            appState?.sparkleUpdateStatus = .upToDate
+        } else {
+            appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
+        }
     }
 
     func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -17,6 +17,16 @@ enum MeetingsNavigationState: Equatable {
     case document(Int64)
 }
 
+enum SparkleUpdateStatus: Equatable {
+    case idle
+    case checking
+    case available(version: String)
+    case downloaded(version: String)
+    case installing(version: String)
+    case upToDate
+    case failed(message: String)
+}
+
 @MainActor
 @Observable
 final class AppState {
@@ -52,6 +62,8 @@ final class AppState {
     var isGoogleCalendarAuthenticated: Bool = false
     var upcomingCalendarEvents: [UnifiedCalendarEvent] = []
     var hiddenCalendarEventIDs: Set<String> = []
+    var sparkleUpdateStatus: SparkleUpdateStatus = .idle
+    var sparkleLastCheckedAt: Date?
 
     // Dictation pagination & filtering
     var dictationPageSize: Int = 50

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -24,6 +24,7 @@ enum SparkleUpdateStatus: Equatable {
     case downloaded(version: String)
     case installing(version: String)
     case upToDate
+    case disabled(message: String)
     case failed(message: String)
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -42,7 +42,7 @@ struct DashboardRootView: View {
                     case .settings:
                         SettingsView(appState: appState, controller: controller)
                     case .about:
-                        AboutView(controller: controller)
+                        AboutView(appState: appState, controller: controller)
                     }
                 }
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1114,8 +1114,12 @@ final class MuesliController: NSObject {
     }
 
     @objc func checkForUpdates() {
+        guard let updaterController else {
+            appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
+            return
+        }
         appState.sparkleUpdateStatus = .checking
-        updaterController?.checkForUpdates(nil)
+        updaterController.checkForUpdates(nil)
     }
 
     func refreshUpdateInformation() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1118,6 +1118,7 @@ final class MuesliController: NSObject {
             appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
             return
         }
+        guard updaterController.updater.canCheckForUpdates else { return }
         appState.sparkleUpdateStatus = .checking
         updaterController.checkForUpdates(nil)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1114,7 +1114,15 @@ final class MuesliController: NSObject {
     }
 
     @objc func checkForUpdates() {
+        appState.sparkleUpdateStatus = .checking
         updaterController?.checkForUpdates(nil)
+    }
+
+    func refreshUpdateInformation() {
+        guard case .idle = appState.sparkleUpdateStatus else { return }
+        guard let updater = updaterController?.updater, updater.canCheckForUpdates else { return }
+        appState.sparkleUpdateStatus = .checking
+        updater.checkForUpdateInformation()
     }
 
     @objc func quitApp() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -29,6 +29,15 @@ struct SidebarView: View {
         appState.config.userName
     }
 
+    private var hasPendingUpdate: Bool {
+        switch appState.sparkleUpdateStatus {
+        case .available, .downloaded:
+            return true
+        case .idle, .checking, .installing, .upToDate, .disabled, .failed:
+            return false
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             sidebarHeader
@@ -43,7 +52,7 @@ struct SidebarView: View {
             Spacer()
 
             sidebarItem(tab: .settings, icon: "gearshape", label: "Settings")
-            sidebarItem(tab: .about, icon: "info.circle", label: "About")
+            sidebarItem(tab: .about, icon: "info.circle", label: "About", showsBadge: hasPendingUpdate)
             darkModeToggle
                 .padding(.bottom, MuesliTheme.spacing16)
         }
@@ -267,7 +276,7 @@ struct SidebarView: View {
     }
 
     @ViewBuilder
-    private func sidebarItem(tab: DashboardTab, icon: String, label: String) -> some View {
+    private func sidebarItem(tab: DashboardTab, icon: String, label: String, showsBadge: Bool = false) -> some View {
         let isSelected = appState.selectedTab == tab
         Button {
             withAnimation(.easeInOut(duration: 0.15)) {
@@ -283,6 +292,16 @@ struct SidebarView: View {
                     .font(MuesliTheme.headline())
                     .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
                 Spacer()
+                if showsBadge {
+                    Circle()
+                        .fill(MuesliTheme.recording)
+                        .frame(width: 9, height: 9)
+                        .overlay(
+                            Circle()
+                                .stroke(MuesliTheme.backgroundDeep, lineWidth: 2)
+                        )
+                        .accessibilityLabel("Update available")
+                }
             }
             .padding(.horizontal, sidebarRowHorizontalPadding)
             .padding(.vertical, MuesliTheme.spacing8)

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -157,6 +157,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Settings…", action: #selector(MuesliController.openSettingsTab)))
+        menu.addItem(actionItem(title: "Check for Updates…", action: #selector(MuesliController.checkForUpdates)))
         statusLabel.isEnabled = false
         menu.addItem(statusLabel)
         menu.addItem(.separator())

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -14,6 +14,8 @@ APP_BUNDLE_NAME="${MUESLI_APP_BUNDLE_NAME:-$APP_NAME.app}"
 APP_EXECUTABLE_NAME="${MUESLI_EXECUTABLE_NAME:-Muesli}"
 APP_SUPPORT_DIR_NAME="${MUESLI_SUPPORT_DIR_NAME:-$APP_DISPLAY_NAME}"
 BUNDLE_ID="${MUESLI_BUNDLE_ID:-com.muesli.app}"
+DEFAULT_APP_VERSION="0.6.2"
+APP_VERSION="${MUESLI_BUILD_VERSION:-$DEFAULT_APP_VERSION}"
 SPARKLE_FEED_URL="${MUESLI_SPARKLE_FEED_URL-https://pHequals7.github.io/muesli/appcast.xml}"
 SPARKLE_EDKEY="${MUESLI_SPARKLE_EDKEY-ok9CQBJ3f0MJ2GXuGBubc6VyeWyb5exmqP2b9DceqH4=}"
 STAGED_APP_DIR="$DIST_DIR/$APP_BUNDLE_NAME"
@@ -97,9 +99,9 @@ cat > "$STAGED_APP_DIR/Contents/Info.plist" <<PLIST
   <key>CFBundleIdentifier</key>
   <string>$BUNDLE_ID</string>
   <key>CFBundleVersion</key>
-  <string>0.6.2</string>
+  <string>$APP_VERSION</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.6.2</string>
+  <string>$APP_VERSION</string>
   <key>CFBundleExecutable</key>
   <string>$APP_EXECUTABLE_NAME</string>
   <key>CFBundlePackageType</key>

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -14,6 +14,8 @@ APP_BUNDLE_NAME="${MUESLI_APP_BUNDLE_NAME:-$APP_NAME.app}"
 APP_EXECUTABLE_NAME="${MUESLI_EXECUTABLE_NAME:-Muesli}"
 APP_SUPPORT_DIR_NAME="${MUESLI_SUPPORT_DIR_NAME:-$APP_DISPLAY_NAME}"
 BUNDLE_ID="${MUESLI_BUNDLE_ID:-com.muesli.app}"
+SPARKLE_FEED_URL="${MUESLI_SPARKLE_FEED_URL-https://pHequals7.github.io/muesli/appcast.xml}"
+SPARKLE_EDKEY="${MUESLI_SPARKLE_EDKEY-ok9CQBJ3f0MJ2GXuGBubc6VyeWyb5exmqP2b9DceqH4=}"
 STAGED_APP_DIR="$DIST_DIR/$APP_BUNDLE_NAME"
 APP_DIR="$INSTALL_DIR/$APP_BUNDLE_NAME"
 DEFAULT_SIGN_IDENTITY="Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)"
@@ -119,9 +121,9 @@ cat > "$STAGED_APP_DIR/Contents/Info.plist" <<PLIST
   <key>NSCalendarsFullAccessUsageDescription</key>
   <string>$APP_DISPLAY_NAME reads calendar events to help with meeting recordings.</string>
   <key>SUFeedURL</key>
-  <string>${MUESLI_SPARKLE_FEED_URL:-https://pHequals7.github.io/muesli/appcast.xml}</string>
+  <string>$SPARKLE_FEED_URL</string>
   <key>SUPublicEDKey</key>
-  <string>${MUESLI_SPARKLE_EDKEY:-ok9CQBJ3f0MJ2GXuGBubc6VyeWyb5exmqP2b9DceqH4=}</string>
+  <string>$SPARKLE_EDKEY</string>
   <key>SUEnableAutomaticChecks</key>
   <true/>
 </dict>

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -1,35 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Alpha release pipeline — signed, notarized, GitHub prerelease.
+# Pre-production Sparkle release pipeline.
 #
-# What this does:
-#   - Builds and signs with the same Developer ID as stable releases
-#   - Notarizes + staples both the app bundle and the DMG
-#   - Creates a GitHub prerelease tagged v{VERSION}-alpha.N
-#   - Verifies the hosted asset matches the local artifact
+# This is the safe end-to-end updater channel for testing Sparkle before a
+# stable release. It intentionally does not touch the production appcast,
+# landing page, llms.txt, or Homebrew tap.
 #
-# What this does NOT do (intentional):
-#   - Does not update docs/appcast.xml (stable Sparkle feed is untouched)
-#   - Does not update docs/index.html or docs/llms.txt (site stays on stable)
-#   - Does not update the Homebrew tap
-#   - Does not commit or push to main
+# It builds:
+#   - App name: MuesliPreprod
+#   - Bundle ID: com.muesli.preprod
+#   - Support dir: ~/Library/Application Support/MuesliPreprod
+#   - Sparkle feed: https://pHequals7.github.io/muesli/appcast-preprod.xml
 #
-# Sparkle is disabled in alpha builds. Use scripts/release-preprod.sh when you
-# need a signed, notarized build that exercises the Sparkle update flow.
-#
-# Usage: ./scripts/release-alpha.sh [version]
-#   e.g.: ./scripts/release-alpha.sh 0.5.6-alpha.1
-#   If no version given, auto-increments from the current stable base.
+# Usage: ./scripts/release-preprod.sh [version]
+#   e.g. ./scripts/release-preprod.sh 0.6.3-preprod.1
+#   If no version is given, auto-increments from the next stable patch base.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
-APP_DIR="/Applications/MuesliCanary.app"
-OUTPUT_DIR="$ROOT/dist-release"
-HOSTED_MOUNT_POINT=""
+APP_NAME="MuesliPreprod"
+BUNDLE_ID="com.muesli.preprod"
+SUPPORT_DIR_NAME="MuesliPreprod"
+PREPROD_FEED_URL="https://pHequals7.github.io/muesli/appcast-preprod.xml"
+OUTPUT_DIR="$ROOT/dist-preprod"
+INSTALL_DIR="$OUTPUT_DIR/install-root"
+APP_DIR="$INSTALL_DIR/${APP_NAME}.app"
+APPCAST_PATH="$ROOT/docs/appcast-preprod.xml"
+GENERATE_APPCAST="$ROOT/native/MuesliNative/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
 VERIFY_DIR=""
+HOSTED_MOUNT_POINT=""
 
 cleanup() {
   if [[ -n "$HOSTED_MOUNT_POINT" ]]; then
@@ -44,8 +47,7 @@ trap cleanup EXIT
 
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
-  # Derive base from latest stable: bump patch by 1
-  LATEST_STABLE=$(gh release list --limit 20 --json tagName,isPrerelease \
+  LATEST_STABLE=$(gh release list --limit 30 --json tagName,isPrerelease \
     -q '[.[] | select(.isPrerelease == false)] | .[0].tagName' 2>/dev/null || echo "")
 
   if [[ -z "$LATEST_STABLE" ]]; then
@@ -59,18 +61,17 @@ if [[ -z "$VERSION" ]]; then
   NEXT_PATCH=$((PATCH + 1))
   BASE="${MAJOR}.${MINOR}.${NEXT_PATCH}"
 
-  # Find the highest existing alpha.N for this base
   LATEST_N=$(gh release list --limit 100 --json tagName,isPrerelease \
     -q "[.[] | select(.isPrerelease == true) | .tagName \
-        | select(startswith(\"v${BASE}-alpha.\")) \
-        | ltrimstr(\"v${BASE}-alpha.\") \
+        | select(startswith(\"v${BASE}-preprod.\")) \
+        | ltrimstr(\"v${BASE}-preprod.\") \
         | tonumber] | max // 0" 2>/dev/null || echo "0")
 
   NEXT_N=$((LATEST_N + 1))
-  VERSION="${BASE}-alpha.${NEXT_N}"
+  VERSION="${BASE}-preprod.${NEXT_N}"
 
-  echo "Latest stable:  ${LATEST_STABLE}"
-  echo "Proposed alpha: v${VERSION}"
+  echo "Latest stable:   ${LATEST_STABLE}"
+  echo "Proposed preprod: v${VERSION}"
   echo ""
   read -p "Release as v${VERSION}? [Y/n] " confirm
   if [[ "$confirm" == "n" || "$confirm" == "N" ]]; then
@@ -79,53 +80,60 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
-  echo "ERROR: Working tree must be clean before running the release pipeline." >&2
+  echo "ERROR: Working tree must be clean before running the preprod release pipeline." >&2
+  exit 1
+fi
+
+if [[ ! -x "$GENERATE_APPCAST" ]]; then
+  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
   exit 1
 fi
 
 TAG="v${VERSION}"
-RELEASE_TITLE="MuesliCanary ${VERSION}"
-DMG_PATH="$OUTPUT_DIR/MuesliCanary-${VERSION}.dmg"
+DMG_PATH="$OUTPUT_DIR/${APP_NAME}-${VERSION}.dmg"
+RELEASE_TITLE="${APP_NAME} ${VERSION}"
 
 RELEASE_NOTES="$(cat <<EOF
-## MuesliCanary ${VERSION}
+## ${APP_NAME} ${VERSION}
 
-Alpha build — signed and notarized, but not yet stable.
-Installs as **MuesliCanary** alongside your existing Muesli install.
+Pre-production build for validating the Sparkle update flow before a stable release.
 
 ### Install
-1. Download \`MuesliCanary-${VERSION}.dmg\`
-2. Open the DMG and drag MuesliCanary to Applications
-3. Launch MuesliCanary from Applications
+1. Download \`${APP_NAME}-${VERSION}.dmg\`
+2. Open the DMG and drag ${APP_NAME} to Applications
+3. Launch ${APP_NAME} from Applications
 
 ### Notes
-- Stores data separately in \`~/Library/Application Support/MuesliCanary/\`
-- Raw ASR + post-processed pairs logged to \`MuesliCanary/postproc-pairs.jsonl\`
-- Sparkle is disabled; use MuesliPreprod for updater-flow testing
-
-### Not linked from the main site
-Download from [GitHub Releases](https://github.com/pHequals7/muesli/releases).
+- Installs alongside production Muesli.
+- Stores data separately in \`~/Library/Application Support/${SUPPORT_DIR_NAME}/\`.
+- Uses the pre-production Sparkle feed: \`${PREPROD_FEED_URL}\`.
+- Does not update the production appcast, public download page, or Homebrew tap.
 EOF
 )"
 
-echo "=== MuesliCanary Alpha v${VERSION} ==="
+echo "=== ${APP_NAME} Preprod v${VERSION} ==="
 echo ""
 
 mkdir -p "$OUTPUT_DIR"
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
 
 # --- Step 1: Run tests ---
-echo "[1/10] Running tests..."
+echo "[1/11] Running tests..."
 swift test --package-path "$ROOT/native/MuesliNative"
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
-echo "[2/10] Building and signing (version: ${VERSION})..."
-echo "y" | MUESLI_BUILD_VERSION="$VERSION" \
-  MUESLI_APP_NAME=MuesliCanary \
-  MUESLI_BUNDLE_ID=com.muesli.canary \
-  MUESLI_DISPLAY_NAME=MuesliCanary \
-  MUESLI_SUPPORT_DIR_NAME=MuesliCanary \
-  MUESLI_SPARKLE_FEED_URL="" \
+echo "[2/11] Building and signing..."
+MUESLI_INSTALL_DIR="$INSTALL_DIR" \
+  MUESLI_BUILD_VERSION="$VERSION" \
+  MUESLI_APP_NAME="$APP_NAME" \
+  MUESLI_APP_BUNDLE_NAME="${APP_NAME}.app" \
+  MUESLI_BUNDLE_ID="$BUNDLE_ID" \
+  MUESLI_DISPLAY_NAME="$APP_NAME" \
+  MUESLI_SUPPORT_DIR_NAME="$SUPPORT_DIR_NAME" \
+  MUESLI_SPARKLE_FEED_URL="$PREPROD_FEED_URL" \
+  MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY" \
   "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
 
@@ -133,8 +141,8 @@ FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')
 echo "  Signature: $FLAGS"
 
 # --- Step 3: Notarize app bundle ---
-echo "[3/10] Notarizing app bundle (this may take several minutes)..."
-APP_ZIP="$OUTPUT_DIR/MuesliCanary-app-${VERSION}.zip"
+echo "[3/11] Notarizing app bundle with Apple..."
+APP_ZIP="$OUTPUT_DIR/${APP_NAME}-app-${VERSION}.zip"
 ditto -c -k --keepParent "$APP_DIR" "$APP_ZIP"
 NOTARY_OUTPUT=$(xcrun notarytool submit "$APP_ZIP" \
   --keychain-profile "$PROFILE_NAME" \
@@ -151,18 +159,21 @@ fi
 echo "  App notarization accepted."
 
 # --- Step 4: Staple app bundle ---
-echo "[4/10] Stapling app bundle..."
+echo "[4/11] Stapling app bundle..."
 xcrun stapler staple "$APP_DIR"
 echo "  App stapled."
 
-# --- Step 5: Create DMG from stapled app ---
-echo "[5/10] Creating DMG from stapled app..."
+# --- Step 5: Create DMG ---
+echo "[5/11] Creating DMG..."
 "$ROOT/scripts/create_dmg.sh" "$APP_DIR" "$OUTPUT_DIR"
-# create_dmg.sh reads CFBundleShortVersionString from the app, so the DMG is
-# already named MuesliCanary-{VERSION}.dmg — no rename needed.
+
+if [[ ! -f "$DMG_PATH" ]]; then
+  echo "ERROR: expected DMG not found at $DMG_PATH" >&2
+  exit 1
+fi
 
 # --- Step 6: Notarize DMG ---
-echo "[6/10] Notarizing DMG..."
+echo "[6/11] Notarizing DMG with Apple..."
 NOTARY_OUTPUT=$(xcrun notarytool submit "$DMG_PATH" \
   --keychain-profile "$PROFILE_NAME" \
   --wait 2>&1)
@@ -176,8 +187,8 @@ if ! echo "$NOTARY_OUTPUT" | grep -q "status: Accepted"; then
 fi
 echo "  DMG notarization accepted."
 
-# --- Step 7: Staple + verify DMG ---
-echo "[7/10] Stapling and verifying DMG..."
+# --- Step 7: Staple and verify local DMG ---
+echo "[7/11] Stapling and verifying local DMG..."
 xcrun stapler staple "$DMG_PATH"
 
 MOUNT_POINT=$(hdiutil attach "$DMG_PATH" -nobrowse 2>&1 | grep "/Volumes" | awk -F'\t' '{print $NF}')
@@ -186,8 +197,8 @@ if [[ -z "$MOUNT_POINT" ]]; then
   exit 1
 fi
 
-SPCTL_RESULT=$(spctl -a -vv "$MOUNT_POINT/MuesliCanary.app" 2>&1)
-STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/MuesliCanary.app" 2>&1)
+SPCTL_RESULT=$(spctl -a -vv "$MOUNT_POINT/${APP_NAME}.app" 2>&1)
+STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/${APP_NAME}.app" 2>&1)
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
 
 if ! echo "$SPCTL_RESULT" | grep -q "accepted"; then
@@ -204,10 +215,10 @@ if ! echo "$DMG_FLAGS" | grep -q "runtime"; then
   echo "  RELEASE ABORTED: DMG missing hardened runtime flag."
   exit 1
 fi
-echo "  Gatekeeper, staple, and hardened runtime verified."
+echo "  Local DMG verified."
 
 # --- Step 8: Tag ---
-echo "[8/10] Tagging..."
+echo "[8/11] Tagging..."
 if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
   echo "ERROR: Local tag ${TAG} already exists." >&2
   exit 1
@@ -217,12 +228,12 @@ if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
   exit 1
 fi
 
-git tag -a "$TAG" -m "Alpha release ${VERSION}"
+git tag -a "$TAG" -m "Preprod release ${VERSION}"
 git push origin "$TAG"
-echo "  Pushed tag $TAG (pointing at current main HEAD — no commit to main)."
+echo "  Pushed tag $TAG."
 
-# --- Step 9: Create draft GitHub prerelease + upload DMG ---
-echo "[9/10] Creating draft GitHub prerelease..."
+# --- Step 9: Create draft GitHub prerelease ---
+echo "[9/11] Creating draft GitHub prerelease..."
 gh release create "$TAG" \
   --draft \
   --prerelease \
@@ -234,13 +245,13 @@ gh release create "$TAG" \
 DRAFT_URL=$(gh release view "$TAG" --json url -q .url)
 echo "  Draft prerelease: $DRAFT_URL"
 
-# --- Step 10: Verify hosted asset + publish ---
-echo "[10/10] Verifying hosted DMG and publishing..."
+# --- Step 10: Verify hosted asset and publish ---
+echo "[10/11] Verifying hosted DMG and publishing..."
 VERIFY_DIR=$(mktemp -d)
-HOSTED_DMG="$VERIFY_DIR/MuesliCanary-${VERSION}.dmg"
+HOSTED_DMG="$VERIFY_DIR/${APP_NAME}-${VERSION}.dmg"
 
 gh release download "$TAG" \
-  -p "MuesliCanary-${VERSION}.dmg" \
+  -p "${APP_NAME}-${VERSION}.dmg" \
   -D "$VERIFY_DIR" \
   --clobber >/dev/null
 
@@ -256,7 +267,6 @@ fi
 
 HOSTED_SPCTL=$(spctl -a -vv -t open --context context:primary-signature "$HOSTED_DMG" 2>&1)
 HOSTED_STAPLE=$(xcrun stapler validate "$HOSTED_DMG" 2>&1)
-
 if ! echo "$HOSTED_SPCTL" | grep -q "accepted"; then
   echo "  RELEASE ABORTED: Hosted DMG rejected by Gatekeeper."
   exit 1
@@ -267,7 +277,7 @@ if ! echo "$HOSTED_STAPLE" | grep -q "worked"; then
 fi
 
 HOSTED_MOUNT_POINT=$(hdiutil attach "$HOSTED_DMG" -nobrowse 2>&1 | grep "/Volumes" | awk -F'\t' '{print $NF}')
-HOSTED_APP_SPCTL=$(spctl -a -vv "$HOSTED_MOUNT_POINT/MuesliCanary.app" 2>&1)
+HOSTED_APP_SPCTL=$(spctl -a -vv "$HOSTED_MOUNT_POINT/${APP_NAME}.app" 2>&1)
 hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
 HOSTED_MOUNT_POINT=""
 
@@ -275,7 +285,6 @@ if ! echo "$HOSTED_APP_SPCTL" | grep -q "accepted"; then
   echo "  RELEASE ABORTED: App inside hosted DMG rejected by Gatekeeper."
   exit 1
 fi
-echo "  Hosted asset verified."
 
 gh release edit "$TAG" \
   --draft=false \
@@ -283,12 +292,37 @@ gh release edit "$TAG" \
   --notes "$RELEASE_NOTES"
 
 RELEASE_URL=$(gh release view "$TAG" --json url -q .url)
+echo "  Hosted asset verified and prerelease published."
+
+# --- Step 11: Update preprod appcast ---
+echo "[11/11] Updating preprod appcast..."
+"$GENERATE_APPCAST" "$OUTPUT_DIR" -o "$APPCAST_PATH"
+
+perl -0pi -e 's{https://pHequals7\.github\.io/muesli/(MuesliPreprod-([0-9][0-9A-Za-z\.\-]*)\.dmg)}{"https://github.com/pHequals7/muesli/releases/download/v$2/$1"}ge' "$APPCAST_PATH"
+perl -0pi -e 's{^\h*<enclosure\b[^>]*\bsparkle:deltaFrom="[^"]*"[^>]*/>\n}{}mg' "$APPCAST_PATH"
+
+"$ROOT/scripts/verify_update_flow.sh" \
+  --version "$VERSION" \
+  --appcast "$APPCAST_PATH" \
+  --dmg "$DMG_PATH" \
+  --app-name "$APP_NAME" \
+  --feed-url "$PREPROD_FEED_URL" \
+  --require-notarized
+
+git add "$APPCAST_PATH"
+if git diff --cached --quiet; then
+  echo "  No preprod appcast changes to commit."
+else
+  git commit -m "Update preprod appcast for v${VERSION}"
+  git push origin HEAD
+  echo "  Pushed preprod appcast update."
+fi
 
 echo ""
-echo "=== Alpha release complete ==="
+echo "=== Preprod release complete ==="
 echo "  Version:  ${VERSION}"
-echo "  Tag:      ${TAG} (no commit pushed to main)"
+echo "  Tag:      ${TAG}"
 echo "  DMG:      $DMG_PATH"
 echo "  Release:  $RELEASE_URL"
-echo "  Sparkle:  disabled (use release-preprod.sh for updater-flow testing)"
-echo "  Site:     unchanged (freedspeech.xyz stays on stable)"
+echo "  Appcast:  $PREPROD_FEED_URL"
+echo "  Stable:   production appcast/site/Homebrew unchanged"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -141,8 +141,7 @@ echo ""
 
 # --- Step 0: Update version in build script ---
 echo "[0/13] Setting version to ${VERSION}..."
-sed -i '' "/CFBundleVersion<\/key>/{n;s/<string>[^<]*<\/string>/<string>${VERSION}<\/string>/;}" "$ROOT/scripts/build_native_app.sh"
-sed -i '' "/CFBundleShortVersionString<\/key>/{n;s/<string>[^<]*<\/string>/<string>${VERSION}<\/string>/;}" "$ROOT/scripts/build_native_app.sh"
+sed -i '' "s/^DEFAULT_APP_VERSION=.*/DEFAULT_APP_VERSION=\"${VERSION}\"/" "$ROOT/scripts/build_native_app.sh"
 
 # --- Step 1: Run tests ---
 echo "[1/13] Running tests..."

--- a/scripts/verify_update_flow.sh
+++ b/scripts/verify_update_flow.sh
@@ -5,6 +5,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APPCAST="$ROOT/docs/appcast.xml"
 VERSION=""
 DMG_PATH=""
+APP_NAME="Muesli"
+EXPECTED_FEED_URL="https://pHequals7.github.io/muesli/appcast.xml"
 SKIP_DMG=0
 REQUIRE_NOTARIZED=0
 
@@ -19,6 +21,8 @@ Options:
   --version <version>       Require the latest appcast item to match this version.
   --appcast <path>          Appcast XML path. Defaults to docs/appcast.xml.
   --dmg <path>              DMG path. Defaults to dist-release/Muesli-<version>.dmg.
+  --app-name <name>         App bundle/update artifact name. Defaults to Muesli.
+  --feed-url <url>          Expected SUFeedURL. Defaults to the production appcast.
   --skip-dmg                Only validate appcast metadata. Suitable for CI.
   --require-notarized       Also require Gatekeeper/stapler checks for DMG and app.
   -h, --help                Show this help.
@@ -37,6 +41,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dmg)
       DMG_PATH="${2:?missing value for --dmg}"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="${2:?missing value for --app-name}"
+      shift 2
+      ;;
+    --feed-url)
+      EXPECTED_FEED_URL="${2:?missing value for --feed-url}"
       shift 2
       ;;
     --skip-dmg)
@@ -64,7 +76,7 @@ if [[ ! -f "$APPCAST" ]]; then
   exit 1
 fi
 
-if ! APPCAST_METADATA="$(python3 - "$APPCAST" "$VERSION" <<'PY'
+if ! APPCAST_METADATA="$(python3 - "$APPCAST" "$VERSION" "$APP_NAME" <<'PY'
 import base64
 import re
 import shlex
@@ -73,6 +85,7 @@ import xml.etree.ElementTree as ET
 
 appcast_path = sys.argv[1]
 expected_version = sys.argv[2]
+app_name = sys.argv[3]
 sparkle_ns = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 
 try:
@@ -113,7 +126,7 @@ signature = enclosure.attrib.get(f"{{{sparkle_ns}}}edSignature", "")
 if not signature:
     raise SystemExit("ERROR: latest appcast enclosure is missing sparkle:edSignature")
 
-expected_url = f"https://github.com/pHequals7/muesli/releases/download/v{version}/Muesli-{version}.dmg"
+expected_url = f"https://github.com/pHequals7/muesli/releases/download/v{version}/{app_name}-{version}.dmg"
 if url != expected_url:
     raise SystemExit(f"ERROR: latest appcast URL is {url!r}, expected {expected_url!r}")
 
@@ -169,7 +182,7 @@ if [[ "$SKIP_DMG" == "1" ]]; then
 fi
 
 if [[ -z "$DMG_PATH" ]]; then
-  DMG_PATH="$ROOT/dist-release/Muesli-${APPCAST_VERSION}.dmg"
+  DMG_PATH="$ROOT/dist-release/${APP_NAME}-${APPCAST_VERSION}.dmg"
 fi
 
 if [[ ! -f "$DMG_PATH" ]]; then
@@ -223,10 +236,10 @@ if [[ -z "$MOUNT_POINT" ]]; then
   exit 1
 fi
 
-APP_PATH="$MOUNT_POINT/Muesli.app"
+APP_PATH="$MOUNT_POINT/${APP_NAME}.app"
 INFO_PLIST="$APP_PATH/Contents/Info.plist"
 if [[ ! -d "$APP_PATH" ]]; then
-  echo "ERROR: mounted DMG does not contain Muesli.app" >&2
+  echo "ERROR: mounted DMG does not contain ${APP_NAME}.app" >&2
   exit 1
 fi
 
@@ -240,8 +253,9 @@ if [[ "$BUNDLE_SHORT_VERSION" != "$APPCAST_VERSION" || "$BUNDLE_VERSION" != "$AP
   exit 1
 fi
 
-if [[ "$FEED_URL" != "https://pHequals7.github.io/muesli/appcast.xml" ]]; then
+if [[ "$FEED_URL" != "$EXPECTED_FEED_URL" ]]; then
   echo "ERROR: app bundle SUFeedURL is $FEED_URL" >&2
+  echo "       expected $EXPECTED_FEED_URL" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- wire the About page Check Now button to Sparkle instead of leaving it as a no-op
- track Sparkle update-cycle state in AppState and show an About-page banner for checking, available, downloaded/pending, installing, up-to-date, disabled, and failed states
- show a red notification dot on the About sidebar item when an update is available or downloaded
- add a menu-bar Check for Updates entry so users have a standard macOS update path
- fix native app packaging so dev/canary builds can explicitly disable the production Sparkle feed with an empty MUESLI_SPARKLE_FEED_URL
- skip Sparkle startup entirely when no feed URL is configured, so MuesliDev cannot enter a bad updater state
- add a pre-production Sparkle channel via docs/appcast-preprod.xml and scripts/release-preprod.sh for signed/notarized updater-flow testing without touching the stable appcast/site/Homebrew tap
- preserve Sparkle's default on-quit install handling by removing the willInstallUpdateOnQuit override, and assign appState before starting Sparkle
- handle Sparkle no-update errors by checking the error code before showing up-to-date, and make downloaded updates instruct users to quit/reopen instead of showing a dead install button

## Root cause
The 0.6.2 appcast was present and valid, but the About page Check Now button was still a TODO and never called Sparkle. While rebuilding MuesliDev, we also found the dev script's empty Sparkle feed override was being defeated by bash defaulting in build_native_app.sh, and the app still started Sparkle even when the installed feed URL was empty. We also lacked a safe pre-production Sparkle feed for testing the full update path before production.

## Validation
- swift build --package-path native/MuesliNative --product MuesliNativeApp
- swift test --package-path native/MuesliNative
- ./scripts/dev-test.sh
- bash -n scripts/build_native_app.sh scripts/release.sh scripts/release-alpha.sh scripts/release-preprod.sh scripts/verify_update_flow.sh
- git diff --check
- packaging smoke test confirmed MuesliPreprod plist gets com.muesli.preprod, 9.9.9-preprod.1, MuesliPreprod support dir, and appcast-preprod.xml feed
- verified /Applications/MuesliDev.app uses com.muesli.dev, MuesliDev support directory, and empty SUFeedURL