### PR TITLE
Fix OpenHands publish arguments

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -205,7 +205,6 @@ jobs:
         continue-on-error: true
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
-          ISSUE_TYPE: ${{ steps.context.outputs.issue_type }}
           RESULT_SUCCESS: ${{ steps.result.outputs.success }}
         run: |
           args=(

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -212,7 +212,6 @@ jobs:
             python -m openhands.resolver.send_pull_request
             --selected-repo "${GITHUB_REPOSITORY}"
             --issue-number "${ISSUE_NUMBER}"
-            --issue-type "${ISSUE_TYPE}"
             --output-dir output
             --token "${PAT_TOKEN}"
             --username "${PAT_USERNAME}"


### PR DESCRIPTION
## Summary
- remove unsupported --issue-type from the OpenHands send_pull_request invocation
- keep --issue-type on resolve_issue, where it is accepted

## Testing
- ruby YAML parse for .github/workflows/openhands-resolver.yml

## Context
This fixes the publish failure seen in run https://github.com/pHequals7/muesli/actions/runs/25093119214 where send_pull_request exited with: unrecognized arguments: --issue-type issue.