### PR TITLE
[codex] Polish meeting detection notification

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -65,8 +65,10 @@ final class BrowserMeetingActivityCollector {
             return normalized
         }
 
-        guard app.isActive,
-              let bundleID = app.bundleIdentifier,
+        // Query the browser's active tab even after another app/overlay becomes
+        // frontmost. Strict URL normalization plus resolver media checks keep
+        // background meeting tabs from prompting by themselves.
+        guard let bundleID = app.bundleIdentifier,
               let url = activeBrowserURLViaAppleScript(bundleID: bundleID) else {
             return nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -32,7 +32,8 @@ final class BrowserMeetingActivityCollector {
                 url: normalized.url,
                 normalizedID: normalized.id,
                 platform: normalized.platform,
-                isFocused: app.isActive
+                isFocused: app.isActive,
+                requiresMediaActivity: normalized.requiresMediaActivity
             )
             cachedMeetings[bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
             return context
@@ -53,7 +54,8 @@ final class BrowserMeetingActivityCollector {
                     url: cached.context.url,
                     normalizedID: cached.context.normalizedID,
                     platform: cached.context.platform,
-                    isFocused: false
+                    isFocused: false,
+                    requiresMediaActivity: cached.context.requiresMediaActivity
                 )
             }
 
@@ -70,7 +72,7 @@ final class BrowserMeetingActivityCollector {
               let url = activeBrowserURLViaAppleScript(bundleID: bundleID) else {
             return nil
         }
-        return MeetingURLNormalizer.normalize(url)
+        return MeetingURLNormalizer.normalizeBrowserActivity(url)
     }
 
     private func normalizedAXDocumentURL(for app: NSRunningApplication) -> NormalizedMeetingURL? {
@@ -89,7 +91,7 @@ final class BrowserMeetingActivityCollector {
             return nil
         }
 
-        return MeetingURLNormalizer.normalize(rawURL)
+        return MeetingURLNormalizer.normalizeBrowserActivity(rawURL)
     }
 
     private func activeBrowserURLViaAppleScript(bundleID: String) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -32,8 +32,7 @@ final class BrowserMeetingActivityCollector {
                 url: normalized.url,
                 normalizedID: normalized.id,
                 platform: normalized.platform,
-                isFocused: app.isActive,
-                requiresMediaActivity: normalized.requiresMediaActivity
+                isFocused: app.isActive
             )
             cachedMeetings[bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
             return context
@@ -54,8 +53,7 @@ final class BrowserMeetingActivityCollector {
                     url: cached.context.url,
                     normalizedID: cached.context.normalizedID,
                     platform: cached.context.platform,
-                    isFocused: false,
-                    requiresMediaActivity: cached.context.requiresMediaActivity
+                    isFocused: false
                 )
             }
 
@@ -72,7 +70,7 @@ final class BrowserMeetingActivityCollector {
               let url = activeBrowserURLViaAppleScript(bundleID: bundleID) else {
             return nil
         }
-        return MeetingURLNormalizer.normalizeBrowserActivity(url)
+        return MeetingURLNormalizer.normalize(url)
     }
 
     private func normalizedAXDocumentURL(for app: NSRunningApplication) -> NormalizedMeetingURL? {
@@ -91,7 +89,7 @@ final class BrowserMeetingActivityCollector {
             return nil
         }
 
-        return MeetingURLNormalizer.normalizeBrowserActivity(rawURL)
+        return MeetingURLNormalizer.normalize(rawURL)
     }
 
     private func activeBrowserURLViaAppleScript(bundleID: String) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -5,16 +5,27 @@ import Foundation
 @MainActor
 final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
+    private let cachedMeetingTTL: TimeInterval = 8
+    private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
     func collect() -> [BrowserMeetingContext] {
-        NSWorkspace.shared.runningApplications.compactMap { app in
-            guard let bundleID = app.bundleIdentifier,
-                  browserBundleIDs.contains(bundleID),
-                  let normalized = normalizedFocusedURL(for: app) else {
+        let now = Date()
+        let browserApps = NSWorkspace.shared.runningApplications.filter { app in
+            guard let bundleID = app.bundleIdentifier else { return false }
+            return browserBundleIDs.contains(bundleID)
+        }
+        let runningBrowserIDs = Set(browserApps.compactMap(\.bundleIdentifier))
+
+        let liveMeetings: [BrowserMeetingContext] = browserApps.compactMap { app in
+            guard let bundleID = app.bundleIdentifier else { return nil }
+            guard let normalized = normalizedFocusedURL(for: app) else {
+                if app.isActive {
+                    cachedMeetings.removeValue(forKey: bundleID)
+                }
                 return nil
             }
 
-            return BrowserMeetingContext(
+            let context = BrowserMeetingContext(
                 bundleID: bundleID,
                 appName: app.localizedName ?? MeetingCandidateResolver.browserApps[bundleID] ?? bundleID,
                 pid: app.processIdentifier,
@@ -23,7 +34,30 @@ final class BrowserMeetingActivityCollector {
                 platform: normalized.platform,
                 isFocused: app.isActive
             )
+            cachedMeetings[bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
+            return context
         }
+
+        let liveBundleIDs = Set(liveMeetings.map(\.bundleID))
+        cachedMeetings = cachedMeetings.filter { bundleID, cached in
+            runningBrowserIDs.contains(bundleID) && now.timeIntervalSince(cached.observedAt) <= cachedMeetingTTL
+        }
+
+        let cachedOnlyMeetings = cachedMeetings.values
+            .filter { !liveBundleIDs.contains($0.context.bundleID) }
+            .map { cached in
+                BrowserMeetingContext(
+                    bundleID: cached.context.bundleID,
+                    appName: cached.context.appName,
+                    pid: cached.context.pid,
+                    url: cached.context.url,
+                    normalizedID: cached.context.normalizedID,
+                    platform: cached.context.platform,
+                    isFocused: false
+                )
+            }
+
+        return liveMeetings + cachedOnlyMeetings
     }
 
     private func normalizedFocusedURL(for app: NSRunningApplication) -> NormalizedMeetingURL? {
@@ -86,4 +120,9 @@ final class BrowserMeetingActivityCollector {
         }
         return output
     }
+}
+
+private struct CachedBrowserMeeting {
+    let context: BrowserMeetingContext
+    let observedAt: Date
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ControlCenterSensorAttributionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ControlCenterSensorAttributionMonitor.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+struct SensorAttributionSnapshot: Equatable {
+    let micBundleIDs: Set<String>
+    let cameraBundleIDs: Set<String>
+    let observedAt: Date?
+
+    static let empty = SensorAttributionSnapshot(
+        micBundleIDs: [],
+        cameraBundleIDs: [],
+        observedAt: nil
+    )
+}
+
+final class ControlCenterSensorAttributionMonitor {
+    var onAttributionsChanged: (() -> Void)?
+
+    private let lock = NSLock()
+    private var process: Process?
+    private var outputPipe: Pipe?
+    private var lineBuffer = ""
+    private var currentSnapshot = SensorAttributionSnapshot.empty
+
+    func start() {
+        lock.lock()
+        let alreadyRunning = process != nil
+        lock.unlock()
+        guard !alreadyRunning else { return }
+
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "stream",
+            "--style",
+            "compact",
+            "--predicate",
+            "subsystem == \"com.apple.controlcenter\" && category == \"sensor-indicators\" && eventMessage BEGINSWITH \"Active activity attributions changed to \"",
+        ]
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty,
+                  let text = String(data: data, encoding: .utf8) else { return }
+            self?.consume(text)
+        }
+
+        process.terminationHandler = { [weak self] _ in
+            self?.clearProcess()
+        }
+
+        do {
+            try process.run()
+            lock.lock()
+            self.process = process
+            outputPipe = pipe
+            lock.unlock()
+        } catch {
+            pipe.fileHandleForReading.readabilityHandler = nil
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        let runningProcess = process
+        let pipe = outputPipe
+        process = nil
+        outputPipe = nil
+        lineBuffer = ""
+        currentSnapshot = .empty
+        lock.unlock()
+
+        pipe?.fileHandleForReading.readabilityHandler = nil
+        if runningProcess?.isRunning == true {
+            runningProcess?.terminate()
+        }
+    }
+
+    func snapshot(maxAge: TimeInterval = 8, now: Date = Date()) -> SensorAttributionSnapshot {
+        lock.lock()
+        let snapshot = currentSnapshot
+        lock.unlock()
+
+        guard let observedAt = snapshot.observedAt,
+              now.timeIntervalSince(observedAt) <= maxAge else {
+            return .empty
+        }
+        return snapshot
+    }
+
+    private func consume(_ text: String) {
+        let lines: [String]
+        lock.lock()
+        lineBuffer += text
+        let parts = lineBuffer.split(separator: "\n", omittingEmptySubsequences: false)
+        if lineBuffer.hasSuffix("\n") {
+            lines = parts.map(String.init)
+            lineBuffer = ""
+        } else {
+            lines = parts.dropLast().map(String.init)
+            lineBuffer = parts.last.map(String.init) ?? ""
+        }
+        lock.unlock()
+
+        for line in lines {
+            guard let snapshot = Self.parseSnapshot(from: line) else { continue }
+            lock.lock()
+            currentSnapshot = snapshot
+            lock.unlock()
+            onAttributionsChanged?()
+        }
+    }
+
+    private func clearProcess() {
+        lock.lock()
+        process = nil
+        outputPipe = nil
+        lineBuffer = ""
+        lock.unlock()
+    }
+
+    static func parseSnapshot(from line: String, now: Date = Date()) -> SensorAttributionSnapshot? {
+        guard let range = line.range(of: "Active activity attributions changed to [") else {
+            return nil
+        }
+
+        let tail = line[range.upperBound...]
+        guard let closingBracket = tail.firstIndex(of: "]") else { return nil }
+        let payload = tail[..<closingBracket]
+
+        var micBundleIDs = Set<String>()
+        var cameraBundleIDs = Set<String>()
+        let pattern = #""(mic|cam):([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsPayload = NSString(string: String(payload))
+        let matches = regex.matches(
+            in: String(payload),
+            range: NSRange(location: 0, length: nsPayload.length)
+        )
+
+        for match in matches where match.numberOfRanges == 3 {
+            let kind = nsPayload.substring(with: match.range(at: 1))
+            let bundleID = nsPayload.substring(with: match.range(at: 2))
+            if kind == "mic" {
+                micBundleIDs.insert(bundleID)
+            } else if kind == "cam" {
+                cameraBundleIDs.insert(bundleID)
+            }
+        }
+
+        return SensorAttributionSnapshot(
+            micBundleIDs: micBundleIDs,
+            cameraBundleIDs: cameraBundleIDs,
+            observedAt: now
+        )
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ControlCenterSensorAttributionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ControlCenterSensorAttributionMonitor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 struct SensorAttributionSnapshot: Equatable {
     let micBundleIDs: Set<String>
@@ -13,6 +14,8 @@ struct SensorAttributionSnapshot: Equatable {
 }
 
 final class ControlCenterSensorAttributionMonitor {
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
+
     var onAttributionsChanged: (() -> Void)?
 
     private let lock = NSLock()
@@ -34,6 +37,8 @@ final class ControlCenterSensorAttributionMonitor {
             "stream",
             "--style",
             "compact",
+            "--level",
+            "debug",
             "--predicate",
             "subsystem == \"com.apple.controlcenter\" && category == \"sensor-indicators\" && eventMessage BEGINSWITH \"Active activity attributions changed to \"",
         ]
@@ -53,11 +58,13 @@ final class ControlCenterSensorAttributionMonitor {
 
         do {
             try process.run()
+            Self.logger.notice("sensor_attribution_stream_started")
             lock.lock()
             self.process = process
             outputPipe = pipe
             lock.unlock()
         } catch {
+            Self.logger.error("sensor_attribution_stream_failed error=\(String(describing: error), privacy: .public)")
             pipe.fileHandleForReading.readabilityHandler = nil
         }
     }
@@ -109,6 +116,7 @@ final class ControlCenterSensorAttributionMonitor {
             lock.lock()
             currentSnapshot = snapshot
             lock.unlock()
+            logSnapshot(snapshot)
             onAttributionsChanged?()
         }
     }
@@ -119,6 +127,16 @@ final class ControlCenterSensorAttributionMonitor {
         outputPipe = nil
         lineBuffer = ""
         lock.unlock()
+    }
+
+    private func logSnapshot(_ snapshot: SensorAttributionSnapshot) {
+        let mic = snapshot.micBundleIDs.sorted().joined(separator: ",")
+        let camera = snapshot.cameraBundleIDs.sorted().joined(separator: ",")
+        if mic.isEmpty && camera.isEmpty {
+            Self.logger.notice("sensor_attributions_cleared")
+        } else {
+            Self.logger.notice("sensor_attributions mic=\(mic, privacy: .public) camera=\(camera, privacy: .public)")
+        }
     }
 
     static func parseSnapshot(from line: String, now: Date = Date()) -> SensorAttributionSnapshot? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ControlCenterSensorAttributionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ControlCenterSensorAttributionMonitor.swift
@@ -15,6 +15,7 @@ struct SensorAttributionSnapshot: Equatable {
 
 final class ControlCenterSensorAttributionMonitor {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
+    private static let attributionRegex = try? NSRegularExpression(pattern: #""(mic|cam):([^"]+)""#)
 
     var onAttributionsChanged: (() -> Void)?
 
@@ -115,9 +116,10 @@ final class ControlCenterSensorAttributionMonitor {
             guard let snapshot = Self.parseSnapshot(from: line) else { continue }
             lock.lock()
             currentSnapshot = snapshot
+            let callback = onAttributionsChanged
             lock.unlock()
             logSnapshot(snapshot)
-            onAttributionsChanged?()
+            callback?()
         }
     }
 
@@ -150,8 +152,7 @@ final class ControlCenterSensorAttributionMonitor {
 
         var micBundleIDs = Set<String>()
         var cameraBundleIDs = Set<String>()
-        let pattern = #""(mic|cam):([^"]+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let regex = attributionRegex else { return nil }
         let nsPayload = NSString(string: String(payload))
         let matches = regex.matches(
             in: String(payload),

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -95,6 +95,7 @@ struct BrowserMeetingContext: Equatable {
     let normalizedID: String
     let platform: MeetingCandidate.Platform
     let isFocused: Bool
+    let requiresMediaActivity: Bool
 
     init(
         bundleID: String,
@@ -103,7 +104,8 @@ struct BrowserMeetingContext: Equatable {
         url: String,
         normalizedID: String,
         platform: MeetingCandidate.Platform,
-        isFocused: Bool
+        isFocused: Bool,
+        requiresMediaActivity: Bool = false
     ) {
         self.bundleID = bundleID
         self.appName = appName
@@ -112,6 +114,7 @@ struct BrowserMeetingContext: Equatable {
         self.normalizedID = normalizedID
         self.platform = platform
         self.isFocused = isFocused
+        self.requiresMediaActivity = requiresMediaActivity
     }
 }
 
@@ -150,10 +153,34 @@ struct NormalizedMeetingURL: Equatable {
     let id: String
     let url: String
     let platform: MeetingCandidate.Platform
+    let requiresMediaActivity: Bool
+
+    init(
+        id: String,
+        url: String,
+        platform: MeetingCandidate.Platform,
+        requiresMediaActivity: Bool = false
+    ) {
+        self.id = id
+        self.url = url
+        self.platform = platform
+        self.requiresMediaActivity = requiresMediaActivity
+    }
 }
 
 enum MeetingURLNormalizer {
     static func normalize(_ rawValue: String) -> NormalizedMeetingURL? {
+        normalizedURL(rawValue, allowGoogleMeetLanding: false)
+    }
+
+    static func normalizeBrowserActivity(_ rawValue: String) -> NormalizedMeetingURL? {
+        normalizedURL(rawValue, allowGoogleMeetLanding: true)
+    }
+
+    private static func normalizedURL(
+        _ rawValue: String,
+        allowGoogleMeetLanding: Bool
+    ) -> NormalizedMeetingURL? {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
@@ -170,8 +197,17 @@ enum MeetingURLNormalizer {
             .joined(separator: "/")
 
         if host == "meet.google.com" {
-            guard let code = path.split(separator: "/").first.map(String.init),
-                  isGoogleMeetCode(code) else { return nil }
+            guard let code = path.split(separator: "/").first.map(String.init) else { return nil }
+            if allowGoogleMeetLanding, code.lowercased() == "landing" {
+                let identity = "meet.google.com/landing"
+                return NormalizedMeetingURL(
+                    id: "googleMeet:\(identity)",
+                    url: identity,
+                    platform: .googleMeet,
+                    requiresMediaActivity: true
+                )
+            }
+            guard isGoogleMeetCode(code) else { return nil }
             let identity = "meet.google.com/\(code.lowercased())"
             return NormalizedMeetingURL(
                 id: "googleMeet:\(identity)",
@@ -302,7 +338,8 @@ final class MeetingCandidateResolver {
         }
 
         if let browserMeeting,
-           browserMeeting.isFocused {
+           browserMeeting.isFocused,
+           !browserMeeting.requiresMediaActivity || hasMediaActivity(snapshot) {
             return candidate(
                 id: browserMeeting.normalizedID,
                 platform: browserMeeting.platform,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -302,7 +302,7 @@ final class MeetingCandidateResolver {
         }
 
         if let browserMeeting,
-           snapshot.micActive || snapshot.cameraActive || browserMeeting.isFocused {
+           browserMeeting.isFocused {
             return candidate(
                 id: browserMeeting.normalizedID,
                 platform: browserMeeting.platform,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -71,7 +71,7 @@ struct MeetingCandidate: Equatable {
     }
 
     var subtitle: String {
-        meetingTitle ?? platform.displayName
+        meetingTitle ?? (platform == .unknown ? appName : platform.displayName)
     }
 
     static func == (lhs: MeetingCandidate, rhs: MeetingCandidate) -> Bool {
@@ -370,7 +370,7 @@ final class MeetingCandidateResolver {
                 )
                 return candidate(
                     id: "cal:\(calendarEvent.id)",
-                    platform: .googleMeet,
+                    platform: .unknown,
                     appName: browserAudio.appName,
                     url: nil,
                     title: calendarEvent.title,
@@ -404,7 +404,7 @@ final class MeetingCandidateResolver {
             )
             return candidate(
                 id: sessionID,
-                platform: .googleMeet,
+                platform: .unknown,
                 appName: browserAudio.appName,
                 url: nil,
                 title: nil,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -295,7 +295,7 @@ final class MeetingCandidateResolver {
                 url: browserMeeting.url,
                 title: snapshot.calendarEvent?.title,
                 evidence: browserEvidence(from: snapshot, context: browserMeeting, inputProcess: inputProcess),
-                sourceBundleID: inputProcess.bundleID,
+                sourceBundleID: browserMeeting.bundleID,
                 sourcePID: inputProcess.pid,
                 now: snapshot.now
             )
@@ -328,7 +328,7 @@ final class MeetingCandidateResolver {
                     url: browserMeeting.url,
                     title: calendarEvent.title,
                     evidence: browserEvidence(from: snapshot, context: browserMeeting, inputProcess: inputProcess).union([.calendarEvent]),
-                    sourceBundleID: inputProcess?.bundleID ?? browserMeeting.bundleID,
+                    sourceBundleID: browserMeeting.bundleID,
                     sourcePID: inputProcess?.pid ?? browserMeeting.pid,
                     now: snapshot.now
                 )
@@ -487,7 +487,13 @@ final class MeetingCandidateResolver {
         for bundleID: String,
         in snapshot: MeetingSignalSnapshot
     ) -> AudioProcessActivity? {
-        snapshot.audioInputProcesses.first { $0.bundleID == bundleID }
+        snapshot.audioInputProcesses.first {
+            $0.bundleID == bundleID || isHelperBundleID($0.bundleID, for: bundleID)
+        }
+    }
+
+    private func isHelperBundleID(_ helperBundleID: String, for parentBundleID: String) -> Bool {
+        helperBundleID.lowercased().hasPrefix("\(parentBundleID.lowercased()).")
     }
 
     private func platform(for bundleID: String) -> MeetingCandidate.Platform? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -350,6 +350,26 @@ final class MeetingCandidateResolver {
                 )
             }
 
+            if let browserAudio = bestBrowserAudioProcess(from: snapshot.audioInputProcesses) {
+                let sessionID = appAudioSessionID(
+                    forBundleID: browserAudio.bundleID,
+                    prefix: "browser",
+                    now: snapshot.now
+                )
+                return candidate(
+                    id: "cal:\(calendarEvent.id)",
+                    platform: .googleMeet,
+                    appName: browserAudio.appName,
+                    url: nil,
+                    title: calendarEvent.title,
+                    evidence: browserMediaEvidence(from: snapshot, browserBundleID: browserAudio.bundleID).union([.calendarEvent]),
+                    sourceBundleID: browserAudio.bundleID,
+                    sourcePID: browserAudio.process.pid,
+                    suppressionID: sessionID,
+                    now: snapshot.now
+                )
+            }
+
             let app = bestApp(from: snapshot.runningApps, includeWeakApps: true)
             return candidate(
                 id: "cal:\(calendarEvent.id)",
@@ -360,6 +380,26 @@ final class MeetingCandidateResolver {
                 evidence: mediaEvidence(from: snapshot).union([.calendarEvent]),
                 sourceBundleID: app?.bundleID,
                 sourcePID: nil,
+                now: snapshot.now
+            )
+        }
+
+        if let browserAudio = bestBrowserAudioProcess(from: snapshot.audioInputProcesses) {
+            let sessionID = appAudioSessionID(
+                forBundleID: browserAudio.bundleID,
+                prefix: "browser",
+                now: snapshot.now
+            )
+            return candidate(
+                id: sessionID,
+                platform: .googleMeet,
+                appName: browserAudio.appName,
+                url: nil,
+                title: nil,
+                evidence: browserMediaEvidence(from: snapshot, browserBundleID: browserAudio.bundleID),
+                sourceBundleID: browserAudio.bundleID,
+                sourcePID: browserAudio.process.pid,
+                suppressionID: sessionID,
                 now: snapshot.now
             )
         }
@@ -460,6 +500,34 @@ final class MeetingCandidateResolver {
         }.first
     }
 
+    private func bestBrowserAudioProcess(
+        from processes: [AudioProcessActivity]
+    ) -> (process: AudioProcessActivity, bundleID: String, appName: String)? {
+        let candidates = processes.compactMap { process -> (process: AudioProcessActivity, bundleID: String, appName: String)? in
+            guard process.bundleID != selfBundleID,
+                  let browserBundleID = browserBundleID(for: process.bundleID),
+                  let appName = Self.browserApps[browserBundleID] else {
+                return nil
+            }
+            return (process, browserBundleID, appName)
+        }
+
+        return candidates.sorted { lhs, rhs in
+            if lhs.bundleID != rhs.bundleID { return lhs.appName < rhs.appName }
+            let lhsExact = lhs.process.bundleID == lhs.bundleID
+            let rhsExact = rhs.process.bundleID == rhs.bundleID
+            if lhsExact != rhsExact { return lhsExact && !rhsExact }
+            return lhs.process.appName < rhs.process.appName
+        }.first
+    }
+
+    private func browserBundleID(for processBundleID: String) -> String? {
+        if Self.browserApps[processBundleID] != nil { return processBundleID }
+        return Self.browserApps.keys.first { browserBundleID in
+            isHelperBundleID(processBundleID, for: browserBundleID)
+        }
+    }
+
     private func browserEvidence(
         from snapshot: MeetingSignalSnapshot,
         context: BrowserMeetingContext,
@@ -469,6 +537,18 @@ final class MeetingCandidateResolver {
         evidence.insert(.browserURL)
         if context.isFocused { evidence.insert(.foregroundApp) }
         if inputProcess != nil { evidence.insert(.audioInputProcess) }
+        return evidence
+    }
+
+    private func browserMediaEvidence(
+        from snapshot: MeetingSignalSnapshot,
+        browserBundleID: String
+    ) -> Set<MeetingCandidate.Evidence> {
+        var evidence = mediaEvidence(from: snapshot)
+        evidence.insert(.audioInputProcess)
+        if snapshot.foregroundBundleID == browserBundleID {
+            evidence.insert(.foregroundApp)
+        }
         return evidence
     }
 
@@ -501,7 +581,10 @@ final class MeetingCandidateResolver {
     }
 
     private func appAudioSessionID(for process: AudioProcessActivity, now: Date) -> String {
-        let key = process.bundleID
+        appAudioSessionID(forBundleID: process.bundleID, prefix: "app", now: now)
+    }
+
+    private func appAudioSessionID(forBundleID key: String, prefix: String, now: Date) -> String {
         if var session = appAudioSessions[key],
            now.timeIntervalSince(session.lastSeenAt) <= appAudioSessionIdleTimeout {
             session.lastSeenAt = now
@@ -511,7 +594,7 @@ final class MeetingCandidateResolver {
 
         let sessionStartedAt = Int(now.timeIntervalSince1970)
         let session = AppAudioSession(
-            id: "app:\(process.bundleID):session:\(sessionStartedAt)",
+            id: "\(prefix):\(key):session:\(sessionStartedAt)",
             lastSeenAt: now
         )
         appAudioSessions[key] = session

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -171,7 +171,7 @@ enum MeetingURLNormalizer {
 
         if host == "meet.google.com" {
             guard let code = path.split(separator: "/").first.map(String.init),
-                  !code.isEmpty else { return nil }
+                  isGoogleMeetCode(code) else { return nil }
             let identity = "meet.google.com/\(code.lowercased())"
             return NormalizedMeetingURL(
                 id: "googleMeet:\(identity)",
@@ -205,6 +205,19 @@ enum MeetingURLNormalizer {
         }
 
         return nil
+    }
+
+    private static func isGoogleMeetCode(_ value: String) -> Bool {
+        let parts = value.lowercased().split(separator: "-")
+        guard parts.count == 3,
+              parts[0].count == 3,
+              parts[1].count == 4,
+              parts[2].count == 3 else {
+            return false
+        }
+        return parts.allSatisfy { part in
+            part.allSatisfy { $0 >= "a" && $0 <= "z" }
+        }
     }
 
     private static func zoomMeetingID(from path: String) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -95,7 +95,6 @@ struct BrowserMeetingContext: Equatable {
     let normalizedID: String
     let platform: MeetingCandidate.Platform
     let isFocused: Bool
-    let requiresMediaActivity: Bool
 
     init(
         bundleID: String,
@@ -104,8 +103,7 @@ struct BrowserMeetingContext: Equatable {
         url: String,
         normalizedID: String,
         platform: MeetingCandidate.Platform,
-        isFocused: Bool,
-        requiresMediaActivity: Bool = false
+        isFocused: Bool
     ) {
         self.bundleID = bundleID
         self.appName = appName
@@ -114,7 +112,6 @@ struct BrowserMeetingContext: Equatable {
         self.normalizedID = normalizedID
         self.platform = platform
         self.isFocused = isFocused
-        self.requiresMediaActivity = requiresMediaActivity
     }
 }
 
@@ -153,34 +150,10 @@ struct NormalizedMeetingURL: Equatable {
     let id: String
     let url: String
     let platform: MeetingCandidate.Platform
-    let requiresMediaActivity: Bool
-
-    init(
-        id: String,
-        url: String,
-        platform: MeetingCandidate.Platform,
-        requiresMediaActivity: Bool = false
-    ) {
-        self.id = id
-        self.url = url
-        self.platform = platform
-        self.requiresMediaActivity = requiresMediaActivity
-    }
 }
 
 enum MeetingURLNormalizer {
     static func normalize(_ rawValue: String) -> NormalizedMeetingURL? {
-        normalizedURL(rawValue, allowGoogleMeetLanding: false)
-    }
-
-    static func normalizeBrowserActivity(_ rawValue: String) -> NormalizedMeetingURL? {
-        normalizedURL(rawValue, allowGoogleMeetLanding: true)
-    }
-
-    private static func normalizedURL(
-        _ rawValue: String,
-        allowGoogleMeetLanding: Bool
-    ) -> NormalizedMeetingURL? {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
@@ -197,17 +170,8 @@ enum MeetingURLNormalizer {
             .joined(separator: "/")
 
         if host == "meet.google.com" {
-            guard let code = path.split(separator: "/").first.map(String.init) else { return nil }
-            if allowGoogleMeetLanding, code.lowercased() == "landing" {
-                let identity = "meet.google.com/landing"
-                return NormalizedMeetingURL(
-                    id: "googleMeet:\(identity)",
-                    url: identity,
-                    platform: .googleMeet,
-                    requiresMediaActivity: true
-                )
-            }
-            guard isGoogleMeetCode(code) else { return nil }
+            guard let code = path.split(separator: "/").first.map(String.init),
+                  isGoogleMeetCode(code) else { return nil }
             let identity = "meet.google.com/\(code.lowercased())"
             return NormalizedMeetingURL(
                 id: "googleMeet:\(identity)",
@@ -338,8 +302,7 @@ final class MeetingCandidateResolver {
         }
 
         if let browserMeeting,
-           browserMeeting.isFocused,
-           !browserMeeting.requiresMediaActivity || hasMediaActivity(snapshot) {
+           browserMeeting.isFocused {
             return candidate(
                 id: browserMeeting.normalizedID,
                 platform: browserMeeting.platform,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -301,7 +301,7 @@ final class MeetingCandidateResolver {
                 title: snapshot.calendarEvent?.title,
                 evidence: browserEvidence(from: snapshot, context: browserMeeting, inputProcess: inputProcess),
                 sourceBundleID: browserMeeting.bundleID,
-                sourcePID: inputProcess.pid,
+                sourcePID: validSourcePID(inputProcess.pid),
                 suppressionID: suppressionID,
                 now: snapshot.now
             )
@@ -340,7 +340,7 @@ final class MeetingCandidateResolver {
                     title: calendarEvent.title,
                     evidence: browserEvidence(from: snapshot, context: browserMeeting, inputProcess: inputProcess).union([.calendarEvent]),
                     sourceBundleID: browserMeeting.bundleID,
-                    sourcePID: inputProcess?.pid ?? browserMeeting.pid,
+                    sourcePID: inputProcess.flatMap { validSourcePID($0.pid) } ?? browserMeeting.pid,
                     suppressionID: suppressionID,
                     now: snapshot.now
                 )
@@ -356,7 +356,7 @@ final class MeetingCandidateResolver {
                     title: calendarEvent.title,
                     evidence: mediaEvidence(from: snapshot).union([.calendarEvent, .audioInputProcess]),
                     sourceBundleID: audioApp.bundleID,
-                    sourcePID: audioApp.pid,
+                    sourcePID: validSourcePID(audioApp.pid),
                     suppressionID: appSessionID,
                     now: snapshot.now
                 )
@@ -376,7 +376,7 @@ final class MeetingCandidateResolver {
                     title: calendarEvent.title,
                     evidence: browserMediaEvidence(from: snapshot, browserBundleID: browserAudio.bundleID).union([.calendarEvent]),
                     sourceBundleID: browserAudio.bundleID,
-                    sourcePID: browserAudio.process.pid,
+                    sourcePID: validSourcePID(browserAudio.process.pid),
                     suppressionID: sessionID,
                     now: snapshot.now
                 )
@@ -410,7 +410,7 @@ final class MeetingCandidateResolver {
                 title: nil,
                 evidence: browserMediaEvidence(from: snapshot, browserBundleID: browserAudio.bundleID),
                 sourceBundleID: browserAudio.bundleID,
-                sourcePID: browserAudio.process.pid,
+                sourcePID: validSourcePID(browserAudio.process.pid),
                 suppressionID: sessionID,
                 now: snapshot.now
             )
@@ -427,7 +427,7 @@ final class MeetingCandidateResolver {
                 title: nil,
                 evidence: mediaEvidence(from: snapshot).union([.audioInputProcess, .dedicatedApp]),
                 sourceBundleID: audioApp.bundleID,
-                sourcePID: audioApp.pid,
+                sourcePID: validSourcePID(audioApp.pid),
                 suppressionID: appSessionID,
                 now: snapshot.now
             )
@@ -590,6 +590,10 @@ final class MeetingCandidateResolver {
 
     private func platform(for bundleID: String) -> MeetingCandidate.Platform? {
         Self.dedicatedApps[bundleID]?.platform
+    }
+
+    private func validSourcePID(_ pid: pid_t) -> pid_t? {
+        pid > 0 ? pid : nil
     }
 
     private func appAudioSessionID(for process: AudioProcessActivity, now: Date) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -288,6 +288,11 @@ final class MeetingCandidateResolver {
 
         if let browserMeeting,
            let inputProcess = activeInputProcess(for: browserMeeting.bundleID, in: snapshot) {
+            let suppressionID = appAudioSessionID(
+                forBundleID: browserMeeting.bundleID,
+                prefix: "browser",
+                now: snapshot.now
+            )
             return candidate(
                 id: browserMeeting.normalizedID,
                 platform: browserMeeting.platform,
@@ -297,6 +302,7 @@ final class MeetingCandidateResolver {
                 evidence: browserEvidence(from: snapshot, context: browserMeeting, inputProcess: inputProcess),
                 sourceBundleID: browserMeeting.bundleID,
                 sourcePID: inputProcess.pid,
+                suppressionID: suppressionID,
                 now: snapshot.now
             )
         }
@@ -321,6 +327,11 @@ final class MeetingCandidateResolver {
         if let calendarEvent = snapshot.calendarEvent {
             if let browserMeeting {
                 let inputProcess = activeInputProcess(for: browserMeeting.bundleID, in: snapshot)
+                let suppressionID = inputProcess == nil ? nil : appAudioSessionID(
+                    forBundleID: browserMeeting.bundleID,
+                    prefix: "browser",
+                    now: snapshot.now
+                )
                 return candidate(
                     id: "cal:\(calendarEvent.id):\(browserMeeting.normalizedID)",
                     platform: browserMeeting.platform,
@@ -330,6 +341,7 @@ final class MeetingCandidateResolver {
                     evidence: browserEvidence(from: snapshot, context: browserMeeting, inputProcess: inputProcess).union([.calendarEvent]),
                     sourceBundleID: browserMeeting.bundleID,
                     sourcePID: inputProcess?.pid ?? browserMeeting.pid,
+                    suppressionID: suppressionID,
                     now: snapshot.now
                 )
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -17,6 +17,7 @@ final class MeetingMonitor {
     private let browserCollector = BrowserMeetingActivityCollector()
     private let audioProcessCollector = AudioProcessAttributionCollector()
     private let cameraMonitor = CameraActivityMonitor()
+    private let sensorAttributionMonitor = ControlCenterSensorAttributionMonitor()
     private let promptState = MeetingPromptStateMachine()
 
     private var micListenerDeviceID: AudioDeviceID = 0
@@ -38,6 +39,11 @@ final class MeetingMonitor {
         }
         cameraMonitor.start()
 
+        sensorAttributionMonitor.onAttributionsChanged = { [weak self] in
+            DispatchQueue.main.async { self?.evaluateNow() }
+        }
+        sensorAttributionMonitor.start()
+
         installEvaluationTimer()
         evaluateNow()
     }
@@ -47,6 +53,7 @@ final class MeetingMonitor {
         removeDeviceChangeListener()
         removeWorkspaceActivationObserver()
         cameraMonitor.stop()
+        sensorAttributionMonitor.stop()
         evaluationTimer?.invalidate()
         evaluationTimer = nil
     }
@@ -104,12 +111,17 @@ final class MeetingMonitor {
         let now = Date()
         let visibility = promptVisibilityProvider?() ?? MeetingPromptVisibility(isVisible: false, currentPromptID: nil, shownAt: nil)
         cameraMonitor.refresh()
-        let audioInputProcesses = audioProcessCollector.activeInputProcesses()
-        let micActive = isMicActive() || !audioInputProcesses.isEmpty
+        let sensorAttributions = sensorAttributionMonitor.snapshot(now: now)
+        let audioInputProcesses = mergedAudioInputProcesses(
+            audioProcessCollector.activeInputProcesses(),
+            sensorAttributions: sensorAttributions
+        )
+        let micActive = isMicActive() || !audioInputProcesses.isEmpty || !sensorAttributions.micBundleIDs.isEmpty
+        let cameraActive = cameraMonitor.isCameraActive || !sensorAttributions.cameraBundleIDs.isEmpty
 
         let snapshot = MeetingSignalSnapshot(
             micActive: micActive,
-            cameraActive: cameraMonitor.isCameraActive,
+            cameraActive: cameraActive,
             calendarEvent: calendarEventProvider?(),
             runningApps: currentRunningApps(),
             browserMeetings: browserCollector.collect(),
@@ -222,6 +234,34 @@ final class MeetingMonitor {
             guard let bundleID = app.bundleIdentifier else { return nil }
             return RunningAppInfo(bundleID: bundleID, isActive: app.isActive)
         }
+    }
+
+    private func mergedAudioInputProcesses(
+        _ coreAudioProcesses: [AudioProcessActivity],
+        sensorAttributions: SensorAttributionSnapshot
+    ) -> [AudioProcessActivity] {
+        var processes = coreAudioProcesses
+        let existingBundleIDs = Set(coreAudioProcesses.map(\.bundleID))
+
+        for bundleID in sensorAttributions.micBundleIDs.sorted() {
+            guard let appName = MeetingCandidateResolver.browserApps[bundleID] else { continue }
+            guard !existingBundleIDs.contains(bundleID),
+                  !existingBundleIDs.contains(where: { helperBundleID in
+                      helperBundleID.lowercased().hasPrefix("\(bundleID.lowercased()).")
+                  }) else {
+                continue
+            }
+
+            processes.append(AudioProcessActivity(
+                pid: NSWorkspace.shared.runningApplications.first { $0.bundleIdentifier == bundleID }?.processIdentifier ?? 0,
+                bundleID: bundleID,
+                appName: appName,
+                isRunningInput: true,
+                isRunningOutput: false
+            ))
+        }
+
+        return processes
     }
 
     private func installMicListener() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -10,6 +10,7 @@ final class MeetingMonitor {
     var isStartingRecordingProvider: (() -> Bool)?
     var isCalendarNotificationVisibleProvider: (() -> Bool)?
     var promptVisibilityProvider: (() -> MeetingPromptVisibility)?
+    var mutedDetectionBundleIDsProvider: (() -> Set<String>)?
     var onPromptCandidateChanged: ((MeetingCandidate?) -> Void)?
 
     private let resolver = MeetingCandidateResolver()
@@ -117,7 +118,8 @@ final class MeetingMonitor {
             now: now
         )
 
-        let candidate = isGloballySuppressed(now: now) ? nil : resolver.resolve(snapshot)
+        let resolvedCandidate = isGloballySuppressed(now: now) ? nil : resolver.resolve(snapshot)
+        let candidate = isMuted(resolvedCandidate) ? nil : resolvedCandidate
         logCandidateIfChanged(candidate)
 
         let decision = promptState.evaluate(
@@ -149,6 +151,11 @@ final class MeetingMonitor {
             return false
         }
         return true
+    }
+
+    private func isMuted(_ candidate: MeetingCandidate?) -> Bool {
+        guard let sourceBundleID = candidate?.sourceBundleID else { return false }
+        return mutedDetectionBundleIDsProvider?().contains(sourceBundleID) ?? false
     }
 
     private func logCandidateIfChanged(_ candidate: MeetingCandidate?) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -1,9 +1,12 @@
 import AppKit
 import CoreAudio
 import Foundation
+import os
 
 @MainActor
 final class MeetingMonitor {
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
+
     var calendarEventProvider: (() -> CalendarEventContext?)?
     var detectionEnabledProvider: (() -> Bool)?
     var isRecordingProvider: (() -> Bool)?
@@ -372,6 +375,7 @@ final class MeetingMonitor {
     }
 
     private func log(_ message: String) {
+        Self.logger.notice("\(message, privacy: .public)")
         fputs("[meeting-monitor] \(message)\n", stderr)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -2,9 +2,12 @@ import AppKit
 import QuartzCore
 import Foundation
 import MuesliCore
+import os
 
 @MainActor
 final class MeetingNotificationController {
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingNotification")
+
     private var panel: NSPanel?
     private var dismissTimer: Timer?
     private var progressLayer: CALayer?
@@ -62,7 +65,10 @@ final class MeetingNotificationController {
             width: width,
             height: height,
             margin: margin
-        ) else { return false }
+        ) else {
+            Self.logger.error("notification_frame_unavailable title=\(title, privacy: .public)")
+            return false
+        }
         self.onClose = onClose
 
         let panel = NSPanel(
@@ -71,7 +77,7 @@ final class MeetingNotificationController {
             backing: .buffered,
             defer: false
         )
-        panel.level = .statusBar
+        panel.level = .screenSaver
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -199,6 +205,9 @@ final class MeetingNotificationController {
         isVisible = true
         currentPromptID = promptID
         shownAt = Date()
+        Self.logger.notice(
+            "notification_panel_shown promptID=\(promptID ?? "nil", privacy: .public) level=\(panel.level.rawValue) frame=\(NSStringFromRect(frame), privacy: .public)"
+        )
 
         startDismissCountdown(duration: duration)
         return true

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -8,6 +8,9 @@ final class MeetingNotificationController {
     private var panel: NSPanel?
     private var dismissTimer: Timer?
     private var progressLayer: CALayer?
+    private var dismissDeadline: Date?
+    private var remainingDismissDuration: TimeInterval = 0
+    private var isDismissPaused = false
     private var onStartRecording: (() -> Void)?
     private var onJoinAndRecord: (() -> Void)?
     private var onJoinOnly: (() -> Void)?
@@ -19,6 +22,7 @@ final class MeetingNotificationController {
 
     private static let dismissDuration: TimeInterval = 15
 
+    @discardableResult
     func show(
         promptID: String? = nil,
         title: String,
@@ -34,7 +38,7 @@ final class MeetingNotificationController {
         onDismiss: (() -> Void)? = nil,
         onAutoDismiss: (() -> Void)? = nil,
         onClose: (() -> Void)? = nil
-    ) {
+    ) -> Bool {
         // Nil out onClose before close() so the old panel's teardown
         // doesn't fire its callback (e.g. resetting isShowingCalendarNotification).
         self.onClose = nil
@@ -51,15 +55,15 @@ final class MeetingNotificationController {
         let hasJoinButton = meetingURL != nil && onJoinAndRecord != nil
         let platform = explicitPlatform ?? meetingURL.flatMap { MeetingPlatform.detect(from: $0) }
 
-        let width: CGFloat = 360
-        let height: CGFloat = 70
+        let width: CGFloat = 420
+        let height: CGFloat = 74
         let margin: CGFloat = 16
         guard let frame = verifiedNotificationFrame(
             preferredScreen: preferredScreen,
             width: width,
             height: height,
             margin: margin
-        ) else { return }
+        ) else { return false }
 
         let panel = NSPanel(
             contentRect: frame,
@@ -67,7 +71,7 @@ final class MeetingNotificationController {
             backing: .buffered,
             defer: false
         )
-        panel.level = .init(rawValue: Int(CGShieldingWindowLevel()) + 1) // Above everything including full-screen
+        panel.level = .floating
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -75,7 +79,9 @@ final class MeetingNotificationController {
         panel.ignoresMouseEvents = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
 
-        let contentView = NSView(frame: NSRect(origin: .zero, size: NSSize(width: width, height: height)))
+        let contentView = HoverAwareView(frame: NSRect(origin: .zero, size: NSSize(width: width, height: height)))
+        contentView.onMouseEntered = { [weak self] in self?.pauseDismissCountdown() }
+        contentView.onMouseExited = { [weak self] in self?.resumeDismissCountdown() }
         contentView.wantsLayer = true
         contentView.layer?.cornerRadius = 12
         contentView.layer?.masksToBounds = true
@@ -90,17 +96,20 @@ final class MeetingNotificationController {
         contentView.layer?.addSublayer(progressBar)
         self.progressLayer = progressBar
 
-        // Animate progress bar shrinking from full width to 0
-        let shrink = CABasicAnimation(keyPath: "bounds.size.width")
-        shrink.fromValue = width
-        shrink.toValue = 0
-        shrink.duration = duration
-        shrink.timingFunction = CAMediaTimingFunction(name: .linear)
-        shrink.fillMode = .forwards
-        shrink.isRemovedOnCompletion = false
         progressBar.anchorPoint = CGPoint(x: 0, y: 0.5)
         progressBar.position = CGPoint(x: 0, y: 1.5)
-        progressBar.add(shrink, forKey: "countdown")
+
+        let dismissButton = NSButton(title: "×", target: self, action: #selector(handleDismiss))
+        dismissButton.font = .systemFont(ofSize: 24, weight: .regular)
+        dismissButton.frame = NSRect(x: 12, y: (height - 36) / 2, width: 36, height: 36)
+        dismissButton.wantsLayer = true
+        dismissButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.08).cgColor
+        dismissButton.layer?.borderWidth = 1
+        dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.20).cgColor
+        dismissButton.layer?.cornerRadius = 18
+        dismissButton.isBordered = false
+        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.90)
+        contentView.addSubview(dismissButton)
 
         // Platform icon + text layout
         let textX: CGFloat
@@ -108,25 +117,25 @@ final class MeetingNotificationController {
             let iconSize: CGFloat = 28
             let iconView = NSImageView(image: icon)
             iconView.imageScaling = .scaleProportionallyUpOrDown
-            iconView.frame = NSRect(x: 14, y: (height - iconSize) / 2 + 2, width: iconSize, height: iconSize)
+            iconView.frame = NSRect(x: 60, y: (height - iconSize) / 2 + 2, width: iconSize, height: iconSize)
             contentView.addSubview(iconView)
-            textX = 14 + iconSize + 8
+            textX = 60 + iconSize + 10
         } else {
-            textX = 14
+            textX = 60
         }
 
         // Title label
         let titleLabel = NSTextField(labelWithString: title)
         titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         titleLabel.textColor = .white
-        titleLabel.frame = NSRect(x: textX, y: 40, width: 180, height: 18)
+        titleLabel.frame = NSRect(x: textX, y: 43, width: 180, height: 18)
         contentView.addSubview(titleLabel)
 
         // Subtitle label
         let subtitleLabel = NSTextField(labelWithString: subtitle)
         subtitleLabel.font = .systemFont(ofSize: 11)
         subtitleLabel.textColor = NSColor.white.withAlphaComponent(0.55)
-        subtitleLabel.frame = NSRect(x: textX, y: 20, width: 180, height: 16)
+        subtitleLabel.frame = NSRect(x: textX, y: 23, width: 180, height: 16)
         contentView.addSubview(subtitleLabel)
 
         if hasJoinButton {
@@ -134,7 +143,7 @@ final class MeetingNotificationController {
             let buttonWidth: CGFloat = 110
             let chevronWidth: CGFloat = 24
             let totalWidth = buttonWidth + chevronWidth
-            let buttonX = width - totalWidth - 10
+            let buttonX = width - totalWidth - 18
             let textMaxX = buttonX - 8
             let greenColor = NSColor(red: 0.20, green: 0.72, blue: 0.53, alpha: 1.0)
             let greenDarker = NSColor(red: 0.15, green: 0.58, blue: 0.42, alpha: 1.0)
@@ -146,7 +155,7 @@ final class MeetingNotificationController {
             // Main "Join & Record" button
             let joinButton = NSButton(title: "Join & Record", target: self, action: #selector(handleJoinAndRecord))
             joinButton.font = .systemFont(ofSize: 11, weight: .medium)
-            joinButton.frame = NSRect(x: buttonX, y: 20, width: buttonWidth, height: 28)
+            joinButton.frame = NSRect(x: buttonX, y: 22, width: buttonWidth, height: 30)
             joinButton.wantsLayer = true
             joinButton.layer?.backgroundColor = greenColor.cgColor
             joinButton.layer?.cornerRadius = 6
@@ -158,7 +167,7 @@ final class MeetingNotificationController {
             // Chevron dropdown button
             let chevronButton = NSButton(title: "▾", target: self, action: #selector(handleChevronClick(_:)))
             chevronButton.font = .systemFont(ofSize: 9, weight: .medium)
-            chevronButton.frame = NSRect(x: buttonX + buttonWidth, y: 20, width: chevronWidth, height: 28)
+            chevronButton.frame = NSRect(x: buttonX + buttonWidth, y: 22, width: chevronWidth, height: 30)
             chevronButton.wantsLayer = true
             chevronButton.layer?.backgroundColor = greenDarker.cgColor
             chevronButton.layer?.cornerRadius = 6
@@ -170,7 +179,7 @@ final class MeetingNotificationController {
             // Single "Start Recording" button
             let startButton = NSButton(title: actionLabel, target: self, action: #selector(handleStartRecording))
             startButton.font = .systemFont(ofSize: 12, weight: .medium)
-            startButton.frame = NSRect(x: width - 140, y: 20, width: 120, height: 30)
+            startButton.frame = NSRect(x: width - 158, y: 22, width: 140, height: 30)
             startButton.wantsLayer = true
             startButton.layer?.backgroundColor = NSColor(red: 0.2, green: 0.5, blue: 1.0, alpha: 1.0).cgColor
             startButton.layer?.cornerRadius = 6
@@ -178,14 +187,6 @@ final class MeetingNotificationController {
             startButton.contentTintColor = .white
             contentView.addSubview(startButton)
         }
-
-        // Dismiss button (×)
-        let dismissButton = NSButton(title: "×", target: self, action: #selector(handleDismiss))
-        dismissButton.font = .systemFont(ofSize: 14, weight: .medium)
-        dismissButton.frame = NSRect(x: width - 22, y: height - 20, width: 14, height: 14)
-        dismissButton.isBordered = false
-        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.35)
-        contentView.addSubview(dismissButton)
 
         panel.contentView = contentView
         panel.alphaValue = 0
@@ -201,25 +202,26 @@ final class MeetingNotificationController {
         currentPromptID = promptID
         shownAt = Date()
 
-        // Auto-dismiss
-        dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.animateOut {
-                    let autoDismiss = self?.onAutoDismiss
-                    self?.onClose = nil
-                    self?.close()
-                    autoDismiss?()
-                }
-            }
-        }
+        startDismissCountdown(duration: duration)
+        return true
     }
 
     var onClose: (() -> Void)?
 
+    static func suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: Bool) -> Bool {
+        hasAutoDismissHandler
+    }
+
     func close() {
         dismissTimer?.invalidate()
         dismissTimer = nil
+        dismissDeadline = nil
+        remainingDismissDuration = 0
+        isDismissPaused = false
         progressLayer?.removeAllAnimations()
+        progressLayer?.speed = 1
+        progressLayer?.timeOffset = 0
+        progressLayer?.beginTime = 0
         progressLayer = nil
         panel?.close()
         panel = nil
@@ -233,6 +235,77 @@ final class MeetingNotificationController {
         shownAt = nil
         onClose?()
         onClose = nil
+    }
+
+    private func startDismissCountdown(duration: TimeInterval) {
+        remainingDismissDuration = duration
+        isDismissPaused = false
+        startProgressAnimation(duration: duration)
+        scheduleDismissTimer(after: duration)
+    }
+
+    private func startProgressAnimation(duration: TimeInterval) {
+        guard let progressLayer else { return }
+        let shrink = CABasicAnimation(keyPath: "bounds.size.width")
+        shrink.fromValue = progressLayer.bounds.width
+        shrink.toValue = 0
+        shrink.duration = duration
+        shrink.timingFunction = CAMediaTimingFunction(name: .linear)
+        shrink.fillMode = .forwards
+        shrink.isRemovedOnCompletion = false
+        progressLayer.add(shrink, forKey: "countdown")
+    }
+
+    private func scheduleDismissTimer(after duration: TimeInterval) {
+        dismissTimer?.invalidate()
+        dismissDeadline = Date().addingTimeInterval(duration)
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.autoDismissNow()
+            }
+        }
+    }
+
+    private func autoDismissNow() {
+        guard !isDismissPaused else { return }
+        animateOut { [weak self] in
+            let autoDismiss = self?.onAutoDismiss
+            if Self.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: autoDismiss != nil) {
+                self?.onClose = nil
+            }
+            self?.close()
+            autoDismiss?()
+        }
+    }
+
+    private func pauseDismissCountdown() {
+        guard isVisible, !isDismissPaused else { return }
+        isDismissPaused = true
+        if let dismissDeadline {
+            remainingDismissDuration = max(0.1, dismissDeadline.timeIntervalSinceNow)
+        }
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+        dismissDeadline = nil
+
+        guard let progressLayer else { return }
+        let pausedTime = progressLayer.convertTime(CACurrentMediaTime(), from: nil)
+        progressLayer.speed = 0
+        progressLayer.timeOffset = pausedTime
+    }
+
+    private func resumeDismissCountdown() {
+        guard isVisible, isDismissPaused else { return }
+        isDismissPaused = false
+        scheduleDismissTimer(after: remainingDismissDuration)
+
+        guard let progressLayer else { return }
+        let pausedTime = progressLayer.timeOffset
+        progressLayer.speed = 1
+        progressLayer.timeOffset = 0
+        progressLayer.beginTime = 0
+        let timeSincePause = progressLayer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
+        progressLayer.beginTime = timeSincePause
     }
 
     private func animateOut(completion: @escaping () -> Void) {
@@ -295,7 +368,7 @@ final class MeetingNotificationController {
         margin: CGFloat
     ) -> NSRect? {
         let orderedScreens = uniqueScreens(
-            [preferredScreen, screenForMouse(), NSScreen.main].compactMap { $0 } + NSScreen.screens
+            [preferredScreen, NSScreen.main, screenForMouse()].compactMap { $0 } + NSScreen.screens
         )
 
         for screen in orderedScreens {
@@ -304,7 +377,8 @@ final class MeetingNotificationController {
                 return frame
             }
         }
-        return nil
+        guard let fallbackScreen = NSScreen.main ?? NSScreen.screens.first else { return nil }
+        return notificationFrame(on: fallbackScreen, width: width, height: height, margin: margin)
     }
 
     private func screenForMouse() -> NSScreen? {
@@ -335,6 +409,34 @@ final class MeetingNotificationController {
         return screens.filter { screen in
             seen.insert(ObjectIdentifier(screen)).inserted
         }
+    }
+}
+
+private final class HoverAwareView: NSView {
+    var onMouseEntered: (() -> Void)?
+    var onMouseExited: (() -> Void)?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for trackingArea in trackingAreas {
+            removeTrackingArea(trackingArea)
+        }
+        addTrackingArea(
+            NSTrackingArea(
+                rect: bounds,
+                options: [.activeAlways, .mouseEnteredAndExited, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+        )
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onMouseEntered?()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onMouseExited?()
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -55,8 +55,8 @@ final class MeetingNotificationController {
         let hasJoinButton = meetingURL != nil && onJoinAndRecord != nil
         let platform = explicitPlatform ?? meetingURL.flatMap { MeetingPlatform.detect(from: $0) }
 
-        let width: CGFloat = 420
-        let height: CGFloat = 74
+        let width: CGFloat = 344
+        let height: CGFloat = 60
         let margin: CGFloat = 16
         guard let frame = verifiedNotificationFrame(
             preferredScreen: preferredScreen,
@@ -83,7 +83,7 @@ final class MeetingNotificationController {
         contentView.onMouseEntered = { [weak self] in self?.pauseDismissCountdown() }
         contentView.onMouseExited = { [weak self] in self?.resumeDismissCountdown() }
         contentView.wantsLayer = true
-        contentView.layer?.cornerRadius = 12
+        contentView.layer?.cornerRadius = 10
         contentView.layer?.masksToBounds = true
         contentView.layer?.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.12, alpha: 0.97).cgColor
         contentView.layer?.borderWidth = 1
@@ -100,13 +100,13 @@ final class MeetingNotificationController {
         progressBar.position = CGPoint(x: 0, y: 1.5)
 
         let dismissButton = NSButton(title: "×", target: self, action: #selector(handleDismiss))
-        dismissButton.font = .systemFont(ofSize: 15, weight: .medium)
-        dismissButton.frame = NSRect(x: 12, y: height - 32, width: 24, height: 24)
+        dismissButton.font = .systemFont(ofSize: 13, weight: .medium)
+        dismissButton.frame = NSRect(x: 9, y: height - 27, width: 20, height: 20)
         dismissButton.wantsLayer = true
         dismissButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.055).cgColor
         dismissButton.layer?.borderWidth = 1
         dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.14).cgColor
-        dismissButton.layer?.cornerRadius = 12
+        dismissButton.layer?.cornerRadius = 10
         dismissButton.alignment = .center
         dismissButton.focusRingType = .none
         dismissButton.isBordered = false
@@ -117,36 +117,36 @@ final class MeetingNotificationController {
         // Platform icon + text layout
         let textX: CGFloat
         if let platform, let icon = platform.loadIcon() {
-            let iconSize: CGFloat = 28
+            let iconSize: CGFloat = 26
             let iconView = NSImageView(image: icon)
             iconView.imageScaling = .scaleProportionallyUpOrDown
-            iconView.frame = NSRect(x: 52, y: (height - iconSize) / 2 + 2, width: iconSize, height: iconSize)
+            iconView.frame = NSRect(x: 38, y: (height - iconSize) / 2 + 1, width: iconSize, height: iconSize)
             contentView.addSubview(iconView)
-            textX = 52 + iconSize + 10
+            textX = 38 + iconSize + 9
         } else {
-            textX = 52
+            textX = 38
         }
 
         // Title label
         let titleLabel = NSTextField(labelWithString: title)
         titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         titleLabel.textColor = .white
-        titleLabel.frame = NSRect(x: textX, y: 43, width: 180, height: 18)
+        titleLabel.frame = NSRect(x: textX, y: 32, width: 144, height: 18)
         contentView.addSubview(titleLabel)
 
         // Subtitle label
         let subtitleLabel = NSTextField(labelWithString: subtitle)
         subtitleLabel.font = .systemFont(ofSize: 11)
         subtitleLabel.textColor = NSColor.white.withAlphaComponent(0.55)
-        subtitleLabel.frame = NSRect(x: textX, y: 23, width: 180, height: 16)
+        subtitleLabel.frame = NSRect(x: textX, y: 14, width: 144, height: 16)
         contentView.addSubview(subtitleLabel)
 
         if hasJoinButton {
             // Split button: "Join & Record" (main) + chevron dropdown with "Join Only"
-            let buttonWidth: CGFloat = 110
+            let buttonWidth: CGFloat = 98
             let chevronWidth: CGFloat = 24
             let totalWidth = buttonWidth + chevronWidth
-            let buttonX = width - totalWidth - 18
+            let buttonX = width - totalWidth - 12
             let textMaxX = buttonX - 8
             let greenColor = NSColor(red: 0.20, green: 0.72, blue: 0.53, alpha: 1.0)
             let greenDarker = NSColor(red: 0.15, green: 0.58, blue: 0.42, alpha: 1.0)
@@ -158,7 +158,7 @@ final class MeetingNotificationController {
             // Main "Join & Record" button
             let joinButton = NSButton(title: "Join & Record", target: self, action: #selector(handleJoinAndRecord))
             joinButton.font = .systemFont(ofSize: 11, weight: .medium)
-            joinButton.frame = NSRect(x: buttonX, y: 22, width: buttonWidth, height: 30)
+            joinButton.frame = NSRect(x: buttonX, y: 15, width: buttonWidth, height: 30)
             joinButton.wantsLayer = true
             joinButton.layer?.backgroundColor = greenColor.cgColor
             joinButton.layer?.cornerRadius = 6
@@ -170,7 +170,7 @@ final class MeetingNotificationController {
             // Chevron dropdown button
             let chevronButton = NSButton(title: "▾", target: self, action: #selector(handleChevronClick(_:)))
             chevronButton.font = .systemFont(ofSize: 9, weight: .medium)
-            chevronButton.frame = NSRect(x: buttonX + buttonWidth, y: 22, width: chevronWidth, height: 30)
+            chevronButton.frame = NSRect(x: buttonX + buttonWidth, y: 15, width: chevronWidth, height: 30)
             chevronButton.wantsLayer = true
             chevronButton.layer?.backgroundColor = greenDarker.cgColor
             chevronButton.layer?.cornerRadius = 6
@@ -182,7 +182,7 @@ final class MeetingNotificationController {
             // Single "Start Recording" button
             let startButton = NSButton(title: actionLabel, target: self, action: #selector(handleStartRecording))
             startButton.font = .systemFont(ofSize: 12, weight: .medium)
-            startButton.frame = NSRect(x: width - 158, y: 22, width: 140, height: 30)
+            startButton.frame = NSRect(x: width - 122, y: 15, width: 110, height: 30)
             startButton.wantsLayer = true
             startButton.layer?.backgroundColor = NSColor(red: 0.2, green: 0.5, blue: 1.0, alpha: 1.0).cgColor
             startButton.layer?.cornerRadius = 6

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -71,7 +71,7 @@ final class MeetingNotificationController {
             backing: .buffered,
             defer: false
         )
-        panel.level = .init(rawValue: Int(CGShieldingWindowLevel()) + 1)
+        panel.level = .statusBar
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -192,14 +192,9 @@ final class MeetingNotificationController {
         }
 
         panel.contentView = contentView
-        panel.alphaValue = 0
+        panel.alphaValue = 1
         panel.orderFrontRegardless()
 
-        // Fade in
-        NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.25
-            panel.animator().alphaValue = 1
-        }
         self.panel = panel
         isVisible = true
         currentPromptID = promptID

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -43,7 +43,6 @@ final class MeetingNotificationController {
         // doesn't fire its callback (e.g. resetting isShowingCalendarNotification).
         self.onClose = nil
         close()
-        self.onClose = onClose
 
         let duration = dismissAfter ?? Self.dismissDuration
         self.onStartRecording = onStartRecording
@@ -64,6 +63,7 @@ final class MeetingNotificationController {
             height: height,
             margin: margin
         ) else { return false }
+        self.onClose = onClose
 
         let panel = NSPanel(
             contentRect: frame,
@@ -71,7 +71,7 @@ final class MeetingNotificationController {
             backing: .buffered,
             defer: false
         )
-        panel.level = .floating
+        panel.level = .init(rawValue: Int(CGShieldingWindowLevel()) + 1)
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -272,6 +272,7 @@ final class MeetingNotificationController {
     private func autoDismissNow() {
         guard !isDismissPaused else { return }
         animateOut { [weak self] in
+            guard self?.isDismissPaused == false else { return }
             let autoDismiss = self?.onAutoDismiss
             if Self.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: autoDismiss != nil) {
                 self?.onClose = nil
@@ -304,11 +305,11 @@ final class MeetingNotificationController {
 
         guard let progressLayer else { return }
         let pausedTime = progressLayer.timeOffset
+        let resumeHostTime = CACurrentMediaTime()
         progressLayer.speed = 1
         progressLayer.timeOffset = 0
         progressLayer.beginTime = 0
-        let timeSincePause = progressLayer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
-        progressLayer.beginTime = timeSincePause
+        progressLayer.beginTime = resumeHostTime - pausedTime
     }
 
     private func animateOut(completion: @escaping () -> Void) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -100,15 +100,18 @@ final class MeetingNotificationController {
         progressBar.position = CGPoint(x: 0, y: 1.5)
 
         let dismissButton = NSButton(title: "×", target: self, action: #selector(handleDismiss))
-        dismissButton.font = .systemFont(ofSize: 24, weight: .regular)
-        dismissButton.frame = NSRect(x: 12, y: (height - 36) / 2, width: 36, height: 36)
+        dismissButton.font = .systemFont(ofSize: 15, weight: .medium)
+        dismissButton.frame = NSRect(x: 12, y: height - 32, width: 24, height: 24)
         dismissButton.wantsLayer = true
-        dismissButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.08).cgColor
+        dismissButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.055).cgColor
         dismissButton.layer?.borderWidth = 1
-        dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.20).cgColor
-        dismissButton.layer?.cornerRadius = 18
+        dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.14).cgColor
+        dismissButton.layer?.cornerRadius = 12
+        dismissButton.alignment = .center
+        dismissButton.focusRingType = .none
         dismissButton.isBordered = false
-        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.90)
+        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.72)
+        dismissButton.toolTip = "Dismiss"
         contentView.addSubview(dismissButton)
 
         // Platform icon + text layout
@@ -117,11 +120,11 @@ final class MeetingNotificationController {
             let iconSize: CGFloat = 28
             let iconView = NSImageView(image: icon)
             iconView.imageScaling = .scaleProportionallyUpOrDown
-            iconView.frame = NSRect(x: 60, y: (height - iconSize) / 2 + 2, width: iconSize, height: iconSize)
+            iconView.frame = NSRect(x: 52, y: (height - iconSize) / 2 + 2, width: iconSize, height: iconSize)
             contentView.addSubview(iconView)
-            textX = 60 + iconSize + 10
+            textX = 52 + iconSize + 10
         } else {
-            textX = 60
+            textX = 52
         }
 
         // Title label

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -73,7 +73,7 @@ final class MeetingNotificationController {
 
         let panel = NSPanel(
             contentRect: frame,
-            styleMask: .borderless,
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -83,7 +83,8 @@ final class MeetingNotificationController {
         panel.hasShadow = true
         panel.hidesOnDeactivate = false
         panel.ignoresMouseEvents = false
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary, .transient, .ignoresCycle]
+        panel.becomesKeyOnlyIfNeeded = true
 
         let contentView = HoverAwareView(frame: NSRect(origin: .zero, size: NSSize(width: width, height: height)))
         contentView.onMouseEntered = { [weak self] in self?.pauseDismissCountdown() }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -220,6 +220,10 @@ final class MeetingNotificationController {
         hasAutoDismissHandler
     }
 
+    static func firesAutoDismissCallbackAfterFade(wasDismissPaused: Bool) -> Bool {
+        !wasDismissPaused
+    }
+
     func close() {
         dismissTimer?.invalidate()
         dismissTimer = nil
@@ -277,13 +281,18 @@ final class MeetingNotificationController {
     private func autoDismissNow() {
         guard !isDismissPaused else { return }
         animateOut { [weak self] in
-            guard self?.isDismissPaused == false else { return }
-            let autoDismiss = self?.onAutoDismiss
-            if Self.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: autoDismiss != nil) {
-                self?.onClose = nil
+            guard let self else { return }
+            let wasPaused = self.isDismissPaused
+            let autoDismiss = self.onAutoDismiss
+            let shouldFireAutoDismiss = Self.firesAutoDismissCallbackAfterFade(wasDismissPaused: wasPaused)
+            if shouldFireAutoDismiss,
+               Self.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: autoDismiss != nil) {
+                self.onClose = nil
             }
-            self?.close()
-            autoDismiss?()
+            self.close()
+            if shouldFireAutoDismiss {
+                autoDismiss?()
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -313,7 +313,6 @@ final class MeetingNotificationController {
         let resumeHostTime = CACurrentMediaTime()
         progressLayer.speed = 1
         progressLayer.timeOffset = 0
-        progressLayer.beginTime = 0
         progressLayer.beginTime = resumeHostTime - pausedTime
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
@@ -33,14 +33,16 @@ struct MeetingPromptDecision: Equatable {
 final class MeetingPromptStateMachine {
     private(set) var visiblePromptID: String?
     private var userDismissedSuppressionIDs: Set<String> = []
-    private var autoDismissedSuppressionIDs: Set<String> = []
+    private var autoDismissedSuppressionIDs: [String: Date] = [:]
     private var lastCandidateID: String?
     private let candidateStabilityDelay: TimeInterval
+    private let browserAutoDismissCooldown: TimeInterval
     private var pendingCandidateID: String?
     private var pendingCandidateFirstSeenAt: Date?
 
-    init(candidateStabilityDelay: TimeInterval = 3) {
+    init(candidateStabilityDelay: TimeInterval = 3, browserAutoDismissCooldown: TimeInterval = 120) {
         self.candidateStabilityDelay = candidateStabilityDelay
+        self.browserAutoDismissCooldown = browserAutoDismissCooldown
     }
 
     func evaluate(
@@ -52,6 +54,7 @@ final class MeetingPromptStateMachine {
         visibility: MeetingPromptVisibility,
         now: Date
     ) -> MeetingPromptDecision {
+        expireAutoDismissSuppressions(now: now)
         reconcileVisibility(visibility)
 
         guard detectionEnabled else {
@@ -92,7 +95,7 @@ final class MeetingPromptStateMachine {
             return MeetingPromptDecision(action: .none, candidate: candidate, reason: .userDismissedSuppression)
         }
 
-        if autoDismissedSuppressionIDs.contains(candidate.suppressionID) {
+        if autoDismissedSuppressionIDs.keys.contains(candidate.suppressionID) {
             resetPendingCandidate()
             return MeetingPromptDecision(action: .none, candidate: candidate, reason: .autoDismissedSuppression)
         }
@@ -114,17 +117,17 @@ final class MeetingPromptStateMachine {
         resetPendingCandidate()
     }
 
-    func markAutoDismissed(_ candidate: MeetingCandidate) {
+    func markAutoDismissed(_ candidate: MeetingCandidate, now: Date = Date()) {
         if visiblePromptID == candidate.id { visiblePromptID = nil }
         lastCandidateID = candidate.id
-        autoDismissedSuppressionIDs.insert(candidate.suppressionID)
+        autoDismissedSuppressionIDs[candidate.suppressionID] = autoDismissExpiry(for: candidate, now: now)
         resetPendingCandidate()
     }
 
     func markUserDismissed(_ candidate: MeetingCandidate) {
         if visiblePromptID == candidate.id { visiblePromptID = nil }
         userDismissedSuppressionIDs.insert(candidate.suppressionID)
-        autoDismissedSuppressionIDs.remove(candidate.suppressionID)
+        autoDismissedSuppressionIDs.removeValue(forKey: candidate.suppressionID)
         resetPendingCandidate()
     }
 
@@ -159,6 +162,17 @@ final class MeetingPromptStateMachine {
             visiblePromptID = visibility.currentPromptID
         } else if visiblePromptID == visibility.currentPromptID || visibility.currentPromptID == nil {
             visiblePromptID = nil
+        }
+    }
+
+    private func autoDismissExpiry(for candidate: MeetingCandidate, now: Date) -> Date {
+        guard candidate.evidence.contains(.browserURL) else { return .distantFuture }
+        return now.addingTimeInterval(browserAutoDismissCooldown)
+    }
+
+    private func expireAutoDismissSuppressions(now: Date) {
+        autoDismissedSuppressionIDs = autoDismissedSuppressionIDs.filter { _, expiry in
+            return expiry > now
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -516,7 +516,9 @@ struct AppConfig: Codable {
     var whisperModel: String = BackendOption.whisper.model
     var idleTimeout: Double = 120
     var autoRecordMeetings: Bool = false
+    var showScheduledMeetingNotifications: Bool = true
     var showMeetingDetectionNotification: Bool = true
+    var mutedMeetingDetectionAppBundleIDs: [String] = []
     var meetingRecordingSavePolicy: MeetingRecordingSavePolicy = .never
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
@@ -569,7 +571,9 @@ struct AppConfig: Codable {
         case whisperModel = "whisper_model"
         case idleTimeout = "idle_timeout"
         case autoRecordMeetings = "auto_record_meetings"
+        case showScheduledMeetingNotifications = "show_scheduled_meeting_notifications"
         case showMeetingDetectionNotification = "show_meeting_detection_notification"
+        case mutedMeetingDetectionAppBundleIDs = "muted_meeting_detection_app_bundle_ids"
         case meetingRecordingSavePolicy = "meeting_recording_save_policy"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
@@ -625,7 +629,9 @@ struct AppConfig: Codable {
         whisperModel = (try? c.decode(String.self, forKey: .whisperModel)) ?? defaults.whisperModel
         idleTimeout = (try? c.decode(Double.self, forKey: .idleTimeout)) ?? defaults.idleTimeout
         autoRecordMeetings = (try? c.decode(Bool.self, forKey: .autoRecordMeetings)) ?? defaults.autoRecordMeetings
+        showScheduledMeetingNotifications = (try? c.decode(Bool.self, forKey: .showScheduledMeetingNotifications)) ?? defaults.showScheduledMeetingNotifications
         showMeetingDetectionNotification = (try? c.decode(Bool.self, forKey: .showMeetingDetectionNotification)) ?? defaults.showMeetingDetectionNotification
+        mutedMeetingDetectionAppBundleIDs = (try? c.decode([String].self, forKey: .mutedMeetingDetectionAppBundleIDs)) ?? defaults.mutedMeetingDetectionAppBundleIDs
         meetingRecordingSavePolicy = (try? c.decode(MeetingRecordingSavePolicy.self, forKey: .meetingRecordingSavePolicy)) ?? defaults.meetingRecordingSavePolicy
         darkMode = (try? c.decode(Bool.self, forKey: .darkMode)) ?? defaults.darkMode
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -629,8 +629,12 @@ struct AppConfig: Codable {
         whisperModel = (try? c.decode(String.self, forKey: .whisperModel)) ?? defaults.whisperModel
         idleTimeout = (try? c.decode(Double.self, forKey: .idleTimeout)) ?? defaults.idleTimeout
         autoRecordMeetings = (try? c.decode(Bool.self, forKey: .autoRecordMeetings)) ?? defaults.autoRecordMeetings
-        showScheduledMeetingNotifications = (try? c.decode(Bool.self, forKey: .showScheduledMeetingNotifications)) ?? defaults.showScheduledMeetingNotifications
-        showMeetingDetectionNotification = (try? c.decode(Bool.self, forKey: .showMeetingDetectionNotification)) ?? defaults.showMeetingDetectionNotification
+        let decodedShowMeetingDetectionNotification = try? c.decode(Bool.self, forKey: .showMeetingDetectionNotification)
+        showScheduledMeetingNotifications =
+            (try? c.decode(Bool.self, forKey: .showScheduledMeetingNotifications))
+            ?? decodedShowMeetingDetectionNotification
+            ?? defaults.showScheduledMeetingNotifications
+        showMeetingDetectionNotification = decodedShowMeetingDetectionNotification ?? defaults.showMeetingDetectionNotification
         mutedMeetingDetectionAppBundleIDs = (try? c.decode([String].self, forKey: .mutedMeetingDetectionAppBundleIDs)) ?? defaults.mutedMeetingDetectionAppBundleIDs
         meetingRecordingSavePolicy = (try? c.decode(MeetingRecordingSavePolicy.self, forKey: .meetingRecordingSavePolicy)) ?? defaults.meetingRecordingSavePolicy
         darkMode = (try? c.decode(Bool.self, forKey: .darkMode)) ?? defaults.darkMode

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -257,6 +257,9 @@ final class MuesliController: NSObject {
         meetingMonitor.detectionEnabledProvider = { [weak self] in
             self?.config.showMeetingDetectionNotification ?? false
         }
+        meetingMonitor.mutedDetectionBundleIDsProvider = { [weak self] in
+            Set(self?.config.mutedMeetingDetectionAppBundleIDs ?? [])
+        }
         meetingMonitor.isRecordingProvider = { [weak self] in
             guard let self else { return false }
             return self.isMeetingRecording() || self.isDictationActivityInProgress
@@ -479,7 +482,8 @@ final class MuesliController: NSObject {
     }
 
     func recoverStaleLiveMeetings() {
-        guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        guard !isMeetingRecording(),
+              !isStartingMeetingRecording else { return }
         let meetings: [MeetingRecord]
         do {
             meetings = try dictationStore.staleLiveMeetings()
@@ -948,7 +952,9 @@ final class MuesliController: NSObject {
 
     /// Show a "Meeting starting now" notification — independent of Marauder's Map.
     private func showMeetingStartingNowNotification(title: String, calendarEventID: String?, meetingURL: URL?, endDate: Date?) {
-        guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        guard config.showScheduledMeetingNotifications,
+              !isMeetingRecording(),
+              !isStartingMeetingRecording else { return }
         isShowingCalendarNotification = true
 
         meetingNotification.show(
@@ -3004,7 +3010,7 @@ final class MuesliController: NSObject {
         }
 
         // Show notification panel for calendar events (if not auto-recording)
-        guard config.showMeetingDetectionNotification,
+        guard config.showScheduledMeetingNotifications,
               !isMeetingRecording(),
               !isStartingMeetingRecording else {
             return

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2572,7 +2572,7 @@ final class MuesliController: NSObject {
             return
         }
 
-        let title = candidate.meetingTitle ?? candidate.platform.displayName
+        let title = candidate.subtitle
         presentedMeetingCandidate = candidate
         let preferredScreen = meetingSourceWindowLocator.screen(for: candidate)
         let didShow = meetingNotification.show(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2569,7 +2569,7 @@ final class MuesliController: NSObject {
         let title = candidate.meetingTitle ?? candidate.platform.displayName
         presentedMeetingCandidate = candidate
         let preferredScreen = meetingSourceWindowLocator.screen(for: candidate)
-        meetingNotification.show(
+        let didShow = meetingNotification.show(
             promptID: candidate.id,
             title: "Meeting detected",
             subtitle: title,
@@ -2601,7 +2601,11 @@ final class MuesliController: NSObject {
                 self.meetingMonitor.markPromptClosed(candidate)
             }
         )
-        meetingMonitor.markPromptShown(candidate)
+        if didShow {
+            meetingMonitor.markPromptShown(candidate)
+        } else if presentedMeetingCandidate == candidate {
+            presentedMeetingCandidate = nil
+        }
     }
 
     @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -2,6 +2,14 @@ import AVFoundation
 import SwiftUI
 import MuesliCore
 
+private struct MeetingDetectionAppOption: Identifiable {
+    let bundleID: String
+    let name: String
+    let icon: String
+
+    var id: String { bundleID }
+}
+
 struct SettingsView: View {
     private enum PendingDataDestruction {
         case dictations
@@ -79,6 +87,18 @@ struct SettingsView: View {
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
     private let meetingControlWidth: CGFloat = 275
+    private let meetingDetectionAppOptions: [MeetingDetectionAppOption] = [
+        MeetingDetectionAppOption(bundleID: "com.google.Chrome", name: "Chrome", icon: "globe"),
+        MeetingDetectionAppOption(bundleID: "company.thebrowser.Browser", name: "Arc", icon: "globe"),
+        MeetingDetectionAppOption(bundleID: "com.apple.Safari", name: "Safari", icon: "globe"),
+        MeetingDetectionAppOption(bundleID: "com.microsoft.edgemac", name: "Edge", icon: "globe"),
+        MeetingDetectionAppOption(bundleID: "com.brave.Browser", name: "Brave", icon: "globe"),
+        MeetingDetectionAppOption(bundleID: "com.tinyspeck.slackmacgap", name: "Slack", icon: "message.fill"),
+        MeetingDetectionAppOption(bundleID: "us.zoom.xos", name: "Zoom", icon: "video.fill"),
+        MeetingDetectionAppOption(bundleID: "com.microsoft.teams2", name: "Teams", icon: "person.2.fill"),
+        MeetingDetectionAppOption(bundleID: "com.apple.FaceTime", name: "FaceTime", icon: "video.fill"),
+        MeetingDetectionAppOption(bundleID: "net.whatsapp.WhatsApp", name: "WhatsApp", icon: "phone.fill"),
+    ]
 
     private var dictationBackendOptions: [BackendOption] {
         backendOptions(including: appState.selectedBackend)
@@ -441,12 +461,6 @@ struct SettingsView: View {
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Notify when meeting detected") {
-                    settingsSwitch(isOn: appState.config.showMeetingDetectionNotification) { newValue in
-                        controller.updateConfig { $0.showMeetingDetectionNotification = newValue }
-                    }
-                }
-                Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Save meeting recording") {
                     settingsMenu(
                         selection: recordingSaveLabel(for: appState.config.meetingRecordingSavePolicy),
@@ -455,6 +469,29 @@ struct SettingsView: View {
                         guard let policy = recordingSavePolicy(for: label) else { return }
                         controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
                     }
+                }
+            }
+
+            settingsSection("Meeting Notifications") {
+                settingsRow("Scheduled meetings") {
+                    settingsSwitch(isOn: appState.config.showScheduledMeetingNotifications) { newValue in
+                        controller.updateConfig { $0.showScheduledMeetingNotifications = newValue }
+                    }
+                }
+                settingsDescription("Show notifications before meetings start based on your calendar.")
+
+                Divider().background(MuesliTheme.surfaceBorder)
+
+                settingsRow("Auto-detected meetings") {
+                    settingsSwitch(isOn: appState.config.showMeetingDetectionNotification) { newValue in
+                        controller.updateConfig { $0.showMeetingDetectionNotification = newValue }
+                    }
+                }
+                settingsDescription("Show notifications when a call is detected from browser, camera, microphone, or app audio activity.")
+
+                if appState.config.showMeetingDetectionNotification {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    mutedMeetingDetectionAppsControl
                 }
             }
 
@@ -1095,6 +1132,15 @@ struct SettingsView: View {
         .frame(minHeight: 32)
     }
 
+    private func settingsDescription(_ text: String) -> some View {
+        Text(text)
+            .font(MuesliTheme.caption())
+            .foregroundStyle(MuesliTheme.textTertiary)
+            .padding(.horizontal, MuesliTheme.spacing16)
+            .padding(.top, -4)
+            .padding(.bottom, MuesliTheme.spacing8)
+    }
+
     // MARK: - Controls
 
     @ViewBuilder
@@ -1112,6 +1158,73 @@ struct SettingsView: View {
     private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
         FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
             .frame(height: 24)
+    }
+
+    private var mutedMeetingDetectionAppsControl: some View {
+        let muted = Set(appState.config.mutedMeetingDetectionAppBundleIDs)
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("Don't notify me when a call is detected in these apps:")
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textPrimary)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8),
+            ], alignment: .leading, spacing: 8) {
+                ForEach(meetingDetectionAppOptions) { app in
+                    mutedDetectionAppButton(app, isMuted: muted.contains(app.bundleID))
+                }
+            }
+        }
+        .padding(.leading, MuesliTheme.spacing16)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(MuesliTheme.surfaceBorder)
+                .frame(width: 2)
+        }
+    }
+
+    private func mutedDetectionAppButton(_ app: MeetingDetectionAppOption, isMuted: Bool) -> some View {
+        Button {
+            updateMutedMeetingDetectionApp(app.bundleID, isMuted: !isMuted)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: isMuted ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(isMuted ? MuesliTheme.accent : MuesliTheme.textTertiary)
+                    .frame(width: 16)
+                Image(systemName: app.icon)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .frame(width: 14)
+                Text(app.name)
+                    .font(.system(size: 12))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(isMuted ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(isMuted ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func updateMutedMeetingDetectionApp(_ bundleID: String, isMuted: Bool) {
+        controller.updateConfig { config in
+            var muted = Set(config.mutedMeetingDetectionAppBundleIDs)
+            if isMuted {
+                muted.insert(bundleID)
+            } else {
+                muted.remove(bundleID)
+            }
+            config.mutedMeetingDetectionAppBundleIDs = muted.sorted()
+        }
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Tests/MuesliTests/ControlCenterSensorAttributionMonitorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ControlCenterSensorAttributionMonitorTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("ControlCenterSensorAttributionMonitor")
+struct ControlCenterSensorAttributionMonitorTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("parses active mic and camera bundle attributions")
+    func parsesActiveMicAndCameraBundleAttributions() {
+        let snapshot = ControlCenterSensorAttributionMonitor.parseSnapshot(
+            from: #"2026-05-01 ControlCenter[695] [com.apple.controlcenter:sensor-indicators] Active activity attributions changed to ["cam:com.google.Chrome", "mic:com.google.Chrome"]"#,
+            now: now
+        )
+
+        #expect(snapshot?.micBundleIDs == ["com.google.Chrome"])
+        #expect(snapshot?.cameraBundleIDs == ["com.google.Chrome"])
+        #expect(snapshot?.observedAt == now)
+    }
+
+    @Test("parses empty active attribution list")
+    func parsesEmptyActiveAttributionList() {
+        let snapshot = ControlCenterSensorAttributionMonitor.parseSnapshot(
+            from: #"2026-05-01 ControlCenter[695] [com.apple.controlcenter:sensor-indicators] Active activity attributions changed to []"#,
+            now: now
+        )
+
+        #expect(snapshot?.micBundleIDs.isEmpty == true)
+        #expect(snapshot?.cameraBundleIDs.isEmpty == true)
+        #expect(snapshot?.observedAt == now)
+    }
+
+    @Test("ignores unrelated sensor log lines")
+    func ignoresUnrelatedSensorLogLines() {
+        let snapshot = ControlCenterSensorAttributionMonitor.parseSnapshot(
+            from: #"2026-05-01 ControlCenter[695] [com.apple.controlcenter:sensor-indicators] Recent activity attributions changed to ["mic:com.google.Chrome"]"#,
+            now: now
+        )
+
+        #expect(snapshot == nil)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -190,6 +190,94 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.sourceBundleID == "com.google.Chrome")
     }
 
+    @Test("focused Google Meet landing is ignored without media activity")
+    func focusedGoogleMeetLandingIsIgnoredWithoutMediaActivity() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/landing",
+                    normalizedID: "googleMeet:meet.google.com/landing",
+                    platform: .googleMeet,
+                    isFocused: true,
+                    requiresMediaActivity: true
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome"
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("focused Google Meet landing with media activity resolves")
+    func focusedGoogleMeetLandingWithMediaActivityResolves() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: true,
+            cameraActive: true,
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/landing",
+                    normalizedID: "googleMeet:meet.google.com/landing",
+                    platform: .googleMeet,
+                    isFocused: true,
+                    requiresMediaActivity: true
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome"
+        ))
+
+        #expect(candidate?.id == "googleMeet:meet.google.com/landing")
+        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.sourceBundleID == "com.google.Chrome")
+    }
+
+    @Test("background Google Meet landing with browser helper audio resolves")
+    func backgroundGoogleMeetLandingWithBrowserHelperAudioResolves() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            runningApps: [
+                RunningAppInfo(bundleID: "com.google.Chrome", isActive: false),
+                RunningAppInfo(bundleID: "com.granola.app", isActive: true),
+            ],
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/landing",
+                    normalizedID: "googleMeet:meet.google.com/landing",
+                    platform: .googleMeet,
+                    isFocused: false,
+                    requiresMediaActivity: true
+                ),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.granola.app"
+        ))
+
+        #expect(candidate?.id == "googleMeet:meet.google.com/landing")
+        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.sourceBundleID == "com.google.Chrome")
+        #expect(candidate?.sourcePID == 9876)
+        #expect(candidate?.evidence.contains(.audioInputProcess) == true)
+    }
+
     @Test("Teams active audio input resolves to Teams")
     func teamsActiveAudioInputResolvesToTeams() {
         let candidate = resolver().resolve(snapshot(
@@ -456,5 +544,15 @@ struct MeetingCandidateResolverTests {
     func googleMeetURLNormalizationRejectsLandingPages() {
         #expect(MeetingURLNormalizer.normalize("https://meet.google.com/landing") == nil)
         #expect(MeetingURLNormalizer.normalize("https://meet.google.com/") == nil)
+    }
+
+    @Test("browser activity normalizer admits Google Meet landing with media requirement")
+    func browserActivityNormalizerAdmitsGoogleMeetLandingWithMediaRequirement() {
+        let normalized = MeetingURLNormalizer.normalizeBrowserActivity("https://meet.google.com/landing?authuser=0")
+
+        #expect(normalized?.id == "googleMeet:meet.google.com/landing")
+        #expect(normalized?.url == "meet.google.com/landing")
+        #expect(normalized?.platform == .googleMeet)
+        #expect(normalized?.requiresMediaActivity == true)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -383,4 +383,10 @@ struct MeetingCandidateResolverTests {
         #expect(normalized?.url == "meet.google.com/pwm-txwq-txy")
         #expect(normalized?.platform == .googleMeet)
     }
+
+    @Test("URL normalizer rejects Google Meet landing pages")
+    func googleMeetURLNormalizationRejectsLandingPages() {
+        #expect(MeetingURLNormalizer.normalize("https://meet.google.com/landing") == nil)
+        #expect(MeetingURLNormalizer.normalize("https://meet.google.com/") == nil)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -190,94 +190,6 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.sourceBundleID == "com.google.Chrome")
     }
 
-    @Test("focused Google Meet landing is ignored without media activity")
-    func focusedGoogleMeetLandingIsIgnoredWithoutMediaActivity() {
-        let candidate = resolver().resolve(snapshot(
-            micActive: false,
-            cameraActive: false,
-            browserMeetings: [
-                BrowserMeetingContext(
-                    bundleID: "com.google.Chrome",
-                    appName: "Chrome",
-                    pid: 1234,
-                    url: "meet.google.com/landing",
-                    normalizedID: "googleMeet:meet.google.com/landing",
-                    platform: .googleMeet,
-                    isFocused: true,
-                    requiresMediaActivity: true
-                ),
-            ],
-            foregroundBundleID: "com.google.Chrome"
-        ))
-
-        #expect(candidate == nil)
-    }
-
-    @Test("focused Google Meet landing with media activity resolves")
-    func focusedGoogleMeetLandingWithMediaActivityResolves() {
-        let candidate = resolver().resolve(snapshot(
-            micActive: true,
-            cameraActive: true,
-            browserMeetings: [
-                BrowserMeetingContext(
-                    bundleID: "com.google.Chrome",
-                    appName: "Chrome",
-                    pid: 1234,
-                    url: "meet.google.com/landing",
-                    normalizedID: "googleMeet:meet.google.com/landing",
-                    platform: .googleMeet,
-                    isFocused: true,
-                    requiresMediaActivity: true
-                ),
-            ],
-            foregroundBundleID: "com.google.Chrome"
-        ))
-
-        #expect(candidate?.id == "googleMeet:meet.google.com/landing")
-        #expect(candidate?.platform == .googleMeet)
-        #expect(candidate?.sourceBundleID == "com.google.Chrome")
-    }
-
-    @Test("background Google Meet landing with browser helper audio resolves")
-    func backgroundGoogleMeetLandingWithBrowserHelperAudioResolves() {
-        let candidate = resolver().resolve(snapshot(
-            micActive: false,
-            cameraActive: false,
-            runningApps: [
-                RunningAppInfo(bundleID: "com.google.Chrome", isActive: false),
-                RunningAppInfo(bundleID: "com.granola.app", isActive: true),
-            ],
-            browserMeetings: [
-                BrowserMeetingContext(
-                    bundleID: "com.google.Chrome",
-                    appName: "Chrome",
-                    pid: 1234,
-                    url: "meet.google.com/landing",
-                    normalizedID: "googleMeet:meet.google.com/landing",
-                    platform: .googleMeet,
-                    isFocused: false,
-                    requiresMediaActivity: true
-                ),
-            ],
-            audioInputProcesses: [
-                AudioProcessActivity(
-                    pid: 9876,
-                    bundleID: "com.google.Chrome.helper",
-                    appName: "Google Chrome Helper",
-                    isRunningInput: true,
-                    isRunningOutput: false
-                ),
-            ],
-            foregroundBundleID: "com.granola.app"
-        ))
-
-        #expect(candidate?.id == "googleMeet:meet.google.com/landing")
-        #expect(candidate?.platform == .googleMeet)
-        #expect(candidate?.sourceBundleID == "com.google.Chrome")
-        #expect(candidate?.sourcePID == 9876)
-        #expect(candidate?.evidence.contains(.audioInputProcess) == true)
-    }
-
     @Test("Teams active audio input resolves to Teams")
     func teamsActiveAudioInputResolvesToTeams() {
         let candidate = resolver().resolve(snapshot(
@@ -544,15 +456,5 @@ struct MeetingCandidateResolverTests {
     func googleMeetURLNormalizationRejectsLandingPages() {
         #expect(MeetingURLNormalizer.normalize("https://meet.google.com/landing") == nil)
         #expect(MeetingURLNormalizer.normalize("https://meet.google.com/") == nil)
-    }
-
-    @Test("browser activity normalizer admits Google Meet landing with media requirement")
-    func browserActivityNormalizerAdmitsGoogleMeetLandingWithMediaRequirement() {
-        let normalized = MeetingURLNormalizer.normalizeBrowserActivity("https://meet.google.com/landing?authuser=0")
-
-        #expect(normalized?.id == "googleMeet:meet.google.com/landing")
-        #expect(normalized?.url == "meet.google.com/landing")
-        #expect(normalized?.platform == .googleMeet)
-        #expect(normalized?.requiresMediaActivity == true)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -213,7 +213,8 @@ struct MeetingCandidateResolverTests {
 
         #expect(candidate?.id == "browser:com.google.Chrome:session:1800000000")
         #expect(candidate?.suppressionID == candidate?.id)
-        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.platform == .unknown)
+        #expect(candidate?.subtitle == "Chrome")
         #expect(candidate?.appName == "Chrome")
         #expect(candidate?.sourceBundleID == "com.google.Chrome")
         #expect(candidate?.sourcePID == 9876)
@@ -243,7 +244,8 @@ struct MeetingCandidateResolverTests {
         ))
 
         #expect(candidate?.id == "browser:com.google.Chrome:session:1800000000")
-        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.platform == .unknown)
+        #expect(candidate?.subtitle == "Chrome")
         #expect(candidate?.appName == "Chrome")
         #expect(candidate?.sourceBundleID == "com.google.Chrome")
         #expect(candidate?.evidence.contains(.foregroundApp) == true)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -138,6 +138,65 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.evidence.contains(.foregroundApp) == false)
     }
 
+    @Test("Chrome audio input resolves without URL after foreground loss")
+    func chromeAudioInputResolvesWithoutURLAfterForegroundLoss() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            runningApps: [
+                RunningAppInfo(bundleID: "com.google.Chrome", isActive: false),
+                RunningAppInfo(bundleID: "com.granola.app", isActive: true),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.granola.app"
+        ))
+
+        #expect(candidate?.id == "browser:com.google.Chrome:session:1800000000")
+        #expect(candidate?.suppressionID == candidate?.id)
+        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.appName == "Chrome")
+        #expect(candidate?.sourceBundleID == "com.google.Chrome")
+        #expect(candidate?.sourcePID == 9876)
+        #expect(candidate?.evidence.contains(.audioInputProcess) == true)
+        #expect(candidate?.evidence.contains(.foregroundApp) == false)
+    }
+
+    @Test("Chrome audio input without URL beats background WhatsApp")
+    func chromeAudioInputWithoutURLBeatsBackgroundWhatsApp() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            runningApps: [
+                RunningAppInfo(bundleID: "net.whatsapp.WhatsApp", isActive: false),
+                RunningAppInfo(bundleID: "com.google.Chrome", isActive: true),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome"
+        ))
+
+        #expect(candidate?.id == "browser:com.google.Chrome:session:1800000000")
+        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.appName == "Chrome")
+        #expect(candidate?.sourceBundleID == "com.google.Chrome")
+        #expect(candidate?.evidence.contains(.foregroundApp) == true)
+    }
+
     @Test("background Meet URL without browser audio does not steal foreground app detection")
     func backgroundMeetURLWithoutBrowserAudioDoesNotStealForegroundAppDetection() {
         let candidate = resolver().resolve(snapshot(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -98,6 +98,73 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.evidence.contains(.audioInputProcess) == true)
     }
 
+    @Test("Chrome Meet audio input resolves after transient foreground loss")
+    func chromeMeetAudioInputResolvesAfterForegroundLoss() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            runningApps: [
+                RunningAppInfo(bundleID: "com.google.Chrome", isActive: false),
+                RunningAppInfo(bundleID: "com.granola.app", isActive: true),
+            ],
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/pwm-txwq-txy",
+                    normalizedID: "googleMeet:meet.google.com/pwm-txwq-txy",
+                    platform: .googleMeet,
+                    isFocused: false
+                ),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 1234,
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.granola.app"
+        ))
+
+        #expect(candidate?.id == "googleMeet:meet.google.com/pwm-txwq-txy")
+        #expect(candidate?.platform == .googleMeet)
+        #expect(candidate?.sourceBundleID == "com.google.Chrome")
+        #expect(candidate?.evidence.contains(.audioInputProcess) == true)
+        #expect(candidate?.evidence.contains(.foregroundApp) == false)
+    }
+
+    @Test("background Meet URL without browser audio does not steal foreground app detection")
+    func backgroundMeetURLWithoutBrowserAudioDoesNotStealForegroundAppDetection() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: true,
+            cameraActive: true,
+            runningApps: [
+                RunningAppInfo(bundleID: "com.google.Chrome", isActive: false),
+                RunningAppInfo(bundleID: "us.zoom.xos", isActive: true),
+            ],
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/pwm-txwq-txy",
+                    normalizedID: "googleMeet:meet.google.com/pwm-txwq-txy",
+                    platform: .googleMeet,
+                    isFocused: false
+                ),
+            ],
+            foregroundBundleID: "us.zoom.xos"
+        ))
+
+        #expect(candidate?.id == "app:us.zoom.xos")
+        #expect(candidate?.platform == .zoom)
+        #expect(candidate?.appName == "Zoom")
+    }
+
     @Test("focused Meet URL is eligible before mic flips")
     func focusedMeetURLIsEligibleBeforeMicFlips() {
         let candidate = resolver().resolve(snapshot(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -120,9 +120,9 @@ struct MeetingCandidateResolverTests {
             ],
             audioInputProcesses: [
                 AudioProcessActivity(
-                    pid: 1234,
-                    bundleID: "com.google.Chrome",
-                    appName: "Chrome",
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
                     isRunningInput: true,
                     isRunningOutput: false
                 ),
@@ -133,6 +133,7 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.id == "googleMeet:meet.google.com/pwm-txwq-txy")
         #expect(candidate?.platform == .googleMeet)
         #expect(candidate?.sourceBundleID == "com.google.Chrome")
+        #expect(candidate?.sourcePID == 9876)
         #expect(candidate?.evidence.contains(.audioInputProcess) == true)
         #expect(candidate?.evidence.contains(.foregroundApp) == false)
     }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -251,6 +251,27 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.evidence.contains(.foregroundApp) == true)
     }
 
+    @Test("synthetic browser audio PID is not exposed as source PID")
+    func syntheticBrowserAudioPIDIsNotExposedAsSourcePID() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 0,
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome"
+        ))
+
+        #expect(candidate?.id == "browser:com.google.Chrome:session:1800000000")
+        #expect(candidate?.sourcePID == nil)
+    }
+
     @Test("background Meet URL without browser audio does not steal foreground app detection")
     func backgroundMeetURLWithoutBrowserAudioDoesNotStealForegroundAppDetection() {
         let candidate = resolver().resolve(snapshot(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -138,6 +138,58 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.evidence.contains(.foregroundApp) == false)
     }
 
+    @Test("Chrome URL and media fallback share suppression session")
+    func chromeURLAndMediaFallbackShareSuppressionSession() {
+        let resolver = resolver()
+        let urlCandidate = resolver.resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/pwm-txwq-txy",
+                    normalizedID: "googleMeet:meet.google.com/pwm-txwq-txy",
+                    platform: .googleMeet,
+                    isFocused: true
+                ),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome",
+            now: now
+        ))
+
+        let mediaCandidate = resolver.resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
+                    isRunningInput: true,
+                    isRunningOutput: false
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome",
+            now: now.addingTimeInterval(5)
+        ))
+
+        #expect(urlCandidate?.id == "googleMeet:meet.google.com/pwm-txwq-txy")
+        #expect(mediaCandidate?.id == "browser:com.google.Chrome:session:1800000000")
+        #expect(urlCandidate?.suppressionID == "browser:com.google.Chrome:session:1800000000")
+        #expect(mediaCandidate?.suppressionID == urlCandidate?.suppressionID)
+    }
+
     @Test("Chrome audio input resolves without URL after foreground loss")
     func chromeAudioInputResolvesWithoutURLAfterForegroundLoss() {
         let candidate = resolver().resolve(snapshot(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -14,4 +14,16 @@ struct MeetingNotificationControllerTests {
         #expect(MeetingPlatform(.whatsApp) == nil)
         #expect(MeetingPlatform(.unknown) == nil)
     }
+
+    @Test("Auto-dismiss without a dedicated handler still fires close cleanup")
+    @MainActor
+    func autoDismissWithoutHandlerFiresCloseCleanup() {
+        #expect(MeetingNotificationController.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: false) == false)
+    }
+
+    @Test("Detection auto-dismiss owns its cleanup path")
+    @MainActor
+    func detectionAutoDismissOwnsCleanupPath() {
+        #expect(MeetingNotificationController.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: true))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -26,4 +26,11 @@ struct MeetingNotificationControllerTests {
     func detectionAutoDismissOwnsCleanupPath() {
         #expect(MeetingNotificationController.suppressesCloseCallbackDuringAutoDismiss(hasAutoDismissHandler: true))
     }
+
+    @Test("Auto-dismiss callback is skipped when hover pauses during fade-out")
+    @MainActor
+    func autoDismissCallbackSkippedWhenPausedDuringFadeOut() {
+        #expect(MeetingNotificationController.firesAutoDismissCallbackAfterFade(wasDismissPaused: false))
+        #expect(!MeetingNotificationController.firesAutoDismissCallbackAfterFade(wasDismissPaused: true))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
@@ -8,14 +8,15 @@ struct MeetingPromptStateMachineTests {
 
     private func candidate(
         _ id: String = "googleMeet:meet.google.com/pwm-txwq-txy",
-        suppressionID: String? = nil
+        suppressionID: String? = nil,
+        evidence: Set<MeetingCandidate.Evidence> = [.micActive, .cameraActive, .browserURL, .foregroundApp]
     ) -> MeetingCandidate {
         MeetingCandidate(
             id: id,
             platform: .googleMeet,
             appName: "Chrome",
             url: "meet.google.com/pwm-txwq-txy",
-            evidence: [.micActive, .cameraActive, .browserURL, .foregroundApp],
+            evidence: evidence,
             startedAt: now,
             meetingTitle: nil,
             suppressionID: suppressionID
@@ -50,7 +51,7 @@ struct MeetingPromptStateMachineTests {
     @Test("eligible candidate waits for stability delay")
     func eligibleCandidateWaitsForStabilityDelay() {
         let machine = MeetingPromptStateMachine()
-        let candidate = candidate()
+        let candidate = candidate(evidence: [.micActive, .cameraActive, .dedicatedApp])
 
         let first = decision(machine, candidate: candidate, now: now)
         let second = decision(machine, candidate: candidate, now: now.addingTimeInterval(2.9))
@@ -64,11 +65,27 @@ struct MeetingPromptStateMachineTests {
         #expect(third.candidate?.id == candidate.id)
     }
 
+    @Test("browser URL candidate waits for stability delay")
+    func browserCandidateWaitsForStabilityDelay() {
+        let machine = MeetingPromptStateMachine()
+        let candidate = candidate()
+
+        let first = decision(machine, candidate: candidate, now: now)
+        let second = decision(machine, candidate: candidate, now: now.addingTimeInterval(3.1))
+
+        #expect(first.reason == .candidatePending)
+        #expect(second.action == .show)
+        #expect(second.candidate?.id == candidate.id)
+    }
+
     @Test("candidate change restarts stability delay")
     func candidateChangeRestartsStabilityDelay() {
         let machine = MeetingPromptStateMachine()
-        let firstCandidate = candidate()
-        let secondCandidate = candidate("googleMeet:meet.google.com/abc-defg-hij")
+        let firstCandidate = candidate(evidence: [.micActive, .cameraActive, .dedicatedApp])
+        let secondCandidate = candidate(
+            "googleMeet:meet.google.com/abc-defg-hij",
+            evidence: [.micActive, .cameraActive, .dedicatedApp]
+        )
 
         #expect(decision(machine, candidate: firstCandidate, now: now).reason == .candidatePending)
         #expect(decision(machine, candidate: secondCandidate, now: now.addingTimeInterval(2)).reason == .candidatePending)
@@ -85,7 +102,7 @@ struct MeetingPromptStateMachineTests {
         let candidate = candidate()
 
         machine.markShown(candidate)
-        machine.markAutoDismissed(candidate)
+        machine.markAutoDismissed(candidate, now: now)
         let result = decision(machine, candidate: candidate)
 
         #expect(machine.visiblePromptID == nil)
@@ -100,7 +117,7 @@ struct MeetingPromptStateMachineTests {
         let newCandidate = candidate("googleMeet:meet.google.com/abc-defg-hij")
 
         machine.markShown(oldCandidate)
-        machine.markAutoDismissed(oldCandidate)
+        machine.markAutoDismissed(oldCandidate, now: now)
         let result = decision(machine, candidate: newCandidate)
 
         #expect(result.action == .show)
@@ -159,7 +176,7 @@ struct MeetingPromptStateMachineTests {
         let candidate = candidate()
 
         machine.markShown(candidate)
-        machine.markAutoDismissed(candidate)
+        machine.markAutoDismissed(candidate, now: now)
 
         #expect(decision(machine, candidate: nil, now: now.addingTimeInterval(1)).reason == .noCandidate)
 
@@ -169,13 +186,30 @@ struct MeetingPromptStateMachineTests {
         #expect(result.reason == .autoDismissedSuppression)
     }
 
-    @Test("auto-dismiss suppression does not expire for same candidate")
-    func autoDismissSuppressionDoesNotExpire() {
+    @Test("browser auto-dismiss suppression expires for same candidate")
+    func browserAutoDismissSuppressionExpires() {
         let machine = immediateMachine()
         let candidate = candidate()
 
         machine.markShown(candidate)
-        machine.markAutoDismissed(candidate)
+        machine.markAutoDismissed(candidate, now: now)
+
+        let result = decision(machine, candidate: candidate, now: now.addingTimeInterval(121))
+
+        #expect(result.action == .show)
+    }
+
+    @Test("app auto-dismiss suppression does not expire for same session")
+    func appAutoDismissSuppressionDoesNotExpire() {
+        let machine = immediateMachine()
+        let candidate = candidate(
+            "app:com.tinyspeck.slackmacgap:session:1",
+            suppressionID: "app:com.tinyspeck.slackmacgap:session:1",
+            evidence: [.micActive, .audioInputProcess, .dedicatedApp]
+        )
+
+        machine.markShown(candidate)
+        machine.markAutoDismissed(candidate, now: now)
 
         let result = decision(machine, candidate: candidate, now: now.addingTimeInterval(3_600))
 
@@ -195,7 +229,7 @@ struct MeetingPromptStateMachineTests {
     @Test("recording state resets pending candidate dwell")
     func recordingStateResetsPendingCandidateDwell() {
         let machine = MeetingPromptStateMachine()
-        let candidate = candidate()
+        let candidate = candidate(evidence: [.micActive, .cameraActive, .dedicatedApp])
 
         #expect(decision(machine, candidate: candidate, now: now).reason == .candidatePending)
         #expect(decision(machine, candidate: candidate, isRecording: true, now: now.addingTimeInterval(2)).reason == .recording)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -339,6 +339,9 @@ struct AppConfigTests {
         #expect(config.meetingSummaryBackend == "openai")
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
+        #expect(config.showScheduledMeetingNotifications == true)
+        #expect(config.showMeetingDetectionNotification == true)
+        #expect(config.mutedMeetingDetectionAppBundleIDs.isEmpty)
         #expect(config.openAIAPIKey.isEmpty)
         #expect(config.openRouterAPIKey.isEmpty)
         #expect(config.dictationHotkey == .default)
@@ -372,6 +375,9 @@ struct AppConfigTests {
         config.meetingHookEnabled = true
         config.meetingHookPath = "/tmp/meeting-hook.sh"
         config.meetingHookTimeoutSeconds = 45
+        config.showScheduledMeetingNotifications = false
+        config.showMeetingDetectionNotification = false
+        config.mutedMeetingDetectionAppBundleIDs = ["com.google.Chrome", "com.tinyspeck.slackmacgap"]
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -388,6 +394,9 @@ struct AppConfigTests {
         #expect(decoded.meetingHookEnabled == true)
         #expect(decoded.meetingHookPath == "/tmp/meeting-hook.sh")
         #expect(decoded.meetingHookTimeoutSeconds == 45)
+        #expect(decoded.showScheduledMeetingNotifications == false)
+        #expect(decoded.showMeetingDetectionNotification == false)
+        #expect(decoded.mutedMeetingDetectionAppBundleIDs == ["com.google.Chrome", "com.tinyspeck.slackmacgap"])
         #expect(decoded.meetingTranscriptionBackend == config.meetingTranscriptionBackend)
         #expect(decoded.indicatorAnchor == config.indicatorAnchor)
     }
@@ -408,6 +417,9 @@ struct AppConfigTests {
         #expect(json["user_name"] != nil)
         #expect(json["default_meeting_template_id"] != nil)
         #expect(json["meeting_recording_save_policy"] != nil)
+        #expect(json["show_scheduled_meeting_notifications"] != nil)
+        #expect(json["show_meeting_detection_notification"] != nil)
+        #expect(json["muted_meeting_detection_app_bundle_ids"] != nil)
         #expect(json["custom_meeting_templates"] != nil)
         #expect(json["meeting_hook_enabled"] != nil)
         #expect(json["meeting_hook_path"] != nil)
@@ -426,6 +438,9 @@ struct AppConfigTests {
         #expect(config.hasCompletedOnboarding == false)
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
+        #expect(config.showScheduledMeetingNotifications == true)
+        #expect(config.showMeetingDetectionNotification == true)
+        #expect(config.mutedMeetingDetectionAppBundleIDs.isEmpty)
         #expect(config.customMeetingTemplates.isEmpty)
         #expect(config.meetingHookEnabled == false)
         #expect(config.meetingHookPath.isEmpty)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -447,6 +447,33 @@ struct AppConfigTests {
         #expect(config.meetingHookTimeoutSeconds == 30)
     }
 
+    @Test("scheduled meeting notifications inherit legacy detection opt-out")
+    func scheduledMeetingNotificationsInheritLegacyDetectionOptOut() throws {
+        let json = """
+        {
+          "show_meeting_detection_notification": false
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.showScheduledMeetingNotifications == false)
+        #expect(config.showMeetingDetectionNotification == false)
+    }
+
+    @Test("explicit scheduled meeting notification setting overrides legacy detection setting")
+    func explicitScheduledMeetingNotificationSettingOverridesLegacyDetectionSetting() throws {
+        let json = """
+        {
+          "show_scheduled_meeting_notifications": true,
+          "show_meeting_detection_notification": false
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.showScheduledMeetingNotifications == true)
+        #expect(config.showMeetingDetectionNotification == false)
+    }
+
     @Test("unsupported cohere language falls back to english")
     func unsupportedCohereLanguageFallsBackToEnglish() throws {
         let json = """


### PR DESCRIPTION
## Summary
- Restores the 3-second stability delay for browser-based meeting detections.
- Updates the meeting detection notification with a larger left-side close control and hover-paused dismiss countdown.
- Keeps Google Meet URL normalization strict so landing pages do not trigger detection prompts.

## Why
The Meet prompt was firing immediately after the previous hardening pass, and the notification close affordance was too small. This brings the behavior closer to the intended Granola-style interaction while preserving the Slack/Meet detection fixes.

## Validation
- `swift test --package-path native/MuesliNative --filter MeetingPromptStateMachine`
- `swift test --package-path native/MuesliNative --filter MeetingNotificationController`
- `swift test --package-path native/MuesliNative --filter MeetingCandidateResolver`
- `swift test --package-path native/MuesliNative`
- `./scripts/dev-test.sh`
- Runtime log check confirmed `candidate_detected` followed by `prompt_shown` for Google Meet URLs after rebuild.