### PR TITLE
Recognize Slack huddle URLs in calendar events

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -138,6 +138,7 @@ final class CalendarMonitor {
             "https://[a-z0-9.-]*webex\\.com/[^\\s\"<>]+/j\\.php[^\\s\"<>]*",
             "https://[a-z0-9.-]*chime\\.aws/[^\\s\"<>]+",
             "https://facetime\\.apple\\.com/join[^\\s\"<>]*",
+            "https://app\\.slack\\.com/huddle/[A-Z0-9]+/[A-Z0-9]+",
         ]
         return try? NSRegularExpression(pattern: "(\(patterns.joined(separator: "|")))", options: .caseInsensitive)
     }()
@@ -163,7 +164,7 @@ final class CalendarMonitor {
 
     private static func isMeetingURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
-        let meetingHosts = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com", "chime.aws", "facetime.apple.com"]
+        let meetingHosts = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com", "chime.aws", "facetime.apple.com", "app.slack.com"]
         return meetingHosts.contains(where: { host.hasSuffix($0) })
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -362,6 +362,7 @@ final class CalendarMonitor {
             "https://[a-z0-9.-]*webex\\.com/[^\\s\"<>]+/j\\.php[^\\s\"<>]*",
             "https://[a-z0-9.-]*chime\\.aws/[^\\s\"<>]+",
             "https://facetime\\.apple\\.com/join[^\\s\"<>]*",
+            "https://app\\.slack\\.com/huddle/[A-Z0-9]+/[A-Z0-9]+",
         ]
         return try? NSRegularExpression(pattern: "(\(patterns.joined(separator: "|")))", options: .caseInsensitive)
     }()
@@ -387,7 +388,7 @@ final class CalendarMonitor {
 
     private static func isMeetingURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
-        let meetingHosts = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com", "chime.aws", "facetime.apple.com"]
+        let meetingHosts = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com", "chime.aws", "facetime.apple.com", "app.slack.com"]
         return meetingHosts.contains(where: { host.hasSuffix($0) })
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -362,7 +362,7 @@ final class CalendarMonitor {
             "https://[a-z0-9.-]*webex\\.com/[^\\s\"<>]+/j\\.php[^\\s\"<>]*",
             "https://[a-z0-9.-]*chime\\.aws/[^\\s\"<>]+",
             "https://facetime\\.apple\\.com/join[^\\s\"<>]*",
-            "https://app\\.slack\\.com/huddle/[A-Z0-9]+/[A-Z0-9]+",
+            "https://app\\.slack\\.com/huddle/[A-Z0-9]+/[A-Z0-9]+[^\\s\"<>]*",
         ]
         return try? NSRegularExpression(pattern: "(\(patterns.joined(separator: "|")))", options: .caseInsensitive)
     }()
@@ -388,7 +388,11 @@ final class CalendarMonitor {
 
     private static func isMeetingURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
-        let meetingHosts = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com", "chime.aws", "facetime.apple.com", "app.slack.com"]
+        // Slack: only huddle URLs are meetings; app.slack.com/client/... etc. are not.
+        if host == "app.slack.com" {
+            return url.path.hasPrefix("/huddle/")
+        }
+        let meetingHosts = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com", "chime.aws", "facetime.apple.com"]
         return meetingHosts.contains(where: { host.hasSuffix($0) })
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -521,6 +521,16 @@ final class GoogleCalendarClient {
                     }
                 }
             }
+            // Non-Google meeting links (Slack huddles, Zoom, ...) usually live in
+            // the event description or location rather than conferenceData.
+            if let description = item["description"] as? String,
+               let url = CalendarMonitor.findMeetingURL(in: description) {
+                return url
+            }
+            if let location = item["location"] as? String,
+               let url = CalendarMonitor.findMeetingURL(in: location) {
+                return url
+            }
             return nil
         }()
         let recurringEventID = item["recurringEventId"] as? String

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -204,6 +204,11 @@ enum MeetingURLNormalizer {
             return NormalizedMeetingURL(id: "facetime:\(identity)", url: identity, platform: .facetime)
         }
 
