### PR TITLE
Fix OpenHands resolver runtime

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -166,15 +166,21 @@ jobs:
             --selected-repo "${GITHUB_REPOSITORY}"
             --issue-number "${ISSUE_NUMBER}"
             --issue-type "${ISSUE_TYPE}"
-            --comment-id "${COMMENT_ID}"
             --max-iterations "${OPENHANDS_MAX_ITER}"
             --token "${PAT_TOKEN}"
             --username "${PAT_USERNAME}"
             --llm-model "${LLM_MODEL}"
             --llm-api-key "${LLM_API_KEY}"
-            --repo-instruction-file ".openhands/microagents/repo.md"
             --output-dir output
           )
+          if [ "${COMMENT_ID}" != "none" ]; then
+            args+=(--comment-id "${COMMENT_ID}")
+          fi
+          if [ -f ".openhands/microagents/repo.md" ]; then
+            args+=(--repo-instruction-file ".openhands/microagents/repo.md")
+          else
+            echo "Warning: .openhands/microagents/repo.md not found; running without repository instructions."
+          fi
           if [ -n "${LLM_BASE_URL}" ]; then
             args+=(--llm-base-url "${LLM_BASE_URL}")
           fi
@@ -200,6 +206,7 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           ISSUE_TYPE: ${{ steps.context.outputs.issue_type }}
+          RESULT_SUCCESS: ${{ steps.result.outputs.success }}
         run: |
           args=(
             python -m openhands.resolver.send_pull_request
@@ -219,7 +226,7 @@ jobs:
             args+=(--llm-base-url "${LLM_BASE_URL}")
           fi
 
-          if [ "${{ steps.result.outputs.success }}" = "true" ]; then
+          if [ "${RESULT_SUCCESS}" = "true" ]; then
             args+=(--pr-type draft)
           else
             args+=(--pr-type branch --send-on-failure)

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -224,7 +224,7 @@ jobs:
           else
             args+=(--pr-type branch --send-on-failure)
           fi
-          "${args[@]}" | tee publish_result.txt
+          "${args[@]}"
 
       - name: Comment on resolver result
         if: always() && steps.context.outputs.smoke_only != 'true'

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -11,29 +11,7 @@ on:
     types: [created]
 
 jobs:
-  openhands-config:
-    if: github.actor == 'pHequals7'
-    runs-on: ubuntu-latest
-    permissions: {}
-    outputs:
-      llm_model: ${{ steps.config.outputs.llm_model }}
-    steps:
-      - name: Read OpenHands configuration
-        id: config
-        env:
-          LLM_MODEL: ${{ vars.LLM_MODEL }}
-        run: echo "llm_model=${LLM_MODEL}" >> "$GITHUB_OUTPUT"
-
-  call-openhands-resolver:
-    needs: openhands-config
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-
-    # The resolver receives write-capable credentials. Only allow maintainer
-    # invocations, only run on explicit OpenHands requests, and keep fork PRs
-    # out of the write-token path.
+  resolve-with-openhands:
     if: |
       github.actor == 'pHequals7' &&
       (
@@ -57,15 +35,214 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
         )
       )
