### PR TITLE
Add per-calendar enable/disable for notifications and meeting detection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to Muesli
+
+Thanks for helping improve Muesli. This project is a native macOS app built
+with SwiftPM, AppKit, SwiftUI, and a small set of shell scripts around local
+builds and CI shards.
+
+## Requirements
+
+- macOS 14.2 or newer
+- Xcode 16 or newer
+- Apple Silicon Mac for the main app workflows
+
+## Local Development Build
+
+Maintainer release builds are signed with a Developer ID certificate that
+external contributors do not have. For local development, build the isolated
+dev app without signing:
+
+```bash
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
+```
+
+That installs `/Applications/MuesliDev.app` with bundle ID `com.muesli.dev`
+and stores data under `~/Library/Application Support/MuesliDev/`, so it does
+not touch your production Muesli install or data.
+
+Useful dev commands:
+
+```bash
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh          # Build and launch MuesliDev
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh --reset  # Re-run onboarding, keep data
+./scripts/dev-reset-permissions.sh                # Reset macOS privacy permissions for MuesliDev
+```
+
+If you do have your own signing certificate, you can override the identity:
+
+```bash
+MUESLI_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" ./scripts/dev-test.sh
+```
+
+## SwiftPM Build Cache
+
+SwiftPM writes build artifacts to `native/MuesliNative/.build` by default,
+which can become large across worktrees. Use a shared scratch path for local
+testing:
+
+```bash
+MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" \
+  MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
+```
+
+Do not run concurrent builds from different worktrees into the same scratch
+path. Use separate names such as `dev`, `test`, or `agent-1`.
+
+## Tests
+
+Run the native test package:
+
+```bash
+swift test --package-path native/MuesliNative
+```
+
+For CI-sized local checks, use the shard script:
+
+```bash
+./scripts/run_ci_test_shard.sh core
+./scripts/run_ci_test_shard.sh dictation-transcription
+./scripts/run_ci_test_shard.sh meetings
+```
+
+For direct SwiftPM test runs with a shared cache:
+
+```bash
+swift test --package-path native/MuesliNative \
+  --scratch-path "$HOME/Library/Caches/muesli-spm/test"
+```
+
+## Pull Requests
+
+- Keep changes focused and include tests for behavioral changes.
+- Mention the test commands you ran in the PR description.
+- Use `MUESLI_SKIP_SIGN=1` for local app verification unless you have a valid
+  signing identity.
+- Avoid committing generated build artifacts, app bundles, model files, or
+  local application data.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
 Release builds are signed by the maintainer Developer ID certificate. External
 contributors can use the unsigned dev build for local testing; it installs
 `MuesliDev.app` with a separate bundle ID and app data directory.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full local development workflow.
 
 The transcription model (~450MB for Parakeet v3) downloads automatically on first use.
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -34,6 +34,13 @@ enum UserInitiatedUpdateAction: Equatable {
     case showBusy(message: String)
 }
 
