### PR TITLE
Fix issue #85: Meeting notes : Title should be meeting title not summary

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -504,6 +504,8 @@ final class MeetingSession {
         onProgress?(.generatingTitle)
         if let liveTitle = await userEditedLiveTitle() {
             generatedTitle = liveTitle
+        } else if calendarEventID != nil {
+            generatedTitle = title
         } else if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: rawTranscript, config: config),
            !autoTitle.isEmpty {
             generatedTitle = autoTitle

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -504,7 +504,7 @@ final class MeetingSession {
         onProgress?(.generatingTitle)
         if let liveTitle = await userEditedLiveTitle() {
             generatedTitle = liveTitle
-        } else if calendarEventID != nil {
+        } else if calendarEventID != nil, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             generatedTitle = title
         } else if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: rawTranscript, config: config),
            !autoTitle.isEmpty {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -504,8 +504,11 @@ final class MeetingSession {
         onProgress?(.generatingTitle)
         if let liveTitle = await userEditedLiveTitle() {
             generatedTitle = liveTitle
-        } else if calendarEventID != nil, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            generatedTitle = title
+        } else if let calendarTitle = Self.calendarTitleCandidate(
+            originalTitle: title,
+            calendarEventID: calendarEventID
+        ) {
+            generatedTitle = calendarTitle
         } else if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: rawTranscript, config: config),
            !autoTitle.isEmpty {
             generatedTitle = autoTitle
@@ -558,6 +561,12 @@ final class MeetingSession {
             systemRecordingURL: systemAudioURL,
             templateSnapshot: templateSnapshot
         )
+    }
+
+    static func calendarTitleCandidate(originalTitle: String, calendarEventID: String?) -> String? {
+        guard calendarEventID != nil else { return nil }
+        guard !originalTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return originalTitle
     }
 
     private func userEditedLiveTitle() async -> String? {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSessionTitleTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSessionTitleTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting session title selection")
+struct MeetingSessionTitleTests {
+    @Test("calendar event title is used when present")
+    func calendarEventTitleCandidate() {
+        let title = MeetingSession.calendarTitleCandidate(
+            originalTitle: "April Town Hall",
+            calendarEventID: "calendar-event-123"
+        )
+
+        #expect(title == "April Town Hall")
+    }
+
+    @Test("blank calendar event title falls through")
+    func blankCalendarEventTitleFallsThrough() {
+        let title = MeetingSession.calendarTitleCandidate(
+            originalTitle: "  \n\t  ",
+            calendarEventID: "calendar-event-123"
+        )
+
+        #expect(title == nil)
+    }
+
+    @Test("non-calendar meeting does not use original title as a calendar title")
+    func nonCalendarMeetingFallsThrough() {
+        let title = MeetingSession.calendarTitleCandidate(
+            originalTitle: "Quick Note",
+            calendarEventID: nil
+        )
+
+        #expect(title == nil)
+    }
+}


### PR DESCRIPTION
This pull request fixes #85.

The patch modifies the title generation logic in `MeetingSession.swift` to prioritize the calendar event's title when a calendar meeting is associated. Specifically, after checking for a user-edited live title, it now checks if `calendarEventID != nil` and, if so, sets `generatedTitle = title` (the calendar event's title). This directly addresses the issue: instead of using an AI-generated summary as the default title, the meeting will now use the calendar meeting title (e.g., "April Town Hall", "1:1 with Mike") when a calendar event is linked. The change is narrow and does not affect other title generation paths. Therefore, the issue is resolved.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