### PR TITLE
[codex] Move meeting detection collection off the main thread

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -14,17 +14,18 @@ final class BrowserMeetingActivityCollector {
     private let cachedMeetingTTL: TimeInterval = 8
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
-    func collect(runningApps: [RunningAppSnapshot]) -> [BrowserMeetingContext] {
+    func collect(runningApps: [RunningAppSnapshot]) async -> [BrowserMeetingContext] {
         let now = Date()
         let browserApps = runningApps.filter { browserBundleIDs.contains($0.bundleID) }
         let runningBrowserIDs = Set(browserApps.map(\.bundleID))
 
-        let liveMeetings: [BrowserMeetingContext] = browserApps.compactMap { app in
-            guard let normalized = normalizedFocusedURL(for: app) else {
+        var liveMeetings: [BrowserMeetingContext] = []
+        for app in browserApps {
+            guard let normalized = await normalizedFocusedURL(for: app) else {
                 if app.isActive {
                     cachedMeetings.removeValue(forKey: app.bundleID)
                 }
-                return nil
+                continue
             }
 
             let context = BrowserMeetingContext(
@@ -37,7 +38,7 @@ final class BrowserMeetingActivityCollector {
                 isFocused: app.isActive
             )
             cachedMeetings[app.bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
-            return context
+            liveMeetings.append(context)
         }
 
         let liveBundleIDs = Set(liveMeetings.map(\.bundleID))
@@ -62,7 +63,7 @@ final class BrowserMeetingActivityCollector {
         return liveMeetings + cachedOnlyMeetings
     }
 
-    private func normalizedFocusedURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
+    private func normalizedFocusedURL(for app: RunningAppSnapshot) async -> NormalizedMeetingURL? {
         if let normalized = normalizedAXDocumentURL(for: app) {
             return normalized
         }
@@ -70,7 +71,7 @@ final class BrowserMeetingActivityCollector {
         // Query the browser's active tab even after another app/overlay becomes
         // frontmost. Strict URL normalization plus resolver media checks keep
         // background meeting tabs from prompting by themselves.
-        guard let url = activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
+        guard let url = await activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
             return nil
         }
         return MeetingURLNormalizer.normalize(url)
@@ -95,6 +96,7 @@ final class BrowserMeetingActivityCollector {
         return MeetingURLNormalizer.normalize(rawURL)
     }
 
+    @MainActor
     private func activeBrowserURLViaAppleScript(bundleID: String) -> String? {
         let source: String
         switch bundleID {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -2,39 +2,41 @@ import AppKit
 import ApplicationServices
 import Foundation
 
-@MainActor
+struct RunningAppSnapshot: Sendable {
+    let bundleID: String
+    let appName: String
+    let processIdentifier: pid_t
+    let isActive: Bool
+}
+
 final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
     private let cachedMeetingTTL: TimeInterval = 8
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
-    func collect() -> [BrowserMeetingContext] {
+    func collect(runningApps: [RunningAppSnapshot]) -> [BrowserMeetingContext] {
         let now = Date()
-        let browserApps = NSWorkspace.shared.runningApplications.filter { app in
-            guard let bundleID = app.bundleIdentifier else { return false }
-            return browserBundleIDs.contains(bundleID)
-        }
-        let runningBrowserIDs = Set(browserApps.compactMap(\.bundleIdentifier))
+        let browserApps = runningApps.filter { browserBundleIDs.contains($0.bundleID) }
+        let runningBrowserIDs = Set(browserApps.map(\.bundleID))
 
         let liveMeetings: [BrowserMeetingContext] = browserApps.compactMap { app in
-            guard let bundleID = app.bundleIdentifier else { return nil }
             guard let normalized = normalizedFocusedURL(for: app) else {
                 if app.isActive {
-                    cachedMeetings.removeValue(forKey: bundleID)
+                    cachedMeetings.removeValue(forKey: app.bundleID)
                 }
                 return nil
             }
 
             let context = BrowserMeetingContext(
-                bundleID: bundleID,
-                appName: app.localizedName ?? MeetingCandidateResolver.browserApps[bundleID] ?? bundleID,
+                bundleID: app.bundleID,
+                appName: app.appName,
                 pid: app.processIdentifier,
                 url: normalized.url,
                 normalizedID: normalized.id,
                 platform: normalized.platform,
                 isFocused: app.isActive
             )
-            cachedMeetings[bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
+            cachedMeetings[app.bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
             return context
         }
 
@@ -60,7 +62,7 @@ final class BrowserMeetingActivityCollector {
         return liveMeetings + cachedOnlyMeetings
     }
 
-    private func normalizedFocusedURL(for app: NSRunningApplication) -> NormalizedMeetingURL? {
+    private func normalizedFocusedURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
         if let normalized = normalizedAXDocumentURL(for: app) {
             return normalized
         }
@@ -68,14 +70,13 @@ final class BrowserMeetingActivityCollector {
         // Query the browser's active tab even after another app/overlay becomes
         // frontmost. Strict URL normalization plus resolver media checks keep
         // background meeting tabs from prompting by themselves.
-        guard let bundleID = app.bundleIdentifier,
-              let url = activeBrowserURLViaAppleScript(bundleID: bundleID) else {
+        guard let url = activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
             return nil
         }
         return MeetingURLNormalizer.normalize(url)
     }
 
-    private func normalizedAXDocumentURL(for app: NSRunningApplication) -> NormalizedMeetingURL? {
+    private func normalizedAXDocumentURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
         var windowRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, &windowRef) == .success,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -395,15 +395,16 @@ private actor MeetingSignalCollector {
     private let browserCollector = BrowserMeetingActivityCollector()
     private let audioProcessCollector = AudioProcessAttributionCollector()
 
-    func collect(micDeviceID: AudioDeviceID) -> MeetingCollectedSignals {
+    func collect(micDeviceID: AudioDeviceID) async -> MeetingCollectedSignals {
         let runningAppSnapshots = currentRunningApps()
+        let browserMeetings = await browserCollector.collect(runningApps: runningAppSnapshots)
 
         return MeetingCollectedSignals(
             micActive: isMicActive(deviceID: micDeviceID),
             runningApps: runningAppSnapshots.map {
                 RunningAppInfo(bundleID: $0.bundleID, isActive: $0.isActive)
             },
-            browserMeetings: browserCollector.collect(runningApps: runningAppSnapshots),
+            browserMeetings: browserMeetings,
             audioInputProcesses: audioProcessCollector.activeInputProcesses(),
             foregroundBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
             runningProcessIDsByBundleID: runningProcessIDsByBundleID(from: runningAppSnapshots)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -6,6 +6,7 @@ import os
 @MainActor
 final class MeetingMonitor {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
+    private static let evaluationInterval: UInt64 = 3_000_000_000
 
     var calendarEventProvider: (() -> CalendarEventContext?)?
     var detectionEnabledProvider: (() -> Bool)?
@@ -17,8 +18,7 @@ final class MeetingMonitor {
     var onPromptCandidateChanged: ((MeetingCandidate?) -> Void)?
 
     private let resolver = MeetingCandidateResolver()
-    private let browserCollector = BrowserMeetingActivityCollector()
-    private let audioProcessCollector = AudioProcessAttributionCollector()
+    private let signalCollector = MeetingSignalCollector()
     private let cameraMonitor = CameraActivityMonitor()
     private let sensorAttributionMonitor = ControlCenterSensorAttributionMonitor()
     private let promptState = MeetingPromptStateMachine()
@@ -26,7 +26,9 @@ final class MeetingMonitor {
     private var micListenerDeviceID: AudioDeviceID = 0
     private var micListenerBlock: AudioObjectPropertyListenerBlock?
     private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
-    private var evaluationTimer: Timer?
+    private var periodicEvaluationTask: Task<Void, Never>?
+    private var evaluationTask: Task<Void, Never>?
+    private var pendingEvaluation = false
     private var workspaceObserver: NSObjectProtocol?
     private var globalSuppressUntil: Date?
     private var lastLoggedCandidateID: String?
@@ -38,17 +40,17 @@ final class MeetingMonitor {
         installWorkspaceActivationObserver()
 
         cameraMonitor.onCameraStateChanged = { [weak self] _ in
-            self?.evaluateNow()
+            self?.scheduleEvaluation()
         }
         cameraMonitor.start()
 
         sensorAttributionMonitor.onAttributionsChanged = { [weak self] in
-            DispatchQueue.main.async { self?.evaluateNow() }
+            DispatchQueue.main.async { self?.scheduleEvaluation() }
         }
         sensorAttributionMonitor.start()
 
-        installEvaluationTimer()
-        evaluateNow()
+        installPeriodicEvaluationLoop()
+        scheduleEvaluation()
     }
 
     func stop() {
@@ -57,12 +59,15 @@ final class MeetingMonitor {
         removeWorkspaceActivationObserver()
         cameraMonitor.stop()
         sensorAttributionMonitor.stop()
-        evaluationTimer?.invalidate()
-        evaluationTimer = nil
+        periodicEvaluationTask?.cancel()
+        periodicEvaluationTask = nil
+        evaluationTask?.cancel()
+        evaluationTask = nil
+        pendingEvaluation = false
     }
 
     func refreshState() {
-        evaluateNow()
+        scheduleEvaluation()
     }
 
     func suppress(for duration: TimeInterval = 120) {
@@ -110,26 +115,53 @@ final class MeetingMonitor {
         onPromptCandidateChanged?(nil)
     }
 
-    private func evaluateNow() {
+    private func scheduleEvaluation() {
+        guard detectionEnabledProvider?() ?? true else {
+            dismissVisiblePromptForSuppression()
+            return
+        }
+
+        if evaluationTask != nil {
+            pendingEvaluation = true
+            return
+        }
+
+        evaluationTask = Task { [weak self] in
+            await self?.runScheduledEvaluations()
+        }
+    }
+
+    private func runScheduledEvaluations() async {
+        repeat {
+            pendingEvaluation = false
+            await evaluateNow()
+        } while pendingEvaluation && !Task.isCancelled
+        evaluationTask = nil
+    }
+
+    private func evaluateNow() async {
         let now = Date()
         let visibility = promptVisibilityProvider?() ?? MeetingPromptVisibility(isVisible: false, currentPromptID: nil, shownAt: nil)
         cameraMonitor.refresh()
         let sensorAttributions = sensorAttributionMonitor.snapshot(now: now)
+        let collectedSignals = await signalCollector.collect(micDeviceID: micListenerDeviceID)
+        guard !Task.isCancelled else { return }
         let audioInputProcesses = mergedAudioInputProcesses(
-            audioProcessCollector.activeInputProcesses(),
-            sensorAttributions: sensorAttributions
+            collectedSignals.audioInputProcesses,
+            sensorAttributions: sensorAttributions,
+            runningProcessIDsByBundleID: collectedSignals.runningProcessIDsByBundleID
         )
-        let micActive = isMicActive() || !audioInputProcesses.isEmpty || !sensorAttributions.micBundleIDs.isEmpty
+        let micActive = collectedSignals.micActive || !audioInputProcesses.isEmpty || !sensorAttributions.micBundleIDs.isEmpty
         let cameraActive = cameraMonitor.isCameraActive || !sensorAttributions.cameraBundleIDs.isEmpty
 
         let snapshot = MeetingSignalSnapshot(
             micActive: micActive,
             cameraActive: cameraActive,
             calendarEvent: calendarEventProvider?(),
-            runningApps: currentRunningApps(),
-            browserMeetings: browserCollector.collect(),
+            runningApps: collectedSignals.runningApps,
+            browserMeetings: collectedSignals.browserMeetings,
             audioInputProcesses: audioInputProcesses,
-            foregroundBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
+            foregroundBundleID: collectedSignals.foregroundBundleID,
             now: now
         )
 
@@ -203,15 +235,14 @@ final class MeetingMonitor {
         }
     }
 
-    private func installEvaluationTimer() {
-        evaluationTimer?.invalidate()
-        let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.evaluateNow()
+    private func installPeriodicEvaluationLoop() {
+        periodicEvaluationTask?.cancel()
+        periodicEvaluationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.evaluationInterval)
+                self?.scheduleEvaluation()
             }
         }
-        evaluationTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
     }
 
     private func installWorkspaceActivationObserver() {
@@ -221,7 +252,7 @@ final class MeetingMonitor {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.evaluateNow()
+                self?.scheduleEvaluation()
             }
         }
     }
@@ -232,16 +263,10 @@ final class MeetingMonitor {
         self.workspaceObserver = nil
     }
 
-    private func currentRunningApps() -> [RunningAppInfo] {
-        NSWorkspace.shared.runningApplications.compactMap { app in
-            guard let bundleID = app.bundleIdentifier else { return nil }
-            return RunningAppInfo(bundleID: bundleID, isActive: app.isActive)
-        }
-    }
-
     private func mergedAudioInputProcesses(
         _ coreAudioProcesses: [AudioProcessActivity],
-        sensorAttributions: SensorAttributionSnapshot
+        sensorAttributions: SensorAttributionSnapshot,
+        runningProcessIDsByBundleID: [String: pid_t]
     ) -> [AudioProcessActivity] {
         var processes = coreAudioProcesses
         let existingBundleIDs = Set(coreAudioProcesses.map(\.bundleID))
@@ -256,7 +281,7 @@ final class MeetingMonitor {
             }
 
             processes.append(AudioProcessActivity(
-                pid: NSWorkspace.shared.runningApplications.first { $0.bundleIdentifier == bundleID }?.processIdentifier ?? 0,
+                pid: runningProcessIDsByBundleID[bundleID] ?? 0,
                 bundleID: bundleID,
                 appName: appName,
                 isRunningInput: true,
@@ -288,7 +313,7 @@ final class MeetingMonitor {
         micListenerDeviceID = deviceID
 
         let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            DispatchQueue.main.async { self?.evaluateNow() }
+            DispatchQueue.main.async { self?.scheduleEvaluation() }
         }
         micListenerBlock = block
 
@@ -317,7 +342,7 @@ final class MeetingMonitor {
             DispatchQueue.main.async {
                 self?.removeMicListener()
                 self?.installMicListener()
-                self?.evaluateNow()
+                self?.scheduleEvaluation()
             }
         }
         deviceChangeListenerBlock = block
@@ -351,8 +376,62 @@ final class MeetingMonitor {
         deviceChangeListenerBlock = nil
     }
 
-    private func isMicActive() -> Bool {
-        guard micListenerDeviceID != 0 else { return false }
+    private func log(_ message: String) {
+        Self.logger.notice("\(message, privacy: .public)")
+        fputs("[meeting-monitor] \(message)\n", stderr)
+    }
+}
+
+private struct MeetingCollectedSignals {
+    let micActive: Bool
+    let runningApps: [RunningAppInfo]
+    let browserMeetings: [BrowserMeetingContext]
+    let audioInputProcesses: [AudioProcessActivity]
+    let foregroundBundleID: String?
+    let runningProcessIDsByBundleID: [String: pid_t]
+}
+
+private actor MeetingSignalCollector {
+    private let browserCollector = BrowserMeetingActivityCollector()
+    private let audioProcessCollector = AudioProcessAttributionCollector()
+
+    func collect(micDeviceID: AudioDeviceID) -> MeetingCollectedSignals {
+        let runningAppSnapshots = currentRunningApps()
+
+        return MeetingCollectedSignals(
+            micActive: isMicActive(deviceID: micDeviceID),
+            runningApps: runningAppSnapshots.map {
+                RunningAppInfo(bundleID: $0.bundleID, isActive: $0.isActive)
+            },
+            browserMeetings: browserCollector.collect(runningApps: runningAppSnapshots),
+            audioInputProcesses: audioProcessCollector.activeInputProcesses(),
+            foregroundBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
+            runningProcessIDsByBundleID: runningProcessIDsByBundleID(from: runningAppSnapshots)
+        )
+    }
+
+    private func currentRunningApps() -> [RunningAppSnapshot] {
+        NSWorkspace.shared.runningApplications.compactMap { app in
+            guard let bundleID = app.bundleIdentifier else { return nil }
+            return RunningAppSnapshot(
+                bundleID: bundleID,
+                appName: app.localizedName ?? MeetingCandidateResolver.browserApps[bundleID] ?? bundleID,
+                processIdentifier: app.processIdentifier,
+                isActive: app.isActive
+            )
+        }
+    }
+
+    private func runningProcessIDsByBundleID(from apps: [RunningAppSnapshot]) -> [String: pid_t] {
+        var processIDs: [String: pid_t] = [:]
+        for app in apps where processIDs[app.bundleID] == nil {
+            processIDs[app.bundleID] = app.processIdentifier
+        }
+        return processIDs
+    }
+
+    private func isMicActive(deviceID: AudioDeviceID) -> Bool {
+        guard deviceID != 0 else { return false }
 
         var isRunning: UInt32 = 0
         var runningAddress = AudioObjectPropertyAddress(
@@ -363,7 +442,7 @@ final class MeetingMonitor {
         var size = UInt32(MemoryLayout<UInt32>.size)
 
         guard AudioObjectGetPropertyData(
-            micListenerDeviceID,
+            deviceID,
             &runningAddress,
             0,
             nil,
@@ -372,10 +451,5 @@ final class MeetingMonitor {
         ) == noErr else { return false }
 
         return isRunning != 0
-    }
-
-    private func log(_ message: String) {
-        Self.logger.notice("\(message, privacy: .public)")
-        fputs("[meeting-monitor] \(message)\n", stderr)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -938,20 +938,7 @@ final class MuesliController: NSObject {
     }
 
     private func currentOrNearbyCachedCalendarEvent() -> CalendarEventContext? {
-        let now = Date()
-        let searchStart = now.addingTimeInterval(-15 * 60)
-        let searchEnd = now.addingTimeInterval(5 * 60)
-        let candidates = appState.upcomingCalendarEvents
-            .filter { event in
-                !event.isAllDay && event.endDate > searchStart && event.startDate < searchEnd
-            }
-            .sorted { $0.startDate < $1.startDate }
-
-        if let active = candidates.first(where: { $0.startDate <= now && $0.endDate > now }) {
-            return CalendarEventContext(id: active.id, title: active.title)
-        }
-
-        return candidates.first.map { CalendarEventContext(id: $0.id, title: $0.title) }
+        selectCurrentOrNearbyCachedCalendarEvent(from: appState.upcomingCalendarEvents)
     }
 
     private func startMeetingFeatureMonitors(includeMaraudersMap: Bool) {
@@ -4016,4 +4003,23 @@ final class MuesliController: NSObject {
             return dict
         }
     }
+}
+
+func selectCurrentOrNearbyCachedCalendarEvent(
+    from events: [UnifiedCalendarEvent],
+    now: Date = Date()
+) -> CalendarEventContext? {
+    let searchEnd = now.addingTimeInterval(5 * 60)
+    let candidates = events
+        .filter { event in
+            !event.isAllDay && event.endDate > now && event.startDate < searchEnd
+        }
+        .sorted { $0.startDate < $1.startDate }
+
+    if let active = candidates.first(where: { $0.startDate <= now && $0.endDate > now }) {
+        return CalendarEventContext(id: active.id, title: active.title)
+    }
+
+    return candidates.first(where: { $0.startDate > now })
+        .map { CalendarEventContext(id: $0.id, title: $0.title) }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -296,7 +296,7 @@ final class MuesliController: NSObject {
         refreshUI()
 
         meetingMonitor.calendarEventProvider = { [weak self] in
-            self?.calendarMonitor.currentOrNearbyEvent()
+            self?.currentOrNearbyCachedCalendarEvent()
         }
         meetingMonitor.detectionEnabledProvider = { [weak self] in
             self?.config.showMeetingDetectionNotification ?? false
@@ -935,6 +935,23 @@ final class MuesliController: NSObject {
             await self.refreshUpcomingCalendarEvents()
             self.checkUpcomingCalendarNotifications()
         }
+    }
+
+    private func currentOrNearbyCachedCalendarEvent() -> CalendarEventContext? {
+        let now = Date()
+        let searchStart = now.addingTimeInterval(-15 * 60)
+        let searchEnd = now.addingTimeInterval(5 * 60)
+        let candidates = appState.upcomingCalendarEvents
+            .filter { event in
+                !event.isAllDay && event.endDate > searchStart && event.startDate < searchEnd
+            }
+            .sorted { $0.startDate < $1.startDate }
+
+        if let active = candidates.first(where: { $0.startDate <= now && $0.endDate > now }) {
+            return CalendarEventContext(id: active.id, title: active.title)
+        }
+
+        return candidates.first.map { CalendarEventContext(id: $0.id, title: $0.title) }
     }
 
     private func startMeetingFeatureMonitors(includeMaraudersMap: Bool) {

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -225,6 +225,45 @@ struct GoogleCalendarTests {
         #expect(merged[1].title == "Late")
     }
 
+    // MARK: - Cached meeting detection event selection
+
+    @Test("cached meeting detection ignores recently ended events")
+    func cachedDetectionIgnoresRecentlyEndedEvents() {
+        let now = date("2026-04-10T10:08:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "ended", title: "Already done", startDate: date("2026-04-10T09:50:00Z"), endDate: date("2026-04-10T10:00:00Z"), isAllDay: false, source: .eventKit),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        #expect(selected == nil)
+    }
+
+    @Test("cached meeting detection prefers active over upcoming events")
+    func cachedDetectionPrefersActiveEvent() {
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "upcoming", title: "Next call", startDate: date("2026-04-10T10:04:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .googleCalendar),
+            UnifiedCalendarEvent(id: "active", title: "Current call", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        #expect(selected?.id == "active")
+        #expect(selected?.title == "Current call")
+    }
+
+    @Test("cached meeting detection can select imminent future events")
+    func cachedDetectionSelectsImminentFutureEvent() {
+        let now = date("2026-04-10T10:00:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "later", title: "Later call", startDate: date("2026-04-10T10:20:00Z"), endDate: date("2026-04-10T11:00:00Z"), isAllDay: false, source: .eventKit),
+            UnifiedCalendarEvent(id: "soon", title: "Soon call", startDate: date("2026-04-10T10:03:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .googleCalendar),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        #expect(selected?.id == "soon")
+        #expect(selected?.title == "Soon call")
+    }
+
     // MARK: - Helpers
 
     private func date(_ iso: String) -> Date {


### PR DESCRIPTION
## Summary
- move CoreAudio, browser URL, and running-application signal collection into a background actor
- replace the 1s common-run-loop timer with a coalesced async evaluation loop
- use cached calendar events for detection instead of synchronous EventKit queries on the main actor

## Why
The meeting detection timer was running expensive CoreAudio, AppleScript/AX, LaunchServices, and EventKit work from the main actor. That made MuesliPreprod janky during normal UI interaction even though CPU and memory looked modest.

## Validation
- `swift test --package-path native/MuesliNative --filter 'MeetingCandidateResolverTests|MeetingPromptStateMachineTests|MeetingDetectorTests|GoogleCalendarTests'`\n- Built and launched `/Applications/MuesliPreprod.app` locally\n- Profiled final build with `sample`; expensive meeting detection work moved off the AppKit main thread