### PR TITLE
Fix issue #80: Meetings : Limit the list to the next 5 meetings

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -262,6 +262,8 @@ struct MeetingsView: View {
         let f = DateFormatter(); f.dateFormat = "EEE"; return f
     }()
 
+    private static let maxUpcomingEvents = 5
+
     private var groupedUpcomingEvents: [UpcomingEventGroup] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
@@ -273,7 +275,16 @@ struct MeetingsView: View {
         let monthFormatter = Self.monthFormatter
         let weekdayFormatter = Self.weekdayFormatter
 
-        return grouped.keys.sorted().map { date in
+        let sortedDates = grouped.keys.sorted()
+        var result: [UpcomingEventGroup] = []
+        var remaining = Self.maxUpcomingEvents
+
+        for date in sortedDates {
+            guard remaining > 0 else { break }
+            let sortedEvents = grouped[date]!.sorted { $0.startDate < $1.startDate }
+            let limitedEvents = Array(sortedEvents.prefix(remaining))
+            remaining -= limitedEvents.count
+
             let isToday = calendar.isDate(date, inSameDayAs: today)
             let isTomorrow = calendar.date(byAdding: .day, value: 1, to: today).map { calendar.isDate(date, inSameDayAs: $0) } ?? false
             let dayLabel: String
@@ -284,16 +295,18 @@ struct MeetingsView: View {
             } else {
                 dayLabel = monthFormatter.string(from: date)
             }
-            return UpcomingEventGroup(
+            result.append(UpcomingEventGroup(
                 id: date.description,
                 date: date,
                 dayLabel: dayLabel,
                 dayNumber: dayFormatter.string(from: date),
                 dayOfWeek: weekdayFormatter.string(from: date),
                 isToday: isToday,
-                events: grouped[date]!.sorted { $0.startDate < $1.startDate }
-            )
+                events: limitedEvents
+            ))
         }
+
+        return result
     }
 
     @ViewBuilder


### PR DESCRIPTION
This pull request fixes #80.

The patch modifies `MeetingsView.swift` to limit the displayed upcoming meetings to a maximum of 5 events. It introduces a constant `maxUpcomingEvents = 5` and rewrites the `groupedUpcomingEvents` computed property to iterate over sorted dates, taking only the first `remaining` events (starting at 5) across all groups. This directly addresses the issue of an overly long meeting list by ensuring no more than 5 upcoming meetings are shown, making it easy to see the last notes. The change is self-contained and correctly implements the requested limit.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