+        if host == "app.slack.com", path.hasPrefix("/huddle/") {
+            let identity = compactIdentity(host: host, path: compactPath)
+            return NormalizedMeetingURL(id: "slack:\(identity)", url: identity, platform: .slack)
+        }
+
         return nil
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
@@ -343,5 +343,6 @@ final class MeetingDetector {
             || lowercased.contains("teams.microsoft.com")
             || lowercased.contains("webex.com")
             || lowercased.contains("facetime.apple.com")
+            || lowercased.contains("app.slack.com/huddle/")
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
@@ -344,5 +344,6 @@ final class MeetingDetector {
             || lowercased.contains("teams.microsoft.com")
             || lowercased.contains("webex.com")
             || lowercased.contains("facetime.apple.com")
+            || lowercased.contains("app.slack.com/huddle/")
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -474,6 +474,7 @@ enum MeetingPlatform: Equatable {
         if host.hasSuffix("teams.microsoft.com") { return .teams }
         if host.hasSuffix("webex.com") { return .webex }
         if host == "facetime.apple.com" { return .facetime }
+        if host == "app.slack.com" && url.path.hasPrefix("/huddle/") { return .slack }
         return nil
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -551,6 +551,7 @@ enum MeetingPlatform: Equatable {
         if host.hasSuffix("teams.microsoft.com") { return .teams }
         if host.hasSuffix("webex.com") { return .webex }
         if host == "facetime.apple.com" { return .facetime }
+        if host == "app.slack.com" && url.path.hasPrefix("/huddle/") { return .slack }
         return nil
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -161,6 +161,30 @@ struct GoogleCalendarTests {
         #expect(url?.absoluteString == "https://meet.google.com/abc-defg-hij")
     }
 
+    @Test("CalendarMonitor extracts Slack huddle URL from text")
+    func extractsSlackHuddleURL() {
+        let url = CalendarMonitor.findMeetingURL(in: "Join the standup huddle: https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU thanks")
+        #expect(url?.absoluteString == "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU")
+    }
+
+    @Test("CalendarMonitor returns nil for non-huddle Slack URL")
+    func slackNonHuddleURLNotMatched() {
+        let url = CalendarMonitor.findMeetingURL(in: "Open the channel: https://app.slack.com/client/T026CMCFV4H/C026SCN0LAU")
+        #expect(url == nil)
+    }
+
+    @Test("MeetingPlatform.detect recognizes Slack huddle URL")
+    func detectSlackHuddle() {
+        let url = URL(string: "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU")!
+        #expect(MeetingPlatform.detect(from: url) == .slack)
+    }
+
+    @Test("MeetingPlatform.detect ignores non-huddle Slack URL")
+    func detectSlackNonHuddleReturnsNil() {
+        let url = URL(string: "https://app.slack.com/client/T026CMCFV4H/C026SCN0LAU")!
+        #expect(MeetingPlatform.detect(from: url) == nil)
+    }
+
     @Test("CalendarMonitor returns nil for text without meeting URLs")
     func returnsNilForNonMeetingText() {
         let url = CalendarMonitor.findMeetingURL(in: "Conference room 3B on the second floor")

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -186,6 +186,30 @@ struct GoogleCalendarTests {
         #expect(url?.absoluteString == "https://meet.google.com/abc-defg-hij")
     }
 
+    @Test("CalendarMonitor extracts Slack huddle URL from text")
+    func extractsSlackHuddleURL() {
+        let url = CalendarMonitor.findMeetingURL(in: "Join the standup huddle: https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU thanks")
+        #expect(url?.absoluteString == "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU")
+    }
+
+    @Test("CalendarMonitor returns nil for non-huddle Slack URL")
+    func slackNonHuddleURLNotMatched() {
+        let url = CalendarMonitor.findMeetingURL(in: "Open the channel: https://app.slack.com/client/T026CMCFV4H/C026SCN0LAU")
+        #expect(url == nil)
+    }
+
+    @Test("MeetingPlatform.detect recognizes Slack huddle URL")
+    func detectSlackHuddle() {
+        let url = URL(string: "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU")!
+        #expect(MeetingPlatform.detect(from: url) == .slack)
+    }
+
+    @Test("MeetingPlatform.detect ignores non-huddle Slack URL")
+    func detectSlackNonHuddleReturnsNil() {
+        let url = URL(string: "https://app.slack.com/client/T026CMCFV4H/C026SCN0LAU")!
+        #expect(MeetingPlatform.detect(from: url) == nil)
+    }
+
     @Test("CalendarMonitor returns nil for text without meeting URLs")
     func returnsNilForNonMeetingText() {
         let url = CalendarMonitor.findMeetingURL(in: "Conference room 3B on the second floor")

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -210,6 +210,51 @@ struct GoogleCalendarTests {
         #expect(MeetingPlatform.detect(from: url) == nil)
     }
 
+    @Test("CalendarMonitor extracts huddle URL with query parameters")
+    func extractsSlackHuddleURLWithQueryParams() {
+        let url = CalendarMonitor.findMeetingURL(in: "Standup: https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU?x=1")
+        #expect(url?.absoluteString == "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU?x=1")
+    }
+
+    @Test("Google event picks up huddle URL from description")
+    func googleEventHuddleFromDescription() throws {
+        let item: [String: Any] = [
+            "id": "huddle1",
+            "summary": "Standup",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T14:30:00Z"],
+            "description": "Join: https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU",
+        ]
+        let event = try #require(GoogleCalendarClient().parseEvent(item, calendarID: "primary"))
+        #expect(event.meetingURL?.absoluteString == "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU")
+    }
+
+    @Test("Google event picks up huddle URL from location")
+    func googleEventHuddleFromLocation() throws {
+        let item: [String: Any] = [
+            "id": "huddle2",
+            "summary": "Standup",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T14:30:00Z"],
+            "location": "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU",
+        ]
+        let event = try #require(GoogleCalendarClient().parseEvent(item, calendarID: "primary"))
+        #expect(event.meetingURL?.absoluteString == "https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU")
+    }
+
+    @Test("Google event ignores non-huddle Slack URL in description")
+    func googleEventNonHuddleSlackIgnored() throws {
+        let item: [String: Any] = [
+            "id": "notmeeting1",
+            "summary": "Async update",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T14:30:00Z"],
+            "description": "Discuss in https://app.slack.com/client/T026CMCFV4H/C026SCN0LAU",
+        ]
+        let event = try #require(GoogleCalendarClient().parseEvent(item, calendarID: "primary"))
+        #expect(event.meetingURL == nil)
+    }
+
     @Test("CalendarMonitor returns nil for text without meeting URLs")
     func returnsNilForNonMeetingText() {
         let url = CalendarMonitor.findMeetingURL(in: "Conference room 3B on the second floor")


### PR DESCRIPTION
## Summary
- Slack huddle URLs (e.g. `https://app.slack.com/huddle/T026CMCFV4H/D026SCN0LAU`) in calendar invites are now recognized as meeting URLs.
- The Join & Record notification fires for huddle-equipped events with the existing Slack platform icon (already scaffolded in `MeetingPlatform.slack` / `MeetingCandidate.Platform.slack`).
- Non-huddle Slack URLs (e.g. `app.slack.com/client/...`) are intentionally NOT matched — they aren't meeting links.

## Why
Lots of teams (mine included) run their standups and quick syncs in Slack huddles. The calendar invite typically just contains an `app.slack.com/huddle/...` link. Without recognizing it, the notification's Join button is missing and the event doesn't get the meeting URL associated for auto-record. Everything else (`MeetingPlatform.slack`, the icon loader looking for `slack.png`, the Slack app bundle ID in the meeting-detection allowlist) was already in place — only the URL recognition was missing.

## Changes
- `CalendarMonitor.swift`: huddle pattern added to `meetingURLPattern` regex; `app.slack.com` added to `isMeetingURL` host whitelist.
- `MeetingNotificationController.swift`: `MeetingPlatform.detect(from:)` returns `.slack` for `app.slack.com` URLs whose path starts with `/huddle/`.
- `MeetingCandidateResolver.swift`: huddle URLs normalize to a `slack:` identity for dedup parity with the other platforms.
- `MeetingDetector.swift`: `isMeetingURL` keyword scan recognizes `app.slack.com/huddle/`.

## Tests
4 new swift-testing cases in `GoogleCalendarTests.swift`:
- `CalendarMonitor extracts Slack huddle URL from text` (positive)
- `CalendarMonitor returns nil for non-huddle Slack URL` (negative — `app.slack.com/client/...` should not match)
- `MeetingPlatform.detect recognizes Slack huddle URL` (positive)
- `MeetingPlatform.detect ignores non-huddle Slack URL` (negative)

## Validation
```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
    swift test --package-path native/MuesliNative --filter GoogleCalendarTests
# → Test run with 24 tests in 1 suite passed
```

## Notes
- Branched from `main`, no dependency on PRs #109 or #110.
- Slack icon: the `MeetingPlatform.slack.loadIcon()` path looks for `slack.png` in the bundle and falls back to SF Symbol `message.fill` if absent. Whichever you have today is what shows up — no asset added in this PR.
- Slack workspace IDs always start with `T`, channel IDs with `C`, DM IDs with `D`. The regex (`[A-Z0-9]+/[A-Z0-9]+`) is broad enough to catch all variants and is case-insensitive via the existing pattern flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack Huddle links are now recognized in calendar events, browser detection, meeting handling, and notifications.
  * Slack Huddle URLs are consistently identified, including links with query parameters.
  * Calendar events can now surface supported meeting links from descriptions and locations when no primary conference link is available.
* **Bug Fixes**
  * Non-Huddle Slack links are excluded from meeting detection.
* **Tests**
  * Added coverage for Slack Huddle detection and calendar extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->