### PR TITLE
[codex] Harden OpenHands workflow controls

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -96,7 +96,8 @@ jobs:
             const requestedBlockingReviewFix = issueType === 'pr' && (
               /p0\s*(?:\/|and|&|\+)?\s*p1/i.test(commentBody) ||
               /p1\s*(?:\/|and|&|\+)?\s*p0/i.test(commentBody) ||
-              /p0p1/i.test(commentBody)
+              /p0p1/i.test(commentBody) ||
+              /\bp[01]s?\b/i.test(commentBody)
             );
 
             const defaultMaxIterations = process.env.OPENHANDS_MAX_ITER || '20';
@@ -159,7 +160,7 @@ jobs:
             const issueNumber = Number('${{ steps.context.outputs.issue_number }}');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const botAuthorPattern = /(claude|greptile)/i;
+            const botAuthorPattern = /^(claude|greptile)(?:$|-|\[bot\])/i;
 
             const issueComments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -424,7 +425,7 @@ jobs:
           exit 1
 
       - name: Comment on resolver result
-        if: always() && steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true'
+        if: always() && steps.context.outputs.smoke_only != 'true' && steps.context.outputs.max_iterations_error == '' && steps.review_gate.outputs.should_skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -190,7 +190,8 @@ jobs:
             ].filter((item) => botAuthorPattern.test(item.author));
 
             function hasBlockingFinding(body) {
-              return body
+              const bodyWithBadges = body.replace(/<img[^>]*badges\/(p[01])\.svg[^>]*>/gi, ' $1-badge ');
+              return bodyWithBadges
                 .replace(/<[^>]*>/g, ' ')
                 .split(/\r?\n/)
                 .some((line) => {

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -97,7 +97,7 @@ jobs:
               /p0\s*(?:\/|and|&|\+)?\s*p1/i.test(commentBody) ||
               /p1\s*(?:\/|and|&|\+)?\s*p0/i.test(commentBody) ||
               /p0p1/i.test(commentBody) ||
-              /\b(?:fix|address|resolve|handle|review|triage)\b.{0,80}\bp[01]s?\b/is.test(commentBody)
+              /\b(?:fix|address|resolve|handle)\b.{0,80}\bp[01]s?\b/is.test(commentBody)
             );
 
             const defaultMaxIterations = process.env.OPENHANDS_MAX_ITER || '20';
@@ -154,6 +154,7 @@ jobs:
       - name: Check PR blocking review findings
         id: review_gate
         if: steps.context.outputs.smoke_only != 'true' && steps.context.outputs.requested_blocking_review_fix == 'true'
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -245,6 +246,16 @@ jobs:
               }
             }
 
+      - name: Comment on PR review gate failure
+        if: steps.review_gate.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
+            -f body="OpenHands did not run because the PR review gate failed while reading Claude/Greptile review comments. Check the workflow logs, then retry the trigger comment. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          exit 1
+
       - name: Comment on skipped PR review request
         if: steps.review_gate.outputs.should_skip == 'true'
         env:
@@ -255,7 +266,7 @@ jobs:
             -f body="OpenHands did not run because no current P0/P1 findings were found in Claude/Greptile PR review comments. Re-trigger with a specific P2/minor request if you want optional findings handled. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Check required configuration
-        if: steps.review_gate.outputs.should_skip != 'true'
+        if: steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         run: |
           required_vars=(LLM_MODEL LLM_API_KEY PAT_TOKEN PAT_USERNAME)
           for var in "${required_vars[@]}"; do
@@ -266,11 +277,11 @@ jobs:
           done
 
       - name: Check out repository
-        if: steps.review_gate.outputs.should_skip != 'true'
+        if: steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         uses: actions/checkout@v4
 
       - name: Preflight PAT publishing credentials
-        if: steps.review_gate.outputs.should_skip != 'true'
+        if: steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         run: |
           pat_login="$(GH_TOKEN="${PAT_TOKEN}" gh api user --jq .login)"
           if [ "${pat_login}" = "${PAT_USERNAME}" ]; then
@@ -301,20 +312,20 @@ jobs:
           echo "PAT HTTPS git push dry run succeeded."
 
       - name: Set up Python
