### PR TITLE
[codex] Add live quick note meetings

### DIFF
--- a/native/MuesliNative/Sources/MuesliCLI/main.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/main.swift
@@ -169,6 +169,8 @@ struct MeetingListRow: Encodable {
     let durationSeconds: Double
     let wordCount: Int
     let folderID: Int64?
+    let status: String
+    let manualNotes: String
     let notesState: String
     let selectedTemplateID: String
     let selectedTemplateName: String
@@ -181,6 +183,8 @@ struct MeetingListRow: Encodable {
         durationSeconds = record.durationSeconds
         wordCount = record.wordCount
         folderID = record.folderID
+        status = record.status.rawValue
+        manualNotes = record.manualNotes
         notesState = record.notesState.rawValue
         selectedTemplateID = record.appliedTemplateID
         selectedTemplateName = record.appliedTemplateName
@@ -197,6 +201,8 @@ struct MeetingDetailPayload: Encodable {
     let formattedNotes: String
     let wordCount: Int
     let folderID: Int64?
+    let status: String
+    let manualNotes: String
     let notesState: String
     let calendarEventID: String?
     let micAudioPath: String?
@@ -216,6 +222,8 @@ struct MeetingDetailPayload: Encodable {
         formattedNotes = record.formattedNotes
         wordCount = record.wordCount
         folderID = record.folderID
+        status = record.status.rawValue
+        manualNotes = record.manualNotes
         notesState = record.notesState.rawValue
         calendarEventID = record.calendarEventID
         micAudioPath = record.micAudioPath

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -1,6 +1,17 @@
 import Foundation
 import SQLite3
 
+public enum DictationStoreError: Error, LocalizedError {
+    case meetingNotFound(id: Int64)
+
+    public var errorDescription: String? {
+        switch self {
+        case .meetingNotFound(let id):
+            return "Meeting \(id) no longer exists."
+        }
+    }
+}
+
 public final class DictationStore {
     private let databaseURL: URL
     private static let meetingColumns = """
@@ -596,6 +607,9 @@ public final class DictationStore {
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.meetingNotFound(id: id)
+        }
     }
 
     public func clearDictations() throws {
@@ -729,6 +743,9 @@ public final class DictationStore {
         sqlite3_bind_int64(statement, 17, id)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
+        }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.meetingNotFound(id: id)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -3,6 +3,9 @@ import SQLite3
 
 public final class DictationStore {
     private let databaseURL: URL
+    private static let meetingColumns = """
+    id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt
+    """
 
     public init() {
         self.databaseURL = MuesliPaths.defaultDatabaseURL()
@@ -51,6 +54,8 @@ public final class DictationStore {
             mic_audio_path TEXT,
             system_audio_path TEXT,
             saved_recording_path TEXT,
+            meeting_status TEXT NOT NULL DEFAULT 'completed',
+            manual_notes TEXT NOT NULL DEFAULT '',
             word_count INTEGER NOT NULL DEFAULT 0,
             selected_template_id TEXT,
             selected_template_name TEXT,
@@ -92,6 +97,12 @@ public final class DictationStore {
             // Column may already exist.
         }
         if sqlite3_exec(db, "ALTER TABLE meetings ADD COLUMN saved_recording_path TEXT", nil, nil, nil) != SQLITE_OK {
+            // Column may already exist.
+        }
+        if sqlite3_exec(db, "ALTER TABLE meetings ADD COLUMN meeting_status TEXT NOT NULL DEFAULT 'completed'", nil, nil, nil) != SQLITE_OK {
+            // Column may already exist.
+        }
+        if sqlite3_exec(db, "ALTER TABLE meetings ADD COLUMN manual_notes TEXT NOT NULL DEFAULT ''", nil, nil, nil) != SQLITE_OK {
             // Column may already exist.
         }
         let _ = sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_meetings_folder ON meetings(folder_id)", nil, nil, nil)
@@ -247,12 +258,11 @@ public final class DictationStore {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
-        let columns = "id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt"
         var sql: String
-        if let folderID {
-            sql = "SELECT \(columns) FROM meetings WHERE folder_id = ? ORDER BY id DESC"
+        if folderID != nil {
+            sql = "SELECT \(Self.meetingColumns) FROM meetings WHERE folder_id = ? ORDER BY id DESC"
         } else {
-            sql = "SELECT \(columns) FROM meetings ORDER BY id DESC"
+            sql = "SELECT \(Self.meetingColumns) FROM meetings ORDER BY id DESC"
         }
         if limit != nil { sql += " LIMIT ?" }
 
@@ -282,7 +292,7 @@ public final class DictationStore {
         defer { sqlite3_close(db) }
 
         let sql = """
-        SELECT id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt
+        SELECT \(Self.meetingColumns)
         FROM meetings
         WHERE id = ?
         LIMIT 1
@@ -350,9 +360,9 @@ public final class DictationStore {
         defer { sqlite3_close(db) }
 
         let sql = """
-        SELECT id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt
+        SELECT \(Self.meetingColumns)
         FROM meetings
-        WHERE title LIKE ? ESCAPE '\\' OR raw_transcript LIKE ? ESCAPE '\\' OR formatted_notes LIKE ? ESCAPE '\\'
+        WHERE title LIKE ? ESCAPE '\\' OR raw_transcript LIKE ? ESCAPE '\\' OR formatted_notes LIKE ? ESCAPE '\\' OR manual_notes LIKE ? ESCAPE '\\'
         ORDER BY id DESC
         LIMIT ?
         """
@@ -365,7 +375,8 @@ public final class DictationStore {
         sqlite3_bind_text(statement, 1, pattern.utf8String, -1, nil)
         sqlite3_bind_text(statement, 2, pattern.utf8String, -1, nil)
         sqlite3_bind_text(statement, 3, pattern.utf8String, -1, nil)
-        sqlite3_bind_int(statement, 4, Int32(limit))
+        sqlite3_bind_text(statement, 4, pattern.utf8String, -1, nil)
+        sqlite3_bind_int(statement, 5, Int32(limit))
 
         var rows: [MeetingRecord] = []
         while sqlite3_step(statement) == SQLITE_ROW {
@@ -379,7 +390,7 @@ public final class DictationStore {
         defer { sqlite3_close(db) }
 
         let sql = """
-        SELECT id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt
+        SELECT \(Self.meetingColumns)
         FROM meetings
         WHERE calendar_event_id = ?
         LIMIT 1
@@ -448,6 +459,46 @@ public final class DictationStore {
         bindOptionalText(selectedTemplateName, at: 13, statement: statement)
         bindOptionalText(selectedTemplateKind?.rawValue, at: 14, statement: statement)
         bindOptionalText(selectedTemplatePrompt, at: 15, statement: statement)
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+        return sqlite3_last_insert_rowid(db)
+    }
+
+    @discardableResult
+    public func createLiveMeeting(
+        title: String,
+        calendarEventID: String?,
+        startTime: Date,
+        selectedTemplateID: String? = nil,
+        selectedTemplateName: String? = nil,
+        selectedTemplateKind: MeetingTemplateKind? = nil,
+        selectedTemplatePrompt: String? = nil
+    ) throws -> Int64 {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        INSERT INTO meetings
+        (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, word_count, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source)
+        VALUES (?, ?, ?, NULL, 0, '', '', NULL, NULL, NULL, ?, '', 0, ?, ?, ?, ?, 'meeting')
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        let startString = ISO8601DateFormatter().string(from: startTime)
+        sqlite3_bind_text(statement, 1, (title as NSString).utf8String, -1, nil)
+        bindOptionalText(calendarEventID, at: 2, statement: statement)
+        sqlite3_bind_text(statement, 3, (startString as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 4, (MeetingStatus.recording.rawValue as NSString).utf8String, -1, nil)
+        bindOptionalText(selectedTemplateID, at: 5, statement: statement)
+        bindOptionalText(selectedTemplateName, at: 6, statement: statement)
+        bindOptionalText(selectedTemplateKind?.rawValue, at: 7, statement: statement)
+        bindOptionalText(selectedTemplatePrompt, at: 8, statement: statement)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
@@ -587,6 +638,95 @@ public final class DictationStore {
         defer { sqlite3_finalize(statement) }
         sqlite3_bind_text(statement, 1, (formattedNotes as NSString).utf8String, -1, nil)
         sqlite3_bind_int64(statement, 2, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    public func updateMeetingManualNotes(id: Int64, manualNotes: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "UPDATE meetings SET manual_notes = ? WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (manualNotes as NSString).utf8String, -1, nil)
+        sqlite3_bind_int64(statement, 2, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    public func updateMeetingStatus(id: Int64, status: MeetingStatus) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "UPDATE meetings SET meeting_status = ? WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (status.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_int64(statement, 2, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    public func completeLiveMeeting(
+        id: Int64,
+        title: String,
+        calendarEventID: String?,
+        startTime: Date,
+        endTime: Date,
+        rawTranscript: String,
+        formattedNotes: String,
+        micAudioPath: String?,
+        systemAudioPath: String?,
+        savedRecordingPath: String? = nil,
+        selectedTemplateID: String? = nil,
+        selectedTemplateName: String? = nil,
+        selectedTemplateKind: MeetingTemplateKind? = nil,
+        selectedTemplatePrompt: String? = nil
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = """
+        UPDATE meetings
+        SET title = ?, calendar_event_id = ?, start_time = ?, end_time = ?, duration_seconds = ?, raw_transcript = ?, formatted_notes = ?, mic_audio_path = ?, system_audio_path = ?, saved_recording_path = ?, meeting_status = ?, word_count = ?, selected_template_id = ?, selected_template_name = ?, selected_template_kind = ?, selected_template_prompt = ?
+        WHERE id = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        let formatter = ISO8601DateFormatter()
+        let startString = formatter.string(from: startTime)
+        let endString = formatter.string(from: endTime)
+        let durationSeconds = max(endTime.timeIntervalSince(startTime), 0)
+        let wordCount = Self.countWords(in: rawTranscript)
+
+        sqlite3_bind_text(statement, 1, (title as NSString).utf8String, -1, nil)
+        bindOptionalText(calendarEventID, at: 2, statement: statement)
+        sqlite3_bind_text(statement, 3, (startString as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 4, (endString as NSString).utf8String, -1, nil)
+        sqlite3_bind_double(statement, 5, durationSeconds)
+        sqlite3_bind_text(statement, 6, (rawTranscript as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 7, (formattedNotes as NSString).utf8String, -1, nil)
+        bindOptionalText(micAudioPath, at: 8, statement: statement)
+        bindOptionalText(systemAudioPath, at: 9, statement: statement)
+        bindOptionalText(savedRecordingPath, at: 10, statement: statement)
+        sqlite3_bind_text(statement, 11, (MeetingStatus.completed.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(statement, 12, Int32(wordCount))
+        bindOptionalText(selectedTemplateID, at: 13, statement: statement)
+        bindOptionalText(selectedTemplateName, at: 14, statement: statement)
+        bindOptionalText(selectedTemplateKind?.rawValue, at: 15, statement: statement)
+        bindOptionalText(selectedTemplatePrompt, at: 16, statement: statement)
+        sqlite3_bind_int64(statement, 17, id)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
@@ -781,12 +921,14 @@ public final class DictationStore {
         let micAudioPath: String? = sqlite3_column_type(statement, 9) == SQLITE_NULL ? nil : stringColumn(statement, index: 9)
         let systemAudioPath: String? = sqlite3_column_type(statement, 10) == SQLITE_NULL ? nil : stringColumn(statement, index: 10)
         let savedRecordingPath: String? = sqlite3_column_type(statement, 11) == SQLITE_NULL ? nil : stringColumn(statement, index: 11)
-        let selectedTemplateID: String? = sqlite3_column_type(statement, 12) == SQLITE_NULL ? nil : stringColumn(statement, index: 12)
-        let selectedTemplateName: String? = sqlite3_column_type(statement, 13) == SQLITE_NULL ? nil : stringColumn(statement, index: 13)
-        let selectedTemplateKind: MeetingTemplateKind? = sqlite3_column_type(statement, 14) == SQLITE_NULL
+        let status = MeetingStatus(rawValue: stringColumn(statement, index: 12)) ?? .completed
+        let manualNotes = stringColumn(statement, index: 13)
+        let selectedTemplateID: String? = sqlite3_column_type(statement, 14) == SQLITE_NULL ? nil : stringColumn(statement, index: 14)
+        let selectedTemplateName: String? = sqlite3_column_type(statement, 15) == SQLITE_NULL ? nil : stringColumn(statement, index: 15)
+        let selectedTemplateKind: MeetingTemplateKind? = sqlite3_column_type(statement, 16) == SQLITE_NULL
             ? nil
-            : MeetingTemplateKind(rawValue: stringColumn(statement, index: 14))
-        let selectedTemplatePrompt: String? = sqlite3_column_type(statement, 15) == SQLITE_NULL ? nil : stringColumn(statement, index: 15)
+            : MeetingTemplateKind(rawValue: stringColumn(statement, index: 16))
+        let selectedTemplatePrompt: String? = sqlite3_column_type(statement, 17) == SQLITE_NULL ? nil : stringColumn(statement, index: 17)
         return MeetingRecord(
             id: sqlite3_column_int64(statement, 0),
             title: stringColumn(statement, index: 1),
@@ -800,6 +942,8 @@ public final class DictationStore {
             micAudioPath: micAudioPath,
             systemAudioPath: systemAudioPath,
             savedRecordingPath: savedRecordingPath,
+            status: status,
+            manualNotes: manualNotes,
             selectedTemplateID: selectedTemplateID,
             selectedTemplateName: selectedTemplateName,
             selectedTemplateKind: selectedTemplateKind,

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -298,6 +298,31 @@ public final class DictationStore {
         return rows
     }
 
+    public func staleLiveMeetings() throws -> [MeetingRecord] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT \(Self.meetingColumns)
+        FROM meetings
+        WHERE meeting_status IN (?, ?)
+        ORDER BY id DESC
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (MeetingStatus.recording.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (MeetingStatus.processing.rawValue as NSString).utf8String, -1, nil)
+
+        var rows: [MeetingRecord] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append(makeMeetingRecord(statement))
+        }
+        return rows
+    }
+
     public func meeting(id: Int64) throws -> MeetingRecord? {
         let db = try openDatabase()
         defer { sqlite3_close(db) }

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -696,6 +696,9 @@ public final class DictationStore {
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.meetingNotFound(id: id)
+        }
     }
 
     public func updateMeetingStatus(id: Int64, status: MeetingStatus) throws {
@@ -711,6 +714,9 @@ public final class DictationStore {
         sqlite3_bind_int64(statement, 2, id)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
+        }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.meetingNotFound(id: id)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -704,14 +704,22 @@ public final class DictationStore {
     public func updateMeetingStatus(id: Int64, status: MeetingStatus) throws {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
-        let sql = "UPDATE meetings SET meeting_status = ? WHERE id = ?"
+        let wordCount = try manualNoteWordCountIfNeeded(for: status, id: id, db: db)
+        let sql = wordCount == nil
+            ? "UPDATE meetings SET meeting_status = ? WHERE id = ?"
+            : "UPDATE meetings SET meeting_status = ?, word_count = ? WHERE id = ?"
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
             throw lastError(db)
         }
         defer { sqlite3_finalize(statement) }
         sqlite3_bind_text(statement, 1, (status.rawValue as NSString).utf8String, -1, nil)
-        sqlite3_bind_int64(statement, 2, id)
+        if let wordCount {
+            sqlite3_bind_int(statement, 2, Int32(wordCount))
+            sqlite3_bind_int64(statement, 3, id)
+        } else {
+            sqlite3_bind_int64(statement, 2, id)
+        }
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
@@ -753,7 +761,8 @@ public final class DictationStore {
         let startString = formatter.string(from: startTime)
         let endString = formatter.string(from: endTime)
         let durationSeconds = max(endTime.timeIntervalSince(startTime), 0)
-        let wordCount = Self.countWords(in: rawTranscript)
+        let manualNotes = try manualNotesForMeeting(id: id, db: db)
+        let wordCount = Self.countWords(in: rawTranscript) + Self.countWords(in: manualNotes)
 
         sqlite3_bind_text(statement, 1, (title as NSString).utf8String, -1, nil)
         bindOptionalText(calendarEventID, at: 2, statement: statement)
@@ -778,6 +787,29 @@ public final class DictationStore {
         guard sqlite3_changes(db) > 0 else {
             throw DictationStoreError.meetingNotFound(id: id)
         }
+    }
+
+    private func manualNoteWordCountIfNeeded(for status: MeetingStatus, id: Int64, db: OpaquePointer?) throws -> Int? {
+        switch status {
+        case .noteOnly, .failed:
+            return Self.countWords(in: try manualNotesForMeeting(id: id, db: db))
+        case .recording, .processing, .completed:
+            return nil
+        }
+    }
+
+    private func manualNotesForMeeting(id: Int64, db: OpaquePointer?) throws -> String {
+        let sql = "SELECT manual_notes FROM meetings WHERE id = ? LIMIT 1"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, id)
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw DictationStoreError.meetingNotFound(id: id)
+        }
+        return stringColumn(statement, index: 0)
     }
 
     public func updateMeetingSummary(

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -586,12 +586,15 @@ public final class DictationStore {
             COALESCE(SUM(word_count), 0) AS total_words,
             COALESCE(SUM(duration_seconds), 0) AS total_duration_seconds
         FROM meetings
+        WHERE meeting_status IN (?, ?)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
             throw lastError(db)
         }
         defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (MeetingStatus.completed.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (MeetingStatus.noteOnly.rawValue as NSString).utf8String, -1, nil)
         guard sqlite3_step(statement) == SQLITE_ROW else {
             return MeetingStats(totalWords: 0, totalMeetings: 0, averageWPM: 0)
         }

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -6,6 +6,14 @@ public enum MeetingNotesState: String, Codable, Sendable {
     case structuredNotes = "structured_notes"
 }
 
+public enum MeetingStatus: String, Codable, Sendable {
+    case recording
+    case processing
+    case completed
+    case noteOnly = "note_only"
+    case failed
+}
+
 public enum MeetingTemplateKind: String, Codable, Sendable {
     case auto
     case builtin
@@ -49,6 +57,8 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
     public let micAudioPath: String?
     public let systemAudioPath: String?
     public let savedRecordingPath: String?
+    public let status: MeetingStatus
+    public let manualNotes: String
     public let selectedTemplateID: String?
     public let selectedTemplateName: String?
     public let selectedTemplateKind: MeetingTemplateKind?
@@ -67,6 +77,8 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         micAudioPath: String? = nil,
         systemAudioPath: String? = nil,
         savedRecordingPath: String? = nil,
+        status: MeetingStatus = .completed,
+        manualNotes: String = "",
         selectedTemplateID: String? = nil,
         selectedTemplateName: String? = nil,
         selectedTemplateKind: MeetingTemplateKind? = nil,
@@ -84,10 +96,57 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         self.micAudioPath = micAudioPath
         self.systemAudioPath = systemAudioPath
         self.savedRecordingPath = savedRecordingPath
+        self.status = status
+        self.manualNotes = manualNotes
         self.selectedTemplateID = selectedTemplateID
         self.selectedTemplateName = selectedTemplateName
         self.selectedTemplateKind = selectedTemplateKind
         self.selectedTemplatePrompt = selectedTemplatePrompt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case startTime
+        case durationSeconds
+        case rawTranscript
+        case formattedNotes
+        case wordCount
+        case folderID
+        case calendarEventID
+        case micAudioPath
+        case systemAudioPath
+        case savedRecordingPath
+        case status
+        case manualNotes
+        case selectedTemplateID
+        case selectedTemplateName
+        case selectedTemplateKind
+        case selectedTemplatePrompt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try c.decode(Int64.self, forKey: .id),
+            title: try c.decode(String.self, forKey: .title),
+            startTime: try c.decode(String.self, forKey: .startTime),
+            durationSeconds: try c.decode(Double.self, forKey: .durationSeconds),
+            rawTranscript: try c.decode(String.self, forKey: .rawTranscript),
+            formattedNotes: try c.decode(String.self, forKey: .formattedNotes),
+            wordCount: try c.decode(Int.self, forKey: .wordCount),
+            folderID: try c.decodeIfPresent(Int64.self, forKey: .folderID),
+            calendarEventID: try c.decodeIfPresent(String.self, forKey: .calendarEventID),
+            micAudioPath: try c.decodeIfPresent(String.self, forKey: .micAudioPath),
+            systemAudioPath: try c.decodeIfPresent(String.self, forKey: .systemAudioPath),
+            savedRecordingPath: try c.decodeIfPresent(String.self, forKey: .savedRecordingPath),
+            status: (try? c.decode(MeetingStatus.self, forKey: .status)) ?? .completed,
+            manualNotes: (try? c.decode(String.self, forKey: .manualNotes)) ?? "",
+            selectedTemplateID: try c.decodeIfPresent(String.self, forKey: .selectedTemplateID),
+            selectedTemplateName: try c.decodeIfPresent(String.self, forKey: .selectedTemplateName),
+            selectedTemplateKind: try c.decodeIfPresent(MeetingTemplateKind.self, forKey: .selectedTemplateKind),
+            selectedTemplatePrompt: try c.decodeIfPresent(String.self, forKey: .selectedTemplatePrompt)
+        )
     }
 
     public var notesState: MeetingNotesState {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -417,8 +417,7 @@ final class FloatingIndicatorController {
         glassView?.isHidden = false
         tintLayer?.isHidden = false
         tintLayer?.backgroundColor = NSColor.colorWith(hexString: "1e1e2e", alpha: 0.72).cgColor
-        tintLayer?.frame = CGRect(origin: .zero, size: loadingSize)
-        tintLayer?.cornerRadius = loadingSize.height / 2
+        applyTintLayerGeometry(size: loadingSize, radius: loadingSize.height / 2)
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.18
@@ -617,8 +616,7 @@ final class FloatingIndicatorController {
         }
         tintLayer?.isHidden = false
         tintLayer?.backgroundColor = NSColor.colorWith(hexString: tintHex, alpha: tintAlpha).cgColor
-        tintLayer?.frame = CGRect(origin: .zero, size: frameSize)
-        tintLayer?.cornerRadius = radius
+        applyTintLayerGeometry(size: frameSize, radius: radius)
 
         let iconSize = NSSize(width: 18, height: 18)
 
@@ -740,6 +738,8 @@ final class FloatingIndicatorController {
         // dark glass presence rather than showing everything underneath.
         let tint = CALayer()
         tint.backgroundColor = NSColor.colorWith(hex: 0x1e1e2e, alpha: 0.44).cgColor
+        tint.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+        tint.masksToBounds = true
         tint.isHidden = true
         contentView.layer?.addSublayer(tint)
         tintLayer = tint
@@ -769,6 +769,19 @@ final class FloatingIndicatorController {
         contentView.addSubview(wandView)
         wandIconView = wandView
 
+    }
+
+    private func applyTintLayerGeometry(size: NSSize, radius: CGFloat) {
+        // Slightly overdraw inside contentView's clipped pill so subpixel
+        // antialiasing cannot expose the darker visual-effect view underneath.
+        let overdraw: CGFloat = 1
+        tintLayer?.frame = CGRect(
+            x: -overdraw,
+            y: -overdraw,
+            width: size.width + overdraw * 2,
+            height: size.height + overdraw * 2
+        )
+        tintLayer?.cornerRadius = radius + overdraw
     }
 
     static func defaultIndicatorCenter(in visibleFrame: NSRect, idleSize: NSSize = NSSize(width: 44, height: 28)) -> CGPoint {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -72,7 +72,7 @@ private final class HoverIndicatorView: NSView {
 }
 
 @MainActor
-final class FloatingIndicatorController {
+final class FloatingIndicatorController: NSObject {
     private var panel: NSPanel?
     private var contentView: HoverIndicatorView?
     private var iconLabel: NSTextField?
@@ -104,6 +104,7 @@ final class FloatingIndicatorController {
 
     init(configStore: ConfigStore) {
         self.configStore = configStore
+        super.init()
     }
 
     var onStopToggleDictation: (() -> Void)?
@@ -154,6 +155,7 @@ final class FloatingIndicatorController {
         contentView.layer?.cornerRadius = targetFrame.height / 2
         contentView.layer?.backgroundColor = style.background.cgColor
         contentView.layer?.borderColor = style.border.cgColor
+        glassView?.frame = NSRect(origin: .zero, size: targetFrame.size)
         panel.alphaValue = style.alpha
 
         iconLabel.stringValue = style.icon
@@ -565,27 +567,34 @@ final class FloatingIndicatorController {
 
     private func startWaveformAnimation() {
         amplitudeTimer?.invalidate()
+        amplitudeTimer = Timer.scheduledTimer(
+            timeInterval: 1.0 / 30.0,
+            target: self,
+            selector: #selector(waveformTimerFired(_:)),
+            userInfo: nil,
+            repeats: true
+        )
+    }
+
+    @objc private func waveformTimerFired(_ timer: Timer) {
+        guard let contentView else { return }
         let multipliers: [CGFloat] = [0.6, 0.85, 1.0, 0.85, 0.6]
         let minHeight: CGFloat = 3
         let maxHeight: CGFloat = 14
+        let dB = CGFloat(powerProvider?() ?? -160)
+        let raw = max(0, min(1, (dB + 50) / 50))
+        smoothedAmplitude = 0.35 * raw + 0.65 * smoothedAmplitude
+        let pillHeight = contentView.frame.height
 
-        amplitudeTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
-            guard let self, let contentView = self.contentView else { return }
-            let dB = CGFloat(self.powerProvider?() ?? -160)
-            let raw = max(0, min(1, (dB + 50) / 50))
-            self.smoothedAmplitude = 0.35 * raw + 0.65 * self.smoothedAmplitude
-            let pillHeight = contentView.frame.height
-
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            for (i, bar) in self.barLayers.enumerated() {
-                let m = i < multipliers.count ? multipliers[i] : 1.0
-                let h = minHeight + (maxHeight - minHeight) * self.smoothedAmplitude * m
-                bar.frame.size.height = h
-                bar.frame.origin.y = (pillHeight - h) / 2
-            }
-            CATransaction.commit()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for (i, bar) in barLayers.enumerated() {
+            let m = i < multipliers.count ? multipliers[i] : 1.0
+            let h = minHeight + (maxHeight - minHeight) * smoothedAmplitude * m
+            bar.frame.size.height = h
+            bar.frame.origin.y = (pillHeight - h) / 2
         }
+        CATransaction.commit()
     }
 
     private func applyGlassState(_ state: DictationState, frameSize: NSSize) {
@@ -596,7 +605,9 @@ final class FloatingIndicatorController {
         // During recording, hide frost and show solid accent. Otherwise frosted glass.
         let isRecording = (state == .recording)
         glassView?.isHidden = isRecording
+        glassView?.frame = NSRect(origin: .zero, size: frameSize)
         glassView?.layer?.cornerRadius = radius
+        glassView?.layer?.masksToBounds = true
 
         let tintAlpha: CGFloat
         let tintHex: String
@@ -739,9 +750,10 @@ final class FloatingIndicatorController {
         let tint = CALayer()
         tint.backgroundColor = NSColor.colorWith(hex: 0x1e1e2e, alpha: 0.44).cgColor
         tint.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
-        tint.masksToBounds = true
+        tint.masksToBounds = false
+        tint.cornerCurve = .continuous
         tint.isHidden = true
-        contentView.layer?.addSublayer(tint)
+        contentView.layer?.insertSublayer(tint, at: 0)
         tintLayer = tint
 
         // Idle icon — uses the user's selected menu bar icon from config.
@@ -772,16 +784,12 @@ final class FloatingIndicatorController {
     }
 
     private func applyTintLayerGeometry(size: NSSize, radius: CGFloat) {
-        // Slightly overdraw inside contentView's clipped pill so subpixel
-        // antialiasing cannot expose the darker visual-effect view underneath.
-        let overdraw: CGFloat = 1
-        tintLayer?.frame = CGRect(
-            x: -overdraw,
-            y: -overdraw,
-            width: size.width + overdraw * 2,
-            height: size.height + overdraw * 2
-        )
-        tintLayer?.cornerRadius = radius + overdraw
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        tintLayer?.frame = CGRect(origin: .zero, size: size)
+        tintLayer?.cornerRadius = radius
+        tintLayer?.cornerCurve = .continuous
+        CATransaction.commit()
     }
 
     static func defaultIndicatorCenter(in visibleFrame: NSRect, idleSize: NSSize = NSSize(width: 44, height: 28)) -> CGPoint {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -17,6 +17,7 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
     @Binding var text: String
     @Binding var command: MarkdownEditorCommand?
     var shouldFocus: Bool = false
+    var isEditable: Bool = true
     var placeholder: String = "Write notes here..."
 
     func makeCoordinator() -> Coordinator {
@@ -38,6 +39,8 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         textView.usesRuler = false
         textView.isAutomaticQuoteSubstitutionEnabled = true
         textView.isAutomaticDashSubstitutionEnabled = true
+        textView.isEditable = isEditable
+        textView.isSelectable = true
         textView.allowsUndo = true
         textView.drawsBackground = false
         textView.insertionPointColor = NSColor.controlAccentColor
@@ -60,6 +63,8 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? PlaceholderTextView else { return }
         textView.placeholder = placeholder
+        textView.isEditable = isEditable
+        textView.isSelectable = true
         if context.coordinator.serializedMarkdown(from: textView) != text {
             context.coordinator.apply(markdown: text, to: textView)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -160,9 +160,7 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             let lines = markdown.components(separatedBy: .newlines)
             for (index, rawLine) in lines.enumerated() {
                 let parsed = parseLine(rawLine)
-                let line = NSMutableAttributedString(string: parsed.displayText, attributes: parsed.attributes)
-                applyInlineBold(in: line, baseAttributes: parsed.attributes)
-                result.append(line)
+                result.append(attributedLine(from: parsed.displayText, attributes: parsed.attributes))
                 if index < lines.count - 1 {
                     result.append(NSAttributedString(string: "\n", attributes: bodyAttributes()))
                 }
@@ -193,33 +191,37 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             return (line, bodyAttributes())
         }
 
-        private func applyInlineBold(
-            in line: NSMutableAttributedString,
-            baseAttributes: [NSAttributedString.Key: Any]
-        ) {
-            let raw = line.string as NSString
-            var searchRange = NSRange(location: 0, length: raw.length)
-            while true {
-                let opening = raw.range(of: "**", options: [], range: searchRange)
-                guard opening.location != NSNotFound else { break }
-                let afterOpening = NSRange(
-                    location: opening.location + opening.length,
-                    length: raw.length - opening.location - opening.length
-                )
-                let closing = raw.range(of: "**", options: [], range: afterOpening)
-                guard closing.location != NSNotFound else { break }
-
-                line.deleteCharacters(in: closing)
-                line.deleteCharacters(in: opening)
-                let boldRange = NSRange(location: opening.location, length: closing.location - opening.location - 2)
-                if boldRange.length > 0 {
-                    let baseFont = baseAttributes[.font] as? NSFont ?? bodyFont
-                    line.addAttribute(.font, value: boldVersion(of: baseFont), range: boldRange)
+        private func attributedLine(
+            from line: String,
+            attributes: [NSAttributedString.Key: Any]
+        ) -> NSAttributedString {
+            let result = NSMutableAttributedString()
+            var cursor = line.startIndex
+            while cursor < line.endIndex {
+                guard let opening = line.range(of: "**", range: cursor..<line.endIndex),
+                      let closing = line.range(of: "**", range: opening.upperBound..<line.endIndex)
+                else {
+                    append(String(line[cursor..<line.endIndex]), to: result, attributes: attributes)
+                    break
                 }
-                let nextLocation = opening.location + max(boldRange.length, 0)
-                searchRange = NSRange(location: nextLocation, length: max(line.length - nextLocation, 0))
-                if searchRange.length == 0 { break }
+
+                append(String(line[cursor..<opening.lowerBound]), to: result, attributes: attributes)
+                var boldAttributes = attributes
+                let baseFont = attributes[.font] as? NSFont ?? bodyFont
+                boldAttributes[.font] = boldVersion(of: baseFont)
+                append(String(line[opening.upperBound..<closing.lowerBound]), to: result, attributes: boldAttributes)
+                cursor = closing.upperBound
             }
+            return result
+        }
+
+        private func append(
+            _ string: String,
+            to result: NSMutableAttributedString,
+            attributes: [NSAttributedString.Key: Any]
+        ) {
+            guard !string.isEmpty else { return }
+            result.append(NSAttributedString(string: string, attributes: attributes))
         }
 
         private func applyHeading(in textView: NSTextView) {
@@ -385,7 +387,7 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         private func lineIsHeading(storage: NSTextStorage, range: NSRange) -> Bool {
             guard range.length > 0 else { return false }
             let font = storage.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
-            return (font?.pointSize ?? 0) >= 22
+            return abs((font?.pointSize ?? 0) - headingFont.pointSize) < 0.1
         }
 
         private func selectionIsBold(in storage: NSTextStorage, range: NSRange) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -181,6 +181,10 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             publishBinding(markdown)
             textView.needsDisplay = true
             self.command = nil
+            DispatchQueue.main.async { [weak textView] in
+                guard let textView else { return }
+                textView.window?.makeFirstResponder(textView)
+            }
         }
 
         private func scheduleBindingPublish(_ markdown: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -281,7 +281,13 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             }
             isHandlingNewline = true
             defer { isHandlingNewline = false }
-            textView.insertText(prefix ?? "\n", replacementRange: affectedCharRange)
+            if prefix == nil {
+                // Exiting empty list item — delete the marker line, leave a plain newline
+                let exitText = paragraphRange.upperBound < full.length ? "\n" : ""
+                textView.insertText(exitText, replacementRange: paragraphRange)
+            } else {
+                textView.insertText(prefix!, replacementRange: affectedCharRange)
+            }
         }
 
         private func paragraphRanges(for textView: NSTextView) -> [NSRange] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -1,0 +1,116 @@
+import AppKit
+import SwiftUI
+
+struct MarkdownRichTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    var shouldFocus: Bool = false
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+
+        let textView = NSTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 22, height: 20)
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: scrollView.contentSize.width, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+        context.coordinator.apply(text: text, to: textView)
+
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        if textView.string != text {
+            context.coordinator.apply(text: text, to: textView)
+        } else {
+            context.coordinator.restyle(textView)
+        }
+        if shouldFocus, !context.coordinator.didFocus {
+            DispatchQueue.main.async {
+                textView.window?.makeFirstResponder(textView)
+                context.coordinator.didFocus = true
+            }
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        @Binding private var text: String
+        weak var textView: NSTextView?
+        var didFocus = false
+        private var isApplying = false
+
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard !isApplying, let textView = notification.object as? NSTextView else { return }
+            text = textView.string
+            restyle(textView)
+        }
+
+        func apply(text: String, to textView: NSTextView) {
+            isApplying = true
+            textView.textStorage?.setAttributedString(styledMarkdown(text))
+            isApplying = false
+        }
+
+        func restyle(_ textView: NSTextView) {
+            let selectedRanges = textView.selectedRanges
+            isApplying = true
+            textView.textStorage?.setAttributedString(styledMarkdown(textView.string))
+            textView.selectedRanges = selectedRanges
+            isApplying = false
+        }
+
+        private func styledMarkdown(_ markdown: String) -> NSAttributedString {
+            let result = NSMutableAttributedString()
+            let bodyFont = NSFont.systemFont(ofSize: 14)
+            let bodyColor = NSColor.labelColor
+            let secondaryColor = NSColor.secondaryLabelColor
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.lineSpacing = 4
+            paragraph.paragraphSpacing = 7
+
+            let lines = markdown.components(separatedBy: .newlines)
+            for (index, line) in lines.enumerated() {
+                let attrs: [NSAttributedString.Key: Any]
+                if line.hasPrefix("# ") {
+                    attrs = [.font: NSFont.systemFont(ofSize: 22, weight: .bold), .foregroundColor: bodyColor, .paragraphStyle: paragraph]
+                } else if line.hasPrefix("## ") {
+                    attrs = [.font: NSFont.systemFont(ofSize: 18, weight: .semibold), .foregroundColor: bodyColor, .paragraphStyle: paragraph]
+                } else if line.hasPrefix("### ") {
+                    attrs = [.font: NSFont.systemFont(ofSize: 15, weight: .semibold), .foregroundColor: bodyColor, .paragraphStyle: paragraph]
+                } else if line.hasPrefix("- [ ] ") || line.hasPrefix("- [x] ") || line.hasPrefix("- [X] ") || line.hasPrefix("- ") {
+                    attrs = [.font: bodyFont, .foregroundColor: bodyColor, .paragraphStyle: paragraph]
+                } else {
+                    attrs = [.font: bodyFont, .foregroundColor: bodyColor, .paragraphStyle: paragraph]
+                }
+                result.append(NSAttributedString(string: line, attributes: attrs))
+                if index < lines.count - 1 {
+                    result.append(NSAttributedString(string: "\n", attributes: [.font: bodyFont, .foregroundColor: secondaryColor]))
+                }
+            }
+            return result
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -86,6 +86,7 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         weak var textView: NSTextView?
         var didFocus = false
         private var isApplying = false
+        private var isHandlingNewline = false
 
         private let bodyFont = NSFont.systemFont(ofSize: 16)
         private let boldFont = NSFont.boldSystemFont(ofSize: 16)
@@ -109,6 +110,7 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             shouldChangeTextIn affectedCharRange: NSRange,
             replacementString: String?
         ) -> Bool {
+            guard !isHandlingNewline else { return true }
             guard replacementString == "\n" else { return true }
             continueListIfNeeded(in: textView, affectedCharRange: affectedCharRange)
             return false
@@ -277,6 +279,8 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             } else {
                 prefix = "\n"
             }
+            isHandlingNewline = true
+            defer { isHandlingNewline = false }
             textView.insertText(prefix ?? "\n", replacementRange: affectedCharRange)
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -225,13 +225,20 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         private func applyHeading(in textView: NSTextView) {
             let ranges = paragraphRanges(for: textView)
             guard let storage = textView.textStorage else { return }
+            let removeHeading = ranges.allSatisfy { range in
+                range.length > 0 && lineIsHeading(storage: storage, range: range)
+            }
             isApplying = true
             for range in ranges {
-                storage.addAttributes([
-                    .font: headingFont,
-                    .foregroundColor: bodyColor,
-                    .paragraphStyle: paragraphStyle(spacing: 14, lineHeightMultiple: 1.02)
-                ], range: range)
+                if removeHeading {
+                    storage.addAttributes(bodyAttributes(), range: range)
+                } else {
+                    storage.addAttributes([
+                        .font: headingFont,
+                        .foregroundColor: bodyColor,
+                        .paragraphStyle: paragraphStyle(spacing: 14, lineHeightMultiple: 1.02)
+                    ], range: range)
+                }
             }
             isApplying = false
         }
@@ -257,17 +264,35 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         }
 
         private func insertLinePrefix(_ prefix: String, in textView: NSTextView) {
-            let selectedRange = textView.selectedRange()
+            let ranges = paragraphRanges(for: textView)
             let full = textView.string as NSString
-            let paragraphRange = full.paragraphRange(for: selectedRange)
-            let existingLine = full.substring(with: paragraphRange).trimmingCharacters(in: .newlines)
-            let cleaned = existingLine
-                .replacingOccurrences(of: "• ", with: "")
-                .replacingOccurrences(of: "☐ ", with: "")
-                .replacingOccurrences(of: "☑ ", with: "")
-            let replacement = prefix + cleaned
-            textView.replaceCharacters(in: paragraphRange, with: replacement + (paragraphRange.upperBound < full.length ? "\n" : ""))
-            textView.setSelectedRange(NSRange(location: paragraphRange.location + replacement.count, length: 0))
+            let replacements = ranges.map { range in
+                let existingLine = full.substring(with: range).trimmingCharacters(in: .newlines)
+                return prefix + removingListPrefix(from: existingLine)
+            }
+
+            isApplying = true
+            var totalDelta = 0
+            for (range, replacement) in zip(ranges, replacements).reversed() {
+                textView.replaceCharacters(in: range, with: replacement)
+                totalDelta += replacement.count - range.length
+            }
+            isApplying = false
+
+            guard let firstRange = ranges.first, let lastRange = ranges.last else { return }
+            if ranges.count == 1 {
+                textView.setSelectedRange(NSRange(location: firstRange.location + replacements[0].count, length: 0))
+            } else {
+                let originalEnd = lastRange.location + lastRange.length
+                textView.setSelectedRange(NSRange(location: firstRange.location, length: originalEnd + totalDelta - firstRange.location))
+            }
+        }
+
+        private func removingListPrefix(from line: String) -> String {
+            for existingPrefix in ["• ", "☐ ", "☑ "] where line.hasPrefix(existingPrefix) {
+                return String(line.dropFirst(existingPrefix.count))
+            }
+            return line
         }
 
         private func continueListIfNeeded(in textView: NSTextView, affectedCharRange: NSRange) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -19,9 +19,10 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
     var shouldFocus: Bool = false
     var isEditable: Bool = true
     var placeholder: String = "Write notes here..."
+    var onTextChange: ((String) -> Void)?
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, command: $command)
+        Coordinator(text: $text, command: $command, onTextChange: onTextChange)
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -65,7 +66,8 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         textView.placeholder = placeholder
         textView.isEditable = isEditable
         textView.isSelectable = true
-        if context.coordinator.serializedMarkdown(from: textView) != text {
+        context.coordinator.onTextChange = onTextChange
+        if context.coordinator.shouldApplyExternalMarkdown(text) {
             context.coordinator.apply(markdown: text, to: textView)
         }
         if let command {
@@ -88,10 +90,16 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding private var text: String
         @Binding private var command: MarkdownEditorCommand?
+        var onTextChange: ((String) -> Void)?
         weak var textView: NSTextView?
         var didFocus = false
+        private(set) var currentMarkdown = ""
         private var isApplying = false
         private var isHandlingNewline = false
+        private var usesMarkdownStyling = false
+        private var lastBindingMarkdown = ""
+        private var pendingLocalMarkdown: String?
+        private var bindingPublishWorkItem: DispatchWorkItem?
 
         private let bodyFont = NSFont.systemFont(ofSize: 16)
         private let boldFont = NSFont.boldSystemFont(ofSize: 16)
@@ -99,15 +107,34 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         private let bodyColor = NSColor.labelColor
         private let secondaryColor = NSColor.secondaryLabelColor
 
-        init(text: Binding<String>, command: Binding<MarkdownEditorCommand?>) {
+        init(text: Binding<String>, command: Binding<MarkdownEditorCommand?>, onTextChange: ((String) -> Void)?) {
             _text = text
             _command = command
+            self.onTextChange = onTextChange
         }
 
         func textDidChange(_ notification: Notification) {
             guard !isApplying, let textView = notification.object as? NSTextView else { return }
-            text = serializedMarkdown(from: textView)
+            let markdown = markdownForLiveEdit(from: textView)
+            currentMarkdown = markdown
+            pendingLocalMarkdown = markdown
+            onTextChange?(markdown)
+            scheduleBindingPublish(markdown)
             textView.needsDisplay = true
+        }
+
+        func shouldApplyExternalMarkdown(_ markdown: String) -> Bool {
+            if markdown == currentMarkdown {
+                lastBindingMarkdown = markdown
+                if pendingLocalMarkdown == markdown {
+                    pendingLocalMarkdown = nil
+                }
+                return false
+            }
+            if pendingLocalMarkdown != nil, markdown == lastBindingMarkdown {
+                return false
+            }
+            return true
         }
 
         func textView(
@@ -124,9 +151,13 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         func apply(markdown: String, to textView: NSTextView) {
             let selectedRanges = textView.selectedRanges
             isApplying = true
+            usesMarkdownStyling = Self.markdownNeedsRichRendering(markdown)
             textView.textStorage?.setAttributedString(attributedString(from: markdown))
             textView.typingAttributes = bodyAttributes()
             textView.selectedRanges = selectedRanges.clamped(to: textView.string.count)
+            currentMarkdown = markdown
+            lastBindingMarkdown = markdown
+            pendingLocalMarkdown = nil
             isApplying = false
             textView.needsDisplay = true
         }
@@ -142,9 +173,40 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
             case .checkbox:
                 insertLinePrefix("☐ ", in: textView)
             }
-            text = serializedMarkdown(from: textView)
+            usesMarkdownStyling = true
+            let markdown = serializedMarkdown(from: textView)
+            currentMarkdown = markdown
+            pendingLocalMarkdown = markdown
+            onTextChange?(markdown)
+            publishBinding(markdown)
             textView.needsDisplay = true
             self.command = nil
+        }
+
+        private func scheduleBindingPublish(_ markdown: String) {
+            bindingPublishWorkItem?.cancel()
+            let item = DispatchWorkItem { [weak self] in
+                self?.publishBinding(markdown)
+            }
+            bindingPublishWorkItem = item
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: item)
+        }
+
+        private func publishBinding(_ markdown: String) {
+            bindingPublishWorkItem?.cancel()
+            bindingPublishWorkItem = nil
+            guard text != markdown else {
+                lastBindingMarkdown = markdown
+                if pendingLocalMarkdown == markdown {
+                    pendingLocalMarkdown = nil
+                }
+                return
+            }
+            text = markdown
+            lastBindingMarkdown = markdown
+            if pendingLocalMarkdown == markdown {
+                pendingLocalMarkdown = nil
+            }
         }
 
         func bodyAttributes() -> [NSAttributedString.Key: Any] {
@@ -166,6 +228,30 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
                 }
             }
             return result
+        }
+
+        private func markdownForLiveEdit(from textView: NSTextView) -> String {
+            // Plain note taking should stay on the NSTextView fast path. Full
+            // markdown serialization walks every attribute run, which is only
+            // needed after the user has used rich editor commands or opened
+            // notes that already contain markdown structure.
+            guard usesMarkdownStyling else {
+                return textView.string
+            }
+            return serializedMarkdown(from: textView)
+        }
+
+        private static func markdownNeedsRichRendering(_ markdown: String) -> Bool {
+            markdown
+                .components(separatedBy: .newlines)
+                .contains { line in
+                    line.hasPrefix("# ")
+                        || line.hasPrefix("- ")
+                        || line.hasPrefix("- [ ] ")
+                        || line.hasPrefix("- [x] ")
+                        || line.hasPrefix("- [X] ")
+                        || line.contains("**")
+                }
         }
 
         private func parseLine(_ line: String) -> (displayText: String, attributes: [NSAttributedString.Key: Any]) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MarkdownRichTextEditor.swift
@@ -1,12 +1,26 @@
 import AppKit
 import SwiftUI
 
+struct MarkdownEditorCommand: Equatable {
+    enum Kind: Equatable {
+        case heading
+        case bold
+        case bullet
+        case checkbox
+    }
+
+    let id = UUID()
+    let kind: Kind
+}
+
 struct MarkdownRichTextEditor: NSViewRepresentable {
     @Binding var text: String
+    @Binding var command: MarkdownEditorCommand?
     var shouldFocus: Bool = false
+    var placeholder: String = "Write notes here..."
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, command: $command)
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -15,14 +29,19 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         scrollView.drawsBackground = false
         scrollView.borderType = .noBorder
 
-        let textView = NSTextView()
+        let textView = PlaceholderTextView()
+        textView.placeholder = placeholder
         textView.delegate = context.coordinator
-        textView.isRichText = false
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isRichText = true
+        textView.importsGraphics = false
+        textView.usesFontPanel = false
+        textView.usesRuler = false
+        textView.isAutomaticQuoteSubstitutionEnabled = true
+        textView.isAutomaticDashSubstitutionEnabled = true
         textView.allowsUndo = true
         textView.drawsBackground = false
-        textView.textContainerInset = NSSize(width: 22, height: 20)
+        textView.insertionPointColor = NSColor.controlAccentColor
+        textView.textContainerInset = NSSize(width: 34, height: 30)
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.isVerticallyResizable = true
@@ -30,7 +49,8 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
         textView.autoresizingMask = [.width]
         textView.textContainer?.containerSize = NSSize(width: scrollView.contentSize.width, height: CGFloat.greatestFiniteMagnitude)
         textView.textContainer?.widthTracksTextView = true
-        context.coordinator.apply(text: text, to: textView)
+        textView.typingAttributes = context.coordinator.bodyAttributes()
+        context.coordinator.apply(markdown: text, to: textView)
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
@@ -38,11 +58,18 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
-        guard let textView = scrollView.documentView as? NSTextView else { return }
-        if textView.string != text {
-            context.coordinator.apply(text: text, to: textView)
-        } else {
-            context.coordinator.restyle(textView)
+        guard let textView = scrollView.documentView as? PlaceholderTextView else { return }
+        textView.placeholder = placeholder
+        if context.coordinator.serializedMarkdown(from: textView) != text {
+            context.coordinator.apply(markdown: text, to: textView)
+        }
+        if let command {
+            context.coordinator.perform(command.kind, in: textView)
+            DispatchQueue.main.async {
+                if self.command?.id == command.id {
+                    self.command = nil
+                }
+            }
         }
         if shouldFocus, !context.coordinator.didFocus {
             DispatchQueue.main.async {
@@ -50,67 +77,354 @@ struct MarkdownRichTextEditor: NSViewRepresentable {
                 context.coordinator.didFocus = true
             }
         }
+        textView.needsDisplay = true
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding private var text: String
+        @Binding private var command: MarkdownEditorCommand?
         weak var textView: NSTextView?
         var didFocus = false
         private var isApplying = false
 
-        init(text: Binding<String>) {
+        private let bodyFont = NSFont.systemFont(ofSize: 16)
+        private let boldFont = NSFont.boldSystemFont(ofSize: 16)
+        private let headingFont = NSFont.systemFont(ofSize: 26, weight: .bold)
+        private let bodyColor = NSColor.labelColor
+        private let secondaryColor = NSColor.secondaryLabelColor
+
+        init(text: Binding<String>, command: Binding<MarkdownEditorCommand?>) {
             _text = text
+            _command = command
         }
 
         func textDidChange(_ notification: Notification) {
             guard !isApplying, let textView = notification.object as? NSTextView else { return }
-            text = textView.string
-            restyle(textView)
+            text = serializedMarkdown(from: textView)
+            textView.needsDisplay = true
         }
 
-        func apply(text: String, to textView: NSTextView) {
-            isApplying = true
-            textView.textStorage?.setAttributedString(styledMarkdown(text))
-            isApplying = false
+        func textView(
+            _ textView: NSTextView,
+            shouldChangeTextIn affectedCharRange: NSRange,
+            replacementString: String?
+        ) -> Bool {
+            guard replacementString == "\n" else { return true }
+            continueListIfNeeded(in: textView, affectedCharRange: affectedCharRange)
+            return false
         }
 
-        func restyle(_ textView: NSTextView) {
+        func apply(markdown: String, to textView: NSTextView) {
             let selectedRanges = textView.selectedRanges
             isApplying = true
-            textView.textStorage?.setAttributedString(styledMarkdown(textView.string))
-            textView.selectedRanges = selectedRanges
+            textView.textStorage?.setAttributedString(attributedString(from: markdown))
+            textView.typingAttributes = bodyAttributes()
+            textView.selectedRanges = selectedRanges.clamped(to: textView.string.count)
             isApplying = false
+            textView.needsDisplay = true
         }
 
-        private func styledMarkdown(_ markdown: String) -> NSAttributedString {
-            let result = NSMutableAttributedString()
-            let bodyFont = NSFont.systemFont(ofSize: 14)
-            let bodyColor = NSColor.labelColor
-            let secondaryColor = NSColor.secondaryLabelColor
-            let paragraph = NSMutableParagraphStyle()
-            paragraph.lineSpacing = 4
-            paragraph.paragraphSpacing = 7
+        func perform(_ command: MarkdownEditorCommand.Kind, in textView: NSTextView) {
+            switch command {
+            case .heading:
+                applyHeading(in: textView)
+            case .bold:
+                toggleBold(in: textView)
+            case .bullet:
+                insertLinePrefix("• ", in: textView)
+            case .checkbox:
+                insertLinePrefix("☐ ", in: textView)
+            }
+            text = serializedMarkdown(from: textView)
+            textView.needsDisplay = true
+            self.command = nil
+        }
 
+        func bodyAttributes() -> [NSAttributedString.Key: Any] {
+            [
+                .font: bodyFont,
+                .foregroundColor: bodyColor,
+                .paragraphStyle: paragraphStyle(spacing: 8, lineHeightMultiple: 1.08)
+            ]
+        }
+
+        private func attributedString(from markdown: String) -> NSAttributedString {
+            let result = NSMutableAttributedString()
             let lines = markdown.components(separatedBy: .newlines)
-            for (index, line) in lines.enumerated() {
-                let attrs: [NSAttributedString.Key: Any]
-                if line.hasPrefix("# ") {
-                    attrs = [.font: NSFont.systemFont(ofSize: 22, weight: .bold), .foregroundColor: bodyColor, .paragraphStyle: paragraph]
-                } else if line.hasPrefix("## ") {
-                    attrs = [.font: NSFont.systemFont(ofSize: 18, weight: .semibold), .foregroundColor: bodyColor, .paragraphStyle: paragraph]
-                } else if line.hasPrefix("### ") {
-                    attrs = [.font: NSFont.systemFont(ofSize: 15, weight: .semibold), .foregroundColor: bodyColor, .paragraphStyle: paragraph]
-                } else if line.hasPrefix("- [ ] ") || line.hasPrefix("- [x] ") || line.hasPrefix("- [X] ") || line.hasPrefix("- ") {
-                    attrs = [.font: bodyFont, .foregroundColor: bodyColor, .paragraphStyle: paragraph]
-                } else {
-                    attrs = [.font: bodyFont, .foregroundColor: bodyColor, .paragraphStyle: paragraph]
-                }
-                result.append(NSAttributedString(string: line, attributes: attrs))
+            for (index, rawLine) in lines.enumerated() {
+                let parsed = parseLine(rawLine)
+                let line = NSMutableAttributedString(string: parsed.displayText, attributes: parsed.attributes)
+                applyInlineBold(in: line, baseAttributes: parsed.attributes)
+                result.append(line)
                 if index < lines.count - 1 {
-                    result.append(NSAttributedString(string: "\n", attributes: [.font: bodyFont, .foregroundColor: secondaryColor]))
+                    result.append(NSAttributedString(string: "\n", attributes: bodyAttributes()))
                 }
             }
             return result
         }
+
+        private func parseLine(_ line: String) -> (displayText: String, attributes: [NSAttributedString.Key: Any]) {
+            if line.hasPrefix("# ") {
+                return (
+                    String(line.dropFirst(2)),
+                    [
+                        .font: headingFont,
+                        .foregroundColor: bodyColor,
+                        .paragraphStyle: paragraphStyle(spacing: 14, lineHeightMultiple: 1.02)
+                    ]
+                )
+            }
+            if line.hasPrefix("- [ ] ") {
+                return ("☐ " + line.dropFirst(6), bodyAttributes())
+            }
+            if line.hasPrefix("- [x] ") || line.hasPrefix("- [X] ") {
+                return ("☑ " + line.dropFirst(6), bodyAttributes())
+            }
+            if line.hasPrefix("- ") {
+                return ("• " + line.dropFirst(2), bodyAttributes())
+            }
+            return (line, bodyAttributes())
+        }
+
+        private func applyInlineBold(
+            in line: NSMutableAttributedString,
+            baseAttributes: [NSAttributedString.Key: Any]
+        ) {
+            let raw = line.string as NSString
+            var searchRange = NSRange(location: 0, length: raw.length)
+            while true {
+                let opening = raw.range(of: "**", options: [], range: searchRange)
+                guard opening.location != NSNotFound else { break }
+                let afterOpening = NSRange(
+                    location: opening.location + opening.length,
+                    length: raw.length - opening.location - opening.length
+                )
+                let closing = raw.range(of: "**", options: [], range: afterOpening)
+                guard closing.location != NSNotFound else { break }
+
+                line.deleteCharacters(in: closing)
+                line.deleteCharacters(in: opening)
+                let boldRange = NSRange(location: opening.location, length: closing.location - opening.location - 2)
+                if boldRange.length > 0 {
+                    let baseFont = baseAttributes[.font] as? NSFont ?? bodyFont
+                    line.addAttribute(.font, value: boldVersion(of: baseFont), range: boldRange)
+                }
+                let nextLocation = opening.location + max(boldRange.length, 0)
+                searchRange = NSRange(location: nextLocation, length: max(line.length - nextLocation, 0))
+                if searchRange.length == 0 { break }
+            }
+        }
+
+        private func applyHeading(in textView: NSTextView) {
+            let ranges = paragraphRanges(for: textView)
+            guard let storage = textView.textStorage else { return }
+            isApplying = true
+            for range in ranges {
+                storage.addAttributes([
+                    .font: headingFont,
+                    .foregroundColor: bodyColor,
+                    .paragraphStyle: paragraphStyle(spacing: 14, lineHeightMultiple: 1.02)
+                ], range: range)
+            }
+            isApplying = false
+        }
+
+        private func toggleBold(in textView: NSTextView) {
+            let selectedRange = textView.selectedRange()
+            if selectedRange.length == 0 {
+                var attributes = textView.typingAttributes
+                let currentFont = attributes[.font] as? NSFont ?? bodyFont
+                attributes[.font] = isBold(currentFont) ? bodyFont : boldVersion(of: currentFont)
+                textView.typingAttributes = attributes
+                return
+            }
+            guard let storage = textView.textStorage else { return }
+            let shouldUnbold = selectionIsBold(in: storage, range: selectedRange)
+            isApplying = true
+            storage.enumerateAttribute(.font, in: selectedRange) { value, range, _ in
+                let currentFont = value as? NSFont ?? bodyFont
+                let replacement = shouldUnbold ? regularVersion(of: currentFont) : boldVersion(of: currentFont)
+                storage.addAttribute(.font, value: replacement, range: range)
+            }
+            isApplying = false
+        }
+
+        private func insertLinePrefix(_ prefix: String, in textView: NSTextView) {
+            let selectedRange = textView.selectedRange()
+            let full = textView.string as NSString
+            let paragraphRange = full.paragraphRange(for: selectedRange)
+            let existingLine = full.substring(with: paragraphRange).trimmingCharacters(in: .newlines)
+            let cleaned = existingLine
+                .replacingOccurrences(of: "• ", with: "")
+                .replacingOccurrences(of: "☐ ", with: "")
+                .replacingOccurrences(of: "☑ ", with: "")
+            let replacement = prefix + cleaned
+            textView.replaceCharacters(in: paragraphRange, with: replacement + (paragraphRange.upperBound < full.length ? "\n" : ""))
+            textView.setSelectedRange(NSRange(location: paragraphRange.location + replacement.count, length: 0))
+        }
+
+        private func continueListIfNeeded(in textView: NSTextView, affectedCharRange: NSRange) {
+            let full = textView.string as NSString
+            let paragraphRange = full.paragraphRange(for: affectedCharRange)
+            let line = full.substring(with: paragraphRange).trimmingCharacters(in: .newlines)
+            let prefix: String?
+            if line.hasPrefix("• ") {
+                prefix = line == "• " ? nil : "\n• "
+            } else if line.hasPrefix("☐ ") {
+                prefix = line == "☐ " ? nil : "\n☐ "
+            } else if line.hasPrefix("☑ ") {
+                prefix = line == "☑ " ? nil : "\n☐ "
+            } else {
+                prefix = "\n"
+            }
+            textView.insertText(prefix ?? "\n", replacementRange: affectedCharRange)
+        }
+
+        private func paragraphRanges(for textView: NSTextView) -> [NSRange] {
+            let selectedRange = textView.selectedRange()
+            let full = textView.string as NSString
+            guard full.length > 0 else { return [NSRange(location: 0, length: 0)] }
+            return full.paragraphRanges(for: selectedRange).map { range in
+                NSRange(location: range.location, length: max(range.length - 1, 0))
+            }
+        }
+
+        func serializedMarkdown(from textView: NSTextView) -> String {
+            guard let storage = textView.textStorage else { return textView.string }
+            var lines: [String] = []
+            let full = storage.string as NSString
+            let fullRange = NSRange(location: 0, length: full.length)
+            full.enumerateSubstrings(in: fullRange, options: [.byLines, .substringNotRequired]) { _, range, _, _ in
+                lines.append(self.markdownLine(from: storage, range: range))
+            }
+            if storage.string.hasSuffix("\n") {
+                lines.append("")
+            }
+            return lines.joined(separator: "\n")
+        }
+
+        private func markdownLine(from storage: NSTextStorage, range: NSRange) -> String {
+            let raw = (storage.string as NSString).substring(with: range)
+            let prefix: String
+            let content: String
+            if raw.hasPrefix("☐ ") {
+                prefix = "- [ ] "
+                content = String(raw.dropFirst(2))
+            } else if raw.hasPrefix("☑ ") {
+                prefix = "- [x] "
+                content = String(raw.dropFirst(2))
+            } else if raw.hasPrefix("• ") {
+                prefix = "- "
+                content = String(raw.dropFirst(2))
+            } else if lineIsHeading(storage: storage, range: range) {
+                prefix = "# "
+                content = raw
+            } else {
+                prefix = ""
+                content = raw
+            }
+            let contentRange = NSRange(location: range.location + raw.count - content.count, length: content.count)
+            return prefix + markdownInline(from: storage, contentRange: contentRange)
+        }
+
+        private func markdownInline(from storage: NSTextStorage, contentRange: NSRange) -> String {
+            guard contentRange.length > 0 else { return "" }
+            var output = ""
+            storage.enumerateAttributes(in: contentRange) { attrs, range, _ in
+                let substring = (storage.string as NSString).substring(with: range)
+                let font = attrs[.font] as? NSFont ?? bodyFont
+                if isBold(font), !lineIsHeading(storage: storage, range: contentRange) {
+                    output += "**\(substring)**"
+                } else {
+                    output += substring
+                }
+            }
+            return output
+        }
+
+        private func lineIsHeading(storage: NSTextStorage, range: NSRange) -> Bool {
+            guard range.length > 0 else { return false }
+            let font = storage.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+            return (font?.pointSize ?? 0) >= 22
+        }
+
+        private func selectionIsBold(in storage: NSTextStorage, range: NSRange) -> Bool {
+            guard range.length > 0 else { return false }
+            var allBold = true
+            storage.enumerateAttribute(.font, in: range) { value, _, stop in
+                let font = value as? NSFont ?? bodyFont
+                if !isBold(font) {
+                    allBold = false
+                    stop.pointee = true
+                }
+            }
+            return allBold
+        }
+
+        private func isBold(_ font: NSFont) -> Bool {
+            NSFontManager.shared.traits(of: font).contains(.boldFontMask)
+        }
+
+        private func boldVersion(of font: NSFont) -> NSFont {
+            NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask)
+        }
+
+        private func regularVersion(of font: NSFont) -> NSFont {
+            NSFontManager.shared.convert(font, toNotHaveTrait: .boldFontMask)
+        }
+
+        private func paragraphStyle(spacing: CGFloat, lineHeightMultiple: CGFloat) -> NSParagraphStyle {
+            let style = NSMutableParagraphStyle()
+            style.lineSpacing = 4
+            style.paragraphSpacing = spacing
+            style.lineHeightMultiple = lineHeightMultiple
+            return style
+        }
+    }
+}
+
+private final class PlaceholderTextView: NSTextView {
+    var placeholder: String = "" {
+        didSet { needsDisplay = true }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard string.isEmpty, !placeholder.isEmpty else { return }
+        let origin = NSPoint(
+            x: textContainerInset.width + 5,
+            y: textContainerInset.height
+        )
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 16),
+            .foregroundColor: NSColor.placeholderTextColor
+        ]
+        placeholder.draw(at: origin, withAttributes: attributes)
+    }
+}
+
+private extension Array where Element == NSValue {
+    func clamped(to stringLength: Int) -> [NSValue] {
+        map { value in
+            let range = value.rangeValue
+            let location = Swift.min(range.location, stringLength)
+            let length = Swift.min(range.length, Swift.max(stringLength - location, 0))
+            return NSValue(range: NSRange(location: location, length: length))
+        }
+    }
+}
+
+private extension NSString {
+    func paragraphRanges(for range: NSRange) -> [NSRange] {
+        let safeRange = NSRange(location: min(range.location, length), length: min(range.length, max(length - range.location, 0)))
+        let paragraphRange = self.paragraphRange(for: safeRange)
+        var ranges: [NSRange] = []
+        var location = paragraphRange.location
+        while location < paragraphRange.upperBound {
+            let current = self.paragraphRange(for: NSRange(location: location, length: 0))
+            ranges.append(current)
+            location = current.upperBound
+        }
+        return ranges.isEmpty ? [paragraphRange] : ranges
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -6,6 +6,18 @@ private enum MeetingDocumentMode: Hashable {
     case transcript
 }
 
+private enum ManualNotesSaveStatus {
+    case saved
+    case saving
+
+    var label: String {
+        switch self {
+        case .saved: return "Saved"
+        case .saving: return "Saving..."
+        }
+    }
+}
+
 struct MeetingDetailView: View {
     let meeting: MeetingRecord?
     let controller: MuesliController
@@ -17,11 +29,14 @@ struct MeetingDetailView: View {
     @State private var editableTitle: String
     @State private var editableNotes: String
     @State private var editableManualNotes: String
+    @State private var loadedMeetingID: Int64?
+    @State private var manualNotesSaveStatus: ManualNotesSaveStatus = .saved
     @State private var manualEditorCommand: MarkdownEditorCommand?
     @State private var pendingTemplateID: String
     @State private var documentMode: MeetingDocumentMode
     @State private var titleSaveTask: DispatchWorkItem?
     @State private var notesSaveTask: DispatchWorkItem?
+    @State private var manualNotesSaveStatusTask: DispatchWorkItem?
     @State private var summaryErrorMessage: String?
     @State private var showDeleteConfirmation = false
 
@@ -41,6 +56,7 @@ struct MeetingDetailView: View {
         _editableTitle = State(initialValue: meeting?.title ?? "")
         _editableNotes = State(initialValue: meeting.map { Self.notesContent(for: $0) } ?? "")
         _editableManualNotes = State(initialValue: meeting?.manualNotes ?? "")
+        _loadedMeetingID = State(initialValue: meeting?.id)
         _pendingTemplateID = State(initialValue: initialTemplateID)
         _documentMode = State(initialValue: meeting.map(Self.defaultDocumentMode(for:)) ?? .notes)
     }
@@ -62,6 +78,9 @@ struct MeetingDetailView: View {
                 }
                 .onChange(of: meeting.status) { _, _ in
                     syncLocalState(with: meeting)
+                }
+                .onChange(of: meeting.manualNotes) { _, _ in
+                    syncManualNotesState(with: meeting)
                 }
                 .onChange(of: appState.config.customMeetingTemplates) { _, _ in
                     syncPendingTemplateSelectionIfNeeded(for: meeting)
@@ -458,6 +477,12 @@ struct MeetingDetailView: View {
     @ViewBuilder
     private func manualNotesToolbar(for meeting: MeetingRecord) -> some View {
         HStack(spacing: MuesliTheme.spacing8) {
+            if canEditManualNotes(for: meeting) {
+                Text(manualNotesSaveStatus.label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+
             Spacer()
 
             markdownToolbarButton(systemImage: "textformat.size", label: "Heading") {
@@ -773,7 +798,22 @@ struct MeetingDetailView: View {
     }
 
     private func saveManualNotes(meetingID: Int64, notes: String) {
+        manualNotesSaveStatus = .saving
         controller.cacheMeetingManualNotes(id: meetingID, notes: notes)
+        scheduleManualNotesSaveStatusCheck(meetingID: meetingID, notes: notes)
+    }
+
+    private func scheduleManualNotesSaveStatusCheck(meetingID: Int64, notes: String) {
+        manualNotesSaveStatusTask?.cancel()
+        let item = DispatchWorkItem {
+            guard loadedMeetingID == meetingID else { return }
+            guard editableManualNotes == notes else { return }
+            if controller.hasPersistedMeetingManualNotes(id: meetingID, notes: notes) {
+                manualNotesSaveStatus = .saved
+            }
+        }
+        manualNotesSaveStatusTask = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: item)
     }
 
     private var summaryErrorBinding: Binding<Bool> {
@@ -812,11 +852,27 @@ struct MeetingDetailView: View {
     }
 
     private func syncLocalState(with meeting: MeetingRecord?) {
+        let previousMeetingID = loadedMeetingID
+        loadedMeetingID = meeting?.id
         editableTitle = meeting?.title ?? ""
         editableNotes = meeting.map { Self.notesContent(for: $0) } ?? ""
-        editableManualNotes = meeting?.manualNotes ?? ""
+        if previousMeetingID != meeting?.id {
+            editableManualNotes = meeting?.manualNotes ?? ""
+            manualNotesSaveStatus = .saved
+        } else {
+            syncManualNotesState(with: meeting)
+        }
         pendingTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
+    }
+
+    private func syncManualNotesState(with meeting: MeetingRecord?) {
+        let persistedManualNotes = meeting?.manualNotes ?? ""
+        if manualNotesSaveStatus == .saving, editableManualNotes != persistedManualNotes {
+            return
+        }
+        editableManualNotes = persistedManualNotes
+        manualNotesSaveStatus = .saved
     }
 
     private func formatMeta(_ meeting: MeetingRecord) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -480,9 +480,9 @@ struct MeetingDetailView: View {
     private func statusChip(for meeting: MeetingRecord) -> some View {
         HStack(spacing: 6) {
             Circle()
-                .fill(statusColor(for: meeting.status))
+                .fill(meeting.status.displayColor)
                 .frame(width: 7, height: 7)
-            Text(statusLabel(for: meeting.status))
+            Text(meeting.status.displayLabel)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
@@ -764,36 +764,6 @@ struct MeetingDetailView: View {
 
     private func saveManualNotes(meetingID: Int64) {
         controller.cacheMeetingManualNotes(id: meetingID, notes: editableManualNotes)
-    }
-
-    private func statusLabel(for status: MeetingStatus) -> String {
-        switch status {
-        case .recording:
-            return "Recording"
-        case .processing:
-            return "Processing"
-        case .completed:
-            return "Completed"
-        case .noteOnly:
-            return "Note only"
-        case .failed:
-            return "Needs attention"
-        }
-    }
-
-    private func statusColor(for status: MeetingStatus) -> Color {
-        switch status {
-        case .recording:
-            return MuesliTheme.recording
-        case .processing:
-            return MuesliTheme.accent
-        case .completed:
-            return MuesliTheme.success
-        case .noteOnly:
-            return MuesliTheme.textTertiary
-        case .failed:
-            return MuesliTheme.transcribing
-        }
     }
 
     private var summaryErrorBinding: Binding<Bool> {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -16,6 +16,7 @@ struct MeetingDetailView: View {
     @State private var isEditingNotes = false
     @State private var editableTitle: String
     @State private var editableNotes: String
+    @State private var editableManualNotes: String
     @State private var pendingTemplateID: String
     @State private var documentMode: MeetingDocumentMode
     @State private var titleSaveTask: DispatchWorkItem?
@@ -38,6 +39,7 @@ struct MeetingDetailView: View {
         let initialTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         _editableTitle = State(initialValue: meeting?.title ?? "")
         _editableNotes = State(initialValue: meeting.map { Self.notesContent(for: $0) } ?? "")
+        _editableManualNotes = State(initialValue: meeting?.manualNotes ?? "")
         _pendingTemplateID = State(initialValue: initialTemplateID)
         _documentMode = State(initialValue: meeting.map(Self.defaultDocumentMode(for:)) ?? .notes)
     }
@@ -55,6 +57,9 @@ struct MeetingDetailView: View {
                 }
                 .background(MuesliTheme.backgroundBase)
                 .onChange(of: meeting.id) { _, _ in
+                    syncLocalState(with: meeting)
+                }
+                .onChange(of: meeting.status) { _, _ in
                     syncLocalState(with: meeting)
                 }
                 .onChange(of: appState.config.customMeetingTemplates) { _, _ in
@@ -133,26 +138,35 @@ struct MeetingDetailView: View {
                 Spacer(minLength: MuesliTheme.spacing16)
 
                 VStack(alignment: .trailing, spacing: 10) {
-                    documentModePicker
-
-                    ViewThatFits(in: .horizontal) {
+                    if showsManualNotesEditor(for: meeting) {
                         HStack(spacing: MuesliTheme.spacing8) {
-                            templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                            recordingAction(for: meeting)
-                            summaryAction(for: meeting)
-                            editButton(for: meeting)
-                            deleteButton
+                            statusChip(for: meeting)
+                            if meeting.status == .noteOnly || meeting.status == .failed {
+                                deleteButton
+                            }
                         }
+                    } else {
+                        documentModePicker
 
-                        VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
+                        ViewThatFits(in: .horizontal) {
                             HStack(spacing: MuesliTheme.spacing8) {
                                 templateMenu(for: meeting, appliedTemplate: appliedTemplate)
                                 recordingAction(for: meeting)
                                 summaryAction(for: meeting)
-                            }
-                            HStack(spacing: MuesliTheme.spacing8) {
                                 editButton(for: meeting)
                                 deleteButton
+                            }
+
+                            VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
+                                HStack(spacing: MuesliTheme.spacing8) {
+                                    templateMenu(for: meeting, appliedTemplate: appliedTemplate)
+                                    recordingAction(for: meeting)
+                                    summaryAction(for: meeting)
+                                }
+                                HStack(spacing: MuesliTheme.spacing8) {
+                                    editButton(for: meeting)
+                                    deleteButton
+                                }
                             }
                         }
                     }
@@ -171,7 +185,30 @@ struct MeetingDetailView: View {
 
     @ViewBuilder
     private func content(for meeting: MeetingRecord) -> some View {
-        if isEditingNotes {
+        if showsManualNotesEditor(for: meeting) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                manualNotesToolbar(for: meeting)
+
+                MarkdownRichTextEditor(
+                    text: $editableManualNotes,
+                    shouldFocus: meeting.status == .recording
+                )
+                .frame(maxWidth: 980, maxHeight: .infinity, alignment: .topLeading)
+                .background(MuesliTheme.backgroundBase)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+                .onChange(of: editableManualNotes) { _, _ in
+                    saveManualNotes(meetingID: meeting.id)
+                }
+            }
+            .padding(.horizontal, 40)
+            .padding(.top, 12)
+            .padding(.bottom, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        } else if isEditingNotes {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 contentToolbar(for: meeting)
 
@@ -222,6 +259,15 @@ struct MeetingDetailView: View {
         .tint(MuesliTheme.accent)
         .frame(width: 220)
         .disabled(isEditingNotes)
+    }
+
+    private func showsManualNotesEditor(for meeting: MeetingRecord) -> Bool {
+        switch meeting.status {
+        case .recording, .processing, .noteOnly, .failed:
+            return true
+        case .completed:
+            return false
+        }
     }
 
     @ViewBuilder
@@ -390,6 +436,74 @@ struct MeetingDetailView: View {
             .buttonStyle(.plain)
         }
         .frame(maxWidth: 980, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func manualNotesToolbar(for meeting: MeetingRecord) -> some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            statusChip(for: meeting)
+
+            Spacer()
+
+            markdownToolbarButton("H1", label: "Heading") {
+                appendManualMarkdown("# ")
+            }
+            markdownToolbarButton("B", label: "Bold") {
+                appendManualMarkdown("**bold text**")
+            }
+            markdownToolbarButton("list.bullet", label: "Bullet") {
+                appendManualMarkdown("- ")
+            }
+            markdownToolbarButton("checklist", label: "Checkbox") {
+                appendManualMarkdown("- [ ] ")
+            }
+        }
+        .frame(maxWidth: 980, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func statusChip(for meeting: MeetingRecord) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(statusColor(for: meeting.status))
+                .frame(width: 7, height: 7)
+            Text(statusLabel(for: meeting.status))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textSecondary)
+        }
+        .padding(.horizontal, MuesliTheme.spacing8)
+        .padding(.vertical, 6)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(Capsule())
+        .overlay(
+            Capsule()
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func markdownToolbarButton(_ title: String, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Group {
+                if title.contains(".") {
+                    Image(systemName: title)
+                        .font(.system(size: 12, weight: .semibold))
+                } else {
+                    Text(title)
+                        .font(.system(size: 12, weight: .bold))
+                }
+            }
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .frame(width: 30, height: 28)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help(label)
     }
 
     @ViewBuilder
@@ -578,6 +692,9 @@ struct MeetingDetailView: View {
     }
 
     static func notesContent(for meeting: MeetingRecord) -> String {
+        if meeting.status == .noteOnly {
+            return meeting.manualNotes
+        }
         if meeting.notesState != .structuredNotes {
             return "# \(meeting.title)\n\n## Raw Transcript\n\n\(meeting.rawTranscript)"
         }
@@ -585,7 +702,12 @@ struct MeetingDetailView: View {
     }
 
     private static func defaultDocumentMode(for meeting: MeetingRecord) -> MeetingDocumentMode {
-        meeting.notesState == .structuredNotes ? .notes : .transcript
+        if meeting.status == .noteOnly || meeting.status == .recording || meeting.status == .processing || meeting.status == .failed {
+            return .notes
+        }
+        return meeting.notesState == .structuredNotes
+            ? MeetingDocumentMode.notes
+            : MeetingDocumentMode.transcript
     }
 
     private func debounceSaveTitle(meetingID: Int64) {
@@ -604,6 +726,47 @@ struct MeetingDetailView: View {
         let item = DispatchWorkItem { c.updateMeetingNotes(id: meetingID, notes: notes) }
         notesSaveTask = item
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
+    }
+
+    private func saveManualNotes(meetingID: Int64) {
+        controller.updateMeetingManualNotes(id: meetingID, notes: editableManualNotes)
+    }
+
+    private func appendManualMarkdown(_ markdown: String) {
+        if !editableManualNotes.isEmpty, !editableManualNotes.hasSuffix("\n") {
+            editableManualNotes += "\n"
+        }
+        editableManualNotes += markdown
+    }
+
+    private func statusLabel(for status: MeetingStatus) -> String {
+        switch status {
+        case .recording:
+            return "Recording"
+        case .processing:
+            return "Processing"
+        case .completed:
+            return "Completed"
+        case .noteOnly:
+            return "Note only"
+        case .failed:
+            return "Needs attention"
+        }
+    }
+
+    private func statusColor(for status: MeetingStatus) -> Color {
+        switch status {
+        case .recording:
+            return MuesliTheme.recording
+        case .processing:
+            return MuesliTheme.accent
+        case .completed:
+            return MuesliTheme.success
+        case .noteOnly:
+            return MuesliTheme.textTertiary
+        case .failed:
+            return MuesliTheme.transcribing
+        }
     }
 
     private var summaryErrorBinding: Binding<Bool> {
@@ -644,6 +807,7 @@ struct MeetingDetailView: View {
     private func syncLocalState(with meeting: MeetingRecord?) {
         editableTitle = meeting?.title ?? ""
         editableNotes = meeting.map { Self.notesContent(for: $0) } ?? ""
+        editableManualNotes = meeting?.manualNotes ?? ""
         pendingTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -203,7 +203,11 @@ struct MeetingDetailView: View {
                     text: $editableManualNotes,
                     command: $manualEditorCommand,
                     shouldFocus: isManualNotesEditable && meeting.status == .recording,
-                    isEditable: isManualNotesEditable
+                    isEditable: isManualNotesEditable,
+                    onTextChange: { notes in
+                        guard isManualNotesEditable else { return }
+                        saveManualNotes(meetingID: meeting.id, notes: notes)
+                    }
                 )
                 .frame(maxWidth: 980, maxHeight: .infinity, alignment: .topLeading)
                 .background(MuesliTheme.backgroundBase)
@@ -212,10 +216,6 @@ struct MeetingDetailView: View {
                     RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                         .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
                 )
-                .onChange(of: editableManualNotes) { _, _ in
-                    guard isManualNotesEditable else { return }
-                    saveManualNotes(meetingID: meeting.id)
-                }
             }
             .padding(.horizontal, 40)
             .padding(.top, 12)
@@ -591,6 +591,9 @@ struct MeetingDetailView: View {
 
     private var stopRecordingButton: some View {
         Button {
+            if let meeting {
+                flushTitleSave(meetingID: meeting.id)
+            }
             controller.stopMeetingRecording()
         } label: {
             HStack(spacing: 6) {
@@ -753,6 +756,12 @@ struct MeetingDetailView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
     }
 
+    private func flushTitleSave(meetingID: Int64) {
+        titleSaveTask?.cancel()
+        titleSaveTask = nil
+        controller.updateMeetingTitle(id: meetingID, title: editableTitle)
+    }
+
     private func debounceSaveNotes(meetingID: Int64) {
         notesSaveTask?.cancel()
         let notes = editableNotes
@@ -762,8 +771,8 @@ struct MeetingDetailView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
     }
 
-    private func saveManualNotes(meetingID: Int64) {
-        controller.cacheMeetingManualNotes(id: meetingID, notes: editableManualNotes)
+    private func saveManualNotes(meetingID: Int64, notes: String) {
+        controller.cacheMeetingManualNotes(id: meetingID, notes: notes)
     }
 
     private var summaryErrorBinding: Binding<Bool> {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -17,6 +17,7 @@ struct MeetingDetailView: View {
     @State private var editableTitle: String
     @State private var editableNotes: String
     @State private var editableManualNotes: String
+    @State private var manualEditorCommand: MarkdownEditorCommand?
     @State private var pendingTemplateID: String
     @State private var documentMode: MeetingDocumentMode
     @State private var titleSaveTask: DispatchWorkItem?
@@ -141,7 +142,10 @@ struct MeetingDetailView: View {
                     if showsManualNotesEditor(for: meeting) {
                         HStack(spacing: MuesliTheme.spacing8) {
                             statusChip(for: meeting)
-                            if meeting.status == .noteOnly || meeting.status == .failed {
+                            if meeting.status == .recording {
+                                stopRecordingButton
+                                discardRecordingButton
+                            } else if meeting.status == .noteOnly || meeting.status == .failed {
                                 deleteButton
                             }
                         }
@@ -173,7 +177,7 @@ struct MeetingDetailView: View {
                 }
             }
 
-            if isRawTranscript(meeting) && documentMode == .notes {
+            if !showsManualNotesEditor(for: meeting), isRawTranscript(meeting), documentMode == .notes {
                 transcriptCTA
             }
         }
@@ -191,6 +195,7 @@ struct MeetingDetailView: View {
 
                 MarkdownRichTextEditor(
                     text: $editableManualNotes,
+                    command: $manualEditorCommand,
                     shouldFocus: meeting.status == .recording
                 )
                 .frame(maxWidth: 980, maxHeight: .infinity, alignment: .topLeading)
@@ -441,21 +446,19 @@ struct MeetingDetailView: View {
     @ViewBuilder
     private func manualNotesToolbar(for meeting: MeetingRecord) -> some View {
         HStack(spacing: MuesliTheme.spacing8) {
-            statusChip(for: meeting)
-
             Spacer()
 
-            markdownToolbarButton("H1", label: "Heading") {
-                appendManualMarkdown("# ")
+            markdownToolbarButton(systemImage: "textformat.size", label: "Heading") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .heading)
             }
-            markdownToolbarButton("B", label: "Bold") {
-                appendManualMarkdown("**bold text**")
+            markdownToolbarButton(systemImage: "bold", label: "Bold") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .bold)
             }
-            markdownToolbarButton("list.bullet", label: "Bullet") {
-                appendManualMarkdown("- ")
+            markdownToolbarButton(systemImage: "list.bullet", label: "Bullet") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .bullet)
             }
-            markdownToolbarButton("checklist", label: "Checkbox") {
-                appendManualMarkdown("- [ ] ")
+            markdownToolbarButton(systemImage: "checklist", label: "Checkbox") {
+                manualEditorCommand = MarkdownEditorCommand(kind: .checkbox)
             }
         }
         .frame(maxWidth: 980, alignment: .leading)
@@ -482,19 +485,12 @@ struct MeetingDetailView: View {
     }
 
     @ViewBuilder
-    private func markdownToolbarButton(_ title: String, label: String, action: @escaping () -> Void) -> some View {
+    private func markdownToolbarButton(systemImage: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            Group {
-                if title.contains(".") {
-                    Image(systemName: title)
-                        .font(.system(size: 12, weight: .semibold))
-                } else {
-                    Text(title)
-                        .font(.system(size: 12, weight: .bold))
-                }
-            }
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .semibold))
             .foregroundStyle(MuesliTheme.textSecondary)
-            .frame(width: 30, height: 28)
+            .frame(width: 34, height: 30)
             .background(MuesliTheme.surfacePrimary)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             .overlay(
@@ -578,6 +574,32 @@ struct MeetingDetailView: View {
     private var deleteButton: some View {
         iconButton("trash", label: "Delete") {
             showDeleteConfirmation = true
+        }
+    }
+
+    private var stopRecordingButton: some View {
+        Button {
+            controller.stopMeetingRecording()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text("Stop Recording")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, 8)
+            .background(MuesliTheme.recording)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        }
+        .buttonStyle(.plain)
+        .help("Stop recording")
+    }
+
+    private var discardRecordingButton: some View {
+        iconButton("xmark", label: "Discard") {
+            controller.discardMeetingRecording()
         }
     }
 
@@ -730,13 +752,6 @@ struct MeetingDetailView: View {
 
     private func saveManualNotes(meetingID: Int64) {
         controller.updateMeetingManualNotes(id: meetingID, notes: editableManualNotes)
-    }
-
-    private func appendManualMarkdown(_ markdown: String) {
-        if !editableManualNotes.isEmpty, !editableManualNotes.hasSuffix("\n") {
-            editableManualNotes += "\n"
-        }
-        editableManualNotes += markdown
     }
 
     private func statusLabel(for status: MeetingStatus) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -22,6 +22,7 @@ struct MeetingDetailView: View {
     @State private var documentMode: MeetingDocumentMode
     @State private var titleSaveTask: DispatchWorkItem?
     @State private var notesSaveTask: DispatchWorkItem?
+    @State private var manualNotesSaveTask: DispatchWorkItem?
     @State private var summaryErrorMessage: String?
     @State private var showDeleteConfirmation = false
 
@@ -751,7 +752,14 @@ struct MeetingDetailView: View {
     }
 
     private func saveManualNotes(meetingID: Int64) {
-        controller.updateMeetingManualNotes(id: meetingID, notes: editableManualNotes)
+        controller.cacheMeetingManualNotes(id: meetingID, notes: editableManualNotes)
+        manualNotesSaveTask?.cancel()
+        let c = controller
+        let item = DispatchWorkItem {
+            c.flushCachedMeetingManualNotes(id: meetingID)
+        }
+        manualNotesSaveTask = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
     }
 
     private func statusLabel(for status: MeetingStatus) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -22,7 +22,6 @@ struct MeetingDetailView: View {
     @State private var documentMode: MeetingDocumentMode
     @State private var titleSaveTask: DispatchWorkItem?
     @State private var notesSaveTask: DispatchWorkItem?
-    @State private var manualNotesSaveTask: DispatchWorkItem?
     @State private var summaryErrorMessage: String?
     @State private var showDeleteConfirmation = false
 
@@ -195,13 +194,16 @@ struct MeetingDetailView: View {
     @ViewBuilder
     private func content(for meeting: MeetingRecord) -> some View {
         if showsManualNotesEditor(for: meeting) {
+            let isManualNotesEditable = canEditManualNotes(for: meeting)
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 manualNotesToolbar(for: meeting)
+                    .disabled(!isManualNotesEditable)
 
                 MarkdownRichTextEditor(
                     text: $editableManualNotes,
                     command: $manualEditorCommand,
-                    shouldFocus: meeting.status == .recording
+                    shouldFocus: isManualNotesEditable && meeting.status == .recording,
+                    isEditable: isManualNotesEditable
                 )
                 .frame(maxWidth: 980, maxHeight: .infinity, alignment: .topLeading)
                 .background(MuesliTheme.backgroundBase)
@@ -211,6 +213,7 @@ struct MeetingDetailView: View {
                         .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
                 )
                 .onChange(of: editableManualNotes) { _, _ in
+                    guard isManualNotesEditable else { return }
                     saveManualNotes(meetingID: meeting.id)
                 }
             }
@@ -278,6 +281,10 @@ struct MeetingDetailView: View {
         case .completed:
             return false
         }
+    }
+
+    private func canEditManualNotes(for meeting: MeetingRecord) -> Bool {
+        meeting.status != .processing
     }
 
     @ViewBuilder
@@ -757,13 +764,6 @@ struct MeetingDetailView: View {
 
     private func saveManualNotes(meetingID: Int64) {
         controller.cacheMeetingManualNotes(id: meetingID, notes: editableManualNotes)
-        manualNotesSaveTask?.cancel()
-        let c = controller
-        let item = DispatchWorkItem {
-            c.flushCachedMeetingManualNotes(id: meetingID)
-        }
-        manualNotesSaveTask = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
     }
 
     private func statusLabel(for status: MeetingStatus) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -146,7 +146,7 @@ struct MeetingDetailView: View {
                             if meeting.status == .recording {
                                 stopRecordingButton
                                 discardRecordingButton
-                            } else if meeting.status == .noteOnly || meeting.status == .failed {
+                            } else if controller.canDeleteMeeting(meeting), meeting.status == .noteOnly || meeting.status == .failed {
                                 deleteButton
                             }
                         }
@@ -159,7 +159,9 @@ struct MeetingDetailView: View {
                                 recordingAction(for: meeting)
                                 summaryAction(for: meeting)
                                 editButton(for: meeting)
-                                deleteButton
+                                if controller.canDeleteMeeting(meeting) {
+                                    deleteButton
+                                }
                             }
 
                             VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
@@ -170,7 +172,9 @@ struct MeetingDetailView: View {
                                 }
                                 HStack(spacing: MuesliTheme.spacing8) {
                                     editButton(for: meeting)
-                                    deleteButton
+                                    if controller.canDeleteMeeting(meeting) {
+                                        deleteButton
+                                    }
                                 }
                             }
                         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -284,7 +284,7 @@ struct MeetingDetailView: View {
     }
 
     private func canEditManualNotes(for meeting: MeetingRecord) -> Bool {
-        meeting.status != .processing
+        meeting.status == .recording || meeting.status == .noteOnly || meeting.status == .failed
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -751,6 +751,7 @@ struct MeetingDetailView: View {
         titleSaveTask?.cancel()
         let title = editableTitle
         let c = controller
+        c.cacheMeetingTitle(id: meetingID, title: title)
         let item = DispatchWorkItem { c.updateMeetingTitle(id: meetingID, title: title) }
         titleSaveTask = item
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
@@ -196,12 +196,12 @@ struct MeetingListItemView: View {
     // MARK: - Formatting
 
     private var statusBadge: some View {
-        Text(statusLabel(record.status))
+        Text(record.status.displayLabel)
             .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(statusColor(record.status))
+            .foregroundStyle(record.status.displayColor)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(statusColor(record.status).opacity(0.12))
+            .background(record.status.displayColor.opacity(0.12))
             .clipShape(Capsule())
     }
 
@@ -247,33 +247,4 @@ struct MeetingListItemView: View {
         return compact.isEmpty ? "No notes yet" : compact
     }
 
-    private func statusLabel(_ status: MeetingStatus) -> String {
-        switch status {
-        case .recording:
-            return "Recording"
-        case .processing:
-            return "Processing"
-        case .completed:
-            return "Completed"
-        case .noteOnly:
-            return "Note only"
-        case .failed:
-            return "Needs attention"
-        }
-    }
-
-    private func statusColor(_ status: MeetingStatus) -> Color {
-        switch status {
-        case .recording:
-            return MuesliTheme.recording
-        case .processing:
-            return MuesliTheme.accent
-        case .completed:
-            return MuesliTheme.success
-        case .noteOnly:
-            return MuesliTheme.textSecondary
-        case .failed:
-            return MuesliTheme.transcribing
-        }
-    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
@@ -41,6 +41,12 @@ struct MeetingListItemView: View {
             }
 
             HStack(spacing: MuesliTheme.spacing4) {
+                if record.status != .completed {
+                    statusBadge
+                    Text("\u{2022}")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
                 Text(formatMeta())
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textSecondary)
@@ -189,6 +195,16 @@ struct MeetingListItemView: View {
 
     // MARK: - Formatting
 
+    private var statusBadge: some View {
+        Text(statusLabel(record.status))
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(statusColor(record.status))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(statusColor(record.status).opacity(0.12))
+            .clipShape(Capsule())
+    }
+
     private func formatMeta() -> String {
         let time = formatTime(record.startTime)
         let duration = formatDuration(record.durationSeconds)
@@ -217,11 +233,47 @@ struct MeetingListItemView: View {
     }
 
     private func previewText() -> String {
-        let source = record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
+        let source: String
+        if !record.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           record.status != .completed {
+            source = record.manualNotes
+        } else {
+            source = record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
+        }
         let compact = source.split(whereSeparator: \.isWhitespace).joined(separator: " ")
         if compact.count > 88 {
             return String(compact.prefix(85)) + "..."
         }
-        return compact
+        return compact.isEmpty ? "No notes yet" : compact
+    }
+
+    private func statusLabel(_ status: MeetingStatus) -> String {
+        switch status {
+        case .recording:
+            return "Recording"
+        case .processing:
+            return "Processing"
+        case .completed:
+            return "Completed"
+        case .noteOnly:
+            return "Note only"
+        case .failed:
+            return "Needs attention"
+        }
+    }
+
+    private func statusColor(_ status: MeetingStatus) -> Color {
+        switch status {
+        case .recording:
+            return MuesliTheme.recording
+        case .processing:
+            return MuesliTheme.accent
+        case .completed:
+            return MuesliTheme.success
+        case .noteOnly:
+            return MuesliTheme.textSecondary
+        case .failed:
+            return MuesliTheme.transcribing
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -473,15 +473,26 @@ final class MeetingSession {
         fputs("[meeting] visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(config.useCoreAudioTap)\n", stderr)
         onProgress?(.summarizingNotes)
         let manualNotes = await manualNotesProvider?()
-        let formattedNotes = await MeetingSummaryClient.summarize(
-            transcript: rawTranscript,
-            meetingTitle: generatedTitle,
-            config: config,
-            template: templateSnapshot,
-            existingNotes: manualNotes,
-            manualNotesToRetain: manualNotes,
-            visualContext: visualContext.isEmpty ? nil : visualContext
-        )
+        let formattedNotes: String
+        do {
+            formattedNotes = try await MeetingSummaryClient.summarize(
+                transcript: rawTranscript,
+                meetingTitle: generatedTitle,
+                config: config,
+                template: templateSnapshot,
+                existingNotes: manualNotes,
+                manualNotesToRetain: manualNotes,
+                visualContext: visualContext.isEmpty ? nil : visualContext
+            )
+        } catch {
+            fputs("[meeting] summary generation failed: \(error.localizedDescription)\n", stderr)
+            formattedNotes = MeetingSummaryClient.summaryFailureNotes(
+                transcript: rawTranscript,
+                meetingTitle: generatedTitle,
+                error: error,
+                manualNotes: manualNotes
+            )
+        }
 
         return MeetingSessionResult(
             title: generatedTitle,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -109,6 +109,7 @@ final class MeetingSession {
     private var systemChunkTimingTracker = MeetingChunkTimingTracker()
     private var systemChunkRecorder: PCMChunkRecorder?
     var onProgress: ((MeetingProcessingStage) -> Void)?
+    var manualNotesProvider: (() async -> String?)?
     private let screenContextCollector = MeetingScreenContextCollector()
 
     /// Current mic power level for waveform visualization.
@@ -471,11 +472,14 @@ final class MeetingSession {
         Self.logger.info("visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(self.config.useCoreAudioTap)")
         fputs("[meeting] visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(config.useCoreAudioTap)\n", stderr)
         onProgress?(.summarizingNotes)
+        let manualNotes = await manualNotesProvider?()
         let formattedNotes = await MeetingSummaryClient.summarize(
             transcript: rawTranscript,
             meetingTitle: generatedTitle,
             config: config,
             template: templateSnapshot,
+            existingNotes: manualNotes,
+            manualNotesToRetain: manualNotes,
             visualContext: visualContext.isEmpty ? nil : visualContext
         )
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -54,6 +54,7 @@ final class MeetingChunkCollector {
 
 struct MeetingSessionResult {
     let title: String
+    let originalTitle: String
     let calendarEventID: String?
     let startTime: Date
     let endTime: Date
@@ -110,6 +111,7 @@ final class MeetingSession {
     private var systemChunkRecorder: PCMChunkRecorder?
     var onProgress: ((MeetingProcessingStage) -> Void)?
     var manualNotesProvider: (() async -> String?)?
+    var liveTitleProvider: (() async -> String?)?
     private let screenContextCollector = MeetingScreenContextCollector()
 
     /// Current mic power level for waveform visualization.
@@ -456,7 +458,9 @@ final class MeetingSession {
 
         let generatedTitle: String
         onProgress?(.generatingTitle)
-        if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: rawTranscript, config: config),
+        if let liveTitle = await userEditedLiveTitle() {
+            generatedTitle = liveTitle
+        } else if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: rawTranscript, config: config),
            !autoTitle.isEmpty {
             generatedTitle = autoTitle
             fputs("[meeting] auto-generated title: \(generatedTitle)\n", stderr)
@@ -496,6 +500,7 @@ final class MeetingSession {
 
         return MeetingSessionResult(
             title: generatedTitle,
+            originalTitle: title,
             calendarEventID: calendarEventID,
             startTime: meetingStart,
             endTime: endTime,
@@ -507,6 +512,15 @@ final class MeetingSession {
             systemRecordingURL: systemAudioURL,
             templateSnapshot: templateSnapshot
         )
+    }
+
+    private func userEditedLiveTitle() async -> String? {
+        guard let candidate = await liveTitleProvider?() else { return nil }
+        let trimmedCandidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedOriginal = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCandidate.isEmpty else { return nil }
+        guard trimmedCandidate != trimmedOriginal else { return nil }
+        return trimmedCandidate
     }
 
     /// Called by VAD on speech boundaries or max-duration fallback.

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -480,7 +480,7 @@ final class MeetingSession {
                 meetingTitle: generatedTitle,
                 config: config,
                 template: templateSnapshot,
-                existingNotes: manualNotes,
+                existingNotes: nil,
                 manualNotesToRetain: manualNotes,
                 visualContext: visualContext.isEmpty ? nil : visualContext
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStatusDisplay.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStatusDisplay.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import MuesliCore
+
+extension MeetingStatus {
+    var displayLabel: String {
+        switch self {
+        case .recording:
+            return "Recording"
+        case .processing:
+            return "Processing"
+        case .completed:
+            return "Completed"
+        case .noteOnly:
+            return "Note only"
+        case .failed:
+            return "Needs attention"
+        }
+    }
+
+    var displayColor: Color {
+        switch self {
+        case .recording:
+            return MuesliTheme.recording
+        case .processing:
+            return MuesliTheme.accent
+        case .completed:
+            return MuesliTheme.success
+        case .noteOnly:
+            return MuesliTheme.textTertiary
+        case .failed:
+            return MuesliTheme.transcribing
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -31,11 +31,13 @@ enum MeetingSummaryClient {
         config: AppConfig,
         template: MeetingTemplateSnapshot = MeetingTemplates.auto.snapshot,
         existingNotes: String? = nil,
+        manualNotesToRetain: String? = nil,
         visualContext: String? = nil
     ) async -> String {
         let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.openAI.backend : config.meetingSummaryBackend).lowercased()
+        let generatedNotes: String
         if backend == MeetingSummaryBackendOption.chatGPT.backend {
-            return await summarizeWithChatGPT(
+            generatedNotes = await summarizeWithChatGPT(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -43,9 +45,10 @@ enum MeetingSummaryClient {
                 template: template,
                 visualContext: visualContext
             )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
         }
         if backend == MeetingSummaryBackendOption.openRouter.backend {
-            return await summarizeWithOpenRouter(
+            generatedNotes = await summarizeWithOpenRouter(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -53,8 +56,9 @@ enum MeetingSummaryClient {
                 template: template,
                 visualContext: visualContext
             )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
         }
-        return await summarizeWithOpenAI(
+        generatedNotes = await summarizeWithOpenAI(
             transcript: transcript,
             meetingTitle: meetingTitle,
             existingNotes: existingNotes,
@@ -62,13 +66,14 @@ enum MeetingSummaryClient {
             template: template,
             visualContext: visualContext
         )
+        return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
     }
 
     static func summaryInstructions(for template: MeetingTemplateSnapshot, existingNotes: String? = nil) -> String {
         let notePreservationInstructions: String
         if let existingNotes,
            !existingNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            notePreservationInstructions = "\n\nCurrent notes may also be provided. Preserve any concrete user-added details, clarifications, and edits from those notes when they do not conflict with the transcript. Reformat that information into the requested template instead of discarding it."
+            notePreservationInstructions = "\n\nCurrent notes may also be provided. Preserve every concrete user-added detail, clarification, decision, and edit from those notes when they do not conflict with the transcript. These manual notes must not be skipped. Reformat that information into the requested template instead of discarding it."
         } else {
             notePreservationInstructions = ""
         }
@@ -96,6 +101,21 @@ enum MeetingSummaryClient {
 
         prompt += "Raw transcript:\n\(transcript)"
         return prompt
+    }
+
+    static func notesByRetainingManualNotes(generatedNotes: String, manualNotes: String?) -> String {
+        let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedManualNotes.isEmpty else { return generatedNotes }
+
+        let trimmedGeneratedNotes = generatedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let manualSection = "## Manual Notes\n\n\(trimmedManualNotes)"
+        if trimmedGeneratedNotes.contains(manualSection) {
+            return trimmedGeneratedNotes
+        }
+        if trimmedGeneratedNotes.isEmpty {
+            return manualSection
+        }
+        return "\(trimmedGeneratedNotes)\n\n\(manualSection)"
     }
 
     private static func summarizeWithOpenAI(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -268,7 +268,8 @@ enum MeetingSummaryClient {
             return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
         }
 
-        let model = config.openRouterModel.isEmpty ? defaultOpenRouterModel : config.openRouterModel
+        let configuredModel = config.openRouterModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = configuredModel.isEmpty ? defaultOpenRouterModel : configuredModel
         let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
         let userPrompt = summaryUserPrompt(
             transcript: transcript,
@@ -510,7 +511,8 @@ enum MeetingSummaryClient {
         if backend == MeetingSummaryBackendOption.openRouter.backend {
             let apiKey = ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] ?? config.openRouterAPIKey
             guard !apiKey.isEmpty else { return nil }
-            let model = config.openRouterModel.isEmpty ? defaultOpenRouterModel : config.openRouterModel
+            let configuredModel = config.openRouterModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            let model = configuredModel.isEmpty ? defaultOpenRouterModel : configuredModel
             return await callChatCompletions(
                 url: openRouterURL,
                 apiKey: apiKey,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -211,11 +211,30 @@ enum MeetingSummaryClient {
     }
 
     private static func normalizedManualNoteMatchText(_ text: String) -> String {
-        text
+        normalizedManualNoteContent(text)
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(whereSeparator: \.isWhitespace)
             .joined(separator: " ")
             .lowercased()
+    }
+
+    private static func normalizedManualNoteContent(_ text: String) -> String {
+        var trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixes = [
+            "- [ ] ", "- [x] ", "- [X] ",
+            "* [ ] ", "* [x] ", "* [X] ",
+            "• [ ] ", "• [x] ", "• [X] ",
+            "- ", "* ", "• "
+        ]
+        if let prefix = prefixes.first(where: { trimmed.hasPrefix($0) }) {
+            trimmed.removeFirst(prefix.count)
+            return trimmed
+        }
+
+        if let match = trimmed.range(of: #"^\d+[.)]\s+"#, options: .regularExpression) {
+            trimmed.removeSubrange(match)
+        }
+        return trimmed
     }
 
     private static func isNumberedListLine(_ line: String) -> Bool {
@@ -225,7 +244,7 @@ enum MeetingSummaryClient {
             sawDigit = true
             index = line.index(after: index)
         }
-        guard sawDigit, index < line.endIndex, line[index] == "." else { return false }
+        guard sawDigit, index < line.endIndex, line[index] == "." || line[index] == ")" else { return false }
         let next = line.index(after: index)
         return next < line.endIndex && line[next].isWhitespace
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -2,6 +2,24 @@ import Foundation
 import MuesliCore
 import os
 
+enum MeetingSummaryError: LocalizedError {
+    case backendFailed(backend: String, statusCode: Int?, message: String)
+    case emptyResponse(backend: String)
+    case requestFailed(backend: String, underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case let .backendFailed(backend, statusCode, message):
+            let statusText = statusCode.map { " Status \($0)." } ?? ""
+            return "\(backend) could not generate meeting notes.\(statusText) \(message) The selected model may be unavailable or retired."
+        case let .emptyResponse(backend):
+            return "\(backend) returned an empty response while generating meeting notes. The selected model may be unavailable or incompatible."
+        case let .requestFailed(backend, underlying):
+            return "\(backend) could not be reached while generating meeting notes. \(underlying.localizedDescription)"
+        }
+    }
+}
+
 enum MeetingSummaryClient {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingSummary")
     private static let openAIURL = URL(string: "https://api.openai.com/v1/responses")!
@@ -33,11 +51,11 @@ enum MeetingSummaryClient {
         existingNotes: String? = nil,
         manualNotesToRetain: String? = nil,
         visualContext: String? = nil
-    ) async -> String {
+    ) async throws -> String {
         let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.openAI.backend : config.meetingSummaryBackend).lowercased()
         let generatedNotes: String
         if backend == MeetingSummaryBackendOption.chatGPT.backend {
-            generatedNotes = await summarizeWithChatGPT(
+            generatedNotes = try await summarizeWithChatGPT(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -49,7 +67,7 @@ enum MeetingSummaryClient {
             return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
         }
         if backend == MeetingSummaryBackendOption.openRouter.backend {
-            generatedNotes = await summarizeWithOpenRouter(
+            generatedNotes = try await summarizeWithOpenRouter(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -60,7 +78,7 @@ enum MeetingSummaryClient {
             )
             return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
         }
-        generatedNotes = await summarizeWithOpenAI(
+        generatedNotes = try await summarizeWithOpenAI(
             transcript: transcript,
             meetingTitle: meetingTitle,
             existingNotes: existingNotes,
@@ -70,6 +88,21 @@ enum MeetingSummaryClient {
             visualContext: visualContext
         )
         return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+    }
+
+    static func summaryFailureNotes(transcript: String, meetingTitle: String, error: Error, manualNotes: String? = nil) -> String {
+        let trimmedTitle = meetingTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        var sections = ["## Summary failed"]
+        if !trimmedTitle.isEmpty {
+            sections.append("Meeting: \(trimmedTitle)")
+        }
+        sections.append("Muesli could not generate structured meeting notes.\n\n\(error.localizedDescription)")
+        if !trimmedManualNotes.isEmpty {
+            sections.append("### Written notes\n\n\(trimmedManualNotes)")
+        }
+        sections.append("## Raw Transcript\n\n\(transcript)")
+        return sections.joined(separator: "\n\n")
     }
 
     static func summaryInstructions(for template: MeetingTemplateSnapshot, existingNotes: String? = nil, manualNotes: String? = nil) -> String {
@@ -171,7 +204,7 @@ enum MeetingSummaryClient {
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil
-    ) async -> String {
+    ) async throws -> String {
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey
         guard !apiKey.isEmpty else {
             return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
@@ -203,17 +236,21 @@ enum MeetingSummaryClient {
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
         do {
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "OpenAI")
             guard
                 let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                 let text = extractOpenAIText(from: json),
                 !text.isEmpty
             else {
-                return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+                if let message = extractErrorMessage(from: data) {
+                    throw MeetingSummaryError.backendFailed(backend: "OpenAI", statusCode: nil, message: message)
+                }
+                throw MeetingSummaryError.emptyResponse(backend: "OpenAI")
             }
             return text
         } catch {
-            return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+            throw summaryRequestError(backend: "OpenAI", error: error)
         }
     }
 
@@ -225,7 +262,7 @@ enum MeetingSummaryClient {
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil
-    ) async -> String {
+    ) async throws -> String {
         let apiKey = ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] ?? config.openRouterAPIKey
         guard !apiKey.isEmpty else {
             return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
@@ -257,17 +294,21 @@ enum MeetingSummaryClient {
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
         do {
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "OpenRouter")
             guard
                 let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                 let text = extractOpenRouterText(from: json),
                 !text.isEmpty
             else {
-                return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+                if let message = extractErrorMessage(from: data) {
+                    throw MeetingSummaryError.backendFailed(backend: "OpenRouter", statusCode: nil, message: message)
+                }
+                throw MeetingSummaryError.emptyResponse(backend: "OpenRouter")
             }
             return text
         } catch {
-            return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+            throw summaryRequestError(backend: "OpenRouter", error: error)
         }
     }
 
@@ -279,7 +320,7 @@ enum MeetingSummaryClient {
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil
-    ) async -> String {
+    ) async throws -> String {
         do {
             let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
             let text = try await callWHAM(
@@ -296,10 +337,10 @@ enum MeetingSummaryClient {
             if let text, !text.isEmpty {
                 return text
             }
-            return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+            throw MeetingSummaryError.emptyResponse(backend: "ChatGPT")
         } catch {
             fputs("[summary] ChatGPT summarization failed: \(error)\n", stderr)
-            return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+            throw summaryRequestError(backend: "ChatGPT", error: error)
         }
     }
 
@@ -339,9 +380,9 @@ enum MeetingSummaryClient {
             // Collect error body
             var errorData = Data()
             for try await byte in bytes { errorData.append(byte) }
-            let errorBody = String(data: errorData, encoding: .utf8) ?? "(unknown)"
-            fputs("[summary] ChatGPT WHAM: HTTP \(httpStatus): \(String(errorBody.prefix(500)))\n", stderr)
-            return nil
+            let message = extractErrorMessage(from: errorData) ?? String(data: errorData, encoding: .utf8) ?? "(unknown)"
+            fputs("[summary] ChatGPT WHAM: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
+            throw MeetingSummaryError.backendFailed(backend: "ChatGPT", statusCode: httpStatus, message: message)
         }
 
         // Parse SSE stream: collect text deltas from response.output_text.delta events
@@ -383,6 +424,55 @@ enum MeetingSummaryClient {
             }
         }
         return nil
+    }
+
+    private static func validateHTTPResponse(_ response: URLResponse, data: Data, backend: String) throws {
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let message = extractErrorMessage(from: data)
+                ?? String(data: data, encoding: .utf8)
+                ?? HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode)
+            throw MeetingSummaryError.backendFailed(
+                backend: backend,
+                statusCode: httpResponse.statusCode,
+                message: String(message.prefix(800))
+            )
+        }
+    }
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        if let error = json["error"] as? [String: Any] {
+            if let message = error["message"] as? String, !message.isEmpty {
+                return message
+            }
+            if let code = error["code"] as? String, !code.isEmpty {
+                return code
+            }
+            return String(describing: error)
+        }
+
+        if let message = json["message"] as? String, !message.isEmpty {
+            return message
+        }
+
+        if let detail = json["detail"] as? String, !detail.isEmpty {
+            return detail
+        }
+
+        return nil
+    }
+
+    private static func summaryRequestError(backend: String, error: Error) -> Error {
+        if error is MeetingSummaryError {
+            return error
+        }
+        return MeetingSummaryError.requestFailed(backend: backend, underlying: error)
     }
 
     private static func extractOpenRouterText(from payload: [String: Any]) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -161,7 +161,7 @@ enum MeetingSummaryClient {
 
         let trimmedGeneratedNotes = generatedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
         let missingNotes = manualNoteBlocks(from: trimmedManualNotes).filter { note in
-            !trimmedGeneratedNotes.localizedCaseInsensitiveContains(note)
+            !generatedNotesContainManualNote(trimmedGeneratedNotes, note: note)
         }
         guard !missingNotes.isEmpty else {
             return trimmedGeneratedNotes
@@ -195,6 +195,27 @@ enum MeetingSummaryClient {
             return listLines.map { $0.trimmingCharacters(in: .whitespaces) }
         }
         return [normalized]
+    }
+
+    private static func generatedNotesContainManualNote(_ generatedNotes: String, note: String) -> Bool {
+        let normalizedNote = normalizedManualNoteMatchText(note)
+        guard !normalizedNote.isEmpty else { return true }
+        let generatedLines = generatedNotes
+            .components(separatedBy: .newlines)
+            .map(normalizedManualNoteMatchText)
+        if generatedLines.contains(normalizedNote) {
+            return true
+        }
+        return normalizedNote.count >= 40
+            && normalizedManualNoteMatchText(generatedNotes).contains(normalizedNote)
+    }
+
+    private static func normalizedManualNoteMatchText(_ text: String) -> String {
+        text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .lowercased()
     }
 
     private static func isNumberedListLine(_ line: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -189,11 +189,24 @@ enum MeetingSummaryClient {
                 || trimmed.hasPrefix("- [ ] ")
                 || trimmed.hasPrefix("- [x] ")
                 || trimmed.hasPrefix("- [X] ")
+                || isNumberedListLine(trimmed)
         }
         if !listLines.isEmpty, listLines.count == nonEmptyLines.count {
             return listLines.map { $0.trimmingCharacters(in: .whitespaces) }
         }
         return [normalized]
+    }
+
+    private static func isNumberedListLine(_ line: String) -> Bool {
+        var sawDigit = false
+        var index = line.startIndex
+        while index < line.endIndex, line[index].isNumber {
+            sawDigit = true
+            index = line.index(after: index)
+        }
+        guard sawDigit, index < line.endIndex, line[index] == "." else { return false }
+        let next = line.index(after: index)
+        return next < line.endIndex && line[next].isWhitespace
     }
 
     private static func summarizeWithOpenAI(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -41,6 +41,7 @@ enum MeetingSummaryClient {
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
                 config: config,
                 template: template,
                 visualContext: visualContext
@@ -52,6 +53,7 @@ enum MeetingSummaryClient {
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
                 config: config,
                 template: template,
                 visualContext: visualContext
@@ -62,6 +64,7 @@ enum MeetingSummaryClient {
             transcript: transcript,
             meetingTitle: meetingTitle,
             existingNotes: existingNotes,
+            manualNotes: manualNotesToRetain,
             config: config,
             template: template,
             visualContext: visualContext
@@ -69,22 +72,33 @@ enum MeetingSummaryClient {
         return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
     }
 
-    static func summaryInstructions(for template: MeetingTemplateSnapshot, existingNotes: String? = nil) -> String {
+    static func summaryInstructions(for template: MeetingTemplateSnapshot, existingNotes: String? = nil, manualNotes: String? = nil) -> String {
         let notePreservationInstructions: String
+        let hasManualNotes = !(manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         if let existingNotes,
            !existingNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            notePreservationInstructions = "\n\nCurrent notes may also be provided. Preserve every concrete user-added detail, clarification, decision, and edit from those notes when they do not conflict with the transcript. These manual notes must not be skipped. Reformat that information into the requested template instead of discarding it."
+            notePreservationInstructions = "\n\nCurrent generated notes may also be provided. Preserve useful concrete details from those notes when they do not conflict with the transcript."
         } else {
             notePreservationInstructions = ""
         }
+        let manualNoteInstructions = hasManualNotes
+            ? "\n\nProtected written notes may also be provided. These are notes the user typed by hand during the meeting. Use them as high-priority context. Place each written note near the most relevant section of the summary, preserving the user's wording verbatim when possible. Do not rewrite, polish, summarize away, or omit concrete user-written notes. Avoid creating a large standalone Manual Notes appendix unless there is no relevant section for a note."
+            : ""
 
         return baseSummaryInstructions
             + notePreservationInstructions
+            + manualNoteInstructions
             + "\n\nFollow this note template exactly:\n\n"
             + template.prompt
     }
 
-    static func summaryUserPrompt(transcript: String, meetingTitle: String, existingNotes: String? = nil, visualContext: String? = nil) -> String {
+    static func summaryUserPrompt(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String? = nil,
+        manualNotes: String? = nil,
+        visualContext: String? = nil
+    ) -> String {
         var prompt = "Meeting title: \(meetingTitle)\n\n"
         let visualContextCharCount = visualContext?.trimmingCharacters(in: .whitespacesAndNewlines).count ?? 0
         logger.info("summary prompt visualContextIncluded=\(visualContextCharCount > 0) visualContextChars=\(visualContextCharCount)")
@@ -96,7 +110,12 @@ enum MeetingSummaryClient {
 
         let trimmedNotes = existingNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmedNotes.isEmpty {
-            prompt += "Current notes to preserve and reformat:\n\(trimmedNotes)\n\n"
+            prompt += "Current generated notes to preserve and reformat:\n\(trimmedNotes)\n\n"
+        }
+
+        let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedManualNotes.isEmpty {
+            prompt += "Protected written notes typed by the user during the meeting. Preserve these verbatim and place them where they belong in the summary:\n\(trimmedManualNotes)\n\n"
         }
 
         prompt += "Raw transcript:\n\(transcript)"
@@ -108,20 +127,47 @@ enum MeetingSummaryClient {
         guard !trimmedManualNotes.isEmpty else { return generatedNotes }
 
         let trimmedGeneratedNotes = generatedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
-        let manualSection = "## Manual Notes\n\n\(trimmedManualNotes)"
-        if trimmedGeneratedNotes.contains(manualSection) {
+        let missingNotes = manualNoteBlocks(from: trimmedManualNotes).filter { note in
+            !trimmedGeneratedNotes.localizedCaseInsensitiveContains(note)
+        }
+        guard !missingNotes.isEmpty else {
             return trimmedGeneratedNotes
         }
+        let manualSection = "### Written notes\n\n\(missingNotes.joined(separator: "\n"))"
         if trimmedGeneratedNotes.isEmpty {
             return manualSection
         }
         return "\(trimmedGeneratedNotes)\n\n\(manualSection)"
     }
 
+    static func manualNoteBlocks(from notes: String) -> [String] {
+        let normalized = notes
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return [] }
+
+        let lines = normalized.components(separatedBy: .newlines)
+        let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        let listLines = nonEmptyLines.filter { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return trimmed.hasPrefix("- ")
+                || trimmed.hasPrefix("* ")
+                || trimmed.hasPrefix("• ")
+                || trimmed.hasPrefix("- [ ] ")
+                || trimmed.hasPrefix("- [x] ")
+                || trimmed.hasPrefix("- [X] ")
+        }
+        if !listLines.isEmpty, listLines.count == nonEmptyLines.count {
+            return listLines.map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+        return [normalized]
+    }
+
     private static func summarizeWithOpenAI(
         transcript: String,
         meetingTitle: String,
         existingNotes: String?,
+        manualNotes: String?,
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil
@@ -131,11 +177,12 @@ enum MeetingSummaryClient {
             return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
         }
 
-        let instructions = summaryInstructions(for: template, existingNotes: existingNotes)
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
         let userPrompt = summaryUserPrompt(
             transcript: transcript,
             meetingTitle: meetingTitle,
             existingNotes: existingNotes,
+            manualNotes: manualNotes,
             visualContext: visualContext
         )
         let body: [String: Any] = [
@@ -174,6 +221,7 @@ enum MeetingSummaryClient {
         transcript: String,
         meetingTitle: String,
         existingNotes: String?,
+        manualNotes: String?,
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil
@@ -184,11 +232,12 @@ enum MeetingSummaryClient {
         }
 
         let model = config.openRouterModel.isEmpty ? defaultOpenRouterModel : config.openRouterModel
-        let instructions = summaryInstructions(for: template, existingNotes: existingNotes)
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
         let userPrompt = summaryUserPrompt(
             transcript: transcript,
             meetingTitle: meetingTitle,
             existingNotes: existingNotes,
+            manualNotes: manualNotes,
             visualContext: visualContext
         )
         let body: [String: Any] = [
@@ -226,18 +275,20 @@ enum MeetingSummaryClient {
         transcript: String,
         meetingTitle: String,
         existingNotes: String?,
+        manualNotes: String?,
         config: AppConfig,
         template: MeetingTemplateSnapshot,
         visualContext: String? = nil
     ) async -> String {
         do {
-            let instructions = summaryInstructions(for: template, existingNotes: existingNotes)
+            let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
             let text = try await callWHAM(
                 systemPrompt: instructions,
                 userPrompt: summaryUserPrompt(
                     transcript: transcript,
                     meetingTitle: meetingTitle,
                     existingNotes: existingNotes,
+                    manualNotes: manualNotes,
                     visualContext: visualContext
                 ),
                 model: config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -225,9 +225,9 @@ struct MeetingsView: View {
                                 onCreateFolderAndMove: { name in
                                     controller.createFolderAndMoveMeeting(name: name, meetingID: meeting.id)
                                 },
-                                onDelete: {
+                                onDelete: controller.canDeleteMeeting(meeting) ? {
                                     controller.deleteMeeting(id: meeting.id)
-                                }
+                                } : nil
                             )
                         }
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -161,6 +161,10 @@ struct MeetingsView: View {
         return controller.meeting(id: id)
     }
 
+    private var activeLiveMeeting: MeetingRecord? {
+        appState.meetingRows.first { $0.status == .recording || $0.status == .processing }
+    }
+
     var body: some View {
         Group {
             if let meeting = currentDocumentMeeting {
@@ -197,6 +201,10 @@ struct MeetingsView: View {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
                 if !appState.upcomingCalendarEvents.isEmpty {
                     comingUpSection
+                }
+
+                if let activeLiveMeeting {
+                    activeMeetingBanner(activeLiveMeeting)
                 }
 
                 browserHeader
@@ -546,6 +554,71 @@ struct MeetingsView: View {
             .fixedSize()
         }
         .fixedSize(horizontal: true, vertical: false)
+    }
+
+    @ViewBuilder
+    private func activeMeetingBanner(_ meeting: MeetingRecord) -> some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(meeting.status == .recording ? MuesliTheme.recording : MuesliTheme.accent)
+                    .frame(width: 8, height: 8)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(meeting.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+                    Text(meeting.status == .recording ? "Recording now" : "Finalizing notes")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+            }
+
+            Spacer(minLength: MuesliTheme.spacing12)
+
+            Button {
+                controller.showMeetingDocument(id: meeting.id)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "square.and.pencil")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Open Notes")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .padding(.horizontal, MuesliTheme.spacing12)
+                .padding(.vertical, 8)
+                .background(MuesliTheme.surfacePrimary)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+
+            if meeting.status == .recording {
+                Button {
+                    controller.stopMeetingRecording()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Stop Recording")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 8)
+                    .background(MuesliTheme.recording)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -498,6 +498,27 @@ struct MeetingsView: View {
     @ViewBuilder
     private var browserHeaderActions: some View {
         HStack(spacing: MuesliTheme.spacing8) {
+            Button {
+                controller.startQuickNoteMeeting()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Quick Note")
+                        .font(.system(size: 12, weight: .semibold))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(MuesliTheme.backgroundBase)
+                .padding(.horizontal, MuesliTheme.spacing12)
+                .padding(.vertical, 8)
+                .background(appState.isMeetingRecording ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+            .disabled(appState.isMeetingRecording)
+            .help("Start a quick meeting note")
+            .fixedSize()
+
             sortButton
             dateFilterButton
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -162,7 +162,7 @@ struct MeetingsView: View {
     }
 
     private var activeLiveMeeting: MeetingRecord? {
-        appState.meetingRows.first { $0.status == .recording || $0.status == .processing }
+        controller.activeLiveMeetingRecord()
     }
 
     var body: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -187,6 +187,90 @@ struct SummaryModelPreset {
     }
 }
 
+struct OpenRouterModelCatalog: Decodable {
+    let data: [OpenRouterModel]
+}
+
+struct OpenRouterModel: Decodable {
+    let id: String
+    let name: String
+    let contextLength: Int?
+    let pricing: Pricing
+    let architecture: Architecture?
+
+    struct Pricing: Decodable {
+        let prompt: String?
+        let completion: String?
+        let request: String?
+
+        var isFreeForTextGeneration: Bool {
+            isExplicitZero(prompt)
+                && isExplicitZero(completion)
+                && isZeroOrMissing(request)
+        }
+
+        private func isExplicitZero(_ value: String?) -> Bool {
+            guard let value else { return false }
+            return Decimal(string: value, locale: Locale(identifier: "en_US_POSIX")) == 0
+        }
+
+        private func isZeroOrMissing(_ value: String?) -> Bool {
+            guard let value else { return true }
+            return Decimal(string: value, locale: Locale(identifier: "en_US_POSIX")) == 0
+        }
+    }
+
+    struct Architecture: Decodable {
+        let outputModalities: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case outputModalities = "output_modalities"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case contextLength = "context_length"
+        case pricing
+        case architecture
+    }
+}
+
+extension OpenRouterModel {
+    var producesText: Bool {
+        architecture?.outputModalities?.contains("text") ?? true
+    }
+
+    var summaryPresetLabel: String {
+        if let contextLength, contextLength > 0 {
+            return "\(name) (\(Self.formatContextLength(contextLength)) ctx)"
+        }
+        return name
+    }
+
+    private static func formatContextLength(_ value: Int) -> String {
+        if value >= 1000 {
+            return "\(value / 1000)k"
+        }
+        return "\(value)"
+    }
+}
+
+enum OpenRouterModelCatalogFilter {
+    static func freeTextSummaryPresets(from models: [OpenRouterModel]) -> [SummaryModelPreset] {
+        models
+            .filter { $0.producesText && $0.pricing.isFreeForTextGeneration }
+            .sorted {
+                if $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedSame {
+                    return $0.id < $1.id
+                }
+                return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            .map { SummaryModelPreset(id: $0.id, label: $0.summaryPresetLabel) }
+    }
+}
+
 struct MeetingSummaryBackendOption: Equatable {
     let backend: String
     let label: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -238,8 +238,11 @@ struct OpenRouterModel: Decodable {
 }
 
 extension OpenRouterModel {
-    var producesText: Bool {
-        architecture?.outputModalities?.contains("text") ?? true
+    var producesOnlyText: Bool {
+        guard let outputModalities = architecture?.outputModalities else {
+            return false
+        }
+        return outputModalities == ["text"]
     }
 
     var summaryPresetLabel: String {
@@ -263,7 +266,7 @@ enum OpenRouterModelCatalogFilter {
     static func freeTextSummaryPresets(from models: [OpenRouterModel]) -> [SummaryModelPreset] {
         models
             .filter { model in
-                model.producesText
+                model.producesOnlyText
                     && model.pricing.isFreeForTextGeneration
                     && (model.contextLength ?? 0) >= minimumSummaryContextLength
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -258,9 +258,15 @@ extension OpenRouterModel {
 }
 
 enum OpenRouterModelCatalogFilter {
+    private static let minimumSummaryContextLength = 100_000
+
     static func freeTextSummaryPresets(from models: [OpenRouterModel]) -> [SummaryModelPreset] {
         models
-            .filter { $0.producesText && $0.pricing.isFreeForTextGeneration }
+            .filter { model in
+                model.producesText
+                    && model.pricing.isFreeForTextGeneration
+                    && (model.contextLength ?? 0) >= minimumSummaryContextLength
+            }
             .sorted {
                 if $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedSame {
                     return $0.id < $1.id

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -173,11 +173,18 @@ struct SummaryModelPreset {
     ]
 
     static let openRouterModels: [SummaryModelPreset] = [
-        SummaryModelPreset(id: "stepfun/step-3.5-flash:free", label: "Step 3.5 Flash (free, 256k ctx)"),
-        SummaryModelPreset(id: "nvidia/nemotron-3-super-120b-a12b:free", label: "Nemotron 3 Super 120B (free, 262k ctx)"),
-        SummaryModelPreset(id: "nvidia/nemotron-3-nano-30b-a3b:free", label: "Nemotron 3 Nano 30B (free, 256k ctx)"),
-        SummaryModelPreset(id: "arcee-ai/trinity-large-preview:free", label: "Trinity Large (free, 131k ctx)"),
+        SummaryModelPreset(id: "stepfun/step-3.5-flash:free", label: "Step 3.5 Flash (256k ctx)"),
+        SummaryModelPreset(id: "nvidia/nemotron-3-super-120b-a12b:free", label: "Nemotron 3 Super 120B (262k ctx)"),
+        SummaryModelPreset(id: "nvidia/nemotron-3-nano-30b-a3b:free", label: "Nemotron 3 Nano 30B (256k ctx)"),
+        SummaryModelPreset(id: "arcee-ai/trinity-large-preview:free", label: "Trinity Large (131k ctx)"),
     ]
+
+    static func menuPresets(_ presets: [SummaryModelPreset], currentModel: String) -> [SummaryModelPreset] {
+        let trimmedModel = currentModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedModel.isEmpty else { return presets }
+        guard !presets.contains(where: { $0.id == trimmedModel }) else { return presets }
+        return presets + [SummaryModelPreset(id: trimmedModel, label: "Custom: \(trimmedModel)")]
+    }
 }
 
 struct MeetingSummaryBackendOption: Equatable {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2051,7 +2051,9 @@ final class MuesliController: NSObject {
                 await MainActor.run {
                     self.setMeetingProcessingStatus("Finalizing")
                 }
-                let persistenceResult = try self.persistCompletedMeetingResultAndDispatchHook(result, existingMeetingID: liveMeetingID)
+                let persistenceResult = try await MainActor.run {
+                    try self.persistCompletedMeetingResultAndDispatchHook(result, existingMeetingID: liveMeetingID)
+                }
                 completedMeetingID = persistenceResult.meetingID
                 if let recordingSaveError = persistenceResult.recordingSaveError {
                     await MainActor.run {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -111,6 +111,10 @@ final class MuesliController: NSObject {
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
     private var liveManualNotesCache: [Int64: String] = [:]
+    private var liveManualNotesLastPersistedAt: [Int64: Date] = [:]
+    private var liveManualNotesLastPersistedValue: [Int64: String] = [:]
+    private var liveManualNotesPersistWorkItems: [Int64: DispatchWorkItem] = [:]
+    private let liveManualNotesPersistInterval: TimeInterval = 0.75
     private var dictationStartedAt: Date?
     private var _streamingDictationController: Any?  // StreamingDictationController (macOS 15+)
     private var isNemotronStreaming = false
@@ -1375,22 +1379,80 @@ final class MuesliController: NSObject {
     }
 
     func updateMeetingManualNotes(id: Int64, notes: String) {
+        liveManualNotesPersistWorkItems[id]?.cancel()
+        liveManualNotesPersistWorkItems[id] = nil
         liveManualNotesCache[id] = notes
         try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
+        liveManualNotesLastPersistedAt[id] = Date()
+        liveManualNotesLastPersistedValue[id] = notes
         syncAppState()
     }
 
     func cacheMeetingManualNotes(id: Int64, notes: String) {
         liveManualNotesCache[id] = notes
-        try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
+        scheduleCachedMeetingManualNotesPersistence(id: id)
     }
 
     func flushCachedMeetingManualNotes(id: Int64, sync: Bool = true) {
+        liveManualNotesPersistWorkItems[id]?.cancel()
+        liveManualNotesPersistWorkItems[id] = nil
         guard let notes = liveManualNotesCache[id] else { return }
+        persistCachedMeetingManualNotes(id: id, notes: notes, sync: sync)
+    }
+
+    private func scheduleCachedMeetingManualNotesPersistence(id: Int64) {
+        guard let notes = liveManualNotesCache[id] else { return }
+        if shouldPersistCachedMeetingManualNotesImmediately(id: id, notes: notes) {
+            flushCachedMeetingManualNotes(id: id, sync: false)
+            return
+        }
+
+        let lastPersistedAt = liveManualNotesLastPersistedAt[id] ?? .distantPast
+        let delay = max(liveManualNotesPersistInterval - Date().timeIntervalSince(lastPersistedAt), 0)
+        liveManualNotesPersistWorkItems[id]?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            self?.flushCachedMeetingManualNotes(id: id, sync: false)
+        }
+        liveManualNotesPersistWorkItems[id] = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+    }
+
+    private func shouldPersistCachedMeetingManualNotesImmediately(id: Int64, notes: String) -> Bool {
+        if liveManualNotesLastPersistedValue[id] == nil { return true }
+        if notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return true }
+        let lastPersistedAt = liveManualNotesLastPersistedAt[id] ?? .distantPast
+        return Date().timeIntervalSince(lastPersistedAt) >= liveManualNotesPersistInterval
+    }
+
+    private func persistCachedMeetingManualNotes(id: Int64, notes: String, sync: Bool) {
+        if liveManualNotesLastPersistedValue[id] == notes {
+            if sync {
+                syncAppState()
+            }
+            return
+        }
         try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
+        liveManualNotesLastPersistedAt[id] = Date()
+        liveManualNotesLastPersistedValue[id] = notes
         if sync {
             syncAppState()
         }
+    }
+
+    private func clearCachedMeetingManualNotes(id: Int64) {
+        liveManualNotesPersistWorkItems[id]?.cancel()
+        liveManualNotesPersistWorkItems[id] = nil
+        liveManualNotesCache[id] = nil
+        liveManualNotesLastPersistedAt[id] = nil
+        liveManualNotesLastPersistedValue[id] = nil
+    }
+
+    private func clearAllCachedMeetingManualNotes() {
+        liveManualNotesPersistWorkItems.values.forEach { $0.cancel() }
+        liveManualNotesPersistWorkItems.removeAll()
+        liveManualNotesCache.removeAll()
+        liveManualNotesLastPersistedAt.removeAll()
+        liveManualNotesLastPersistedValue.removeAll()
     }
 
     private func manualNotesForLiveMeeting(id: Int64) -> String {
@@ -1537,7 +1599,7 @@ final class MuesliController: NSObject {
                 appState.meetingsNavigationState = .browser
             }
         }
-        liveManualNotesCache[id] = nil
+        clearCachedMeetingManualNotes(id: id)
 
         historyWindowController?.reload()
         statusBarController?.refresh()
@@ -1581,7 +1643,7 @@ final class MuesliController: NSObject {
         }
 
         try? dictationStore.clearMeetings()
-        liveManualNotesCache.removeAll()
+        clearAllCachedMeetingManualNotes()
         appState.selectedMeetingID = nil
         appState.selectedMeetingRecord = nil
         appState.meetingsNavigationState = .browser
@@ -1853,7 +1915,7 @@ final class MuesliController: NSObject {
         let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1873,10 +1935,10 @@ final class MuesliController: NSObject {
         if alert.runModal() == .alertFirstButtonReturn {
             flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
         } else {
             try? dictationStore.deleteMeeting(id: id)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1890,7 +1952,7 @@ final class MuesliController: NSObject {
         let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1899,7 +1961,7 @@ final class MuesliController: NSObject {
         } else {
             flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .failed)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
         }
         if activeMeetingID == id {
             activeMeetingID = nil
@@ -1911,7 +1973,7 @@ final class MuesliController: NSObject {
         let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1920,7 +1982,7 @@ final class MuesliController: NSObject {
         } else {
             flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .failed)
-            liveManualNotesCache[id] = nil
+            clearCachedMeetingManualNotes(id: id)
         }
         syncAppState()
     }
@@ -1963,6 +2025,7 @@ final class MuesliController: NSObject {
             var meetingTitle = "Meeting"
             var completedMeetingID: Int64?
             var meetingResult: MeetingSessionResult?
+            var failedLiveMeetingID: Int64?
             defer {
                 if let meetingResult {
                     self.cleanupTemporaryMeetingAudioFiles(for: meetingResult)
@@ -1978,20 +2041,27 @@ final class MuesliController: NSObject {
                 let persistenceResult = try self.persistCompletedMeetingResultAndDispatchHook(result, existingMeetingID: liveMeetingID)
                 completedMeetingID = persistenceResult.meetingID
                 if let recordingSaveError = persistenceResult.recordingSaveError {
-                    self.presentErrorAlert(title: "Meeting Recording", message: recordingSaveError.localizedDescription)
+                    await MainActor.run {
+                        self.presentErrorAlert(title: "Meeting Recording", message: recordingSaveError.localizedDescription)
+                    }
                 }
             } catch {
                 fputs("[muesli-native] meeting transcription failed: \(error)\n", stderr)
+                let message: String
                 if let lifecycleError = error as? MeetingLifecycleError {
-                    self.presentErrorAlert(title: "Meeting Recording", message: lifecycleError.localizedDescription)
+                    message = lifecycleError.localizedDescription
                 } else {
-                    self.presentErrorAlert(title: "Meeting Recording", message: error.localizedDescription)
+                    message = error.localizedDescription
                 }
-                if let liveMeetingID {
-                    self.resolveLiveMeetingAfterStopFailure(id: liveMeetingID)
+                failedLiveMeetingID = liveMeetingID
+                await MainActor.run {
+                    self.presentErrorAlert(title: "Meeting Recording", message: message)
                 }
             }
             await MainActor.run {
+                if let failedLiveMeetingID {
+                    self.resolveLiveMeetingAfterStopFailure(id: failedLiveMeetingID)
+                }
                 self.activeMeetingSession = nil
                 self.activeMeetingID = nil
                 self.isStoppingMeetingRecording = false
@@ -2066,7 +2136,7 @@ final class MuesliController: NSObject {
                 selectedTemplatePrompt: result.templateSnapshot.prompt
             )
             meetingID = existingMeetingID
-            liveManualNotesCache[existingMeetingID] = nil
+            clearCachedMeetingManualNotes(id: existingMeetingID)
         } else {
             meetingID = try dictationStore.insertMeeting(
                 title: result.title,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -115,6 +115,7 @@ final class MuesliController: NSObject {
     private var liveManualNotesLastPersistedValue: [Int64: String] = [:]
     private var liveManualNotesPersistWorkItems: [Int64: DispatchWorkItem] = [:]
     private let liveManualNotesPersistInterval: TimeInterval = 0.75
+    private var staleLiveMeetingRecoveryFailures = Set<Int64>()
     private var dictationStartedAt: Date?
     private var _streamingDictationController: Any?  // StreamingDictationController (macOS 15+)
     private var isNemotronStreaming = false
@@ -473,9 +474,26 @@ final class MuesliController: NSObject {
 
     func recoverStaleLiveMeetings() {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
-        let meetings = (try? dictationStore.staleLiveMeetings()) ?? []
+        let meetings: [MeetingRecord]
+        do {
+            meetings = try dictationStore.staleLiveMeetings()
+        } catch {
+            fputs("[muesli-native] failed to load stale live meetings: \(error)\n", stderr)
+            return
+        }
+
         for meeting in meetings {
-            try? dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
+            do {
+                try dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
+                staleLiveMeetingRecoveryFailures.remove(meeting.id)
+            } catch {
+                staleLiveMeetingRecoveryFailures.insert(meeting.id)
+                fputs("[muesli-native] failed to recover stale meeting \(meeting.id): \(error)\n", stderr)
+            }
+        }
+
+        if !meetings.isEmpty {
+            syncAppState()
         }
     }
 
@@ -1608,6 +1626,7 @@ final class MuesliController: NSObject {
             }
         }
         clearCachedMeetingManualNotes(id: id)
+        staleLiveMeetingRecoveryFailures.remove(id)
 
         historyWindowController?.reload()
         statusBarController?.refresh()
@@ -1623,6 +1642,9 @@ final class MuesliController: NSObject {
 
     func canDeleteMeeting(_ meeting: MeetingRecord) -> Bool {
         guard meeting.id != activeMeetingID else { return false }
+        if staleLiveMeetingRecoveryFailures.contains(meeting.id) {
+            return true
+        }
         switch meeting.status {
         case .recording, .processing:
             return false
@@ -1899,7 +1921,7 @@ final class MuesliController: NSObject {
     }
 
     func discardMeetingRecording() {
-        guard let activeMeetingSession else {
+        guard let sessionToDiscard = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
             indicator.setMeetingRecording(false, config: config)
@@ -1912,7 +1934,7 @@ final class MuesliController: NSObject {
             setState(.idle)
             return
         }
-        activeMeetingSession.discard()
+        sessionToDiscard.discard()
         self.activeMeetingSession = nil
         indicator.setMeetingRecording(false, config: config)
         if let activeMeetingID {
@@ -2007,7 +2029,7 @@ final class MuesliController: NSObject {
 
     func stopMeetingRecording() {
         guard !isStoppingMeetingRecording else { return }
-        guard let activeMeetingSession else {
+        guard let sessionToStop = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
             if let activeMeetingID {
@@ -2033,7 +2055,7 @@ final class MuesliController: NSObject {
         indicator.setMeetingRecording(false, config: config)
         indicator.setTranscribingTitle("Transcribing", config: config)
         setState(.transcribing)
-        activeMeetingSession.onProgress = { [weak self] stage in
+        sessionToStop.onProgress = { [weak self] stage in
             Task { @MainActor [weak self] in
                 self?.setMeetingProcessingStage(stage)
             }
@@ -2045,7 +2067,7 @@ final class MuesliController: NSObject {
             var meetingResult: MeetingSessionResult?
             var failedLiveMeetingID: Int64?
             do {
-                let result = try await activeMeetingSession.stop()
+                let result = try await sessionToStop.stop()
                 meetingResult = result
                 meetingTitle = result.title
                 await MainActor.run {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -110,6 +110,7 @@ final class MuesliController: NSObject {
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
+    private var liveManualNotesCache: [Int64: String] = [:]
     private var dictationStartedAt: Date?
     private var _streamingDictationController: Any?  // StreamingDictationController (macOS 15+)
     private var isNemotronStreaming = false
@@ -1319,18 +1320,28 @@ final class MuesliController: NSObject {
     // MARK: - Meeting Editing
 
     private func notesContextForResummary(_ meeting: MeetingRecord) -> String? {
-        var parts: [String] = []
-        if meeting.notesState == .structuredNotes {
-            let trimmed = meeting.formattedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                parts.append(meeting.formattedNotes)
+        Self.notesContextForResummary(meeting)
+    }
+
+    static func notesContextForResummary(_ meeting: MeetingRecord) -> String? {
+        guard meeting.notesState == .structuredNotes else { return nil }
+        let trimmed = stripManualNotesSection(from: meeting.formattedNotes)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func stripManualNotesSection(from notes: String) -> String {
+        let markers = [
+            "\n\n## Manual Notes\n\n",
+            "\n## Manual Notes\n\n",
+            "## Manual Notes\n\n"
+        ]
+        for marker in markers {
+            if let range = notes.range(of: marker, options: [.backwards]) {
+                return String(notes[..<range.lowerBound])
             }
         }
-        let manualNotes = meeting.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !manualNotes.isEmpty {
-            parts.append("Manual notes:\n\(manualNotes)")
-        }
-        return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
+        return notes
     }
 
     func updateMeetingTitle(id: Int64, title: String) {
@@ -1344,8 +1355,28 @@ final class MuesliController: NSObject {
     }
 
     func updateMeetingManualNotes(id: Int64, notes: String) {
+        liveManualNotesCache[id] = notes
         try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
         syncAppState()
+    }
+
+    func cacheMeetingManualNotes(id: Int64, notes: String) {
+        liveManualNotesCache[id] = notes
+    }
+
+    func flushCachedMeetingManualNotes(id: Int64, sync: Bool = true) {
+        guard let notes = liveManualNotesCache[id] else { return }
+        try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
+        if sync {
+            syncAppState()
+        }
+    }
+
+    private func manualNotesForLiveMeeting(id: Int64) -> String {
+        if let cached = liveManualNotesCache[id] {
+            return cached
+        }
+        return (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
     }
 
     // MARK: - Folder Management
@@ -1484,6 +1515,7 @@ final class MuesliController: NSObject {
                 appState.meetingsNavigationState = .browser
             }
         }
+        liveManualNotesCache[id] = nil
 
         historyWindowController?.reload()
         statusBarController?.refresh()
@@ -1517,6 +1549,7 @@ final class MuesliController: NSObject {
         }
 
         try? dictationStore.clearMeetings()
+        liveManualNotesCache.removeAll()
         appState.selectedMeetingID = nil
         appState.selectedMeetingRecord = nil
         appState.meetingsNavigationState = .browser
@@ -1683,7 +1716,7 @@ final class MuesliController: NSObject {
                 meetingSession.manualNotesProvider = { [weak self] in
                     await MainActor.run {
                         guard let self else { return nil }
-                        return try? self.dictationStore.meeting(id: meetingID)?.manualNotes
+                        return self.manualNotesForLiveMeeting(id: meetingID)
                     }
                 }
                 try await meetingSession.start()
@@ -1756,6 +1789,7 @@ final class MuesliController: NSObject {
     func discardMeetingRecording() {
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
+            guard !isStartingMeetingRecording else { return }
             if let activeMeetingID {
                 resolveLiveMeetingAfterDiscard(id: activeMeetingID)
                 self.activeMeetingID = nil
@@ -1784,9 +1818,10 @@ final class MuesliController: NSObject {
     }
 
     private func resolveLiveMeetingAfterDiscard(id: Int64) {
-        let manualNotes = (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
+        let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
+            liveManualNotesCache[id] = nil
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1804,9 +1839,12 @@ final class MuesliController: NSObject {
         alert.addButton(withTitle: "Delete Draft")
         alert.buttons.dropFirst().first?.hasDestructiveAction = true
         if alert.runModal() == .alertFirstButtonReturn {
+            flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
+            liveManualNotesCache[id] = nil
         } else {
             try? dictationStore.deleteMeeting(id: id)
+            liveManualNotesCache[id] = nil
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1817,16 +1855,19 @@ final class MuesliController: NSObject {
     }
 
     private func resolveLiveMeetingAfterStartFailure(id: Int64) {
-        let manualNotes = (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
+        let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
+            liveManualNotesCache[id] = nil
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
                 appState.meetingsNavigationState = .browser
             }
         } else {
+            flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .failed)
+            liveManualNotesCache[id] = nil
         }
         if activeMeetingID == id {
             activeMeetingID = nil
@@ -1835,16 +1876,19 @@ final class MuesliController: NSObject {
     }
 
     private func resolveLiveMeetingAfterStopFailure(id: Int64) {
-        let manualNotes = (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
+        let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
+            liveManualNotesCache[id] = nil
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
                 appState.meetingsNavigationState = .browser
             }
         } else {
+            flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .failed)
+            liveManualNotesCache[id] = nil
         }
         syncAppState()
     }
@@ -1853,6 +1897,7 @@ final class MuesliController: NSObject {
         guard !isStoppingMeetingRecording else { return }
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
+            guard !isStartingMeetingRecording else { return }
             indicator.setMeetingRecording(false, config: config)
             isStoppingMeetingRecording = false
             endMeetingActivity()
@@ -1865,6 +1910,7 @@ final class MuesliController: NSObject {
         meetingNotification.close()
         let liveMeetingID = activeMeetingID
         if let liveMeetingID {
+            flushCachedMeetingManualNotes(id: liveMeetingID, sync: false)
             try? dictationStore.updateMeetingStatus(id: liveMeetingID, status: .processing)
             syncAppState()
         }
@@ -1984,6 +2030,7 @@ final class MuesliController: NSObject {
                 selectedTemplatePrompt: result.templateSnapshot.prompt
             )
             meetingID = existingMeetingID
+            liveManualNotesCache[existingMeetingID] = nil
         } else {
             meetingID = try dictationStore.insertMeeting(
                 title: result.title,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -473,8 +473,8 @@ final class MuesliController: NSObject {
 
     func recoverStaleLiveMeetings() {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
-        let meetings = (try? dictationStore.recentMeetings(limit: 500)) ?? []
-        for meeting in meetings where meeting.status == .recording || meeting.status == .processing {
+        let meetings = (try? dictationStore.staleLiveMeetings()) ?? []
+        for meeting in meetings {
             let manualNotes = meeting.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines)
             if manualNotes.isEmpty {
                 try? dictationStore.deleteMeeting(id: meeting.id)
@@ -2039,11 +2039,6 @@ final class MuesliController: NSObject {
             var completedMeetingID: Int64?
             var meetingResult: MeetingSessionResult?
             var failedLiveMeetingID: Int64?
-            defer {
-                if let meetingResult {
-                    self.cleanupTemporaryMeetingAudioFiles(for: meetingResult)
-                }
-            }
             do {
                 let result = try await activeMeetingSession.stop()
                 meetingResult = result
@@ -2087,6 +2082,9 @@ final class MuesliController: NSObject {
                 self.statusBarController?.refresh()
                 self.historyWindowController?.reload()
                 self.syncAppState()
+                if let meetingResult {
+                    self.cleanupTemporaryMeetingAudioFiles(for: meetingResult)
+                }
                 TelemetryDeck.signal("meeting.completed")
 
                 self.presentedMeetingCandidate = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1298,16 +1298,15 @@ final class MuesliController: NSObject {
         Task { [weak self] in
             guard let self else { return }
             let plan = MeetingResummarizationPolicy.plan(for: meeting)
-            let notes = await MeetingSummaryClient.summarize(
-                transcript: meeting.rawTranscript,
-                meetingTitle: plan.promptTitle,
-                config: self.config,
-                template: templateSnapshot,
-                existingNotes: self.notesContextForResummary(meeting),
-                manualNotesToRetain: meeting.manualNotes
-            )
-
             do {
+                let notes = try await MeetingSummaryClient.summarize(
+                    transcript: meeting.rawTranscript,
+                    meetingTitle: plan.promptTitle,
+                    config: self.config,
+                    template: templateSnapshot,
+                    existingNotes: self.notesContextForResummary(meeting),
+                    manualNotesToRetain: meeting.manualNotes
+                )
                 try self.dictationStore.updateMeetingSummary(
                     id: meeting.id,
                     title: plan.persistedTitle,
@@ -1323,9 +1322,13 @@ final class MuesliController: NSObject {
                     completion(.success(()))
                 }
             } catch {
-                fputs("[muesli-native] failed to persist meeting summary: \(error)\n", stderr)
+                fputs("[muesli-native] failed to generate or persist meeting summary: \(error)\n", stderr)
                 await MainActor.run {
-                    completion(.failure(MeetingSummaryPersistenceError.failedToSaveSummary(underlying: error)))
+                    if error is MeetingSummaryError {
+                        completion(.failure(error))
+                    } else {
+                        completion(.failure(MeetingSummaryPersistenceError.failedToSaveSummary(underlying: error)))
+                    }
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -475,12 +475,7 @@ final class MuesliController: NSObject {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
         let meetings = (try? dictationStore.staleLiveMeetings()) ?? []
         for meeting in meetings {
-            let manualNotes = meeting.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines)
-            if manualNotes.isEmpty {
-                try? dictationStore.deleteMeeting(id: meeting.id)
-            } else {
-                try? dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
-            }
+            try? dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1099,6 +1099,7 @@ final class MuesliController: NSObject {
     }
 
     @objc func openHistoryWindow() {
+        showActiveMeetingDocumentIfNeeded()
         DispatchQueue.main.async { [weak self] in
             self?.historyWindowController?.show()
         }
@@ -1124,6 +1125,14 @@ final class MuesliController: NSObject {
         appState.selectedMeetingID = id
         appState.selectedMeetingRecord = meeting(id: id)
         appState.meetingsNavigationState = .document(id)
+    }
+
+    private func showActiveMeetingDocumentIfNeeded() {
+        guard let activeMeetingID,
+              isMeetingRecording() || isStartingMeetingRecording else {
+            return
+        }
+        showMeetingDocument(id: activeMeetingID)
     }
 
     func showMeetingTemplatesManager() {
@@ -1711,13 +1720,18 @@ final class MuesliController: NSObject {
         if isMeetingRecording() {
             stopMeetingRecording()
         } else {
-            startMeetingRecording()
+            startForegroundMeetingRecording()
         }
     }
 
     @objc func startMeetingFromCalendarMenuItem(_ sender: NSMenuItem) {
         guard let title = sender.representedObject as? String else { return }
-        startMeetingRecording(title: title)
+        startForegroundMeetingRecording(title: title)
+    }
+
+    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil) {
+        startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true)
+        openHistoryWindow()
     }
 
     func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) {
@@ -1789,8 +1803,7 @@ final class MuesliController: NSObject {
     }
 
     func startQuickNoteMeeting() {
-        startMeetingRecording(title: "Meeting", openDocument: true)
-        openHistoryWindow()
+        startForegroundMeetingRecording(title: "Meeting")
     }
 
     private func startMeetingRecordingWithSystemAudioRecovery(title: String, calendarEventID: String?, meetingID: Int64) async throws {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1654,7 +1654,7 @@ final class MuesliController: NSObject {
     }
 
     func clearMeetingHistory() {
-        guard !isMeetingRecording() else {
+        guard !isMeetingRecording(), !isStartingMeetingRecording else {
             presentErrorAlert(
                 title: "Couldn't Clear Meeting History",
                 message: "Stop the current meeting recording before clearing saved meetings."

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1382,6 +1382,7 @@ final class MuesliController: NSObject {
 
     func cacheMeetingManualNotes(id: Int64, notes: String) {
         liveManualNotesCache[id] = notes
+        try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
     }
 
     func flushCachedMeetingManualNotes(id: Int64, sync: Bool = true) {
@@ -1509,6 +1510,7 @@ final class MuesliController: NSObject {
 
     func deleteMeeting(id: Int64) {
         guard let meeting = meeting(id: id) else { return }
+        guard canDeleteMeeting(meeting) else { return }
 
         do {
             // Delete the retained file first so a failed file removal does not orphan
@@ -1547,6 +1549,16 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         historyWindowController?.reload()
         syncAppState()
+    }
+
+    func canDeleteMeeting(_ meeting: MeetingRecord) -> Bool {
+        guard meeting.id != activeMeetingID else { return false }
+        switch meeting.status {
+        case .recording, .processing:
+            return false
+        case .completed, .noteOnly, .failed:
+            return true
+        }
     }
 
     func clearMeetingHistory() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -110,6 +110,7 @@ final class MuesliController: NSObject {
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
+    private var liveMeetingTitleCache: [Int64: String] = [:]
     private var liveManualNotesCache: [Int64: String] = [:]
     private var liveManualNotesLastPersistedAt: [Int64: Date] = [:]
     private var liveManualNotesLastPersistedValue: [Int64: String] = [:]
@@ -1395,8 +1396,18 @@ final class MuesliController: NSObject {
     }
 
     func updateMeetingTitle(id: Int64, title: String) {
-        try? dictationStore.updateMeetingTitle(id: id, title: title)
+        liveMeetingTitleCache[id] = title
+        do {
+            try dictationStore.updateMeetingTitle(id: id, title: title)
+            liveMeetingTitleCache[id] = nil
+        } catch {
+            fputs("[muesli-native] failed to update meeting title \(id): \(error)\n", stderr)
+        }
         syncAppState()
+    }
+
+    func cacheMeetingTitle(id: Int64, title: String) {
+        liveMeetingTitleCache[id] = title
     }
 
     func updateMeetingNotes(id: Int64, notes: String) {
@@ -1473,12 +1484,30 @@ final class MuesliController: NSObject {
         liveManualNotesLastPersistedValue[id] = nil
     }
 
+    private func clearCachedMeetingTitle(id: Int64) {
+        liveMeetingTitleCache[id] = nil
+    }
+
+    private func flushCachedMeetingTitle(id: Int64) {
+        guard let title = liveMeetingTitleCache[id] else { return }
+        do {
+            try dictationStore.updateMeetingTitle(id: id, title: title)
+            liveMeetingTitleCache[id] = nil
+        } catch {
+            fputs("[muesli-native] failed to flush cached meeting title \(id): \(error)\n", stderr)
+        }
+    }
+
     private func clearAllCachedMeetingManualNotes() {
         liveManualNotesPersistWorkItems.values.forEach { $0.cancel() }
         liveManualNotesPersistWorkItems.removeAll()
         liveManualNotesCache.removeAll()
         liveManualNotesLastPersistedAt.removeAll()
         liveManualNotesLastPersistedValue.removeAll()
+    }
+
+    private func clearAllCachedMeetingTitles() {
+        liveMeetingTitleCache.removeAll()
     }
 
     private func manualNotesForLiveMeeting(id: Int64) -> String {
@@ -1626,6 +1655,7 @@ final class MuesliController: NSObject {
             }
         }
         clearCachedMeetingManualNotes(id: id)
+        clearCachedMeetingTitle(id: id)
         staleLiveMeetingRecoveryFailures.remove(id)
 
         historyWindowController?.reload()
@@ -1674,6 +1704,7 @@ final class MuesliController: NSObject {
 
         try? dictationStore.clearMeetings()
         clearAllCachedMeetingManualNotes()
+        clearAllCachedMeetingTitles()
         appState.selectedMeetingID = nil
         appState.selectedMeetingRecord = nil
         appState.meetingsNavigationState = .browser
@@ -1956,6 +1987,7 @@ final class MuesliController: NSObject {
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1973,12 +2005,15 @@ final class MuesliController: NSObject {
         alert.addButton(withTitle: "Delete Draft")
         alert.buttons.dropFirst().first?.hasDestructiveAction = true
         if alert.runModal() == .alertFirstButtonReturn {
+            flushCachedMeetingTitle(id: id)
             flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
         } else {
             try? dictationStore.deleteMeeting(id: id)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
@@ -1993,15 +2028,18 @@ final class MuesliController: NSObject {
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
                 appState.meetingsNavigationState = .browser
             }
         } else {
+            flushCachedMeetingTitle(id: id)
             flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .failed)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
         }
         if activeMeetingID == id {
             activeMeetingID = nil
@@ -2014,15 +2052,18 @@ final class MuesliController: NSObject {
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
             if appState.selectedMeetingID == id {
                 appState.selectedMeetingID = nil
                 appState.selectedMeetingRecord = nil
                 appState.meetingsNavigationState = .browser
             }
         } else {
+            flushCachedMeetingTitle(id: id)
             flushCachedMeetingManualNotes(id: id, sync: false)
             try? dictationStore.updateMeetingStatus(id: id, status: .failed)
             clearCachedMeetingManualNotes(id: id)
+            clearCachedMeetingTitle(id: id)
         }
         syncAppState()
     }
@@ -2178,6 +2219,7 @@ final class MuesliController: NSObject {
             )
             meetingID = existingMeetingID
             clearCachedMeetingManualNotes(id: existingMeetingID)
+            clearCachedMeetingTitle(id: existingMeetingID)
         } else {
             meetingID = try dictationStore.insertMeeting(
                 title: result.title,
@@ -2199,7 +2241,10 @@ final class MuesliController: NSObject {
     }
 
     private func liveMeetingTitle(id: Int64) -> String? {
-        try? dictationStore.meeting(id: id)?.title
+        if let cached = liveMeetingTitleCache[id] {
+            return cached
+        }
+        return try? dictationStore.meeting(id: id)?.title
     }
 
     private func completedLiveMeetingTitle(for result: MeetingSessionResult, existingMeetingID: Int64) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1825,6 +1825,12 @@ final class MuesliController: NSObject {
                         return self.manualNotesForLiveMeeting(id: meetingID)
                     }
                 }
+                meetingSession.liveTitleProvider = { [weak self] in
+                    await MainActor.run {
+                        guard let self else { return nil }
+                        return self.liveMeetingTitle(id: meetingID)
+                    }
+                }
                 try await meetingSession.start()
                 activeMeetingSession = meetingSession
                 activeMeetingID = meetingID
@@ -2131,9 +2137,10 @@ final class MuesliController: NSObject {
         }
 
         if let existingMeetingID {
+            let persistedTitle = completedLiveMeetingTitle(for: result, existingMeetingID: existingMeetingID)
             try dictationStore.completeLiveMeeting(
                 id: existingMeetingID,
-                title: result.title,
+                title: persistedTitle,
                 calendarEventID: result.calendarEventID,
                 startTime: result.startTime,
                 endTime: result.endTime,
@@ -2167,6 +2174,19 @@ final class MuesliController: NSObject {
             )
         }
         return CompletedMeetingPersistenceResult(meetingID: meetingID, recordingSaveError: recordingSaveError)
+    }
+
+    private func liveMeetingTitle(id: Int64) -> String? {
+        try? dictationStore.meeting(id: id)?.title
+    }
+
+    private func completedLiveMeetingTitle(for result: MeetingSessionResult, existingMeetingID: Int64) -> String {
+        guard let liveTitle = liveMeetingTitle(id: existingMeetingID)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !liveTitle.isEmpty,
+              liveTitle != result.originalTitle.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return result.title
+        }
+        return liveTitle
     }
 
     func persistCompletedMeetingResultAndDispatchHook(_ result: MeetingSessionResult, existingMeetingID: Int64? = nil) throws -> CompletedMeetingPersistenceResult {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1095,6 +1095,10 @@ final class MuesliController: NSObject {
 
     @objc func openHistoryWindow() {
         showActiveMeetingDocumentIfNeeded()
+        presentHistoryWindow()
+    }
+
+    private func presentHistoryWindow() {
         DispatchQueue.main.async { [weak self] in
             self?.historyWindowController?.show()
         }
@@ -1726,7 +1730,7 @@ final class MuesliController: NSObject {
 
     func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil) {
         startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true)
-        openHistoryWindow()
+        presentHistoryWindow()
     }
 
     func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -162,6 +162,7 @@ final class MuesliController: NSObject {
         } catch {
             fputs("[muesli-native] startup error: \(error)\n", stderr)
         }
+        recoverStaleLiveMeetings()
 
         // Clean up phantom aggregate devices left by a previous crash
         CoreAudioSystemRecorder.cleanupStaleDevices()
@@ -463,6 +464,19 @@ final class MuesliController: NSObject {
         let persisted = Set(config.hiddenCalendarEventIDs)
         if appState.hiddenCalendarEventIDs != persisted {
             appState.hiddenCalendarEventIDs = persisted
+        }
+    }
+
+    func recoverStaleLiveMeetings() {
+        guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        let meetings = (try? dictationStore.recentMeetings(limit: 500)) ?? []
+        for meeting in meetings where meeting.status == .recording || meeting.status == .processing {
+            let manualNotes = meeting.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+            if manualNotes.isEmpty {
+                try? dictationStore.deleteMeeting(id: meeting.id)
+            } else {
+                try? dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1440,6 +1440,13 @@ final class MuesliController: NSObject {
         persistCachedMeetingManualNotes(id: id, notes: notes, sync: sync)
     }
 
+    func hasPersistedMeetingManualNotes(id: Int64, notes: String) -> Bool {
+        if liveManualNotesLastPersistedValue[id] == notes {
+            return true
+        }
+        return (try? dictationStore.meeting(id: id)?.manualNotes) == notes
+    }
+
     private func scheduleCachedMeetingManualNotesPersistence(id: Int64) {
         guard let notes = liveManualNotesCache[id] else { return }
         if shouldPersistCachedMeetingManualNotesImmediately(id: id, notes: notes) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -954,7 +954,7 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startMeetingRecording(title: title, calendarEventID: calendarEventID)
+                self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID)
                 self.scheduleMeetingEndNotification(endDate: endDate, title: title)
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
@@ -1947,7 +1947,7 @@ final class MuesliController: NSObject {
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
     func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
         NSWorkspace.shared.open(meetingURL)
-        startMeetingRecording(title: title, calendarEventID: calendarEventID)
+        startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID)
         scheduleMeetingEndNotification(endDate: endDate, title: title)
     }
 
@@ -2488,7 +2488,7 @@ final class MuesliController: NSObject {
                 guard let self else { return }
                 self.meetingMonitor.markRecordingStarted(candidate)
                 self.presentedMeetingCandidate = nil
-                self.startMeetingRecording(title: title)
+                self.startForegroundMeetingRecording(title: title)
             },
             onDismiss: { [weak self] in
                 guard let self else { return }
@@ -2886,7 +2886,7 @@ final class MuesliController: NSObject {
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
 
         if config.autoRecordMeetings, !isMeetingRecording() {
-            startMeetingRecording(title: event.title, calendarEventID: event.id)
+            startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true)
             scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
             return
         }
@@ -2917,7 +2917,7 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startMeetingRecording(title: title, calendarEventID: event.id)
+                self.startForegroundMeetingRecording(title: title, calendarEventID: event.id)
                 self.scheduleMeetingEndNotification(endDate: calendarEndDate, title: title)
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1346,6 +1346,9 @@ final class MuesliController: NSObject {
 
     static func stripManualNotesSection(from notes: String) -> String {
         let markers = [
+            "\n\n### Written notes\n\n",
+            "\n### Written notes\n\n",
+            "### Written notes\n\n",
             "\n\n## Manual Notes\n\n",
             "\n## Manual Notes\n\n",
             "## Manual Notes\n\n"

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -109,6 +109,7 @@ final class MuesliController: NSObject {
     private(set) var selectedMeetingTranscriptionBackend: BackendOption
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
     private var activeMeetingSession: MeetingSession?
+    private var activeMeetingID: Int64?
     private var dictationStartedAt: Date?
     private var _streamingDictationController: Any?  // StreamingDictationController (macOS 15+)
     private var isNemotronStreaming = false
@@ -349,6 +350,10 @@ final class MuesliController: NSObject {
         meetingNotification.close()
         activeMeetingSession?.discard()
         activeMeetingSession = nil
+        if let activeMeetingID {
+            resolveLiveMeetingAfterStopFailure(id: activeMeetingID)
+            self.activeMeetingID = nil
+        }
         endMeetingActivity()
         recorder.cancel()
         Task {
@@ -894,7 +899,7 @@ final class MuesliController: NSObject {
                     DispatchQueue.main.async { [weak self] in
                         guard let self, !self.isMeetingRecording() else { return }
                         self.meetingStartingNowTimers.removeValue(forKey: key)
-                        self.showMeetingStartingNowNotification(title: title, meetingURL: meetingURL, endDate: endDate)
+                        self.showMeetingStartingNowNotification(title: title, calendarEventID: key, meetingURL: meetingURL, endDate: endDate)
                     }
                 }
             }
@@ -904,7 +909,7 @@ final class MuesliController: NSObject {
     }
 
     /// Show a "Meeting starting now" notification — independent of Marauder's Map.
-    private func showMeetingStartingNowNotification(title: String, meetingURL: URL?, endDate: Date?) {
+    private func showMeetingStartingNowNotification(title: String, calendarEventID: String?, meetingURL: URL?, endDate: Date?) {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
         isShowingCalendarNotification = true
 
@@ -916,13 +921,13 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startMeetingRecording(title: title)
+                self.startMeetingRecording(title: title, calendarEventID: calendarEventID)
                 self.scheduleMeetingEndNotification(endDate: endDate, title: title)
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.joinAndRecord(title: title, meetingURL: meetingURL!, endDate: endDate)
+                self.joinAndRecord(title: title, meetingURL: meetingURL!, endDate: endDate, calendarEventID: calendarEventID)
             } : nil,
             onJoinOnly: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -1283,7 +1288,8 @@ final class MuesliController: NSObject {
                 meetingTitle: plan.promptTitle,
                 config: self.config,
                 template: templateSnapshot,
-                existingNotes: self.notesContextForResummary(meeting)
+                existingNotes: self.notesContextForResummary(meeting),
+                manualNotesToRetain: meeting.manualNotes
             )
 
             do {
@@ -1313,9 +1319,18 @@ final class MuesliController: NSObject {
     // MARK: - Meeting Editing
 
     private func notesContextForResummary(_ meeting: MeetingRecord) -> String? {
-        guard meeting.notesState == .structuredNotes else { return nil }
-        let trimmed = meeting.formattedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : meeting.formattedNotes
+        var parts: [String] = []
+        if meeting.notesState == .structuredNotes {
+            let trimmed = meeting.formattedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                parts.append(meeting.formattedNotes)
+            }
+        }
+        let manualNotes = meeting.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !manualNotes.isEmpty {
+            parts.append("Manual notes:\n\(manualNotes)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
     }
 
     func updateMeetingTitle(id: Int64, title: String) {
@@ -1325,6 +1340,11 @@ final class MuesliController: NSObject {
 
     func updateMeetingNotes(id: Int64, notes: String) {
         try? dictationStore.updateMeetingNotes(id: id, formattedNotes: notes)
+        syncAppState()
+    }
+
+    func updateMeetingManualNotes(id: Int64, notes: String) {
+        try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
         syncAppState()
     }
 
@@ -1573,8 +1593,30 @@ final class MuesliController: NSObject {
         startMeetingRecording(title: title)
     }
 
-    func startMeetingRecording(title: String = "Meeting") {
+    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        let templateSnapshot = defaultMeetingTemplate()
+        let meetingID: Int64
+        do {
+            meetingID = try dictationStore.createLiveMeeting(
+                title: title,
+                calendarEventID: calendarEventID,
+                startTime: Date(),
+                selectedTemplateID: templateSnapshot.id,
+                selectedTemplateName: templateSnapshot.name,
+                selectedTemplateKind: templateSnapshot.kind,
+                selectedTemplatePrompt: templateSnapshot.prompt
+            )
+            activeMeetingID = meetingID
+            syncAppState()
+            if openDocument {
+                showMeetingDocument(id: meetingID)
+            }
+        } catch {
+            fputs("[muesli-native] failed to create live meeting: \(error)\n", stderr)
+            presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
+            return
+        }
         isStartingMeetingRecording = true
         beginMeetingActivity(reason: "Recording and transcribing a meeting")
         meetingMonitor.suppressWhileActive()
@@ -1586,9 +1628,10 @@ final class MuesliController: NSObject {
         Task { [weak self] in
             guard let self else { return }
             do {
-                try await self.startMeetingRecordingWithSystemAudioRecovery(title: title)
+                try await self.startMeetingRecordingWithSystemAudioRecovery(title: title, calendarEventID: calendarEventID, meetingID: meetingID)
             } catch {
                 fputs("[muesli-native] failed to start meeting: \(error)\n", stderr)
+                self.resolveLiveMeetingAfterStartFailure(id: meetingID)
                 self.meetingMonitor.resumeAfterCooldown()
                 self.meetingMonitor.refreshState()
                 self.statusBarController?.setStatus("Idle")
@@ -1618,13 +1661,18 @@ final class MuesliController: NSObject {
         }
     }
 
-    private func startMeetingRecordingWithSystemAudioRecovery(title: String) async throws {
+    func startQuickNoteMeeting() {
+        startMeetingRecording(title: "Meeting", openDocument: true)
+        openHistoryWindow()
+    }
+
+    private func startMeetingRecordingWithSystemAudioRecovery(title: String, calendarEventID: String?, meetingID: Int64) async throws {
         var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
 
         while true {
             let meetingSession = MeetingSession(
                 title: title,
-                calendarEventID: nil,
+                calendarEventID: calendarEventID,
                 backend: selectedMeetingTranscriptionBackend,
                 runtime: runtime,
                 config: config,
@@ -1632,8 +1680,15 @@ final class MuesliController: NSObject {
             )
 
             do {
+                meetingSession.manualNotesProvider = { [weak self] in
+                    await MainActor.run {
+                        guard let self else { return nil }
+                        return try? self.dictationStore.meeting(id: meetingID)?.manualNotes
+                    }
+                }
                 try await meetingSession.start()
                 activeMeetingSession = meetingSession
+                activeMeetingID = meetingID
                 meetingMonitor.suppressWhileActive()
                 meetingMonitor.refreshState()
                 statusBarController?.setStatus("Meeting: \(title)")
@@ -1666,9 +1721,9 @@ final class MuesliController: NSObject {
 
     /// Open meeting URL, start recording, schedule end notification, and suppress detection.
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
-    func joinAndRecord(title: String, meetingURL: URL, endDate: Date?) {
+    func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
         NSWorkspace.shared.open(meetingURL)
-        startMeetingRecording(title: title)
+        startMeetingRecording(title: title, calendarEventID: calendarEventID)
         scheduleMeetingEndNotification(endDate: endDate, title: title)
     }
 
@@ -1701,6 +1756,10 @@ final class MuesliController: NSObject {
     func discardMeetingRecording() {
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
+            if let activeMeetingID {
+                resolveLiveMeetingAfterDiscard(id: activeMeetingID)
+                self.activeMeetingID = nil
+            }
             indicator.setMeetingRecording(false, config: config)
             isStoppingMeetingRecording = false
             endMeetingActivity()
@@ -1709,6 +1768,10 @@ final class MuesliController: NSObject {
         }
         activeMeetingSession.discard()
         self.activeMeetingSession = nil
+        if let activeMeetingID {
+            resolveLiveMeetingAfterDiscard(id: activeMeetingID)
+            self.activeMeetingID = nil
+        }
         isStoppingMeetingRecording = false
         endMeetingActivity()
         indicator.setMeetingRecording(false, config: config)
@@ -1718,6 +1781,72 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         syncAppState()
         updateMeetingNotificationVisibility()
+    }
+
+    private func resolveLiveMeetingAfterDiscard(id: Int64) {
+        let manualNotes = (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
+        if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try? dictationStore.deleteMeeting(id: id)
+            if appState.selectedMeetingID == id {
+                appState.selectedMeetingID = nil
+                appState.selectedMeetingRecord = nil
+                appState.meetingsNavigationState = .browser
+            }
+            syncAppState()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Keep manual notes?"
+        alert.informativeText = "This recording will be discarded, but this meeting has manually written notes. Keep them as a note-only meeting or delete the draft?"
+        alert.addButton(withTitle: "Keep Notes")
+        alert.addButton(withTitle: "Delete Draft")
+        alert.buttons.dropFirst().first?.hasDestructiveAction = true
+        if alert.runModal() == .alertFirstButtonReturn {
+            try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
+        } else {
+            try? dictationStore.deleteMeeting(id: id)
+            if appState.selectedMeetingID == id {
+                appState.selectedMeetingID = nil
+                appState.selectedMeetingRecord = nil
+                appState.meetingsNavigationState = .browser
+            }
+        }
+        syncAppState()
+    }
+
+    private func resolveLiveMeetingAfterStartFailure(id: Int64) {
+        let manualNotes = (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
+        if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try? dictationStore.deleteMeeting(id: id)
+            if appState.selectedMeetingID == id {
+                appState.selectedMeetingID = nil
+                appState.selectedMeetingRecord = nil
+                appState.meetingsNavigationState = .browser
+            }
+        } else {
+            try? dictationStore.updateMeetingStatus(id: id, status: .failed)
+        }
+        if activeMeetingID == id {
+            activeMeetingID = nil
+        }
+        syncAppState()
+    }
+
+    private func resolveLiveMeetingAfterStopFailure(id: Int64) {
+        let manualNotes = (try? dictationStore.meeting(id: id)?.manualNotes) ?? ""
+        if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try? dictationStore.deleteMeeting(id: id)
+            if appState.selectedMeetingID == id {
+                appState.selectedMeetingID = nil
+                appState.selectedMeetingRecord = nil
+                appState.meetingsNavigationState = .browser
+            }
+        } else {
+            try? dictationStore.updateMeetingStatus(id: id, status: .failed)
+        }
+        syncAppState()
     }
 
     func stopMeetingRecording() {
@@ -1734,6 +1863,11 @@ final class MuesliController: NSObject {
         meetingEndTimer?.invalidate()
         meetingEndTimer = nil
         meetingNotification.close()
+        let liveMeetingID = activeMeetingID
+        if let liveMeetingID {
+            try? dictationStore.updateMeetingStatus(id: liveMeetingID, status: .processing)
+            syncAppState()
+        }
         indicator.setMeetingRecording(false, config: config)
         indicator.setTranscribingTitle("Transcribing", config: config)
         setState(.transcribing)
@@ -1759,7 +1893,7 @@ final class MuesliController: NSObject {
                 await MainActor.run {
                     self.setMeetingProcessingStatus("Finalizing")
                 }
-                let persistenceResult = try self.persistCompletedMeetingResultAndDispatchHook(result)
+                let persistenceResult = try self.persistCompletedMeetingResultAndDispatchHook(result, existingMeetingID: liveMeetingID)
                 completedMeetingID = persistenceResult.meetingID
                 if let recordingSaveError = persistenceResult.recordingSaveError {
                     self.presentErrorAlert(title: "Meeting Recording", message: recordingSaveError.localizedDescription)
@@ -1771,9 +1905,13 @@ final class MuesliController: NSObject {
                 } else {
                     self.presentErrorAlert(title: "Meeting Recording", message: error.localizedDescription)
                 }
+                if let liveMeetingID {
+                    self.resolveLiveMeetingAfterStopFailure(id: liveMeetingID)
+                }
             }
             await MainActor.run {
                 self.activeMeetingSession = nil
+                self.activeMeetingID = nil
                 self.isStoppingMeetingRecording = false
                 self.endMeetingActivity()
                 self.setState(.idle)
@@ -1816,40 +1954,58 @@ final class MuesliController: NSObject {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
-    func persistCompletedMeetingResult(_ result: MeetingSessionResult) throws -> CompletedMeetingPersistenceResult {
-        let meetingID = try dictationStore.insertMeeting(
-            title: result.title,
-            calendarEventID: result.calendarEventID,
-            startTime: result.startTime,
-            endTime: result.endTime,
-            rawTranscript: result.rawTranscript,
-            formattedNotes: result.formattedNotes,
-            micAudioPath: nil,
-            systemAudioPath: nil,
-            savedRecordingPath: nil,
-            selectedTemplateID: result.templateSnapshot.id,
-            selectedTemplateName: result.templateSnapshot.name,
-            selectedTemplateKind: result.templateSnapshot.kind,
-            selectedTemplatePrompt: result.templateSnapshot.prompt
-        )
-
+    func persistCompletedMeetingResult(_ result: MeetingSessionResult, existingMeetingID: Int64? = nil) throws -> CompletedMeetingPersistenceResult {
+        let meetingID: Int64
+        var savedRecordingPath: String?
+        var recordingSaveError: MeetingLifecycleError?
         do {
-            if let savedRecordingPath = try persistMeetingRecordingIfNeeded(for: result) {
-                try dictationStore.updateMeetingSavedRecordingPath(id: meetingID, path: savedRecordingPath)
-            }
-            return CompletedMeetingPersistenceResult(meetingID: meetingID, recordingSaveError: nil)
+            savedRecordingPath = try persistMeetingRecordingIfNeeded(for: result)
         } catch let error as MeetingLifecycleError {
-            return CompletedMeetingPersistenceResult(meetingID: meetingID, recordingSaveError: error)
+            recordingSaveError = error
         } catch {
-            return CompletedMeetingPersistenceResult(
-                meetingID: meetingID,
-                recordingSaveError: .failedToSaveRecording(underlying: error)
+            recordingSaveError = .failedToSaveRecording(underlying: error)
+        }
+
+        if let existingMeetingID {
+            try dictationStore.completeLiveMeeting(
+                id: existingMeetingID,
+                title: result.title,
+                calendarEventID: result.calendarEventID,
+                startTime: result.startTime,
+                endTime: result.endTime,
+                rawTranscript: result.rawTranscript,
+                formattedNotes: result.formattedNotes,
+                micAudioPath: nil,
+                systemAudioPath: nil,
+                savedRecordingPath: savedRecordingPath,
+                selectedTemplateID: result.templateSnapshot.id,
+                selectedTemplateName: result.templateSnapshot.name,
+                selectedTemplateKind: result.templateSnapshot.kind,
+                selectedTemplatePrompt: result.templateSnapshot.prompt
+            )
+            meetingID = existingMeetingID
+        } else {
+            meetingID = try dictationStore.insertMeeting(
+                title: result.title,
+                calendarEventID: result.calendarEventID,
+                startTime: result.startTime,
+                endTime: result.endTime,
+                rawTranscript: result.rawTranscript,
+                formattedNotes: result.formattedNotes,
+                micAudioPath: nil,
+                systemAudioPath: nil,
+                savedRecordingPath: savedRecordingPath,
+                selectedTemplateID: result.templateSnapshot.id,
+                selectedTemplateName: result.templateSnapshot.name,
+                selectedTemplateKind: result.templateSnapshot.kind,
+                selectedTemplatePrompt: result.templateSnapshot.prompt
             )
         }
+        return CompletedMeetingPersistenceResult(meetingID: meetingID, recordingSaveError: recordingSaveError)
     }
 
-    func persistCompletedMeetingResultAndDispatchHook(_ result: MeetingSessionResult) throws -> CompletedMeetingPersistenceResult {
-        let persistenceResult = try persistCompletedMeetingResult(result)
+    func persistCompletedMeetingResultAndDispatchHook(_ result: MeetingSessionResult, existingMeetingID: Int64? = nil) throws -> CompletedMeetingPersistenceResult {
+        let persistenceResult = try persistCompletedMeetingResult(result, existingMeetingID: existingMeetingID)
         meetingHookDispatcher.dispatchCompletedMeetingHook(
             meetingID: persistenceResult.meetingID,
             completedAt: result.endTime,
@@ -2422,6 +2578,7 @@ final class MuesliController: NSObject {
                 // Reuse the same notification method as the timer path
                 self.showMeetingStartingNowNotification(
                     title: info.title,
+                    calendarEventID: info.id,
                     meetingURL: event?.meetingURL,
                     endDate: event?.endDate
                 )
@@ -2451,7 +2608,7 @@ final class MuesliController: NSObject {
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
 
         if config.autoRecordMeetings, !isMeetingRecording() {
-            startMeetingRecording(title: event.title)
+            startMeetingRecording(title: event.title, calendarEventID: event.id)
             scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
             return
         }
@@ -2482,13 +2639,13 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startMeetingRecording(title: title)
+                self.startMeetingRecording(title: title, calendarEventID: event.id)
                 self.scheduleMeetingEndNotification(endDate: calendarEndDate, title: title)
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.joinAndRecord(title: title, meetingURL: meetingURL!, endDate: calendarEndDate)
+                self.joinAndRecord(title: title, meetingURL: meetingURL!, endDate: calendarEndDate, calendarEventID: event.id)
             } : nil,
             onJoinOnly: meetingURL != nil ? { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1915,6 +1915,10 @@ final class MuesliController: NSObject {
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
+            if let activeMeetingID {
+                resolveLiveMeetingAfterStopFailure(id: activeMeetingID)
+                self.activeMeetingID = nil
+            }
             indicator.setMeetingRecording(false, config: config)
             isStoppingMeetingRecording = false
             endMeetingActivity()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1896,11 +1896,11 @@ final class MuesliController: NSObject {
         guard let activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
+            indicator.setMeetingRecording(false, config: config)
             if let activeMeetingID {
                 resolveLiveMeetingAfterDiscard(id: activeMeetingID)
                 self.activeMeetingID = nil
             }
-            indicator.setMeetingRecording(false, config: config)
             isStoppingMeetingRecording = false
             endMeetingActivity()
             setState(.idle)
@@ -1908,13 +1908,13 @@ final class MuesliController: NSObject {
         }
         activeMeetingSession.discard()
         self.activeMeetingSession = nil
+        indicator.setMeetingRecording(false, config: config)
         if let activeMeetingID {
             resolveLiveMeetingAfterDiscard(id: activeMeetingID)
             self.activeMeetingID = nil
         }
         isStoppingMeetingRecording = false
         endMeetingActivity()
-        indicator.setMeetingRecording(false, config: config)
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
         setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1419,9 +1419,12 @@ final class MuesliController: NSObject {
         liveManualNotesPersistWorkItems[id]?.cancel()
         liveManualNotesPersistWorkItems[id] = nil
         liveManualNotesCache[id] = notes
-        try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
-        liveManualNotesLastPersistedAt[id] = Date()
-        liveManualNotesLastPersistedValue[id] = notes
+        do {
+            try dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
+            markMeetingManualNotesPersisted(id: id, notes: notes)
+        } catch {
+            fputs("[muesli-native] failed to update manual notes for \(id): \(error)\n", stderr)
+        }
         syncAppState()
     }
 
@@ -1468,12 +1471,20 @@ final class MuesliController: NSObject {
             }
             return
         }
-        try? dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
-        liveManualNotesLastPersistedAt[id] = Date()
-        liveManualNotesLastPersistedValue[id] = notes
+        do {
+            try dictationStore.updateMeetingManualNotes(id: id, manualNotes: notes)
+            markMeetingManualNotesPersisted(id: id, notes: notes)
+        } catch {
+            fputs("[muesli-native] failed to persist manual notes for \(id): \(error)\n", stderr)
+        }
         if sync {
             syncAppState()
         }
+    }
+
+    private func markMeetingManualNotesPersisted(id: Int64, notes: String) {
+        liveManualNotesLastPersistedAt[id] = Date()
+        liveManualNotesLastPersistedValue[id] = notes
     }
 
     private func clearCachedMeetingManualNotes(id: Int64) {
@@ -1681,6 +1692,14 @@ final class MuesliController: NSObject {
         case .completed, .noteOnly, .failed:
             return true
         }
+    }
+
+    func activeLiveMeetingRecord() -> MeetingRecord? {
+        guard let activeMeetingID,
+              isMeetingRecording() || isStartingMeetingRecording else {
+            return nil
+        }
+        return meeting(id: activeMeetingID)
     }
 
     func clearMeetingHistory() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1765,7 +1765,7 @@ final class MuesliController: NSObject {
         statusBarController?.setStatus("Starting meeting: \(title)")
         statusBarController?.refresh()
 
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 try await self.startMeetingRecordingWithSystemAudioRecovery(title: title, calendarEventID: calendarEventID, meetingID: meetingID)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1052,9 +1052,9 @@ struct OnboardingView: View {
                 }
             } else {
                 if summaryBackend == .openRouter {
-                    Text("OpenRouter offers free models — no payment required.")
+                    Text("OpenRouter supports many model providers through one API key.")
                         .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.success)
+                        .foregroundStyle(MuesliTheme.textTertiary)
                 }
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -407,13 +407,6 @@ struct SettingsView: View {
                         .frame(height: 22)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Suggested model", controlWidth: meetingControlWidth) {
-                        settingsModelMenu(
-                            currentModel: appState.config.openRouterModel,
-                            presets: SummaryModelPreset.openRouterModels
-                        ) { val in controller.updateConfig { $0.openRouterModel = val } }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Free model", controlWidth: meetingControlWidth) {
                         openRouterFreeModelMenu
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -395,10 +395,17 @@ struct SettingsView: View {
                         .frame(height: 22)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model") {
+                    settingsRow("Suggested model") {
                         settingsModelMenu(
                             currentModel: appState.config.openRouterModel,
                             presets: SummaryModelPreset.openRouterModels
+                        ) { val in controller.updateConfig { $0.openRouterModel = val } }
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model ID") {
+                        settingsModelTextField(
+                            currentModel: appState.config.openRouterModel,
+                            placeholder: SummaryModelPreset.openRouterModels.first?.id ?? "provider/model"
                         ) { val in controller.updateConfig { $0.openRouterModel = val } }
                     }
                     keyStatusRow(key: appState.config.openRouterAPIKey)
@@ -1190,18 +1197,31 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func settingsModelMenu(currentModel: String, presets: [SummaryModelPreset], onChange: @escaping (String) -> Void) -> some View {
+        let menuPresets = SummaryModelPreset.menuPresets(presets, currentModel: currentModel)
         let effectiveModel = currentModel.isEmpty ? (presets.first?.id ?? "") : currentModel
-        let selectedLabel = presets.first(where: { $0.id == effectiveModel })?.label ?? presets.first?.label ?? ""
+        let selectedLabel = menuPresets.first(where: { $0.id == effectiveModel })?.label ?? menuPresets.first?.label ?? ""
         FixedWidthPopUp(
             selection: selectedLabel,
-            options: presets.map(\.label),
+            options: menuPresets.map(\.label),
             onSelectIndex: { index in
-                guard index >= 0 && index < presets.count else { return }
-                let selectedId = presets[index].id
+                guard index >= 0 && index < menuPresets.count else { return }
+                let selectedId = menuPresets[index].id
                 onChange(selectedId == presets.first?.id ? "" : selectedId)
             }
         )
         .frame(height: 24)
+    }
+
+    @ViewBuilder
+    private func settingsModelTextField(currentModel: String, placeholder: String, onChange: @escaping (String) -> Void) -> some View {
+        PastableTextField(
+            text: currentModel,
+            placeholder: placeholder,
+            onChange: { value in
+                onChange(value.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        )
+        .frame(height: 22)
     }
 
     @ViewBuilder
@@ -1362,6 +1382,48 @@ struct PastableSecureField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: EditableNSSecureTextField, context: Context) {
+        if nsView.stringValue != text {
+            nsView.stringValue = text
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onChange: onChange)
+    }
+
+    class Coordinator: NSObject, NSTextFieldDelegate {
+        let onChange: (String) -> Void
+
+        init(onChange: @escaping (String) -> Void) {
+            self.onChange = onChange
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            onChange(field.stringValue)
+        }
+    }
+}
+
+/// Plain text field with the same accessory-app edit shortcuts as secure fields.
+struct PastableTextField: NSViewRepresentable {
+    let text: String
+    let placeholder: String
+    let onChange: (String) -> Void
+
+    func makeNSView(context: Context) -> EditableNSTextField {
+        let field = EditableNSTextField()
+        field.placeholderString = placeholder
+        field.font = .systemFont(ofSize: 13)
+        field.isBordered = true
+        field.isBezeled = true
+        field.bezelStyle = .roundedBezel
+        field.delegate = context.coordinator
+        field.stringValue = text
+        return field
+    }
+
+    func updateNSView(_ nsView: EditableNSTextField, context: Context) {
         if nsView.stringValue != text {
             nsView.stringValue = text
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -72,9 +72,13 @@ struct SettingsView: View {
     @State private var screenRecordingGranted = false
     @State private var systemAudioGranted = false
     @State private var isCheckingSystemAudioPermission = false
+    @State private var openRouterFreeModels: [SummaryModelPreset] = []
+    @State private var isLoadingOpenRouterFreeModels = false
+    @State private var openRouterFreeModelsError: String?
 
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
+    private let meetingControlWidth: CGFloat = 275
 
     private var dictationBackendOptions: [BackendOption] {
         backendOptions(including: appState.selectedBackend)
@@ -104,6 +108,9 @@ struct SettingsView: View {
         .onAppear {
             refreshDownloadedModelOptions()
             startPermissionPolling()
+            if appState.selectedMeetingSummaryBackend == .openRouter {
+                loadOpenRouterFreeModelsIfNeeded()
+            }
         }
         .onDisappear {
             SoundController.stopMaraudersMapClip()
@@ -121,6 +128,11 @@ struct SettingsView: View {
         }
         .onChange(of: appState.selectedMeetingTranscriptionBackend) { _, _ in
             refreshDownloadedModelOptions()
+        }
+        .onChange(of: appState.selectedMeetingSummaryBackend) { _, backend in
+            if backend == .openRouter {
+                loadOpenRouterFreeModelsIfNeeded()
+            }
         }
         .alert(
             pendingDataDestruction?.title ?? "Confirm Destructive Action",
@@ -345,7 +357,7 @@ struct SettingsView: View {
             }
 
             settingsSection("Meeting Summaries") {
-                settingsRow("Summary backend") {
+                settingsRow("Summary backend", controlWidth: meetingControlWidth) {
                     settingsMenu(
                         selection: appState.selectedMeetingSummaryBackend.label,
                         options: MeetingSummaryBackendOption.all.map(\.label)
@@ -358,18 +370,18 @@ struct SettingsView: View {
                 Divider().background(MuesliTheme.surfaceBorder)
 
                 if appState.selectedMeetingSummaryBackend == .chatGPT {
-                    settingsRow("Account") {
+                    settingsRow("Account", controlWidth: meetingControlWidth) {
                         chatGPTAccountControl
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model") {
+                    settingsRow("Model", controlWidth: meetingControlWidth) {
                         settingsModelMenu(
                             currentModel: appState.config.chatGPTModel,
                             presets: SummaryModelPreset.chatGPTModels
                         ) { val in controller.updateConfig { $0.chatGPTModel = val } }
                     }
                 } else if appState.selectedMeetingSummaryBackend == .openAI {
-                    settingsRow("API Key") {
+                    settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(
                             text: appState.config.openAIAPIKey,
                             placeholder: "sk-...",
@@ -378,7 +390,7 @@ struct SettingsView: View {
                         .frame(height: 22)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model") {
+                    settingsRow("Model", controlWidth: meetingControlWidth) {
                         settingsModelMenu(
                             currentModel: appState.config.openAIModel,
                             presets: SummaryModelPreset.openAIModels
@@ -386,7 +398,7 @@ struct SettingsView: View {
                     }
                     keyStatusRow(key: appState.config.openAIAPIKey)
                 } else {
-                    settingsRow("API Key") {
+                    settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(
                             text: appState.config.openRouterAPIKey,
                             placeholder: "sk-or-...",
@@ -395,30 +407,34 @@ struct SettingsView: View {
                         .frame(height: 22)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Suggested model") {
+                    settingsRow("Suggested model", controlWidth: meetingControlWidth) {
                         settingsModelMenu(
                             currentModel: appState.config.openRouterModel,
                             presets: SummaryModelPreset.openRouterModels
                         ) { val in controller.updateConfig { $0.openRouterModel = val } }
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model ID") {
+                    settingsRow("Free model", controlWidth: meetingControlWidth) {
+                        openRouterFreeModelMenu
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
                         settingsModelTextField(
                             currentModel: appState.config.openRouterModel,
-                            placeholder: SummaryModelPreset.openRouterModels.first?.id ?? "provider/model"
+                            placeholder: "provider/model or openrouter/free"
                         ) { val in controller.updateConfig { $0.openRouterModel = val } }
                     }
                     keyStatusRow(key: appState.config.openRouterAPIKey)
                 }
 
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Default template") {
+                settingsRow("Default template", controlWidth: meetingControlWidth) {
                     meetingTemplateMenu(selectionID: appState.config.defaultMeetingTemplateID) { id in
                         controller.updateDefaultMeetingTemplate(id: id)
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Templates") {
+                settingsRow("Templates", controlWidth: meetingControlWidth) {
                     actionButton("Manage Templates…") {
                         controller.showMeetingTemplatesManager()
                     }
@@ -1068,7 +1084,8 @@ struct SettingsView: View {
     /// Standardized row: label on left, control on right.
     /// Controls share a fixed-width column so they all right-align consistently.
     @ViewBuilder
-    private func settingsRow(_ label: String, @ViewBuilder control: () -> some View) -> some View {
+    private func settingsRow(_ label: String, controlWidth rowControlWidth: CGFloat? = nil, @ViewBuilder control: () -> some View) -> some View {
+        let width = rowControlWidth ?? controlWidth
         HStack(alignment: .center) {
             Text(label)
                 .font(MuesliTheme.body())
@@ -1077,9 +1094,9 @@ struct SettingsView: View {
             Spacer(minLength: 20)
             ZStack(alignment: .trailing) {
                 // Invisible spacer forces the ZStack to exactly controlWidth
-                Color.clear.frame(width: controlWidth, height: 1)
+                Color.clear.frame(width: width, height: 1)
                 control()
-                    .frame(maxWidth: controlWidth)
+                    .frame(maxWidth: width)
             }
         }
         .frame(minHeight: 32)
@@ -1222,6 +1239,75 @@ struct SettingsView: View {
             }
         )
         .frame(height: 22)
+    }
+
+    @ViewBuilder
+    private var openRouterFreeModelMenu: some View {
+        if isLoadingOpenRouterFreeModels {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading models")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        } else if !openRouterFreeModels.isEmpty {
+            settingsModelMenu(
+                currentModel: appState.config.openRouterModel,
+                presets: openRouterFreeModels
+            ) { val in controller.updateConfig { $0.openRouterModel = val } }
+        } else {
+            HStack(spacing: 8) {
+                if let openRouterFreeModelsError {
+                    Text(openRouterFreeModelsError)
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .lineLimit(1)
+                }
+                Button("Load") {
+                    loadOpenRouterFreeModels(force: true)
+                }
+                .font(.system(size: 12, weight: .medium))
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    private func loadOpenRouterFreeModelsIfNeeded() {
+        guard openRouterFreeModels.isEmpty, !isLoadingOpenRouterFreeModels else { return }
+        loadOpenRouterFreeModels(force: false)
+    }
+
+    private func loadOpenRouterFreeModels(force: Bool) {
+        guard force || openRouterFreeModels.isEmpty else { return }
+        isLoadingOpenRouterFreeModels = true
+        openRouterFreeModelsError = nil
+
+        Task {
+            do {
+                let url = URL(string: "https://openrouter.ai/api/v1/models?output_modalities=text")!
+                let (data, response) = try await URLSession.shared.data(from: url)
+                if let httpResponse = response as? HTTPURLResponse,
+                   !(200..<300).contains(httpResponse.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+                let catalog = try JSONDecoder().decode(OpenRouterModelCatalog.self, from: data)
+                let presets = OpenRouterModelCatalogFilter.freeTextSummaryPresets(from: catalog.data)
+
+                await MainActor.run {
+                    openRouterFreeModels = presets
+                    openRouterFreeModelsError = presets.isEmpty ? "No free text models found" : nil
+                    isLoadingOpenRouterFreeModels = false
+                }
+            } catch {
+                await MainActor.run {
+                    openRouterFreeModels = []
+                    openRouterFreeModelsError = "Could not load"
+                    isLoadingOpenRouterFreeModels = false
+                }
+            }
+        }
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -139,6 +139,24 @@ struct DictationStoreTests {
         #expect(meeting.formattedNotes == "")
     }
 
+    @Test("manual notes update fails when the meeting row is missing")
+    func updateManualNotesFailsWhenMeetingMissing() throws {
+        let store = try makeStore()
+
+        #expect(throws: Error.self) {
+            try store.updateMeetingManualNotes(id: 9_999, manualNotes: "Lost note")
+        }
+    }
+
+    @Test("status update fails when the meeting row is missing")
+    func updateMeetingStatusFailsWhenMeetingMissing() throws {
+        let store = try makeStore()
+
+        #expect(throws: Error.self) {
+            try store.updateMeetingStatus(id: 9_999, status: .failed)
+        }
+    }
+
     @Test("live meeting completes the same row")
     func completeLiveMeetingUpdatesExistingRow() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -188,8 +188,21 @@ struct DictationStoreTests {
         #expect(completed.status == .completed)
         #expect(completed.title == "Generated Title")
         #expect(completed.rawTranscript == "hello world")
-        #expect(completed.wordCount == 2)
+        #expect(completed.wordCount == 5)
         #expect(completed.manualNotes == "- Keep this")
+    }
+
+    @Test("note-only status updates word count from manual notes")
+    func noteOnlyStatusCountsManualNotes() throws {
+        let store = try makeStore()
+        let id = try store.createLiveMeeting(title: "Manual Draft", calendarEventID: nil, startTime: Date())
+        try store.updateMeetingManualNotes(id: id, manualNotes: "Decision ship today")
+
+        try store.updateMeetingStatus(id: id, status: .noteOnly)
+
+        let meeting = try #require(try store.meeting(id: id))
+        #expect(meeting.status == .noteOnly)
+        #expect(meeting.wordCount == 3)
     }
 
     @Test("live meeting completion fails when the row disappeared")

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -199,6 +199,33 @@ struct DictationStoreTests {
         }
     }
 
+    @Test("staleLiveMeetings returns only recording and processing rows")
+    func staleLiveMeetingsFiltersLiveStatuses() throws {
+        let store = try makeStore()
+        let start = Date()
+
+        let recordingID = try store.createLiveMeeting(title: "Recording", calendarEventID: nil, startTime: start)
+        let processingID = try store.createLiveMeeting(title: "Processing", calendarEventID: nil, startTime: start.addingTimeInterval(1))
+        let noteOnlyID = try store.createLiveMeeting(title: "Note Only", calendarEventID: nil, startTime: start.addingTimeInterval(2))
+        try store.updateMeetingStatus(id: processingID, status: .processing)
+        try store.updateMeetingStatus(id: noteOnlyID, status: .noteOnly)
+        try store.insertMeeting(
+            title: "Completed",
+            calendarEventID: nil,
+            startTime: start.addingTimeInterval(3),
+            endTime: start.addingTimeInterval(60),
+            rawTranscript: "done",
+            formattedNotes: "## Summary\nDone",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+
+        let stale = try store.staleLiveMeetings()
+
+        #expect(stale.map(\.id) == [processingID, recordingID])
+        #expect(stale.allSatisfy { $0.status == .recording || $0.status == .processing })
+    }
+
     @Test("insert and retrieve dictation")
     func insertAndRetrieve() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -546,10 +546,23 @@ struct DictationStoreTests {
             rawTranscript: "This is a test transcript with several words",
             formattedNotes: "", micAudioPath: nil, systemAudioPath: nil
         )
+        let liveID = try store.createLiveMeeting(
+            title: "Live Draft",
+            calendarEventID: nil,
+            startTime: start.addingTimeInterval(60)
+        )
+        let noteOnlyID = try store.createLiveMeeting(
+            title: "Written Notes",
+            calendarEventID: nil,
+            startTime: start.addingTimeInterval(120)
+        )
+        try store.updateMeetingManualNotes(id: noteOnlyID, manualNotes: "manual note words")
+        try store.updateMeetingStatus(id: noteOnlyID, status: .noteOnly)
+        try store.updateMeetingStatus(id: liveID, status: .failed)
 
         let stats = try store.meetingStats()
-        #expect(stats.totalMeetings == 1)
-        #expect(stats.totalWords == 8)
+        #expect(stats.totalMeetings == 2)
+        #expect(stats.totalWords == 11)
     }
 
     @Test("clear dictations removes all records")

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -76,6 +76,8 @@ struct DictationStoreTests {
         #expect(inserted?.selectedTemplateID == "one-to-one")
         #expect(inserted?.selectedTemplateKind == .builtin)
         #expect(inserted?.savedRecordingPath == nil)
+        #expect(inserted?.status == .completed)
+        #expect(inserted?.manualNotes == "")
     }
 
     @Test("migration adds saved recording path column to legacy meeting schema")
@@ -99,6 +101,77 @@ struct DictationStoreTests {
 
         let inserted = try store.recentMeetings(limit: 1).first
         #expect(inserted?.savedRecordingPath == "/tmp/meeting.wav")
+    }
+
+    @Test("live meeting starts as recording with empty manual notes")
+    func createLiveMeeting() throws {
+        let store = try makeStore()
+        let start = Date()
+
+        let id = try store.createLiveMeeting(
+            title: "Quick Note",
+            calendarEventID: nil,
+            startTime: start,
+            selectedTemplateID: "auto",
+            selectedTemplateName: "Auto",
+            selectedTemplateKind: .auto,
+            selectedTemplatePrompt: "## Summary"
+        )
+
+        let meeting = try #require(try store.meeting(id: id))
+        #expect(meeting.title == "Quick Note")
+        #expect(meeting.status == .recording)
+        #expect(meeting.manualNotes == "")
+        #expect(meeting.rawTranscript == "")
+        #expect(meeting.formattedNotes == "")
+        #expect(meeting.selectedTemplateID == "auto")
+    }
+
+    @Test("manual notes update independently from final notes")
+    func updateManualNotes() throws {
+        let store = try makeStore()
+        let id = try store.createLiveMeeting(title: "Quick Note", calendarEventID: nil, startTime: Date())
+
+        try store.updateMeetingManualNotes(id: id, manualNotes: "- Decision: ship today")
+
+        let meeting = try #require(try store.meeting(id: id))
+        #expect(meeting.manualNotes == "- Decision: ship today")
+        #expect(meeting.formattedNotes == "")
+    }
+
+    @Test("live meeting completes the same row")
+    func completeLiveMeetingUpdatesExistingRow() throws {
+        let store = try makeStore()
+        let start = Date()
+        let id = try store.createLiveMeeting(title: "Draft", calendarEventID: nil, startTime: start)
+        try store.updateMeetingManualNotes(id: id, manualNotes: "- Keep this")
+
+        try store.completeLiveMeeting(
+            id: id,
+            title: "Generated Title",
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(120),
+            rawTranscript: "hello world",
+            formattedNotes: "## Summary\nHello\n\n## Manual Notes\n\n- Keep this",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: nil,
+            selectedTemplateID: "auto",
+            selectedTemplateName: "Auto",
+            selectedTemplateKind: .auto,
+            selectedTemplatePrompt: "## Summary"
+        )
+
+        let meetings = try store.recentMeetings(limit: 10)
+        #expect(meetings.count == 1)
+        let completed = try #require(meetings.first)
+        #expect(completed.id == id)
+        #expect(completed.status == .completed)
+        #expect(completed.title == "Generated Title")
+        #expect(completed.rawTranscript == "hello world")
+        #expect(completed.wordCount == 2)
+        #expect(completed.manualNotes == "- Keep this")
     }
 
     @Test("insert and retrieve dictation")
@@ -729,6 +802,17 @@ struct DictationStoreTests {
 
         let byNotes = try store.searchMeetings(query: "Prioritized")
         #expect(byNotes.count == 1)
+    }
+
+    @Test("searchMeetings matches manual notes")
+    func searchMeetingsManualNotes() throws {
+        let store = try makeStore()
+        let id = try store.createLiveMeeting(title: "Quick Note", calendarEventID: nil, startTime: Date())
+        try store.updateMeetingManualNotes(id: id, manualNotes: "Escalate renewal risk")
+
+        let results = try store.searchMeetings(query: "renewal")
+
+        #expect(results.map(\.id).contains(id))
     }
 
     @Test("search is case-insensitive for ASCII")

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -174,6 +174,31 @@ struct DictationStoreTests {
         #expect(completed.manualNotes == "- Keep this")
     }
 
+    @Test("live meeting completion fails when the row disappeared")
+    func completeLiveMeetingFailsWhenRowMissing() throws {
+        let store = try makeStore()
+        let start = Date()
+
+        #expect(throws: Error.self) {
+            try store.completeLiveMeeting(
+                id: 9_999,
+                title: "Generated Title",
+                calendarEventID: nil,
+                startTime: start,
+                endTime: start.addingTimeInterval(120),
+                rawTranscript: "hello world",
+                formattedNotes: "## Summary\nHello",
+                micAudioPath: nil,
+                systemAudioPath: nil,
+                savedRecordingPath: nil,
+                selectedTemplateID: "auto",
+                selectedTemplateName: "Auto",
+                selectedTemplateKind: .auto,
+                selectedTemplatePrompt: "## Summary"
+            )
+        }
+    }
+
     @Test("insert and retrieve dictation")
     func insertAndRetrieve() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -121,6 +121,7 @@ struct MeetingHookIntegrationTests {
         let end = start.addingTimeInterval(300)
         return MeetingSessionResult(
             title: "Tim V1 Meeting",
+            originalTitle: "Meeting",
             calendarEventID: calendarEventID,
             startTime: start,
             endTime: end,

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -58,12 +58,13 @@ struct MeetingSummaryClientTests {
     func promptMentionsPreservingCurrentNotes() {
         let instructions = MeetingSummaryClient.summaryInstructions(
             for: customTemplate,
-            existingNotes: "## Notes\n- User added follow-up detail"
+            existingNotes: "## Notes\n- Generated follow-up detail",
+            manualNotes: "- User added follow-up detail"
         )
 
-        #expect(instructions.contains("Preserve every concrete user-added detail"))
-        #expect(instructions.contains("must not be skipped"))
-        #expect(instructions.contains("requested template instead of discarding it"))
+        #expect(instructions.contains("Protected written notes"))
+        #expect(instructions.contains("Place each written note near the most relevant section"))
+        #expect(instructions.contains("Do not rewrite, polish, summarize away, or omit"))
     }
 
     @Test("summary user prompt includes existing notes context when provided")
@@ -74,9 +75,23 @@ struct MeetingSummaryClientTests {
             existingNotes: "## Notes\n- User added detail"
         )
 
-        #expect(prompt.contains("Current notes to preserve and reformat:"))
+        #expect(prompt.contains("Current generated notes to preserve and reformat:"))
         #expect(prompt.contains("User added detail"))
         #expect(prompt.contains("Raw transcript:\nTranscript body"))
+    }
+
+    @Test("summary user prompt includes protected written notes separately")
+    func userPromptIncludesProtectedWrittenNotes() {
+        let prompt = MeetingSummaryClient.summaryUserPrompt(
+            transcript: "Transcript body",
+            meetingTitle: "Customer Call",
+            existingNotes: "## Notes\n- Generated detail",
+            manualNotes: "- User typed decision"
+        )
+
+        #expect(prompt.contains("Current generated notes to preserve and reformat:"))
+        #expect(prompt.contains("Protected written notes typed by the user during the meeting"))
+        #expect(prompt.contains("- User typed decision"))
     }
 
     @Test("final notes retain manual notes verbatim")
@@ -87,9 +102,19 @@ struct MeetingSummaryClientTests {
         )
 
         #expect(result.contains("## Summary"))
-        #expect(result.contains("## Manual Notes"))
+        #expect(result.contains("### Written notes"))
         #expect(result.contains("- Decision: ship today"))
         #expect(result.contains("- [ ] Follow up with Priy"))
+    }
+
+    @Test("final notes do not append written notes already placed in summary")
+    func finalNotesSkipAlreadyPlacedManualNotes() {
+        let result = MeetingSummaryClient.notesByRetainingManualNotes(
+            generatedNotes: "## Decisions\n- Decision: ship today",
+            manualNotes: "- Decision: ship today"
+        )
+
+        #expect(result == "## Decisions\n- Decision: ship today")
     }
 
     @Test("fallback summary retains manual notes")
@@ -107,7 +132,7 @@ struct MeetingSummaryClientTests {
         )
 
         #expect(result.contains("## Raw Transcript"))
-        #expect(result.contains("## Manual Notes"))
+        #expect(result.contains("### Written notes"))
         #expect(result.contains("- Manual decision"))
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -117,6 +117,16 @@ struct MeetingSummaryClientTests {
         #expect(result == "## Decisions\n- Decision: ship today")
     }
 
+    @Test("final notes retain missing numbered written notes without duplicating placed ones")
+    func finalNotesRetainMissingNumberedManualNotes() {
+        let result = MeetingSummaryClient.notesByRetainingManualNotes(
+            generatedNotes: "## Decisions\n1. First decision",
+            manualNotes: "1. First decision\n2. Second decision"
+        )
+
+        #expect(result == "## Decisions\n1. First decision\n\n### Written notes\n\n2. Second decision")
+    }
+
     @Test("fallback summary retains manual notes")
     func fallbackSummaryRetainsManualNotes() async throws {
         var config = AppConfig()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -61,7 +61,8 @@ struct MeetingSummaryClientTests {
             existingNotes: "## Notes\n- User added follow-up detail"
         )
 
-        #expect(instructions.contains("Preserve any concrete user-added details"))
+        #expect(instructions.contains("Preserve every concrete user-added detail"))
+        #expect(instructions.contains("must not be skipped"))
         #expect(instructions.contains("requested template instead of discarding it"))
     }
 
@@ -76,6 +77,38 @@ struct MeetingSummaryClientTests {
         #expect(prompt.contains("Current notes to preserve and reformat:"))
         #expect(prompt.contains("User added detail"))
         #expect(prompt.contains("Raw transcript:\nTranscript body"))
+    }
+
+    @Test("final notes retain manual notes verbatim")
+    func finalNotesRetainManualNotesVerbatim() {
+        let result = MeetingSummaryClient.notesByRetainingManualNotes(
+            generatedNotes: "## Summary\n- Shipped the plan",
+            manualNotes: "- Decision: ship today\n- [ ] Follow up with Priy"
+        )
+
+        #expect(result.contains("## Summary"))
+        #expect(result.contains("## Manual Notes"))
+        #expect(result.contains("- Decision: ship today"))
+        #expect(result.contains("- [ ] Follow up with Priy"))
+    }
+
+    @Test("fallback summary retains manual notes")
+    func fallbackSummaryRetainsManualNotes() async {
+        var config = AppConfig()
+        config.openAIAPIKey = ""
+        config.meetingSummaryBackend = "openai"
+
+        let result = await MeetingSummaryClient.summarize(
+            transcript: "Hello world",
+            meetingTitle: "Test",
+            config: config,
+            existingNotes: "- Manual decision",
+            manualNotesToRetain: "- Manual decision"
+        )
+
+        #expect(result.contains("## Raw Transcript"))
+        #expect(result.contains("## Manual Notes"))
+        #expect(result.contains("- Manual decision"))
     }
 
     @Test("summary user prompt includes meeting context when provided")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -21,12 +21,12 @@ struct MeetingSummaryClientTests {
     )
 
     @Test("summarize returns raw transcript fallback when no API key")
-    func fallbackWithoutKey() async {
+    func fallbackWithoutKey() async throws {
         var config = AppConfig()
         config.openAIAPIKey = ""
         config.meetingSummaryBackend = "openai"
 
-        let result = await MeetingSummaryClient.summarize(
+        let result = try await MeetingSummaryClient.summarize(
             transcript: "Hello world",
             meetingTitle: "Test",
             config: config
@@ -118,12 +118,12 @@ struct MeetingSummaryClientTests {
     }
 
     @Test("fallback summary retains manual notes")
-    func fallbackSummaryRetainsManualNotes() async {
+    func fallbackSummaryRetainsManualNotes() async throws {
         var config = AppConfig()
         config.openAIAPIKey = ""
         config.meetingSummaryBackend = "openai"
 
-        let result = await MeetingSummaryClient.summarize(
+        let result = try await MeetingSummaryClient.summarize(
             transcript: "Hello world",
             meetingTitle: "Test",
             config: config,
@@ -158,12 +158,12 @@ struct MeetingSummaryClientTests {
     }
 
     @Test("summarize routes to OpenRouter when configured")
-    func routesToOpenRouter() async {
+    func routesToOpenRouter() async throws {
         var config = AppConfig()
         config.openRouterAPIKey = ""
         config.meetingSummaryBackend = "openrouter"
 
-        let result = await MeetingSummaryClient.summarize(
+        let result = try await MeetingSummaryClient.summarize(
             transcript: "Test transcript",
             meetingTitle: "My Meeting",
             config: config
@@ -171,6 +171,39 @@ struct MeetingSummaryClientTests {
 
         // No key → falls back to raw transcript
         #expect(result.contains("## Raw Transcript"))
+    }
+
+    @Test("summary failure notes make backend failure visible")
+    func summaryFailureNotesAreExplicit() {
+        let error = MeetingSummaryError.backendFailed(
+            backend: "OpenRouter",
+            statusCode: 400,
+            message: "No endpoints found for model retired/example"
+        )
+
+        let result = MeetingSummaryClient.summaryFailureNotes(
+            transcript: "Raw words",
+            meetingTitle: "Customer Review",
+            error: error,
+            manualNotes: "- User typed this during the meeting"
+        )
+
+        #expect(result.contains("## Summary failed"))
+        #expect(result.contains("OpenRouter could not generate meeting notes."))
+        #expect(result.contains("Status 400"))
+        #expect(result.contains("selected model may be unavailable or retired"))
+        #expect(result.contains("### Written notes"))
+        #expect(result.contains("- User typed this during the meeting"))
+        #expect(result.contains("## Raw Transcript"))
+        #expect(result.contains("Raw words"))
+    }
+
+    @Test("summary backend errors describe retired or unavailable models")
+    func summaryBackendErrorDescriptionMentionsModelAvailability() {
+        let error = MeetingSummaryError.emptyResponse(backend: "OpenRouter")
+
+        #expect(error.localizedDescription.contains("OpenRouter returned an empty response"))
+        #expect(error.localizedDescription.contains("unavailable or incompatible"))
     }
 
     @Test("generateTitle returns nil without API key")
@@ -202,12 +235,12 @@ struct MeetingSummaryClientTests {
     }
 
     @Test("summarize defaults to openai backend when empty")
-    func defaultsToOpenAI() async {
+    func defaultsToOpenAI() async throws {
         var config = AppConfig()
         config.meetingSummaryBackend = ""
         config.openAIAPIKey = ""
 
-        let result = await MeetingSummaryClient.summarize(
+        let result = try await MeetingSummaryClient.summarize(
             transcript: "Test", meetingTitle: "Title", config: config
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -127,6 +127,16 @@ struct MeetingSummaryClientTests {
         #expect(result == "## Decisions\n1. First decision\n\n### Written notes\n\n2. Second decision")
     }
 
+    @Test("short written notes are not dropped by section title substring matches")
+    func shortManualNotesDoNotFalseMatchSectionTitles() {
+        let result = MeetingSummaryClient.notesByRetainingManualNotes(
+            generatedNotes: "## Next steps\n- Follow up with Priy",
+            manualNotes: "Next steps"
+        )
+
+        #expect(result == "## Next steps\n- Follow up with Priy\n\n### Written notes\n\nNext steps")
+    }
+
     @Test("fallback summary retains manual notes")
     func fallbackSummaryRetainsManualNotes() async throws {
         var config = AppConfig()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -127,6 +127,26 @@ struct MeetingSummaryClientTests {
         #expect(result == "## Decisions\n1. First decision\n\n### Written notes\n\n2. Second decision")
     }
 
+    @Test("final notes match manual notes across list marker changes")
+    func finalNotesMatchManualNotesAcrossListMarkers() {
+        let result = MeetingSummaryClient.notesByRetainingManualNotes(
+            generatedNotes: """
+            ## Decisions
+            - Decision: ship today
+            - Follow up with Priy
+            1. First decision
+            """,
+            manualNotes: """
+            • Decision: ship today
+            - [ ] Follow up with Priy
+            1) First decision
+            2) Second decision
+            """
+        )
+
+        #expect(result == "## Decisions\n- Decision: ship today\n- Follow up with Priy\n1. First decision\n\n### Written notes\n\n2) Second decision")
+    }
+
     @Test("short written notes are not dropped by section title substring matches")
     func shortManualNotesDoNotFalseMatchSectionTitles() {
         let result = MeetingSummaryClient.notesByRetainingManualNotes(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -202,6 +202,47 @@ struct MeetingsNavigationTests {
         #expect(context == "## Summary\n- Decision captured")
     }
 
+    @Test("startup recovery preserves stale live meetings with notes")
+    func startupRecoveryPreservesStaleLiveMeetingWithNotes() throws {
+        let store = try makeStore()
+        let id = try store.createLiveMeeting(title: "Crashed Draft", calendarEventID: nil, startTime: Date())
+        try store.updateMeetingManualNotes(id: id, manualNotes: "Important draft")
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        controller.recoverStaleLiveMeetings()
+
+        let meeting = try #require(try store.meeting(id: id))
+        #expect(meeting.status == .failed)
+        #expect(meeting.manualNotes == "Important draft")
+    }
+
+    @Test("startup recovery removes empty stale live drafts")
+    func startupRecoveryDeletesEmptyStaleLiveDrafts() throws {
+        let store = try makeStore()
+        let id = try store.createLiveMeeting(title: "Empty Draft", calendarEventID: nil, startTime: Date())
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        controller.recoverStaleLiveMeetings()
+
+        #expect(try store.meeting(id: id) == nil)
+    }
+
     @Test("showMeetingTemplatesManager preserves current meetings context and presents manager")
     func showMeetingTemplatesManagerPresentsManager() {
         let controller = makeController()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -243,12 +243,15 @@ struct MeetingsNavigationTests {
         )
 
         controller.cacheMeetingManualNotes(id: meetingID, notes: "First durable note")
+        #expect(controller.hasPersistedMeetingManualNotes(id: meetingID, notes: "First durable note"))
         controller.cacheMeetingManualNotes(id: meetingID, notes: "Second cached note")
+        #expect(!controller.hasPersistedMeetingManualNotes(id: meetingID, notes: "Second cached note"))
 
         let beforeFlush = try #require(try store.meeting(id: meetingID))
         #expect(beforeFlush.manualNotes == "First durable note")
 
         controller.flushCachedMeetingManualNotes(id: meetingID, sync: false)
+        #expect(controller.hasPersistedMeetingManualNotes(id: meetingID, notes: "Second cached note"))
 
         let afterFlush = try #require(try store.meeting(id: meetingID))
         #expect(afterFlush.manualNotes == "Second cached note")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -246,6 +246,7 @@ struct MeetingsNavigationTests {
             .appendingPathExtension("wav")
         let result = MeetingSessionResult(
             title: "Customer Review",
+            originalTitle: "Meeting",
             calendarEventID: nil,
             startTime: Date(),
             endTime: Date().addingTimeInterval(90),
@@ -265,6 +266,44 @@ struct MeetingsNavigationTests {
         #expect(storedMeeting?.title == "Customer Review")
         #expect(storedMeeting?.rawTranscript == "Discussed roadmap and blockers.")
         #expect(storedMeeting?.savedRecordingPath == nil)
+    }
+
+    @Test("persistCompletedMeetingResult preserves user-edited live meeting title")
+    func persistCompletedMeetingResultPreservesEditedLiveTitle() async throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        let start = Date()
+        let liveID = try store.createLiveMeeting(title: "Meeting", calendarEventID: nil, startTime: start)
+        try store.updateMeetingTitle(id: liveID, title: "Investor Follow-up")
+
+        let result = MeetingSessionResult(
+            title: "Generated Summary Title",
+            originalTitle: "Meeting",
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(120),
+            durationSeconds: 120,
+            rawTranscript: "Discussed fundraising updates.",
+            formattedNotes: "## Summary\nFundraising updates discussed.",
+            retainedRecordingURL: nil,
+            retainedRecordingError: nil,
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+
+        _ = try controller.persistCompletedMeetingResult(result, existingMeetingID: liveID)
+
+        let storedMeeting = try #require(try store.meeting(id: liveID))
+        #expect(storedMeeting.title == "Investor Follow-up")
+        #expect(storedMeeting.formattedNotes == "## Summary\nFundraising updates discussed.")
     }
 
     @Test("resummary context strips appended written notes section")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -147,6 +147,56 @@ struct MeetingsNavigationTests {
         #expect(FileManager.default.fileExists(atPath: savedRecordingURL.path) == false)
     }
 
+    @Test("deleteMeeting refuses live meeting rows")
+    func deleteMeetingRefusesLiveRows() throws {
+        let store = try makeStore()
+        let meetingID = try store.createLiveMeeting(
+            title: "Live Quick Note",
+            calendarEventID: nil,
+            startTime: Date()
+        )
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        let liveMeeting = try #require(try store.meeting(id: meetingID))
+        #expect(controller.canDeleteMeeting(liveMeeting) == false)
+
+        controller.deleteMeeting(id: meetingID)
+
+        #expect(try store.meeting(id: meetingID) != nil)
+    }
+
+    @Test("cached manual notes are persisted before debounce")
+    func cachedManualNotesPersistImmediately() throws {
+        let store = try makeStore()
+        let meetingID = try store.createLiveMeeting(
+            title: "Live Quick Note",
+            calendarEventID: nil,
+            startTime: Date()
+        )
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        controller.cacheMeetingManualNotes(id: meetingID, notes: "Decision before crash")
+
+        let persisted = try #require(try store.meeting(id: meetingID))
+        #expect(persisted.manualNotes == "Decision before crash")
+    }
+
     @Test("persistCompletedMeetingResult keeps transcript when recording save fails")
     func persistCompletedMeetingResultPreservesMeetingOnRecordingFailure() async throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -197,6 +197,33 @@ struct MeetingsNavigationTests {
         #expect(persisted.manualNotes == "Decision before crash")
     }
 
+    @Test("failed manual note persistence retries on later flush")
+    func failedManualNotePersistenceRetriesOnFlush() throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        controller.cacheMeetingManualNotes(id: 1, notes: "Draft survives retry")
+        let meetingID = try store.createLiveMeeting(
+            title: "Live Quick Note",
+            calendarEventID: nil,
+            startTime: Date()
+        )
+        #expect(meetingID == 1)
+
+        controller.flushCachedMeetingManualNotes(id: meetingID, sync: false)
+
+        let stored = try #require(try store.meeting(id: meetingID))
+        #expect(stored.manualNotes == "Draft survives retry")
+    }
+
     @Test("manual note cache coalesces repeated writes until flush")
     func cachedManualNotesCoalesceRepeatedWrites() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -187,6 +187,21 @@ struct MeetingsNavigationTests {
         #expect(storedMeeting?.savedRecordingPath == nil)
     }
 
+    @Test("resummary context strips appended manual notes section")
+    func resummaryContextStripsManualNotesSection() {
+        let meeting = makeMeeting(
+            id: 909,
+            title: "Resummarize",
+            formattedNotes: "## Summary\n- Decision captured\n\n## Manual Notes\n\n- User typed this",
+            status: .completed,
+            manualNotes: "- User typed this"
+        )
+
+        let context = MuesliController.notesContextForResummary(meeting)
+
+        #expect(context == "## Summary\n- Decision captured")
+    }
+
     @Test("showMeetingTemplatesManager preserves current meetings context and presents manager")
     func showMeetingTemplatesManagerPresentsManager() {
         let controller = makeController()
@@ -237,19 +252,27 @@ struct MeetingsNavigationTests {
         #expect(controller.appState.config.meetingTranscriptionModel == BackendOption.whisperLargeTurbo.model)
     }
 
-    private func makeMeeting(id: Int64, title: String) -> MeetingRecord {
+    private func makeMeeting(
+        id: Int64,
+        title: String,
+        formattedNotes: String = "## Summary",
+        status: MeetingStatus = .completed,
+        manualNotes: String = ""
+    ) -> MeetingRecord {
         MeetingRecord(
             id: id,
             title: title,
             startTime: "2026-03-24 10:00",
             durationSeconds: 1800,
             rawTranscript: "Transcript",
-            formattedNotes: "## Summary",
+            formattedNotes: formattedNotes,
             wordCount: 42,
             folderID: nil,
             calendarEventID: nil,
             micAudioPath: nil,
             systemAudioPath: nil,
+            status: status,
+            manualNotes: manualNotes,
             selectedTemplateID: MeetingTemplates.autoID,
             selectedTemplateName: "Auto",
             selectedTemplateKind: .auto,

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -304,8 +304,8 @@ struct MeetingsNavigationTests {
         #expect(meeting.manualNotes == "Important draft")
     }
 
-    @Test("startup recovery removes empty stale live drafts")
-    func startupRecoveryDeletesEmptyStaleLiveDrafts() throws {
+    @Test("startup recovery marks empty stale live drafts as failed")
+    func startupRecoveryMarksEmptyStaleLiveDraftsFailed() throws {
         let store = try makeStore()
         let id = try store.createLiveMeeting(title: "Empty Draft", calendarEventID: nil, startTime: Date())
         let controller = MuesliController(
@@ -320,7 +320,8 @@ struct MeetingsNavigationTests {
 
         controller.recoverStaleLiveMeetings()
 
-        #expect(try store.meeting(id: id) == nil)
+        let meeting = try #require(try store.meeting(id: id))
+        #expect(meeting.status == .failed)
     }
 
     @Test("showMeetingTemplatesManager preserves current meetings context and presents manager")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -306,6 +306,44 @@ struct MeetingsNavigationTests {
         #expect(storedMeeting.formattedNotes == "## Summary\nFundraising updates discussed.")
     }
 
+    @Test("persistCompletedMeetingResult preserves cached live title before debounce")
+    func persistCompletedMeetingResultPreservesCachedLiveTitle() async throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        let start = Date()
+        let liveID = try store.createLiveMeeting(title: "Meeting", calendarEventID: nil, startTime: start)
+        controller.cacheMeetingTitle(id: liveID, title: "Status Bar Stop Title")
+
+        let result = MeetingSessionResult(
+            title: "Generated Summary Title",
+            originalTitle: "Meeting",
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(120),
+            durationSeconds: 120,
+            rawTranscript: "Discussed follow-up items.",
+            formattedNotes: "## Summary\nFollow-up items discussed.",
+            retainedRecordingURL: nil,
+            retainedRecordingError: nil,
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+
+        _ = try controller.persistCompletedMeetingResult(result, existingMeetingID: liveID)
+
+        let storedMeeting = try #require(try store.meeting(id: liveID))
+        #expect(storedMeeting.title == "Status Bar Stop Title")
+        #expect(storedMeeting.formattedNotes == "## Summary\nFollow-up items discussed.")
+    }
+
     @Test("resummary context strips appended written notes section")
     func resummaryContextStripsWrittenNotesSection() {
         let meeting = makeMeeting(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -197,6 +197,36 @@ struct MeetingsNavigationTests {
         #expect(persisted.manualNotes == "Decision before crash")
     }
 
+    @Test("manual note cache coalesces repeated writes until flush")
+    func cachedManualNotesCoalesceRepeatedWrites() throws {
+        let store = try makeStore()
+        let meetingID = try store.createLiveMeeting(
+            title: "Live Quick Note",
+            calendarEventID: nil,
+            startTime: Date()
+        )
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        controller.cacheMeetingManualNotes(id: meetingID, notes: "First durable note")
+        controller.cacheMeetingManualNotes(id: meetingID, notes: "Second cached note")
+
+        let beforeFlush = try #require(try store.meeting(id: meetingID))
+        #expect(beforeFlush.manualNotes == "First durable note")
+
+        controller.flushCachedMeetingManualNotes(id: meetingID, sync: false)
+
+        let afterFlush = try #require(try store.meeting(id: meetingID))
+        #expect(afterFlush.manualNotes == "Second cached note")
+    }
+
     @Test("persistCompletedMeetingResult keeps transcript when recording save fails")
     func persistCompletedMeetingResultPreservesMeetingOnRecordingFailure() async throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -187,12 +187,12 @@ struct MeetingsNavigationTests {
         #expect(storedMeeting?.savedRecordingPath == nil)
     }
 
-    @Test("resummary context strips appended manual notes section")
-    func resummaryContextStripsManualNotesSection() {
+    @Test("resummary context strips appended written notes section")
+    func resummaryContextStripsWrittenNotesSection() {
         let meeting = makeMeeting(
             id: 909,
             title: "Resummarize",
-            formattedNotes: "## Summary\n- Decision captured\n\n## Manual Notes\n\n- User typed this",
+            formattedNotes: "## Summary\n- Decision captured\n\n### Written notes\n\n- User typed this",
             status: .completed,
             manualNotes: "- User typed this"
         )

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -255,6 +255,13 @@ struct SummaryModelPresetTests {
               "architecture": { "output_modalities": ["text"] }
             },
             {
+              "id": "free/small-context",
+              "name": "Free Small Context",
+              "context_length": 99999,
+              "pricing": { "prompt": "0", "completion": "0", "request": "0" },
+              "architecture": { "output_modalities": ["text"] }
+            },
+            {
               "id": "paid/model",
               "name": "Paid Model",
               "context_length": 128000,

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -255,6 +255,19 @@ struct SummaryModelPresetTests {
               "architecture": { "output_modalities": ["text"] }
             },
             {
+              "id": "google/lyria-3-pro-preview",
+              "name": "Google: Lyria 3 Pro Preview",
+              "context_length": 1048576,
+              "pricing": { "prompt": "0", "completion": "0" },
+              "architecture": { "output_modalities": ["text", "audio"] }
+            },
+            {
+              "id": "missing/architecture",
+              "name": "Missing Architecture",
+              "context_length": 200000,
+              "pricing": { "prompt": "0", "completion": "0", "request": "0" }
+            },
+            {
               "id": "free/small-context",
               "name": "Free Small Context",
               "context_length": 99999,

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -241,6 +241,50 @@ struct SummaryModelPresetTests {
 
         #expect(menuPresets.count == SummaryModelPreset.openRouterModels.count)
     }
+
+    @Test("OpenRouter catalog filters free text generation models")
+    func openRouterCatalogFiltersFreeTextModels() throws {
+        let payload = """
+        {
+          "data": [
+            {
+              "id": "openrouter/free",
+              "name": "Free Models Router",
+              "context_length": 200000,
+              "pricing": { "prompt": "0", "completion": "0", "request": "0" },
+              "architecture": { "output_modalities": ["text"] }
+            },
+            {
+              "id": "paid/model",
+              "name": "Paid Model",
+              "context_length": 128000,
+              "pricing": { "prompt": "0.000001", "completion": "0", "request": "0" },
+              "architecture": { "output_modalities": ["text"] }
+            },
+            {
+              "id": "unknown/pricing",
+              "name": "Unknown Pricing",
+              "context_length": 4096,
+              "pricing": { "request": "0" },
+              "architecture": { "output_modalities": ["text"] }
+            },
+            {
+              "id": "free/image",
+              "name": "Free Image",
+              "context_length": 4096,
+              "pricing": { "prompt": "0", "completion": "0", "request": "0" },
+              "architecture": { "output_modalities": ["image"] }
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let catalog = try JSONDecoder().decode(OpenRouterModelCatalog.self, from: payload)
+        let presets = OpenRouterModelCatalogFilter.freeTextSummaryPresets(from: catalog.data)
+
+        #expect(presets.map(\.id) == ["openrouter/free"])
+        #expect(presets[0].label == "Free Models Router (200k ctx)")
+    }
 }
 
 @Suite("MeetingSummaryBackendOption")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -210,13 +210,36 @@ struct SummaryModelPresetTests {
         }
     }
 
-    @Test("OpenRouter presets are free models")
-    func openRouterModelsFree() {
+    @Test("OpenRouter presets have valid model IDs")
+    func openRouterModels() {
         #expect(!SummaryModelPreset.openRouterModels.isEmpty)
         for preset in SummaryModelPreset.openRouterModels {
             #expect(!preset.id.isEmpty)
-            #expect(preset.id.contains(":free"), "OpenRouter preset should be free: \(preset.id)")
+            #expect(!preset.label.isEmpty)
         }
+    }
+
+    @Test("model menu includes custom configured model")
+    func modelMenuIncludesCustomConfiguredModel() {
+        let customModel = "anthropic/claude-sonnet-4.5"
+        let menuPresets = SummaryModelPreset.menuPresets(
+            SummaryModelPreset.openRouterModels,
+            currentModel: customModel
+        )
+
+        #expect(menuPresets.last?.id == customModel)
+        #expect(menuPresets.last?.label == "Custom: \(customModel)")
+    }
+
+    @Test("model menu does not duplicate known models")
+    func modelMenuDoesNotDuplicateKnownModels() {
+        let knownModel = SummaryModelPreset.openRouterModels[0].id
+        let menuPresets = SummaryModelPreset.menuPresets(
+            SummaryModelPreset.openRouterModels,
+            currentModel: knownModel
+        )
+
+        #expect(menuPresets.count == SummaryModelPreset.openRouterModels.count)
     }
 }
 

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -5,13 +5,12 @@ set -euo pipefail
 #
 # - Separate bundle ID (com.muesli.dev) — won't interfere with production Muesli
 # - Separate data directory (~/Library/Application Support/MuesliDev/)
-# - Fresh config and database each time (use --clean to wipe)
+# - Preserves existing dev config and database by default
 # - Signed with Developer ID (Accessibility permission persists across rebuilds)
 # - Installs to /Applications/MuesliDev.app
 #
 # Usage:
 #   ./scripts/dev-test.sh              # Build and launch
-#   ./scripts/dev-test.sh --clean      # Wipe dev data and rebuild fresh (tests onboarding)
 #   ./scripts/dev-test.sh --reset      # Reset onboarding only (keeps data)
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -20,24 +19,25 @@ DEV_APP="/Applications/MuesliDev.app"
 ONBOARDING_PROGRESS_FILE="$DEV_SUPPORT_DIR/onboarding-progress.json"
 
 # Parse args
-CLEAN=0
 RESET=0
 for arg in "$@"; do
   case "$arg" in
-    --clean) CLEAN=1 ;;
+    --clean)
+      echo "Error: --clean has been removed because it deletes MuesliDev data." >&2
+      echo "To test a fresh profile, create a named backup first and use a separate support directory." >&2
+      exit 2
+      ;;
     --reset) RESET=1 ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
   esac
 done
 
 # Kill any running dev instance
 pkill -f "MuesliDev.app" 2>/dev/null || true
 sleep 0.5
-
-# Clean dev data if requested
-if [[ "$CLEAN" -eq 1 ]]; then
-  echo "Wiping dev data at: $DEV_SUPPORT_DIR"
-  rm -rf "$DEV_SUPPORT_DIR"
-fi
 
 # Reset onboarding only if requested
 if [[ "$RESET" -eq 1 ]] && [[ -f "$DEV_SUPPORT_DIR/config.json" ]]; then
@@ -78,6 +78,5 @@ echo "  Data: $DEV_SUPPORT_DIR"
 echo "  DB: $DEV_SUPPORT_DIR/muesli.db"
 echo ""
 echo "Tips:"
-echo "  ./scripts/dev-test.sh --clean    # Fresh install (test onboarding)"
 echo "  ./scripts/dev-test.sh --reset    # Re-run onboarding (keep data)"
 echo "  pkill -f MuesliDev               # Kill dev app"


### PR DESCRIPTION
## Summary
- add live meeting rows with `meeting_status` and `manual_notes` so Quick Note starts create a visible editable meeting immediately
- add a native markdown notes editor for recording/processing/note-only meetings and wire manual-note persistence through the controller lifecycle
- preserve manual notes during final summarization by passing them as context and appending a verbatim `## Manual Notes` section
- update calendar/status-bar/dashboard start paths to complete the same live row instead of creating a second meeting

Refs #56 and #72.

## Validation
- `swift test --package-path native/MuesliNative`
- `swift test --package-path native/MuesliNative --filter 'DictationStore|MeetingSummaryClient|MuesliCLI'`\n- `swift build --package-path native/MuesliNative`\n- `./scripts/dev-test.sh --clean` installed, signed, and launched `/Applications/MuesliDev.app`\n\n## QA Notes\n- Verified the MuesliDev debug app launches against a clean dev data directory.\n- Verified the dev DB schema includes `meeting_status` and `manual_notes`.\n- The critical persistence and summary paths are covered by new unit tests; full interactive recording QA should be repeated before promoting beyond pre-prod.