### PR TITLE
[codex] Improve onboarding use-case flow

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -59,6 +59,8 @@ final class AppState {
     // Live status
     var isMeetingRecording: Bool = false
     var isMeetingRecordingPaused: Bool = false
+    var dictationState: DictationState = .idle
+    var isVoiceNoteRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false
     var isGoogleCalendarAvailable: Bool = false
     var isGoogleCalendarVerified: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -52,7 +52,7 @@ final class AppState {
     // Config-driven state
     var selectedBackend: BackendOption = .whisper
     var selectedMeetingTranscriptionBackend: BackendOption = .whisper
-    var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .openAI
+    var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .chatGPT
     var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -74,6 +74,15 @@ struct DictationsView: View {
                 meetingStats: appState.meetingStats
             )
 
+            if appState.config.resolvedOnboardingUseCase.includesVoiceNotes {
+                HStack {
+                    Spacer()
+                    voiceNoteButton
+                }
+                .padding(.horizontal, MuesliTheme.spacing24)
+                .padding(.bottom, MuesliTheme.spacing12)
+            }
+
             if appState.dictationRows.isEmpty {
                 Spacer()
                 VStack(spacing: MuesliTheme.spacing12) {
@@ -83,7 +92,7 @@ struct DictationsView: View {
                     Text("No dictations yet")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textSecondary)
-                    Text("Hold \(appState.config.dictationHotkey.label) to start dictating")
+                    Text(emptyStateInstruction)
                         .font(MuesliTheme.callout())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
@@ -160,6 +169,34 @@ struct DictationsView: View {
                 }
             }
         }
+    }
+
+    private var emptyStateInstruction: String {
+        appState.config.resolvedOnboardingUseCase.includesVoiceNotes
+            ? "Click Record Voice Note to capture your first note"
+            : "Hold \(appState.config.dictationHotkey.label) to start dictating"
+    }
+
+    private var voiceNoteButton: some View {
+        let isRecording = appState.isVoiceNoteRecording
+        return Button {
+            controller.toggleVoiceNoteRecording()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isRecording ? "stop.fill" : "mic.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(isRecording ? "Stop Voice Note" : "Record Voice Note")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .frame(height: 30)
+            .background(isRecording ? MuesliTheme.recording : MuesliTheme.accent)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.dictationState == .transcribing)
+        .opacity(appState.dictationState == .transcribing ? 0.55 : 1)
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -52,7 +52,7 @@ enum MeetingSummaryClient {
         manualNotesToRetain: String? = nil,
         visualContext: String? = nil
     ) async throws -> String {
-        let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.openAI.backend : config.meetingSummaryBackend).lowercased()
+        let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.chatGPT.backend : config.meetingSummaryBackend).lowercased()
         let generatedNotes: String
         if backend == MeetingSummaryBackendOption.chatGPT.backend {
             generatedNotes = try await summarizeWithChatGPT(
@@ -552,7 +552,7 @@ enum MeetingSummaryClient {
     }
 
     static func generateTitle(transcript: String, config: AppConfig) async -> String? {
-        let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.openAI.backend : config.meetingSummaryBackend).lowercased()
+        let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.chatGPT.backend : config.meetingSummaryBackend).lowercased()
 
         // Use a short prefix of the transcript for title generation (save tokens)
         let truncated = String(transcript.prefix(1500))

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -557,6 +557,10 @@ enum OnboardingUseCase: String, Codable, CaseIterable {
         self == .meetings || self == .dictationAndMeetings
     }
 
+    var canSwitchToVoiceNotesOnly: Bool {
+        self == .dictation
+    }
+
     static func resolved(_ rawValue: String?) -> OnboardingUseCase {
         guard let rawValue, let useCase = OnboardingUseCase(rawValue: rawValue) else {
             return .dictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -117,6 +117,9 @@ struct BackendOption: Equatable {
     /// Models available for download and use.
     static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe] + experimental
 
+    /// Conservative first-run choices. Experimental and very large models stay in Models.
+    static let onboarding: [BackendOption] = [.parakeetMultilingual, .whisperTinyEnglish, .whisperSmall]
+
     /// Models coming soon — shown greyed out in the Models tab.
     static let comingSoon: [BackendOption] = []
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -506,8 +506,8 @@ enum IndicatorAnchor: String, Codable, CaseIterable {
 }
 
 struct HotkeyConfig: Codable, Equatable {
-    var keyCode: UInt16 = 55
-    var label: String = "Left Cmd"
+    var keyCode: UInt16 = 61
+    var label: String = "Right Option"
 
     static func label(for keyCode: UInt16) -> String? {
         switch keyCode {
@@ -533,12 +533,21 @@ struct HotkeyConfig: Codable, Equatable {
 }
 
 enum OnboardingUseCase: String, Codable, CaseIterable {
+    case voiceNotes = "voice_notes"
     case dictation = "dictation"
     case meetings = "meetings"
     case dictationAndMeetings = "dictation_and_meetings"
 
     var includesDictation: Bool {
         self == .dictation || self == .dictationAndMeetings
+    }
+
+    var includesVoiceNotes: Bool {
+        self == .voiceNotes
+    }
+
+    var includesPushToTalk: Bool {
+        includesVoiceNotes || includesDictation
     }
 
     var includesMeetings: Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -117,8 +117,8 @@ struct BackendOption: Equatable {
     /// Models available for download and use.
     static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe] + experimental
 
-    /// Conservative first-run choices. Experimental and very large models stay in Models.
-    static let onboarding: [BackendOption] = [.parakeetMultilingual, .whisperTinyEnglish, .whisperSmall]
+    /// Conservative first-run choices. Experimental models stay in Models.
+    static let onboarding: [BackendOption] = [.parakeetMultilingual, .whisperTinyEnglish, .whisperSmall, .cohereTranscribe]
 
     /// Models coming soon — shown greyed out in the Models tab.
     static let comingSoon: [BackendOption] = []

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -318,11 +318,11 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "ChatGPT"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.openAI, .openRouter, .chatGPT]
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
-            return .openAI
+            return .chatGPT
         }
         return option
     }
@@ -577,7 +577,7 @@ struct AppConfig: Codable {
     var cohereLanguage: String = CohereTranscribeLanguage.defaultLanguage.rawValue
     var meetingTranscriptionBackend: String = BackendOption.whisper.backend
     var meetingTranscriptionModel: String = BackendOption.whisper.model
-    var meetingSummaryBackend: String = MeetingSummaryBackendOption.openAI.backend
+    var meetingSummaryBackend: String = MeetingSummaryBackendOption.chatGPT.backend
     var defaultMeetingTemplateID: String = MeetingTemplates.autoID
     var whisperModel: String = BackendOption.whisper.model
     var idleTimeout: Double = 120

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1473,32 +1473,6 @@ final class MuesliController: NSObject {
         )
     }
 
-    func promoteVoiceNotesToDictationIfReady(
-        microphoneGranted: Bool,
-        accessibilityGranted: Bool,
-        inputMonitoringGranted: Bool
-    ) {
-        guard config.resolvedOnboardingUseCase == .voiceNotes else { return }
-        guard OnboardingPermissionGate.hasRequiredDictationPermissions(
-            OnboardingPermissionSnapshot(
-                microphone: microphoneGranted,
-                accessibility: accessibilityGranted,
-                inputMonitoring: inputMonitoringGranted,
-                systemAudio: false,
-                screenRecording: false
-            )
-        ) else { return }
-
-        updateConfig { $0.onboardingUseCase = OnboardingUseCase.dictation.rawValue }
-        hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
-        hotkeyMonitor.start()
-        startComputerUseHotkeyMonitorIfNeeded()
-        TelemetryDeck.signal("onboarding.capability_promoted", parameters: [
-            "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
-            "to_use_case": OnboardingUseCase.dictation.rawValue,
-        ])
-    }
-
     private func ensureBasicDictationPermissionsBeforeDashboard() -> Bool {
         guard hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase) else {
             historyWindowController?.close()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1069,7 +1069,8 @@ final class MuesliController: NSObject {
     func updateComputerUseHotkey(_ hotkey: HotkeyConfig) -> ShortcutHotkeyUpdateResult {
         let result = ShortcutHotkeyPolicy.validateComputerUseHotkey(
             hotkey,
-            dictationHotkey: config.dictationHotkey
+            dictationHotkey: config.dictationHotkey,
+            isComputerUseEnabled: config.enableComputerUseHotkey
         )
         guard result.didUpdate else {
             fputs("[hotkeys] rejected computer use hotkey because it matches dictation hotkey\n", stderr)
@@ -3476,7 +3477,9 @@ final class MuesliController: NSObject {
                 if !delta.isEmpty {
                     self.previousStreamText = fullText
                     DispatchQueue.main.async {
-                        PasteController.typeText(delta)
+                        if self.currentDictationOutputMode != .voiceNote {
+                            PasteController.typeText(delta)
+                        }
                     }
                 }
             }
@@ -3518,11 +3521,11 @@ final class MuesliController: NSObject {
 
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
-            resetDictationOutputMode()
             if #available(macOS 15, *) {
                 isNemotronStreaming = true
                 previousStreamText = ""
                 dictationStartedAt = Date()
+                setState(.recording)
                 indicator.setToggleDictation(true, config: config)
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
                 startNemotronStreamingAsync()
@@ -3605,6 +3608,7 @@ final class MuesliController: NSObject {
             statusBarController?.refresh()
             historyWindowController?.reload()
             syncAppState()
+            resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1473,6 +1473,33 @@ final class MuesliController: NSObject {
         )
     }
 
+    func reclassifyVoiceNotesAsDictationIfReady(
+        microphoneGranted: Bool,
+        accessibilityGranted: Bool,
+        inputMonitoringGranted: Bool
+    ) {
+        guard config.resolvedOnboardingUseCase == .voiceNotes else { return }
+        guard OnboardingPermissionGate.hasRequiredDictationPermissions(
+            OnboardingPermissionSnapshot(
+                microphone: microphoneGranted,
+                accessibility: accessibilityGranted,
+                inputMonitoring: inputMonitoringGranted,
+                systemAudio: false,
+                screenRecording: false
+            )
+        ) else { return }
+
+        updateConfig { $0.onboardingUseCase = OnboardingUseCase.dictation.rawValue }
+        hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
+        hotkeyMonitor.start()
+        startComputerUseHotkeyMonitorIfNeeded()
+        TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
+            "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
+            "to_use_case": OnboardingUseCase.dictation.rawValue,
+            "reason": "dictation_permissions_granted",
+        ])
+    }
+
     private func ensureBasicDictationPermissionsBeforeDashboard() -> Bool {
         guard hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase) else {
             historyWindowController?.close()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5,6 +5,20 @@ import Sparkle
 import TelemetryDeck
 import MuesliCore
 
+private enum DictationOutputMode {
+    case paste
+    case voiceNote
+
+    var pasteMethod: String {
+        switch self {
+        case .paste:
+            return "clipboard_restore"
+        case .voiceNote:
+            return "voice_note"
+        }
+    }
+}
+
 struct MeetingResummarizationPlan: Equatable {
     let promptTitle: String
     let persistedTitle: String
@@ -121,6 +135,7 @@ final class MuesliController: NSObject {
     private var staleLiveMeetingRecoveryFailures = Set<Int64>()
     private var dictationState: DictationState = .idle
     private var dictationStartedAt: Date?
+    private var currentDictationOutputMode: DictationOutputMode = .paste
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
@@ -209,7 +224,7 @@ final class MuesliController: NSObject {
             && hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase)
 
         // Defer permission-triggering monitors until after onboarding
-        if canRunMainApp && config.resolvedOnboardingUseCase.includesDictation {
+        if canRunMainApp && config.resolvedOnboardingUseCase.includesPushToTalk {
             hotkeyMonitor.targetKeyCode = config.dictationHotkey.keyCode
             hotkeyMonitor.start()
             startComputerUseHotkeyMonitorIfNeeded()
@@ -1033,19 +1048,64 @@ final class MuesliController: NSObject {
         updateConfig { $0.customWords.removeAll { $0.id == id } }
     }
 
-    func updateDictationHotkey(_ hotkey: HotkeyConfig) {
+    @discardableResult
+    func updateDictationHotkey(_ hotkey: HotkeyConfig) -> ShortcutHotkeyUpdateResult {
+        let result = ShortcutHotkeyPolicy.validateDictationHotkey(
+            hotkey,
+            computerUseHotkey: config.computerUseHotkey,
+            isComputerUseEnabled: config.enableComputerUseHotkey
+        )
+        guard result.didUpdate else {
+            fputs("[hotkeys] rejected dictation hotkey because it matches computer use hotkey\n", stderr)
+            return result
+        }
         updateConfig { $0.dictationHotkey = hotkey }
         hotkeyMonitor.configure(keyCode: hotkey.keyCode)
         configureComputerUseHotkeyMonitor()
+        return result
     }
 
-    func updateComputerUseHotkey(_ hotkey: HotkeyConfig) {
+    @discardableResult
+    func updateComputerUseHotkey(_ hotkey: HotkeyConfig) -> ShortcutHotkeyUpdateResult {
+        let result = ShortcutHotkeyPolicy.validateComputerUseHotkey(
+            hotkey,
+            dictationHotkey: config.dictationHotkey
+        )
+        guard result.didUpdate else {
+            fputs("[hotkeys] rejected computer use hotkey because it matches dictation hotkey\n", stderr)
+            return result
+        }
         updateConfig { $0.computerUseHotkey = hotkey }
         configureComputerUseHotkeyMonitor()
+        return result
     }
 
-    func updateComputerUseHotkeyEnabled(_ enabled: Bool) {
+    @discardableResult
+    func updateComputerUseHotkeyEnabled(_ enabled: Bool) -> ShortcutHotkeyUpdateResult {
+        if enabled {
+            let resolution = ShortcutHotkeyPolicy.resolvedComputerUseHotkeyWhenEnabling(
+                currentHotkey: config.computerUseHotkey,
+                dictationHotkey: config.dictationHotkey
+            )
+            updateConfig { config in
+                config.computerUseHotkey = resolution.hotkey
+                config.enableComputerUseHotkey = true
+            }
+            configureComputerUseHotkeyMonitor()
+            return resolution.result
+        }
         updateConfig { $0.enableComputerUseHotkey = enabled }
+        configureComputerUseHotkeyMonitor()
+        return .updated
+    }
+
+    func resetShortcutDefaults() {
+        updateConfig { config in
+            config.dictationHotkey = .default
+            config.computerUseHotkey = .computerUseDefault
+            config.enableComputerUseHotkey = false
+        }
+        hotkeyMonitor.configure(keyCode: HotkeyConfig.default.keyCode)
         configureComputerUseHotkeyMonitor()
     }
 
@@ -1323,7 +1383,7 @@ final class MuesliController: NSObject {
             config.meetingTranscriptionModel = backend.model
             config.dictationHotkey = hotkey
             config.computerUseHotkey = HotkeyConfig.computerUseDefault(avoiding: hotkey)
-            config.enableComputerUseHotkey = true
+            config.enableComputerUseHotkey = false
             config.enableComputerUsePlanner = true
             config.onboardingUseCase = onboardingUseCase.rawValue
             if let summaryBackend {
@@ -1350,7 +1410,7 @@ final class MuesliController: NSObject {
         onboardingWindowController?.close()
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {
-            if onboardingUseCase.includesDictation {
+            if onboardingUseCase.includesPushToTalk {
                 hotkeyMonitor.start()
                 startComputerUseHotkeyMonitorIfNeeded()
             }
@@ -1360,8 +1420,12 @@ final class MuesliController: NSObject {
             }
             TelemetryDeck.signal("onboarding.completed", parameters: [
                 "use_case": onboardingUseCase.rawValue,
+                "voice_notes_selected": onboardingUseCase.includesVoiceNotes ? "true" : "false",
                 "dictation_selected": onboardingUseCase.includesDictation ? "true" : "false",
                 "meetings_selected": onboardingUseCase.includesMeetings ? "true" : "false",
+                "microphone_granted": AVCaptureDevice.authorizationStatus(for: .audio) == .authorized ? "true" : "false",
+                "accessibility_granted": AXIsProcessTrusted() ? "true" : "false",
+                "input_monitoring_granted": CGPreflightListenEventAccess() ? "true" : "false",
             ])
             let completionTab = OnboardingFlow.completionTab(for: onboardingUseCase)
             openHistoryWindow(tab: completionTab)
@@ -1396,18 +1460,42 @@ final class MuesliController: NSObject {
     }
 
     private func hasRequiredStartupPermissions(for useCase: OnboardingUseCase) -> Bool {
-        if !useCase.includesDictation {
-            return AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
-        }
-        return OnboardingPermissionGate.hasRequiredDictationPermissions(
+        OnboardingPermissionGate.hasRequiredPermissions(
             OnboardingPermissionSnapshot(
                 microphone: AVCaptureDevice.authorizationStatus(for: .audio) == .authorized,
                 accessibility: AXIsProcessTrusted(),
                 inputMonitoring: CGPreflightListenEventAccess(),
                 systemAudio: false,
                 screenRecording: false
-            )
+            ),
+            for: useCase
         )
+    }
+
+    func promoteVoiceNotesToDictationIfReady(
+        microphoneGranted: Bool,
+        accessibilityGranted: Bool,
+        inputMonitoringGranted: Bool
+    ) {
+        guard config.resolvedOnboardingUseCase == .voiceNotes else { return }
+        guard OnboardingPermissionGate.hasRequiredDictationPermissions(
+            OnboardingPermissionSnapshot(
+                microphone: microphoneGranted,
+                accessibility: accessibilityGranted,
+                inputMonitoring: inputMonitoringGranted,
+                systemAudio: false,
+                screenRecording: false
+            )
+        ) else { return }
+
+        updateConfig { $0.onboardingUseCase = OnboardingUseCase.dictation.rawValue }
+        hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
+        hotkeyMonitor.start()
+        startComputerUseHotkeyMonitorIfNeeded()
+        TelemetryDeck.signal("onboarding.capability_promoted", parameters: [
+            "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
+            "to_use_case": OnboardingUseCase.dictation.rawValue,
+        ])
     }
 
     private func ensureBasicDictationPermissionsBeforeDashboard() -> Bool {
@@ -2808,6 +2896,7 @@ final class MuesliController: NSObject {
 
     private func setState(_ state: DictationState) {
         dictationState = state
+        appState.dictationState = state
         let status: String
         switch state {
         case .idle: status = "Idle"
@@ -3315,6 +3404,20 @@ final class MuesliController: NSObject {
         }
     }
 
+    private var defaultDictationOutputMode: DictationOutputMode {
+        config.resolvedOnboardingUseCase.includesVoiceNotes ? .voiceNote : .paste
+    }
+
+    private func beginDictationOutput(mode: DictationOutputMode? = nil) {
+        currentDictationOutputMode = mode ?? defaultDictationOutputMode
+        appState.isVoiceNoteRecording = currentDictationOutputMode == .voiceNote
+    }
+
+    private func resetDictationOutputMode() {
+        currentDictationOutputMode = .paste
+        appState.isVoiceNoteRecording = false
+    }
+
     private func handleStart() {
         if isMeetingRecording() { return }
 
@@ -3328,6 +3431,7 @@ final class MuesliController: NSObject {
 
         fputs("[muesli-native] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
+        beginDictationOutput()
 
         do {
             try recorder.start()
@@ -3351,6 +3455,7 @@ final class MuesliController: NSObject {
             SoundController.playDictationStart(enabled: config.soundEnabled && !isDictationTestMode)
         } catch {
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
+            resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
@@ -3387,6 +3492,7 @@ final class MuesliController: NSObject {
     private func handleCancel() {
         if isMeetingRecording() { return }
         fputs("[muesli-native] cancel\n", stderr)
+        resetDictationOutputMode()
 
         if isNemotronStreaming {
             isNemotronStreaming = false
@@ -3404,13 +3510,15 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
     }
 
-    private func handleToggleStart() {
+    private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
         if isMeetingRecording() { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         meetingMonitor.suppressWhileActive()
+        beginDictationOutput(mode: outputMode)
 
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
+            resetDictationOutputMode()
             if #available(macOS 15, *) {
                 isNemotronStreaming = true
                 previousStreamText = ""
@@ -3439,6 +3547,7 @@ final class MuesliController: NSObject {
             indicator.setToggleDictation(true, config: config)
         } catch {
             fputs("[muesli-native] toggle start failed: \(error)\n", stderr)
+            resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
@@ -3449,6 +3558,14 @@ final class MuesliController: NSObject {
         fputs("[muesli-native] toggle dictation stop\n", stderr)
         indicator.isToggleDictation = false
         handleStop()
+    }
+
+    func toggleVoiceNoteRecording() {
+        if dictationStartedAt != nil {
+            handleToggleStop()
+        } else if dictationState == .idle {
+            handleToggleStart(outputMode: .voiceNote)
+        }
     }
 
     private func handleStop() {
@@ -3497,6 +3614,7 @@ final class MuesliController: NSObject {
         // Standard path: stop recording → transcribe → paste
         guard let wavURL = recorder.stop() else {
             fputs("[muesli-native] stop without wav\n", stderr)
+            resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             return
@@ -3508,6 +3626,7 @@ final class MuesliController: NSObject {
             if isDictationTestMode {
                 dictationTestCallback?("")
             }
+            resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             return
@@ -3515,6 +3634,7 @@ final class MuesliController: NSObject {
 
         setState(.transcribing)
         let isTestMode = isDictationTestMode
+        let outputMode = currentDictationOutputMode
         let transcriptionBackend = isTestMode ? (dictationTestBackend ?? selectedBackend) : selectedBackend
         let transcriptionLanguage = isTestMode ? (dictationTestCohereLanguage ?? config.resolvedCohereLanguage) : config.resolvedCohereLanguage
         let task = Task { [weak self] in
@@ -3540,6 +3660,7 @@ final class MuesliController: NSObject {
                 if isTestMode {
                     await MainActor.run {
                         self.dictationTestCallback?(text)
+                        self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
                     }
@@ -3551,6 +3672,7 @@ final class MuesliController: NSObject {
                 }
                 guard !text.isEmpty else {
                     await MainActor.run {
+                        self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
                     }
@@ -3569,18 +3691,24 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()
-                    PasteController.paste(text: text)
-                    SoundController.playDictationInsert(enabled: self.config.soundEnabled)
+                    if outputMode == .voiceNote {
+                        SoundController.playDictationInsert(enabled: self.config.soundEnabled)
+                    } else {
+                        PasteController.paste(text: text)
+                        SoundController.playDictationInsert(enabled: self.config.soundEnabled)
+                    }
+                    self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
                     TelemetryDeck.signal("dictation.completed", parameters: [
                         "backend": self.selectedBackend.backend,
-                        "paste_method": "clipboard_restore",
+                        "paste_method": outputMode.pasteMethod,
                     ])
                 }
             } catch is CancellationError {
                 fputs("[muesli-native] test dictation cancelled\n", stderr)
                 await MainActor.run {
+                    self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
                 }
@@ -3590,6 +3718,7 @@ final class MuesliController: NSObject {
                     if self.isDictationTestMode {
                         self.dictationTestFailureCallback?(self.userFacingDictationTestError(error))
                     }
+                    self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1129,6 +1129,11 @@ final class MuesliController: NSObject {
     }
 
     @MainActor
+    func prepareOnboardingForNativePermissionPrompt() {
+        onboardingWindowController?.prepareForNativePermissionPrompt()
+    }
+
+    @MainActor
     func notifyOnboardingModelReady() {
         guard onboardingWindowController != nil else { return }
         SoundController.playModelReady(enabled: config.soundEnabled)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -181,7 +181,7 @@ final class MuesliController: NSObject {
         }) ?? self.selectedBackend
         self.selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == loadedConfig.meetingSummaryBackend
-        }) ?? .openAI
+        }) ?? .chatGPT
         self.indicator = FloatingIndicatorController(configStore: configStore)
         ComputerUseCursorOverlay.shared.attachIndicator(self.indicator)
         super.init()
@@ -580,7 +580,7 @@ final class MuesliController: NSObject {
         }) ?? selectedBackend
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == config.meetingSummaryBackend
-        }) ?? .openAI
+        }) ?? .chatGPT
         statusBarController?.refresh()
         statusBarController?.refreshIcon()
         indicator.refreshIcon()

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingFlow.swift
@@ -13,7 +13,7 @@ enum OnboardingFlow {
 
     static func orderedSteps(for useCase: OnboardingUseCase) -> [Int] {
         var steps = [Step.welcome.rawValue, Step.model.rawValue]
-        if useCase.includesDictation {
+        if useCase.includesPushToTalk {
             steps += [Step.hotkey.rawValue, Step.permissions.rawValue, Step.dictationTest.rawValue]
         } else if useCase.includesMeetings {
             steps += [Step.permissions.rawValue]

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingProgress.swift
@@ -13,12 +13,19 @@ enum OnboardingPermissionGate {
         permissions.microphone && permissions.accessibility && permissions.inputMonitoring
     }
 
+    static func hasRequiredVoiceNotesPermissions(_ permissions: OnboardingPermissionSnapshot) -> Bool {
+        permissions.microphone && permissions.inputMonitoring
+    }
+
     static func hasRequiredPermissions(
         _ permissions: OnboardingPermissionSnapshot,
         for useCase: OnboardingUseCase
     ) -> Bool {
         if useCase.includesDictation {
             return hasRequiredDictationPermissions(permissions)
+        }
+        if useCase.includesVoiceNotes {
+            return hasRequiredVoiceNotesPermissions(permissions)
         }
         return permissions.microphone
     }
@@ -30,7 +37,7 @@ enum OnboardingPermissionGate {
         permissionsStep: Int,
         dictationTestStep: Int
     ) -> Int {
-        let gatedStep = useCase.includesDictation ? dictationTestStep : permissionsStep + 1
+        let gatedStep = useCase.includesPushToTalk ? dictationTestStep : permissionsStep + 1
         if requestedStep >= gatedStep && !hasRequiredPermissions(permissions, for: useCase) {
             return permissionsStep
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -885,7 +885,7 @@ struct OnboardingView: View {
                     .buttonStyle(.plain)
                 }
 
-                if selectedUseCase.includesDictation && step.name == "Accessibility" {
+                if selectedUseCase.canSwitchToVoiceNotesOnly && step.name == "Accessibility" {
                     Button {
                         switchToVoiceNotesOnly()
                     } label: {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -73,8 +73,10 @@ struct OnboardingView: View {
     }
 
     private var onboardingAlternativeModels: [BackendOption] {
-        var options: [BackendOption] = [.whisperTinyEnglish, .whisperSmall]
-        if selectedBackend != .parakeetMultilingual, !options.contains(selectedBackend) {
+        var options = BackendOption.onboarding.filter { $0 != .parakeetMultilingual }
+        if BackendOption.onboarding.contains(selectedBackend),
+           selectedBackend != .parakeetMultilingual,
+           !options.contains(selectedBackend) {
             options.insert(selectedBackend, at: 0)
         }
         return options
@@ -122,7 +124,8 @@ struct OnboardingView: View {
         _currentStep = State(initialValue: effectiveInitialStep)
         _userName = State(initialValue: initialUserName)
         _selectedUseCase = State(initialValue: initialUseCase)
-        _selectedBackend = State(initialValue: initialBackend)
+        let sanitizedInitialBackend = BackendOption.onboarding.contains(initialBackend) ? initialBackend : .parakeetMultilingual
+        _selectedBackend = State(initialValue: sanitizedInitialBackend)
         _selectedCohereLanguage = State(initialValue: initialCohereLanguage)
         _selectedHotkey = State(initialValue: initialHotkey)
         _summaryBackend = State(initialValue: initialSummaryBackend)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -821,6 +821,7 @@ struct OnboardingView: View {
 
                 Button {
                     if grantingPermissionName == step.name && !isConfirmingGrant {
+                        guard !isWaitingForNativePermissionPrompt(step.name) else { return }
                         openSystemSettingsForPermission(at: displayIndex)
                     } else {
                         grantingPermissionName = step.name
@@ -844,7 +845,7 @@ struct OnboardingView: View {
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 }
                 .buttonStyle(.plain)
-                .disabled(isConfirmingGrant)
+                .disabled(isConfirmingGrant || isWaitingForNativePermissionPrompt(step.name))
                 .animation(.easeInOut(duration: 0.2), value: isConfirmingGrant)
 
                 // Progress dots
@@ -918,8 +919,13 @@ struct OnboardingView: View {
 
     private func permissionButtonTitle(for permissionName: String, isConfirmingGrant: Bool) -> String {
         if isConfirmingGrant { return "Granted" }
+        if isWaitingForNativePermissionPrompt(permissionName) { return "Waiting for macOS..." }
         if grantingPermissionName == permissionName { return "Open Settings" }
         return "Grant Permission"
+    }
+
+    private func isWaitingForNativePermissionPrompt(_ permissionName: String) -> Bool {
+        permissionName == "Accessibility" && grantingPermissionName == permissionName
     }
 
     private func switchToVoiceNotesOnly() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -247,9 +247,11 @@ struct OnboardingView: View {
                 goToNextStep()
             }
         case 3:
-            onboardingButton("Continue", enabled: requiredPermissionsGranted) {
-                if selectedUseCase.includesDictation {
+            onboardingButton(currentStepIndex == orderedSteps.count - 1 ? "Finish" : "Continue", enabled: requiredPermissionsGranted) {
+                if selectedUseCase.includesPushToTalk {
                     saveProgressAndRestart()
+                } else if currentStepIndex == orderedSteps.count - 1 {
+                    finishOnboarding(withKey: false)
                 } else {
                     goToNextStep()
                 }
@@ -444,17 +446,23 @@ struct OnboardingView: View {
     }
 
     private var dictationTestSubtitle: AttributedString {
-        let markdown = isSelectedModelReadyForDictationTest
-            ? "Hold **\(selectedHotkey.label)** and say something, then release.\nYour words should appear below."
-            : dictationTestPreparationSubtitleMarkdown
+        let markdown: String
+        if isSelectedModelReadyForDictationTest {
+            markdown = selectedUseCase.includesVoiceNotes
+                ? "Hold **\(selectedHotkey.label)** to record a voice note, then release.\nYour words should appear below."
+                : "Hold **\(selectedHotkey.label)** and say something, then release.\nYour words should appear below."
+        } else {
+            markdown = dictationTestPreparationSubtitleMarkdown
+        }
         return (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown.replacingOccurrences(of: "**", with: ""))
     }
 
     private var dictationTestPreparationSubtitleMarkdown: String {
+        let unlockCopy = selectedUseCase.includesVoiceNotes ? "Voice note test" : "Dictation"
         if isModelPreparingAfterDownload {
-            return "Optimizing **\(selectedBackend.label)** for this Mac.\nDictation will unlock when it is ready."
+            return "Optimizing **\(selectedBackend.label)** for this Mac.\n\(unlockCopy) will unlock when it is ready."
         }
-        return "Preparing **\(selectedBackend.label)** for your first test.\nDictation will unlock when the model is ready."
+        return "Preparing **\(selectedBackend.label)** for your first test.\n\(unlockCopy) will unlock when the model is ready."
     }
 
     private var modelPreparationHints: [String] {
@@ -511,37 +519,47 @@ struct OnboardingView: View {
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
 
-                HStack(spacing: MuesliTheme.spacing8) {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.fixed(132), spacing: MuesliTheme.spacing8),
+                        GridItem(.fixed(132), spacing: MuesliTheme.spacing8),
+                    ],
+                    spacing: MuesliTheme.spacing8
+                ) {
                     useCaseCard(
-                        icon: "mic.fill",
-                        title: "Dictation",
-                        subtitle: "Talk to type",
-                        selected: selectedUseCase.includesDictation
+                        icon: "waveform",
+                        title: "Voice Notes",
+                        subtitle: "Record in Muesli",
+                        selected: selectedUseCase == .voiceNotes
                     ) {
-                        switch selectedUseCase {
-                        case .dictation:
-                            selectedUseCase = .dictation
-                        case .meetings:
-                            selectedUseCase = .dictationAndMeetings
-                        case .dictationAndMeetings:
-                            selectedUseCase = .meetings
-                        }
+                        selectedUseCase = .voiceNotes
+                    }
+
+                    useCaseCard(
+                        icon: "keyboard.fill",
+                        title: "Dictation",
+                        subtitle: "Paste into apps",
+                        selected: selectedUseCase == .dictation
+                    ) {
+                        selectedUseCase = .dictation
                     }
 
                     useCaseCard(
                         icon: "person.2.fill",
                         title: "Meetings",
                         subtitle: "Notes and summaries",
-                        selected: selectedUseCase.includesMeetings
+                        selected: selectedUseCase == .meetings
                     ) {
-                        switch selectedUseCase {
-                        case .dictation:
-                            selectedUseCase = .dictationAndMeetings
-                        case .meetings:
-                            selectedUseCase = .meetings
-                        case .dictationAndMeetings:
-                            selectedUseCase = .dictation
-                        }
+                        selectedUseCase = .meetings
+                    }
+
+                    useCaseCard(
+                        icon: "rectangle.3.group.fill",
+                        title: "Everything",
+                        subtitle: "Dictation + meetings",
+                        selected: selectedUseCase == .dictationAndMeetings
+                    ) {
+                        selectedUseCase = .dictationAndMeetings
                     }
                 }
             }
@@ -571,7 +589,7 @@ struct OnboardingView: View {
                     .minimumScaleFactor(0.8)
             }
             .foregroundStyle(selected ? .white : MuesliTheme.textSecondary)
-            .frame(width: 138, height: 78)
+            .frame(width: 132, height: 74)
             .background(selected ? MuesliTheme.accent : MuesliTheme.backgroundRaised)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             .overlay(
@@ -729,17 +747,21 @@ struct OnboardingView: View {
     /// successful transcription before meeting-specific permissions appear.
     private var permissionSteps: [(icon: String, name: String, description: String, granted: Bool, action: () -> Void)] {
         var steps: [(String, String, String, Bool, () -> Void)] = [
-            ("mic.fill", "Microphone", "Record audio for dictation and meetings", micGranted, {
+            ("mic.fill", "Microphone", "Record audio for voice notes, dictation, and meetings", micGranted, {
                 AVCaptureDevice.requestAccess(for: .audio) { _ in }
             })
         ]
-        if selectedUseCase.includesDictation {
+        if selectedUseCase.includesPushToTalk {
+            if selectedUseCase.includesDictation {
+                steps += [
+                    ("hand.raised.fill", "Accessibility", "Paste transcribed text into other apps", accessibilityGranted, {
+                        let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+                        AXIsProcessTrustedWithOptions(opts)
+                    }),
+                ]
+            }
             steps += [
-            ("hand.raised.fill", "Accessibility", "Paste transcribed text into other apps", accessibilityGranted, {
-                let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
-                AXIsProcessTrustedWithOptions(opts)
-            }),
-            ("keyboard.fill", "Input Monitoring", "Detect hotkey for push-to-talk dictation", inputMonitoringGranted, {
+            ("keyboard.fill", "Input Monitoring", "Detect hotkey for push-to-talk recording", inputMonitoringGranted, {
                 if !CGRequestListenEventAccess() {
                     self.openSystemSettings("Privacy_ListenEvent")
                 }
@@ -854,6 +876,23 @@ struct OnboardingView: View {
                     }
                     .buttonStyle(.plain)
                 }
+
+                if selectedUseCase.includesDictation && step.name == "Accessibility" {
+                    Button {
+                        switchToVoiceNotesOnly()
+                    } label: {
+                        VStack(spacing: 2) {
+                            Text("Use Voice Notes instead")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text("Keeps the hotkey, skips paste permission")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                        }
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 2)
+                }
             } else {
                 // All granted
                 VStack(spacing: MuesliTheme.spacing8) {
@@ -878,6 +917,14 @@ struct OnboardingView: View {
         if isConfirmingGrant { return "Granted" }
         if grantingPermissionName == permissionName { return "Open Settings" }
         return "Grant Permission"
+    }
+
+    private func switchToVoiceNotesOnly() {
+        grantingPermissionName = nil
+        recentlyGrantedPermissionName = nil
+        selectedUseCase = .voiceNotes
+        currentStep = OnboardingFlow.normalizedStep(currentStep, for: .voiceNotes)
+        saveProgress(atStep: currentStep)
     }
 
     private func systemSettingsPane(for permissionIndex: Int) -> String {
@@ -943,17 +990,15 @@ struct OnboardingView: View {
     }
 
     private var requiredPermissionsGranted: Bool {
-        if !selectedUseCase.includesDictation {
-            return micGranted
-        }
-        return OnboardingPermissionGate.hasRequiredDictationPermissions(
+        OnboardingPermissionGate.hasRequiredPermissions(
             OnboardingPermissionSnapshot(
                 microphone: micGranted,
                 accessibility: accessibilityGranted,
                 inputMonitoring: inputMonitoringGranted,
                 systemAudio: systemAudioGranted,
                 screenRecording: screenRecordingGranted
-            )
+            ),
+            for: selectedUseCase
         )
     }
 
@@ -1149,7 +1194,7 @@ struct OnboardingView: View {
             Spacer()
 
             VStack(spacing: MuesliTheme.spacing8) {
-                Text("Test Dictation")
+                Text(selectedUseCase.includesVoiceNotes ? "Test Voice Note" : "Test Dictation")
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -934,8 +934,7 @@ struct OnboardingView: View {
 
     private func requestAccessibilityPermission() {
         nativePermissionPromptName = "Accessibility"
-        controller.bringOnboardingToFront()
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        controller.prepareOnboardingForNativePermissionPrompt()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -12,7 +12,7 @@ struct OnboardingView: View {
     @State private var selectedUseCase: OnboardingUseCase
     @State private var selectedBackend: BackendOption
     @State private var selectedCohereLanguage: CohereTranscribeLanguage
-    @State private var summaryBackend: MeetingSummaryBackendOption = .openAI
+    @State private var summaryBackend: MeetingSummaryBackendOption = .chatGPT
     @State private var apiKey = ""
     @State private var isSigningInChatGPT = false
     @State private var chatGPTSignInDone = false
@@ -26,6 +26,7 @@ struct OnboardingView: View {
     @State private var systemAudioGranted = false
     @State private var permissionPollTimer: Timer?
     @State private var grantingPermissionName: String?
+    @State private var nativePermissionPromptName: String?
     @State private var recentlyGrantedPermissionName: String?
 
     // Hotkey recorder
@@ -92,7 +93,7 @@ struct OnboardingView: View {
         initialHotkey: HotkeyConfig = .default,
         initialSystemAudioRequested: Bool = false,
         initialUseCase: OnboardingUseCase = .dictation,
-        initialSummaryBackend: MeetingSummaryBackendOption = .openAI,
+        initialSummaryBackend: MeetingSummaryBackendOption = .chatGPT,
         initialModelDownloadProgress: Double? = nil,
         initialModelDownloadStatus: String? = nil
     ) {
@@ -757,10 +758,7 @@ struct OnboardingView: View {
         if selectedUseCase.includesPushToTalk {
             if selectedUseCase.includesDictation {
                 steps += [
-                    ("hand.raised.fill", "Accessibility", "Paste transcribed text into other apps", accessibilityGranted, {
-                        let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
-                        AXIsProcessTrustedWithOptions(opts)
-                    }),
+                    ("hand.raised.fill", "Accessibility", "Paste transcribed text into other apps", accessibilityGranted, requestAccessibilityPermission),
                 ]
             }
             steps += [
@@ -861,14 +859,20 @@ struct OnboardingView: View {
                     }
                 }
 
-                Button {
-                    openSystemSettingsForPermission(at: displayIndex)
-                } label: {
-                    Text("Not seeing a prompt? Open System Settings")
+                if isWaitingForNativePermissionPrompt(step.name) {
+                    Text("Respond to the macOS permission prompt")
                         .font(.system(size: 11))
-                        .foregroundStyle(MuesliTheme.accent)
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                } else {
+                    Button {
+                        openSystemSettingsForPermission(at: displayIndex)
+                    } label: {
+                        Text("Not seeing a prompt? Open System Settings")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuesliTheme.accent)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
 
                 if step.name == "Input Monitoring", grantingPermissionName == step.name {
                     Button {
@@ -925,11 +929,30 @@ struct OnboardingView: View {
     }
 
     private func isWaitingForNativePermissionPrompt(_ permissionName: String) -> Bool {
-        permissionName == "Accessibility" && grantingPermissionName == permissionName
+        nativePermissionPromptName == permissionName
+    }
+
+    private func requestAccessibilityPermission() {
+        nativePermissionPromptName = "Accessibility"
+        controller.bringOnboardingToFront()
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+            AXIsProcessTrustedWithOptions(opts)
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(6))
+            if nativePermissionPromptName == "Accessibility", !accessibilityGranted {
+                nativePermissionPromptName = nil
+            }
+        }
     }
 
     private func switchToVoiceNotesOnly() {
         grantingPermissionName = nil
+        nativePermissionPromptName = nil
         recentlyGrantedPermissionName = nil
         selectedUseCase = .voiceNotes
         currentStep = OnboardingFlow.normalizedStep(currentStep, for: .voiceNotes)
@@ -1054,6 +1077,7 @@ struct OnboardingView: View {
     private func notePermissionGranted(_ permissionName: String) {
         guard recentlyGrantedPermissionName != permissionName else { return }
         grantingPermissionName = nil
+        nativePermissionPromptName = nil
         recentlyGrantedPermissionName = permissionName
         saveProgress(atStep: currentStep)
         controller.bringOnboardingToFront()
@@ -1095,6 +1119,7 @@ struct OnboardingView: View {
         let steps = permissionSteps
         if permissionIndex < steps.count {
             grantingPermissionName = steps[permissionIndex].name
+            nativePermissionPromptName = nil
             recentlyGrantedPermissionName = nil
             saveProgress(atStep: currentStep)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -33,6 +33,13 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         window.orderBack(nil)
     }
 
+    func prepareForNativePermissionPrompt() {
+        guard let window else { return }
+        window.level = .normal
+        window.makeKeyAndOrderFront(nil)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+    }
+
     func close() {
         window?.close()
         window = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -71,7 +71,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
                 initialHotkey: hotkey,
                 initialSystemAudioRequested: progress.systemAudioRequested,
                 initialUseCase: OnboardingUseCase.resolved(progress.onboardingUseCaseRawValue),
-                initialSummaryBackend: MeetingSummaryBackendOption.resolved(controller.config.meetingSummaryBackend),
+                initialSummaryBackend: .chatGPT,
                 initialModelDownloadProgress: progress.modelDownloadProgress,
                 initialModelDownloadStatus: progress.modelDownloadStatus
             )
@@ -81,7 +81,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
                 appState: controller.appState,
                 initialCohereLanguage: controller.config.resolvedCohereLanguage,
                 initialUseCase: controller.config.resolvedOnboardingUseCase,
-                initialSummaryBackend: MeetingSummaryBackendOption.resolved(controller.config.meetingSummaryBackend)
+                initialSummaryBackend: .chatGPT
             )
         }
         window.contentView = NSHostingView(rootView: rootView)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -84,7 +84,6 @@ struct SettingsView: View {
     @AppStorage("settings.pendingScreenContextRequestedAt") private var pendingScreenContextRequestedAt = 0.0
     @State private var systemAudioGranted = false
     @State private var isCheckingSystemAudioPermission = false
-    @State private var voiceNotesUpgradeMessage: String?
     @State private var openRouterFreeModels: [SummaryModelPreset] = []
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
@@ -116,13 +115,6 @@ struct SettingsView: View {
 
     private var selectedCohereLanguage: CohereTranscribeLanguage {
         appState.config.resolvedCohereLanguage
-    }
-
-    private var canUpgradeVoiceNotesToDictation: Bool {
-        appState.config.resolvedOnboardingUseCase == .voiceNotes
-            && micGranted
-            && accessibilityGranted
-            && inputMonitoringGranted
     }
 
     var body: some View {
@@ -1024,10 +1016,6 @@ struct SettingsView: View {
 
     private var permissionsSection: some View {
         settingsSection("Permissions") {
-            if appState.config.resolvedOnboardingUseCase == .voiceNotes {
-                voiceNotesUpgradePrompt
-                Divider().background(MuesliTheme.surfaceBorder)
-            }
             permissionStatusRow(
                 "Microphone",
                 granted: micGranted,
@@ -1074,54 +1062,6 @@ struct SettingsView: View {
                 )
             }
         }
-    }
-
-    private var voiceNotesUpgradePrompt: some View {
-        HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                Text("Voice Notes mode")
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                Text(voiceNotesUpgradeCopy)
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .lineLimit(2)
-                if let voiceNotesUpgradeMessage {
-                    Text(voiceNotesUpgradeMessage)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(MuesliTheme.success)
-                }
-            }
-            Spacer(minLength: MuesliTheme.spacing16)
-            Button("Upgrade to Dictation") {
-                controller.promoteVoiceNotesToDictationIfReady(
-                    microphoneGranted: micGranted,
-                    accessibilityGranted: accessibilityGranted,
-                    inputMonitoringGranted: inputMonitoringGranted
-                )
-                voiceNotesUpgradeMessage = "Dictation enabled. Push to Talk will now paste into active apps."
-            }
-            .buttonStyle(.plain)
-            .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(canUpgradeVoiceNotesToDictation ? MuesliTheme.accent : MuesliTheme.textTertiary)
-            .padding(.horizontal, MuesliTheme.spacing12)
-            .padding(.vertical, MuesliTheme.spacing8)
-            .background(canUpgradeVoiceNotesToDictation ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(canUpgradeVoiceNotesToDictation ? MuesliTheme.accent.opacity(0.25) : MuesliTheme.surfaceBorder, lineWidth: 1)
-            )
-            .disabled(!canUpgradeVoiceNotesToDictation)
-        }
-        .frame(minHeight: 48)
-    }
-
-    private var voiceNotesUpgradeCopy: String {
-        if canUpgradeVoiceNotesToDictation {
-            return "Dictation permissions are ready. Upgrade only if you want Push to Talk to paste into other apps."
-        }
-        return "Grant Accessibility to enable paste dictation. Voice Notes will keep saving inside Muesli."
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -84,6 +84,7 @@ struct SettingsView: View {
     @AppStorage("settings.pendingScreenContextRequestedAt") private var pendingScreenContextRequestedAt = 0.0
     @State private var systemAudioGranted = false
     @State private var isCheckingSystemAudioPermission = false
+    @State private var voiceNotesUpgradeMessage: String?
     @State private var openRouterFreeModels: [SummaryModelPreset] = []
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
@@ -115,6 +116,13 @@ struct SettingsView: View {
 
     private var selectedCohereLanguage: CohereTranscribeLanguage {
         appState.config.resolvedCohereLanguage
+    }
+
+    private var canUpgradeVoiceNotesToDictation: Bool {
+        appState.config.resolvedOnboardingUseCase == .voiceNotes
+            && micGranted
+            && accessibilityGranted
+            && inputMonitoringGranted
     }
 
     var body: some View {
@@ -1016,6 +1024,10 @@ struct SettingsView: View {
 
     private var permissionsSection: some View {
         settingsSection("Permissions") {
+            if appState.config.resolvedOnboardingUseCase == .voiceNotes {
+                voiceNotesUpgradePrompt
+                Divider().background(MuesliTheme.surfaceBorder)
+            }
             permissionStatusRow(
                 "Microphone",
                 granted: micGranted,
@@ -1062,6 +1074,54 @@ struct SettingsView: View {
                 )
             }
         }
+    }
+
+    private var voiceNotesUpgradePrompt: some View {
+        HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("Voice Notes mode")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(voiceNotesUpgradeCopy)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(2)
+                if let voiceNotesUpgradeMessage {
+                    Text(voiceNotesUpgradeMessage)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MuesliTheme.success)
+                }
+            }
+            Spacer(minLength: MuesliTheme.spacing16)
+            Button("Upgrade to Dictation") {
+                controller.promoteVoiceNotesToDictationIfReady(
+                    microphoneGranted: micGranted,
+                    accessibilityGranted: accessibilityGranted,
+                    inputMonitoringGranted: inputMonitoringGranted
+                )
+                voiceNotesUpgradeMessage = "Dictation enabled. Push to Talk will now paste into active apps."
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(canUpgradeVoiceNotesToDictation ? MuesliTheme.accent : MuesliTheme.textTertiary)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, MuesliTheme.spacing8)
+            .background(canUpgradeVoiceNotesToDictation ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(canUpgradeVoiceNotesToDictation ? MuesliTheme.accent.opacity(0.25) : MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+            .disabled(!canUpgradeVoiceNotesToDictation)
+        }
+        .frame(minHeight: 48)
+    }
+
+    private var voiceNotesUpgradeCopy: String {
+        if canUpgradeVoiceNotesToDictation {
+            return "Dictation permissions are ready. Upgrade only if you want Push to Talk to paste into other apps."
+        }
+        return "Grant Accessibility to enable paste dictation. Voice Notes will keep saving inside Muesli."
     }
 
     @ViewBuilder
@@ -1190,11 +1250,6 @@ struct SettingsView: View {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = false }
         }
-        controller.promoteVoiceNotesToDictationIfReady(
-            microphoneGranted: micGranted,
-            accessibilityGranted: accessibilityGranted,
-            inputMonitoringGranted: inputMonitoringGranted
-        )
         refreshSystemAudioPermissionIfNeeded()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1190,6 +1190,11 @@ struct SettingsView: View {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = false }
         }
+        controller.reclassifyVoiceNotesAsDictationIfReady(
+            microphoneGranted: micGranted,
+            accessibilityGranted: accessibilityGranted,
+            inputMonitoringGranted: inputMonitoringGranted
+        )
         refreshSystemAudioPermissionIfNeeded()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1190,6 +1190,11 @@ struct SettingsView: View {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = false }
         }
+        controller.promoteVoiceNotesToDictationIfReady(
+            microphoneGranted: micGranted,
+            accessibilityGranted: accessibilityGranted,
+            inputMonitoringGranted: inputMonitoringGranted
+        )
         refreshSystemAudioPermissionIfNeeded()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
@@ -41,9 +41,10 @@ struct ShortcutHotkeyPolicy {
 
     static func validateComputerUseHotkey(
         _ hotkey: HotkeyConfig,
-        dictationHotkey: HotkeyConfig
+        dictationHotkey: HotkeyConfig,
+        isComputerUseEnabled: Bool
     ) -> ShortcutHotkeyUpdateResult {
-        guard hotkey.keyCode != dictationHotkey.keyCode else {
+        guard !isComputerUseEnabled || hotkey.keyCode != dictationHotkey.keyCode else {
             return .conflict(message: conflictMessage)
         }
         return .updated

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
@@ -1,0 +1,66 @@
+enum ShortcutHotkeyUpdateResult: Equatable {
+    case updated(notice: String?)
+    case conflict(message: String)
+
+    var message: String? {
+        switch self {
+        case .updated(let notice):
+            return notice
+        case .conflict(let message):
+            return message
+        }
+    }
+
+    var didUpdate: Bool {
+        switch self {
+        case .updated:
+            return true
+        case .conflict:
+            return false
+        }
+    }
+
+    static var updated: ShortcutHotkeyUpdateResult {
+        .updated(notice: nil)
+    }
+}
+
+struct ShortcutHotkeyPolicy {
+    static let conflictMessage = "Push to Talk and Computer Use Command need different keys."
+
+    static func validateDictationHotkey(
+        _ hotkey: HotkeyConfig,
+        computerUseHotkey: HotkeyConfig,
+        isComputerUseEnabled: Bool
+    ) -> ShortcutHotkeyUpdateResult {
+        guard !isComputerUseEnabled || hotkey.keyCode != computerUseHotkey.keyCode else {
+            return .conflict(message: conflictMessage)
+        }
+        return .updated
+    }
+
+    static func validateComputerUseHotkey(
+        _ hotkey: HotkeyConfig,
+        dictationHotkey: HotkeyConfig
+    ) -> ShortcutHotkeyUpdateResult {
+        guard hotkey.keyCode != dictationHotkey.keyCode else {
+            return .conflict(message: conflictMessage)
+        }
+        return .updated
+    }
+
+    static func resolvedComputerUseHotkeyWhenEnabling(
+        currentHotkey: HotkeyConfig,
+        dictationHotkey: HotkeyConfig
+    ) -> (hotkey: HotkeyConfig, result: ShortcutHotkeyUpdateResult) {
+        guard currentHotkey.keyCode == dictationHotkey.keyCode else {
+            return (currentHotkey, .updated)
+        }
+
+        let fallback = HotkeyConfig.computerUseDefault(avoiding: dictationHotkey)
+        return (
+            fallback,
+            .updated(notice: "Computer Use Command moved to \(fallback.label) to avoid matching Push to Talk.")
+        )
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -7,6 +7,8 @@ struct ShortcutsView: View {
     let controller: MuesliController
     @State private var recordingTarget: ShortcutTarget?
     @State private var eventMonitor: Any?
+    @State private var dictationShortcutMessage: String?
+    @State private var computerUseShortcutMessage: String?
 
     var body: some View {
         ScrollView {
@@ -59,6 +61,10 @@ struct ShortcutsView: View {
                 .background(MuesliTheme.surfaceBorder)
 
             changeButton(for: .dictation)
+
+            if let dictationShortcutMessage {
+                shortcutMessage(dictationShortcutMessage)
+            }
         }
         .padding(MuesliTheme.spacing16)
         .background(MuesliTheme.backgroundRaised)
@@ -84,7 +90,11 @@ struct ShortcutsView: View {
                 Toggle("", isOn: Binding(
                     get: { appState.config.enableComputerUseHotkey },
                     set: { newValue in
-                        controller.updateComputerUseHotkeyEnabled(newValue)
+                        let result = controller.updateComputerUseHotkeyEnabled(newValue)
+                        computerUseShortcutMessage = result.message
+                        if result.didUpdate {
+                            dictationShortcutMessage = nil
+                        }
                     }
                 ))
                 .toggleStyle(.switch)
@@ -104,9 +114,9 @@ struct ShortcutsView: View {
 
             if appState.config.enableComputerUseHotkey,
                appState.config.computerUseHotkey.keyCode == appState.config.dictationHotkey.keyCode {
-                Text("Choose a different key than dictation.")
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.transcribing)
+                shortcutMessage(ShortcutHotkeyPolicy.conflictMessage)
+            } else if let computerUseShortcutMessage {
+                shortcutMessage(computerUseShortcutMessage)
             }
         }
         .padding(MuesliTheme.spacing16)
@@ -130,6 +140,12 @@ struct ShortcutsView: View {
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
+    }
+
+    private func shortcutMessage(_ message: String) -> some View {
+        Text(message)
+            .font(MuesliTheme.caption())
+            .foregroundStyle(MuesliTheme.transcribing)
     }
 
     private func changeButton(for target: ShortcutTarget) -> some View {
@@ -189,9 +205,9 @@ struct ShortcutsView: View {
 
     private var resetButton: some View {
         Button {
-            controller.updateDictationHotkey(.default)
-            controller.updateComputerUseHotkey(.computerUseDefault)
-            controller.updateComputerUseHotkeyEnabled(true)
+            controller.resetShortcutDefaults()
+            dictationShortcutMessage = nil
+            computerUseShortcutMessage = nil
         } label: {
             Text("Reset to Defaults")
                 .font(MuesliTheme.body())
@@ -201,26 +217,48 @@ struct ShortcutsView: View {
         .disabled(
             appState.config.dictationHotkey == .default
                 && appState.config.computerUseHotkey == .computerUseDefault
-                && appState.config.enableComputerUseHotkey
+                && !appState.config.enableComputerUseHotkey
         )
     }
 
     private func startRecording(_ target: ShortcutTarget) {
         stopRecording()
+        clearShortcutMessage(for: target)
         recordingTarget = target
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [self] event in
             let keyCode = event.keyCode
             if let label = HotkeyConfig.label(for: keyCode) {
                 let newConfig = HotkeyConfig(keyCode: keyCode, label: label)
+                let result: ShortcutHotkeyUpdateResult
                 switch target {
                 case .dictation:
-                    controller.updateDictationHotkey(newConfig)
+                    result = controller.updateDictationHotkey(newConfig)
                 case .computerUse:
-                    controller.updateComputerUseHotkey(newConfig)
+                    result = controller.updateComputerUseHotkey(newConfig)
                 }
+                setShortcutMessage(result.message, for: target)
                 stopRecording()
             }
             return event
+        }
+    }
+
+    private func clearShortcutMessage(for target: ShortcutTarget) {
+        setShortcutMessage(nil, for: target)
+    }
+
+    private func setShortcutMessage(_ message: String?, for target: ShortcutTarget) {
+        switch target {
+        case .dictation:
+            dictationShortcutMessage = message
+            if message == nil {
+                computerUseShortcutMessage = nil
+            }
+        case .computerUse:
+            computerUseShortcutMessage = message
+            if message == nil {
+                dictationShortcutMessage = nil
+            }
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -274,17 +274,15 @@ struct MeetingSummaryClientTests {
         #expect(title == nil)
     }
 
-    @Test("summarize defaults to openai backend when empty")
-    func defaultsToOpenAI() async throws {
+    @Test("empty summary backend resolves to ChatGPT")
+    func defaultsToChatGPT() {
         var config = AppConfig()
         config.meetingSummaryBackend = ""
-        config.openAIAPIKey = ""
 
-        let result = try await MeetingSummaryClient.summarize(
-            transcript: "Test", meetingTitle: "Title", config: config
+        let backend = MeetingSummaryBackendOption.resolved(
+            config.meetingSummaryBackend.isEmpty ? nil : config.meetingSummaryBackend
         )
 
-        // Should hit OpenAI path, fail (no key), return fallback
-        #expect(result.contains("## Raw Transcript"))
+        #expect(backend == .chatGPT)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -544,6 +544,14 @@ struct AppConfigTests {
         #expect(!OnboardingUseCase.voiceNotes.includesMeetings)
     }
 
+    @Test("voice notes escape hatch is dictation-only")
+    func voiceNotesEscapeHatchIsDictationOnly() {
+        #expect(OnboardingUseCase.dictation.canSwitchToVoiceNotesOnly)
+        #expect(!OnboardingUseCase.dictationAndMeetings.canSwitchToVoiceNotesOnly)
+        #expect(!OnboardingUseCase.meetings.canSwitchToVoiceNotesOnly)
+        #expect(!OnboardingUseCase.voiceNotes.canSwitchToVoiceNotesOnly)
+    }
+
     @Test("scheduled meeting notifications inherit legacy detection opt-out")
     func scheduledMeetingNotificationsInheritLegacyDetectionOptOut() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -78,6 +78,14 @@ struct BackendOptionTests {
         #expect(!BackendOption.experimental.contains(.cohereTranscribe))
     }
 
+    @Test("onboarding model choices exclude experimental models")
+    func onboardingModelsExcludeExperimentalOptions() {
+        #expect(BackendOption.onboarding == [.parakeetMultilingual, .whisperTinyEnglish, .whisperSmall])
+        for option in BackendOption.experimental {
+            #expect(!BackendOption.onboarding.contains(option))
+        }
+    }
+
     @Test("Whisper models use WhisperKit CoreML identifiers")
     func whisperKitModels() {
         // WhisperKit models use short variant names, not ggml- prefixed binaries
@@ -962,8 +970,15 @@ struct HotkeyConfigTests {
 
         #expect(ShortcutHotkeyPolicy.validateComputerUseHotkey(
             .default,
-            dictationHotkey: .default
+            dictationHotkey: .default,
+            isComputerUseEnabled: true
         ) == .conflict(message: ShortcutHotkeyPolicy.conflictMessage))
+
+        #expect(ShortcutHotkeyPolicy.validateComputerUseHotkey(
+            .default,
+            dictationHotkey: .default,
+            isComputerUseEnabled: false
+        ) == .updated)
     }
 
     @Test("hotkey policy moves computer use key when enabling with a stale conflict")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -528,6 +528,14 @@ struct AppConfigTests {
         #expect(config.resolvedOnboardingUseCase == .dictation)
     }
 
+    @Test("voice notes use push-to-talk without paste dictation")
+    func voiceNotesUsePushToTalkWithoutPasteDictation() {
+        #expect(OnboardingUseCase.voiceNotes.includesVoiceNotes)
+        #expect(OnboardingUseCase.voiceNotes.includesPushToTalk)
+        #expect(!OnboardingUseCase.voiceNotes.includesDictation)
+        #expect(!OnboardingUseCase.voiceNotes.includesMeetings)
+    }
+
     @Test("scheduled meeting notifications inherit legacy detection opt-out")
     func scheduledMeetingNotificationsInheritLegacyDetectionOptOut() throws {
         let json = """
@@ -918,11 +926,11 @@ struct WordCountTests {
 @Suite("HotkeyConfig")
 struct HotkeyConfigTests {
 
-    @Test("default is Left Cmd")
+    @Test("default is Right Option")
     func defaultConfig() {
         let config = HotkeyConfig.default
-        #expect(config.keyCode == 55)
-        #expect(config.label == "Left Cmd")
+        #expect(config.keyCode == 61)
+        #expect(config.label == "Right Option")
     }
 
     @Test("computer use default is Right Cmd")
@@ -938,14 +946,49 @@ struct HotkeyConfigTests {
         #expect(HotkeyConfig.computerUseDefault(avoiding: .computerUseDefault) == .default)
     }
 
+    @Test("hotkey policy blocks active duplicate shortcuts")
+    func hotkeyPolicyBlocksActiveDuplicateShortcuts() {
+        #expect(ShortcutHotkeyPolicy.validateDictationHotkey(
+            .computerUseDefault,
+            computerUseHotkey: .computerUseDefault,
+            isComputerUseEnabled: true
+        ) == .conflict(message: ShortcutHotkeyPolicy.conflictMessage))
+
+        #expect(ShortcutHotkeyPolicy.validateDictationHotkey(
+            .computerUseDefault,
+            computerUseHotkey: .computerUseDefault,
+            isComputerUseEnabled: false
+        ) == .updated)
+
+        #expect(ShortcutHotkeyPolicy.validateComputerUseHotkey(
+            .default,
+            dictationHotkey: .default
+        ) == .conflict(message: ShortcutHotkeyPolicy.conflictMessage))
+    }
+
+    @Test("hotkey policy moves computer use key when enabling with a stale conflict")
+    func hotkeyPolicyMovesComputerUseKeyWhenEnablingWithStaleConflict() {
+        let resolution = ShortcutHotkeyPolicy.resolvedComputerUseHotkeyWhenEnabling(
+            currentHotkey: .default,
+            dictationHotkey: .default
+        )
+
+        #expect(resolution.hotkey == .computerUseDefault)
+        #expect(resolution.result.didUpdate)
+        #expect(resolution.result.message == "Computer Use Command moved to Right Cmd to avoid matching Push to Talk.")
+    }
+
     @Test("label for known key codes")
     func knownKeyCodes() {
         #expect(HotkeyConfig.label(for: 55) == "Left Cmd")
         #expect(HotkeyConfig.label(for: 54) == "Right Cmd")
         #expect(HotkeyConfig.label(for: 63) == "Fn")
         #expect(HotkeyConfig.label(for: 59) == "Left Ctrl")
+        #expect(HotkeyConfig.label(for: 62) == "Right Ctrl")
         #expect(HotkeyConfig.label(for: 58) == "Left Option")
+        #expect(HotkeyConfig.label(for: 61) == "Right Option")
         #expect(HotkeyConfig.label(for: 56) == "Left Shift")
+        #expect(HotkeyConfig.label(for: 60) == "Right Shift")
     }
 
     @Test("unknown key code returns nil")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -80,7 +80,7 @@ struct BackendOptionTests {
 
     @Test("onboarding model choices exclude experimental models")
     func onboardingModelsExcludeExperimentalOptions() {
-        #expect(BackendOption.onboarding == [.parakeetMultilingual, .whisperTinyEnglish, .whisperSmall])
+        #expect(BackendOption.onboarding == [.parakeetMultilingual, .whisperTinyEnglish, .whisperSmall, .cohereTranscribe])
         for option in BackendOption.experimental {
             #expect(!BackendOption.onboarding.contains(option))
         }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -344,12 +344,12 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.openRouter.backend == "openrouter")
     }
 
-    @Test("configured values resolve with OpenAI fallback")
+    @Test("configured values resolve with ChatGPT fallback")
     func resolvedValues() {
         #expect(MeetingSummaryBackendOption.resolved("chatgpt") == .chatGPT)
         #expect(MeetingSummaryBackendOption.resolved("openrouter") == .openRouter)
-        #expect(MeetingSummaryBackendOption.resolved("unknown") == .openAI)
-        #expect(MeetingSummaryBackendOption.resolved(nil) == .openAI)
+        #expect(MeetingSummaryBackendOption.resolved("unknown") == .chatGPT)
+        #expect(MeetingSummaryBackendOption.resolved(nil) == .chatGPT)
     }
 }
 
@@ -364,7 +364,7 @@ struct AppConfigTests {
         #expect(config.cohereLanguage == CohereTranscribeLanguage.defaultLanguage.rawValue)
         #expect(config.meetingTranscriptionBackend == BackendOption.whisper.backend)
         #expect(config.meetingTranscriptionModel == BackendOption.whisper.model)
-        #expect(config.meetingSummaryBackend == "openai")
+        #expect(config.meetingSummaryBackend == "chatgpt")
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
         #expect(config.showScheduledMeetingNotifications == true)

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingFlowTests.swift
@@ -3,6 +3,11 @@ import Testing
 
 @Suite("OnboardingFlow")
 struct OnboardingFlowTests {
+    @Test("voice notes orders push-to-talk steps without paste permission")
+    func voiceNotesOrderedSteps() {
+        #expect(OnboardingFlow.orderedSteps(for: .voiceNotes) == [0, 1, 2, 3, 4])
+    }
+
     @Test("dictation orders dictation-only steps")
     func dictationOrderedSteps() {
         #expect(OnboardingFlow.orderedSteps(for: .dictation) == [0, 1, 2, 3, 4])
@@ -28,6 +33,7 @@ struct OnboardingFlowTests {
     func normalizedStepKeepsValidAndClampsAfterFinalStep() {
         #expect(OnboardingFlow.normalizedStep(3, for: .meetings) == 3)
         #expect(OnboardingFlow.normalizedStep(99, for: .dictation) == 4)
+        #expect(OnboardingFlow.normalizedStep(4, for: .voiceNotes) == 4)
     }
 
     @Test("can go back is disabled after successful dictation test")
@@ -56,6 +62,7 @@ struct OnboardingFlowTests {
     @Test("completion tab routes meetings-only to meetings and others to dictations")
     func completionTab() {
         #expect(OnboardingFlow.completionTab(for: .meetings) == .meetings)
+        #expect(OnboardingFlow.completionTab(for: .voiceNotes) == .dictations)
         #expect(OnboardingFlow.completionTab(for: .dictation) == .dictations)
         #expect(OnboardingFlow.completionTab(for: .dictationAndMeetings) == .dictations)
     }

--- a/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/OnboardingProgressTests.swift
@@ -149,4 +149,71 @@ struct OnboardingProgressTests {
         #expect(!OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .meetings))
         #expect(step == 3)
     }
+
+    @Test("meetings-only does not require input monitoring")
+    func meetingsOnlyDoesNotRequireInputMonitoring() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: false,
+            systemAudio: false,
+            screenRecording: false
+        )
+
+        let step = OnboardingPermissionGate.resumeStep(
+            requestedStep: 5,
+            permissions: permissions,
+            useCase: .meetings,
+            permissionsStep: 3,
+            dictationTestStep: 4
+        )
+
+        #expect(OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .meetings))
+        #expect(step == 5)
+    }
+
+    @Test("voice notes require microphone and input monitoring")
+    func voiceNotesRequireMicrophoneAndInputMonitoring() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: true,
+            systemAudio: false,
+            screenRecording: false
+        )
+
+        let step = OnboardingPermissionGate.resumeStep(
+            requestedStep: 5,
+            permissions: permissions,
+            useCase: .voiceNotes,
+            permissionsStep: 3,
+            dictationTestStep: 4
+        )
+
+        #expect(OnboardingPermissionGate.hasRequiredVoiceNotesPermissions(permissions))
+        #expect(OnboardingPermissionGate.hasRequiredPermissions(permissions, for: .voiceNotes))
+        #expect(step == 5)
+    }
+
+    @Test("voice notes cannot leave permissions without input monitoring")
+    func voiceNotesMissingInputMonitoringResumesAtPermissionsStep() {
+        let permissions = OnboardingPermissionSnapshot(
+            microphone: true,
+            accessibility: false,
+            inputMonitoring: false,
+            systemAudio: false,
+            screenRecording: false
+        )
+
+        let step = OnboardingPermissionGate.resumeStep(
+            requestedStep: 4,
+            permissions: permissions,
+            useCase: .voiceNotes,
+            permissionsStep: 3,
+            dictationTestStep: 4
+        )
+
+        #expect(!OnboardingPermissionGate.hasRequiredVoiceNotesPermissions(permissions))
+        #expect(step == 3)
+    }
 }


### PR DESCRIPTION
## Summary

This PR hardens first-run onboarding around use-case selection, voice-note-only setup, and shortcut safety.

- Adds a Voice Notes onboarding path for users who can grant microphone + input monitoring but cannot grant Accessibility for paste dictation.
- Keeps Dictation, Meetings, and Everything flows tailored to the permissions they actually need.
- Changes the default push-to-talk key to Right Option and disables the Computer Use Command hotkey after onboarding.
- Adds a pure shortcut policy so Push to Talk and Computer Use Command cannot actively share the same hotkey.
- Stores voice-note recordings in Muesli without pasting, and promotes voice-note users to Dictation when they later grant Accessibility.
- Wires focused onboarding/use-case telemetry fields and expands onboarding flow tests.

## Why

Some first-run users cannot grant Accessibility permissions because of employer device policy, but can still use Muesli as a local voice-notes product. The previous onboarding model treated paste dictation as the baseline and could leave these users blocked or misclassified.

## Validation

- `swift test --package-path native/MuesliNative --filter ModelsTests`
- `swift test --package-path native/MuesliNative --filter OnboardingFlowTests`
- `swift test --package-path native/MuesliNative --filter OnboardingProgressTests`
- `swift test --package-path native/MuesliNative --filter HotkeyConfig`
- `swift test --package-path native/MuesliNative --filter PasteController`
- `swift test --package-path native/MuesliNative` was run; it hit the known shared-pasteboard flake once in `paste restores clipboard after delay`, and the isolated `PasteController` rerun passed.