-        if: steps.review_gate.outputs.should_skip != 'true'
+        if: steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Cache pip dependencies
-        if: steps.review_gate.outputs.should_skip != 'true'
+        if: steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}/lib/python3.12/site-packages
           key: ${{ runner.os }}-pip-openhands-ai-1.6.0
 
       - name: Install OpenHands resolver runtime
-        if: steps.review_gate.outputs.should_skip != 'true'
+        if: steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install "openhands-ai==1.6.0"
@@ -355,7 +366,7 @@ jobs:
 
       - name: Resolve issue or PR
         id: resolve
-        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true'
+        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         continue-on-error: true
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -393,7 +404,7 @@ jobs:
 
       - name: Check resolver result
         id: result
-        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true' && hashFiles('output/output.jsonl') != ''
+        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true' && hashFiles('output/output.jsonl') != ''
         run: |
           if grep -qE '"success"[[:space:]]*:[[:space:]]*true' output/output.jsonl; then
             echo "success=true" >> "$GITHUB_OUTPUT"
@@ -403,7 +414,7 @@ jobs:
 
       - name: Publish resolver changes
         id: publish
-        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true' && hashFiles('output/output.jsonl') != ''
+        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true' && hashFiles('output/output.jsonl') != ''
         continue-on-error: true
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -447,7 +458,7 @@ jobs:
           exit 1
 
       - name: Comment on resolver result
-        if: always() && steps.context.outputs.smoke_only != 'true' && steps.context.outputs.max_iterations_error == '' && steps.review_gate.outputs.should_skip != 'true'
+        if: always() && steps.context.outputs.smoke_only != 'true' && steps.context.outputs.max_iterations_error == '' && steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -468,7 +479,7 @@ jobs:
             -f body="${status} Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Upload resolver output
-        if: always() && steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true'
+        if: always() && steps.context.outputs.smoke_only != 'true' && steps.review_gate.outcome != 'failure' && steps.review_gate.outputs.should_skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: resolver-output

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -155,9 +155,11 @@ jobs:
         id: review_gate
         if: steps.context.outputs.smoke_only != 'true' && steps.context.outputs.requested_blocking_review_fix == 'true'
         uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:
           script: |
-            const issueNumber = Number('${{ steps.context.outputs.issue_number }}');
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const botAuthorPattern = /^(claude|greptile)(?:$|-|\[bot\])/i;

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -141,7 +141,7 @@ jobs:
             -f content="eyes" || true
 
       - name: Reject invalid trigger options
-        if: steps.context.outputs.max_iterations_error != ''
+        if: steps.context.outputs.smoke_only != 'true' && steps.context.outputs.max_iterations_error != ''
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -97,8 +97,7 @@ jobs:
               /p0\s*(?:\/|and|&|\+)?\s*p1/i.test(commentBody) ||
               /p1\s*(?:\/|and|&|\+)?\s*p0/i.test(commentBody) ||
               /p0p1/i.test(commentBody) ||
-              /\b(?:fix|address|resolve|handle|review|triage)\b.{0,80}\bp[01]s?\b/is.test(commentBody) ||
-              /\bp[01]s?\b.{0,80}\b(?:issue|issues|finding|findings|bug|bugs|blocker|blockers|review|reviews|claude|greptile)\b/is.test(commentBody)
+              /\b(?:fix|address|resolve|handle|review|triage)\b.{0,80}\bp[01]s?\b/is.test(commentBody)
             );
 
             const defaultMaxIterations = process.env.OPENHANDS_MAX_ITER || '20';
