### PR TITLE
[codex] Wire launch at login to macOS login items

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -55,6 +55,7 @@ final class AppState {
     var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .chatGPT
     var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()
+    var launchAtLoginRegistrationState: LaunchAtLoginRegistrationState = .disabled
 
     // Live status
     var isMeetingRecording: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/LaunchAtLoginManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/LaunchAtLoginManager.swift
@@ -1,13 +1,30 @@
 import Foundation
 import ServiceManagement
 
+enum LaunchAtLoginRegistrationState: Equatable {
+    case disabled
+    case enabled
+    case requiresApproval
+
+    var isRequested: Bool {
+        switch self {
+        case .disabled:
+            return false
+        case .enabled, .requiresApproval:
+            return true
+        }
+    }
+}
+
 protocol LaunchAtLoginManaging {
-    var isEnabled: Bool { get }
+    var registrationState: LaunchAtLoginRegistrationState { get }
     func setEnabled(_ enabled: Bool) throws
+    func openSystemSettingsLoginItems()
 }
 
 struct LaunchAtLoginUpdateResult {
     let config: AppConfig
+    let registrationState: LaunchAtLoginRegistrationState
     let error: Error?
 }
 
@@ -15,42 +32,62 @@ struct LaunchAtLoginCoordinator {
     let manager: LaunchAtLoginManaging
 
     func reconcileOnStartup(config: AppConfig) -> LaunchAtLoginUpdateResult {
-        if config.launchAtLogin, !manager.isEnabled {
+        if config.launchAtLogin, !manager.registrationState.isRequested {
             return setEnabled(true, config: config)
         }
 
         var updated = config
-        updated.launchAtLogin = manager.isEnabled
-        return LaunchAtLoginUpdateResult(config: updated, error: nil)
+        let state = manager.registrationState
+        updated.launchAtLogin = state.isRequested
+        return LaunchAtLoginUpdateResult(config: updated, registrationState: state, error: nil)
     }
 
     func setEnabled(_ enabled: Bool, config: AppConfig) -> LaunchAtLoginUpdateResult {
         var updated = config
         do {
             try manager.setEnabled(enabled)
-            updated.launchAtLogin = manager.isEnabled
-            return LaunchAtLoginUpdateResult(config: updated, error: nil)
+            let state = manager.registrationState
+            updated.launchAtLogin = state.isRequested
+            return LaunchAtLoginUpdateResult(config: updated, registrationState: state, error: nil)
         } catch {
-            updated.launchAtLogin = manager.isEnabled
-            return LaunchAtLoginUpdateResult(config: updated, error: error)
+            let state = manager.registrationState
+            updated.launchAtLogin = state.isRequested
+            return LaunchAtLoginUpdateResult(config: updated, registrationState: state, error: error)
         }
+    }
+
+    func openSystemSettingsLoginItems() {
+        manager.openSystemSettingsLoginItems()
     }
 }
 
 final class SystemLaunchAtLoginManager: LaunchAtLoginManaging {
-    var isEnabled: Bool {
-        SMAppService.mainApp.status == .enabled
+    var registrationState: LaunchAtLoginRegistrationState {
+        switch SMAppService.mainApp.status {
+        case .enabled:
+            return .enabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notRegistered, .notFound:
+            return .disabled
+        @unknown default:
+            return .disabled
+        }
     }
 
     func setEnabled(_ enabled: Bool) throws {
         let service = SMAppService.mainApp
-        switch (enabled, service.status) {
-        case (true, .enabled), (false, .notRegistered):
+        switch (enabled, registrationState) {
+        case (true, .enabled), (true, .requiresApproval), (false, .disabled):
             return
         case (true, _):
             try service.register()
         case (false, _):
             try service.unregister()
         }
+    }
+
+    func openSystemSettingsLoginItems() {
+        SMAppService.openSystemSettingsLoginItems()
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/LaunchAtLoginManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/LaunchAtLoginManager.swift
@@ -36,6 +36,10 @@ struct LaunchAtLoginCoordinator {
             return setEnabled(true, config: config)
         }
 
+        return refreshStatus(config: config)
+    }
+
+    func refreshStatus(config: AppConfig) -> LaunchAtLoginUpdateResult {
         var updated = config
         let state = manager.registrationState
         updated.launchAtLogin = state.isRequested

--- a/native/MuesliNative/Sources/MuesliNativeApp/LaunchAtLoginManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/LaunchAtLoginManager.swift
@@ -1,0 +1,56 @@
+import Foundation
+import ServiceManagement
+
+protocol LaunchAtLoginManaging {
+    var isEnabled: Bool { get }
+    func setEnabled(_ enabled: Bool) throws
+}
+
+struct LaunchAtLoginUpdateResult {
+    let config: AppConfig
+    let error: Error?
+}
+
+struct LaunchAtLoginCoordinator {
+    let manager: LaunchAtLoginManaging
+
+    func reconcileOnStartup(config: AppConfig) -> LaunchAtLoginUpdateResult {
+        if config.launchAtLogin, !manager.isEnabled {
+            return setEnabled(true, config: config)
+        }
+
+        var updated = config
+        updated.launchAtLogin = manager.isEnabled
+        return LaunchAtLoginUpdateResult(config: updated, error: nil)
+    }
+
+    func setEnabled(_ enabled: Bool, config: AppConfig) -> LaunchAtLoginUpdateResult {
+        var updated = config
+        do {
+            try manager.setEnabled(enabled)
+            updated.launchAtLogin = manager.isEnabled
+            return LaunchAtLoginUpdateResult(config: updated, error: nil)
+        } catch {
+            updated.launchAtLogin = manager.isEnabled
+            return LaunchAtLoginUpdateResult(config: updated, error: error)
+        }
+    }
+}
+
+final class SystemLaunchAtLoginManager: LaunchAtLoginManaging {
+    var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        let service = SMAppService.mainApp
+        switch (enabled, service.status) {
+        case (true, .enabled), (false, .notRegistered):
+            return
+        case (true, _):
+            try service.register()
+        case (false, _):
+            try service.unregister()
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -634,6 +634,14 @@ final class MuesliController: NSObject {
         launchAtLoginCoordinator.openSystemSettingsLoginItems()
     }
 
+    func refreshLaunchAtLoginState() {
+        let result = launchAtLoginCoordinator.refreshStatus(config: config)
+        appState.launchAtLoginRegistrationState = result.registrationState
+        let refreshed = result.config
+        guard refreshed.launchAtLogin != config.launchAtLogin else { return }
+        updateConfig { $0.launchAtLogin = refreshed.launchAtLogin }
+    }
+
     private func syncLaunchAtLoginConfigWithSystem() {
         let result = launchAtLoginCoordinator.reconcileOnStartup(config: config)
         if let error = result.error {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -623,7 +623,15 @@ final class MuesliController: NSObject {
         if let error = result.error {
             fputs("[launch-at-login] failed to set enabled=\(enabled): \(error)\n", stderr)
         }
+        appState.launchAtLoginRegistrationState = result.registrationState
         updateConfig { $0.launchAtLogin = result.config.launchAtLogin }
+        if enabled, result.registrationState == .requiresApproval {
+            launchAtLoginCoordinator.openSystemSettingsLoginItems()
+        }
+    }
+
+    func openLaunchAtLoginSettings() {
+        launchAtLoginCoordinator.openSystemSettingsLoginItems()
     }
 
     private func syncLaunchAtLoginConfigWithSystem() {
@@ -631,10 +639,10 @@ final class MuesliController: NSObject {
         if let error = result.error {
             fputs("[launch-at-login] failed to apply saved launch-at-login setting: \(error)\n", stderr)
         }
+        appState.launchAtLoginRegistrationState = result.registrationState
         let reconciled = result.config
         guard reconciled.launchAtLogin != config.launchAtLogin else { return }
-        config = reconciled
-        configStore.save(config)
+        updateConfig { $0.launchAtLogin = reconciled.launchAtLogin }
     }
 
     func selectBackend(_ option: BackendOption) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -89,6 +89,7 @@ final class MuesliController: NSObject {
     private let configStore = ConfigStore()
     private let dictationStore: DictationStore
     private let meetingHookDispatcher: MeetingHookDispatching
+    private let launchAtLoginCoordinator: LaunchAtLoginCoordinator
     let transcriptionCoordinator = TranscriptionCoordinator()
     private let hotkeyMonitor = HotkeyMonitor()
     private let computerUseHotkeyMonitor = HotkeyMonitor()
@@ -162,7 +163,8 @@ final class MuesliController: NSObject {
     init(
         runtime: RuntimePaths,
         dictationStore: DictationStore? = nil,
-        meetingHookDispatcher: MeetingHookDispatching = MeetingHookRunner()
+        meetingHookDispatcher: MeetingHookDispatching = MeetingHookRunner(),
+        launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager()
     ) {
         let loadedConfig = configStore.load()
         self.runtime = runtime
@@ -170,6 +172,7 @@ final class MuesliController: NSObject {
             databaseURL: MuesliPaths.defaultDatabaseURL(appName: AppIdentity.supportDirectoryName)
         )
         self.meetingHookDispatcher = meetingHookDispatcher
+        self.launchAtLoginCoordinator = LaunchAtLoginCoordinator(manager: launchAtLoginManager)
         self.config = loadedConfig
         if loadedConfig.recordingColorHex != "1e1e2e" {
             MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
@@ -198,6 +201,8 @@ final class MuesliController: NSObject {
 
         // Clean up phantom aggregate devices left by a previous crash
         CoreAudioSystemRecorder.cleanupStaleDevices()
+
+        syncLaunchAtLoginConfigWithSystem()
 
         // Clean up leftover audio temp files from previous sessions.
         cleanupTemporaryDirectory(
@@ -611,6 +616,25 @@ final class MuesliController: NSObject {
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         updateMeetingNotificationVisibility()
+    }
+
+    func setLaunchAtLogin(_ enabled: Bool) {
+        let result = launchAtLoginCoordinator.setEnabled(enabled, config: config)
+        if let error = result.error {
+            fputs("[launch-at-login] failed to set enabled=\(enabled): \(error)\n", stderr)
+        }
+        updateConfig { $0.launchAtLogin = result.config.launchAtLogin }
+    }
+
+    private func syncLaunchAtLoginConfigWithSystem() {
+        let result = launchAtLoginCoordinator.reconcileOnStartup(config: config)
+        if let error = result.error {
+            fputs("[launch-at-login] failed to apply saved launch-at-login setting: \(error)\n", stderr)
+        }
+        let reconciled = result.config
+        guard reconciled.launchAtLogin != config.launchAtLogin else { return }
+        config = reconciled
+        configStore.save(config)
     }
 
     func selectBackend(_ option: BackendOption) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -277,9 +277,14 @@ struct SettingsView: View {
     private var generalSettingsPane: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
             settingsSection("General") {
-                settingsRow("Launch at login") {
-                    settingsSwitch(isOn: appState.config.launchAtLogin) { newValue in
-                        controller.setLaunchAtLogin(newValue)
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                    settingsRow("Launch at login") {
+                        settingsSwitch(isOn: appState.config.launchAtLogin) { newValue in
+                            controller.setLaunchAtLogin(newValue)
+                        }
+                    }
+                    if appState.launchAtLoginRegistrationState == .requiresApproval {
+                        launchAtLoginApprovalPrompt
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
@@ -305,6 +310,38 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    private var launchAtLoginApprovalPrompt: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MuesliTheme.recording)
+            Text("Requires approval in System Settings")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+            Spacer(minLength: MuesliTheme.spacing12)
+            Button {
+                controller.openLaunchAtLoginSettings()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up.forward.square")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Open")
+                }
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(MuesliTheme.accent)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(MuesliTheme.accentSubtle)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .help("Open Login Items in System Settings")
+        }
+        .padding(.leading, MuesliTheme.spacing16)
+        .padding(.trailing, MuesliTheme.spacing16)
+        .padding(.bottom, MuesliTheme.spacing8)
     }
 
     private var dictationSettingsPane: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1232,6 +1232,7 @@ struct SettingsView: View {
         accessibilityGranted = AXIsProcessTrusted()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
+        controller.refreshLaunchAtLoginState()
         if screenRecordingGranted && pendingScreenContextEnable {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = true }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -279,7 +279,7 @@ struct SettingsView: View {
             settingsSection("General") {
                 settingsRow("Launch at login") {
                     settingsSwitch(isOn: appState.config.launchAtLogin) { newValue in
-                        controller.updateConfig { $0.launchAtLogin = newValue }
+                        controller.setLaunchAtLogin(newValue)
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)

--- a/native/MuesliNative/Tests/MuesliTests/LaunchAtLoginManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/LaunchAtLoginManagerTests.swift
@@ -92,6 +92,36 @@ struct LaunchAtLoginManagerTests {
         #expect(manager.requests.isEmpty)
     }
 
+    @Test("status refresh re-queries approval without re-registering")
+    func statusRefreshRequeriesApprovalWithoutReregistering() {
+        var config = AppConfig()
+        config.launchAtLogin = true
+        let manager = FakeLaunchAtLoginManager(registrationState: .enabled)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.refreshStatus(config: config)
+
+        #expect(result.error == nil)
+        #expect(result.registrationState == .enabled)
+        #expect(result.config.launchAtLogin)
+        #expect(manager.requests.isEmpty)
+    }
+
+    @Test("status refresh reflects external disable")
+    func statusRefreshReflectsExternalDisable() {
+        var config = AppConfig()
+        config.launchAtLogin = true
+        let manager = FakeLaunchAtLoginManager(registrationState: .disabled)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.refreshStatus(config: config)
+
+        #expect(result.error == nil)
+        #expect(result.registrationState == .disabled)
+        #expect(result.config.launchAtLogin == false)
+        #expect(manager.requests.isEmpty)
+    }
+
     @Test("opening login item settings delegates to backend")
     func openLoginItemSettingsDelegatesToBackend() {
         let manager = FakeLaunchAtLoginManager(registrationState: .requiresApproval)

--- a/native/MuesliNative/Tests/MuesliTests/LaunchAtLoginManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/LaunchAtLoginManagerTests.swift
@@ -8,7 +8,7 @@ struct LaunchAtLoginManagerTests {
     func startupReconciliationReflectsActualEnabledStatus() {
         var config = AppConfig()
         config.launchAtLogin = false
-        let manager = FakeLaunchAtLoginManager(isEnabled: true)
+        let manager = FakeLaunchAtLoginManager(registrationState: .enabled)
         let coordinator = LaunchAtLoginCoordinator(manager: manager)
 
         let result = coordinator.reconcileOnStartup(config: config)
@@ -22,7 +22,7 @@ struct LaunchAtLoginManagerTests {
     func startupReconciliationAppliesLegacySavedEnabledSetting() {
         var config = AppConfig()
         config.launchAtLogin = true
-        let manager = FakeLaunchAtLoginManager(isEnabled: false)
+        let manager = FakeLaunchAtLoginManager(registrationState: .disabled)
         let coordinator = LaunchAtLoginCoordinator(manager: manager)
 
         let result = coordinator.reconcileOnStartup(config: config)
@@ -36,7 +36,7 @@ struct LaunchAtLoginManagerTests {
     func settingLaunchAtLoginUsesBackendStatus() {
         var config = AppConfig()
         config.launchAtLogin = false
-        let manager = FakeLaunchAtLoginManager(isEnabled: false)
+        let manager = FakeLaunchAtLoginManager(registrationState: .disabled)
         let coordinator = LaunchAtLoginCoordinator(manager: manager)
 
         let result = coordinator.setEnabled(true, config: config)
@@ -50,7 +50,7 @@ struct LaunchAtLoginManagerTests {
     func failedBackendUpdateRollsBackConfig() {
         var config = AppConfig()
         config.launchAtLogin = true
-        let manager = FakeLaunchAtLoginManager(isEnabled: false)
+        let manager = FakeLaunchAtLoginManager(registrationState: .disabled)
         manager.errorToThrow = TestLaunchAtLoginError.denied
         let coordinator = LaunchAtLoginCoordinator(manager: manager)
 
@@ -60,6 +60,47 @@ struct LaunchAtLoginManagerTests {
         #expect(result.config.launchAtLogin == false)
         #expect(manager.requests == [true])
     }
+
+    @Test("requires approval stays requested instead of reverting to off")
+    func requiresApprovalStaysRequested() {
+        var config = AppConfig()
+        config.launchAtLogin = false
+        let manager = FakeLaunchAtLoginManager(registrationState: .disabled)
+        manager.stateAfterSuccessfulSet = .requiresApproval
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.setEnabled(true, config: config)
+
+        #expect(result.error == nil)
+        #expect(result.registrationState == .requiresApproval)
+        #expect(result.config.launchAtLogin)
+        #expect(manager.requests == [true])
+    }
+
+    @Test("startup reconciliation reflects pending approval as requested")
+    func startupReconciliationReflectsPendingApprovalAsRequested() {
+        var config = AppConfig()
+        config.launchAtLogin = false
+        let manager = FakeLaunchAtLoginManager(registrationState: .requiresApproval)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.reconcileOnStartup(config: config)
+
+        #expect(result.error == nil)
+        #expect(result.registrationState == .requiresApproval)
+        #expect(result.config.launchAtLogin)
+        #expect(manager.requests.isEmpty)
+    }
+
+    @Test("opening login item settings delegates to backend")
+    func openLoginItemSettingsDelegatesToBackend() {
+        let manager = FakeLaunchAtLoginManager(registrationState: .requiresApproval)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        coordinator.openSystemSettingsLoginItems()
+
+        #expect(manager.openedSettings)
+    }
 }
 
 private enum TestLaunchAtLoginError: Error {
@@ -67,12 +108,14 @@ private enum TestLaunchAtLoginError: Error {
 }
 
 private final class FakeLaunchAtLoginManager: LaunchAtLoginManaging {
-    var isEnabled: Bool
+    var registrationState: LaunchAtLoginRegistrationState
     var requests: [Bool] = []
     var errorToThrow: Error?
+    var openedSettings = false
+    var stateAfterSuccessfulSet: LaunchAtLoginRegistrationState?
 
-    init(isEnabled: Bool) {
-        self.isEnabled = isEnabled
+    init(registrationState: LaunchAtLoginRegistrationState) {
+        self.registrationState = registrationState
     }
 
     func setEnabled(_ enabled: Bool) throws {
@@ -80,6 +123,10 @@ private final class FakeLaunchAtLoginManager: LaunchAtLoginManaging {
         if let errorToThrow {
             throw errorToThrow
         }
-        isEnabled = enabled
+        registrationState = stateAfterSuccessfulSet ?? (enabled ? .enabled : .disabled)
+    }
+
+    func openSystemSettingsLoginItems() {
+        openedSettings = true
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/LaunchAtLoginManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/LaunchAtLoginManagerTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Launch at login")
+struct LaunchAtLoginManagerTests {
+    @Test("startup reconciliation reflects actual enabled status when config is off")
+    func startupReconciliationReflectsActualEnabledStatus() {
+        var config = AppConfig()
+        config.launchAtLogin = false
+        let manager = FakeLaunchAtLoginManager(isEnabled: true)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.reconcileOnStartup(config: config)
+
+        #expect(result.error == nil)
+        #expect(result.config.launchAtLogin)
+        #expect(manager.requests.isEmpty)
+    }
+
+    @Test("startup reconciliation applies legacy saved enabled setting")
+    func startupReconciliationAppliesLegacySavedEnabledSetting() {
+        var config = AppConfig()
+        config.launchAtLogin = true
+        let manager = FakeLaunchAtLoginManager(isEnabled: false)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.reconcileOnStartup(config: config)
+
+        #expect(result.error == nil)
+        #expect(result.config.launchAtLogin)
+        #expect(manager.requests == [true])
+    }
+
+    @Test("setting launch at login delegates to backend and stores actual status")
+    func settingLaunchAtLoginUsesBackendStatus() {
+        var config = AppConfig()
+        config.launchAtLogin = false
+        let manager = FakeLaunchAtLoginManager(isEnabled: false)
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.setEnabled(true, config: config)
+
+        #expect(result.error == nil)
+        #expect(result.config.launchAtLogin)
+        #expect(manager.requests == [true])
+    }
+
+    @Test("failed backend update rolls config back to actual status")
+    func failedBackendUpdateRollsBackConfig() {
+        var config = AppConfig()
+        config.launchAtLogin = true
+        let manager = FakeLaunchAtLoginManager(isEnabled: false)
+        manager.errorToThrow = TestLaunchAtLoginError.denied
+        let coordinator = LaunchAtLoginCoordinator(manager: manager)
+
+        let result = coordinator.setEnabled(true, config: config)
+
+        #expect(result.error != nil)
+        #expect(result.config.launchAtLogin == false)
+        #expect(manager.requests == [true])
+    }
+}
+
+private enum TestLaunchAtLoginError: Error {
+    case denied
+}
+
+private final class FakeLaunchAtLoginManager: LaunchAtLoginManaging {
+    var isEnabled: Bool
+    var requests: [Bool] = []
+    var errorToThrow: Error?
+
+    init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        requests.append(enabled)
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        isEnabled = enabled
+    }
+}


### PR DESCRIPTION
## Summary
- wire the Settings "Launch at login" toggle to macOS `SMAppService.mainApp`
- reconcile saved config with real login-item status on startup, including applying legacy `launch_at_login: true` configs
- add unit coverage for successful registration, startup reconciliation, and failure rollback

## Why
The toggle previously only wrote `launch_at_login` to Muesli's config file. It did not register Muesli with macOS Login Items, so enabling the setting had no effect after reboot.

Fixes #103

## Validation
- `swift test --package-path native/MuesliNative --filter 'LaunchAtLoginManagerTests|ConfigStoreTests|ModelsTests'`
