### PR TITLE
fix: skip hotkey handling when text input has keyboard focus

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -55,7 +55,11 @@ final class HotkeyMonitor {
             self?.handle(event)
         }
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { [weak self] event in
-            self?.handle(event)
+            let fr = NSApp.keyWindow?.firstResponder
+            let isTextEditing = fr is NSTextView || fr is NSTextField
+            if !isTextEditing {
+                self?.handle(event)
+            }
             return event
         }
 


### PR DESCRIPTION
## Problem

When editing meeting notes (the `TextEditor` in `MeetingDetailView`), standard Cmd+C, Cmd+V, Cmd+Z and other Command-key shortcuts don't work reliably.

## Root Cause

`HotkeyMonitor` installs a `localMonitor` for `.flagsChanged` and `.keyDown` events on the Muesli window. The default dictation hotkey is the Command key (keyCode 55). When the user is editing notes and presses Cmd+C:

1. Cmd key down → `targetKeyDown = true`, prepare (0.15s) and start (0.25s) timers scheduled
2. If the user holds Cmd for >0.25s before pressing C (common for deliberate shortcuts), `handleStart` fires → **dictation starts** (`recorder.start()`, sound plays, clipboard touched)
3. C key down → `handleKeyDown` calls `onStop` → dictation stops and tries to transcribe empty audio

The event itself passes through (`return event` in the local monitor), so the OS copy action works, but the dictation lifecycle side-effects (sounds, clipboard restore, state changes) break the editing experience.

## Fix

In the `localMonitor` closure, skip hotkey handling when a text input has keyboard focus:

```swift
localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { [weak self] event in
    let fr = NSApp.keyWindow?.firstResponder
    let isTextEditing = fr is NSTextView || fr is NSTextField
    if !isTextEditing {
        self?.handle(event)
    }
    return event
}
```

This covers SwiftUI `TextEditor` (backed by `NSTextView`) and `NSTextField`. The global monitor is unaffected, so dictation still works normally when the Muesli window is not focused.

## Testing

- Swift toolchain not available in CI Linux environment — requires macOS build verification
- Existing `HotkeyMonitorTests` (escape cancels active hold dictation) should continue to pass since it tests `handleKeyDown` directly, not through the event monitor path

Co-authored-by: openhands <openhands@all-hands.dev>