@@ -191,6 +190,7 @@ jobs:
             ].filter((item) => botAuthorPattern.test(item.author));
 
             function hasBlockingFinding(body) {
+              // Greptile uses severity badge images on inline findings; preserve that signal before stripping HTML.
               const bodyWithBadges = body.replace(/<img[^>]*badges\/(p[01])\.svg[^>]*>/gi, ' $1-badge ');
               const lines = bodyWithBadges
                 .replace(/<[^>]*>/g, ' ')

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -203,7 +203,8 @@ jobs:
                   if (
                     /\b(?:no|zero)\s+(?:new\s+)?p0\s*(?:\/|or|and|,)?\s*p1\b/.test(lower) ||
                     /\bp0\s*(?:\/|or|and|,)?\s*p1\s*(?:issues|findings)?\s*(?:found)?\s*[:=-]?\s*(?:0|none|—|-)\b/.test(lower) ||
-                    /\|\s*p0\s*\/\s*p1\s*\|\s*0\s*\|/.test(lower)
+                    /\|\s*p0\s*\/\s*p1\s*\|\s*0\s*\|/.test(lower) ||
+                    /\bp[01]\s*(?:\*{1,2})?\s*(?::|=|—|-)\s*(?:(?:0|none|n\/a)\b|[—-](?:\s|$))/i.test(lower)
                   ) {
                     return false;
                   }
@@ -312,7 +313,7 @@ jobs:
           PY
 
       - name: Smoke test
-        if: steps.context.outputs.smoke_only == 'true' && steps.review_gate.outputs.should_skip != 'true'
+        if: steps.context.outputs.smoke_only == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -97,7 +97,8 @@ jobs:
               /p0\s*(?:\/|and|&|\+)?\s*p1/i.test(commentBody) ||
               /p1\s*(?:\/|and|&|\+)?\s*p0/i.test(commentBody) ||
               /p0p1/i.test(commentBody) ||
-              /\bp[01]s?\b/i.test(commentBody)
+              /\b(?:fix|address|resolve|handle|review|triage)\b.{0,80}\bp[01]s?\b/is.test(commentBody) ||
+              /\bp[01]s?\b.{0,80}\b(?:issue|issues|finding|findings|bug|bugs|blocker|blockers|review|reviews|claude|greptile)\b/is.test(commentBody)
             );
 
             const defaultMaxIterations = process.env.OPENHANDS_MAX_ITER || '20';