-    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@baa2f4515e3a68cb5b8d1fe1eba28c03e474c798
-    with:
-      macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
-      max_iterations: ${{ fromJson(vars.OPENHANDS_MAX_ITER || 20) }}
-    secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-      PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
-      # Upstream declares LLM_MODEL as a workflow-call secret, but Muesli stores
-      # it as a repo variable and forwards it through this read-only job output.
-      LLM_MODEL: ${{ needs.openhands-config.outputs.llm_model }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    env:
+      LLM_MODEL: ${{ vars.LLM_MODEL }}
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
+      OPENHANDS_MAX_ITER: ${{ vars.OPENHANDS_MAX_ITER || '20' }}
+      OPENHANDS_BASE_CONTAINER_IMAGE: ${{ vars.OPENHANDS_BASE_CONTAINER_IMAGE }}
+      TARGET_BRANCH: ${{ vars.TARGET_BRANCH || 'main' }}
+
+    steps:
+      - name: Resolve event context
+        id: context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            const payload = context.payload;
+            let issueNumber;
+            let issueType = 'issue';
+            let commentId = 'None';
+            let commentBody = '';
+
+            if (eventName === 'pull_request') {
+              issueNumber = payload.pull_request.number;
+              issueType = 'pr';
+            } else if (eventName === 'pull_request_review_comment') {
+              issueNumber = payload.pull_request.number;
+              issueType = 'pr';
+              commentId = String(payload.comment.id);
+              commentBody = payload.comment.body || '';
+            } else if (eventName === 'issue_comment') {
+              issueNumber = payload.issue.number;
+              issueType = payload.issue.pull_request ? 'pr' : 'issue';
+              commentId = String(payload.comment.id);
+              commentBody = payload.comment.body || '';
+            } else if (eventName === 'issues') {
+              issueNumber = payload.issue.number;
+              issueType = 'issue';
+            } else {
+              throw new Error(`Unsupported event: ${eventName}`);
+            }
+
+            core.setOutput('issue_number', String(issueNumber));
+            core.setOutput('issue_type', issueType);
+            core.setOutput('comment_id', commentId);
+            core.setOutput('smoke_only', String(/smoke test only/i.test(commentBody)));
+
+      - name: Check required configuration
+        run: |
+          required_vars=(LLM_MODEL LLM_API_KEY PAT_TOKEN PAT_USERNAME)
+          for var in "${required_vars[@]}"; do
+            if [ -z "${!var}" ]; then
+              echo "Error: required configuration $var is not set."
+              exit 1
+            fi
+          done
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}/lib/python3.12/site-packages/*
+          key: ${{ runner.os }}-pip-openhands-ai-1.6.0
+
+      - name: Install OpenHands resolver runtime
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "openhands-ai==1.6.0"
+          python - <<'PY'
+          import importlib.metadata as metadata
+
+          compromised_litellm_versions = {"1.82.7", "1.82.8"}
+          litellm_version = metadata.version("litellm")
+          if litellm_version in compromised_litellm_versions:
+              raise SystemExit(f"Refusing compromised litellm version {litellm_version}")
+
+          print("openhands-ai", metadata.version("openhands-ai"))
+          print("litellm", litellm_version)
+          PY
+
+      - name: Smoke test
+        if: steps.context.outputs.smoke_only == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+        run: |
+          LITELLM_VERSION="$(python - <<'PY'
+          import importlib.metadata as metadata
+          print(metadata.version("litellm"))
+          PY
+          )"
+          OPENHANDS_VERSION="$(python - <<'PY'
+          import importlib.metadata as metadata
+          print(metadata.version("openhands-ai"))
+          PY
+          )"
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
+            -f body="OpenHands smoke test succeeded. Repository instructions are present at \`.openhands/microagents/repo.md\`. Installed versions: \`openhands-ai ${OPENHANDS_VERSION}\`, \`litellm ${LITELLM_VERSION}\`. No code was edited."
+
+      - name: Resolve issue or PR
+        id: resolve
+        if: steps.context.outputs.smoke_only != 'true'
+        continue-on-error: true
+        env:
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+          ISSUE_TYPE: ${{ steps.context.outputs.issue_type }}
+          COMMENT_ID: ${{ steps.context.outputs.comment_id }}
+        run: |
+          args=(
+            python -m openhands.resolver.resolve_issue
+            --selected-repo "${GITHUB_REPOSITORY}"
+            --issue-number "${ISSUE_NUMBER}"
+            --issue-type "${ISSUE_TYPE}"
+            --comment-id "${COMMENT_ID}"
+            --max-iterations "${OPENHANDS_MAX_ITER}"
+            --token "${PAT_TOKEN}"
+            --username "${PAT_USERNAME}"
+            --llm-model "${LLM_MODEL}"
+            --llm-api-key "${LLM_API_KEY}"
+            --repo-instruction-file ".openhands/microagents/repo.md"
+            --output-dir output
+          )
+          if [ -n "${LLM_BASE_URL}" ]; then
+            args+=(--llm-base-url "${LLM_BASE_URL}")
+          fi
+          if [ -n "${OPENHANDS_BASE_CONTAINER_IMAGE}" ]; then
+            args+=(--base-container-image "${OPENHANDS_BASE_CONTAINER_IMAGE}")
+          fi
+          "${args[@]}"
+
+      - name: Check resolver result
+        id: result
+        if: steps.context.outputs.smoke_only != 'true' && hashFiles('output/output.jsonl') != ''
+        run: |
+          if grep -q '"success":true' output/output.jsonl; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish resolver changes
+        id: publish
+        if: steps.context.outputs.smoke_only != 'true' && hashFiles('output/output.jsonl') != ''
+        continue-on-error: true
+        env:
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+          ISSUE_TYPE: ${{ steps.context.outputs.issue_type }}
+        run: |
+          args=(
+            python -m openhands.resolver.send_pull_request
+            --selected-repo "${GITHUB_REPOSITORY}"
+            --issue-number "${ISSUE_NUMBER}"
+            --issue-type "${ISSUE_TYPE}"
+            --output-dir output
+            --token "${PAT_TOKEN}"
+            --username "${PAT_USERNAME}"
+            --llm-model "${LLM_MODEL}"
+            --llm-api-key "${LLM_API_KEY}"
+            --target-branch "${TARGET_BRANCH}"
+            --git-user-name "openhands-agent"
+            --git-user-email "openhands-agent@users.noreply.github.com"
+          )
+          if [ -n "${LLM_BASE_URL}" ]; then
+            args+=(--llm-base-url "${LLM_BASE_URL}")
+          fi
+
+          if [ "${{ steps.result.outputs.success }}" = "true" ]; then
+            args+=(--pr-type draft)
+          else
+            args+=(--pr-type branch --send-on-failure)
+          fi
+          "${args[@]}" | tee publish_result.txt
+
+      - name: Comment on resolver result
+        if: always() && steps.context.outputs.smoke_only != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+          RESOLVE_OUTCOME: ${{ steps.resolve.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          RESULT_SUCCESS: ${{ steps.result.outputs.success }}
+        run: |
+          if [ "${RESOLVE_OUTCOME}" = "success" ] && [ "${PUBLISH_OUTCOME}" = "success" ]; then
+            status="OpenHands finished. Resolver success: ${RESULT_SUCCESS}."
+          else
+            status="OpenHands encountered an error. Resolve step: ${RESOLVE_OUTCOME:-skipped}; publish step: ${PUBLISH_OUTCOME:-skipped}."
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
+            -f body="${status} Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Upload resolver output
+        if: always() && steps.context.outputs.smoke_only != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: resolver-output
+          path: output/
+          if-no-files-found: ignore

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -61,7 +61,7 @@ jobs:
             const payload = context.payload;
             let issueNumber;
             let issueType = 'issue';
-            let commentId = 'None';
+            let commentId = 'none';
             let commentBody = '';
 
             if (eventName === 'pull_request') {
@@ -110,7 +110,7 @@ jobs:
       - name: Cache pip dependencies
         uses: actions/cache@v4
         with:
-          path: ${{ env.pythonLocation }}/lib/python3.12/site-packages/*
+          path: ${{ env.pythonLocation }}/lib/python3.12/site-packages
           key: ${{ runner.os }}-pip-openhands-ai-1.6.0
 
       - name: Install OpenHands resolver runtime
@@ -135,6 +135,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         run: |
+          if [ ! -f ".openhands/microagents/repo.md" ]; then
+            echo "Expected .openhands/microagents/repo.md to exist."
+            exit 1
+          fi
           LITELLM_VERSION="$(python - <<'PY'
           import importlib.metadata as metadata
           print(metadata.version("litellm"))
@@ -183,7 +187,7 @@ jobs:
         id: result
         if: steps.context.outputs.smoke_only != 'true' && hashFiles('output/output.jsonl') != ''
         run: |
-          if grep -q '"success":true' output/output.jsonl; then
+          if grep -qE '"success"[[:space:]]*:[[:space:]]*true' output/output.jsonl; then
             echo "success=true" >> "$GITHUB_OUTPUT"
           else
             echo "success=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Replace the archived OpenHands resolver reusable workflow with an in-repo wrapper around current `openhands-ai==1.6.0`.
- Keep the existing maintainer-only, same-repo/fork-safe trigger guards.
- Add a `Smoke test only` path that installs the runtime, reports OpenHands/LiteLLM versions, and does not edit code.
- Add a runtime guard that refuses compromised LiteLLM versions `1.82.7` and `1.82.8`.

## Why
The smoke test reached the archived `All-Hands-AI/openhands-resolver` workflow, but that workflow installs `openhands-resolver==0.3.1`, which now fails dependency resolution because it depends on yanked OpenHands packages and an impossible `e2b<0.18.0` range. The archived workflow also has a broken cleanup path after install failure.

## Verification
- Parsed workflow YAML locally.
- Ran `python3 -m pip install --dry-run 'openhands-ai==1.6.0'` successfully.

## Follow-up QA
After merge, re-run the issue smoke test with a comment containing `@openhands-agent Smoke test only...`.