+enum GoogleCalendarListLoadState: Equatable {
+    case idle
+    case loading
+    case loaded
+    case failed(String)
+}
+
 enum UpdateInteractionPolicy {
     static let busyMessage = "Sparkle is still finishing the previous update check. Try again in a moment."
 
@@ -86,6 +93,9 @@ final class AppState {
     var isGoogleCalendarAuthenticated: Bool = false
     var upcomingCalendarEvents: [UnifiedCalendarEvent] = []
     var hiddenCalendarEventIDs: Set<String> = []
+    var availableEventKitCalendars: [AvailableCalendar] = []
+    var availableGoogleCalendars: [GoogleCalendarSummary] = []
+    var googleCalendarListLoadState: GoogleCalendarListLoadState = .idle
     var sparkleUpdateStatus: SparkleUpdateStatus = .idle
     var sparkleLastCheckedAt: Date?
     var modelPreparationTitle: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -1,3 +1,4 @@
+import AppKit
 import EventKit
 import Foundation
 import MuesliCore
@@ -7,6 +8,17 @@ struct UpcomingMeetingEvent {
     let title: String
     let startDate: Date
     var meetingURL: URL? = nil
+}
+
+/// A calendar exposed by EventKit (iCloud, On-My-Mac, Exchange, an Internet
+/// Account–linked Google calendar, etc.). Used by Settings to show which
+/// calendars Muesli is reading from and to drive per-calendar enable/disable.
+struct AvailableCalendar: Identifiable, Equatable {
+    let id: String           // EKCalendar.calendarIdentifier
+    let title: String
+    let sourceTitle: String  // e.g. "iCloud", "spencer@dockstreet.com"
+    let colorHex: String?
+    let typeLabel: String
 }
 
 final class CalendarMonitor {
@@ -101,7 +113,8 @@ final class CalendarMonitor {
 
     /// Returns upcoming timed events from the local macOS calendar (EventKit) for the next N days.
     /// All-day events are excluded — they're not useful for meeting recording.
-    func upcomingEvents(daysAhead: Int = 7) -> [UnifiedCalendarEvent] {
+    /// Events from calendars listed in `disabledCalendarIDs` are filtered out.
+    func upcomingEvents(daysAhead: Int = 7, disabledCalendarIDs: Set<String> = []) -> [UnifiedCalendarEvent] {
         // Create a fresh EKEventStore each time to avoid stale cache.
         // EKEventStore instances cache calendar data and don't automatically
         // reflect external changes (e.g., events moved in Google Calendar).
@@ -111,7 +124,7 @@ final class CalendarMonitor {
         guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
         let predicate = freshStore.predicateForEvents(withStart: now, end: future, calendars: nil)
         let events = freshStore.events(matching: predicate)
-        return events.compactMap { event in
+        let unified: [UnifiedCalendarEvent] = events.compactMap { event in
             guard let startDate = event.startDate, let endDate = event.endDate else { return nil }
             guard !event.isAllDay else { return nil }
             return UnifiedCalendarEvent(
@@ -121,9 +134,54 @@ final class CalendarMonitor {
                 endDate: endDate,
                 isAllDay: false,
                 source: .eventKit,
+                calendarID: event.calendar?.calendarIdentifier,
                 meetingURL: Self.extractMeetingURL(from: event)
             )
-        }.sorted { $0.startDate < $1.startDate }
+        }
+        return UnifiedCalendarEvent
+            .filter(unified, disabledCalendarIDs: disabledCalendarIDs)
+            .sorted { $0.startDate < $1.startDate }
+    }
+
+    /// Enumerate every event calendar EventKit exposes — iCloud, On-My-Mac,
+    /// Exchange, and any Google account linked via System Settings > Internet
+    /// Accounts. Used by Settings to surface which calendars Muesli is reading
+    /// from and to power per-calendar enable/disable.
+    func availableCalendars() -> [AvailableCalendar] {
+        let freshStore = EKEventStore()
+        return freshStore.calendars(for: .event)
+            .map { cal in
+                AvailableCalendar(
+                    id: cal.calendarIdentifier,
+                    title: cal.title,
+                    sourceTitle: cal.source.title,
+                    colorHex: Self.hexString(from: cal.cgColor),
+                    typeLabel: Self.typeLabel(for: cal.type)
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.sourceTitle != rhs.sourceTitle { return lhs.sourceTitle < rhs.sourceTitle }
+                return lhs.title < rhs.title
+            }
+    }
+
+    private static func hexString(from cgColor: CGColor?) -> String? {
+        guard let cgColor, let nsColor = NSColor(cgColor: cgColor)?.usingColorSpace(.sRGB) else { return nil }
+        let r = Int(round(nsColor.redComponent * 255))
+        let g = Int(round(nsColor.greenComponent * 255))
+        let b = Int(round(nsColor.blueComponent * 255))
+        return String(format: "%02x%02x%02x", r, g, b)
+    }
+
+    private static func typeLabel(for type: EKCalendarType) -> String {
+        switch type {
+        case .local: return "Local"
+        case .calDAV: return "CalDAV"
+        case .exchange: return "Exchange"
+        case .subscription: return "Subscription"
+        case .birthday: return "Birthday"
+        @unknown default: return "Calendar"
+        }
     }
 
     // MARK: - Meeting URL Extraction

--- a/native/MuesliNative/Sources/MuesliNativeApp/CameraActivityMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CameraActivityMonitor.swift
@@ -72,7 +72,8 @@ final class CameraActivityMonitor {
         for (deviceID, block) in monitoredDevices where !currentDeviceIDs.contains(deviceID) {
             removeRunningListener(deviceID: deviceID, block: block)
         }
-        for id in monitoredDevices.keys where !currentDeviceIDs.contains(id) {
+        let staleDeviceIDs = monitoredDevices.keys.filter { !currentDeviceIDs.contains($0) }
+        for id in staleDeviceIDs {
             monitoredDevices.removeValue(forKey: id)
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarAuthManager.swift
@@ -346,6 +346,11 @@ final class GoogleCalendarAuthManager {
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             let errorBody = String(data: data, encoding: .utf8) ?? "unknown error"
+            if let httpResponse = response as? HTTPURLResponse,
+               (httpResponse.statusCode == 400 || httpResponse.statusCode == 401),
+               errorBody.contains("invalid_grant") {
+                throw GoogleCalendarAuthError.notAuthenticated
+            }
             throw GoogleCalendarAuthError.refreshFailed(errorBody)
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -110,7 +110,13 @@ final class GoogleCalendarClient {
         }
 
         for calendar in enabled {
-            try await fetchEvents(forCalendarID: calendar.id, daysAhead: daysAhead)
+            do {
+                try await fetchEvents(forCalendarID: calendar.id, daysAhead: daysAhead)
+            } catch let authError as GoogleCalendarAuthError {
+                throw authError
+            } catch {
+                fputs("[google-cal] events fetch failed for \(calendar.id), keeping cached events: \(error)\n", stderr)
+            }
         }
 
         let now = Date()

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -9,12 +9,38 @@ struct UnifiedCalendarEvent: Identifiable, Equatable {
     let endDate: Date
     let isAllDay: Bool
     let source: CalendarSource
+    /// Identifier of the calendar this event belongs to.
+    /// EventKit: `EKCalendar.calendarIdentifier`. Google: the calendar list `id`.
+    /// Optional because legacy events deserialized from older state may not have it.
+    var calendarID: String? = nil
     var meetingURL: URL? = nil
 
     enum CalendarSource: String {
         case eventKit
         case googleCalendar
     }
+
+    /// Drop events whose `calendarID` is in `disabledCalendarIDs`. Events with `nil`
+    /// calendarID always pass through (they predate per-calendar filtering).
+    static func filter(
+        _ events: [UnifiedCalendarEvent],
+        disabledCalendarIDs: Set<String>
+    ) -> [UnifiedCalendarEvent] {
+        guard !disabledCalendarIDs.isEmpty else { return events }
+        return events.filter { event in
+            guard let id = event.calendarID else { return true }
+            return !disabledCalendarIDs.contains(id)
+        }
+    }
+}
+
+// MARK: - Google Calendar List Model
+
+struct GoogleCalendarSummary: Identifiable, Equatable {
+    let id: String
+    let summary: String
+    let isPrimary: Bool
+    let colorHex: String?
 }
 
 // MARK: - Google Calendar API Client
@@ -24,36 +50,86 @@ final class GoogleCalendarClient {
     private let auth = GoogleCalendarAuthManager.shared
 
     private static let baseURL = "https://www.googleapis.com/calendar/v3"
+    private static let primaryCalendarID = "primary"
 
-    /// Stored sync token from last full fetch — subsequent requests return only changes.
-    private var syncToken: String?
-    /// Cached events from last fetch, updated incrementally via sync tokens.
-    private var cachedEvents: [String: UnifiedCalendarEvent] = [:]
+    /// Stored sync token per calendar from last full fetch — subsequent requests
+    /// return only changes for that calendar.
+    private var syncTokens: [String: String] = [:]
+    /// Cached events keyed by calendar ID, then by event ID. A 410 (sync token
+    /// expired) for one calendar invalidates only that calendar's cache.
+    private var cachedEventsByCalendar: [String: [String: UnifiedCalendarEvent]] = [:]
+    /// Last fetched calendar list. Refreshed each time `fetchUpcomingEvents` runs
+    /// so calendars added in the Google web UI get picked up automatically.
+    private var cachedCalendarList: [GoogleCalendarSummary] = []
 
-    /// Fetch upcoming events from the user's primary Google Calendar.
-    /// Uses sync tokens for incremental updates and handles pagination.
-    func fetchUpcomingEvents(daysAhead: Int = 7, isRetry: Bool = false) async throws -> [UnifiedCalendarEvent] {
+    /// Fetch upcoming events from every Google calendar the user can read,
+    /// minus any in `disabledCalendarIDs`. Refreshes the calendar list on each
+    /// call so newly-added calendars show up; per-calendar sync tokens keep
+    /// each event fetch incremental.
+    func fetchUpcomingEvents(
+        daysAhead: Int = 7,
+        disabledCalendarIDs: Set<String> = []
+    ) async throws -> [UnifiedCalendarEvent] {
+        // Refresh the calendar list. If this fails, fall back to whatever we
+        // last saw — better to return something than nothing.
+        do {
+            cachedCalendarList = try await fetchCalendarList()
+        } catch {
+            if cachedCalendarList.isEmpty {
+                // First call ever and we can't list — try the primary calendar
+                // directly so users with read-only access at least see something.
+                cachedCalendarList = [GoogleCalendarSummary(
+                    id: Self.primaryCalendarID,
+                    summary: "Primary",
+                    isPrimary: true,
+                    colorHex: nil
+                )]
+            }
+            fputs("[google-cal] calendarList fetch failed, using cached list: \(error)\n", stderr)
+        }
+
+        let enabled = cachedCalendarList.filter { !disabledCalendarIDs.contains($0.id) }
+        // Drop cached events for any calendar that's now disabled or absent so
+        // we don't leak stale events into the merged result.
+        let keepIDs = Set(enabled.map(\.id))
+        for calID in cachedEventsByCalendar.keys where !keepIDs.contains(calID) {
+            cachedEventsByCalendar.removeValue(forKey: calID)
+            syncTokens.removeValue(forKey: calID)
+        }
+
+        for calendar in enabled {
+            try await fetchEvents(forCalendarID: calendar.id, daysAhead: daysAhead)
+        }
+
+        let now = Date()
+        let merged = cachedEventsByCalendar.values
+            .flatMap { $0.values }
+            .filter { $0.endDate > now }
+        return merged.sorted { $0.startDate < $1.startDate }
+    }
+
+    /// Fetch events for a single calendar, populating `cachedEventsByCalendar[calendarID]`.
+    /// Uses the per-calendar sync token if present; falls back to a windowed query otherwise.
+    /// Handles pagination, 401 refresh, and 410 sync-token expiry per calendar.
+    private func fetchEvents(forCalendarID calendarID: String, daysAhead: Int, isRetry: Bool = false) async throws {
         var token = try await auth.validAccessToken()
-
         let isoFormatter = Self.isoFormatter
 
         var pageToken: String? = nil
         var tokenRetried = false
 
+        let escapedID = calendarID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? calendarID
+
         repeat {
-            var components = URLComponents(string: "\(Self.baseURL)/calendars/primary/events")!
+            var components = URLComponents(string: "\(Self.baseURL)/calendars/\(escapedID)/events")!
 
             if let pageToken {
-                components.queryItems = [
-                    URLQueryItem(name: "pageToken", value: pageToken),
-                ]
-            } else if let syncToken {
-                components.queryItems = [
-                    URLQueryItem(name: "syncToken", value: syncToken),
-                ]
+                components.queryItems = [URLQueryItem(name: "pageToken", value: pageToken)]
+            } else if let syncToken = syncTokens[calendarID] {
+                components.queryItems = [URLQueryItem(name: "syncToken", value: syncToken)]
             } else {
                 let now = Date()
-                guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return [] }
+                guard let future = Calendar.current.date(byAdding: .day, value: daysAhead, to: now) else { return }
                 components.queryItems = [
                     URLQueryItem(name: "timeMin", value: isoFormatter.string(from: now)),
                     URLQueryItem(name: "timeMax", value: isoFormatter.string(from: future)),
@@ -69,19 +145,17 @@ final class GoogleCalendarClient {
             let (data, response) = try await URLSession.shared.data(for: request)
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
 
-            // 410 = sync token expired — retry once with full fetch
             if statusCode == 410 {
                 guard !isRetry else {
-                    fputs("[google-cal] 410 on full re-fetch, giving up\n", stderr)
-                    return Array(cachedEvents.values).sorted { $0.startDate < $1.startDate }
+                    fputs("[google-cal] 410 on full re-fetch for \(calendarID), giving up\n", stderr)
+                    return
                 }
-                fputs("[google-cal] sync token expired, performing full re-fetch\n", stderr)
-                syncToken = nil
-                cachedEvents.removeAll()
-                return try await fetchUpcomingEvents(daysAhead: daysAhead, isRetry: true)
+                fputs("[google-cal] sync token expired for \(calendarID), performing full re-fetch\n", stderr)
+                syncTokens.removeValue(forKey: calendarID)
+                cachedEventsByCalendar.removeValue(forKey: calendarID)
+                return try await fetchEvents(forCalendarID: calendarID, daysAhead: daysAhead, isRetry: true)
             }
 
-            // 401 on any page (first or mid-pagination) — refresh token and retry once
             if statusCode == 401 && !tokenRetried {
                 tokenRetried = true
                 token = try await auth.validAccessToken()
@@ -90,7 +164,7 @@ final class GoogleCalendarClient {
 
             guard statusCode == 200 else {
                 let body = String(data: data, encoding: .utf8) ?? ""
-                fputs("[google-cal] API error \(statusCode): \(body.prefix(200))\n", stderr)
+                fputs("[google-cal] API error \(statusCode) for \(calendarID): \(body.prefix(200))\n", stderr)
                 if statusCode == 401 || statusCode == 403 {
                     throw GoogleCalendarAuthError.notAuthenticated
                 }
@@ -101,39 +175,113 @@ final class GoogleCalendarClient {
                 break
             }
 
+            var bucket = cachedEventsByCalendar[calendarID] ?? [:]
             if let items = json["items"] as? [[String: Any]] {
                 for item in items {
                     guard let id = item["id"] as? String else { continue }
                     if item["status"] as? String == "cancelled" {
-                        cachedEvents.removeValue(forKey: id)
+                        bucket.removeValue(forKey: id)
                         continue
                     }
-                    if let event = parseEvent(item) {
-                        cachedEvents[id] = event
+                    if let event = parseEvent(item, calendarID: calendarID) {
+                        bucket[id] = event
                     }
                 }
             }
+            cachedEventsByCalendar[calendarID] = bucket
 
-            // nextPageToken = more pages to fetch; nextSyncToken = done, use for incremental
             if let nextPage = json["nextPageToken"] as? String {
                 pageToken = nextPage
             } else {
                 pageToken = nil
                 if let newSyncToken = json["nextSyncToken"] as? String {
-                    syncToken = newSyncToken
+                    syncTokens[calendarID] = newSyncToken
                 }
             }
         } while pageToken != nil
+    }
 
-        let now = Date()
-        let events = cachedEvents.values.filter { $0.endDate > now }
-        return events.sorted { $0.startDate < $1.startDate }
+    /// Enumerate every Google calendar the authenticated user can read.
+    /// Does not touch the event cache — purely descriptive.
+    func fetchCalendarList() async throws -> [GoogleCalendarSummary] {
+        var token = try await auth.validAccessToken()
+        var pageToken: String? = nil
+        var tokenRetried = false
+        var results: [GoogleCalendarSummary] = []
+
+        repeat {
+            var components = URLComponents(string: "\(Self.baseURL)/users/me/calendarList")!
+            var items: [URLQueryItem] = [
+                URLQueryItem(name: "maxResults", value: "250"),
+                URLQueryItem(name: "minAccessRole", value: "reader"),
+            ]
+            if let pageToken {
+                items.append(URLQueryItem(name: "pageToken", value: pageToken))
+            }
+            components.queryItems = items
+
+            var request = URLRequest(url: components.url!)
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+            if statusCode == 401 && !tokenRetried {
+                tokenRetried = true
+                token = try await auth.validAccessToken()
+                continue
+            }
+
+            guard statusCode == 200 else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                fputs("[google-cal] calendarList error \(statusCode): \(body.prefix(200))\n", stderr)
+                if statusCode == 401 || statusCode == 403 {
+                    throw GoogleCalendarAuthError.notAuthenticated
+                }
+                throw GoogleCalendarAuthError.refreshFailed("calendarList returned \(statusCode)")
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                break
+            }
+            if let entries = json["items"] as? [[String: Any]] {
+                for entry in entries {
+                    if let summary = Self.parseCalendarListEntry(entry) {
+                        results.append(summary)
+                    }
+                }
+            }
+            pageToken = json["nextPageToken"] as? String
+        } while pageToken != nil
+
+        return results.sorted { lhs, rhs in
+            if lhs.isPrimary != rhs.isPrimary { return lhs.isPrimary }
+            return lhs.summary.localizedCaseInsensitiveCompare(rhs.summary) == .orderedAscending
+        }
+    }
+
+    /// Parse a single `calendarList` entry. Static + pure for tests.
+    static func parseCalendarListEntry(_ entry: [String: Any]) -> GoogleCalendarSummary? {
+        guard let id = entry["id"] as? String else { return nil }
+        let summary = (entry["summaryOverride"] as? String)
+            ?? (entry["summary"] as? String)
+            ?? id
+        let isPrimary = (entry["primary"] as? Bool) ?? false
+        let bgColor = entry["backgroundColor"] as? String
+        let colorHex = bgColor?.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        return GoogleCalendarSummary(
+            id: id,
+            summary: summary,
+            isPrimary: isPrimary,
+            colorHex: colorHex
+        )
     }
 
     /// Clear cached state (call on sign-out).
     func resetSync() {
-        syncToken = nil
-        cachedEvents.removeAll()
+        syncTokens.removeAll()
+        cachedEventsByCalendar.removeAll()
+        cachedCalendarList.removeAll()
     }
 
     private static let isoFormatter: ISO8601DateFormatter = {
@@ -148,7 +296,7 @@ final class GoogleCalendarClient {
         return f
     }()
 
-    func parseEvent(_ item: [String: Any]) -> UnifiedCalendarEvent? {
+    func parseEvent(_ item: [String: Any], calendarID: String = "primary") -> UnifiedCalendarEvent? {
         guard let id = item["id"] as? String,
               let summary = item["summary"] as? String else { return nil }
 
@@ -208,6 +356,7 @@ final class GoogleCalendarClient {
             endDate: endDate,
             isAllDay: isAllDay,
             source: .googleCalendar,
+            calendarID: calendarID,
             meetingURL: meetingURL
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -296,7 +296,7 @@ final class GoogleCalendarClient {
         return f
     }()
 
-    func parseEvent(_ item: [String: Any], calendarID: String = "primary") -> UnifiedCalendarEvent? {
+    func parseEvent(_ item: [String: Any], calendarID: String) -> UnifiedCalendarEvent? {
         guard let id = item["id"] as? String,
               let summary = item["summary"] as? String else { return nil }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -92,7 +92,8 @@ final class GoogleCalendarClient {
         // Drop cached events for any calendar that's now disabled or absent so
         // we don't leak stale events into the merged result.
         let keepIDs = Set(enabled.map(\.id))
-        for calID in cachedEventsByCalendar.keys where !keepIDs.contains(calID) {
+        let calendarIDsToRemove = cachedEventsByCalendar.keys.filter { !keepIDs.contains($0) }
+        for calID in calendarIDsToRemove {
             cachedEventsByCalendar.removeValue(forKey: calID)
             syncTokens.removeValue(forKey: calID)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -43,6 +43,17 @@ struct GoogleCalendarSummary: Identifiable, Equatable {
     let colorHex: String?
 }
 
+enum GoogleCalendarClientError: Error, LocalizedError {
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .requestFailed(let message):
+            return "Google Calendar request failed: \(message)"
+        }
+    }
+}
+
 // MARK: - Google Calendar API Client
 
 @MainActor
@@ -169,7 +180,7 @@ final class GoogleCalendarClient {
                 if statusCode == 401 || statusCode == 403 {
                     throw GoogleCalendarAuthError.notAuthenticated
                 }
-                throw GoogleCalendarAuthError.refreshFailed("Calendar API returned \(statusCode)")
+                throw GoogleCalendarClientError.requestFailed("events returned \(statusCode)")
             }
 
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -239,7 +250,7 @@ final class GoogleCalendarClient {
                 if statusCode == 401 || statusCode == 403 {
                     throw GoogleCalendarAuthError.notAuthenticated
                 }
-                throw GoogleCalendarAuthError.refreshFailed("calendarList returned \(statusCode)")
+                throw GoogleCalendarClientError.requestFailed("calendarList returned \(statusCode)")
             }
 
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -629,6 +629,7 @@ struct AppConfig: Codable {
     var maraudersMapAudioClip: String = "bbc_world_news"
     var maraudersMapCustomAudioPath: String?
     var hiddenCalendarEventIDs: [String] = []
+    var disabledCalendarIDs: [String] = []
     var enablePostProcessor: Bool = false
     var activePostProcessorId: String = PostProcessorOption.defaultOption.id
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
@@ -691,6 +692,7 @@ struct AppConfig: Codable {
         case maraudersMapAudioClip = "marauders_map_audio_clip"
         case maraudersMapCustomAudioPath = "marauders_map_custom_audio_path"
         case hiddenCalendarEventIDs = "hidden_calendar_event_ids"
+        case disabledCalendarIDs = "disabled_calendar_ids"
         case enablePostProcessor = "enable_post_processor"
         case activePostProcessorId = "active_post_processor_id"
         case postProcessorSystemPrompt = "post_processor_system_prompt"
@@ -767,6 +769,7 @@ struct AppConfig: Codable {
         maraudersMapAudioClip = (try? c.decode(String.self, forKey: .maraudersMapAudioClip)) ?? defaults.maraudersMapAudioClip
         maraudersMapCustomAudioPath = try? c.decode(String.self, forKey: .maraudersMapCustomAudioPath)
         hiddenCalendarEventIDs = (try? c.decode([String].self, forKey: .hiddenCalendarEventIDs)) ?? defaults.hiddenCalendarEventIDs
+        disabledCalendarIDs = (try? c.decode([String].self, forKey: .disabledCalendarIDs)) ?? defaults.disabledCalendarIDs
         enablePostProcessor = (try? c.decode(Bool.self, forKey: .enablePostProcessor)) ?? defaults.enablePostProcessor
         activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -892,7 +892,10 @@ final class MuesliController: NSObject {
         do {
             try await googleCalAuth.signIn()
             syncAppState()
-            Task { await refreshUpcomingCalendarEvents() }
+            Task {
+                await refreshUpcomingCalendarEvents()
+                await refreshGoogleCalendarList()
+            }
             return nil
         } catch {
             fputs("[muesli-native] Google Calendar sign-in failed: \(error)\n", stderr)
@@ -903,16 +906,48 @@ final class MuesliController: NSObject {
     func signOutGoogleCalendar() {
         googleCalAuth.signOut()
         googleCalClient.resetSync()
+        appState.availableGoogleCalendars = []
+        appState.googleCalendarListLoadState = .idle
         syncAppState()
         Task { await refreshUpcomingCalendarEvents() }
     }
 
+    /// Refresh the EventKit-available calendars list. Cheap (no network), safe
+    /// to call frequently — driven by Settings panel onAppear and by the
+    /// EKEventStoreChangedNotification handler.
+    func refreshAvailableEventKitCalendars() {
+        appState.availableEventKitCalendars = calendarMonitor.availableCalendars()
+    }
+
+    /// Refresh the Google calendar list via the Calendar API. No-op when OAuth
+    /// is not available or the user is not authenticated.
+    func refreshGoogleCalendarList() async {
+        guard googleCalAuth.isAuthenticated else {
+            appState.availableGoogleCalendars = []
+            appState.googleCalendarListLoadState = .idle
+            return
+        }
+        appState.googleCalendarListLoadState = .loading
+        do {
+            let list = try await googleCalClient.fetchCalendarList()
+            appState.availableGoogleCalendars = list
+            appState.googleCalendarListLoadState = .loaded
+        } catch {
+            fputs("[muesli-native] Google calendarList fetch failed: \(error)\n", stderr)
+            appState.googleCalendarListLoadState = .failed(error.localizedDescription)
+        }
+    }
+
     func refreshUpcomingCalendarEvents() async {
-        var ekEvents = calendarMonitor.upcomingEvents(daysAhead: 7)
+        let disabledIDs = Set(config.disabledCalendarIDs)
+        var ekEvents = calendarMonitor.upcomingEvents(daysAhead: 7, disabledCalendarIDs: disabledIDs)
 
         if googleCalAuth.isAuthenticated {
             do {
-                let googleEvents = try await googleCalClient.fetchUpcomingEvents(daysAhead: 7)
+                let googleEvents = try await googleCalClient.fetchUpcomingEvents(
+                    daysAhead: 7,
+                    disabledCalendarIDs: disabledIDs
+                )
                 ekEvents = GoogleCalendarClient.mergeEvents(eventKit: ekEvents, google: googleEvents)
             } catch GoogleCalendarAuthError.notAuthenticated {
                 googleCalAuth.signOut()
@@ -949,6 +984,7 @@ final class MuesliController: NSObject {
         calendarMonitor.onCalendarChanged = { [weak self] in
             guard let self else { return }
             Task { @MainActor in
+                self.refreshAvailableEventKitCalendars()
                 await self.refreshUpcomingCalendarEvents()
                 self.checkUpcomingCalendarNotifications()
             }
@@ -971,6 +1007,7 @@ final class MuesliController: NSObject {
 
         // Run first cycle immediately
         Task { @MainActor in
+            self.refreshAvailableEventKitCalendars()
             await self.refreshUpcomingCalendarEvents()
             self.checkUpcomingCalendarNotifications()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -904,12 +904,16 @@ final class MuesliController: NSObject {
     }
 
     func signOutGoogleCalendar() {
+        invalidateGoogleCalendarAuth()
+        Task { await refreshUpcomingCalendarEvents() }
+    }
+
+    private func invalidateGoogleCalendarAuth() {
         googleCalAuth.signOut()
         googleCalClient.resetSync()
         appState.availableGoogleCalendars = []
         appState.googleCalendarListLoadState = .idle
         syncAppState()
-        Task { await refreshUpcomingCalendarEvents() }
     }
 
     /// Refresh the EventKit-available calendars list. Cheap (no network), safe
@@ -932,6 +936,12 @@ final class MuesliController: NSObject {
             let list = try await googleCalClient.fetchCalendarList()
             appState.availableGoogleCalendars = list
             appState.googleCalendarListLoadState = .loaded
+        } catch GoogleCalendarAuthError.notAuthenticated {
+            invalidateGoogleCalendarAuth()
+            fputs("[muesli-native] Google Calendar token invalid while loading calendar list, signed out\n", stderr)
+        } catch GoogleCalendarAuthError.refreshFailed {
+            invalidateGoogleCalendarAuth()
+            fputs("[muesli-native] Google Calendar refresh token invalid while loading calendar list, signed out\n", stderr)
         } catch {
             fputs("[muesli-native] Google calendarList fetch failed: \(error)\n", stderr)
             appState.googleCalendarListLoadState = .failed(error.localizedDescription)
@@ -950,14 +960,10 @@ final class MuesliController: NSObject {
                 )
                 ekEvents = GoogleCalendarClient.mergeEvents(eventKit: ekEvents, google: googleEvents)
             } catch GoogleCalendarAuthError.notAuthenticated {
-                googleCalAuth.signOut()
-                googleCalClient.resetSync()
-                syncAppState()
+                invalidateGoogleCalendarAuth()
                 fputs("[muesli-native] Google Calendar token invalid, signed out\n", stderr)
             } catch GoogleCalendarAuthError.refreshFailed {
-                googleCalAuth.signOut()
-                googleCalClient.resetSync()
-                syncAppState()
+                invalidateGoogleCalendarAuth()
                 fputs("[muesli-native] Google Calendar refresh token invalid, signed out\n", stderr)
             } catch {
                 fputs("[muesli-native] Google Calendar fetch failed: \(error)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -939,9 +939,9 @@ final class MuesliController: NSObject {
         } catch GoogleCalendarAuthError.notAuthenticated {
             invalidateGoogleCalendarAuth()
             fputs("[muesli-native] Google Calendar token invalid while loading calendar list, signed out\n", stderr)
-        } catch GoogleCalendarAuthError.refreshFailed {
-            invalidateGoogleCalendarAuth()
-            fputs("[muesli-native] Google Calendar refresh token invalid while loading calendar list, signed out\n", stderr)
+        } catch GoogleCalendarAuthError.refreshFailed(let message) {
+            fputs("[muesli-native] Google Calendar token refresh failed while loading calendar list: \(message)\n", stderr)
+            appState.googleCalendarListLoadState = .failed("Token refresh failed: \(message)")
         } catch {
             fputs("[muesli-native] Google calendarList fetch failed: \(error)\n", stderr)
             appState.googleCalendarListLoadState = .failed(error.localizedDescription)
@@ -962,9 +962,8 @@ final class MuesliController: NSObject {
             } catch GoogleCalendarAuthError.notAuthenticated {
                 invalidateGoogleCalendarAuth()
                 fputs("[muesli-native] Google Calendar token invalid, signed out\n", stderr)
-            } catch GoogleCalendarAuthError.refreshFailed {
-                invalidateGoogleCalendarAuth()
-                fputs("[muesli-native] Google Calendar refresh token invalid, signed out\n", stderr)
+            } catch GoogleCalendarAuthError.refreshFailed(let message) {
+                fputs("[muesli-native] Google Calendar token refresh failed: \(message)\n", stderr)
             } catch {
                 fputs("[muesli-native] Google Calendar fetch failed: \(error)\n", stderr)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3912,7 +3912,9 @@ final class MuesliController: NSObject {
                 // Match by event ID prefix so deleted/cancelled events (no longer
                 // in upcomingCalendarEvents) still get their timers cancelled.
                 let prefix = "\(info.id)|"
-                for (key, timer) in self.meetingStartingNowTimers where key.hasPrefix(prefix) {
+                let matchingTimerKeys = self.meetingStartingNowTimers.keys.filter { $0.hasPrefix(prefix) }
+                for key in matchingTimerKeys {
+                    guard let timer = self.meetingStartingNowTimers[key] else { continue }
                     timer.invalidate()
                     self.meetingStartingNowTimers.removeValue(forKey: key)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -642,6 +642,10 @@ struct SettingsView: View {
                     .padding(.horizontal, MuesliTheme.spacing16)
             }
 
+            settingsSection("Calendars") {
+                calendarSourcesControl
+            }
+
             if appState.isGoogleCalendarAvailable {
                 settingsSection("Calendar") {
                     settingsRow("Google Calendar") {
@@ -649,6 +653,10 @@ struct SettingsView: View {
                     }
                 }
             }
+        }
+        .onAppear {
+            controller.refreshAvailableEventKitCalendars()
+            Task { await controller.refreshGoogleCalendarList() }
         }
     }
 
@@ -1416,6 +1424,170 @@ struct SettingsView: View {
             }
             config.mutedMeetingDetectionAppBundleIDs = muted.sorted()
         }
+    }
+
+    // MARK: - Calendars
+
+    private struct CalendarToggleItem: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let colorHex: String?
+        let isEnabled: Bool
+    }
+
+    private struct CalendarSourceGroup: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let items: [CalendarToggleItem]
+    }
+
+    private var calendarSourceGroups: [CalendarSourceGroup] {
+        let disabled = Set(appState.config.disabledCalendarIDs)
+        var groups: [CalendarSourceGroup] = []
+
+        let ekBySource = Dictionary(grouping: appState.availableEventKitCalendars) { $0.sourceTitle }
+        for sourceTitle in ekBySource.keys.sorted() {
+            let items = (ekBySource[sourceTitle] ?? [])
+                .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+                .map { cal in
+                    CalendarToggleItem(
+                        id: cal.id,
+                        title: cal.title,
+                        colorHex: cal.colorHex,
+                        isEnabled: !disabled.contains(cal.id)
+                    )
+                }
+            groups.append(CalendarSourceGroup(id: "ek::\(sourceTitle)", title: sourceTitle, items: items))
+        }
+
+        if appState.isGoogleCalendarAuthenticated && !appState.availableGoogleCalendars.isEmpty {
+            let items = appState.availableGoogleCalendars.map { cal in
+                CalendarToggleItem(
+                    id: cal.id,
+                    title: cal.summary + (cal.isPrimary ? " (Primary)" : ""),
+                    colorHex: cal.colorHex,
+                    isEnabled: !disabled.contains(cal.id)
+                )
+            }
+            groups.append(CalendarSourceGroup(id: "google_oauth", title: "Google (OAuth)", items: items))
+        }
+
+        return groups
+    }
+
+    private var calendarSourcesControl: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            Text("Disabled calendars are hidden from Muesli — no notifications, no Coming Up, no meeting detection.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if calendarSourceGroups.isEmpty {
+                Text("No calendars detected. Make sure Calendar permission is granted in System Settings > Privacy & Security > Calendars.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                ForEach(calendarSourceGroups) { group in
+                    calendarSourceGroupView(group)
+                }
+            }
+
+            if appState.isGoogleCalendarAuthenticated {
+                googleCalendarListLoadStateView
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func calendarSourceGroupView(_ group: CalendarSourceGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(group.title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .textCase(.uppercase)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 8),
+                GridItem(.flexible(), spacing: 8),
+            ], alignment: .leading, spacing: 8) {
+                ForEach(group.items) { item in
+                    calendarToggleButton(item)
+                }
+            }
+        }
+        .padding(.leading, MuesliTheme.spacing16)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(MuesliTheme.surfaceBorder)
+                .frame(width: 2)
+        }
+    }
+
+    private func calendarToggleButton(_ item: CalendarToggleItem) -> some View {
+        Button {
+            updateDisabledCalendar(item.id, isDisabled: item.isEnabled)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: item.isEnabled ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(item.isEnabled ? MuesliTheme.accent : MuesliTheme.textTertiary)
+                    .frame(width: 16)
+                Circle()
+                    .fill(item.colorHex.map { Color(hex: $0) } ?? MuesliTheme.textTertiary)
+                    .frame(width: 8, height: 8)
+                Text(item.title)
+                    .font(.system(size: 12))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(item.isEnabled ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(item.isEnabled ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var googleCalendarListLoadStateView: some View {
+        switch appState.googleCalendarListLoadState {
+        case .loading:
+            Text("Loading Google calendars…")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+        case .failed(let message):
+            HStack(spacing: 8) {
+                Text("Failed to load Google calendars: \(message)")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                Button("Retry") {
+                    Task { await controller.refreshGoogleCalendarList() }
+                }
+                .buttonStyle(.link)
+                .font(MuesliTheme.caption())
+            }
+        case .idle, .loaded:
+            EmptyView()
+        }
+    }
+
+    private func updateDisabledCalendar(_ calendarID: String, isDisabled: Bool) {
+        controller.updateConfig { config in
+            var disabled = Set(config.disabledCalendarIDs)
+            if isDisabled {
+                disabled.insert(calendarID)
+            } else {
+                disabled.remove(calendarID)
+            }
+            config.disabledCalendarIDs = disabled.sorted()
+        }
+        Task { await controller.refreshUpcomingCalendarEvents() }
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -610,6 +610,18 @@ struct SettingsView: View {
                 }
             }
 
+            settingsSection("Calendars") {
+                calendarSourcesControl
+            }
+
+            if appState.isGoogleCalendarAvailable {
+                settingsSection("Calendar") {
+                    settingsRow("Google Calendar") {
+                        googleCalendarControl
+                    }
+                }
+            }
+
             settingsSection("Advanced") {
                 settingsRow("Enable post-meeting hook") {
                     settingsSwitch(isOn: appState.config.meetingHookEnabled) { newValue in
@@ -640,18 +652,6 @@ struct SettingsView: View {
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .padding(.horizontal, MuesliTheme.spacing16)
-            }
-
-            settingsSection("Calendars") {
-                calendarSourcesControl
-            }
-
-            if appState.isGoogleCalendarAvailable {
-                settingsSection("Calendar") {
-                    settingsRow("Google Calendar") {
-                        googleCalendarControl
-                    }
-                }
             }
         }
         .onAppear {
@@ -1438,6 +1438,8 @@ struct SettingsView: View {
     private struct CalendarSourceGroup: Identifiable, Equatable {
         let id: String
         let title: String
+        let subtitle: String
+        let iconName: String
         let items: [CalendarToggleItem]
     }
 
@@ -1457,7 +1459,13 @@ struct SettingsView: View {
                         isEnabled: !disabled.contains(cal.id)
                     )
                 }
-            groups.append(CalendarSourceGroup(id: "ek::\(sourceTitle)", title: sourceTitle, items: items))
+            groups.append(CalendarSourceGroup(
+                id: "ek::\(sourceTitle)",
+                title: sourceTitle,
+                subtitle: calendarSourceSubtitle(for: sourceTitle),
+                iconName: calendarSourceIconName(for: sourceTitle),
+                items: items
+            ))
         }
 
         if appState.isGoogleCalendarAuthenticated && !appState.availableGoogleCalendars.isEmpty {
@@ -1469,7 +1477,13 @@ struct SettingsView: View {
                     isEnabled: !disabled.contains(cal.id)
                 )
             }
-            groups.append(CalendarSourceGroup(id: "google_oauth", title: "Google (OAuth)", items: items))
+            groups.append(CalendarSourceGroup(
+                id: "google_oauth",
+                title: "Google Calendar",
+                subtitle: "Connected directly to Muesli",
+                iconName: "calendar.badge.plus",
+                items: items
+            ))
         }
 
         return groups
@@ -1477,7 +1491,7 @@ struct SettingsView: View {
 
     private var calendarSourcesControl: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-            Text("Disabled calendars are hidden from Muesli — no notifications, no Coming Up, no meeting detection.")
+            Text("Calendar sources are listed first, with their calendars underneath. Disabled calendars are hidden from Muesli — no notifications, no Coming Up, no meeting detection.")
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textTertiary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -1508,11 +1522,27 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func calendarSourceGroupView(_ group: CalendarSourceGroup) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(group.title)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(MuesliTheme.textTertiary)
-                .textCase(.uppercase)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: group.iconName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .frame(width: 18, height: 18)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(group.title)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+
+                    Text("\(group.subtitle) • \(group.items.count) \(group.items.count == 1 ? "calendar" : "calendars")")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+            }
 
             LazyVGrid(columns: [
                 GridItem(.flexible(), spacing: 8),
@@ -1522,13 +1552,37 @@ struct SettingsView: View {
                     calendarToggleButton(item)
                 }
             }
+            .padding(.leading, 28)
         }
-        .padding(.leading, MuesliTheme.spacing16)
-        .overlay(alignment: .leading) {
-            Rectangle()
-                .fill(MuesliTheme.surfaceBorder)
-                .frame(width: 2)
+        .padding(.vertical, 2)
+    }
+
+    private func calendarSourceSubtitle(for sourceTitle: String) -> String {
+        let normalized = sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized == "icloud" {
+            return "iCloud account in macOS Calendar"
         }
+        if normalized == "subscribed calendars" {
+            return "Subscribed in macOS Calendar"
+        }
+        if normalized == "other" {
+            return "System calendars from macOS"
+        }
+        return "Calendar account in macOS"
+    }
+
+    private func calendarSourceIconName(for sourceTitle: String) -> String {
+        let normalized = sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized == "icloud" {
+            return "icloud"
+        }
+        if normalized == "subscribed calendars" {
+            return "calendar.badge.clock"
+        }
+        if normalized == "other" {
+            return "person.crop.circle.badge.clock"
+        }
+        return "calendar"
     }
 
     private func calendarToggleButton(_ item: CalendarToggleItem) -> some View {
@@ -1545,17 +1599,17 @@ struct SettingsView: View {
                     .frame(width: 8, height: 8)
                 Text(item.title)
                     .font(.system(size: 12))
-                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .foregroundStyle(item.isEnabled ? MuesliTheme.textPrimary : MuesliTheme.textTertiary)
                     .lineLimit(1)
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 8)
             .frame(height: 28)
-            .background(item.isEnabled ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
+            .background(MuesliTheme.surfacePrimary)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             .overlay(
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(item.isEnabled ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder, lineWidth: 1)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
         }
         .buttonStyle(.plain)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1493,6 +1493,13 @@ struct SettingsView: View {
                 }
             }
 
+            if appState.isGoogleCalendarAuthenticated && !appState.availableEventKitCalendars.isEmpty {
+                Text("Google calendars may appear once from macOS Calendar and once from Muesli's Google connection. Turn off both copies to hide that calendar completely.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             if appState.isGoogleCalendarAuthenticated {
                 googleCalendarListLoadStateView
             }

--- a/native/MuesliNative/Tests/MuesliTests/DisabledCalendarFilterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DisabledCalendarFilterTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Per-calendar disable filter")
+@MainActor
+struct DisabledCalendarFilterTests {
+
+    @Test("empty disabled set returns events unchanged")
+    func emptyDisabledSetPassesEverythingThrough() {
+        let events = [
+            event(id: "a", calendarID: "cal-1"),
+            event(id: "b", calendarID: "cal-2"),
+        ]
+        let filtered = UnifiedCalendarEvent.filter(events, disabledCalendarIDs: [])
+        #expect(filtered.count == 2)
+        #expect(filtered.map(\.id) == ["a", "b"])
+    }
+
+    @Test("matching calendar IDs are filtered out")
+    func partialDisableDropsMatchingEvents() {
+        let events = [
+            event(id: "a", calendarID: "cal-1"),
+            event(id: "b", calendarID: "cal-2"),
+            event(id: "c", calendarID: "cal-3"),
+        ]
+        let filtered = UnifiedCalendarEvent.filter(events, disabledCalendarIDs: ["cal-2"])
+        #expect(filtered.map(\.id) == ["a", "c"])
+    }
+
+    @Test("disabling all calendars returns empty")
+    func disablingAllCalendarsEmptiesResult() {
+        let events = [
+            event(id: "a", calendarID: "cal-1"),
+            event(id: "b", calendarID: "cal-2"),
+        ]
+        let filtered = UnifiedCalendarEvent.filter(events, disabledCalendarIDs: ["cal-1", "cal-2"])
+        #expect(filtered.isEmpty)
+    }
+
+    @Test("unknown disabled IDs have no effect")
+    func unknownDisabledIDsAreIgnored() {
+        let events = [event(id: "a", calendarID: "cal-1")]
+        let filtered = UnifiedCalendarEvent.filter(events, disabledCalendarIDs: ["never-existed"])
+        #expect(filtered.count == 1)
+    }
+
+    @Test("events with nil calendarID always pass through")
+    func nilCalendarIDPassesThrough() {
+        let events = [
+            event(id: "legacy", calendarID: nil),
+            event(id: "modern", calendarID: "cal-1"),
+        ]
+        let filtered = UnifiedCalendarEvent.filter(events, disabledCalendarIDs: ["cal-1"])
+        #expect(filtered.map(\.id) == ["legacy"])
+    }
+
+    // MARK: - Helpers
+
+    private func event(id: String, calendarID: String?) -> UnifiedCalendarEvent {
+        UnifiedCalendarEvent(
+            id: id,
+            title: "Event \(id)",
+            startDate: Date(timeIntervalSince1970: 1_770_000_000),
+            endDate: Date(timeIntervalSince1970: 1_770_003_600),
+            isAllDay: false,
+            source: .eventKit,
+            calendarID: calendarID
+        )
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -264,6 +264,53 @@ struct GoogleCalendarTests {
         #expect(selected?.title == "Soon call")
     }
 
+    // MARK: - parseCalendarListEntry
+
+    @Test("parses a calendarList entry with summary, primary flag, and color")
+    func parsesCalendarListEntry() {
+        let entry: [String: Any] = [
+            "id": "primary",
+            "summary": "spencer@dockstreet.com",
+            "primary": true,
+            "backgroundColor": "#9fe1e7",
+        ]
+        let summary = GoogleCalendarClient.parseCalendarListEntry(entry)
+        #expect(summary?.id == "primary")
+        #expect(summary?.summary == "spencer@dockstreet.com")
+        #expect(summary?.isPrimary == true)
+        #expect(summary?.colorHex == "9fe1e7")
+    }
+
+    @Test("calendarList entry prefers summaryOverride when present")
+    func calendarListPrefersOverride() {
+        let entry: [String: Any] = [
+            "id": "team@dockstreet.com",
+            "summary": "team@dockstreet.com",
+            "summaryOverride": "Team Standup",
+        ]
+        let summary = GoogleCalendarClient.parseCalendarListEntry(entry)
+        #expect(summary?.summary == "Team Standup")
+        #expect(summary?.isPrimary == false)
+    }
+
+    @Test("calendarList entry returns nil when id missing")
+    func calendarListNilWithoutID() {
+        let entry: [String: Any] = ["summary": "no id"]
+        #expect(GoogleCalendarClient.parseCalendarListEntry(entry) == nil)
+    }
+
+    @Test("parsed event records the calendarID")
+    func parsedEventCarriesCalendarID() {
+        let item: [String: Any] = [
+            "id": "ev1",
+            "summary": "Sync",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T15:00:00Z"],
+        ]
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "team@dockstreet.com")
+        #expect(event?.calendarID == "team@dockstreet.com")
+    }
+
     // MARK: - Helpers
 
     private func date(_ iso: String) -> Date {

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -57,7 +57,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T15:00:00+05:30"],
         ]
 
-        let event = GoogleCalendarClient().parseEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "primary")
         #expect(event != nil)
         #expect(event?.id == "event123")
         #expect(event?.title == "Sprint Planning")
@@ -74,7 +74,7 @@ struct GoogleCalendarTests {
             "end": ["date": "2026-04-11"],
         ]
 
-        let event = GoogleCalendarClient().parseEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "primary")
         #expect(event != nil)
         #expect(event?.isAllDay == true)
         #expect(event?.title == "Company Holiday")
@@ -88,7 +88,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T15:00:00Z"],
         ]
 
-        #expect(GoogleCalendarClient().parseEvent(item) == nil)
+        #expect(GoogleCalendarClient().parseEvent(item, calendarID: "primary") == nil)
     }
 
     @Test("returns nil for event missing id")
@@ -99,7 +99,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T15:00:00Z"],
         ]
 
-        #expect(GoogleCalendarClient().parseEvent(item) == nil)
+        #expect(GoogleCalendarClient().parseEvent(item, calendarID: "primary") == nil)
     }
 
     // MARK: - Meeting URL extraction
@@ -114,7 +114,7 @@ struct GoogleCalendarTests {
             "hangoutLink": "https://meet.google.com/abc-defg-hij",
         ]
 
-        let event = GoogleCalendarClient().parseEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "primary")
         #expect(event?.meetingURL?.absoluteString == "https://meet.google.com/abc-defg-hij")
     }
 
@@ -132,7 +132,7 @@ struct GoogleCalendarTests {
             ],
         ]
 
-        let event = GoogleCalendarClient().parseEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "primary")
         #expect(event?.meetingURL?.absoluteString == "https://us02web.zoom.us/j/123456789")
     }
 
@@ -145,7 +145,7 @@ struct GoogleCalendarTests {
             "end": ["dateTime": "2026-04-10T13:00:00Z"],
         ]
 
-        let event = GoogleCalendarClient().parseEvent(item)
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "primary")
         #expect(event?.meetingURL == nil)
     }
 

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 # - Separate bundle ID (com.muesli.dev) — won't interfere with production Muesli
 # - Separate data directory (~/Library/Application Support/MuesliDev/)
 # - Preserves existing dev config and database by default
-# - Signed with Developer ID (Accessibility permission persists across rebuilds)
+# - Signed with Developer ID by default (Accessibility permission persists across rebuilds)
+# - External contributors can set MUESLI_SKIP_SIGN=1 to build without the
+#   maintainer signing certificate
 # - Installs to /Applications/MuesliDev.app
 #
 # Usage:

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -68,6 +68,7 @@ case "${shard}" in
       MeetingSummaryBackendTests
       MeetingResummarizationPolicyTests
       MeetingTemplateResolutionTests
+      DisabledCalendarFilterTests
     )
     ;;
   *)


### PR DESCRIPTION
## Summary
- New "Calendars" section under **Settings → Meetings** lists every calendar EventKit exposes (iCloud, On-My-Mac, Exchange, plus any Google account linked via System Settings → Internet Accounts), grouped by source.
- Each calendar has a toggle. Disabled calendars are excluded from Coming Up, scheduled-meeting notifications, and meeting-detection cross-reference.
- Doubles as a debugging surface — when a user reports "my invite isn't showing up in Muesli," they can check whether the calendar even reaches EventKit.
- Google OAuth path is also extended to fetch all of the user's Google calendars (was: primary only) and is filtered against the same disable list. The OAuth sub-list only renders when `isGoogleCalendarAvailable && isAuthenticated`, so users without embedded credentials see only EventKit.

## Why
Muesli previously fetched events from every calendar EventKit could see, with no UI to inspect or filter. That makes (a) debugging missing-invite reports painful (no surface to check what EventKit is actually pulling), and (b) high-traffic shared calendars noisy (every event fires a notification).

The opt-out model (`disabled_calendar_ids` rather than `enabled_calendar_ids`) preserves zero-config behavior — empty list = current behavior — and makes newly-added shared calendars show up automatically rather than requiring user action.

## Behavior change to call out
The Google OAuth integration previously fetched only the user's *primary* Google calendar. After this change, it fetches all Google calendars by default, subject to the new disable list. Most users today don't hit the OAuth path (it's gated on embedded credentials per the verification status noted in CLAUDE.md), but anyone who does will see additional calendars after upgrade — they can disable any of them in the new Settings section.

## Implementation notes
- `disabledCalendarIDs: [String]` added to `AppConfig` with snake_case CodingKey, modelled on the existing `mutedMeetingDetectionAppBundleIDs` opt-out pattern.
- `UnifiedCalendarEvent` gains an optional `calendarID` so a single static `filter(_:disabledCalendarIDs:)` works against EventKit and Google sources uniformly.
- `CalendarMonitor.upcomingEvents(daysAhead:disabledCalendarIDs:)` filters at fetch time → all downstream consumers (`appState.upcomingCalendarEvents`, `checkUpcomingCalendarNotifications`, the cached meeting-detection lookup, `StatusBarController` Coming Up) inherit the filter through the existing data flow without further changes.
- `GoogleCalendarClient.fetchUpcomingEvents` refactored to fetch per-enabled-calendar with a per-calendar sync token map (`syncTokens: [String: String]`, `cachedEventsByCalendar: [String: [String: UnifiedCalendarEvent]]`). A 410 (sync token expired) for one calendar invalidates only that cache entry. New `fetchCalendarList()` hits `/users/me/calendarList` for the Settings UI.
- Settings UI mirrors the existing `mutedMeetingDetectionAppsControl` pattern (LazyVGrid + Button + checkmark, color swatches from `EKCalendar.cgColor`).

## Tests
9 new swift-testing tests:
- `DisabledCalendarFilterTests` (new file): empty disabled set / partial disable / all disabled / unknown IDs / nil-calendarID passthrough.
- `GoogleCalendarTests` extensions: `parseCalendarListEntry` happy path, `summaryOverride` precedence, missing-id nil, parsed event records calendarID.

`DisabledCalendarFilterTests` is added to the meetings shard. `GoogleCalendarTests` itself isn't currently in any shard so its new cases don't run in CI under this PR alone — split into a separate PR (#109) that adds it to the meetings shard. Once that lands, the new tests here will be exercised in CI as well.

## Validation
```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
    swift test --package-path native/MuesliNative --filter 'DisabledCalendarFilterTests|GoogleCalendarTests'
# → Test run with 29 tests in 2 suites passed

DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
    bash scripts/run_ci_test_shard.sh meetings
# → Test run with 163 tests in 11 suites passed

DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
    swift test --package-path native/MuesliNative
# → Test run with 693 tests in 93 suites passed
```

Manual (MuesliDev built via `MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh`):
- All EventKit calendars appeared in Settings → Meetings → Calendars, grouped by source, with color swatches matching macOS Calendar.app.
- Toggling a calendar off removed its events from Coming Up; toggling back on restored them.
- Settings persist across app restart; `disabled_calendar_ids` is written into `~/Library/Application Support/MuesliDev/config.json`.

## Out of scope (deferred)
- Per-calendar **auto-record** toggle.
- "Unavailable calendars" UI for stale `disabledCalendarIDs` whose source has been removed (filter silently ignores them today).

## Aside for maintainers
External-contributor friction note: `./scripts/dev-test.sh` requires the `Developer ID Application: Pranav Hari Guruvayurappan` signing identity, which contributors don't have. `MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh` works as a workaround (the env var is honored by `build_native_app.sh`), but it's not documented anywhere visible. Worth a note in CLAUDE.md or scripts/README — happy to send a follow-up PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)