### PR TITLE
[codex] Fix meeting transcription model recovery

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -890,6 +890,46 @@ public final class DictationStore {
         }
     }
 
+    public func updateMeetingTranscriptAndSummary(
+        id: Int64,
+        rawTranscript: String,
+        formattedNotes: String,
+        selectedTemplateID: String,
+        selectedTemplateName: String,
+        selectedTemplateKind: MeetingTemplateKind,
+        selectedTemplatePrompt: String
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let manualNotes = try manualNotesForMeeting(id: id, db: db)
+        let wordCount = Self.countWords(in: rawTranscript) + Self.countWords(in: manualNotes)
+        let sql = """
+        UPDATE meetings
+        SET raw_transcript = ?, formatted_notes = ?, meeting_status = ?, word_count = ?, selected_template_id = ?, selected_template_name = ?, selected_template_kind = ?, selected_template_prompt = ?
+        WHERE id = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (rawTranscript as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (formattedNotes as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 3, (MeetingStatus.completed.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(statement, 4, Int32(wordCount))
+        sqlite3_bind_text(statement, 5, (selectedTemplateID as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 6, (selectedTemplateName as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 7, (selectedTemplateKind.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 8, (selectedTemplatePrompt as NSString).utf8String, -1, nil)
+        sqlite3_bind_int64(statement, 9, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.meetingNotFound(id: id)
+        }
+    }
+
     public func updateMeetingTitle(id: Int64, title: String) throws {
         let db = try openDatabase()
         defer { sqlite3_close(db) }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -25,6 +25,7 @@ struct MeetingDetailView: View {
     let onBack: (() -> Void)?
     let backLabel: String
     @State private var isSummarizing = false
+    @State private var isRetranscribing = false
     @State private var isEditingNotes = false
     @State private var editableTitle: String
     @State private var editableNotes: String
@@ -38,6 +39,7 @@ struct MeetingDetailView: View {
     @State private var notesSaveTask: DispatchWorkItem?
     @State private var manualNotesSaveStatusTask: DispatchWorkItem?
     @State private var summaryErrorMessage: String?
+    @State private var retranscriptionErrorMessage: String?
     @State private var showDeleteConfirmation = false
 
     init(
@@ -104,6 +106,13 @@ struct MeetingDetailView: View {
             }
         } message: {
             Text(summaryErrorMessage ?? "The updated meeting notes could not be saved.")
+        }
+        .alert("Couldn't Re-transcribe Meeting", isPresented: retranscriptionErrorBinding) {
+            Button("OK", role: .cancel) {
+                retranscriptionErrorMessage = nil
+            }
+        } message: {
+            Text(retranscriptionErrorMessage ?? "The saved recording could not be re-transcribed.")
         }
         .alert("Delete Meeting", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
@@ -362,6 +371,38 @@ struct MeetingDetailView: View {
     }
 
     @ViewBuilder
+    private func retranscribeAction(for meeting: MeetingRecord) -> some View {
+        if meeting.savedRecordingPath != nil {
+            if isRetranscribing {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Re-transcribing...")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+                .padding(.horizontal, MuesliTheme.spacing8)
+            } else {
+                iconButton("arrow.clockwise", label: "Re-transcribe") {
+                    isRetranscribing = true
+                    controller.retranscribe(meeting: meeting) { [meeting] result in
+                        isRetranscribing = false
+                        switch result {
+                        case .success:
+                            if let updated = controller.meeting(id: meeting.id) {
+                                syncLocalState(with: updated)
+                            }
+                        case .failure(let error):
+                            retranscriptionErrorMessage = error.localizedDescription
+                        }
+                    }
+                }
+                .disabled(meeting.status == .recording || meeting.status == .processing)
+            }
+        }
+    }
+
+    @ViewBuilder
     private func templateMenu(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
         Menu {
             Button {
@@ -438,6 +479,7 @@ struct MeetingDetailView: View {
         HStack {
             Spacer()
 
+            retranscribeAction(for: meeting)
             exportMenu(for: meeting)
 
             Button(action: {
@@ -876,6 +918,17 @@ struct MeetingDetailView: View {
             set: { isPresented in
                 if !isPresented {
                     summaryErrorMessage = nil
+                }
+            }
+        )
+    }
+
+    private var retranscriptionErrorBinding: Binding<Bool> {
+        Binding(
+            get: { retranscriptionErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    retranscriptionErrorMessage = nil
                 }
             }
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -86,7 +86,7 @@ final class MeetingSession {
 
     private let title: String
     private let calendarEventID: String?
-    private let backend: BackendOption
+    private let backendLock = OSAllocatedUnfairLock(initialState: BackendOption.whisper)
     private let runtime: RuntimePaths
     private let config: AppConfig
     private let transcriptionCoordinator: TranscriptionCoordinator
@@ -143,7 +143,7 @@ final class MeetingSession {
     ) {
         self.title = title
         self.calendarEventID = calendarEventID
-        self.backend = backend
+        backendLock.withLock { $0 = backend }
         self.runtime = runtime
         self.config = config
         self.transcriptionCoordinator = transcriptionCoordinator
@@ -152,6 +152,14 @@ final class MeetingSession {
         } else {
             self.systemAudioRecorder = SystemAudioRecorder()
         }
+    }
+
+    func updateBackend(_ backend: BackendOption) {
+        backendLock.withLock { $0 = backend }
+    }
+
+    private func currentBackend() -> BackendOption {
+        backendLock.withLock { $0 }
     }
 
     func start() async throws {
@@ -349,7 +357,7 @@ final class MeetingSession {
             do {
                 let result = try await transcriptionCoordinator.transcribeMeetingChunk(
                     at: lastSystemChunkURL,
-                    backend: backend,
+                    backend: currentBackend(),
                     cohereLanguage: config.resolvedCohereLanguage
                 )
                 let normalizedSegments = normalizeSystemTranscription(
@@ -645,8 +653,6 @@ final class MeetingSession {
 
         let chunkOffset = chunkTiming.startTimeSeconds
         let chunkDuration = chunkTiming.durationSeconds
-        let backend = self.backend
-
         fputs("[meeting] rotating system chunk at offset=\(String(format: "%.0f", chunkOffset))s\n", stderr)
 
         let task = Task { [weak self] () -> [SpeechSegment] in
@@ -658,6 +664,7 @@ final class MeetingSession {
                 if Task.isCancelled {
                     return []
                 }
+                let backend = self.currentBackend()
                 let result = try await self.transcriptionCoordinator.transcribeMeetingChunk(
                     at: chunkURL,
                     backend: backend,
@@ -818,7 +825,7 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeetingChunk(
                 at: url,
-                backend: backend,
+                backend: currentBackend(),
                 cohereLanguage: config.resolvedCohereLanguage
             )
             if !result.text.isEmpty {
@@ -968,7 +975,7 @@ final class MeetingSession {
 
                     let result = try await transcriptionCoordinator.transcribeMeeting(
                         at: segmentURL,
-                        backend: backend,
+                        backend: currentBackend(),
                         cohereLanguage: config.resolvedCohereLanguage
                     )
                     repairedSegments.append(contentsOf: MicTurnNormalizer.normalize(
@@ -1049,7 +1056,7 @@ final class MeetingSession {
 
                     let result = try await transcriptionCoordinator.transcribeMeeting(
                         at: segmentURL,
-                        backend: backend,
+                        backend: currentBackend(),
                         cohereLanguage: config.resolvedCohereLanguage
                     )
                     repairedSegments.append(contentsOf: normalizeSystemTranscription(
@@ -1080,7 +1087,7 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeeting(
                 at: fullSessionMicURL,
-                backend: backend,
+                backend: currentBackend(),
                 cohereLanguage: config.resolvedCohereLanguage
             )
             return MicTurnNormalizer.normalize(
@@ -1102,7 +1109,7 @@ final class MeetingSession {
         do {
             let result = try await transcriptionCoordinator.transcribeMeeting(
                 at: systemAudioURL,
-                backend: backend,
+                backend: currentBackend(),
                 cohereLanguage: config.resolvedCohereLanguage
             )
             return normalizeSystemTranscription(

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -128,6 +128,26 @@ struct BackendOption: Equatable {
         all.filter { $0.isDownloaded }
     }
 
+    static func resolve(backend: String, model: String) -> BackendOption? {
+        all.first { $0.backend == backend && $0.model == model }
+    }
+
+    static func resolveDownloaded(
+        backend: String,
+        model: String,
+        fallback: BackendOption?,
+        downloadedOptions: [BackendOption]
+    ) -> BackendOption? {
+        if let selected = downloadedOptions.first(where: { $0.backend == backend && $0.model == model }) {
+            return selected
+        }
+        if let fallback,
+           downloadedOptions.contains(where: { $0.backend == fallback.backend && $0.model == fallback.model }) {
+            return fallback
+        }
+        return downloadedOptions.first
+    }
+
     /// Check if this model's files exist on disk.
     var isDownloaded: Bool {
         let fm = FileManager.default

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1991,14 +1991,35 @@ final class MuesliController: NSObject {
                 completion(.success(()))
             } catch {
                 fputs("[muesli-native] failed to re-transcribe meeting \(meeting.id): \(error)\n", stderr)
-                if didSetProcessing {
-                    try? self.dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
+                if let status = Self.retranscriptionFailureStatus(
+                    originalStatus: meeting.status,
+                    didSetProcessing: didSetProcessing,
+                    error: error
+                ) {
+                    try? self.dictationStore.updateMeetingStatus(id: meeting.id, status: status)
                 }
                 self.syncAppState()
                 self.historyWindowController?.reload()
                 completion(.failure(error))
             }
         }
+    }
+
+    static func retranscriptionFailureStatus(
+        originalStatus: MeetingStatus,
+        didSetProcessing: Bool,
+        error: Error
+    ) -> MeetingStatus? {
+        guard didSetProcessing else { return nil }
+        if let retranscriptionError = error as? MeetingRetranscriptionError {
+            switch retranscriptionError {
+            case .emptyTranscript:
+                return originalStatus
+            case .controllerUnavailable, .recordingUnavailable, .noDownloadedTranscriptionModel, .failedToSave:
+                break
+            }
+        }
+        return .failed
     }
 
     // MARK: - Meeting Editing

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -62,6 +62,7 @@ enum MeetingTemplateSelectionError: Error, LocalizedError {
 }
 
 enum MeetingRetranscriptionError: Error, LocalizedError {
+    case controllerUnavailable
     case recordingUnavailable
     case noDownloadedTranscriptionModel
     case emptyTranscript
@@ -69,6 +70,8 @@ enum MeetingRetranscriptionError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .controllerUnavailable:
+            return "Meeting re-transcription could not continue because Muesli is no longer available."
         case .recordingUnavailable:
             return "The saved meeting recording is no longer available on disk."
         case .noDownloadedTranscriptionModel:
@@ -1906,8 +1909,12 @@ final class MuesliController: NSObject {
     }
 
     func retranscribe(meeting: MeetingRecord, completion: @escaping (Result<Void, Error>) -> Void) {
-        Task { [weak self] in
-            guard let self else { return }
+        Task { @MainActor [weak self] in
+            guard let self else {
+                completion(.failure(MeetingRetranscriptionError.controllerUnavailable))
+                return
+            }
+            var didSetProcessing = false
             do {
                 guard let savedRecordingPath = meeting.savedRecordingPath,
                       !savedRecordingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -1922,10 +1929,9 @@ final class MuesliController: NSObject {
                 }
 
                 try self.dictationStore.updateMeetingStatus(id: meeting.id, status: .processing)
-                await MainActor.run {
-                    self.syncAppState()
-                    self.historyWindowController?.reload()
-                }
+                didSetProcessing = true
+                self.syncAppState()
+                self.historyWindowController?.reload()
 
                 try await self.transcriptionCoordinator.preloadRequired(
                     backend: backend,
@@ -1980,19 +1986,17 @@ final class MuesliController: NSObject {
                     throw MeetingRetranscriptionError.failedToSave(underlying: error)
                 }
 
-                await MainActor.run {
-                    self.syncAppState()
-                    self.historyWindowController?.reload()
-                    completion(.success(()))
-                }
+                self.syncAppState()
+                self.historyWindowController?.reload()
+                completion(.success(()))
             } catch {
                 fputs("[muesli-native] failed to re-transcribe meeting \(meeting.id): \(error)\n", stderr)
-                try? self.dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
-                await MainActor.run {
-                    self.syncAppState()
-                    self.historyWindowController?.reload()
-                    completion(.failure(error))
+                if didSetProcessing {
+                    try? self.dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
                 }
+                self.syncAppState()
+                self.historyWindowController?.reload()
+                completion(.failure(error))
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2013,9 +2013,9 @@ final class MuesliController: NSObject {
         guard didSetProcessing else { return nil }
         if let retranscriptionError = error as? MeetingRetranscriptionError {
             switch retranscriptionError {
-            case .emptyTranscript:
+            case .emptyTranscript, .failedToSave:
                 return originalStatus
-            case .controllerUnavailable, .recordingUnavailable, .noDownloadedTranscriptionModel, .failedToSave:
+            case .controllerUnavailable, .recordingUnavailable, .noDownloadedTranscriptionModel:
                 break
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -61,6 +61,26 @@ enum MeetingTemplateSelectionError: Error, LocalizedError {
     }
 }
 
+enum MeetingRetranscriptionError: Error, LocalizedError {
+    case recordingUnavailable
+    case noDownloadedTranscriptionModel
+    case emptyTranscript
+    case failedToSave(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .recordingUnavailable:
+            return "The saved meeting recording is no longer available on disk."
+        case .noDownloadedTranscriptionModel:
+            return "Download a transcription model before re-transcribing this meeting."
+        case .emptyTranscript:
+            return "Re-transcription finished, but no speech was detected in the saved recording."
+        case .failedToSave(let underlying):
+            return "The re-transcribed meeting could not be saved. \(underlying.localizedDescription)"
+        }
+    }
+}
+
 enum MeetingLifecycleError: Error, LocalizedError {
     case failedToSaveRecording(underlying: Error)
     case failedToDeleteRecording(underlying: Error)
@@ -179,9 +199,15 @@ final class MuesliController: NSObject {
         self.selectedBackend = BackendOption.all.first(where: {
             $0.backend == loadedConfig.sttBackend && $0.model == loadedConfig.sttModel
         }) ?? .whisper
-        self.selectedMeetingTranscriptionBackend = BackendOption.all.first(where: {
-            $0.backend == loadedConfig.meetingTranscriptionBackend && $0.model == loadedConfig.meetingTranscriptionModel
-        }) ?? self.selectedBackend
+        let configuredMeetingBackend = BackendOption.resolve(
+            backend: loadedConfig.meetingTranscriptionBackend,
+            model: loadedConfig.meetingTranscriptionModel
+        )
+        self.selectedMeetingTranscriptionBackend = Self.availableMeetingTranscriptionBackend(
+            config: loadedConfig,
+            dictationBackend: self.selectedBackend,
+            downloadedOptions: BackendOption.downloaded
+        ) ?? configuredMeetingBackend ?? self.selectedBackend
         self.selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == loadedConfig.meetingSummaryBackend
         }) ?? .chatGPT
@@ -197,6 +223,7 @@ final class MuesliController: NSObject {
             fputs("[muesli-native] startup error: \(error)\n", stderr)
         }
         recoverStaleLiveMeetings()
+        normalizeMeetingTranscriptionSelectionForAvailability()
 
         // Clean up phantom aggregate devices left by a previous crash
         CoreAudioSystemRecorder.cleanupStaleDevices()
@@ -585,6 +612,60 @@ final class MuesliController: NSObject {
         appState.searchResultMeetings = []
     }
 
+    private static func availableMeetingTranscriptionBackend(
+        config: AppConfig,
+        dictationBackend: BackendOption,
+        downloadedOptions: [BackendOption] = BackendOption.downloaded
+    ) -> BackendOption? {
+        BackendOption.resolveDownloaded(
+            backend: config.meetingTranscriptionBackend,
+            model: config.meetingTranscriptionModel,
+            fallback: dictationBackend,
+            downloadedOptions: downloadedOptions
+        )
+    }
+
+    @discardableResult
+    private func normalizeMeetingTranscriptionSelectionForAvailability(
+        downloadedOptions: [BackendOption] = BackendOption.downloaded
+    ) -> BackendOption? {
+        let dictationBackend = BackendOption.resolve(
+            backend: config.sttBackend,
+            model: config.sttModel
+        ) ?? selectedBackend
+        guard let resolved = Self.availableMeetingTranscriptionBackend(
+            config: config,
+            dictationBackend: dictationBackend,
+            downloadedOptions: downloadedOptions
+        ) else {
+            selectedMeetingTranscriptionBackend = BackendOption.resolve(
+                backend: config.meetingTranscriptionBackend,
+                model: config.meetingTranscriptionModel
+            ) ?? dictationBackend
+            appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
+            appState.config = config
+            return nil
+        }
+
+        selectedMeetingTranscriptionBackend = resolved
+        activeMeetingSession?.updateBackend(resolved)
+        if config.meetingTranscriptionBackend != resolved.backend ||
+            config.meetingTranscriptionModel != resolved.model {
+            config.meetingTranscriptionBackend = resolved.backend
+            config.meetingTranscriptionModel = resolved.model
+            configStore.save(config)
+            fputs("[muesli-native] meeting transcription model unavailable; switched to \(resolved.label)\n", stderr)
+        }
+        appState.selectedMeetingTranscriptionBackend = resolved
+        appState.config = config
+        return resolved
+    }
+
+    @discardableResult
+    func refreshMeetingTranscriptionSelectionForAvailability() -> BackendOption? {
+        normalizeMeetingTranscriptionSelectionForAvailability()
+    }
+
     func updateConfig(_ mutate: (inout AppConfig) -> Void) {
         mutate(&config)
         configStore.save(config)
@@ -689,11 +770,20 @@ final class MuesliController: NSObject {
         }
     }
 
-    func selectMeetingTranscriptionBackend(_ option: BackendOption) {
+    func selectMeetingTranscriptionBackend(_ option: BackendOption, requireDownloaded: Bool = true) {
+        guard !requireDownloaded || option.isDownloaded else {
+            presentErrorAlert(
+                title: "Meeting model unavailable",
+                message: "Download \(option.label) before using it for meeting transcription."
+            )
+            normalizeMeetingTranscriptionSelectionForAvailability()
+            return
+        }
         updateConfig {
             $0.meetingTranscriptionBackend = option.backend
             $0.meetingTranscriptionModel = option.model
         }
+        activeMeetingSession?.updateBackend(option)
         Task { [weak self] in
             guard let self else { return }
             await self.transcriptionCoordinator.preload(
@@ -1815,6 +1905,98 @@ final class MuesliController: NSObject {
         }
     }
 
+    func retranscribe(meeting: MeetingRecord, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                guard let savedRecordingPath = meeting.savedRecordingPath,
+                      !savedRecordingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw MeetingRetranscriptionError.recordingUnavailable
+                }
+                let recordingURL = URL(fileURLWithPath: savedRecordingPath)
+                guard FileManager.default.fileExists(atPath: recordingURL.path) else {
+                    throw MeetingRetranscriptionError.recordingUnavailable
+                }
+                guard let backend = self.normalizeMeetingTranscriptionSelectionForAvailability() else {
+                    throw MeetingRetranscriptionError.noDownloadedTranscriptionModel
+                }
+
+                try self.dictationStore.updateMeetingStatus(id: meeting.id, status: .processing)
+                await MainActor.run {
+                    self.syncAppState()
+                    self.historyWindowController?.reload()
+                }
+
+                try await self.transcriptionCoordinator.preloadRequired(
+                    backend: backend,
+                    enablePostProcessor: false,
+                    includeMeetingHelpers: true
+                )
+                let transcription = try await self.transcriptionCoordinator.transcribeMeeting(
+                    at: recordingURL,
+                    backend: backend,
+                    cohereLanguage: self.config.resolvedCohereLanguage
+                )
+                let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !rawTranscript.isEmpty else {
+                    throw MeetingRetranscriptionError.emptyTranscript
+                }
+
+                let templateSnapshot = MeetingTemplates.snapshot(
+                    for: meeting,
+                    customTemplates: self.config.customMeetingTemplates
+                )
+                let formattedNotes: String
+                do {
+                    formattedNotes = try await MeetingSummaryClient.summarize(
+                        transcript: rawTranscript,
+                        meetingTitle: meeting.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Meeting" : meeting.title,
+                        config: self.config,
+                        template: templateSnapshot,
+                        existingNotes: self.notesContextForResummary(meeting),
+                        manualNotesToRetain: meeting.manualNotes
+                    )
+                } catch {
+                    fputs("[muesli-native] re-transcription summary generation failed: \(error)\n", stderr)
+                    formattedNotes = MeetingSummaryClient.summaryFailureNotes(
+                        transcript: rawTranscript,
+                        meetingTitle: meeting.title,
+                        error: error,
+                        manualNotes: meeting.manualNotes
+                    )
+                }
+
+                do {
+                    try self.dictationStore.updateMeetingTranscriptAndSummary(
+                        id: meeting.id,
+                        rawTranscript: rawTranscript,
+                        formattedNotes: formattedNotes,
+                        selectedTemplateID: templateSnapshot.id,
+                        selectedTemplateName: templateSnapshot.name,
+                        selectedTemplateKind: templateSnapshot.kind,
+                        selectedTemplatePrompt: templateSnapshot.prompt
+                    )
+                } catch {
+                    throw MeetingRetranscriptionError.failedToSave(underlying: error)
+                }
+
+                await MainActor.run {
+                    self.syncAppState()
+                    self.historyWindowController?.reload()
+                    completion(.success(()))
+                }
+            } catch {
+                fputs("[muesli-native] failed to re-transcribe meeting \(meeting.id): \(error)\n", stderr)
+                try? self.dictationStore.updateMeetingStatus(id: meeting.id, status: .failed)
+                await MainActor.run {
+                    self.syncAppState()
+                    self.historyWindowController?.reload()
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
     // MARK: - Meeting Editing
 
     private func notesContextForResummary(_ meeting: MeetingRecord) -> String? {
@@ -2301,6 +2483,13 @@ final class MuesliController: NSObject {
 
     func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        guard normalizeMeetingTranscriptionSelectionForAvailability() != nil else {
+            presentErrorAlert(
+                title: "Meeting failed to start",
+                message: "Download a transcription model before recording a meeting."
+            )
+            return
+        }
         let templateSnapshot = defaultMeetingTemplate()
         let meetingID: Int64
         do {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -110,7 +110,14 @@ struct SettingsView: View {
     }
 
     private var meetingBackendOptions: [BackendOption] {
-        backendOptions(including: appState.selectedMeetingTranscriptionBackend)
+        downloadedBackendOptions
+    }
+
+    private var selectedMeetingBackendLabel: String {
+        if meetingBackendOptions.contains(appState.selectedMeetingTranscriptionBackend) {
+            return appState.selectedMeetingTranscriptionBackend.label
+        }
+        return meetingBackendOptions.first?.label ?? "No downloaded models"
     }
 
     private var selectedCohereLanguage: CohereTranscribeLanguage {
@@ -186,6 +193,7 @@ struct SettingsView: View {
     }
 
     private func refreshDownloadedModelOptions() {
+        controller.refreshMeetingTranscriptionSelectionForAvailability()
         downloadedBackendOptions = BackendOption.downloaded
         downloadedPostProcOptions = PostProcessorOption.downloaded
     }
@@ -450,13 +458,21 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
             settingsSection("Meeting Transcription") {
                 settingsRow("Meeting model") {
-                    settingsMenu(
-                        selection: appState.selectedMeetingTranscriptionBackend.label,
-                        options: meetingBackendOptions.map(\.label)
-                    ) { label in
-                        if let option = meetingBackendOptions.first(where: { $0.label == label }) {
-                            controller.selectMeetingTranscriptionBackend(option)
+                    if meetingBackendOptions.isEmpty {
+                        Text("No downloaded models")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .frame(width: meetingControlWidth, alignment: .leading)
+                    } else {
+                        settingsMenu(
+                            selection: selectedMeetingBackendLabel,
+                            options: meetingBackendOptions.map(\.label)
+                        ) { label in
+                            if let option = meetingBackendOptions.first(where: { $0.label == label }) {
+                                controller.selectMeetingTranscriptionBackend(option)
+                            }
                         }
+                        .frame(width: meetingControlWidth)
                     }
                 }
                 if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -410,6 +410,44 @@ struct DictationStoreTests {
         #expect(updated?.selectedTemplatePrompt == "## Yesterday")
     }
 
+    @Test("update meeting transcript and summary replaces empty transcription")
+    func updateMeetingTranscriptAndSummary() throws {
+        let store = try makeStore()
+
+        let start = Date()
+        let meetingID = try store.insertMeeting(
+            title: "Recovered Meeting",
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(60),
+            rawTranscript: "",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: "/tmp/recovered.wav"
+        )
+        try store.updateMeetingManualNotes(id: meetingID, manualNotes: "Manual note")
+        try store.updateMeetingStatus(id: meetingID, status: .failed)
+
+        try store.updateMeetingTranscriptAndSummary(
+            id: meetingID,
+            rawTranscript: "Recovered transcript words",
+            formattedNotes: "## Summary\nRecovered notes",
+            selectedTemplateID: "auto",
+            selectedTemplateName: "Auto",
+            selectedTemplateKind: .auto,
+            selectedTemplatePrompt: "Auto prompt"
+        )
+
+        let updated = try #require(try store.meeting(id: meetingID))
+        #expect(updated.rawTranscript == "Recovered transcript words")
+        #expect(updated.formattedNotes == "## Summary\nRecovered notes")
+        #expect(updated.status == .completed)
+        #expect(updated.wordCount == 5)
+        #expect(updated.savedRecordingPath == "/tmp/recovered.wav")
+        #expect(updated.manualNotes == "Manual note")
+    }
+
     @Test("fetch dictation by id returns the full record")
     func fetchDictationByID() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -220,6 +220,38 @@ struct MeetingsNavigationTests {
         #expect(updated.formattedNotes == "## Existing notes")
     }
 
+    @Test("retranscribe empty transcript restores original meeting status")
+    func retranscribeEmptyTranscriptRestoresOriginalMeetingStatus() {
+        #expect(MuesliController.retranscriptionFailureStatus(
+            originalStatus: .completed,
+            didSetProcessing: true,
+            error: MeetingRetranscriptionError.emptyTranscript
+        ) == .completed)
+        #expect(MuesliController.retranscriptionFailureStatus(
+            originalStatus: .failed,
+            didSetProcessing: true,
+            error: MeetingRetranscriptionError.emptyTranscript
+        ) == .failed)
+    }
+
+    @Test("retranscribe status is unchanged before processing starts")
+    func retranscribeStatusIsUnchangedBeforeProcessingStarts() {
+        #expect(MuesliController.retranscriptionFailureStatus(
+            originalStatus: .completed,
+            didSetProcessing: false,
+            error: MeetingRetranscriptionError.recordingUnavailable
+        ) == nil)
+    }
+
+    @Test("retranscribe processing failures mark meeting failed")
+    func retranscribeProcessingFailuresMarkMeetingFailed() {
+        #expect(MuesliController.retranscriptionFailureStatus(
+            originalStatus: .completed,
+            didSetProcessing: true,
+            error: MeetingRetranscriptionError.failedToSave(underlying: CocoaError(.fileWriteUnknown))
+        ) == .failed)
+    }
+
     @Test("cached manual notes are persisted before debounce")
     func cachedManualNotesPersistImmediately() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -243,12 +243,21 @@ struct MeetingsNavigationTests {
         ) == nil)
     }
 
+    @Test("retranscribe save failures restore original meeting status")
+    func retranscribeSaveFailuresRestoreOriginalMeetingStatus() {
+        #expect(MuesliController.retranscriptionFailureStatus(
+            originalStatus: .completed,
+            didSetProcessing: true,
+            error: MeetingRetranscriptionError.failedToSave(underlying: CocoaError(.fileWriteUnknown))
+        ) == .completed)
+    }
+
     @Test("retranscribe processing failures mark meeting failed")
     func retranscribeProcessingFailuresMarkMeetingFailed() {
         #expect(MuesliController.retranscriptionFailureStatus(
             originalStatus: .completed,
             didSetProcessing: true,
-            error: MeetingRetranscriptionError.failedToSave(underlying: CocoaError(.fileWriteUnknown))
+            error: CocoaError(.fileReadUnknown)
         ) == .failed)
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -173,6 +173,53 @@ struct MeetingsNavigationTests {
         #expect(try store.meeting(id: meetingID) != nil)
     }
 
+    @Test("retranscribe missing recording preserves completed meeting status")
+    func retranscribeMissingRecordingPreservesCompletedStatus() async throws {
+        let store = try makeStore()
+        let missingRecordingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-meeting-recording-\(UUID().uuidString).wav")
+        let now = Date()
+        let meetingID = try store.insertMeeting(
+            title: "Recovered Meeting",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "Existing transcript",
+            formattedNotes: "## Existing notes",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: missingRecordingURL.path
+        )
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        let meeting = try #require(try store.meeting(id: meetingID))
+
+        let result = await withCheckedContinuation { continuation in
+            controller.retranscribe(meeting: meeting) { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected re-transcription to fail when the retained recording is missing")
+        case .failure(let error):
+            #expect(error is MeetingRetranscriptionError)
+        }
+
+        let updated = try #require(try store.meeting(id: meetingID))
+        #expect(updated.status == .completed)
+        #expect(updated.rawTranscript == "Existing transcript")
+        #expect(updated.formattedNotes == "## Existing notes")
+    }
+
     @Test("cached manual notes are persisted before debounce")
     func cachedManualNotesPersistImmediately() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -473,7 +473,7 @@ struct MeetingsNavigationTests {
         let controller = makeController()
 
         controller.selectBackend(.parakeetEnglish)
-        controller.selectMeetingTranscriptionBackend(.whisperLargeTurbo)
+        controller.selectMeetingTranscriptionBackend(.whisperLargeTurbo, requireDownloaded: false)
 
         #expect(controller.appState.selectedBackend == .parakeetEnglish)
         #expect(controller.appState.selectedMeetingTranscriptionBackend == .whisperLargeTurbo)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -94,6 +94,42 @@ struct BackendOptionTests {
         #expect(BackendOption.whisperMedium.model == "medium.en")
         #expect(BackendOption.whisperLargeTurbo.model.contains("large"))
     }
+
+    @Test("resolveDownloaded keeps selected downloaded meeting model")
+    func resolveDownloadedKeepsSelectedDownloadedModel() {
+        let resolved = BackendOption.resolveDownloaded(
+            backend: BackendOption.whisperLargeTurbo.backend,
+            model: BackendOption.whisperLargeTurbo.model,
+            fallback: .parakeetMultilingual,
+            downloadedOptions: [.parakeetMultilingual, .whisperLargeTurbo]
+        )
+
+        #expect(resolved == .whisperLargeTurbo)
+    }
+
+    @Test("resolveDownloaded falls back when selected meeting model is unavailable")
+    func resolveDownloadedFallsBackWhenSelectedUnavailable() {
+        let resolved = BackendOption.resolveDownloaded(
+            backend: BackendOption.whisperLargeTurbo.backend,
+            model: BackendOption.whisperLargeTurbo.model,
+            fallback: .parakeetMultilingual,
+            downloadedOptions: [.parakeetMultilingual, .whisperSmall]
+        )
+
+        #expect(resolved == .parakeetMultilingual)
+    }
+
+    @Test("resolveDownloaded uses first downloaded model when fallback is unavailable")
+    func resolveDownloadedUsesFirstDownloadedWhenFallbackUnavailable() {
+        let resolved = BackendOption.resolveDownloaded(
+            backend: BackendOption.whisperLargeTurbo.backend,
+            model: BackendOption.whisperLargeTurbo.model,
+            fallback: .parakeetMultilingual,
+            downloadedOptions: [.whisperSmall]
+        )
+
+        #expect(resolved == .whisperSmall)
+    }
 }
 
 @Suite("PostProcessorOption")


### PR DESCRIPTION
## Summary

Fixes a meeting transcription failure mode where Meetings could keep using a stale or unavailable transcription model, such as Whisper Large Turbo, even when that model was not downloaded locally.

## Root cause

Meeting transcription stored its own backend/model selection separately from dictation. If the persisted meeting model pointed at an unavailable local model, the app could still start recording. The live `MeetingSession` also captured the backend once at start, so changing Settings during a meeting did not repair the already-running session.

## Changes

- Resolve meeting transcription to a downloaded model at startup and before recording.
- Prefer the configured meeting model when downloaded, then the downloaded dictation model, then the first downloaded transcription model.
- Block meeting recording when no transcription model is available.
- Restrict the Meetings settings menu to downloaded transcription models.
- Allow active meeting sessions to switch backend when the meeting backend changes.
- Add a Re-transcribe action for meetings with retained recordings, using the saved recording to regenerate transcript and notes.
- Add store support for replacing a failed/empty transcript and summary.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/meeting-recovery" --filter 'BackendOption|DictationStore|MeetingsNavigation'`
- Passed 85 targeted tests.