### PR TITLE
Add OpenHands resolver workflow

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -27,16 +27,13 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: OpenHands/OpenHands/.github/workflows/openhands-resolver.yml@main
+    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main
     with:
       macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
       max_iterations: ${{ fromJson(vars.OPENHANDS_MAX_ITER || 20) }}
-      base_container_image: ${{ vars.OPENHANDS_BASE_CONTAINER_IMAGE || '' }}
-      LLM_MODEL: ${{ vars.LLM_MODEL || 'anthropic/claude-sonnet-4-20250514' }}
-      target_branch: ${{ vars.TARGET_BRANCH || 'main' }}
-      runner: ${{ vars.TARGET_RUNNER }}
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -10,13 +10,13 @@ on:
   pull_request_review_comment:
     types: [created]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
 jobs:
   call-openhands-resolver:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
     # The resolver receives write-capable credentials. Only allow maintainer
     # invocations, only run on explicit OpenHands requests, and keep fork PRs
     # out of the write-token path.
@@ -34,7 +34,7 @@ jobs:
         ) ||
         (
           github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request == null &&
+          github.event.issue.pull_request == '' &&
           startsWith(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent')
         ) ||
         (

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -11,7 +11,20 @@ on:
     types: [created]
 
 jobs:
+  openhands-config:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      llm_model: ${{ steps.config.outputs.llm_model }}
+    steps:
+      - name: Read OpenHands configuration
+        id: config
+        env:
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
+        run: echo "llm_model=${LLM_MODEL}" >> "$GITHUB_OUTPUT"
+
   call-openhands-resolver:
+    needs: openhands-config
     permissions:
       contents: write
       pull-requests: write
@@ -50,6 +63,8 @@ jobs:
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
-      LLM_MODEL: ${{ vars.LLM_MODEL }}
+      # Upstream declares LLM_MODEL as a workflow-call secret, but Muesli stores
+      # it as a repo variable and forwards it through this read-only job output.
+      LLM_MODEL: ${{ needs.openhands-config.outputs.llm_model }}
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -34,6 +34,7 @@ jobs:
         ) ||
         (
           github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request == null &&
           startsWith(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent')
         ) ||
         (

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -9,8 +9,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: write
@@ -20,14 +18,31 @@ permissions:
 jobs:
   call-openhands-resolver:
     # The resolver receives write-capable credentials. Only allow maintainer
-    # invocations, and keep fork PRs out of the write-token path.
+    # invocations, only run on explicit OpenHands requests, and keep fork PRs
+    # out of the write-token path.
     if: |
       github.actor == 'pHequals7' &&
       (
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.head.repo.full_name == github.repository
+        (
+          github.event_name == 'issues' &&
+          github.event.label.name == 'fix-me'
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.label.name == 'fix-me' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          startsWith(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent')
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          startsWith(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent') &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
       )
-    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main
+    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@baa2f4515e3a68cb5b8d1fe1eba28c03e474c798
     with:
       macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
       max_iterations: ${{ fromJson(vars.OPENHANDS_MAX_ITER || 20) }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   openhands-config:
+    if: github.actor == 'pHequals7'
     runs-on: ubuntu-latest
     permissions: {}
     outputs:

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -50,6 +50,6 @@ jobs:
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
-      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+      LLM_MODEL: ${{ vars.LLM_MODEL }}
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -1,0 +1,42 @@
+name: Resolve with OpenHands
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  call-openhands-resolver:
+    # The resolver receives write-capable credentials. Only allow maintainer
+    # invocations, and keep fork PRs out of the write-token path.
+    if: |
+      github.actor == 'pHequals7' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    uses: OpenHands/OpenHands/.github/workflows/openhands-resolver.yml@main
+    with:
+      macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
+      max_iterations: ${{ fromJson(vars.OPENHANDS_MAX_ITER || 20) }}
+      base_container_image: ${{ vars.OPENHANDS_BASE_CONTAINER_IMAGE || '' }}
+      LLM_MODEL: ${{ vars.LLM_MODEL || 'anthropic/claude-sonnet-4-20250514' }}
+      target_branch: ${{ vars.TARGET_BRANCH || 'main' }}
+      runner: ${{ vars.TARGET_RUNNER }}
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -11,6 +11,7 @@ You are working on Muesli, a Swift/SwiftUI macOS app.
 
 ## Hard Rules
 
+- Do not use or install compromised LiteLLM versions `1.82.7` or `1.82.8`.
 - Never run `./scripts/dev-test.sh --clean`.
 - Never delete, reset, replace, or migrate away local MuesliDev data.
 - Never run release scripts.

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,0 +1,36 @@
+# Muesli OpenHands Instructions
+
+You are working on Muesli, a Swift/SwiftUI macOS app.
+
+## Primary Goal
+
+- Fix current PR review findings from Claude Code and Greptile.
+- P0/P1 findings are blocking if they still apply to the current HEAD.
+- P2 findings are optional unless they are low-risk and clearly correct.
+- Greptile findings may be stale. Verify each finding against current code before changing anything.
+
+## Hard Rules
+
+- Never run `./scripts/dev-test.sh --clean`.
+- Never delete, reset, replace, or migrate away local MuesliDev data.
+- Never run release scripts.
+- Never claim real local macOS UX verification from CI or a cloud environment.
+- Do not claim verification of permission prompts, system audio capture, floating window behavior, Sparkle update behavior, or latency-sensitive typing unless it was explicitly tested on a local Mac.
+- Final app acceptance requires local MuesliDev QA by the maintainer.
+
+## Verification
+
+- Prefer targeted Swift tests first when a fix is localized.
+- Run `swift test --package-path native/MuesliNative` when possible.
+- If the environment cannot build macOS-specific code or fetch dependencies, say so plainly and rely on CI/local QA for that layer.
+- Do not treat a skipped or unavailable local build as proof that the app works.
+
+## PR Review Policy
+
+- Read the latest Claude Code and Greptile comments before editing.
+- Classify each review item as current blocking, stale, optional, or out-of-scope.
+- For stale findings, cite the current file/function evidence that makes the finding obsolete.
+- Fix all current code-backed P0/P1 findings.
+- Keep changes narrow and consistent with existing SwiftUI/AppKit patterns.
+- Commit fixes directly to the PR branch.
+- Stop when there are no current code-backed P0/P1 findings and summarize what remains for local MuesliDev QA.


### PR DESCRIPTION
## Summary
- Add OpenHands Resolver GitHub Action for maintainer-triggered PR/issue fixes
- Add Muesli-specific OpenHands repository instructions for review triage and local QA boundaries
- Keep the resolver restricted to maintainer invocations and same-repo PR write paths

## Notes
- Requires repository secrets before use: LLM_API_KEY, optional LLM_BASE_URL, PAT_TOKEN, PAT_USERNAME.
- Requires repository variables before use: LLM_MODEL, OPENHANDS_MAX_ITER.
- Does not include the discarded README.md change from the cloud experiment.