### PR TITLE
Fix floating indicator hover text for configured dictation hotkey

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -102,7 +102,6 @@ final class FloatingIndicatorController: NSObject {
     private var transcribingTitle = "Transcribing"
     private var loadingSpinner: NSProgressIndicator?
     private var isShowingLoading = false
-    var hotkeyLabel: String = "Left Cmd"
 
     init(configStore: ConfigStore) {
         self.configStore = configStore
@@ -150,7 +149,7 @@ final class FloatingIndicatorController: NSObject {
         isHovered = false
 
         let config = configStore.load()
-        let style = styleForState(.idle)
+        let style = styleForState(.idle, config: config)
         let targetFrame = frameForState(.idle, config: config)
 
         // Instant resize — no animation
@@ -243,7 +242,7 @@ final class FloatingIndicatorController: NSObject {
 
         }
 
-        let style = styleForState(state)
+        let style = styleForState(state, config: config)
         let targetFrame = frameForState(state, config: config)
 
         let duration = transitionDuration(
@@ -896,14 +895,14 @@ final class FloatingIndicatorController: NSObject {
         return NSRect(x: x, y: y, width: size.width, height: size.height)
     }
 
-    private func styleForState(_ state: DictationState) -> (background: NSColor, border: NSColor, icon: String, title: String, iconColor: NSColor, textColor: NSColor, alpha: CGFloat) {
+    private func styleForState(_ state: DictationState, config: AppConfig) -> (background: NSColor, border: NSColor, icon: String, title: String, iconColor: NSColor, textColor: NSColor, alpha: CGFloat) {
         switch state {
         case .idle:
             return (
                 .clear,
                 .colorWith(hex: 0xFFFFFF, alpha: isHovered ? 0.14 : 0.22),
                 "",
-                isHovered ? "Hold \(hotkeyLabel) to dictate" : "",
+                isHovered ? "Hold \(config.dictationHotkey.label) to dictate" : "",
                 .colorWith(hex: 0xFFFFFF, alpha: 0.75),
                 .colorWith(hex: 0xFFFFFF, alpha: 0.75),
                 isHovered ? 1.0 : 0.85

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -197,7 +197,6 @@ final class MuesliController: NSObject {
             hotkeyMonitor.targetKeyCode = config.dictationHotkey.keyCode
             hotkeyMonitor.start()
         }
-        indicator.hotkeyLabel = config.dictationHotkey.label
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
         indicator.onToggleMeetingPause = { [weak self] in self?.toggleMeetingRecordingPause() }
@@ -1007,7 +1006,6 @@ final class MuesliController: NSObject {
     func updateDictationHotkey(_ hotkey: HotkeyConfig) {
         updateConfig { $0.dictationHotkey = hotkey }
         hotkeyMonitor.configure(keyCode: hotkey.keyCode)
-        indicator.hotkeyLabel = hotkey.label
     }
 
     // MARK: - Onboarding


### PR DESCRIPTION
## Problem
The floating pill’s idle hover hint always tracked a separate `hotkeyLabel` field instead of persisted `AppConfig.dictationHotkey`, so it could show "Hold Left Cmd" after onboarding or shortcut changes until a restart—or briefly show a stale label when updating from Settings.

## Change
- Build the idle hover string from `config.dictationHotkey.label` in `styleForState(..., config:)`.
- Drop the mirrored `hotkeyLabel` property and related assignments in `MuesliController`.

## Testing
- `swift test --package-path native/MuesliNative` passes locally.

Made with [Cursor](https://cursor.com)