### PR TITLE
[codex] Add pause controls for meeting recordings

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -58,6 +58,7 @@ final class AppState {
 
     // Live status
     var isMeetingRecording: Bool = false
+    var isMeetingRecordingPaused: Bool = false
     var isChatGPTAuthenticated: Bool = false
     var isGoogleCalendarAvailable: Bool = false
     var isGoogleCalendarVerified: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -8,7 +8,10 @@ import MuesliCore
 protocol SystemAudioCapturing: AnyObject {
     var onPCMSamples: (([Int16]) -> Void)? { get set }
     var isRecording: Bool { get }
+    var isPaused: Bool { get }
     func start() async throws
+    func pause()
+    func resume()
     func stop() -> URL?
 }
 
@@ -33,6 +36,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     private var outputURL: URL?
     private var totalBytesWritten = 0
     private(set) var isRecording = false
+    private(set) var isPaused = false
 
     private static let targetSampleRate: Double = 16_000
     private static let maxRenderFrames: UInt32 = 4096
@@ -63,6 +67,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         outputURL = url
         totalBytesWritten = 0
         isRecording = true
+        isPaused = false
 
         do {
             try createTapAndAggregateDevice()
@@ -78,6 +83,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     func stop() -> URL? {
         guard isRecording || outputFile != nil || outputURL != nil else { return nil }
         isRecording = false
+        isPaused = false
         onPCMSamples = nil
 
         if let au = audioUnit {
@@ -116,6 +122,16 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
 
         fputs("[system-audio] CoreAudio tap stopped, \(bytes) bytes written\n", stderr)
         return url
+    }
+
+    func pause() {
+        guard isRecording else { return }
+        isPaused = true
+    }
+
+    func resume() {
+        guard isRecording else { return }
+        isPaused = false
     }
 
     // MARK: - Tap + Aggregate Device Setup
@@ -277,6 +293,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
             au, ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, &bufferList
         )
         guard status == noErr else { return status }
+        guard !recorder.isPaused else { return noErr }
 
         // Copy rendered data and dispatch off the audio thread for conversion + I/O
         let data = Data(bytes: rawBuf, count: byteSize)
@@ -285,7 +302,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         let srcRate = recorder.sourceSampleRate
 
         recorder.processingQueue.async { [weak recorder] in
-            guard let recorder, recorder.isRecording else { return }
+            guard let recorder, recorder.isRecording, !recorder.isPaused else { return }
             recorder.processAudioData(data, frameCount: frameCount, channels: channels, sourceRate: srcRate)
         }
 
@@ -295,6 +312,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     // MARK: - Audio Processing (processing queue)
 
     private func processAudioData(_ data: Data, frameCount: Int, channels: Int, sourceRate: Double) {
+        guard isRecording, !isPaused else { return }
         data.withUnsafeBytes { rawBuffer in
             let floatPtr = rawBuffer.bindMemory(to: Float.self)
 
@@ -544,6 +562,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
 
     private func cleanupFailedStart() {
         isRecording = false
+        isPaused = false
         onPCMSamples = nil
 
         if let au = audioUnit {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -82,6 +82,7 @@ final class FloatingIndicatorController: NSObject {
     private var hoverExitWorkItem: DispatchWorkItem?
     private let configStore: ConfigStore
     private var isMeetingRecording = false
+    private var isMeetingRecordingPaused = false
     private var glassView: NSVisualEffectView?
     private var tintLayer: CALayer?
     private var micIconView: NSImageView?
@@ -93,6 +94,7 @@ final class FloatingIndicatorController: NSObject {
     var powerProvider: (() -> Float)?
     var onStopMeeting: (() -> Void)?
     var onDiscardMeeting: (() -> Void)?
+    var onToggleMeetingPause: (() -> Void)?
     var onCancelToggleDictation: (() -> Void)?
     var onPositionSaved: ((CGPoint) -> Void)?
     var isToggleDictation = false
@@ -113,7 +115,7 @@ final class FloatingIndicatorController: NSObject {
         if state == .recording, let x {
             if x < 30 {
                 if isMeetingRecording {
-                    onDiscardMeeting?()
+                    onToggleMeetingPause?()
                 } else {
                     onCancelToggleDictation?()
                 }
@@ -134,7 +136,9 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func handleOptionClick() {
-        if !isMeetingRecording, state == .recording {
+        if isMeetingRecording, state == .recording {
+            onDiscardMeeting?()
+        } else if state == .recording {
             onCancelToggleDictation?()
         }
     }
@@ -184,11 +188,21 @@ final class FloatingIndicatorController: NSObject {
 
     func setMeetingRecording(_ recording: Bool, config: AppConfig) {
         isMeetingRecording = recording
+        if !recording {
+            isMeetingRecordingPaused = false
+        }
         if recording {
             setState(.recording, config: config)
         } else {
             setState(.idle, config: config)
         }
+    }
+
+    func setMeetingRecordingPaused(_ paused: Bool, config: AppConfig) {
+        guard isMeetingRecordingPaused != paused else { return }
+        isMeetingRecordingPaused = paused
+        guard isMeetingRecording, state == .recording else { return }
+        setState(.recording, config: config)
     }
 
     func setTranscribingTitle(_ title: String, config: AppConfig) {
@@ -254,12 +268,12 @@ final class FloatingIndicatorController: NSObject {
             contentView.layer?.borderColor = style.border.cgColor
 
             if state == .recording {
-                // All recordings: X on left, waveform in middle, stop on right.
+                // Dictation uses cancel on the left. Meeting recordings use pause/resume.
                 iconLabel.isHidden = false
                 iconLabel.animator().alphaValue = 1
-                iconLabel.stringValue = "\u{2715}"  // ✕
-                iconLabel.textColor = .white.withAlphaComponent(0.45)
-                iconLabel.font = NSFont.systemFont(ofSize: 7, weight: .semibold)
+                iconLabel.stringValue = recordingControlSymbol()
+                iconLabel.textColor = .white.withAlphaComponent(isMeetingRecording ? 0.86 : 0.45)
+                iconLabel.font = NSFont.systemFont(ofSize: isMeetingRecording ? 8 : 7, weight: .semibold)
                 let xSize: CGFloat = 10
                 iconLabel.frame = NSRect(
                     x: 7,
@@ -524,6 +538,11 @@ final class FloatingIndicatorController: NSObject {
 
         contentView.layer?.addSublayer(stop)
         stopLayer = stop
+    }
+
+    private func recordingControlSymbol() -> String {
+        guard isMeetingRecording else { return "\u{2715}" }
+        return isMeetingRecordingPaused ? "\u{25B6}" : "\u{23F8}"
     }
 
     private func removeStopLayer() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -693,7 +693,7 @@ struct MeetingDetailView: View {
 
     private var discardRecordingButton: some View {
         iconButton("xmark", label: "Discard") {
-            controller.discardMeetingRecording()
+            controller.discardMeetingWithConfirmation()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -159,15 +159,7 @@ struct MeetingDetailView: View {
 
                 VStack(alignment: .trailing, spacing: 10) {
                     if showsManualNotesEditor(for: meeting) {
-                        HStack(spacing: MuesliTheme.spacing8) {
-                            statusChip(for: meeting)
-                            if meeting.status == .recording {
-                                stopRecordingButton
-                                discardRecordingButton
-                            } else if controller.canDeleteMeeting(meeting), meeting.status == .noteOnly || meeting.status == .failed {
-                                deleteButton
-                            }
-                        }
+                        recordingControlGroup(for: meeting)
                     } else {
                         documentModePicker
 
@@ -503,11 +495,14 @@ struct MeetingDetailView: View {
 
     @ViewBuilder
     private func statusChip(for meeting: MeetingRecord) -> some View {
+        let isPaused = meeting.status == .recording && appState.isMeetingRecordingPaused
+        let label = isPaused ? "Paused" : meeting.status.displayLabel
+        let color = isPaused ? MuesliTheme.transcribing : meeting.status.displayColor
         HStack(spacing: 6) {
             Circle()
-                .fill(meeting.status.displayColor)
+                .fill(color)
                 .frame(width: 7, height: 7)
-            Text(meeting.status.displayLabel)
+            Text(label)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
@@ -519,6 +514,38 @@ struct MeetingDetailView: View {
             Capsule()
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+    }
+
+    @ViewBuilder
+    private func recordingControlGroup(for meeting: MeetingRecord) -> some View {
+        if meeting.status == .recording {
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    statusChip(for: meeting)
+                    pauseResumeRecordingButton
+                    stopRecordingButton
+                    discardRecordingButton
+                }
+                .recordingControlsBackground()
+
+                VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
+                    statusChip(for: meeting)
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        pauseResumeRecordingButton
+                        stopRecordingButton
+                        discardRecordingButton
+                    }
+                    .recordingControlsBackground()
+                }
+            }
+        } else if controller.canDeleteMeeting(meeting), meeting.status == .noteOnly || meeting.status == .failed {
+            HStack(spacing: MuesliTheme.spacing8) {
+                statusChip(for: meeting)
+                deleteButton
+            }
+        } else {
+            statusChip(for: meeting)
+        }
     }
 
     @ViewBuilder
@@ -614,6 +641,32 @@ struct MeetingDetailView: View {
         }
     }
 
+    private var pauseResumeRecordingButton: some View {
+        let isPaused = appState.isMeetingRecordingPaused
+        return Button {
+            controller.toggleMeetingRecordingPause()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isPaused ? "play.fill" : "pause.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(isPaused ? "Resume" : "Pause")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(isPaused ? MuesliTheme.backgroundBase : MuesliTheme.textPrimary)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, 7)
+            .background(isPaused ? MuesliTheme.accent : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(isPaused ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!appState.isMeetingRecording)
+        .help(isPaused ? "Resume recording" : "Pause recording")
+    }
+
     private var stopRecordingButton: some View {
         Button {
             if let meeting {
@@ -624,16 +677,17 @@ struct MeetingDetailView: View {
             HStack(spacing: 6) {
                 Image(systemName: "stop.fill")
                     .font(.system(size: 10, weight: .semibold))
-                Text("Stop Recording")
+                Text("Stop")
                     .font(.system(size: 12, weight: .semibold))
             }
             .foregroundStyle(.white)
             .padding(.horizontal, MuesliTheme.spacing12)
-            .padding(.vertical, 8)
+            .padding(.vertical, 7)
             .background(MuesliTheme.recording)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
         }
         .buttonStyle(.plain)
+        .disabled(!appState.isMeetingRecording)
         .help("Stop recording")
     }
 
@@ -900,6 +954,18 @@ struct MeetingDetailView: View {
             return s == 0 ? "\(m)m" : "\(m)m \(s)s"
         }
         return "\(rounded)s"
+    }
+}
+
+private extension View {
+    func recordingControlsBackground() -> some View {
+        padding(5)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
@@ -240,11 +240,7 @@ struct MeetingListItemView: View {
         } else {
             source = record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
         }
-        let compact = source.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        if compact.count > 88 {
-            return String(compact.prefix(85)) + "..."
-        }
-        return compact.isEmpty ? "No notes yet" : compact
+        return MeetingPreviewText.snippet(from: source)
     }
 
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum MeetingPreviewText {
+    static func snippet(from source: String, limit: Int = 88) -> String {
+        let compact = plainText(from: source)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+
+        guard !compact.isEmpty else { return "No notes yet" }
+        guard compact.count > limit else { return compact }
+
+        let prefixCount = max(0, limit - 3)
+        return String(compact.prefix(prefixCount)) + "..."
+    }
+
+    static func plainText(from markdown: String) -> String {
+        var lines: [String] = []
+        var isInsideFence = false
+
+        for rawLine in markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false) {
+            var line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if line.hasPrefix("```") || line.hasPrefix("~~~") {
+                isInsideFence.toggle()
+                continue
+            }
+            guard !isInsideFence else { continue }
+
+            if line.range(of: #"^\s{0,3}[-*_]{3,}\s*$"#, options: .regularExpression) != nil ||
+                line.range(of: #"^\s{0,3}[=-]{3,}\s*$"#, options: .regularExpression) != nil {
+                continue
+            }
+
+            line = line.replacingOccurrences(
+                of: #"^\s{0,3}#{1,6}\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"^\s*>+\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"^\s*(?:[-+*]|\d+[.)])\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"^\s*\[[ xX]\]\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"!\[([^\]]*)\]\([^)]+\)"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"\[([^\]]+)\]\([^)]+\)"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"[`*~]"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !line.isEmpty {
+                lines.append(line)
+            }
+        }
+
+        return lines.joined(separator: " ")
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
@@ -66,7 +66,7 @@ enum MeetingPreviewText {
                 options: .regularExpression
             )
             line = line.replacingOccurrences(
-                of: #"[`*~]"#,
+                of: #"[`*_~]"#,
                 with: "",
                 options: .regularExpression
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
@@ -66,10 +66,11 @@ enum MeetingPreviewText {
                 options: .regularExpression
             )
             line = line.replacingOccurrences(
-                of: #"[`*_~]"#,
-                with: "",
+                of: #"`([^`\n]+)`"#,
+                with: "$1",
                 options: .regularExpression
             )
+            line = stripMarkdownDelimiters(from: line)
             line = line.trimmingCharacters(in: .whitespacesAndNewlines)
 
             if !line.isEmpty {
@@ -78,5 +79,26 @@ enum MeetingPreviewText {
         }
 
         return lines.joined(separator: " ")
+    }
+
+    private static func stripMarkdownDelimiters(from text: String) -> String {
+        var result = text
+        let replacements = [
+            (#"\*\*([^*\n]+)\*\*"#, "$1"),
+            (#"__([^_\n]+)__"#, "$1"),
+            (#"~~([^~\n]+)~~"#, "$1"),
+            (#"(^|[\s(\[{])\*([^*\n]+)\*($|[\s)\]}.,;:!?])"#, "$1$2$3"),
+            (#"(^|[\s(\[{])_([^_\n]+)_($|[\s)\]}.,;:!?])"#, "$1$2$3")
+        ]
+
+        for (pattern, replacement) in replacements {
+            result = result.replacingOccurrences(
+                of: pattern,
+                with: replacement,
+                options: .regularExpression
+            )
+        }
+
+        return result
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -59,6 +59,12 @@ final class MeetingRecordingWriter {
         }
     }
 
+    func markPauseBoundary() {
+        lock.withLock { state in
+            writeMixedSamples(state: &state, flushAll: true)
+        }
+    }
+
     func cancel() {
         let tempURL = lock.withLock { state -> URL? in
             state.fileHandle?.closeFile()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -106,6 +106,7 @@ final class MeetingSession {
     private let micChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let systemChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let chunkRotationQueue = DispatchQueue(label: "MuesliNative.MeetingSession.chunkRotation")
+    private let pausedDisplayLock = OSAllocatedUnfairLock(initialState: false)
     private var chunkTimingTracker = MeetingChunkTimingTracker()
     private var systemChunkTimingTracker = MeetingChunkTimingTracker()
     private var systemChunkRecorder: PCMChunkRecorder?
@@ -116,7 +117,7 @@ final class MeetingSession {
 
     /// Current mic power level for waveform visualization.
     func currentPower() -> Float {
-        if chunkRotationQueue.sync(execute: { isPaused }) {
+        if pausedDisplayLock.withLock({ $0 }) {
             return -160
         }
         return streamingMicRecorder.currentPower()
@@ -125,6 +126,11 @@ final class MeetingSession {
     private(set) var startTime: Date?
     private(set) var isRecording = false
     private(set) var isPaused = false
+
+    private func setPausedStateOnQueue(_ paused: Bool) {
+        isPaused = paused
+        pausedDisplayLock.withLock { $0 = paused }
+    }
 
     init(
         title: String,
@@ -159,7 +165,7 @@ final class MeetingSession {
             chunkTimingTracker.start()
             systemChunkTimingTracker.start()
             isRecording = true
-            isPaused = false
+            setPausedStateOnQueue(false)
         }
 
         do {
@@ -187,7 +193,7 @@ final class MeetingSession {
             systemChunkRecorder = nil
             chunkRotationQueue.sync {
                 isRecording = false
-                isPaused = false
+                setPausedStateOnQueue(false)
                 startTime = nil
                 chunkTimingTracker.discard()
                 systemChunkTimingTracker.discard()
@@ -218,7 +224,7 @@ final class MeetingSession {
             rotateSystemChunkOnQueue()
             retainedRecordingWriter?.markPauseBoundary()
             neuralAec.resetForStreaming()
-            isPaused = true
+            setPausedStateOnQueue(true)
             return true
         }
         guard shouldPause else { return }
@@ -233,7 +239,7 @@ final class MeetingSession {
     func resume() {
         let shouldResume = chunkRotationQueue.sync { () -> Bool in
             guard isRecording, isPaused else { return false }
-            isPaused = false
+            setPausedStateOnQueue(false)
             return true
         }
         guard shouldResume else { return }
@@ -250,7 +256,7 @@ final class MeetingSession {
         Task { await screenContextCollector.stopAndDrain() }
         let (rawRecorder, systemRecorder) = chunkRotationQueue.sync { () -> (PCMChunkRecorder?, PCMChunkRecorder?) in
             isRecording = false
-            isPaused = false
+            setPausedStateOnQueue(false)
             chunkTimingTracker.discard()
             systemChunkTimingTracker.discard()
             let rawRecorder = rawMicChunkRecorder
@@ -297,7 +303,7 @@ final class MeetingSession {
         systemAudioRecorder.onPCMSamples = nil
         let (meetingStart, lastChunkTiming, lastRawMicURL, lastSystemChunkTiming, lastSystemChunkURL) = chunkRotationQueue.sync { () -> (Date, MeetingChunkTimingSnapshot?, URL?, MeetingChunkTimingSnapshot?, URL?) in
             isRecording = false
-            isPaused = false
+            setPausedStateOnQueue(false)
 
             // Flush partial AEC frame before stopping chunk recorder
             appendFlushedStreamingMicOnQueue()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -116,11 +116,15 @@ final class MeetingSession {
 
     /// Current mic power level for waveform visualization.
     func currentPower() -> Float {
-        streamingMicRecorder.currentPower()
+        if isPaused {
+            return -160
+        }
+        return streamingMicRecorder.currentPower()
     }
 
     private(set) var startTime: Date?
     private(set) var isRecording = false
+    private(set) var isPaused = false
 
     init(
         title: String,
@@ -155,6 +159,7 @@ final class MeetingSession {
             chunkTimingTracker.start()
             systemChunkTimingTracker.start()
             isRecording = true
+            isPaused = false
         }
 
         do {
@@ -182,6 +187,7 @@ final class MeetingSession {
             systemChunkRecorder = nil
             chunkRotationQueue.sync {
                 isRecording = false
+                isPaused = false
                 startTime = nil
                 chunkTimingTracker.discard()
                 systemChunkTimingTracker.discard()
@@ -204,11 +210,47 @@ final class MeetingSession {
         }
     }
 
+    func pause() {
+        let shouldPause = chunkRotationQueue.sync { () -> Bool in
+            guard isRecording, !isPaused else { return false }
+            appendFlushedStreamingMicOnQueue()
+            rotateChunkOnQueue()
+            rotateSystemChunkOnQueue()
+            retainedRecordingWriter?.markPauseBoundary()
+            neuralAec.resetForStreaming()
+            isPaused = true
+            return true
+        }
+        guard shouldPause else { return }
+
+        fullSessionMicRecorder.pause()
+        streamingMicRecorder.pause()
+        systemAudioRecorder.pause()
+        Task { await screenContextCollector.setPaused(true) }
+        fputs("[meeting] recording paused\n", stderr)
+    }
+
+    func resume() {
+        let shouldResume = chunkRotationQueue.sync { () -> Bool in
+            guard isRecording, isPaused else { return false }
+            isPaused = false
+            return true
+        }
+        guard shouldResume else { return }
+
+        fullSessionMicRecorder.resume()
+        streamingMicRecorder.resume()
+        systemAudioRecorder.resume()
+        Task { await screenContextCollector.setPaused(false) }
+        fputs("[meeting] recording resumed\n", stderr)
+    }
+
     /// Abandon the recording — stop everything, delete temp files, don't transcribe.
     func discard() {
         Task { await screenContextCollector.stopAndDrain() }
         let (rawRecorder, systemRecorder) = chunkRotationQueue.sync { () -> (PCMChunkRecorder?, PCMChunkRecorder?) in
             isRecording = false
+            isPaused = false
             chunkTimingTracker.discard()
             systemChunkTimingTracker.discard()
             let rawRecorder = rawMicChunkRecorder
@@ -255,15 +297,10 @@ final class MeetingSession {
         systemAudioRecorder.onPCMSamples = nil
         let (meetingStart, lastChunkTiming, lastRawMicURL, lastSystemChunkTiming, lastSystemChunkURL) = chunkRotationQueue.sync { () -> (Date, MeetingChunkTimingSnapshot?, URL?, MeetingChunkTimingSnapshot?, URL?) in
             isRecording = false
+            isPaused = false
 
             // Flush partial AEC frame before stopping chunk recorder
-            let flushed = self.neuralAec.flushStreamingMic()
-            if !flushed.isEmpty {
-                let flushedInt16 = flushed.map { sample -> Int16 in
-                    Int16(max(-1.0, min(1.0, sample)) * 32767)
-                }
-                self.rawMicChunkRecorder?.append(flushedInt16)
-            }
+            appendFlushedStreamingMicOnQueue()
 
             let meetingStart = self.startTime ?? Date()
             let lastRawMicURL = rawMicChunkRecorder?.stop()
@@ -523,6 +560,15 @@ final class MeetingSession {
         return trimmedCandidate
     }
 
+    private func appendFlushedStreamingMicOnQueue() {
+        let flushed = neuralAec.flushStreamingMic()
+        guard !flushed.isEmpty else { return }
+        let flushedInt16 = flushed.map { sample -> Int16 in
+            Int16(max(-1.0, min(1.0, sample)) * 32767)
+        }
+        rawMicChunkRecorder?.append(flushedInt16)
+    }
+
     /// Called by VAD on speech boundaries or max-duration fallback.
     /// Rotates the streaming mic file and sends the completed chunk for transcription.
     private func rotateChunk() {
@@ -532,7 +578,7 @@ final class MeetingSession {
     }
 
     private func rotateChunkOnQueue() {
-        guard isRecording else { return }
+        guard isRecording, !isPaused else { return }
         guard let chunkTiming = chunkTimingTracker.rotate() else {
             return
         }
@@ -573,7 +619,7 @@ final class MeetingSession {
     }
 
     private func rotateSystemChunkOnQueue() {
-        guard isRecording else { return }
+        guard isRecording, !isPaused else { return }
         guard let chunkURL = systemChunkRecorder?.rotateFile(),
               let chunkTiming = systemChunkTimingTracker.rotate() else {
             return
@@ -679,7 +725,7 @@ final class MeetingSession {
         guard !rawSamples.isEmpty else { return }
 
         chunkRotationQueue.async { [weak self] in
-            guard let self, self.isRecording else { return }
+            guard let self, self.isRecording, !self.isPaused else { return }
 
             self.retainedRecordingWriter?.appendMic(rawSamples)
             self.chunkTimingTracker.append(sampleCount: rawSamples.count)
@@ -706,7 +752,7 @@ final class MeetingSession {
         guard !samples.isEmpty else { return }
 
         chunkRotationQueue.async { [weak self] in
-            guard let self, self.isRecording else { return }
+            guard let self, self.isRecording, !self.isPaused else { return }
 
             self.retainedRecordingWriter?.appendSystem(samples)
             self.systemChunkRecorder?.append(samples)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -116,7 +116,7 @@ final class MeetingSession {
 
     /// Current mic power level for waveform visualization.
     func currentPower() -> Float {
-        if isPaused {
+        if chunkRotationQueue.sync(execute: { isPaused }) {
             return -160
         }
         return streamingMicRecorder.currentPower()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -574,14 +574,14 @@ struct MeetingsView: View {
         HStack(spacing: MuesliTheme.spacing12) {
             HStack(spacing: 8) {
                 Circle()
-                    .fill(meeting.status == .recording ? MuesliTheme.recording : MuesliTheme.accent)
+                    .fill(activeMeetingStatusColor(for: meeting))
                     .frame(width: 8, height: 8)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(meeting.title)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(MuesliTheme.textPrimary)
                         .lineLimit(1)
-                    Text(meeting.status == .recording ? "Recording now" : "Finalizing notes")
+                    Text(activeMeetingStatusText(for: meeting))
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }
@@ -608,12 +608,34 @@ struct MeetingsView: View {
 
             if meeting.status == .recording {
                 Button {
+                    controller.toggleMeetingRecordingPause()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: appState.isMeetingRecordingPaused ? "play.fill" : "pause.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text(appState.isMeetingRecordingPaused ? "Resume" : "Pause")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .foregroundStyle(appState.isMeetingRecordingPaused ? MuesliTheme.backgroundBase : MuesliTheme.textPrimary)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, 8)
+                    .background(appState.isMeetingRecordingPaused ? MuesliTheme.accent : MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(appState.isMeetingRecordingPaused ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(!appState.isMeetingRecording)
+
+                Button {
                     controller.stopMeetingRecording()
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: "stop.fill")
                             .font(.system(size: 10, weight: .semibold))
-                        Text("Stop Recording")
+                        Text("Stop")
                             .font(.system(size: 12, weight: .semibold))
                     }
                     .foregroundStyle(.white)
@@ -623,6 +645,7 @@ struct MeetingsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 }
                 .buttonStyle(.plain)
+                .disabled(!appState.isMeetingRecording)
             }
         }
         .padding(MuesliTheme.spacing12)
@@ -632,6 +655,16 @@ struct MeetingsView: View {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+    }
+
+    private func activeMeetingStatusText(for meeting: MeetingRecord) -> String {
+        guard meeting.status == .recording else { return "Finalizing notes" }
+        return appState.isMeetingRecordingPaused ? "Recording paused" : "Recording now"
+    }
+
+    private func activeMeetingStatusColor(for meeting: MeetingRecord) -> Color {
+        guard meeting.status == .recording else { return MuesliTheme.accent }
+        return appState.isMeetingRecordingPaused ? MuesliTheme.transcribing : MuesliTheme.recording
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -40,6 +40,15 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
         return url
     }
 
+    func pause() {
+        recorder?.pause()
+    }
+
+    func resume() {
+        guard recorder != nil else { return }
+        recorder?.record()
+    }
+
     func currentPower() -> Float {
         recorder?.updateMeters()
         return recorder?.averagePower(forChannel: 0) ?? -160

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -45,7 +45,6 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
     }
 
     func resume() {
-        guard recorder != nil else { return }
         recorder?.record()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -200,6 +200,7 @@ final class MuesliController: NSObject {
         indicator.hotkeyLabel = config.dictationHotkey.label
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
+        indicator.onToggleMeetingPause = { [weak self] in self?.toggleMeetingRecordingPause() }
         indicator.onStopToggleDictation = { [weak self] in
             guard let self else { return }
             if self.hotkeyMonitor.isToggleRecording {
@@ -465,6 +466,7 @@ final class MuesliController: NSObject {
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
         appState.isMeetingRecordingPaused = isMeetingRecordingPaused()
+        indicator.setMeetingRecordingPaused(appState.isMeetingRecordingPaused, config: config)
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
@@ -1816,6 +1818,7 @@ final class MuesliController: NSObject {
               !activeMeetingSession.isPaused,
               !isStoppingMeetingRecording else { return }
         activeMeetingSession.pause()
+        indicator.setMeetingRecordingPaused(true, config: config)
         statusBarController?.setStatus("Meeting paused")
         statusBarController?.refresh()
         syncAppState()
@@ -1827,6 +1830,7 @@ final class MuesliController: NSObject {
               activeMeetingSession.isPaused,
               !isStoppingMeetingRecording else { return }
         activeMeetingSession.resume()
+        indicator.setMeetingRecordingPaused(false, config: config)
         statusBarController?.setStatus("Meeting: \(activeMeetingDisplayTitle())")
         statusBarController?.refresh()
         syncAppState()
@@ -2003,6 +2007,8 @@ final class MuesliController: NSObject {
         alert.addButton(withTitle: "Discard")
         alert.addButton(withTitle: "Cancel")
         alert.buttons.first?.hasDestructiveAction = true
+        alert.window.level = .floating
+        alert.window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         if alert.runModal() == .alertFirstButtonReturn {
             discardMeetingRecording()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2010,19 +2010,34 @@ final class MuesliController: NSObject {
 
     private func presentDiscardMeetingAlert(_ alert: NSAlert, attempt: Int = 0) {
         if let window = confirmationAnchorWindow() {
-            alert.beginSheetModal(for: window) { [weak self] response in
-                guard response == .alertFirstButtonReturn else { return }
-                Task { @MainActor [weak self] in
-                    self?.discardMeetingRecording()
-                }
-            }
+            beginDiscardMeetingAlert(alert, for: window)
             return
         }
 
         showActiveMeetingDocumentIfNeeded()
         historyWindowController?.show()
+        if let window = confirmationAnchorWindow() {
+            beginDiscardMeetingAlert(alert, for: window)
+            return
+        }
+
+        guard attempt < 20 else {
+            NSLog("Unable to present discard meeting confirmation: no anchor window became available")
+            NSSound.beep()
+            return
+        }
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self, alert] in
             self?.presentDiscardMeetingAlert(alert, attempt: attempt + 1)
+        }
+    }
+
+    private func beginDiscardMeetingAlert(_ alert: NSAlert, for window: NSWindow) {
+        alert.beginSheetModal(for: window) { [weak self] response in
+            guard response == .alertFirstButtonReturn else { return }
+            Task { @MainActor [weak self] in
+                self?.discardMeetingRecording()
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2019,8 +2019,8 @@ final class MuesliController: NSObject {
             return
         }
 
-        openHistoryWindow()
-        guard attempt < 5 else { return }
+        showActiveMeetingDocumentIfNeeded()
+        historyWindowController?.show()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self, alert] in
             self?.presentDiscardMeetingAlert(alert, attempt: attempt + 1)
         }
@@ -2031,6 +2031,10 @@ final class MuesliController: NSObject {
             window.isVisible &&
                 !window.isMiniaturized &&
                 !(window is NSPanel) &&
+                window.canBecomeKey
+        } ?? NSApp.windows.first { window in
+            window.isVisible &&
+                !window.isMiniaturized &&
                 window.canBecomeKey
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -464,6 +464,7 @@ final class MuesliController: NSObject {
         appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
+        appState.isMeetingRecordingPaused = isMeetingRecordingPaused()
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
@@ -1738,6 +1739,10 @@ final class MuesliController: NSObject {
         activeMeetingSession?.isRecording == true || isStoppingMeetingRecording
     }
 
+    func isMeetingRecordingPaused() -> Bool {
+        activeMeetingSession?.isPaused == true
+    }
+
     private var meetingTerminationState: MeetingTerminationState {
         MeetingTerminationPolicy.state(
             isStarting: isStartingMeetingRecording,
@@ -1795,6 +1800,36 @@ final class MuesliController: NSObject {
         } else {
             startForegroundMeetingRecording()
         }
+    }
+
+    @objc func toggleMeetingRecordingPause() {
+        if isMeetingRecordingPaused() {
+            resumeMeetingRecording()
+        } else {
+            pauseMeetingRecording()
+        }
+    }
+
+    func pauseMeetingRecording() {
+        guard let activeMeetingSession,
+              activeMeetingSession.isRecording,
+              !activeMeetingSession.isPaused,
+              !isStoppingMeetingRecording else { return }
+        activeMeetingSession.pause()
+        statusBarController?.setStatus("Meeting paused")
+        statusBarController?.refresh()
+        syncAppState()
+    }
+
+    func resumeMeetingRecording() {
+        guard let activeMeetingSession,
+              activeMeetingSession.isRecording,
+              activeMeetingSession.isPaused,
+              !isStoppingMeetingRecording else { return }
+        activeMeetingSession.resume()
+        statusBarController?.setStatus("Meeting: \(activeMeetingDisplayTitle())")
+        statusBarController?.refresh()
+        syncAppState()
     }
 
     @objc func startMeetingFromCalendarMenuItem(_ sender: NSMenuItem) {
@@ -1916,6 +1951,7 @@ final class MuesliController: NSObject {
                 }
                 indicator.setMeetingRecording(true, config: config)
                 statusBarController?.refresh()
+                syncAppState()
                 return
             } catch {
                 guard shouldRetryAfterPermissionRequest,
@@ -2266,6 +2302,15 @@ final class MuesliController: NSObject {
             return cached
         }
         return try? dictationStore.meeting(id: id)?.title
+    }
+
+    private func activeMeetingDisplayTitle() -> String {
+        guard let activeMeetingID,
+              let title = liveMeetingTitle(id: activeMeetingID)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !title.isEmpty else {
+            return "Meeting"
+        }
+        return title
     }
 
     private func completedLiveMeetingTitle(for result: MeetingSessionResult, existingMeetingID: Int64) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1996,8 +1996,6 @@ final class MuesliController: NSObject {
     }
 
     @objc func discardMeetingWithConfirmation() {
-        // Bring app to foreground so the modal alert is visible — Muesli runs as
-        // a background/accessory app and runModal() can get stuck behind other windows.
         NSApp.activate(ignoringOtherApps: true)
 
         let alert = NSAlert()
@@ -2007,10 +2005,33 @@ final class MuesliController: NSObject {
         alert.addButton(withTitle: "Discard")
         alert.addButton(withTitle: "Cancel")
         alert.buttons.first?.hasDestructiveAction = true
-        alert.window.level = .floating
-        alert.window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        if alert.runModal() == .alertFirstButtonReturn {
-            discardMeetingRecording()
+        presentDiscardMeetingAlert(alert)
+    }
+
+    private func presentDiscardMeetingAlert(_ alert: NSAlert, attempt: Int = 0) {
+        if let window = confirmationAnchorWindow() {
+            alert.beginSheetModal(for: window) { [weak self] response in
+                guard response == .alertFirstButtonReturn else { return }
+                Task { @MainActor [weak self] in
+                    self?.discardMeetingRecording()
+                }
+            }
+            return
+        }
+
+        openHistoryWindow()
+        guard attempt < 5 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self, alert] in
+            self?.presentDiscardMeetingAlert(alert, attempt: attempt + 1)
+        }
+    }
+
+    private func confirmationAnchorWindow() -> NSWindow? {
+        NSApp.windows.first { window in
+            window.isVisible &&
+                !window.isMiniaturized &&
+                !(window is NSPanel) &&
+                window.canBecomeKey
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
@@ -280,7 +280,7 @@ actor MeetingScreenContextCollector {
         captureTask = Task {
             while !Task.isCancelled {
                 if isPaused {
-                    try? await Task.sleep(for: .seconds(interval))
+                    try? await Task.sleep(for: .seconds(2))
                     continue
                 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
@@ -263,6 +263,7 @@ actor MeetingScreenContextCollector {
 
     private var snapshots: [Snapshot] = []
     private var captureTask: Task<Void, Never>?
+    private var isPaused = false
 
     private static func isMeaningfulAppContext(_ text: String, appName: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -275,8 +276,14 @@ actor MeetingScreenContextCollector {
     ///   When `false`, uses Accessibility API only (lightweight, no screenshots).
     func startPeriodicCapture(interval: TimeInterval = 60, useOCR: Bool = false) {
         captureTask?.cancel()
+        isPaused = false
         captureTask = Task {
             while !Task.isCancelled {
+                if isPaused {
+                    try? await Task.sleep(for: .seconds(interval))
+                    continue
+                }
+
                 let timestamp = Date()
                 let appContext = DictationContextCapture.capture()
                 let appContextText = DictationContextCapture.formatForPrompt(appContext)
@@ -314,10 +321,15 @@ actor MeetingScreenContextCollector {
         }
     }
 
+    func setPaused(_ paused: Bool) {
+        isPaused = paused
+    }
+
     @discardableResult
     func stopAndDrain() -> String {
         captureTask?.cancel()
         captureTask = nil
+        isPaused = false
         guard !snapshots.isEmpty else { return "" }
 
         var deduped: [Snapshot] = []

--- a/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
@@ -233,10 +233,16 @@ private struct SearchMeetingRow: View {
     private func bestMatchField() -> String {
         let q = query.lowercased()
         if record.title.lowercased().contains(q) {
-            return record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
+            return MeetingPreviewText.plainText(
+                from: record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
+            )
         }
-        if record.formattedNotes.lowercased().contains(q) { return record.formattedNotes }
-        if record.rawTranscript.lowercased().contains(q) { return record.rawTranscript }
+        if record.formattedNotes.lowercased().contains(q) {
+            return MeetingPreviewText.plainText(from: record.formattedNotes)
+        }
+        if record.rawTranscript.lowercased().contains(q) {
+            return MeetingPreviewText.plainText(from: record.rawTranscript)
+        }
         return ""
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -8,7 +8,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private let runtime: RuntimePaths
     private let statusItem: NSStatusItem
     private let menu = NSMenu()
-    private let statusLabel = NSMenuItem(title: "Status: Idle", action: nil, keyEquivalent: "")
+    private let statusLabel = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+    private var statusMessage: String?
     private var countdownOverride: String?
 
     init(controller: MuesliController, runtime: RuntimePaths) {
@@ -21,7 +22,9 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func setStatus(_ text: String) {
-        statusLabel.title = "Status: \(text)"
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        statusMessage = trimmed.isEmpty || trimmed == "Idle" ? nil : trimmed
+        statusLabel.title = statusMessage ?? ""
     }
 
     func refresh() {
@@ -161,8 +164,11 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Settings…", action: #selector(MuesliController.openSettingsTab)))
         menu.addItem(actionItem(title: "Check for Updates…", action: #selector(MuesliController.checkForUpdates)))
-        statusLabel.isEnabled = false
-        menu.addItem(statusLabel)
+        if let statusMessage {
+            statusLabel.title = statusMessage
+            statusLabel.isEnabled = false
+            menu.addItem(statusLabel)
+        }
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Quit", action: #selector(MuesliController.quitApp)))
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -102,10 +102,13 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         }
 
         menu.addItem(actionItem(title: "Open \(AppIdentity.displayName)", action: #selector(MuesliController.openHistoryWindow as (MuesliController) -> () -> Void)))
-        let meetingTitle = controller.isMeetingRecording() ? "Stop Meeting Recording" : "Start Meeting Recording"
-        menu.addItem(actionItem(title: meetingTitle, action: #selector(MuesliController.toggleMeetingRecording)))
         if controller.isMeetingRecording() {
+            let pauseTitle = controller.isMeetingRecordingPaused() ? "Resume Meeting Recording" : "Pause Meeting Recording"
+            menu.addItem(actionItem(title: pauseTitle, action: #selector(MuesliController.toggleMeetingRecordingPause)))
+            menu.addItem(actionItem(title: "Stop Meeting Recording", action: #selector(MuesliController.toggleMeetingRecording)))
             menu.addItem(actionItem(title: "Discard Meeting Recording...", action: #selector(MuesliController.discardMeetingWithConfirmation)))
+        } else {
+            menu.addItem(actionItem(title: "Start Meeting Recording", action: #selector(MuesliController.toggleMeetingRecording)))
         }
         menu.addItem(.separator())
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -19,6 +19,7 @@ final class StreamingMicRecorder {
         var fileURL: URL?
         var bytesWritten: Int = 0
         var latestPowerDB: Float = -160
+        var isPaused = false
     }
 
     private static let sampleRate: Double = 16_000
@@ -104,11 +105,17 @@ final class StreamingMicRecorder {
                 return max(-160, min(0, rawDB))
             }()
 
-            self.lock.withLock { state in
+            let shouldEmit = self.lock.withLock { state -> Bool in
+                guard !state.isPaused else {
+                    state.latestPowerDB = -160
+                    return false
+                }
                 state.fileHandle?.write(pcmData)
                 state.bytesWritten += pcmData.count
                 state.latestPowerDB = powerDB
+                return true
             }
+            guard shouldEmit else { return }
 
             self.onPCMSamples?(int16Samples)
 
@@ -157,6 +164,21 @@ final class StreamingMicRecorder {
         }
 
         return finalizeFile(finalState)
+    }
+
+    func pause() {
+        guard isRunning else { return }
+        lock.withLock { state in
+            state.isPaused = true
+            state.latestPowerDB = -160
+        }
+    }
+
+    func resume() {
+        guard isRunning else { return }
+        lock.withLock { state in
+            state.isPaused = false
+        }
     }
 
     func cancel() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
@@ -11,6 +11,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
     private var outputURL: URL?
     private var totalBytesWritten = 0
     private(set) var isRecording = false
+    private(set) var isPaused = false
 
     private static let sampleRate: Double = 16_000
     private static let channels: Int = 1
@@ -38,6 +39,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
         outputURL = url
         totalBytesWritten = 0
         isRecording = true
+        isPaused = false
 
         do {
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -70,6 +72,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
     func stop() -> URL? {
         guard isRecording || outputFile != nil || outputURL != nil else { return nil }
         isRecording = false
+        isPaused = false
         onPCMSamples = nil
 
         if let stream {
@@ -97,6 +100,16 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
 
         fputs("[system-audio] capture stopped, \(writtenBytes) bytes written\n", stderr)
         return completedURL
+    }
+
+    func pause() {
+        guard isRecording else { return }
+        isPaused = true
+    }
+
+    func resume() {
+        guard isRecording else { return }
+        isPaused = false
     }
 
     // MARK: - SCStream setup
@@ -136,7 +149,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
     // MARK: - SCStreamOutput
 
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
-        guard type == .audio, isRecording else { return }
+        guard type == .audio, isRecording, !isPaused else { return }
 
         guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return }
         let length = CMBlockBufferGetDataLength(blockBuffer)
@@ -228,6 +241,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
 
     private func cleanupFailedStart() {
         isRecording = false
+        isPaused = false
         stream = nil
         onPCMSamples = nil
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
@@ -12,9 +12,10 @@ struct MeetingPreviewTextTests {
         ## Decisions
         - **Ship** pause controls
         - [ ] Follow up with [Rishab](https://example.com)
+        - _Polish_ __meeting__ previews
         """, limit: 120)
 
-        #expect(preview == "Customer Sync Decisions Ship pause controls Follow up with Rishab")
+        #expect(preview == "Customer Sync Decisions Ship pause controls Follow up with Rishab Polish meeting previews")
     }
 
     @Test("falls back when source is empty after cleanup")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
@@ -18,6 +18,16 @@ struct MeetingPreviewTextTests {
         #expect(preview == "Customer Sync Decisions Ship pause controls Follow up with Rishab Polish meeting previews")
     }
 
+    @Test("preserves non-markdown underscores and tildes")
+    func preservesIdentifierCharacters() {
+        let preview = MeetingPreviewText.snippet(from: """
+        ## Implementation Notes
+        Use `my_function` for ~50 rows before _polishing_ the summary.
+        """, limit: 120)
+
+        #expect(preview == "Implementation Notes Use my_function for ~50 rows before polishing the summary.")
+    }
+
     @Test("falls back when source is empty after cleanup")
     func emptyPreviewFallback() {
         let preview = MeetingPreviewText.snippet(from: """

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting preview text")
+struct MeetingPreviewTextTests {
+
+    @Test("removes markdown structure from meeting previews")
+    func removesMarkdownStructure() {
+        let preview = MeetingPreviewText.snippet(from: """
+        # Customer Sync
+
+        ## Decisions
+        - **Ship** pause controls
+        - [ ] Follow up with [Rishab](https://example.com)
+        """, limit: 120)
+
+        #expect(preview == "Customer Sync Decisions Ship pause controls Follow up with Rishab")
+    }
+
+    @Test("falls back when source is empty after cleanup")
+    func emptyPreviewFallback() {
+        let preview = MeetingPreviewText.snippet(from: """
+        ```swift
+        let hidden = true
+        ```
+        """)
+
+        #expect(preview == "No notes yet")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -29,6 +29,19 @@ struct MeetingRecordingWriterTests {
         #expect(samples == [1200, -800, 400])
     }
 
+    @Test("pause boundary prevents unmatched samples from mixing across pause")
+    func pauseBoundaryFlushesPendingSamples() throws {
+        let writer = try MeetingRecordingWriter()
+        writer.appendMic([1000, 3000])
+        writer.markPauseBoundary()
+        writer.appendSystem([5000, 7000])
+
+        let tempURL = try #require(writer.stop())
+        let samples = try readMonoPCM16WAVSamples(from: tempURL)
+
+        #expect(samples == [1000, 3000, 5000, 7000])
+    }
+
     @Test("persistTemporaryRecording moves the temp wav into the meeting recordings directory with a slugged name")
     func persistTemporaryRecordingMovesFile() throws {
         let writer = try MeetingRecordingWriter()


### PR DESCRIPTION
## Summary

Adds real pause/resume support for live meeting recordings and updates the Quick Note meeting UI so recording controls are clearer and less visually heavy.

## What changed

- Added a paused recording state to `AppState` and `MuesliController`, with status bar menu actions for pause/resume.
- Added pause/resume behavior to the meeting session pipeline so mic audio, system audio, waveform power, retained recording output, and periodic screen context stop contributing while paused.
- Added pause/resume support to the mic, streaming mic, ScreenCaptureKit system audio, and CoreAudio system audio recorders.
- Added retained-recording pause boundaries so unmatched mic/system samples do not mix across a paused gap.
- Refined the live meeting/Quick Note header controls with a compact status pill, Pause/Resume button, smaller Stop action, and secondary Discard.
- Updated the active meeting banner to expose Pause/Resume and show `Recording paused` when paused.

## Validation

- `swift build --package-path native/MuesliNative` passed.
- `swift test --package-path native/MuesliNative --filter MeetingRecordingWriter` passed.
- `swift test --package-path native/MuesliNative --filter MeetingsNavigation` passed.
- `swift test --package-path native/MuesliNative` compiled and ran but hit the known shared `NSPasteboard.general` flake in `PasteControllerTests.swift` (`paste restores clipboard after delay`).
- `swift test --package-path native/MuesliNative --filter PasteController` passed on isolated rerun.