@@ -191,40 +192,57 @@ jobs:
 
             function hasBlockingFinding(body) {
               const bodyWithBadges = body.replace(/<img[^>]*badges\/(p[01])\.svg[^>]*>/gi, ' $1-badge ');
-              return bodyWithBadges
+              const lines = bodyWithBadges
                 .replace(/<[^>]*>/g, ' ')
-                .split(/\r?\n/)
-                .some((line) => {
-                  const text = line.trim();
-                  if (!text) {
-                    return false;
-                  }
-                  const lower = text.toLowerCase();
-                  if (
-                    /\b(?:no|zero)\s+(?:new\s+)?p0\s*(?:\/|or|and|,)?\s*p1\b/.test(lower) ||
-                    /\bp0\s*(?:\/|or|and|,)?\s*p1\s*(?:issues|findings)?\s*(?:found)?\s*[:=-]?\s*(?:0|none|—|-)\b/.test(lower) ||
-                    /\|\s*p0\s*\/\s*p1\s*\|\s*0\s*\|/.test(lower) ||
-                    /\bp[01]\s*(?:\*{1,2})?\s*(?::|=|—|-)\s*(?:(?:0|none|n\/a)\b|[—-](?:\s|$))/i.test(lower)
-                  ) {
-                    return false;
-                  }
+                .split(/\r?\n/);
+              let inCodeFence = false;
 
-                  return (
-                    /^(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?\[?\s*p[01]\s*\]?(?:\*\*)?\s*(?::|-|—|–|\|)/i.test(text) ||
-                    /^(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?\[?\s*p[01]\s*\]?(?:\*\*)?\s+(?:issue|finding|bug|blocker|critical|high)\b/i.test(text) ||
-                    /\b(?:priority|severity)\s*[:=-]\s*p[01]\b/i.test(text)
-                  );
-                });
+              for (const line of lines) {
+                const text = line.trim();
+                if (/^(?:```|~~~)/.test(text)) {
+                  inCodeFence = !inCodeFence;
+                  continue;
+                }
+                if (inCodeFence || !text) {
+                  continue;
+                }
+
+                const lower = text.toLowerCase();
+                if (
+                  /\b(?:no|zero)\s+(?:new\s+)?p0\s*(?:\/|or|and|,)?\s*p1\b/.test(lower) ||
+                  /\bp0\s*(?:\/|or|and|,)?\s*p1\s*(?:issues|findings)?\s*(?:found)?\s*[:=-]?\s*(?:0|none|—|-)\b/.test(lower) ||
+                  /\|\s*p0\s*\/\s*p1\s*\|\s*0\s*\|/.test(lower) ||
+                  /\bp[01]\s*(?:\*{1,2})?\s*(?::|=|—|-)\s*(?:(?:0|none|n\/a)\b|[—-](?:\s|$))/i.test(lower)
+                ) {
+                  continue;
+                }
+
+                if (
+                  /^(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?\[?\s*p[01]\s*\]?(?:\*\*)?\s*(?::|-|—|–|\|)/i.test(text) ||
+                  /^(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?\[?\s*p[01]\s*\]?(?:\*\*)?\s+(?:issue|finding|bug|blocker|critical|high)\b/i.test(text) ||
+                  /\b(?:priority|severity)\s*[:=-]\s*p[01]\b/i.test(text)
+                ) {
+                  return true;
+                }
+              }
+
+              return false;
             }
 
-            const blockingSources = reviewSources.filter((item) => hasBlockingFinding(item.body));
-            core.setOutput('blocking_source_count', String(blockingSources.length));
-            core.setOutput('should_skip', String(blockingSources.length === 0));
-
-            if (blockingSources.length === 0) {
-              core.notice(`No P0/P1 findings found in ${reviewSources.length} Claude/Greptile review source(s).`);
+            if (reviewSources.length === 0) {
+              core.setOutput('blocking_source_count', '0');
+              core.setOutput('should_skip', 'false');
+              core.notice('No Claude/Greptile reviews found; proceeding because the PR review gate cannot evaluate yet.');
             } else {
-              core.notice(`Found ${blockingSources.length} Claude/Greptile review source(s) with P0/P1 findings.`);
+              const blockingSources = reviewSources.filter((item) => hasBlockingFinding(item.body));
+              core.setOutput('blocking_source_count', String(blockingSources.length));
+              core.setOutput('should_skip', String(blockingSources.length === 0));
+
+              if (blockingSources.length === 0) {
+                core.notice(`No P0/P1 findings found in ${reviewSources.length} Claude/Greptile review source(s).`);
+              } else {
+                core.notice(`Found ${blockingSources.length} Claude/Greptile review source(s) with P0/P1 findings.`);
+              }
             }
 
       - name: Comment on skipped PR review request

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -93,20 +93,39 @@ jobs:
               throw new Error(`Unsupported event: ${eventName}`);
             }
 
+            const requestedBlockingReviewFix = issueType === 'pr' && (
+              /p0\s*(?:\/|and|&|\+)?\s*p1/i.test(commentBody) ||
+              /p1\s*(?:\/|and|&|\+)?\s*p0/i.test(commentBody) ||
+              /p0p1/i.test(commentBody)
+            );
+
+            const defaultMaxIterations = process.env.OPENHANDS_MAX_ITER || '20';
+            let maxIterations = defaultMaxIterations;
+            let maxIterationsError = '';
+            const maxIterMatch = commentBody.match(/\bmax-iter(?:ations)?\s*=\s*([^\s]+)/i);
+            if (maxIterMatch) {
+              const rawMaxIterations = maxIterMatch[1].trim();
+              if (!/^\d+$/.test(rawMaxIterations)) {
+                maxIterationsError = `Invalid max-iter value "${rawMaxIterations}". Use an integer from 1 to 100.`;
+              } else {
+                const parsedMaxIterations = Number(rawMaxIterations);
+                if (parsedMaxIterations < 1 || parsedMaxIterations > 100) {
+                  maxIterationsError = `Invalid max-iter value "${rawMaxIterations}". Use an integer from 1 to 100.`;
+                } else {
+                  maxIterations = String(parsedMaxIterations);
+                }
+              }
+            } else if (!/^\d+$/.test(defaultMaxIterations) || Number(defaultMaxIterations) < 1 || Number(defaultMaxIterations) > 100) {
+              maxIterationsError = `Invalid OPENHANDS_MAX_ITER value "${defaultMaxIterations}". Use an integer from 1 to 100.`;
+            }
+
             core.setOutput('issue_number', String(issueNumber));
             core.setOutput('issue_type', issueType);
             core.setOutput('comment_id', commentId);
             core.setOutput('smoke_only', String(/smoke test only/i.test(commentBody)));
-
-      - name: Check required configuration
-        run: |
-          required_vars=(LLM_MODEL LLM_API_KEY PAT_TOKEN PAT_USERNAME)
-          for var in "${required_vars[@]}"; do
-            if [ -z "${!var}" ]; then
-              echo "Error: required configuration $var is not set."
-              exit 1
-            fi
-          done
+            core.setOutput('requested_blocking_review_fix', String(requestedBlockingReviewFix));
+            core.setOutput('max_iterations', maxIterations);
+            core.setOutput('max_iterations_error', maxIterationsError);
 
       - name: React to trigger comment
         if: steps.context.outputs.comment_id != 'none'
@@ -120,10 +139,115 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
             -f content="eyes" || true
 
+      - name: Reject invalid trigger options
+        if: steps.context.outputs.max_iterations_error != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+          MAX_ITERATIONS_ERROR: ${{ steps.context.outputs.max_iterations_error }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
+            -f body="OpenHands did not run. ${MAX_ITERATIONS_ERROR} Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          exit 1
+
+      - name: Check PR blocking review findings
+        id: review_gate
+        if: steps.context.outputs.smoke_only != 'true' && steps.context.outputs.requested_blocking_review_fix == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = Number('${{ steps.context.outputs.issue_number }}');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const botAuthorPattern = /(claude|greptile)/i;
+
+            const issueComments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: issueNumber,
+              per_page: 100,
+            });
+            const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner,
+              repo,
+              pull_number: issueNumber,
+              per_page: 100,
+            });
+
+            const reviewSources = [
+              ...issueComments.map((item) => ({ kind: 'PR comment', author: item.user?.login || '', body: item.body || '', url: item.html_url || '' })),
+              ...reviews.map((item) => ({ kind: 'PR review', author: item.user?.login || '', body: item.body || '', url: item.html_url || '' })),
+              ...reviewComments.map((item) => ({ kind: 'inline review comment', author: item.user?.login || '', body: item.body || '', url: item.html_url || '' })),
+            ].filter((item) => botAuthorPattern.test(item.author));
+
+            function hasBlockingFinding(body) {
+              return body
+                .replace(/<[^>]*>/g, ' ')
+                .split(/\r?\n/)
+                .some((line) => {
+                  const text = line.trim();
+                  if (!text) {
+                    return false;
+                  }
+                  const lower = text.toLowerCase();
+                  if (
+                    /\b(?:no|zero)\s+(?:new\s+)?p0\s*(?:\/|or|and|,)?\s*p1\b/.test(lower) ||
+                    /\bp0\s*(?:\/|or|and|,)?\s*p1\s*(?:issues|findings)?\s*(?:found)?\s*[:=-]?\s*(?:0|none|—|-)\b/.test(lower) ||
+                    /\|\s*p0\s*\/\s*p1\s*\|\s*0\s*\|/.test(lower)
+                  ) {
+                    return false;
+                  }
+
+                  return (
+                    /^(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?\[?\s*p[01]\s*\]?(?:\*\*)?\s*(?::|-|—|–|\|)/i.test(text) ||
+                    /^(?:#{1,6}\s*)?(?:[-*]\s*)?(?:\*\*)?\[?\s*p[01]\s*\]?(?:\*\*)?\s+(?:issue|finding|bug|blocker|critical|high)\b/i.test(text) ||
+                    /\b(?:priority|severity)\s*[:=-]\s*p[01]\b/i.test(text)
+                  );
+                });
+            }
+
+            const blockingSources = reviewSources.filter((item) => hasBlockingFinding(item.body));
+            core.setOutput('blocking_source_count', String(blockingSources.length));
+            core.setOutput('should_skip', String(blockingSources.length === 0));
+
+            if (blockingSources.length === 0) {
+              core.notice(`No P0/P1 findings found in ${reviewSources.length} Claude/Greptile review source(s).`);
+            } else {
+              core.notice(`Found ${blockingSources.length} Claude/Greptile review source(s) with P0/P1 findings.`);
+            }
+
+      - name: Comment on skipped PR review request
+        if: steps.review_gate.outputs.should_skip == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
+            -f body="OpenHands did not run because no current P0/P1 findings were found in Claude/Greptile PR review comments. Re-trigger with a specific P2/minor request if you want optional findings handled. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Check required configuration
+        if: steps.review_gate.outputs.should_skip != 'true'
+        run: |
+          required_vars=(LLM_MODEL LLM_API_KEY PAT_TOKEN PAT_USERNAME)
+          for var in "${required_vars[@]}"; do
+            if [ -z "${!var}" ]; then
+              echo "Error: required configuration $var is not set."
+              exit 1
+            fi
+          done
+
       - name: Check out repository
+        if: steps.review_gate.outputs.should_skip != 'true'
         uses: actions/checkout@v4
 
       - name: Preflight PAT publishing credentials
+        if: steps.review_gate.outputs.should_skip != 'true'
         run: |
           pat_login="$(GH_TOKEN="${PAT_TOKEN}" gh api user --jq .login)"
           if [ "${pat_login}" = "${PAT_USERNAME}" ]; then
@@ -154,17 +278,20 @@ jobs:
           echo "PAT HTTPS git push dry run succeeded."
 
       - name: Set up Python
+        if: steps.review_gate.outputs.should_skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Cache pip dependencies
+        if: steps.review_gate.outputs.should_skip != 'true'
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}/lib/python3.12/site-packages
           key: ${{ runner.os }}-pip-openhands-ai-1.6.0
 
       - name: Install OpenHands resolver runtime
+        if: steps.review_gate.outputs.should_skip != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install "openhands-ai==1.6.0"
@@ -181,7 +308,7 @@ jobs:
           PY
 
       - name: Smoke test
-        if: steps.context.outputs.smoke_only == 'true'
+        if: steps.context.outputs.smoke_only == 'true' && steps.review_gate.outputs.should_skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -205,19 +332,20 @@ jobs:
 
       - name: Resolve issue or PR
         id: resolve
-        if: steps.context.outputs.smoke_only != 'true'
+        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true'
         continue-on-error: true
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           ISSUE_TYPE: ${{ steps.context.outputs.issue_type }}
           COMMENT_ID: ${{ steps.context.outputs.comment_id }}
+          MAX_ITERATIONS: ${{ steps.context.outputs.max_iterations }}
         run: |
           args=(
             python -m openhands.resolver.resolve_issue
             --selected-repo "${GITHUB_REPOSITORY}"
             --issue-number "${ISSUE_NUMBER}"
             --issue-type "${ISSUE_TYPE}"
-            --max-iterations "${OPENHANDS_MAX_ITER}"
+            --max-iterations "${MAX_ITERATIONS}"
             --token "${PAT_TOKEN}"
             --username "${PAT_USERNAME}"
             --llm-model "${LLM_MODEL}"
@@ -242,7 +370,7 @@ jobs:
 
       - name: Check resolver result
         id: result
-        if: steps.context.outputs.smoke_only != 'true' && hashFiles('output/output.jsonl') != ''
+        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true' && hashFiles('output/output.jsonl') != ''
         run: |
           if grep -qE '"success"[[:space:]]*:[[:space:]]*true' output/output.jsonl; then
             echo "success=true" >> "$GITHUB_OUTPUT"
@@ -252,7 +380,7 @@ jobs:
 
       - name: Publish resolver changes
         id: publish
-        if: steps.context.outputs.smoke_only != 'true' && hashFiles('output/output.jsonl') != ''
+        if: steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true' && hashFiles('output/output.jsonl') != ''
         continue-on-error: true
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -280,10 +408,23 @@ jobs:
           else
             args+=(--pr-type branch --send-on-failure)
           fi
-          "${args[@]}"
+
+          max_attempts=3
+          for attempt in $(seq 1 "${max_attempts}"); do
+            echo "OpenHands publish attempt ${attempt}/${max_attempts}"
+            if "${args[@]}"; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              sleep_seconds=$((attempt * 15))
+              echo "Publish failed; retrying in ${sleep_seconds}s."
+              sleep "${sleep_seconds}"
+            fi
+          done
+          exit 1
 
       - name: Comment on resolver result
-        if: always() && steps.context.outputs.smoke_only != 'true'
+        if: always() && steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -292,7 +433,11 @@ jobs:
           RESULT_SUCCESS: ${{ steps.result.outputs.success }}
         run: |
           if [ "${RESOLVE_OUTCOME}" = "success" ] && [ "${PUBLISH_OUTCOME}" = "success" ]; then
-            status="OpenHands finished. Resolver success: ${RESULT_SUCCESS}."
+            if [ "${RESULT_SUCCESS}" = "true" ]; then
+              status="OpenHands finished and published resolver changes."
+            else
+              status="OpenHands finished without a successful resolver result; failure output was published when available."
+            fi
           else
             status="OpenHands encountered an error. Resolve step: ${RESOLVE_OUTCOME:-skipped}; publish step: ${PUBLISH_OUTCOME:-skipped}."
           fi
@@ -300,7 +445,7 @@ jobs:
             -f body="${status} Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Upload resolver output
-        if: always() && steps.context.outputs.smoke_only != 'true'
+        if: always() && steps.context.outputs.smoke_only != 'true' && steps.review_gate.outputs.should_skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: resolver-output

--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -213,7 +213,7 @@ jobs:
                   /\b(?:no|zero)\s+(?:new\s+)?p0\s*(?:\/|or|and|,)?\s*p1\b/.test(lower) ||
                   /\bp0\s*(?:\/|or|and|,)?\s*p1\s*(?:issues|findings)?\s*(?:found)?\s*[:=-]?\s*(?:0|none|—|-)\b/.test(lower) ||
                   /\|\s*p0\s*\/\s*p1\s*\|\s*0\s*\|/.test(lower) ||
-                  /\bp[01]\s*(?:\*{1,2})?\s*(?::|=|—|-)\s*(?:(?:0|none|n\/a)\b|[—-](?:\s|$))/i.test(lower)
+                  /\bp[01]\s*(?:\*{1,2})?\s*(?::|=|—|–|-)\s*(?:(?:0|none|n\/a)\b|[—–-](?:\s|$))/i.test(lower)
                 ) {
                   continue;
                 }

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -8,6 +8,7 @@ You are working on Muesli, a Swift/SwiftUI macOS app.
 - P0/P1 findings are blocking if they still apply to the current HEAD.
 - P2 findings are optional unless they are low-risk and clearly correct.
 - Greptile findings may be stale. Verify each finding against current code before changing anything.
+- If the trigger asks specifically for P0/P1 fixes and there are no current code-backed P0/P1 findings, do not fix P2/minor items unless the trigger explicitly asks for them.
 
 ## Hard Rules
 
@@ -32,6 +33,7 @@ You are working on Muesli, a Swift/SwiftUI macOS app.
 - Classify each review item as current blocking, stale, optional, or out-of-scope.
 - For stale findings, cite the current file/function evidence that makes the finding obsolete.
 - Fix all current code-backed P0/P1 findings.
+- Do not spend time on P2/minor findings when the request is scoped to P0/P1 only.
 - Keep changes narrow and consistent with existing SwiftUI/AppKit patterns.
 - Commit fixes directly to the PR branch.
 - Stop when there are no current code-backed P0/P1 findings and summarize what remains for local MuesliDev QA.


### PR DESCRIPTION
## Summary

Harden the OpenHands resolver workflow around the failure modes seen while testing PR review automation.

- add `max-iter=N` parsing from trigger comments, with a hard cap of 100 iterations
- add a PR-review gate for P0/P1-only requests so OpenHands skips immediately when Claude/Greptile have no P0/P1 findings
- retry the OpenHands publish helper up to three times to tolerate transient GitHub API failures such as `ConnectTimeout`
- improve resolver result comments so successful publishes and unsuccessful resolver outputs are easier to distinguish
- tighten `.openhands/microagents/repo.md` so P2/minor findings are not handled when the request is scoped to P0/P1 only

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openhands-resolver.yml"); puts "yaml ok"'`
- `git diff --check`
- local Node regex checks for `max-iter`/P0/P1 detection cases
- simulated the new PR-review gate against PR #84 comments: 2 Claude/Greptile sources, 0 detected P0/P1 sources
