### PR TITLE
Run GoogleCalendarTests in CI via the meetings shard

### DIFF
--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -68,6 +68,7 @@ case "${shard}" in
       MeetingSummaryBackendTests
       MeetingResummarizationPolicyTests
       MeetingTemplateResolutionTests
+      GoogleCalendarTests
     )
     ;;
   *)


### PR DESCRIPTION
## Summary
- Adds `GoogleCalendarTests` to the `meetings` shard in `scripts/run_ci_test_shard.sh`.

## Why
`Tests/MuesliTests/GoogleCalendarTests.swift` exists and passes locally, but the shard script uses hardcoded test-class allowlists (no wildcards). Without an entry, the tests silently never run in CI on PRs that touch calendar code. Adding a single line costs <1s of CI time and closes the gap.

## Validation
```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
    bash scripts/run_ci_test_shard.sh meetings
# → Test run with 163 tests in 11 suites passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)