### PR TITLE
[codex] Harden CUA loop reliability and status UX

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseBrowserAutomation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseBrowserAutomation.swift
@@ -59,6 +59,32 @@ enum ComputerUseBrowserAutomation {
         }
     }
 
+    static func openNewTab(appBundleID: String) async -> ComputerUseExecutionResult {
+        guard supportsBrowser(appBundleID) else {
+            return .unsupported("Browser tools currently support Google Chrome only")
+        }
+        let script = """
+        tell application id "\(appleScriptString(appBundleID))"
+          activate
+          if (count of windows) is 0 then
+            make new window
+          else
+            set index of front window to 1
+            tell front window to make new tab
+            set active tab index of front window to (count of tabs of front window)
+          end if
+        end tell
+        """
+        do {
+            _ = try await runAppleScript(script)
+            return .executed("Opened new browser tab")
+        } catch is CancellationError {
+            return .cancelled()
+        } catch {
+            return .failed(browserScriptError(error))
+        }
+    }
+
     static func navigate(appBundleID: String, windowIndex: Int?, tabIndex: Int?, url: String) async -> ComputerUseExecutionResult {
         guard supportsBrowser(appBundleID) else {
             return .unsupported("Browser tools currently support Google Chrome only")

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseExecutor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseExecutor.swift
@@ -94,15 +94,17 @@ enum ComputerUseToolExecutor {
             return await openApp(named: toolCall.appName?.isEmpty == false ? toolCall.appName! : toolCall.canonicalBundleID)
         case .listWindows:
             return listWindows(appBundleID: toolCall.canonicalBundleID)
-        case .getWindowState:
+        case .getAppState, .getWindowState:
             if !toolCall.canonicalBundleID.isEmpty || toolCall.appName?.isEmpty == false {
                 return await focusApp(named: toolCall.appName?.isEmpty == false ? toolCall.appName! : toolCall.canonicalBundleID)
             }
             return .executed("Captured window state")
         case .moveCursor:
             return moveCursor(toolCall, registry: registry)
-        case .click:
+        case .click, .clickElement, .clickPoint:
             return click(toolCall, registry: registry)
+        case .performSecondaryAction:
+            return performSecondaryAction(toolCall, registry: registry)
         case .setValue:
             return setValue(toolCall, registry: registry)
         case .drag:
@@ -117,7 +119,7 @@ enum ComputerUseToolExecutor {
         case .pasteText:
             return await enterText(toolCall, registry: registry, mode: .paste)
         case .scroll:
-            return scroll(direction: toolCall.direction ?? .down, pages: toolCall.pages ?? 1)
+            return scroll(toolCall, registry: registry)
         case .listBrowserTabs:
             return await ComputerUseBrowserAutomation.listTabs(appBundleID: toolCall.canonicalBundleID)
         case .activateBrowserTab:
@@ -126,11 +128,20 @@ enum ComputerUseToolExecutor {
                 windowIndex: toolCall.windowIndex ?? 1,
                 tabIndex: toolCall.tabIndex ?? 1
             )
+        case .openNewBrowserTab:
+            return await ComputerUseBrowserAutomation.openNewTab(appBundleID: toolCall.canonicalBundleID)
         case .navigateURL:
             return await ComputerUseBrowserAutomation.navigate(
                 appBundleID: toolCall.canonicalBundleID,
                 windowIndex: toolCall.windowIndex,
                 tabIndex: toolCall.tabIndex,
+                url: toolCall.url ?? ""
+            )
+        case .navigateActiveBrowserTab:
+            return await ComputerUseBrowserAutomation.navigate(
+                appBundleID: toolCall.canonicalBundleID,
+                windowIndex: nil,
+                tabIndex: nil,
                 url: toolCall.url ?? ""
             )
         case .pageGetText:
@@ -278,6 +289,20 @@ enum ComputerUseToolExecutor {
         return .executed("Pressed key")
     }
 
+    private static func scroll(_ toolCall: ComputerUseToolCall, registry: ComputerUseElementRegistry?) -> ComputerUseExecutionResult {
+        let direction = toolCall.direction ?? .down
+        let pages = toolCall.pages ?? 1
+        if let elementResult = elementTarget(toolCall, registry: registry) {
+            switch elementResult {
+            case .failure(let message):
+                return .failed(message)
+            case .success(let element):
+                return scrollElement(element, direction: direction, pages: pages, label: toolCall.label)
+            }
+        }
+        return scroll(direction: direction, pages: pages)
+    }
+
     private static func scroll(direction: ComputerUseScrollDirection, pages: Double) -> ComputerUseExecutionResult {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             return .failed("Could not create scroll event")
@@ -297,6 +322,43 @@ enum ComputerUseToolExecutor {
         return .executed("Scrolled \(direction.rawValue)")
     }
 
+    private static func scrollElement(
+        _ element: AXUIElement,
+        direction: ComputerUseScrollDirection,
+        pages: Double,
+        label: String?
+    ) -> ComputerUseExecutionResult {
+        let action = scrollActionName(direction: direction)
+        let advertisedActions = actionNames(of: element) ?? []
+        guard advertisedActions.contains(action) else {
+            let actions = advertisedActions.isEmpty ? "none" : advertisedActions.joined(separator: ", ")
+            return .unsupported("Element does not advertise \(action) for element-scoped scroll (actions: \(actions)).")
+        }
+        let count = max(1, min(8, Int(pages.rounded(.up))))
+        for _ in 0..<count {
+            guard AXUIElementPerformAction(element, action as CFString) == .success else {
+                return .failed("Could not perform \(action) on scroll target")
+            }
+        }
+        if let rect = rect(of: element) {
+            ComputerUseCursorOverlay.shared.show(at: CGPoint(x: rect.midX, y: rect.midY), label: label)
+        }
+        return .executed("Scrolled element \(direction.rawValue)")
+    }
+
+    private static func scrollActionName(direction: ComputerUseScrollDirection) -> String {
+        switch direction {
+        case .up:
+            return "AXScrollUpByPage"
+        case .down:
+            return "AXScrollDownByPage"
+        case .left:
+            return "AXScrollLeftByPage"
+        case .right:
+            return "AXScrollRightByPage"
+        }
+    }
+
     static func scrollDeltas(direction: ComputerUseScrollDirection, pages: Double) -> (vertical: Int32, horizontal: Int32) {
         let units = Int32(max(1, min(8, pages)) * 8)
         switch direction {
@@ -312,17 +374,13 @@ enum ComputerUseToolExecutor {
     }
 
     private static func click(_ toolCall: ComputerUseToolCall, registry: ComputerUseElementRegistry?) -> ComputerUseExecutionResult {
-        if let index = toolCall.elementIndex {
-            guard let element = registry?.element(for: index) else {
-                return .failed("Stale or unknown element_index \(index). Run get_window_state again and use an element from the fresh snapshot.")
+        if toolCall.tool != .clickPoint, let elementResult = elementTarget(toolCall, registry: registry) {
+            switch elementResult {
+            case .failure(let message):
+                return .failed(message)
+            case .success(let element):
+                return clickElement(element, fallbackLabel: toolCall.label ?? elementTargetLabel(toolCall))
             }
-            return clickElement(element, fallbackLabel: toolCall.label ?? "e\(index)")
-        }
-        if let elementID = toolCall.elementID, !elementID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            guard let element = registry?.element(for: elementID) else {
-                return .failed("Stale or unknown element_id \(elementID). Run get_window_state again and use an element from the fresh snapshot.")
-            }
-            return clickElement(element, fallbackLabel: toolCall.label ?? elementID)
         }
         if toolCall.x != nil, toolCall.y != nil {
             return clickPoint(toolCall, registry: registry)
@@ -330,23 +388,51 @@ enum ComputerUseToolExecutor {
         return .needsConfirmation("Confirm: unknown click target")
     }
 
-    private static func setValue(_ toolCall: ComputerUseToolCall, registry: ComputerUseElementRegistry?) -> ComputerUseExecutionResult {
-        let element: AXUIElement?
-        if let index = toolCall.elementIndex {
-            guard let resolved = registry?.element(for: index) else {
-                return .failed("Stale or unknown element_index \(index). Run get_window_state again and use an element from the fresh snapshot.")
-            }
-            element = resolved
-        } else if let elementID = toolCall.elementID {
-            guard let resolved = registry?.element(for: elementID) else {
-                return .failed("Stale or unknown element_id \(elementID). Run get_window_state again and use an element from the fresh snapshot.")
-            }
-            element = resolved
-        } else {
-            element = nil
+    private static func performSecondaryAction(
+        _ toolCall: ComputerUseToolCall,
+        registry: ComputerUseElementRegistry?
+    ) -> ComputerUseExecutionResult {
+        guard let elementResult = elementTarget(toolCall, registry: registry) else {
+            return .failed("perform_secondary_action requires element_index or element_id")
         }
-        guard let element else {
+        let element: AXUIElement
+        switch elementResult {
+        case .failure(let message):
+            return .failed(message)
+        case .success(let resolved):
+            element = resolved
+        }
+        let actionName = toolCall.actionName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !actionName.isEmpty else {
+            return .failed("perform_secondary_action requires action_name")
+        }
+        guard actionName != (kAXPressAction as String) else {
+            return .unsupported("Use click for AXPress; perform_secondary_action only invokes non-press advertised actions.")
+        }
+        let advertisedActions = actionNames(of: element) ?? []
+        guard advertisedActions.contains(actionName) else {
+            let actions = advertisedActions.isEmpty ? "none" : advertisedActions.joined(separator: ", ")
+            return .unsupported("Element does not advertise \(actionName) (actions: \(actions)). Run get_app_state again if the target changed.")
+        }
+        if let rect = rect(of: element) {
+            ComputerUseCursorOverlay.shared.show(at: CGPoint(x: rect.midX, y: rect.midY), label: toolCall.label)
+        }
+        guard AXUIElementPerformAction(element, actionName as CFString) == .success else {
+            return .failed("Could not perform \(actionName) on \(elementTargetLabel(toolCall))")
+        }
+        return .executed("Performed \(actionName) on \(elementTargetLabel(toolCall))")
+    }
+
+    private static func setValue(_ toolCall: ComputerUseToolCall, registry: ComputerUseElementRegistry?) -> ComputerUseExecutionResult {
+        guard let elementResult = elementTarget(toolCall, registry: registry) else {
             return .failed("Stale or unknown element target")
+        }
+        let element: AXUIElement
+        switch elementResult {
+        case .failure(let message):
+            return .failed(message)
+        case .success(let resolved):
+            element = resolved
         }
         let value = toolCall.value ?? ""
         let result = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFTypeRef)
@@ -354,6 +440,38 @@ enum ComputerUseToolExecutor {
             return .executed("Set value")
         }
         return .unsupported("Element does not support set_value")
+    }
+
+    private static func elementTarget(
+        _ toolCall: ComputerUseToolCall,
+        registry: ComputerUseElementRegistry?
+    ) -> ElementTargetResult? {
+        if let index = toolCall.elementIndex {
+            guard let element = registry?.element(for: index) else {
+                return .failure("Stale or unknown element_index \(index). Run get_app_state again and use an element from the fresh snapshot.")
+            }
+            return .success(element)
+        }
+        if let elementID = toolCall.elementID?.trimmingCharacters(in: .whitespacesAndNewlines), !elementID.isEmpty {
+            guard let element = registry?.element(for: elementID) else {
+                return .failure("Stale or unknown element_id \(elementID). Run get_app_state again and use an element from the fresh snapshot.")
+            }
+            return .success(element)
+        }
+        return nil
+    }
+
+    private static func elementTargetLabel(_ toolCall: ComputerUseToolCall) -> String {
+        if let label = toolCall.label?.trimmingCharacters(in: .whitespacesAndNewlines), !label.isEmpty {
+            return label
+        }
+        if let index = toolCall.elementIndex {
+            return "e\(index)"
+        }
+        if let elementID = toolCall.elementID?.trimmingCharacters(in: .whitespacesAndNewlines), !elementID.isEmpty {
+            return elementID
+        }
+        return "element"
     }
 
     private enum TextEntryMode {
@@ -443,6 +561,11 @@ enum ComputerUseToolExecutor {
         case cancelled
     }
 
+    private enum ElementTargetResult {
+        case success(AXUIElement)
+        case failure(String)
+    }
+
     private static func prepareTextEntryApp(_ toolCall: ComputerUseToolCall) async -> AppPreparationResult {
         let target = textEntryAppName(toolCall)
         guard !target.isEmpty else {
@@ -476,12 +599,12 @@ enum ComputerUseToolExecutor {
         let element: AXUIElement?
         if let index = toolCall.elementIndex, index > 0 {
             guard let resolved = registry?.element(for: index) else {
-                return .failure("Stale or unknown element_index \(index). Run get_window_state again and use an element from the fresh snapshot.")
+                return .failure("Stale or unknown element_index \(index). Run get_app_state again and use an element from the fresh snapshot.")
             }
             element = resolved
         } else if let elementID = toolCall.elementID, !elementID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             guard let resolved = registry?.element(for: elementID) else {
-                return .failure("Stale or unknown element_id \(elementID). Run get_window_state again and use an element from the fresh snapshot.")
+                return .failure("Stale or unknown element_id \(elementID). Run get_app_state again and use an element from the fresh snapshot.")
             }
             element = resolved
         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseObservation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseObservation.swift
@@ -34,6 +34,8 @@ struct ComputerUseElementCandidate: Codable, Equatable {
     let enabled: Bool
     let frame: ComputerUseRect?
     let path: String
+    let actionNames: [String]
+    let processID: Int?
 
     enum CodingKeys: String, CodingKey {
         case elementID = "element_id"
@@ -46,6 +48,36 @@ struct ComputerUseElementCandidate: Codable, Equatable {
         case enabled
         case frame
         case path
+        case actionNames = "action_names"
+        case processID = "process_id"
+    }
+
+    init(
+        elementID: String,
+        elementIndex: Int,
+        role: String,
+        title: String,
+        label: String,
+        value: String,
+        help: String,
+        enabled: Bool,
+        frame: ComputerUseRect?,
+        path: String,
+        actionNames: [String] = [],
+        processID: Int? = nil
+    ) {
+        self.elementID = elementID
+        self.elementIndex = elementIndex
+        self.role = role
+        self.title = title
+        self.label = label
+        self.value = value
+        self.help = help
+        self.enabled = enabled
+        self.frame = frame
+        self.path = path
+        self.actionNames = actionNames
+        self.processID = processID
     }
 
     var normalizedText: String {
@@ -57,6 +89,28 @@ struct ComputerUseElementCandidate: Codable, Equatable {
             .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
             .joined(separator: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct ComputerUseFocusedElement: Codable, Equatable {
+    let role: String
+    let title: String
+    let label: String
+    let value: String
+    let frame: ComputerUseRect?
+    let processID: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case title
+        case label
+        case value
+        case frame
+        case processID = "process_id"
+    }
+
+    var normalizedText: String {
+        ComputerUseElementCandidate.normalizedText([title, label, value].joined(separator: " "))
     }
 }
 
@@ -105,24 +159,64 @@ extension ComputerUseScreenshotObservation: Codable {
 }
 
 struct ComputerUseObservation: Codable, Equatable {
+    let stateID: String
     let appName: String
     let bundleID: String
     let windowTitle: String
     let windowFrame: ComputerUseRect?
     let screenshot: ComputerUseScreenshotObservation?
     let cursorPosition: ComputerUseRect?
+    let focusedElement: ComputerUseFocusedElement?
+    let selectedText: String?
+    let appInstructions: String?
     let elements: [ComputerUseElementCandidate]
     let capturedAt: Date
 
     enum CodingKeys: String, CodingKey {
+        case stateID = "state_id"
         case appName = "app_name"
         case bundleID = "bundle_id"
         case windowTitle = "window_title"
         case windowFrame = "window_frame"
         case screenshot
         case cursorPosition = "cursor_position"
+        case focusedElement = "focused_element"
+        case selectedText = "selected_text"
+        case appInstructions = "app_instructions"
         case elements
         case capturedAt = "captured_at"
+    }
+
+    init(
+        stateID: String = Self.newStateID(),
+        appName: String,
+        bundleID: String,
+        windowTitle: String,
+        windowFrame: ComputerUseRect?,
+        screenshot: ComputerUseScreenshotObservation?,
+        cursorPosition: ComputerUseRect?,
+        focusedElement: ComputerUseFocusedElement? = nil,
+        selectedText: String? = nil,
+        appInstructions: String? = nil,
+        elements: [ComputerUseElementCandidate],
+        capturedAt: Date
+    ) {
+        self.stateID = stateID
+        self.appName = appName
+        self.bundleID = bundleID
+        self.windowTitle = windowTitle
+        self.windowFrame = windowFrame
+        self.screenshot = screenshot
+        self.cursorPosition = cursorPosition
+        self.focusedElement = focusedElement
+        self.selectedText = selectedText
+        self.appInstructions = appInstructions
+        self.elements = elements
+        self.capturedAt = capturedAt
+    }
+
+    static func newStateID() -> String {
+        "state-\(Int(Date().timeIntervalSince1970 * 1000))-\(UUID().uuidString.prefix(8))"
     }
 }
 
@@ -140,27 +234,44 @@ struct ComputerUseObservationTarget: Codable, Equatable {
 
 @MainActor
 final class ComputerUseElementRegistry {
+    struct Fingerprint: Equatable {
+        let role: String
+        let path: String
+        let normalizedText: String
+        let frame: ComputerUseRect?
+        let processID: Int?
+    }
+
     private var elements: [String: AXUIElement] = [:]
     private var indexedElements: [Int: AXUIElement] = [:]
+    private var elementFingerprintsByID: [String: Fingerprint] = [:]
+    private var elementFingerprintsByIndex: [Int: Fingerprint] = [:]
     private var screenshot: ComputerUseScreenshotObservation?
 
     func clear() {
         elements.removeAll()
         indexedElements.removeAll()
+        elementFingerprintsByID.removeAll()
+        elementFingerprintsByIndex.removeAll()
         screenshot = nil
     }
 
-    func register(_ element: AXUIElement, id: String, index: Int) {
+    func register(_ element: AXUIElement, candidate: ComputerUseElementCandidate) {
+        let id = candidate.elementID
+        let index = candidate.elementIndex
         elements[id] = element
         indexedElements[index] = element
+        let fingerprint = Fingerprint(candidate)
+        elementFingerprintsByID[id] = fingerprint
+        elementFingerprintsByIndex[index] = fingerprint
     }
 
     func element(for id: String) -> AXUIElement? {
-        elements[id]
+        resolve(elements[id], fingerprint: elementFingerprintsByID[id])
     }
 
     func element(for index: Int) -> AXUIElement? {
-        indexedElements[index]
+        resolve(indexedElements[index], fingerprint: elementFingerprintsByIndex[index])
     }
 
     func registerScreenshot(_ screenshot: ComputerUseScreenshotObservation?) {
@@ -173,6 +284,49 @@ final class ComputerUseElementRegistry {
 
     var registeredIDsForTests: Set<String> {
         Set(elements.keys)
+    }
+
+    private func resolve(_ element: AXUIElement?, fingerprint: Fingerprint?) -> AXUIElement? {
+        guard let element else { return nil }
+        guard let fingerprint else { return element }
+        if Self.isValid(element) {
+            return element
+        }
+        let matches = elements.values.filter { candidate in
+            Self.isValid(candidate) && Self.fingerprint(for: candidate) == fingerprint
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    private static func isValid(_ element: AXUIElement) -> Bool {
+        var value: CFTypeRef?
+        return AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &value) == .success
+    }
+
+    private static func fingerprint(for element: AXUIElement) -> Fingerprint {
+        let role = ComputerUseObservationCapture.axString(element, kAXRoleAttribute)
+        let title = ComputerUseObservationCapture.axString(element, kAXTitleAttribute)
+        let label = ComputerUseObservationCapture.axString(element, kAXDescriptionAttribute)
+        let value = ComputerUseObservationCapture.axString(element, kAXValueAttribute)
+        let help = ComputerUseObservationCapture.axString(element, kAXHelpAttribute)
+        let text = ComputerUseElementCandidate.normalizedText([title, label, value, help].joined(separator: " "))
+        return Fingerprint(
+            role: role,
+            path: "",
+            normalizedText: text,
+            frame: ComputerUseObservationCapture.rect(element).map(ComputerUseRect.init),
+            processID: ComputerUseObservationCapture.processID(of: element).map(Int.init)
+        )
+    }
+}
+
+extension ComputerUseElementRegistry.Fingerprint {
+    init(_ candidate: ComputerUseElementCandidate) {
+        role = candidate.role
+        path = ""
+        normalizedText = candidate.normalizedText
+        frame = candidate.frame
+        processID = candidate.processID
     }
 }
 
@@ -202,6 +356,9 @@ enum ComputerUseObservationCapture {
                 windowFrame: nil,
                 screenshot: nil,
                 cursorPosition: cursorPositionObservation(),
+                focusedElement: nil,
+                selectedText: nil,
+                appInstructions: ComputerUseAppInstructionProvider.instructions(for: bundleID, appName: appName),
                 elements: [],
                 capturedAt: capturedAt
             )
@@ -214,6 +371,9 @@ enum ComputerUseObservationCapture {
         let windowFrame = window.flatMap(rect)
         let screenshot = includeScreenshot ? captureScreenshot(for: app, fallbackFrame: windowFrame) : nil
         registry.registerScreenshot(screenshot)
+        let focusedElement = focusedElementObservation(requiredPID: app.processIdentifier)
+        let selectedText = selectedTextObservation(from: focusedElement)
+        let appInstructions = ComputerUseAppInstructionProvider.instructions(for: bundleID, appName: appName)
 
         var candidates: [ComputerUseElementCandidate] = []
         var visited = Set<AXUIElement>()
@@ -235,6 +395,9 @@ enum ComputerUseObservationCapture {
             windowFrame: windowFrame.map(ComputerUseRect.init),
             screenshot: screenshot,
             cursorPosition: cursorPositionObservation(),
+            focusedElement: focusedElement,
+            selectedText: selectedText,
+            appInstructions: appInstructions,
             elements: candidates,
             capturedAt: capturedAt
         )
@@ -281,7 +444,7 @@ enum ComputerUseObservationCapture {
 
         let nextIndex = candidates.count + 1
         if let candidate = candidate(from: element, id: "e\(nextIndex)", index: nextIndex, path: path) {
-            registry.register(element, id: candidate.elementID, index: candidate.elementIndex)
+            registry.register(element, candidate: candidate)
             candidates.append(candidate)
         }
 
@@ -308,6 +471,8 @@ enum ComputerUseObservationCapture {
         let help = axString(element, kAXHelpAttribute)
         let enabled = axBool(element, kAXEnabledAttribute) ?? true
         let frame = rect(element).map(ComputerUseRect.init)
+        let actions = actionNames(of: element)
+        let pid = processID(of: element).map(Int.init)
 
         let text = ComputerUseElementCandidate.normalizedText([title, label, value, help].joined(separator: " "))
         guard !role.isEmpty || !text.isEmpty else { return nil }
@@ -322,7 +487,9 @@ enum ComputerUseObservationCapture {
             help: truncate(help, limit: 80),
             enabled: enabled,
             frame: frame,
-            path: path
+            path: path,
+            actionNames: actions,
+            processID: pid
         )
     }
 
@@ -367,7 +534,7 @@ enum ComputerUseObservationCapture {
         return rawChildren
     }
 
-    private static func axString(_ element: AXUIElement, _ attribute: String) -> String {
+    static func axString(_ element: AXUIElement, _ attribute: String) -> String {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else { return "" }
         if let string = value as? String {
@@ -385,7 +552,7 @@ enum ComputerUseObservationCapture {
         return value as? Bool
     }
 
-    private static func rect(_ element: AXUIElement) -> CGRect? {
+    static func rect(_ element: AXUIElement) -> CGRect? {
         var positionRef: CFTypeRef?
         var sizeRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef) == .success,
@@ -402,6 +569,51 @@ enum ComputerUseObservationCapture {
               AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
         else { return nil }
         return CGRect(origin: position, size: size)
+    }
+
+    static func processID(of element: AXUIElement) -> pid_t? {
+        var pid: pid_t = 0
+        guard AXUIElementGetPid(element, &pid) == .success else { return nil }
+        return pid
+    }
+
+    private static func actionNames(of element: AXUIElement) -> [String] {
+        var rawActions: CFArray?
+        guard AXUIElementCopyActionNames(element, &rawActions) == .success else { return [] }
+        return (rawActions as? [String]) ?? []
+    }
+
+    private static func focusedElementObservation(requiredPID: pid_t) -> ComputerUseFocusedElement? {
+        let system = AXUIElementCreateSystemWide()
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &value) == .success,
+              let rawElement = value,
+              CFGetTypeID(rawElement) == AXUIElementGetTypeID()
+        else { return nil }
+
+        let element = rawElement as! AXUIElement
+        guard processID(of: element) == requiredPID else { return nil }
+        return ComputerUseFocusedElement(
+            role: axString(element, kAXRoleAttribute),
+            title: truncate(axString(element, kAXTitleAttribute), limit: 80),
+            label: truncate(axString(element, kAXDescriptionAttribute), limit: 80),
+            value: truncate(axString(element, kAXValueAttribute), limit: 160),
+            frame: rect(element).map(ComputerUseRect.init),
+            processID: processID(of: element).map(Int.init)
+        )
+    }
+
+    private static func selectedTextObservation(from focusedElement: ComputerUseFocusedElement?) -> String? {
+        guard focusedElement != nil else { return nil }
+        let system = AXUIElementCreateSystemWide()
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &value) == .success,
+              let rawElement = value,
+              CFGetTypeID(rawElement) == AXUIElementGetTypeID()
+        else { return nil }
+        let selected = axString(rawElement as! AXUIElement, kAXSelectedTextAttribute)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return selected.isEmpty ? nil : truncate(selected, limit: 240)
     }
 
     private static func cursorPositionObservation() -> ComputerUseRect {
@@ -547,6 +759,54 @@ enum ComputerUseObservationCapture {
             .split(whereSeparator: { $0.isWhitespace })
             .joined(separator: " ")
             .replacingOccurrences(of: #" app$"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum ComputerUseAppInstructionProvider {
+    static func instructions(for bundleID: String, appName: String) -> String? {
+        var hints: [String] = []
+        if isBrowser(bundleID: bundleID, appName: appName) {
+            hints.append("Browser hint: for a new web task, open a fresh tab with command+t, then use navigate_url on the active tab without tab indexes. Use tab listing only when continuing or finding an existing tab. If DOM/page tools fail or return nothing, continue with AX, screenshot, keyboard, and mouse control.")
+        }
+        if isNativeRichTextApp(bundleID: bundleID, appName: appName) {
+            hints.append("Native rich-text hint: focus the editable title/body before insertion, prefer paste_text for multi-word text, and verify the focused value or visible AX text changed before proceeding.")
+        }
+        return hints.isEmpty ? nil : hints.joined(separator: "\n")
+    }
+
+    private static func isBrowser(bundleID: String, appName: String) -> Bool {
+        let identifiers = Set([
+            "com.google.Chrome",
+            "com.apple.Safari",
+            "org.mozilla.firefox",
+            "company.thebrowser.Browser",
+            "com.microsoft.edgemac",
+        ])
+        if identifiers.contains(bundleID) {
+            return true
+        }
+        let name = canonical(appName)
+        return ["chrome", "google chrome", "safari", "firefox", "arc", "edge", "microsoft edge"].contains(name)
+    }
+
+    private static func isNativeRichTextApp(bundleID: String, appName: String) -> Bool {
+        let identifiers = Set([
+            "com.apple.Notes",
+            "com.apple.TextEdit",
+            "com.apple.mail",
+        ])
+        if identifiers.contains(bundleID) {
+            return true
+        }
+        let name = canonical(appName)
+        return ["notes", "textedit", "text edit", "mail"].contains(name)
+    }
+
+    private static func canonical(_ value: String) -> String {
+        value.lowercased()
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .joined(separator: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseObservation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseObservation.swift
@@ -371,8 +371,9 @@ enum ComputerUseObservationCapture {
         let windowFrame = window.flatMap(rect)
         let screenshot = includeScreenshot ? captureScreenshot(for: app, fallbackFrame: windowFrame) : nil
         registry.registerScreenshot(screenshot)
-        let focusedElement = focusedElementObservation(requiredPID: app.processIdentifier)
-        let selectedText = selectedTextObservation(from: focusedElement)
+        let focusedElementSnapshot = focusedElementSnapshot(requiredPID: app.processIdentifier)
+        let focusedElement = focusedElementSnapshot?.observation
+        let selectedText = selectedTextObservation(from: focusedElementSnapshot?.element)
         let appInstructions = ComputerUseAppInstructionProvider.instructions(for: bundleID, appName: appName)
 
         var candidates: [ComputerUseElementCandidate] = []
@@ -583,7 +584,12 @@ enum ComputerUseObservationCapture {
         return (rawActions as? [String]) ?? []
     }
 
-    private static func focusedElementObservation(requiredPID: pid_t) -> ComputerUseFocusedElement? {
+    private struct FocusedElementSnapshot {
+        let element: AXUIElement
+        let observation: ComputerUseFocusedElement
+    }
+
+    private static func focusedElementSnapshot(requiredPID: pid_t) -> FocusedElementSnapshot? {
         let system = AXUIElementCreateSystemWide()
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &value) == .success,
@@ -593,7 +599,7 @@ enum ComputerUseObservationCapture {
 
         let element = rawElement as! AXUIElement
         guard processID(of: element) == requiredPID else { return nil }
-        return ComputerUseFocusedElement(
+        let observation = ComputerUseFocusedElement(
             role: axString(element, kAXRoleAttribute),
             title: truncate(axString(element, kAXTitleAttribute), limit: 80),
             label: truncate(axString(element, kAXDescriptionAttribute), limit: 80),
@@ -601,17 +607,12 @@ enum ComputerUseObservationCapture {
             frame: rect(element).map(ComputerUseRect.init),
             processID: processID(of: element).map(Int.init)
         )
+        return FocusedElementSnapshot(element: element, observation: observation)
     }
 
-    private static func selectedTextObservation(from focusedElement: ComputerUseFocusedElement?) -> String? {
-        guard focusedElement != nil else { return nil }
-        let system = AXUIElementCreateSystemWide()
-        var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &value) == .success,
-              let rawElement = value,
-              CFGetTypeID(rawElement) == AXUIElementGetTypeID()
-        else { return nil }
-        let selected = axString(rawElement as! AXUIElement, kAXSelectedTextAttribute)
+    private static func selectedTextObservation(from focusedElement: AXUIElement?) -> String? {
+        guard let focusedElement else { return nil }
+        let selected = axString(focusedElement, kAXSelectedTextAttribute)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return selected.isEmpty ? nil : truncate(selected, limit: 240)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ComputerUsePlannerError: LocalizedError, Equatable {
     case notAuthenticated
     case invalidResponse(String)
+    case invalidToolCall(name: String, arguments: String, message: String)
     case backendFailed(statusCode: Int, message: String)
     case requestFailed(String)
 
@@ -12,6 +13,8 @@ enum ComputerUsePlannerError: LocalizedError, Equatable {
             return "Connect ChatGPT to use model-driven computer use."
         case .invalidResponse(let message):
             return "CUA planner returned an invalid tool call. \(message)"
+        case .invalidToolCall(let name, let arguments, let message):
+            return "CUA planner returned an invalid tool call. \(message) Raw native tool call: \(name) \(String(arguments.prefix(800)))"
         case .backendFailed(let statusCode, let message):
             return "CUA planner failed with status \(statusCode). \(message)"
         case .requestFailed(let message):
@@ -29,27 +32,29 @@ enum ComputerUsePlannerClient {
     You are Muesli's computer-use planner. You do not execute actions. You must choose exactly one native tool call from the provided tool list.
 
     Rules:
-    - Only use element_index or element_id values present in latest_window_state. Element references expire after each new get_window_state or refreshed state.
+    - Only use element_index or element_id values present in latest_window_state. Element references expire after each new get_app_state/get_window_state or refreshed state.
     - Never invent AppleScript, shell commands, code, URLs, or tools.
     - For app launch/navigation, use launch_app with the requested app name or app bundle id. Do not substitute another app because it is frontmost, visible, or present in examples.
-    - After launch_app, Muesli will refresh the requested app's state automatically. If the next state is not the requested app, call get_window_state for that app before using fail.
-    - Prefer get_window_state when the current state is insufficient or appears to be for the wrong app.
-    - Prefer element-targeted click/set_value over coordinate clicks when a matching element exists.
+    - After launch_app, Muesli will refresh the requested app's state automatically. If the next state is not the requested app, call get_app_state for that app before using fail.
+    - Prefer get_app_state when the current state is insufficient or appears to be for the wrong app. get_window_state is a compatibility alias.
+    - Prefer click_element/set_value over coordinate clicks when a matching element exists.
     - For coordinate click/drag, use screenshot pixel coordinates from the current screenshot, not global screen coordinates.
     - Include screenshot_id from latest_window_state when using screenshot-coordinate tools.
-    - For click, choose exactly one addressing mode: either element_index/element_id OR x/y+screenshot_id. Never include both an element target and coordinates in the same click.
-    - For YouTube, Hacker News, and browser tasks in Chrome, prefer list_browser_tabs, activate_browser_tab, navigate_url, page_get_text, and page_query_dom before AX clicking when those tools are available.
-    - Browser page tools are optional shortcuts, not the only way to use a page. If page_get_text or page_query_dom fails, is blocked by Chrome Apple Events JavaScript permission, or returns insufficient content, continue with get_window_state plus AX/screenshot actions such as click, paste_text/type_text, press_key/hotkey, and scroll.
+    - Use click_element for AX candidates and click_point for screenshot coordinates. Never use legacy click unless it appears in an old prior trace.
+    - For new or separate browser tasks, prefer open_new_browser_tab and then navigate_active_browser_tab. Use list_browser_tabs and activate_browser_tab only when the user asks to continue, find, or reuse an existing tab.
+    - Browser DOM/page tools are optional accelerators. Use page_get_text/page_query_dom when useful, but do not depend on them as the control path.
+    - If page_get_text, page_query_dom, or list_browser_tabs fails, is blocked by Chrome Apple Events JavaScript permission, returns insufficient content, or returns no tabs, immediately continue with get_app_state plus AX/screenshot actions such as click_element/click_point, paste_text/type_text, press_key/hotkey, and scroll.
     - For text entry, prefer app-scoped calls: include app_name/app_bundle_id, and include element_index/element_id when an editable target is visible in the latest state.
     - type_text sends literal keyboard input after Muesli activates the requested app and verifies a focused editable target. Use it for normal typing into focused text fields.
     - For Apple Notes and native rich-text editors, first focus the editable note body/title, then prefer paste_text for multi-word text. Use type_text only for short direct key-event text entry when paste_text is inappropriate.
     - Do not use fail only because a browser DOM/page tool failed. Use fail only after trying the available AX/screenshot fallback path or when the requested task is unsafe or truly unsupported.
-    - After get_window_state returns a fresh state, act on the visible AX/screenshot evidence. Do not call get_window_state repeatedly unless a tool result indicates the app/window changed or a previous action needs verification.
-    - If browser page tools are blocked, use the screenshot and AX candidates to click, type, press keys, or scroll; do not loop on observation waiting for DOM access to appear.
-    - navigate_url may only use http or https URLs. Never output javascript:, file:, data:, shell text, or arbitrary code.
-    - For navigate_url, omit window_index and tab_index unless they came from a recent list_browser_tabs result. After hotkey command+t, call navigate_url without tab_index so Muesli navigates the active new tab.
+    - After get_app_state returns a fresh state, act on the visible AX/screenshot evidence. Do not call get_app_state/get_window_state repeatedly unless a tool result indicates the app/window changed or a previous action needs verification.
+    - Every mutating action result includes verification. If the prior outcome says no relevant UI change was observed, choose a different strategy such as a different target, different text primitive, keyboard navigation, or get_app_state before retrying.
+    - If browser page tools are blocked, use the screenshot and AX candidates to click_element/click_point, type, press keys, or scroll; do not loop on observation waiting for DOM access to appear.
+    - navigate_url and navigate_active_browser_tab may only use http or https URLs. Never output javascript:, file:, data:, shell text, or arbitrary code.
+    - For navigate_url, include window_index/tab_index only when they came from a recent list_browser_tabs result. After open_new_browser_tab, call navigate_active_browser_tab.
     - max_steps is a high safety ceiling, not a target. Use as few steps as needed.
-    - Use finish only when the user's command is complete. Use fail(reason) when blocked, unsafe, unsupported, or incomplete.
+    - Use finish only when the user's command is complete and successful. If the task could not be completed, is blocked, is unsafe, or needs missing permission/confirmation, use fail(reason); never put blocked or incomplete language in finish.
     - Risky actions are locally blocked by Muesli; do not try to bypass confirmation.
     """
     }
@@ -167,8 +172,10 @@ enum ComputerUsePlannerClient {
                     arguments: nativeToolCall.arguments
                 )
             } catch {
-                throw ComputerUsePlannerError.invalidResponse(
-                    "\(error.localizedDescription) Raw native tool call: \(nativeToolCall.name) \(String(nativeToolCall.arguments.prefix(800)))"
+                throw ComputerUsePlannerError.invalidToolCall(
+                    name: nativeToolCall.name,
+                    arguments: nativeToolCall.arguments,
+                    message: error.localizedDescription
                 )
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
@@ -504,7 +504,11 @@ final class ComputerUsePlannerRuntime {
         guard shouldTrackForRepetition(toolCall.tool), let delta else { return nil }
         let key = repeatedActionKey(toolCall)
         guard delta.status == .unchanged else {
-            counts.removeValue(forKey: key)
+            if delta.status == .changed {
+                counts.removeAll()
+            } else {
+                counts.removeValue(forKey: key)
+            }
             return nil
         }
         let count = (counts[key] ?? 0) + 1
@@ -536,49 +540,19 @@ final class ComputerUsePlannerRuntime {
 
     private func finishIndicatesFailure(_ reason: String) -> Bool {
         let lowered = reason.lowercased()
-        let failurePhrases = [
-            "cannot",
-            "can't",
-            "could not",
-            "unable",
-            "blocked",
-            "incomplete",
-            "not complete",
-            "not completed",
-            "failed",
-            "unsupported",
-            "permission",
-            "requires confirmation",
-            "was not able",
-            "did not",
+        let failurePatterns = [
+            #"^\s*(blocked|failed|unsupported|incomplete|not completed?)\s*[.!]?\s*$"#,
+            #"\b(requires|needs)\s+confirmation\b"#,
+            #"\b(task|request|command|workflow)\s+(is\s+)?(blocked|incomplete|not completed?|failed|unsupported)\b"#,
+            #"\b(cannot|can't|could not|unable to|was not able to)\s+(complete|finish|perform|do|continue|proceed|access|open|click|type|paste|navigate|find)\b"#,
+            #"\b(did not|didn't)\s+(complete|finish|perform|send|post|open|click|type|paste|navigate|find)\b"#,
+            #"\b(permission|permissions)\s+(required|needed|denied|missing|not granted)\b"#,
+            #"\b(not authorized|not allowed|access denied)\b"#,
+            #"\bfailed to\s+(complete|finish|perform|open|click|type|paste|navigate|send|post)\b"#,
         ]
-        return failurePhrases.contains { lowered.contains($0) }
-    }
-
-    private func repeatedActionMessage(
-        toolCall: ComputerUseToolCall,
-        observation: ComputerUseObservation,
-        repeatedToolCounts: inout [String: Int]
-    ) -> String? {
-        guard shouldTrackForRepetition(toolCall.tool) else { return nil }
-        var keyParts: [String] = []
-        keyParts.append(toolCall.tool.rawValue)
-        keyParts.append(toolCall.elementID ?? "")
-        keyParts.append(toolCall.elementIndex.map(String.init) ?? "")
-        keyParts.append(toolCall.appName ?? "")
-        keyParts.append(toolCall.canonicalBundleID)
-        keyParts.append(toolCall.label ?? "")
-        keyParts.append(toolCall.key ?? "")
-        keyParts.append(toolCall.text ?? "")
-        keyParts.append(toolCall.value ?? "")
-        keyParts.append(toolCall.url ?? "")
-        keyParts.append(toolCall.direction?.rawValue ?? "")
-        keyParts.append(observationSignature(observation))
-        let key = keyParts.joined(separator: "|")
-        let count = (repeatedToolCounts[key] ?? 0) + 1
-        repeatedToolCounts[key] = count
-        guard count > 2 else { return nil }
-        return "CUA stopped repeated \(toolCall.summary) after two unchanged attempts."
+        return failurePatterns.contains { pattern in
+            lowered.range(of: pattern, options: .regularExpression) != nil
+        }
     }
 
     private func shouldTrackForRepetition(_ tool: ComputerUseToolName) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
@@ -4,6 +4,7 @@ import MuesliCore
 struct ComputerUsePlannerRuntimeResult: Equatable {
     enum Status: Equatable {
         case done
+        case timedOut
         case needsConfirmation
         case failed
         case cancelled
@@ -36,6 +37,7 @@ final class ComputerUsePlannerRuntime {
     private let plan: PlanHandler
     private let execute: ExecuteHandler
     private let maxPlannerRetries = 1
+    private let maxUnchangedObservationLoops = 4
 
     init(
         config: AppConfig,
@@ -85,6 +87,7 @@ final class ComputerUsePlannerRuntime {
         let deadline = Date().addingTimeInterval(timeoutSeconds)
         var priorResults: [ComputerUseToolOutcome] = []
         var unchangedActionCounts: [String: Int] = [:]
+        var unchangedObservationCounts: [String: Int] = [:]
         var invalidToolCallRepairCount = 0
         let maxInvalidToolCallRepairs = 2
         // V1 keeps foreground activation, but state is scoped to a target app.
@@ -102,8 +105,8 @@ final class ComputerUsePlannerRuntime {
                 return cancelledResult(traceEvents: traceEvents, step: step)
             }
             if Date() >= deadline {
-                traceEvents.append(traceEvent(kind: "failed", title: "Failed", body: "CUA timed out", status: "failed", step: step))
-                return .init(status: .failed, message: "CUA timed out", traceEvents: traceEvents)
+                traceEvents.append(traceEvent(kind: "timed_out", title: "Timed out", body: "CUA timed out", status: "timed_out", step: step))
+                return .init(status: .timedOut, message: "CUA timed out", traceEvents: traceEvents)
             }
             if let maxSteps, step > maxSteps {
                 traceEvents.append(traceEvent(kind: "failed", title: "Failed", body: "CUA reached its step limit", status: "failed", step: maxSteps))
@@ -222,34 +225,28 @@ final class ComputerUsePlannerRuntime {
                 onStatus("Observing screen")
                 observation = observe(registry, true, currentTarget)
                 traceEvents.append(observationEvent(observation, step: step))
-                let delta = stateDelta(
+                let feedback = observationToolFeedback(
                     before: beforeObservation,
                     after: observation,
                     toolCall: toolCall,
-                    result: result
-                )
-                let outcomeMessage = verifiedOutcomeMessage(
-                    base: recoverableFallbackMessage(for: toolCall, result: result) ?? result.message,
-                    delta: delta
+                    result: result,
+                    counts: &unchangedObservationCounts
                 )
                 priorResults.append(outcome(
                     step: step,
                     toolCall: toolCall,
                     result: result,
-                    message: outcomeMessage,
+                    message: feedback.message,
                     observation: observation,
-                    delta: delta
+                    delta: nil
                 ))
-                if let blocked = repeatedUnchangedMessage(
-                    toolCall: toolCall,
-                    delta: delta,
-                    counts: &unchangedActionCounts
-                ) {
+                if let blocked = feedback.blocked {
                     traceEvents.append(traceEvent(kind: "failed", title: "Repeated action stopped", body: blocked, status: "failed", step: step))
                     return .init(status: .failed, message: blocked, traceEvents: traceEvents)
                 }
                 continue
             default:
+                unchangedObservationCounts.removeAll()
                 onStatus(statusTitle(for: toolCall))
                 traceEvents.append(traceEvent(
                     kind: "tool_call",
@@ -470,6 +467,35 @@ final class ComputerUsePlannerRuntime {
         return "\(base). Verification: \(delta.summary)"
     }
 
+    private func observationToolFeedback(
+        before: ComputerUseObservation,
+        after: ComputerUseObservation,
+        toolCall: ComputerUseToolCall,
+        result: ComputerUseExecutionResult,
+        counts: inout [String: Int]
+    ) -> (message: String, blocked: String?) {
+        let base = recoverableFallbackMessage(for: toolCall, result: result) ?? result.message
+        let key = repeatedActionKey(toolCall)
+        guard observationSignature(before) == observationSignature(after) else {
+            counts.removeValue(forKey: key)
+            return (
+                "\(base). Captured fresh state; continue from the visible AX/screenshot context.",
+                nil
+            )
+        }
+
+        let count = (counts[key] ?? 0) + 1
+        counts[key] = count
+        let message = "\(base). State is unchanged after \(toolCall.summary); choose a concrete action now and do not call get_app_state/get_window_state again unless the target app or window changes."
+        guard count >= maxUnchangedObservationLoops else {
+            return (message, nil)
+        }
+        return (
+            message,
+            "CUA stopped repeated \(toolCall.summary) after \(maxUnchangedObservationLoops) unchanged observations with no intervening action. Choose a concrete action instead of observing again."
+        )
+    }
+
     private func repeatedUnchangedMessage(
         toolCall: ComputerUseToolCall,
         delta: ComputerUseStateDelta?,
@@ -557,9 +583,9 @@ final class ComputerUsePlannerRuntime {
 
     private func shouldTrackForRepetition(_ tool: ComputerUseToolName) -> Bool {
         switch tool {
-        case .moveCursor, .click, .clickElement, .clickPoint, .performSecondaryAction, .drag, .pressKey, .hotkey, .typeText, .pasteText, .setValue, .scroll, .navigateURL, .navigateActiveBrowserTab, .openNewBrowserTab, .activateBrowserTab, .getAppState, .getWindowState:
+        case .moveCursor, .click, .clickElement, .clickPoint, .performSecondaryAction, .drag, .pressKey, .hotkey, .typeText, .pasteText, .setValue, .scroll, .navigateURL, .navigateActiveBrowserTab, .openNewBrowserTab, .activateBrowserTab:
             return true
-        case .listApps, .launchApp, .listWindows, .listBrowserTabs, .pageGetText, .pageQueryDOM, .finish, .fail:
+        case .listApps, .launchApp, .listWindows, .getAppState, .getWindowState, .listBrowserTabs, .pageGetText, .pageQueryDOM, .finish, .fail:
             return false
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerRuntime.swift
@@ -84,7 +84,9 @@ final class ComputerUsePlannerRuntime {
 
         let deadline = Date().addingTimeInterval(timeoutSeconds)
         var priorResults: [ComputerUseToolOutcome] = []
-        var repeatedToolCounts: [String: Int] = [:]
+        var unchangedActionCounts: [String: Int] = [:]
+        var invalidToolCallRepairCount = 0
+        let maxInvalidToolCallRepairs = 2
         // V1 keeps foreground activation, but state is scoped to a target app.
         // Later Codex-style work should replace this with background key-window tracking,
         // synthetic focus enforcement, and user-frontmost-app preservation.
@@ -122,6 +124,31 @@ final class ComputerUsePlannerRuntime {
                 response = try await planWithRetry(request, traceEvents: &traceEvents)
             } catch is CancellationError {
                 return cancelledResult(traceEvents: traceEvents, step: step)
+            } catch ComputerUsePlannerError.invalidToolCall(let name, let arguments, let message) {
+                let repairMessage = "Invalid tool call \(name): \(message). Raw arguments: \(String(arguments.prefix(800))). Choose exactly one valid tool from the current catalog and follow that tool's schema."
+                traceEvents.append(traceEvent(
+                    kind: "planner_repair",
+                    title: "Planner schema repair",
+                    body: repairMessage,
+                    status: "repair",
+                    step: step
+                ))
+                priorResults.append(ComputerUseToolOutcome(
+                    step: step,
+                    tool: .fail,
+                    status: "invalid_schema",
+                    message: repairMessage,
+                    appName: observation.appName,
+                    bundleID: observation.bundleID,
+                    windowTitle: observation.windowTitle,
+                    snapshotID: observation.screenshot?.screenshotID
+                ))
+                invalidToolCallRepairCount += 1
+                if invalidToolCallRepairCount <= maxInvalidToolCallRepairs {
+                    continue
+                }
+                traceEvents.append(traceEvent(kind: "failed", title: "Planner failed", body: repairMessage, status: "failed", step: step))
+                return .init(status: .failed, message: repairMessage, traceEvents: traceEvents)
             } catch {
                 traceEvents.append(traceEvent(
                     kind: "failed",
@@ -134,6 +161,7 @@ final class ComputerUsePlannerRuntime {
             }
 
             let toolCall = response.toolCall
+            invalidToolCallRepairCount = 0
             if let target = target(from: toolCall, fallback: currentTarget) {
                 currentTarget = target
             }
@@ -148,14 +176,6 @@ final class ComputerUsePlannerRuntime {
                 traceEvents.append(traceEvent(kind: "failed", title: "Schema rejected", body: validationFailure, status: "failed", step: step))
                 return .init(status: .failed, message: validationFailure, traceEvents: traceEvents)
             }
-            if let repeatedActionMessage = repeatedActionMessage(
-                toolCall: toolCall,
-                observation: observation,
-                repeatedToolCounts: &repeatedToolCounts
-            ) {
-                traceEvents.append(traceEvent(kind: "failed", title: "Repeated action stopped", body: repeatedActionMessage, status: "failed", step: step))
-                return .init(status: .failed, message: repeatedActionMessage, traceEvents: traceEvents)
-            }
             if toolCall.requiresConfirmation {
                 onStatus("Confirm")
                 let message = "Confirm: \(toolCall.summary)"
@@ -167,6 +187,11 @@ final class ComputerUsePlannerRuntime {
             case .finish:
                 onStatus("Done")
                 let message = toolCall.reason?.isEmpty == false ? toolCall.reason! : "Done"
+                if finishIndicatesFailure(message) {
+                    let blockedMessage = "Planner attempted to finish with an incomplete or blocked result: \(message)"
+                    traceEvents.append(traceEvent(kind: "failed", title: "Final output blocked", body: blockedMessage, status: "failed", step: step))
+                    return .init(status: .failed, message: blockedMessage, traceEvents: traceEvents)
+                }
                 traceEvents.append(traceEvent(kind: "finish", title: "Final output", body: message, status: "done", step: step))
                 return .init(status: .done, message: message, traceEvents: traceEvents)
             case .fail:
@@ -174,30 +199,55 @@ final class ComputerUsePlannerRuntime {
                 let message = toolCall.reason?.isEmpty == false ? toolCall.reason! : "Failed"
                 traceEvents.append(traceEvent(kind: "failed", title: "Final output", body: message, status: "failed", step: step))
                 return .init(status: .failed, message: message, traceEvents: traceEvents)
-            case .getWindowState:
+            case .getAppState, .getWindowState:
                 onStatus("Observing screen")
+                let beforeObservation = observation
                 let result = await execute(toolCall, registry)
                 if Task.isCancelled || result.status == .cancelled {
                     return cancelledResult(traceEvents: traceEvents, step: step)
                 }
-                let outcomeMessage = recoverableFallbackMessage(for: toolCall, result: result) ?? result.message
-                priorResults.append(ComputerUseToolOutcome(
-                    step: step,
-                    tool: toolCall.tool,
-                    status: "\(result.status)",
-                    message: outcomeMessage,
-                    appName: observation.appName,
-                    bundleID: observation.bundleID,
-                    windowTitle: observation.windowTitle,
-                    snapshotID: observation.screenshot?.screenshotID
-                ))
                 if result.status == .failed || result.status == .unsupported {
+                    let outcomeMessage = recoverableFallbackMessage(for: toolCall, result: result) ?? result.message
+                    priorResults.append(outcome(
+                        step: step,
+                        toolCall: toolCall,
+                        result: result,
+                        message: outcomeMessage,
+                        observation: beforeObservation,
+                        delta: nil
+                    ))
                     traceEvents.append(traceEvent(kind: "failed", title: "Failed", body: result.message, status: "failed", step: step))
                     return .init(status: .failed, message: result.message, traceEvents: traceEvents)
                 }
                 onStatus("Observing screen")
                 observation = observe(registry, true, currentTarget)
                 traceEvents.append(observationEvent(observation, step: step))
+                let delta = stateDelta(
+                    before: beforeObservation,
+                    after: observation,
+                    toolCall: toolCall,
+                    result: result
+                )
+                let outcomeMessage = verifiedOutcomeMessage(
+                    base: recoverableFallbackMessage(for: toolCall, result: result) ?? result.message,
+                    delta: delta
+                )
+                priorResults.append(outcome(
+                    step: step,
+                    toolCall: toolCall,
+                    result: result,
+                    message: outcomeMessage,
+                    observation: observation,
+                    delta: delta
+                ))
+                if let blocked = repeatedUnchangedMessage(
+                    toolCall: toolCall,
+                    delta: delta,
+                    counts: &unchangedActionCounts
+                ) {
+                    traceEvents.append(traceEvent(kind: "failed", title: "Repeated action stopped", body: blocked, status: "failed", step: step))
+                    return .init(status: .failed, message: blocked, traceEvents: traceEvents)
+                }
                 continue
             default:
                 onStatus(statusTitle(for: toolCall))
@@ -208,18 +258,8 @@ final class ComputerUsePlannerRuntime {
                     status: "executing",
                     step: step
                 ))
+                let beforeObservation = observation
                 let result = await execute(toolCall, registry)
-                let outcomeMessage = recoverableFallbackMessage(for: toolCall, result: result) ?? result.message
-                priorResults.append(ComputerUseToolOutcome(
-                    step: step,
-                    tool: toolCall.tool,
-                    status: "\(result.status)",
-                    message: outcomeMessage,
-                    appName: observation.appName,
-                    bundleID: observation.bundleID,
-                    windowTitle: observation.windowTitle,
-                    snapshotID: observation.screenshot?.screenshotID
-                ))
                 traceEvents.append(traceEvent(
                     kind: "tool_result",
                     title: "Tool result",
@@ -237,16 +277,59 @@ final class ComputerUsePlannerRuntime {
                     if let resultTitle = resultStatusTitle(for: toolCall, result: result) {
                         onStatus(resultTitle)
                     }
+                    var delta: ComputerUseStateDelta?
                     if toolCall.isMutating {
                         onStatus("Observing screen")
                         observation = observe(registry, true, currentTarget)
                         traceEvents.append(observationEvent(observation, step: step))
+                        delta = stateDelta(
+                            before: beforeObservation,
+                            after: observation,
+                            toolCall: toolCall,
+                            result: result
+                        )
+                    }
+                    let outcomeMessage = verifiedOutcomeMessage(
+                        base: recoverableFallbackMessage(for: toolCall, result: result) ?? result.message,
+                        delta: delta
+                    )
+                    priorResults.append(outcome(
+                        step: step,
+                        toolCall: toolCall,
+                        result: result,
+                        message: outcomeMessage,
+                        observation: observation,
+                        delta: delta
+                    ))
+                    if let blocked = repeatedUnchangedMessage(
+                        toolCall: toolCall,
+                        delta: delta,
+                        counts: &unchangedActionCounts
+                    ) {
+                        traceEvents.append(traceEvent(kind: "failed", title: "Repeated action stopped", body: blocked, status: "failed", step: step))
+                        return .init(status: .failed, message: blocked, traceEvents: traceEvents)
                     }
                 case .needsConfirmation:
+                    priorResults.append(outcome(
+                        step: step,
+                        toolCall: toolCall,
+                        result: result,
+                        message: result.message,
+                        observation: beforeObservation,
+                        delta: nil
+                    ))
                     traceEvents.append(traceEvent(kind: "confirm", title: "Confirmation required", body: result.message, status: "confirm", step: step))
                     return .init(status: .needsConfirmation, message: result.message, traceEvents: traceEvents)
                 case .unsupported, .failed:
                     if let fallbackMessage = recoverableFallbackMessage(for: toolCall, result: result) {
+                        priorResults.append(outcome(
+                            step: step,
+                            toolCall: toolCall,
+                            result: result,
+                            message: fallbackMessage,
+                            observation: beforeObservation,
+                            delta: nil
+                        ))
                         onStatus("Screen fallback")
                         traceEvents.append(traceEvent(
                             kind: "fallback",
@@ -260,6 +343,14 @@ final class ComputerUsePlannerRuntime {
                         traceEvents.append(observationEvent(observation, step: step))
                         continue
                     }
+                    priorResults.append(outcome(
+                        step: step,
+                        toolCall: toolCall,
+                        result: result,
+                        message: result.message,
+                        observation: beforeObservation,
+                        delta: nil
+                    ))
                     traceEvents.append(traceEvent(kind: "failed", title: "Failed", body: result.message, status: "failed", step: step))
                     return .init(status: .failed, message: result.message, traceEvents: traceEvents)
                 case .cancelled:
@@ -275,12 +366,43 @@ final class ComputerUsePlannerRuntime {
         return .init(status: .cancelled, message: "CUA cancelled", traceEvents: events)
     }
 
+    private func outcome(
+        step: Int,
+        toolCall: ComputerUseToolCall,
+        result: ComputerUseExecutionResult,
+        message: String,
+        observation: ComputerUseObservation,
+        delta: ComputerUseStateDelta?
+    ) -> ComputerUseToolOutcome {
+        ComputerUseToolOutcome(
+            step: step,
+            tool: toolCall.tool,
+            status: "\(result.status)",
+            message: message,
+            appName: observation.appName,
+            bundleID: observation.bundleID,
+            windowTitle: observation.windowTitle,
+            snapshotID: observation.screenshot?.screenshotID,
+            verificationStatus: delta?.status,
+            beforeStateID: delta?.beforeStateID,
+            afterStateID: delta?.afterStateID,
+            stateDelta: delta
+        )
+    }
+
     private func observationEvent(_ observation: ComputerUseObservation, step: Int?) -> ComputerUseTraceEvent {
         let app = observation.appName.isEmpty ? "Unknown app" : observation.appName
         let window = observation.windowTitle.isEmpty ? "No focused window" : observation.windowTitle
-        var details = ["\(app) - \(window) - \(observation.elements.count) AX candidates"]
+        var details = ["state \(observation.stateID)", "\(app) - \(window) - \(observation.elements.count) AX candidates"]
         if let screenshot = observation.screenshot {
             details.append("screenshot \(screenshot.screenshotID) \(screenshot.width)x\(screenshot.height)")
+        }
+        if let focused = observation.focusedElement {
+            let text = focused.normalizedText.isEmpty ? focused.role : "\(focused.role) \(focused.normalizedText)"
+            details.append("focused \(String(text.prefix(80)))")
+        }
+        if let selectedText = observation.selectedText, !selectedText.isEmpty {
+            details.append("selected \(selectedText.count) chars")
         }
         if let cursor = observation.cursorPosition {
             details.append("cursor \(Int(cursor.x.rounded())),\(Int(cursor.y.rounded()))")
@@ -296,6 +418,115 @@ final class ComputerUsePlannerRuntime {
 
     private func stepLimitSuffix(_ maxSteps: Int?) -> String {
         maxSteps.map { " of \($0)" } ?? ""
+    }
+
+    private func stateDelta(
+        before: ComputerUseObservation,
+        after: ComputerUseObservation,
+        toolCall: ComputerUseToolCall,
+        result: ComputerUseExecutionResult
+    ) -> ComputerUseStateDelta {
+        if result.status != .executed {
+            return ComputerUseStateDelta(
+                status: .blocked,
+                summary: result.message,
+                beforeStateID: before.stateID,
+                afterStateID: after.stateID
+            )
+        }
+        if toolCall.tool != .launchApp,
+           !before.bundleID.isEmpty,
+           !after.bundleID.isEmpty,
+           before.bundleID != after.bundleID {
+            return ComputerUseStateDelta(
+                status: .targetLost,
+                summary: "Target app changed from \(before.appName) (\(before.bundleID)) to \(after.appName) (\(after.bundleID)); re-query state before acting again.",
+                beforeStateID: before.stateID,
+                afterStateID: after.stateID
+            )
+        }
+
+        let beforeSignature = observationSignature(before)
+        let afterSignature = observationSignature(after)
+        let status: ComputerUseVerificationStatus = beforeSignature == afterSignature ? .unchanged : .changed
+        let summary: String
+        if status == .changed {
+            summary = "Observed UI state changed after \(toolCall.summary)."
+        } else if toolCall.tool == .typeText || toolCall.tool == .pasteText || toolCall.tool == .setValue {
+            summary = "\(toolCall.summary) executed but no focused value, selected text, or visible AX text change was observed; refocus the editable target or use a different insertion primitive."
+        } else {
+            summary = "\(toolCall.summary) executed but no relevant UI change was observed; choose a different strategy."
+        }
+        return ComputerUseStateDelta(
+            status: status,
+            summary: summary,
+            beforeStateID: before.stateID,
+            afterStateID: after.stateID
+        )
+    }
+
+    private func verifiedOutcomeMessage(base: String, delta: ComputerUseStateDelta?) -> String {
+        guard let delta else { return base }
+        return "\(base). Verification: \(delta.summary)"
+    }
+
+    private func repeatedUnchangedMessage(
+        toolCall: ComputerUseToolCall,
+        delta: ComputerUseStateDelta?,
+        counts: inout [String: Int]
+    ) -> String? {
+        guard shouldTrackForRepetition(toolCall.tool), let delta else { return nil }
+        let key = repeatedActionKey(toolCall)
+        guard delta.status == .unchanged else {
+            counts.removeValue(forKey: key)
+            return nil
+        }
+        let count = (counts[key] ?? 0) + 1
+        counts[key] = count
+        guard count >= 2 else { return nil }
+        return "CUA stopped repeated \(toolCall.summary) after two unchanged attempts: no relevant UI change was observed. Choose a different strategy after running get_app_state."
+    }
+
+    private func repeatedActionKey(_ toolCall: ComputerUseToolCall) -> String {
+        let parts: [String] = [
+            toolCall.tool.rawValue,
+            toolCall.elementID ?? "",
+            toolCall.elementIndex.map(String.init) ?? "",
+            toolCall.appName ?? "",
+            toolCall.canonicalBundleID,
+            toolCall.label ?? "",
+            toolCall.actionName ?? "",
+            toolCall.key ?? "",
+            toolCall.text ?? "",
+            toolCall.value ?? "",
+            toolCall.url ?? "",
+            toolCall.direction?.rawValue ?? "",
+            toolCall.screenshotID ?? "",
+            toolCall.x.map { String($0) } ?? "",
+            toolCall.y.map { String($0) } ?? "",
+        ]
+        return parts.joined(separator: "|")
+    }
+
+    private func finishIndicatesFailure(_ reason: String) -> Bool {
+        let lowered = reason.lowercased()
+        let failurePhrases = [
+            "cannot",
+            "can't",
+            "could not",
+            "unable",
+            "blocked",
+            "incomplete",
+            "not complete",
+            "not completed",
+            "failed",
+            "unsupported",
+            "permission",
+            "requires confirmation",
+            "was not able",
+            "did not",
+        ]
+        return failurePhrases.contains { lowered.contains($0) }
     }
 
     private func repeatedActionMessage(
@@ -326,7 +557,7 @@ final class ComputerUsePlannerRuntime {
 
     private func shouldTrackForRepetition(_ tool: ComputerUseToolName) -> Bool {
         switch tool {
-        case .moveCursor, .click, .drag, .pressKey, .hotkey, .typeText, .pasteText, .setValue, .scroll, .navigateURL, .activateBrowserTab, .getWindowState:
+        case .moveCursor, .click, .clickElement, .clickPoint, .performSecondaryAction, .drag, .pressKey, .hotkey, .typeText, .pasteText, .setValue, .scroll, .navigateURL, .navigateActiveBrowserTab, .openNewBrowserTab, .activateBrowserTab, .getAppState, .getWindowState:
             return true
         case .listApps, .launchApp, .listWindows, .listBrowserTabs, .pageGetText, .pageQueryDOM, .finish, .fail:
             return false
@@ -341,7 +572,7 @@ final class ComputerUsePlannerRuntime {
             return ComputerUseObservationTarget(appName: appName, bundleID: nil)
         }
         switch toolCall.tool {
-        case .moveCursor, .click, .setValue, .typeText, .pasteText, .pressKey, .hotkey, .scroll, .drag:
+        case .moveCursor, .click, .clickElement, .clickPoint, .performSecondaryAction, .setValue, .typeText, .pasteText, .pressKey, .hotkey, .scroll, .drag:
             return fallback
         default:
             return nil
@@ -368,6 +599,8 @@ final class ComputerUsePlannerRuntime {
             observation.appName,
             observation.windowTitle,
             "\(observation.elements.count)",
+            observation.focusedElement?.normalizedText ?? "",
+            observation.selectedText ?? "",
             screenshot,
             elementSignature,
         ].joined(separator: "|")
@@ -400,15 +633,19 @@ final class ComputerUsePlannerRuntime {
         switch toolCall.tool {
         case .launchApp:
             return result.message.hasPrefix("Opened") ? result.message : "Opened app"
-        case .click:
+        case .click, .clickElement, .clickPoint:
             return result.message.hasPrefix("Clicked") ? result.message : "Clicked"
+        case .performSecondaryAction:
+            return "Performed action"
         case .moveCursor:
             return "Moving cursor"
         case .typeText:
             return "Typed text"
         case .pasteText:
             return "Pasted text"
-        case .navigateURL:
+        case .openNewBrowserTab:
+            return "Opened new tab"
+        case .navigateURL, .navigateActiveBrowserTab:
             return "Navigated"
         case .pressKey, .hotkey:
             return "Pressed key"
@@ -430,8 +667,10 @@ final class ComputerUsePlannerRuntime {
         case .launchApp:
             let target = toolCall.appName?.trimmingCharacters(in: .whitespacesAndNewlines)
             return "Opening \(target?.isEmpty == false ? target! : "app")"
-        case .click:
+        case .click, .clickElement, .clickPoint:
             return "Clicking"
+        case .performSecondaryAction:
+            return "Performing action"
         case .moveCursor:
             return toolCall.label?.isEmpty == false ? "Moving to \(toolCall.label!)" : "Moving cursor"
         case .setValue:
@@ -446,13 +685,15 @@ final class ComputerUsePlannerRuntime {
             return "Scrolling"
         case .drag:
             return "Dragging"
-        case .navigateURL:
+        case .openNewBrowserTab:
+            return "Opening new tab"
+        case .navigateURL, .navigateActiveBrowserTab:
             return "Navigating"
         case .activateBrowserTab:
             return "Switching tab"
         case .listApps, .listWindows, .listBrowserTabs, .pageGetText, .pageQueryDOM:
             return "Reading"
-        case .getWindowState:
+        case .getAppState, .getWindowState:
             return "Observing"
         case .finish:
             return "Done"
@@ -505,7 +746,7 @@ final class ComputerUsePlannerRuntime {
                 return true
             case .backendFailed(let statusCode, _):
                 return statusCode == 408 || statusCode == 429 || statusCode >= 500
-            case .notAuthenticated, .invalidResponse:
+            case .notAuthenticated, .invalidResponse, .invalidToolCall:
                 return false
             }
         }
@@ -523,17 +764,17 @@ final class ComputerUsePlannerRuntime {
         guard result.status == .failed || result.status == .unsupported else { return nil }
         let message = result.message.trimmingCharacters(in: .whitespacesAndNewlines)
         if browserToolCanFallBackToScreen(toolCall.tool), isBrowserAutomationPermissionFailure(message) {
-            return "\(message). Continue with get_window_state plus AX/screenshot tools: click, paste_text/type_text, press_key/hotkey, and scroll. Do not retry browser page tools unless the user grants Chrome Apple Events JavaScript permission."
+            return "\(message). Continue with get_app_state plus AX/screenshot tools: click_element/click_point, paste_text/type_text, press_key/hotkey, and scroll. Do not retry browser page tools unless the user grants Chrome Apple Events JavaScript permission."
         }
         if (toolCall.tool == .typeText || toolCall.tool == .pasteText), isTextFocusFailure(message) {
-            return "\(message). Continue with get_window_state and focus an editable target using click or set_value before retrying text entry. Prefer paste_text for Apple Notes and native rich-text editors. Do not repeat text entry until the focused target changes."
+            return "\(message). Continue with get_app_state and focus an editable target using click_element or set_value before retrying text entry. Prefer paste_text for Apple Notes and native rich-text editors. Do not repeat text entry until the focused target changes."
         }
         return nil
     }
 
     private func browserToolCanFallBackToScreen(_ tool: ComputerUseToolName) -> Bool {
         switch tool {
-        case .listBrowserTabs, .activateBrowserTab, .navigateURL, .pageGetText, .pageQueryDOM:
+        case .listBrowserTabs, .activateBrowserTab, .openNewBrowserTab, .navigateURL, .navigateActiveBrowserTab, .pageGetText, .pageQueryDOM:
             return true
         default:
             return false

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerTypes.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerTypes.swift
@@ -4,9 +4,13 @@ enum ComputerUseToolName: String, Codable, Equatable, CaseIterable {
     case listApps = "list_apps"
     case launchApp = "launch_app"
     case listWindows = "list_windows"
+    case getAppState = "get_app_state"
     case getWindowState = "get_window_state"
     case moveCursor = "move_cursor"
     case click
+    case clickElement = "click_element"
+    case clickPoint = "click_point"
+    case performSecondaryAction = "perform_secondary_action"
     case setValue = "set_value"
     case typeText = "type_text"
     case pasteText = "paste_text"
@@ -16,7 +20,9 @@ enum ComputerUseToolName: String, Codable, Equatable, CaseIterable {
     case drag
     case listBrowserTabs = "list_browser_tabs"
     case activateBrowserTab = "activate_browser_tab"
+    case openNewBrowserTab = "open_new_browser_tab"
     case navigateURL = "navigate_url"
+    case navigateActiveBrowserTab = "navigate_active_browser_tab"
     case pageGetText = "page_get_text"
     case pageQueryDOM = "page_query_dom"
     case finish
@@ -125,66 +131,112 @@ struct ComputerUseBrowserTabInfo: Codable, Equatable {
     }
 }
 
+enum ComputerUseVerificationStatus: String, Codable, Equatable {
+    case changed
+    case unchanged
+    case targetLost = "target_lost"
+    case blocked
+    case unknown
+}
+
+struct ComputerUseStateDelta: Codable, Equatable {
+    let status: ComputerUseVerificationStatus
+    let summary: String
+    let beforeStateID: String?
+    let afterStateID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case summary
+        case beforeStateID = "before_state_id"
+        case afterStateID = "after_state_id"
+    }
+}
+
 struct ComputerUseWindowState: Codable, Equatable {
+    let stateID: String
     let appName: String
     let bundleID: String
     let windowTitle: String
     let windowFrame: ComputerUseRect?
     let screenshot: ComputerUseScreenshotObservation?
     let cursorPosition: ComputerUseRect?
+    let focusedElement: ComputerUseFocusedElement?
+    let selectedText: String?
+    let appInstructions: String?
     let elements: [ComputerUseElementCandidate]
     let capturedAt: Date
 
     enum CodingKeys: String, CodingKey {
+        case stateID = "state_id"
         case appName = "app_name"
         case bundleID = "bundle_id"
         case windowTitle = "window_title"
         case windowFrame = "window_frame"
         case screenshot
         case cursorPosition = "cursor_position"
+        case focusedElement = "focused_element"
+        case selectedText = "selected_text"
+        case appInstructions = "app_instructions"
         case elements
         case capturedAt = "captured_at"
     }
 
     init(observation: ComputerUseObservation) {
+        stateID = observation.stateID
         appName = observation.appName
         bundleID = observation.bundleID
         windowTitle = observation.windowTitle
         windowFrame = observation.windowFrame
         screenshot = observation.screenshot
         cursorPosition = observation.cursorPosition
+        focusedElement = observation.focusedElement
+        selectedText = observation.selectedText
+        appInstructions = observation.appInstructions
         elements = observation.elements
         capturedAt = observation.capturedAt
     }
 
     init(
+        stateID: String = ComputerUseObservation.newStateID(),
         appName: String,
         bundleID: String,
         windowTitle: String,
         windowFrame: ComputerUseRect?,
         screenshot: ComputerUseScreenshotObservation?,
         cursorPosition: ComputerUseRect?,
+        focusedElement: ComputerUseFocusedElement? = nil,
+        selectedText: String? = nil,
+        appInstructions: String? = nil,
         elements: [ComputerUseElementCandidate],
         capturedAt: Date
     ) {
+        self.stateID = stateID
         self.appName = appName
         self.bundleID = bundleID
         self.windowTitle = windowTitle
         self.windowFrame = windowFrame
         self.screenshot = screenshot
         self.cursorPosition = cursorPosition
+        self.focusedElement = focusedElement
+        self.selectedText = selectedText
+        self.appInstructions = appInstructions
         self.elements = elements
         self.capturedAt = capturedAt
     }
 
     var observation: ComputerUseObservation {
         ComputerUseObservation(
+            stateID: stateID,
             appName: appName,
             bundleID: bundleID,
             windowTitle: windowTitle,
             windowFrame: windowFrame,
             screenshot: screenshot,
             cursorPosition: cursorPosition,
+            focusedElement: focusedElement,
+            selectedText: selectedText,
+            appInstructions: appInstructions,
             elements: elements,
             capturedAt: capturedAt
         )
@@ -203,6 +255,7 @@ struct ComputerUseToolInvocation: Codable, Equatable {
     let elementID: String?
     let elementIndex: Int?
     let screenshotID: String?
+    let actionName: String?
     let label: String?
     let x: Double?
     let y: Double?
@@ -233,6 +286,7 @@ struct ComputerUseToolInvocation: Codable, Equatable {
         case elementID = "element_id"
         case elementIndex = "element_index"
         case screenshotID = "screenshot_id"
+        case actionName = "action_name"
         case label
         case x
         case y
@@ -264,6 +318,7 @@ struct ComputerUseToolInvocation: Codable, Equatable {
         elementID: String? = nil,
         elementIndex: Int? = nil,
         screenshotID: String? = nil,
+        actionName: String? = nil,
         label: String? = nil,
         x: Double? = nil,
         y: Double? = nil,
@@ -293,6 +348,7 @@ struct ComputerUseToolInvocation: Codable, Equatable {
         self.elementID = elementID
         self.elementIndex = elementIndex
         self.screenshotID = screenshotID
+        self.actionName = actionName
         self.label = label
         self.x = x
         self.y = y
@@ -319,12 +375,21 @@ struct ComputerUseToolInvocation: Codable, Equatable {
     func normalizedPlannerOutput() -> ComputerUseToolInvocation {
         var normalizedElementID = elementID
         var normalizedElementIndex = elementIndex
+        var normalizedScreenshotID = screenshotID
+        var normalizedX = x
+        var normalizedY = y
         if tool == .click, x != nil, y != nil {
             if trimmed(normalizedElementID).isEmpty {
                 normalizedElementID = nil
             }
             if let index = normalizedElementIndex, index <= 0 {
                 normalizedElementIndex = nil
+            }
+            let hasElementTarget = normalizedElementIndex != nil || !trimmed(normalizedElementID).isEmpty
+            if hasElementTarget, trimmed(screenshotID).isEmpty {
+                normalizedScreenshotID = nil
+                normalizedX = nil
+                normalizedY = nil
             }
         }
         return ComputerUseToolInvocation(
@@ -338,10 +403,11 @@ struct ComputerUseToolInvocation: Codable, Equatable {
             tabIndex: tabIndex,
             elementID: normalizedElementID,
             elementIndex: normalizedElementIndex,
-            screenshotID: screenshotID,
+            screenshotID: normalizedScreenshotID,
+            actionName: actionName,
             label: label,
-            x: x,
-            y: y,
+            x: normalizedX,
+            y: normalizedY,
             toX: toX,
             toY: toY,
             clicks: clicks,
@@ -361,7 +427,7 @@ struct ComputerUseToolInvocation: Codable, Equatable {
 
     func validationFailure() -> String? {
         switch tool {
-        case .listApps, .listWindows, .getWindowState, .finish:
+        case .listApps, .listWindows, .getAppState, .getWindowState, .finish:
             return nil
         case .launchApp:
             return trimmed(appName).isEmpty && canonicalBundleID.isEmpty ? "launch_app requires app_name or app_bundle_id" : nil
@@ -390,6 +456,24 @@ struct ComputerUseToolInvocation: Codable, Equatable {
                 return "click coordinate mode requires screenshot_id"
             }
             return hasElementTarget || (hasX && hasY) ? nil : "click requires element_index, element_id, or x and y"
+        case .clickElement:
+            if let elementIndex, elementIndex <= 0 {
+                return "click_element element_index must be greater than 0"
+            }
+            return elementIndex == nil && trimmed(elementID).isEmpty ? "click_element requires element_index or element_id" : nil
+        case .clickPoint:
+            if x == nil || y == nil {
+                return "click_point requires x and y"
+            }
+            return trimmed(screenshotID).isEmpty ? "click_point requires screenshot_id" : nil
+        case .performSecondaryAction:
+            if trimmed(actionName).isEmpty {
+                return "perform_secondary_action requires action_name"
+            }
+            if let elementIndex, elementIndex <= 0 {
+                return "perform_secondary_action element_index must be greater than 0"
+            }
+            return elementIndex == nil && trimmed(elementID).isEmpty ? "perform_secondary_action requires element_index or element_id" : nil
         case .setValue:
             if trimmed(value).isEmpty {
                 return "set_value requires value"
@@ -405,6 +489,9 @@ struct ComputerUseToolInvocation: Codable, Equatable {
         case .pressKey, .hotkey:
             return trimmed(key).isEmpty ? "\(tool.rawValue) requires key" : nil
         case .scroll:
+            if let elementIndex, elementIndex <= 0 {
+                return "scroll element_index must be greater than 0"
+            }
             return direction == nil ? "scroll requires direction" : nil
         case .drag:
             if x == nil || y == nil || toX == nil || toY == nil {
@@ -418,9 +505,14 @@ struct ComputerUseToolInvocation: Codable, Equatable {
             if windowIndex == nil { return "activate_browser_tab requires window_index" }
             if tabIndex == nil { return "activate_browser_tab requires tab_index" }
             return nil
+        case .openNewBrowserTab:
+            return canonicalBundleID.isEmpty ? "open_new_browser_tab requires app_bundle_id" : nil
         case .navigateURL:
             if canonicalBundleID.isEmpty { return "navigate_url requires app_bundle_id" }
             return safeHTTPURL(trimmed(url)) == nil ? "navigate_url requires a safe http or https url" : nil
+        case .navigateActiveBrowserTab:
+            if canonicalBundleID.isEmpty { return "navigate_active_browser_tab requires app_bundle_id" }
+            return safeHTTPURL(trimmed(url)) == nil ? "navigate_active_browser_tab requires a safe http or https url" : nil
         case .pageGetText:
             if canonicalBundleID.isEmpty { return "page_get_text requires app_bundle_id" }
             return nil
@@ -436,18 +528,20 @@ struct ComputerUseToolInvocation: Codable, Equatable {
         switch tool {
         case .moveCursor:
             return false
-        case .click:
+        case .click, .clickPoint:
             if elementIndex == nil && trimmed(elementID).isEmpty {
                 if trimmed(label).isEmpty { return true }
                 if screenshotID == nil { return true }
             }
             return containsRiskyWord([label, reason].compactMap { $0 }.joined(separator: " "))
-        case .drag:
+        case .clickElement:
+            return containsRiskyWord([label, reason].compactMap { $0 }.joined(separator: " "))
+        case .performSecondaryAction, .drag:
             return containsRiskyWord([label, reason].compactMap { $0 }.joined(separator: " "))
         case .pressKey, .hotkey:
             let mods = modifiers ?? []
             return mods.contains(.command) && ["q", "w"].contains(canonical(key ?? ""))
-        case .navigateURL:
+        case .navigateURL, .navigateActiveBrowserTab:
             return safeHTTPURL(trimmed(url)) == nil
         default:
             return false
@@ -456,9 +550,9 @@ struct ComputerUseToolInvocation: Codable, Equatable {
 
     var isMutating: Bool {
         switch tool {
-        case .launchApp, .moveCursor, .click, .setValue, .typeText, .pasteText, .pressKey, .hotkey, .scroll, .drag, .activateBrowserTab, .navigateURL:
+        case .launchApp, .moveCursor, .click, .clickElement, .clickPoint, .performSecondaryAction, .setValue, .typeText, .pasteText, .pressKey, .hotkey, .scroll, .drag, .activateBrowserTab, .openNewBrowserTab, .navigateURL, .navigateActiveBrowserTab:
             return true
-        case .listApps, .listWindows, .getWindowState, .listBrowserTabs, .pageGetText, .pageQueryDOM, .finish, .fail:
+        case .listApps, .listWindows, .getAppState, .getWindowState, .listBrowserTabs, .pageGetText, .pageQueryDOM, .finish, .fail:
             return false
         }
     }
@@ -471,6 +565,8 @@ struct ComputerUseToolInvocation: Codable, Equatable {
             return "launch \(trimmed(appName).isEmpty ? canonicalBundleID : trimmed(appName))"
         case .listWindows:
             return "list windows"
+        case .getAppState:
+            return "get app state"
         case .getWindowState:
             return "get window state"
         case .moveCursor:
@@ -483,6 +579,16 @@ struct ComputerUseToolInvocation: Codable, Equatable {
                 return "click \(trimmed(label).isEmpty ? trimmed(elementID) : trimmed(label))"
             }
             return "click \(trimmed(label).isEmpty ? "point" : trimmed(label)) at \(coordinateSummary(x, y))"
+        case .clickElement:
+            if let elementIndex {
+                return "click element \(elementIndexLabel(elementIndex))"
+            }
+            return "click \(trimmed(label).isEmpty ? trimmed(elementID) : trimmed(label))"
+        case .clickPoint:
+            return "click \(trimmed(label).isEmpty ? "point" : trimmed(label)) at \(coordinateSummary(x, y))"
+        case .performSecondaryAction:
+            let target = elementIndex.map(elementIndexLabel) ?? trimmed(elementID)
+            return "perform \(trimmed(actionName)) on \(target)"
         case .setValue:
             let target = elementIndex.map(elementIndexLabel) ?? trimmed(elementID)
             return "set \(target) to \(truncateForSummary(trimmed(value)))"
@@ -494,15 +600,20 @@ struct ComputerUseToolInvocation: Codable, Equatable {
             let parts = (modifiers ?? []).map(\.rawValue) + [trimmed(key)]
             return "press \(parts.filter { !$0.isEmpty }.joined(separator: "+"))"
         case .scroll:
-            return "scroll \(direction?.rawValue ?? "")"
+            let target = elementIndex.map { " element \(elementIndexLabel($0))" } ?? (trimmed(elementID).isEmpty ? "" : " \(trimmed(elementID))")
+            return "scroll\(target) \(direction?.rawValue ?? "")"
         case .drag:
             return "drag \(coordinateSummary(x, y)) to \(coordinateSummary(toX, toY))"
         case .listBrowserTabs:
             return "list browser tabs"
         case .activateBrowserTab:
             return "activate browser tab \(windowIndex ?? 0):\(tabIndex ?? 0)"
+        case .openNewBrowserTab:
+            return "open new browser tab"
         case .navigateURL:
             return "navigate to \(truncateForSummary(trimmed(url)))"
+        case .navigateActiveBrowserTab:
+            return "navigate active browser tab to \(truncateForSummary(trimmed(url)))"
         case .pageGetText:
             return "get page text"
         case .pageQueryDOM:
@@ -719,6 +830,10 @@ struct ComputerUseToolOutcome: Codable, Equatable {
     let bundleID: String?
     let windowTitle: String?
     let snapshotID: String?
+    let verificationStatus: ComputerUseVerificationStatus?
+    let beforeStateID: String?
+    let afterStateID: String?
+    let stateDelta: ComputerUseStateDelta?
 
     enum CodingKeys: String, CodingKey {
         case step
@@ -729,6 +844,10 @@ struct ComputerUseToolOutcome: Codable, Equatable {
         case bundleID = "bundle_id"
         case windowTitle = "window_title"
         case snapshotID = "snapshot_id"
+        case verificationStatus = "verification_status"
+        case beforeStateID = "before_state_id"
+        case afterStateID = "after_state_id"
+        case stateDelta = "state_delta"
     }
 
     init(
@@ -739,7 +858,11 @@ struct ComputerUseToolOutcome: Codable, Equatable {
         appName: String? = nil,
         bundleID: String? = nil,
         windowTitle: String? = nil,
-        snapshotID: String? = nil
+        snapshotID: String? = nil,
+        verificationStatus: ComputerUseVerificationStatus? = nil,
+        beforeStateID: String? = nil,
+        afterStateID: String? = nil,
+        stateDelta: ComputerUseStateDelta? = nil
     ) {
         self.step = step
         self.tool = tool
@@ -749,6 +872,10 @@ struct ComputerUseToolOutcome: Codable, Equatable {
         self.bundleID = bundleID
         self.windowTitle = windowTitle
         self.snapshotID = snapshotID
+        self.verificationStatus = verificationStatus
+        self.beforeStateID = beforeStateID
+        self.afterStateID = afterStateID
+        self.stateDelta = stateDelta
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseToolRegistry.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseToolRegistry.swift
@@ -81,7 +81,11 @@ enum ComputerUseToolRegistry {
         definition(.listWindows, "List visible windows, optionally scoped by app_bundle_id.", required: [], properties: [
             "app_bundle_id": .string("Optional bundle identifier to scope windows."),
         ], risk: "safe read-only"),
-        definition(.getWindowState, "Capture the active window state: screenshot metadata, screenshot image for the planner, AX candidates, cursor, app, and window metadata.", required: [], properties: [
+        definition(.getAppState, "Capture fresh app/window state: state_id, app/window identity, screenshot metadata/image for the planner, AX candidates, focused element, selected text, cursor, and app hints.", required: [], properties: [
+            "app_bundle_id": .string("Optional app bundle to activate before capture."),
+            "window_id": .integer("Optional window id hint."),
+        ], risk: "safe read-only"),
+        definition(.getWindowState, "Compatibility alias for get_app_state. Prefer get_app_state for new planner calls.", required: [], properties: [
             "app_bundle_id": .string("Optional app bundle to activate before capture."),
             "window_id": .integer("Optional window id hint."),
         ], risk: "safe read-only"),
@@ -91,16 +95,27 @@ enum ComputerUseToolRegistry {
             "y": .number("Screenshot pixel y coordinate."),
             "label": .string("Human target label for live feedback and trace."),
         ], risk: "visual feedback only"),
-        definition(.click, "Click exactly one target: either an AX element from the latest get_window_state by element_index/element_id, or a screenshot coordinate when no AX target exists. Do not send both an element target and x/y.", required: [], properties: [
-            "element_index": .integer("Temporary element index from the latest state. Element-indexed clicks are scoped to the current snapshot and expire after a new get_window_state."),
-            "element_id": .string("Temporary element id from the latest state, for example e12. Use only when x/y are absent."),
-            "screenshot_id": .string("Required current screenshot id when using x/y coordinates."),
-            "x": .number("Screenshot pixel x coordinate. Use only with y and screenshot_id, and only when element_index/element_id are absent."),
-            "y": .number("Screenshot pixel y coordinate. Use only with x and screenshot_id, and only when element_index/element_id are absent."),
+        definition(.clickElement, "Click an AX element from the latest get_app_state by element_index or element_id. Use this whenever a matching AX candidate exists.", required: [], properties: [
+            "element_index": .integer("Temporary element index from the latest state."),
+            "element_id": .string("Temporary element id from the latest state, for example e12."),
             "clicks": .integer("1 for single click, 2 for double click."),
             "button": .string("left or right."),
             "label": .string("Human target label for trace and safety."),
-        ], risk: "rejects mixed element/coordinate addressing; confirmation for risky labels or unknown coordinate targets"),
+        ], risk: "confirmation for risky labels"),
+        definition(.clickPoint, "Click a screenshot coordinate when no AX target exists. Requires screenshot_id plus x/y from the latest state.", required: ["screenshot_id", "x", "y"], properties: [
+            "screenshot_id": .string("Current screenshot id."),
+            "x": .number("Screenshot pixel x coordinate."),
+            "y": .number("Screenshot pixel y coordinate."),
+            "clicks": .integer("1 for single click, 2 for double click."),
+            "button": .string("left or right."),
+            "label": .string("Human target label for trace and safety."),
+        ], risk: "confirmation for risky labels or unknown coordinate targets"),
+        definition(.performSecondaryAction, "Perform an advertised AX action other than AXPress on an element from the latest get_app_state. Use only action_name values present on that element's action_names.", required: ["action_name"], properties: [
+            "element_index": .integer("Temporary element index from the latest state."),
+            "element_id": .string("Temporary element id from the latest state."),
+            "action_name": .string("Advertised AX action name, for example AXShowMenu, AXConfirm, AXCancel, AXIncrement, AXDecrement, or AXScrollDownByPage."),
+            "label": .string("Human target label for trace and safety."),
+        ], risk: "only invokes advertised AX actions; confirmation for risky labels"),
         definition(.setValue, "Set an AX element value by element_index/element_id from the latest state.", required: ["value"], properties: [
             "element_index": .integer("Temporary element index from the latest state."),
             "element_id": .string("Temporary element id from the latest state."),
@@ -131,7 +146,9 @@ enum ComputerUseToolRegistry {
             "key": .string("Key name."),
             "modifiers": .array("Required or optional modifiers.", item: .string("Modifier", enumValues: ComputerUseKeyModifier.allCases.map(\.rawValue))),
         ], risk: "confirmation for Cmd-Q and Cmd-W"),
-        definition(.scroll, "Scroll the current view.", required: ["direction"], properties: [
+        definition(.scroll, "Scroll the current view or a scrollable AX element from the latest state.", required: ["direction"], properties: [
+            "element_index": .integer("Optional temporary scrollable element index from the latest state."),
+            "element_id": .string("Optional temporary scrollable element id from the latest state."),
             "direction": .string("Scroll direction.", enumValues: ["up", "down", "left", "right"]),
             "pages": .number("Approximate page count, default 1."),
         ], risk: "safe primitive"),
@@ -151,10 +168,17 @@ enum ComputerUseToolRegistry {
             "window_index": .integer("1-based browser window index."),
             "tab_index": .integer("1-based tab index in the window."),
         ], risk: "foreground activation allowed"),
+        definition(.openNewBrowserTab, "Open a new tab in a supported browser and make it active. Prefer this for new or separate web tasks.", required: ["app_bundle_id"], properties: [
+            "app_bundle_id": .string("Browser bundle identifier, currently com.google.Chrome."),
+        ], risk: "foreground activation allowed"),
         definition(.navigateURL, "Navigate the selected browser tab to a safe http/https URL.", required: ["app_bundle_id", "url"], properties: [
             "app_bundle_id": .string("Browser bundle identifier, currently com.google.Chrome."),
             "window_index": .integer("Optional 1-based browser window index."),
             "tab_index": .integer("Optional 1-based tab index."),
+            "url": .string("http or https URL only."),
+        ], risk: "rejects javascript:, file:, data:, shell-like strings, and unsafe URLs"),
+        definition(.navigateActiveBrowserTab, "Navigate the active browser tab to a safe http/https URL without tab indexes. Prefer this immediately after open_new_browser_tab.", required: ["app_bundle_id", "url"], properties: [
+            "app_bundle_id": .string("Browser bundle identifier, currently com.google.Chrome."),
             "url": .string("http or https URL only."),
         ], risk: "rejects javascript:, file:, data:, shell-like strings, and unsafe URLs"),
         definition(.pageGetText, "Read visible/body text from a Chrome tab using read-only Apple Events JavaScript.", required: ["app_bundle_id"], properties: [

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseTraceFormatter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUseTraceFormatter.swift
@@ -12,7 +12,7 @@ enum ComputerUseTraceFormatter {
             record.rawText,
             "",
             "Final Status",
-            trace.finalStatus,
+            displayFinalStatus(trace.finalStatus),
             "",
             "Final Message",
             trace.finalMessage,
@@ -45,6 +45,23 @@ enum ComputerUseTraceFormatter {
              ("tool_call", "executing"),
              ("model_output", "planned"):
             return nil
+        default:
+            return status
+        }
+    }
+
+    static func displayFinalStatus(_ status: String) -> String {
+        switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "done":
+            return "done"
+        case "timed_out", "timedout":
+            return "timed_out"
+        case "failed", "fail":
+            return "failed"
+        case "confirm", "needsconfirmation", "needs_confirmation":
+            return "confirm"
+        case "cancelled", "canceled":
+            return "cancelled"
         default:
             return status
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationRowView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationRowView.swift
@@ -45,7 +45,7 @@ struct DictationRowView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         if let trace = record.computerUseTrace {
-                            Text(trace.finalStatus.capitalized)
+                            Text(Self.displayFinalStatus(trace.finalStatus))
                                 .font(MuesliTheme.captionMedium())
                                 .foregroundStyle(statusColor(trace.finalStatus))
                         }
@@ -171,10 +171,29 @@ struct DictationRowView: View {
             return MuesliTheme.success
         case "confirm", "needsconfirmation":
             return MuesliTheme.transcribing
+        case "timed_out", "timedout":
+            return MuesliTheme.transcribing
         case "failed", "unsupported":
             return MuesliTheme.recording
         default:
             return MuesliTheme.textTertiary
+        }
+    }
+
+    private static func displayFinalStatus(_ status: String) -> String {
+        switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "done":
+            return "Done"
+        case "timed_out", "timedout":
+            return "Timed out"
+        case "failed", "fail":
+            return "Failed"
+        case "confirm", "needsconfirmation", "needs_confirmation":
+            return "Confirm"
+        case "cancelled", "canceled":
+            return "Cancelled"
+        default:
+            return status.capitalized
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -100,6 +100,7 @@ final class FloatingIndicatorController: NSObject {
     var isToggleDictation = false
     private var stopLayer: CALayer?
     private var transcribingTitle = "Transcribing"
+    private var computerUseTranscriptText: String?
     private var loadingSpinner: NSProgressIndicator?
     private var isShowingLoading = false
     private var isComputerUseCursorMode = false
@@ -207,8 +208,16 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func setTranscribingTitle(_ title: String, config: AppConfig) {
+        computerUseTranscriptText = nil
         transcribingTitle = title
         guard state == .transcribing else { return }
+        setState(.transcribing, config: config)
+    }
+
+    func showComputerUseTranscript(_ transcript: String, config: AppConfig) {
+        let normalized = Self.normalizedComputerUseTranscript(transcript)
+        computerUseTranscriptText = normalized.isEmpty ? nil : normalized
+        transcribingTitle = normalized.isEmpty ? "Starting CUA" : normalized
         setState(.transcribing, config: config)
     }
 
@@ -221,6 +230,7 @@ final class FloatingIndicatorController: NSObject {
         self.state = state
         if state != .transcribing {
             transcribingTitle = "Transcribing"
+            computerUseTranscriptText = nil
         }
         if state != .idle {
             isHovered = false
@@ -294,17 +304,22 @@ final class FloatingIndicatorController: NSObject {
                 iconLabel.font = NSFont.systemFont(ofSize: 14, weight: .bold)
                 iconLabel.stringValue = style.icon
                 iconLabel.textColor = style.iconColor
+                configureTextLabelForTranscript(state == .transcribing && computerUseTranscriptText != nil)
                 textLabel.stringValue = style.title
                 textLabel.textColor = style.textColor
                 textLabel.animator().alphaValue = style.title.isEmpty ? 0 : 1
                 textLabel.isHidden = style.title.isEmpty
-                layoutLabels(
-                    iconLabel: iconLabel,
-                    textLabel: textLabel,
-                    in: targetFrame.size,
-                    hasTitle: !style.title.isEmpty,
-                    animated: true
-                )
+                if state == .transcribing, computerUseTranscriptText != nil {
+                    layoutComputerUseTranscript(in: targetFrame.size, animated: true)
+                } else {
+                    layoutLabels(
+                        iconLabel: iconLabel,
+                        textLabel: textLabel,
+                        in: targetFrame.size,
+                        hasTitle: !style.title.isEmpty,
+                        animated: true
+                    )
+                }
             }
 
             // Apply glass state last so it can override iconLabel visibility set above.
@@ -776,6 +791,10 @@ final class FloatingIndicatorController: NSObject {
             micIconView?.isHidden = true
             iconLabel?.isHidden = true
             wandIconView?.isHidden = false
+            if computerUseTranscriptText != nil {
+                layoutComputerUseTranscript(in: frameSize, animated: false)
+                return
+            }
             if let wand = wandIconView {
                 let gap: CGFloat = 6
                 let horizontalPadding: CGFloat = 14
@@ -802,6 +821,67 @@ final class FloatingIndicatorController: NSObject {
             wandIconView?.isHidden = true
             micIconView?.isHidden = true
             iconLabel?.isHidden = false
+        }
+    }
+
+    private func configureTextLabelForTranscript(_ isTranscript: Bool) {
+        guard let textLabel else { return }
+        Self.configureTextLabel(textLabel, forTranscript: isTranscript)
+    }
+
+    private static func configureTextLabel(_ textLabel: NSTextField, forTranscript isTranscript: Bool) {
+        textLabel.alignment = .left
+        if isTranscript {
+            textLabel.font = NSFont.systemFont(ofSize: 12, weight: .medium)
+            textLabel.lineBreakMode = .byWordWrapping
+            textLabel.maximumNumberOfLines = 0
+            textLabel.usesSingleLineMode = false
+            textLabel.cell?.wraps = true
+            textLabel.cell?.isScrollable = false
+        } else {
+            textLabel.font = NSFont.systemFont(ofSize: 11, weight: .regular)
+            textLabel.lineBreakMode = .byTruncatingTail
+            textLabel.maximumNumberOfLines = 1
+            textLabel.usesSingleLineMode = true
+            textLabel.cell?.wraps = false
+            textLabel.cell?.isScrollable = false
+        }
+    }
+
+    private func layoutComputerUseTranscript(in size: NSSize, animated: Bool) {
+        guard let wand = wandIconView, let textLabel else { return }
+        let iconSize = NSSize(width: 18, height: 18)
+        let gap: CGFloat = 8
+        let horizontalPadding: CGFloat = 16
+        let verticalPadding: CGFloat = 12
+        let textX = horizontalPadding + iconSize.width + gap
+        let textWidth = max(40, size.width - textX - horizontalPadding)
+        let textHeight = max(16, size.height - (verticalPadding * 2))
+        let textFrame = NSRect(
+            x: textX,
+            y: floor((size.height - textHeight) / 2),
+            width: textWidth,
+            height: textHeight
+        )
+        let iconFrame = NSRect(
+            x: horizontalPadding,
+            y: floor(size.height - verticalPadding - iconSize.height),
+            width: iconSize.width,
+            height: iconSize.height
+        )
+
+        wand.isHidden = false
+        textLabel.isHidden = false
+        if animated {
+            wand.animator().alphaValue = 1
+            wand.animator().frame = iconFrame
+            textLabel.animator().alphaValue = 1
+            textLabel.animator().frame = textFrame
+        } else {
+            wand.alphaValue = 1
+            wand.frame = iconFrame
+            textLabel.alphaValue = 1
+            textLabel.frame = textFrame
         }
     }
 
@@ -835,9 +915,7 @@ final class FloatingIndicatorController: NSObject {
         let textLabel = NSTextField(labelWithString: "")
         textLabel.alignment = .left
         textLabel.font = NSFont.systemFont(ofSize: 11, weight: .regular)
-        textLabel.lineBreakMode = .byTruncatingTail
-        textLabel.maximumNumberOfLines = 1
-        textLabel.usesSingleLineMode = true
+        Self.configureTextLabel(textLabel, forTranscript: false)
         contentView.addSubview(textLabel)
 
         panel.contentView = contentView
@@ -1038,7 +1116,11 @@ final class FloatingIndicatorController: NSObject {
         case .preparing: size = NSSize(width: 44, height: 28)
         case .recording: size = NSSize(width: 76, height: 22)
         case .transcribing:
-            size = Self.transcribingPillSize(title: transcribingTitle, screenWidth: screen.width)
+            if let transcript = computerUseTranscriptText {
+                size = Self.computerUseTranscriptPillSize(transcript: transcript, screen: screen)
+            } else {
+                size = Self.transcribingPillSize(title: transcribingTitle, screenWidth: screen.width)
+            }
         }
 
         // Use the pill's current on-screen center if it exists, so state
@@ -1176,6 +1258,17 @@ final class FloatingIndicatorController: NSObject {
         transcribingPillSize(title: title, screenWidth: screenWidth)
     }
 
+    static func computerUseTranscriptPillSizeForTesting(
+        transcript: String,
+        screenWidth: CGFloat,
+        screenHeight: CGFloat = 900
+    ) -> NSSize {
+        computerUseTranscriptPillSize(
+            transcript: transcript,
+            screen: NSRect(x: 0, y: 0, width: screenWidth, height: screenHeight)
+        )
+    }
+
     private static func transcribingPillSize(title: String, screenWidth: CGFloat) -> NSSize {
         let font = NSFont.systemFont(ofSize: 11, weight: .regular)
         let iconWidth: CGFloat = 18
@@ -1186,6 +1279,41 @@ final class FloatingIndicatorController: NSObject {
         let minWidth = min(CGFloat(190), max(120, screenWidth - 32))
         let maxWidth = max(minWidth, min(420, screenWidth - 32))
         return NSSize(width: min(max(preferredWidth, minWidth), maxWidth), height: 32)
+    }
+
+    private static func computerUseTranscriptPillSize(transcript: String, screen: NSRect) -> NSSize {
+        let normalized = normalizedComputerUseTranscript(transcript)
+        let font = NSFont.systemFont(ofSize: 12, weight: .medium)
+        let iconWidth: CGFloat = 18
+        let gap: CGFloat = 8
+        let horizontalPadding: CGFloat = 16
+        let verticalPadding: CGFloat = 12
+        let chromeWidth = horizontalPadding + iconWidth + gap + horizontalPadding
+        let minWidth = min(CGFloat(280), max(160, screen.width - 48))
+        let maxWidth = max(minWidth, min(720, screen.width - 48))
+        let singleLineTextWidth = ceil((normalized as NSString).size(withAttributes: [.font: font]).width) + 2
+        let preferredWidth = min(maxWidth, max(minWidth, chromeWidth + singleLineTextWidth))
+        let textWidth = max(40, preferredWidth - chromeWidth)
+        let textHeight = transcriptTextHeight(normalized, font: font, width: textWidth)
+        let maxHeight = max(CGFloat(56), screen.height - 48)
+        let preferredHeight = max(CGFloat(44), ceil(textHeight) + (verticalPadding * 2))
+        return NSSize(width: preferredWidth, height: min(preferredHeight, maxHeight))
+    }
+
+    private static func transcriptTextHeight(_ text: String, font: NSFont, width: CGFloat) -> CGFloat {
+        let bounding = (text as NSString).boundingRect(
+            with: NSSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font]
+        )
+        return max(16, ceil(bounding.height))
+    }
+
+    private static func normalizedComputerUseTranscript(_ transcript: String) -> String {
+        transcript
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 
     private func pointerIsInsidePanel() -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -126,6 +126,7 @@ final class MuesliController: NSObject {
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
     private var computerUseLastFloatingStatusAt = Date.distantPast
     private var computerUseLastFloatingStatus = ""
+    private var computerUseTranscriptVisible = false
     private let computerUseFloatingStatusMinimumDwell: TimeInterval = 0.85
     private var _streamingDictationController: Any?  // StreamingDictationController (macOS 15+)
     private var isNemotronStreaming = false
@@ -204,7 +205,9 @@ final class MuesliController: NSObject {
         computerUseHotkeyMonitor.onStart = { [weak self] in self?.handleComputerUseStart() }
         computerUseHotkeyMonitor.onStop = { [weak self] in self?.handleComputerUseStop() }
         computerUseHotkeyMonitor.onCancel = { [weak self] in self?.handleComputerUseCancel() }
-        computerUseHotkeyMonitor.doubleTapEnabled = false
+        computerUseHotkeyMonitor.onToggleStart = { [weak self] in self?.handleComputerUseToggleStart() }
+        computerUseHotkeyMonitor.onToggleStop = { [weak self] in self?.handleComputerUseToggleStop() }
+        computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         let canRunMainApp = config.hasCompletedOnboarding
             && hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase)
 
@@ -221,14 +224,24 @@ final class MuesliController: NSObject {
             guard let self else { return }
             if self.hotkeyMonitor.isToggleRecording {
                 self.hotkeyMonitor.stopToggleMode()
+            } else if self.computerUseHotkeyMonitor.isToggleRecording {
+                self.computerUseHotkeyMonitor.stopToggleMode()
+            } else if self.computerUseCommandStartedAt != nil {
+                self.handleComputerUseStop()
             } else {
                 self.handleStop()
             }
         }
         indicator.onCancelToggleDictation = { [weak self] in
-            self?.handleCancel()
-            self?.indicator.isToggleDictation = false
-            self?.hotkeyMonitor.cancelToggleMode()
+            guard let self else { return }
+            if self.computerUseHotkeyMonitor.isToggleRecording || self.computerUseCommandStartedAt != nil {
+                self.handleComputerUseCancel()
+                self.computerUseHotkeyMonitor.cancelToggleMode()
+            } else {
+                self.handleCancel()
+                self.hotkeyMonitor.cancelToggleMode()
+            }
+            self.indicator.isToggleDictation = false
         }
         indicator.onPositionSaved = { [weak self] center in
             self?.updateConfig {
@@ -569,6 +582,8 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         statusBarController?.refreshIcon()
         indicator.refreshIcon()
+        hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         historyWindowController?.updateBackendLabel()
         if config.showFloatingIndicator {
             indicator.ensureVisible(config: config)
@@ -2848,6 +2863,7 @@ final class MuesliController: NSObject {
             fputs("[cua] computer use hotkey disabled because it matches dictation hotkey\n", stderr)
             return
         }
+        computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         computerUseHotkeyMonitor.targetKeyCode = config.computerUseHotkey.keyCode
         computerUseHotkeyMonitor.start()
     }
@@ -2995,18 +3011,36 @@ final class MuesliController: NSObject {
         }
     }
 
+    private func handleComputerUseToggleStart() {
+        guard canStartComputerUseCommand else {
+            computerUseHotkeyMonitor.cancelToggleMode()
+            return
+        }
+        fputs("[cua] toggle command start\n", stderr)
+        indicator.isToggleDictation = true
+        handleComputerUseStart()
+    }
+
+    private func handleComputerUseToggleStop() {
+        fputs("[cua] toggle command stop\n", stderr)
+        indicator.isToggleDictation = false
+        handleComputerUseStop()
+    }
+
     private func handleComputerUseCancel() {
         fputs("[cua] cancel\n", stderr)
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
         recorder.cancel()
         computerUseCommandStartedAt = nil
+        indicator.isToggleDictation = false
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
     }
 
     private func handleComputerUseStop() {
         fputs("[cua] stop\n", stderr)
+        indicator.isToggleDictation = false
         let startedAt = computerUseCommandStartedAt ?? Date()
         computerUseCommandStartedAt = nil
 
@@ -3109,7 +3143,7 @@ final class MuesliController: NSObject {
     @MainActor
     private func handleComputerUseCommand(transcript: String, dictationID: Int64?) async {
         resetComputerUseFloatingStatus()
-        indicator.setTranscribingTitle("Starting CUA", config: config)
+        presentComputerUseTranscript(transcript)
         setState(.transcribing)
         let runtime = ComputerUsePlannerRuntime(config: config) { [weak self] status in
             guard let self else { return }
@@ -3143,6 +3177,15 @@ final class MuesliController: NSObject {
         computerUseFloatingStatusWorkItem = nil
         computerUseLastFloatingStatusAt = .distantPast
         computerUseLastFloatingStatus = ""
+        computerUseTranscriptVisible = false
+    }
+
+    @MainActor
+    private func presentComputerUseTranscript(_ transcript: String) {
+        computerUseTranscriptVisible = true
+        computerUseLastFloatingStatusAt = .distantPast
+        computerUseLastFloatingStatus = ""
+        indicator.showComputerUseTranscript(transcript, config: config)
     }
 
     @MainActor
@@ -3153,6 +3196,9 @@ final class MuesliController: NSObject {
         statusBarController?.setStatus(trimmed)
         guard dictationState == .transcribing else { return }
         guard let floatingStatus = computerUseFloatingStatusLabel(for: trimmed) else { return }
+        if computerUseTranscriptVisible && !shouldReplaceComputerUseTranscript(with: floatingStatus) {
+            return
+        }
         guard floatingStatus != computerUseLastFloatingStatus else { return }
 
         let now = Date()
@@ -3210,6 +3256,14 @@ final class MuesliController: NSObject {
     }
 
     @MainActor
+    private func shouldReplaceComputerUseTranscript(with status: String) -> Bool {
+        if status == "Thinking..." || status == "Reading screen" {
+            return false
+        }
+        return true
+    }
+
+    @MainActor
     private func isConcreteComputerUseFloatingStatus(_ status: String) -> Bool {
         status.hasPrefix("Opening")
             || status.hasPrefix("Opened")
@@ -3228,6 +3282,7 @@ final class MuesliController: NSObject {
 
     @MainActor
     private func applyComputerUseFloatingStatus(_ status: String, at date: Date) {
+        computerUseTranscriptVisible = false
         computerUseLastFloatingStatus = status
         computerUseLastFloatingStatusAt = date
         indicator.setTranscribingTitle(status, config: config)
@@ -3263,6 +3318,8 @@ final class MuesliController: NSObject {
         switch status {
         case .done:
             return "done"
+        case .timedOut:
+            return "timed_out"
         case .needsConfirmation:
             return "confirm"
         case .failed:
@@ -3282,6 +3339,10 @@ final class MuesliController: NSObject {
             message = result.message.hasPrefix("Done") ? result.message : "Done: \(result.message)"
             floatingMessage = "Done"
             icon = ""
+        case .timedOut:
+            message = result.message
+            floatingMessage = "Timed out"
+            icon = "!"
         case .needsConfirmation:
             message = result.message.hasPrefix("Confirm") ? result.message : "Confirm: \(result.message)"
             floatingMessage = "Confirm"

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -162,7 +162,7 @@ struct ShortcutsView: View {
                     Text("Hands-Free Mode")
                         .font(MuesliTheme.headline())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("Double-tap to start, tap again to stop")
+                    Text("Double-tap dictation or CUA to start, tap again to stop")
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUseExecutorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUseExecutorTests.swift
@@ -43,6 +43,32 @@ struct ComputerUseExecutorTests {
         #expect(result.message.contains("Stale or unknown element_index 9"))
     }
 
+    @Test("secondary action rejects stale snapshot")
+    @MainActor
+    func secondaryActionRejectsStaleSnapshot() async {
+        let registry = ComputerUseElementRegistry()
+        let result = await ComputerUseToolExecutor.execute(
+            ComputerUseToolCall(tool: .performSecondaryAction, elementIndex: 9, actionName: "AXShowMenu", label: "More"),
+            registry: registry
+        )
+
+        #expect(result.status == .failed)
+        #expect(result.message.contains("Stale or unknown element_index 9"))
+    }
+
+    @Test("element scroll rejects stale snapshot")
+    @MainActor
+    func elementScrollRejectsStaleSnapshot() async {
+        let registry = ComputerUseElementRegistry()
+        let result = await ComputerUseToolExecutor.execute(
+            ComputerUseToolCall(tool: .scroll, elementIndex: 9, direction: .down),
+            registry: registry
+        )
+
+        #expect(result.status == .failed)
+        #expect(result.message.contains("Stale or unknown element_index 9"))
+    }
+
     @Test("parses browser tab Apple Events output")
     func parsesBrowserTabs() {
         let tabs = ComputerUseBrowserAutomation.parseTabs(
@@ -137,6 +163,22 @@ struct ComputerUseExecutorTests {
         #expect(script.contains("set targetTab to tab 16 of targetWindow"))
         #expect(!script.contains("tab 16 of window 1"))
         #expect(script.contains("used active tab fallback"))
+    }
+
+    @Test("opens new browser tab with mocked Apple Events adapter")
+    func opensNewBrowserTab() async {
+        var capturedScript = ""
+        ComputerUseBrowserAutomation.runAppleScriptForTests = { script in
+            capturedScript = script
+            return ""
+        }
+        defer { ComputerUseBrowserAutomation.runAppleScriptForTests = nil }
+
+        let result = await ComputerUseBrowserAutomation.openNewTab(appBundleID: "com.google.Chrome")
+
+        #expect(result.status == .executed)
+        #expect(capturedScript.contains("make new tab"))
+        #expect(capturedScript.contains("active tab index of front window"))
     }
 
     @Test("page text and DOM query use read-only JavaScript")

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
@@ -8,7 +8,8 @@ import Testing
 struct ComputerUseToolRegistryTests {
     @Test("emits schemas and descriptions for every tool")
     func emitsSchemasAndDescriptions() {
-        #expect(ComputerUseToolRegistry.definitions.count == ComputerUseToolName.allCases.count)
+        #expect(ComputerUseToolRegistry.definitions.count == ComputerUseToolName.allCases.count - 1)
+        #expect(ComputerUseToolRegistry.definition(for: .click) == nil)
         for definition in ComputerUseToolRegistry.definitions {
             #expect(!definition.description.isEmpty)
             #expect(definition.schema.type == "object")
@@ -17,7 +18,14 @@ struct ComputerUseToolRegistryTests {
             #expect(definition.schema.properties["tool"]?.enumValues == [definition.name.rawValue])
         }
         let docs = ComputerUseToolRegistry.promptDocumentation()
+        #expect(docs.contains("Tool: get_app_state"))
         #expect(docs.contains("Tool: get_window_state"))
+        #expect(docs.contains("Tool: click_element"))
+        #expect(docs.contains("Tool: click_point"))
+        #expect(!docs.contains("Tool: click\n"))
+        #expect(docs.contains("Tool: perform_secondary_action"))
+        #expect(docs.contains("Tool: open_new_browser_tab"))
+        #expect(docs.contains("Tool: navigate_active_browser_tab"))
         #expect(docs.contains("Tool: page_query_dom"))
     }
 
@@ -25,8 +33,9 @@ struct ComputerUseToolRegistryTests {
     func emitsNativeToolDefinitions() {
         let tools = ComputerUseToolRegistry.nativeToolDefinitions()
 
-        #expect(tools.count == ComputerUseToolName.allCases.count)
+        #expect(tools.count == ComputerUseToolRegistry.definitions.count)
         #expect(JSONSerialization.isValidJSONObject(tools))
+        #expect(!tools.contains { ($0["name"] as? String) == "click" })
         let launch = tools.first { ($0["name"] as? String) == "launch_app" }
         #expect(launch?["type"] as? String == "function")
         let parameters = launch?["parameters"] as? [String: Any]
@@ -47,14 +56,15 @@ struct ComputerUseToolRegistryTests {
         let instructions = ComputerUsePlannerClient.instructions
 
         #expect(instructions.contains("native tool call"))
-        #expect(instructions.contains("Browser page tools are optional shortcuts"))
+        #expect(instructions.contains("Browser DOM/page tools are optional accelerators"))
         #expect(instructions.contains("Chrome Apple Events JavaScript permission"))
         #expect(instructions.contains("AX/screenshot fallback"))
         #expect(instructions.contains("Do not use fail only because a browser DOM/page tool failed"))
-        #expect(instructions.contains("Do not call get_window_state repeatedly"))
+        #expect(instructions.contains("Do not call get_app_state/get_window_state repeatedly"))
         #expect(instructions.contains("do not loop on observation"))
-        #expect(instructions.contains("After hotkey command+t, call navigate_url without tab_index"))
+        #expect(instructions.contains("After open_new_browser_tab, call navigate_active_browser_tab"))
         #expect(instructions.contains("prefer paste_text for multi-word text"))
+        #expect(instructions.contains("Use finish only when the user's command is complete and successful"))
     }
 }
 
@@ -120,6 +130,25 @@ struct ComputerUsePlannerResponseTests {
         #expect(!response.toolCall.requiresConfirmation)
     }
 
+    @Test("decodes split click tools")
+    func decodesSplitClickTools() throws {
+        let element = try ComputerUsePlannerResponse.decodeNativeToolCall(
+            name: "click_element",
+            arguments: #"{"element_index":12,"label":"Tweet composer"}"#
+        )
+        let point = try ComputerUsePlannerResponse.decodeNativeToolCall(
+            name: "click_point",
+            arguments: #"{"screenshot_id":"s1","x":120,"y":240,"label":"fallback target"}"#
+        )
+
+        #expect(element.toolCall.tool == .clickElement)
+        #expect(element.toolCall.elementIndex == 12)
+        #expect(element.toolCall.x == nil)
+        #expect(point.toolCall.tool == .clickPoint)
+        #expect(point.toolCall.screenshotID == "s1")
+        #expect(point.toolCall.elementIndex == nil)
+    }
+
     @Test("coordinate clicks require screenshot id")
     func coordinateClicksRequireScreenshotID() {
         #expect(throws: Error.self) {
@@ -152,6 +181,22 @@ struct ComputerUsePlannerResponseTests {
         #expect(response.toolCall.y == 871)
         #expect(response.toolCall.screenshotID == "s1778148270271")
         #expect(response.toolCall.summary == "click reply text field on X post at 1050,871")
+    }
+
+    @Test("element click ignores placeholder coordinates without screenshot")
+    func elementClickIgnoresPlaceholderCoordinatesWithoutScreenshot() throws {
+        let response = try ComputerUsePlannerResponse.decodeNativeToolCall(
+            name: "click",
+            arguments: #"{"button":"left","clicks":1,"label":"New tab","y":0,"x":0,"element_id":"e46","element_index":46,"screenshot_id":""}"#
+        )
+
+        #expect(response.toolCall.tool == .click)
+        #expect(response.toolCall.elementIndex == 46)
+        #expect(response.toolCall.elementID == "e46")
+        #expect(response.toolCall.x == nil)
+        #expect(response.toolCall.y == nil)
+        #expect(response.toolCall.screenshotID == nil)
+        #expect(response.toolCall.summary == "click element e46")
     }
 
     @Test("click rejects invalid element index")
@@ -219,6 +264,51 @@ struct ComputerUsePlannerResponseTests {
         #expect(response.toolCall.tool == .pasteText)
         #expect(response.toolCall.elementIndex == 0)
         #expect(response.toolCall.canonicalBundleID == "com.apple.Notes")
+    }
+
+    @Test("decodes get app state compatibility alias")
+    func decodesGetAppStateCompatibilityAlias() throws {
+        let appState = try ComputerUsePlannerResponse.decodeJSON(
+            from: #"{"tool":"get_app_state","app_bundle_id":"com.google.Chrome"}"#
+        )
+        let windowState = try ComputerUsePlannerResponse.decodeJSON(
+            from: #"{"tool":"get_window_state","app_bundle_id":"com.google.Chrome"}"#
+        )
+
+        #expect(appState.toolCall.tool == .getAppState)
+        #expect(windowState.toolCall.tool == .getWindowState)
+        #expect(appState.toolCall.canonicalBundleID == windowState.toolCall.canonicalBundleID)
+    }
+
+    @Test("decodes secondary action and element scroll")
+    func decodesSecondaryActionAndElementScroll() throws {
+        let secondary = try ComputerUsePlannerResponse.decodeJSON(
+            from: #"{"tool":"perform_secondary_action","element_index":3,"action_name":"AXShowMenu","label":"More"}"#
+        )
+        let scroll = try ComputerUsePlannerResponse.decodeJSON(
+            from: #"{"tool":"scroll","element_id":"e7","direction":"down","pages":1}"#
+        )
+
+        #expect(secondary.toolCall.tool == .performSecondaryAction)
+        #expect(secondary.toolCall.actionName == "AXShowMenu")
+        #expect(scroll.toolCall.tool == .scroll)
+        #expect(scroll.toolCall.elementID == "e7")
+    }
+
+    @Test("decodes browser intent tools")
+    func decodesBrowserIntentTools() throws {
+        let newTab = try ComputerUsePlannerResponse.decodeNativeToolCall(
+            name: "open_new_browser_tab",
+            arguments: #"{"app_bundle_id":"com.google.Chrome"}"#
+        )
+        let navigate = try ComputerUsePlannerResponse.decodeNativeToolCall(
+            name: "navigate_active_browser_tab",
+            arguments: #"{"app_bundle_id":"com.google.Chrome","url":"https://twitter.com/compose/tweet"}"#
+        )
+
+        #expect(newTab.toolCall.tool == .openNewBrowserTab)
+        #expect(navigate.toolCall.tool == .navigateActiveBrowserTab)
+        #expect(navigate.toolCall.url == "https://twitter.com/compose/tweet")
     }
 
     @Test("native tool call rejects unsupported fields")
@@ -445,8 +535,8 @@ struct ComputerUsePlannerRuntimeTests {
             config: AppConfig(),
             maxSteps: 2,
             observe: { _, _, _ in Self.observation() },
-            plan: { _ in ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .getWindowState)) },
-            execute: { _, _ in .executed("unexpected") }
+            plan: { _ in ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .listApps)) },
+            execute: { _, _ in .executed("Apps") }
         )
 
         let result = await runtime.run(command: "look around")
@@ -705,6 +795,89 @@ struct ComputerUsePlannerRuntimeTests {
         #expect(result.traceEvents.contains { $0.body.contains("screenshot s1") })
     }
 
+    @Test("window state carries observation state ids")
+    @MainActor
+    func windowStateCarriesObservationStateIDs() {
+        let observation = Self.observation(stateID: "state-test-1", screenshot: Self.screenshot())
+        let state = ComputerUseWindowState(observation: observation)
+
+        #expect(state.stateID == "state-test-1")
+        #expect(state.observation.stateID == "state-test-1")
+    }
+
+    @Test("mutating action records verification state ids")
+    @MainActor
+    func mutatingActionRecordsVerificationStateIDs() async {
+        var observeCount = 0
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in
+                observeCount += 1
+                if observeCount == 1 {
+                    return Self.observation(stateID: "state-before", windowTitle: "Before", screenshot: Self.screenshot())
+                }
+                return Self.observation(stateID: "state-after", windowTitle: "After", screenshot: Self.screenshot())
+            },
+            plan: { request in
+                if request.step == 1 {
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .click, elementID: "e1", label: "Search"))
+                }
+                let outcome = request.priorOutcomes.last
+                #expect(outcome?.verificationStatus == .changed)
+                #expect(outcome?.beforeStateID == "state-before")
+                #expect(outcome?.afterStateID == "state-after")
+                #expect(outcome?.stateDelta?.summary.contains("Observed UI state changed") == true)
+                return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "done"))
+            },
+            execute: { _, _ in .executed("Clicked") }
+        )
+
+        let result = await runtime.run(command: "click search")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.done)
+    }
+
+    @Test("first unchanged action is planner feedback")
+    @MainActor
+    func firstUnchangedActionIsPlannerFeedback() async {
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in Self.observation(screenshot: Self.screenshot()) },
+            plan: { request in
+                if request.step == 1 {
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .pasteText, text: "hello"))
+                }
+                let outcome = request.priorOutcomes.last
+                #expect(outcome?.verificationStatus == .unchanged)
+                #expect(outcome?.message.contains("no focused value, selected text, or visible AX text change was observed") == true)
+                return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "done"))
+            },
+            execute: { _, _ in .executed("Pasted text") }
+        )
+
+        let result = await runtime.run(command: "write hello")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.done)
+    }
+
+    @Test("finish with incomplete language becomes failed")
+    @MainActor
+    func finishWithIncompleteLanguageBecomesFailed() async {
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in Self.observation() },
+            plan: { _ in
+                ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "Could not complete the task."))
+            },
+            execute: { _, _ in .executed("unexpected") }
+        )
+
+        let result = await runtime.run(command: "do something")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.failed)
+        #expect(result.message.contains("attempted to finish with an incomplete or blocked result"))
+    }
+
     @Test("browser page permission failures continue with screen fallback")
     @MainActor
     func browserPagePermissionFailuresContinueWithScreenFallback() async {
@@ -729,7 +902,7 @@ struct ComputerUsePlannerRuntimeTests {
                 }
                 #expect(request.priorOutcomes.last?.tool == .pageGetText)
                 #expect(request.priorOutcomes.last?.status == "failed")
-                #expect(request.priorOutcomes.last?.message.contains("Continue with get_window_state plus AX/screenshot tools") == true)
+                #expect(request.priorOutcomes.last?.message.contains("Continue with get_app_state plus AX/screenshot tools") == true)
                 return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "used screen fallback"))
             },
             execute: { toolCall, _ in
@@ -744,6 +917,36 @@ struct ComputerUsePlannerRuntimeTests {
         #expect(result.message == "used screen fallback")
         #expect(observeCount == 2)
         #expect(result.traceEvents.contains { $0.title == "Screen fallback" })
+    }
+
+    @Test("invalid tool call is repaired through planner feedback")
+    @MainActor
+    func invalidToolCallIsRepairedThroughPlannerFeedback() async {
+        var planCalls = 0
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in Self.observation(screenshot: Self.screenshot()) },
+            plan: { request in
+                planCalls += 1
+                if planCalls == 1 {
+                    throw ComputerUsePlannerError.invalidToolCall(
+                        name: "click_point",
+                        arguments: #"{"x":0,"y":0}"#,
+                        message: "click_point requires screenshot_id"
+                    )
+                }
+                #expect(request.priorOutcomes.last?.status == "invalid_schema")
+                #expect(request.priorOutcomes.last?.message.contains("Choose exactly one valid tool") == true)
+                return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "done"))
+            },
+            execute: { _, _ in .executed("unexpected") }
+        )
+
+        let result = await runtime.run(command: "click something")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.done)
+        #expect(planCalls == 2)
+        #expect(result.traceEvents.contains { $0.title == "Planner schema repair" })
     }
 
     @Test("type text focus failures continue with focus fallback")
@@ -906,12 +1109,14 @@ struct ComputerUsePlannerRuntimeTests {
     }
 
     static func observation(
+        stateID: String = ComputerUseObservation.newStateID(),
         appName: String = "Test",
         bundleID: String = "com.example.Test",
         windowTitle: String = "Window",
         screenshot: ComputerUseScreenshotObservation? = nil
     ) -> ComputerUseObservation {
         ComputerUseObservation(
+            stateID: stateID,
             appName: appName,
             bundleID: bundleID,
             windowTitle: windowTitle,

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
@@ -934,6 +934,41 @@ struct ComputerUsePlannerRuntimeTests {
         #expect(result.status == ComputerUsePlannerRuntimeResult.Status.done)
     }
 
+    @Test("changed action clears previous unchanged action counts")
+    @MainActor
+    func changedActionClearsPreviousUnchangedActionCounts() async {
+        var observeCount = 0
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in
+                observeCount += 1
+                let title = observeCount <= 2 ? "Before" : "After"
+                return Self.observation(windowTitle: title, screenshot: Self.screenshot())
+            },
+            plan: { request in
+                switch request.step {
+                case 1:
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .click, elementID: "e1", label: "Action A"))
+                case 2:
+                    #expect(request.priorOutcomes.last?.verificationStatus == .unchanged)
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .click, elementID: "e2", label: "Action B"))
+                case 3:
+                    #expect(request.priorOutcomes.last?.verificationStatus == .changed)
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .click, elementID: "e1", label: "Action A"))
+                default:
+                    #expect(request.priorOutcomes.last?.verificationStatus == .unchanged)
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "done"))
+                }
+            },
+            execute: { _, _ in .executed("Clicked") }
+        )
+
+        let result = await runtime.run(command: "try alternate actions")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.done)
+        #expect(observeCount == 4)
+    }
+
     @Test("finish with incomplete language becomes failed")
     @MainActor
     func finishWithIncompleteLanguageBecomesFailed() async {
@@ -950,6 +985,32 @@ struct ComputerUsePlannerRuntimeTests {
 
         #expect(result.status == ComputerUsePlannerRuntimeResult.Status.failed)
         #expect(result.message.contains("attempted to finish with an incomplete or blocked result"))
+    }
+
+    @Test("finish failure heuristic avoids success false positives")
+    @MainActor
+    func finishFailureHeuristicAvoidsSuccessFalsePositives() async {
+        var finishReasons = [
+            "Granted the camera permission.",
+            "The modal did not have a cancel button so I pressed Escape instead; task is complete.",
+        ]
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in Self.observation() },
+            plan: { _ in
+                ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(
+                    tool: .finish,
+                    reason: finishReasons.removeFirst()
+                ))
+            },
+            execute: { _, _ in .executed("unexpected") }
+        )
+
+        let permissionResult = await runtime.run(command: "grant permission")
+        let didNotResult = await runtime.run(command: "dismiss modal")
+
+        #expect(permissionResult.status == ComputerUsePlannerRuntimeResult.Status.done)
+        #expect(didNotResult.status == ComputerUsePlannerRuntimeResult.Status.done)
     }
 
     @Test("browser page permission failures continue with screen fallback")

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
@@ -453,6 +453,13 @@ struct ComputerUseTraceFormatterTests {
         #expect(ComputerUseTraceFormatter.displayStatus(for: planning) == nil)
         #expect(ComputerUseTraceFormatter.displayStatus(for: result) == "executed")
     }
+
+    @Test("formats final CUA status buckets")
+    func formatsFinalStatusBuckets() {
+        #expect(ComputerUseTraceFormatter.displayFinalStatus("done") == "done")
+        #expect(ComputerUseTraceFormatter.displayFinalStatus("timedout") == "timed_out")
+        #expect(ComputerUseTraceFormatter.displayFinalStatus("fail") == "failed")
+    }
 }
 
 @Suite("Computer Use planner runtime")
@@ -489,6 +496,24 @@ struct ComputerUsePlannerRuntimeTests {
 
         #expect(result.status == ComputerUsePlannerRuntimeResult.Status.failed)
         #expect(result.message == "blocked")
+    }
+
+    @Test("timeout produces timed out runtime result")
+    @MainActor
+    func timeoutProducesTimedOutResult() async {
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            timeoutSeconds: -1,
+            observe: { _, _, _ in Self.observation() },
+            plan: { _ in ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "done")) },
+            execute: { _, _ in .executed("unexpected") }
+        )
+
+        let result = await runtime.run(command: "do something")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.timedOut)
+        #expect(result.message == "CUA timed out")
+        #expect(result.traceEvents.contains { $0.kind == "timed_out" && $0.status == "timed_out" })
     }
 
     @Test("cancelled executor result produces cancelled runtime result")
@@ -573,9 +598,58 @@ struct ComputerUsePlannerRuntimeTests {
         #expect(result.traceEvents.contains { $0.title == "Repeated action stopped" })
     }
 
-    @Test("stops repeated get window state loops")
+    @Test("repeated get window state gives planner feedback before stopping")
     @MainActor
-    func stopsRepeatedGetWindowStateLoops() async {
+    func repeatedGetWindowStateGivesPlannerFeedbackBeforeStopping() async {
+        var executionCount = 0
+        let runtime = ComputerUsePlannerRuntime(
+            config: AppConfig(),
+            observe: { _, _, _ in
+                Self.observation(
+                    appName: "Google Chrome",
+                    bundleID: "com.google.Chrome",
+                    windowTitle: "YouTube",
+                    screenshot: ComputerUseScreenshotObservation(
+                        screenshotID: "s\(executionCount)",
+                        width: 2940,
+                        height: 1800,
+                        windowFrame: ComputerUseRect(x: 0, y: 0, width: 1470, height: 900),
+                        scaleX: 2,
+                        scaleY: 2,
+                        imageDataURL: "data:image/jpeg;base64,abc"
+                    )
+                )
+            },
+            plan: { request in
+                if request.step == 2 {
+                    #expect(request.priorOutcomes.last?.message.contains("State is unchanged after get window state") == true)
+                    #expect(request.priorOutcomes.last?.message.contains("choose a concrete action now") == true)
+                }
+                if request.step <= 2 {
+                    return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(
+                        tool: .getWindowState,
+                        appBundleID: "com.google.Chrome"
+                    ))
+                }
+                #expect(request.priorOutcomes.last?.message.contains("do not call get_app_state/get_window_state again") == true)
+                return ComputerUsePlannerResponse(toolCall: ComputerUseToolCall(tool: .finish, reason: "done"))
+            },
+            execute: { _, _ in
+                executionCount += 1
+                return .executed("Observed")
+            }
+        )
+
+        let result = await runtime.run(command: "use the visible page")
+
+        #expect(result.status == ComputerUsePlannerRuntimeResult.Status.done)
+        #expect(executionCount == 2)
+        #expect(!result.traceEvents.contains { $0.title == "Repeated action stopped" })
+    }
+
+    @Test("stops observation-only loops after larger budget")
+    @MainActor
+    func stopsObservationOnlyLoopsAfterLargerBudget() async {
         var executionCount = 0
         let runtime = ComputerUsePlannerRuntime(
             config: AppConfig(),
@@ -610,8 +684,8 @@ struct ComputerUsePlannerRuntimeTests {
         let result = await runtime.run(command: "use the visible page")
 
         #expect(result.status == ComputerUsePlannerRuntimeResult.Status.failed)
-        #expect(result.message.contains("repeated get window state after two unchanged attempts"))
-        #expect(executionCount == 2)
+        #expect(result.message.contains("repeated get window state after 4 unchanged observations"))
+        #expect(executionCount == 4)
         #expect(result.traceEvents.contains { $0.title == "Repeated action stopped" })
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -173,6 +173,24 @@ struct IndicatorFrameSizeTests {
         #expect(size.width <= 148)
         #expect(size.height == 32)
     }
+
+    @Test("CUA transcript pill wraps and grows vertically instead of truncating")
+    @MainActor
+    func computerUseTranscriptPillWrapsAndExpands() {
+        let short = FloatingIndicatorController.computerUseTranscriptPillSizeForTesting(
+            transcript: "Open Twitter",
+            screenWidth: 1200
+        )
+        let long = FloatingIndicatorController.computerUseTranscriptPillSizeForTesting(
+            transcript: "Open Twitter in Google Chrome and write a tweet saying this was written using Muesli CUA without posting it",
+            screenWidth: 420
+        )
+
+        #expect(short.width >= 280)
+        #expect(short.height >= 44)
+        #expect(long.width <= 372)
+        #expect(long.height > short.height)
+    }
 }
 
 // MARK: - OpenAI Logo Shape


### PR DESCRIPTION
## Summary

This PR hardens the native Muesli CUA harness around the failure modes we saw in local runs:

- adds `get_app_state` as the primary state tool while keeping `get_window_state` as a compatibility alias
- enriches CUA observations with state IDs, screenshot metadata, focused element details, selected text, cursor position, app/browser hints, and AX candidate fingerprints
- adds post-action verification for mutating actions with `changed`, `unchanged`, `target_lost`, `blocked`, and `unknown` outcomes
- decomposes fragile generic tool schemas into stricter primitives such as `click_element`, `click_point`, `open_new_browser_tab`, and `navigate_active_browser_tab`
- keeps repeated unchanged mutating actions from looping, while allowing repeated observation tools to feed back to the planner before eventually timing out
- adds `perform_secondary_action` and element-scoped `scroll`
- improves stale AX element refetching when exactly one equivalent element exists
- hardens text insertion verification and browser fallback behavior
- classifies runtime outcomes more clearly, including persisted `timed_out` status
- improves CUA UX by showing the transcribed command in an expanding floating pill and enabling double-tap hands-free CUA

## Why

Recent CUA traces showed the planner getting stuck on repeated observations, stale browser/tab assumptions, invalid tool schemas, and text-entry uncertainty. The harness now gives the planner fresher state, tighter schemas, actionable verification feedback, and clearer terminal status buckets so we can distinguish successful commands from true failures and timeouts.

## Validation

- `swift test --package-path native/MuesliNative --filter ComputerUsePlannerTests` passed
- `swift test --package-path native/MuesliNative --filter PasteController` passed
- `./scripts/dev-test.sh` rebuilt, signed, installed, and launched `/Applications/MuesliDev.app`
- Full `swift test --package-path native/MuesliNative` was run; CUA tests passed, but one unrelated shared `NSPasteboard.general` PasteController test failed under parallel full-suite execution and passed when rerun in isolation

## Notes

This intentionally does not add app-specific recipes or a separate CUA helper service. The changes stay inside the generic native app control loop.