### PR TITLE
Fix Sparkle no-update state handling

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -41,7 +41,7 @@ struct AboutView: View {
 
                     aboutRow("Check for Updates") {
                         actionButton("Check Now", icon: "arrow.triangle.2.circlepath") {
-                            controller.checkForUpdates()
+                            controller.retryUpdateCheck()
                         }
                     }
                 }
@@ -119,9 +119,6 @@ struct AboutView: View {
             .padding(MuesliTheme.spacing32)
         }
         .background(MuesliTheme.backgroundBase)
-        .task {
-            controller.refreshUpdateInformation()
-        }
     }
 
     // MARK: - Components
@@ -154,7 +151,30 @@ struct AboutView: View {
         let title: String
         let message: String
         let tint: Color
-        let actionTitle: String?
+        let action: UpdateBannerAction?
+    }
+
+    private enum UpdateBannerAction {
+        case install
+        case retry
+
+        var title: String {
+            switch self {
+            case .install:
+                return "Install Update"
+            case .retry:
+                return "Try Again"
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .install:
+                return "arrow.down.circle"
+            case .retry:
+                return "arrow.triangle.2.circlepath"
+            }
+        }
     }
 
     private var updateBanner: UpdateBanner? {
@@ -167,7 +187,15 @@ struct AboutView: View {
                 title: "Checking for updates",
                 message: "Muesli is checking the appcast for the latest version.",
                 tint: MuesliTheme.transcribing,
-                actionTitle: nil
+                action: nil
+            )
+        case .busy(let message):
+            return UpdateBanner(
+                icon: "clock.arrow.circlepath",
+                title: "Updater is busy",
+                message: message,
+                tint: MuesliTheme.transcribing,
+                action: nil
             )
         case .available(let version):
             return UpdateBanner(
@@ -175,7 +203,7 @@ struct AboutView: View {
                 title: "Muesli \(version) is available",
                 message: "An update is available. Start the updater to download and install it.",
                 tint: MuesliTheme.transcribing,
-                actionTitle: "Install Update"
+                action: .install
             )
         case .downloaded(let version):
             return UpdateBanner(
@@ -183,7 +211,7 @@ struct AboutView: View {
                 title: "Muesli \(version) is ready to install",
                 message: "Quit and reopen Muesli to finish installing the update.",
                 tint: MuesliTheme.transcribing,
-                actionTitle: nil
+                action: nil
             )
         case .installing(let version):
             return UpdateBanner(
@@ -191,7 +219,7 @@ struct AboutView: View {
                 title: "Installing Muesli \(version)",
                 message: "Sparkle is preparing the update. Muesli may relaunch when installation finishes.",
                 tint: MuesliTheme.transcribing,
-                actionTitle: nil
+                action: nil
             )
         case .upToDate:
             return UpdateBanner(
@@ -199,7 +227,7 @@ struct AboutView: View {
                 title: "Muesli is up to date",
                 message: "No newer version was found in the appcast.",
                 tint: MuesliTheme.success,
-                actionTitle: nil
+                action: nil
             )
         case .disabled(let message):
             return UpdateBanner(
@@ -207,7 +235,7 @@ struct AboutView: View {
                 title: "Updates are disabled",
                 message: message,
                 tint: MuesliTheme.textTertiary,
-                actionTitle: nil
+                action: nil
             )
         case .failed(let message):
             return UpdateBanner(
@@ -215,7 +243,7 @@ struct AboutView: View {
                 title: "Update check failed",
                 message: message,
                 tint: MuesliTheme.recording,
-                actionTitle: "Try Again"
+                action: .retry
             )
         }
     }
@@ -240,9 +268,14 @@ struct AboutView: View {
 
             Spacer(minLength: MuesliTheme.spacing16)
 
-            if let actionTitle = banner.actionTitle {
-                actionButton(actionTitle, icon: "arrow.down.circle") {
-                    controller.checkForUpdates()
+            if let action = banner.action {
+                actionButton(action.title, icon: action.icon) {
+                    switch action {
+                    case .install:
+                        controller.installAvailableUpdate()
+                    case .retry:
+                        controller.retryUpdateCheck()
+                    }
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -109,6 +109,11 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
 
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
         let nsError = error as NSError
+        if UpdateFailureGuidance.isNoUpdateError(nsError) {
+            appState?.sparkleUpdateStatus = .upToDate
+            return
+        }
+
         appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
         guard UpdateFailureGuidance.shouldShowFallback(for: nsError) else { return }
 
@@ -122,6 +127,15 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
 
     func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: Error?) {
         appState?.sparkleLastCheckedAt = Date()
+        guard let error else { return }
+        let nsError = error as NSError
+        // didAbortWithError is the primary error callback; this keeps the
+        // final-cycle handler self-contained for any Sparkle path that ends here.
+        if UpdateFailureGuidance.isNoUpdateError(nsError) {
+            appState?.sparkleUpdateStatus = .upToDate
+        } else {
+            appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
+        }
     }
 
     private func showManualInstallGuidance() {
@@ -158,16 +172,7 @@ enum UpdateFailureGuidance {
     static func isNoUpdateError(_ error: NSError) -> Bool {
         guard error.domain == SUSparkleErrorDomain else { return false }
         if error.code == noUpdateErrorCode { return true }
-        if error.userInfo[SPUNoUpdateFoundReasonKey] != nil { return true }
-
-        // Some Sparkle paths report the no-update condition via localized text
-        // while still routing through the error callback. Treat that as a
-        // successful check so the About banner never shows a red failure for
-        // an up-to-date app.
-        let message = error.localizedDescription.lowercased()
-        return message.contains("up to date")
-            || message.contains("up-to-date")
-            || message.contains("no update")
+        return error.userInfo[SPUNoUpdateFoundReasonKey] != nil
     }
 
     static func shouldShowFallback(for error: NSError) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -20,6 +20,7 @@ enum MeetingsNavigationState: Equatable {
 enum SparkleUpdateStatus: Equatable {
     case idle
     case checking
+    case busy(message: String)
     case available(version: String)
     case downloaded(version: String)
     case installing(version: String)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -100,6 +100,7 @@ final class MuesliController: NSObject {
     private var onboardingWindowController: OnboardingWindowController?
     var updaterController: SPUStandardUpdaterController?
     private var updateCheckStatusGeneration = 0
+    private var busyStatusGeneration = 0
 
     let appState = AppState()
 
@@ -1115,24 +1116,70 @@ final class MuesliController: NSObject {
     }
 
     @objc func checkForUpdates() {
+        presentStandardUpdateCheck()
+    }
+
+    func retryUpdateCheck() {
+        checkForUpdateInformation()
+    }
+
+    func installAvailableUpdate() {
+        switch appState.sparkleUpdateStatus {
+        case .available, .downloaded:
+            break
+        case .checking, .busy, .installing:
+            showBusyStatus(
+                "Sparkle is still finishing the previous update check. Try again in a moment.",
+                restoring: appState.sparkleUpdateStatus
+            )
+            return
+        case .idle, .upToDate, .disabled, .failed:
+            checkForUpdateInformation()
+            return
+        }
+
+        presentStandardUpdateCheck()
+    }
+
+    private func presentStandardUpdateCheck() {
         guard let updaterController else {
             appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
             return
         }
-        guard updaterController.updater.canCheckForUpdates else { return }
-        guard !updaterController.updater.sessionInProgress else {
-            beginUpdateCheckStatusTimeout()
+        guard updaterController.updater.canCheckForUpdates else {
+            showBusyStatus(
+                "Sparkle cannot start a new update check yet. Try again in a moment.",
+                restoring: appState.sparkleUpdateStatus
+            )
             return
         }
-        beginUpdateCheckStatusTimeout()
+        guard !updaterController.updater.sessionInProgress else {
+            showBusyStatus(
+                "Sparkle is still finishing the previous update check. Try again in a moment.",
+                restoring: appState.sparkleUpdateStatus
+            )
+            return
+        }
         updaterController.checkForUpdates(nil)
     }
 
-    func refreshUpdateInformation() {
-        guard case .idle = appState.sparkleUpdateStatus else { return }
-        guard let updater = updaterController?.updater, updater.canCheckForUpdates else { return }
+    private func checkForUpdateInformation() {
+        guard let updater = updaterController?.updater else {
+            appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
+            return
+        }
+        guard updater.canCheckForUpdates else {
+            showBusyStatus(
+                "Sparkle cannot start a new update check yet. Try again in a moment.",
+                restoring: appState.sparkleUpdateStatus
+            )
+            return
+        }
         guard !updater.sessionInProgress else {
-            beginUpdateCheckStatusTimeout()
+            showBusyStatus(
+                "Sparkle is still finishing the previous update check. Try again in a moment.",
+                restoring: appState.sparkleUpdateStatus
+            )
             return
         }
         beginUpdateCheckStatusTimeout()
@@ -1152,6 +1199,27 @@ final class MuesliController: NSObject {
                 message: "The updater did not finish checking. Please try again in a moment, or quit and reopen Muesli if it stays stuck."
             )
         }
+    }
+
+    private func showBusyStatus(_ message: String, restoring previousStatus: SparkleUpdateStatus) {
+        busyStatusGeneration += 1
+        let generation = busyStatusGeneration
+        let restoreStatus = nonBusyStatus(previousStatus)
+        appState.sparkleUpdateStatus = .busy(message: message)
+
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard let self, self.busyStatusGeneration == generation else { return }
+            guard case .busy = self.appState.sparkleUpdateStatus else { return }
+            self.appState.sparkleUpdateStatus = restoreStatus
+        }
+    }
+
+    private func nonBusyStatus(_ status: SparkleUpdateStatus) -> SparkleUpdateStatus {
+        if case .busy = status {
+            return .idle
+        }
+        return status
     }
 
     @objc func quitApp() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -33,7 +33,7 @@ struct SidebarView: View {
         switch appState.sparkleUpdateStatus {
         case .available, .downloaded:
             return true
-        case .idle, .checking, .installing, .upToDate, .disabled, .failed:
+        case .idle, .checking, .busy, .installing, .upToDate, .disabled, .failed:
             return false
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -23,15 +23,15 @@ struct UpdateFailureGuidanceTests {
         #expect(UpdateFailureGuidance.isNoUpdateError(error))
     }
 
-    @Test("classifies localized up-to-date message as up to date")
-    func classifiesLocalizedUpToDateMessage() {
+    @Test("does not classify localized text alone as up to date")
+    func rejectsLocalizedTextWithoutSparkleSignal() {
         let error = NSError(
             domain: SUSparkleErrorDomain,
             code: 1002,
             userInfo: [NSLocalizedDescriptionKey: "You’re up to date!"]
         )
 
-        #expect(UpdateFailureGuidance.isNoUpdateError(error))
+        #expect(!UpdateFailureGuidance.isNoUpdateError(error))
     }
 
     @Test("does not classify unrelated Sparkle errors as up to date")


### PR DESCRIPTION
## Summary
- Route the About page `Check Now` action through Sparkle's information-only check instead of the standard user-initiated updater UI.
- Keep Sparkle's standard UI for the actual install path when an update is available.
- Treat Sparkle no-update abort/finish callbacks as a successful up-to-date result.
- Remove the passive About-page refresh that could start a check just by rendering the page.

## Root Cause
The installed preprod build could still accept clicks while the About banner was red, but after `Check Now` reported the app was up to date, normal mouse hit-testing stopped accepting input. The path used `SPUStandardUpdaterController.checkForUpdates`, which invokes Sparkle's standard user-initiated no-update UI. That UI path can leave our SwiftUI window in a bad input/activation state after the no-update transition.

This PR makes `Check Now` use `SPUUpdater.checkForUpdateInformation()` and lets Muesli render the check result in its own About banner. The standard Sparkle UI remains available for installing an actual update.

## Validation
- `swift test --package-path native/MuesliNative --filter UpdateFailureGuidanceTests`
- `swift test --package-path native/MuesliNative` (462 tests)

## Follow-up
After this is merged to `main`, publish `v0.6.3-preprod.5` from `main` so the hosted preprod appcast points at a build containing this fix.
