### PR TITLE
[codex] Refactor meeting detection around media sessions

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -9,6 +9,7 @@ struct RunningAppSnapshot: Sendable {
     let isActive: Bool
 }
 
+// Not thread-safe; MeetingSignalCollector owns this collector from a single actor context.
 final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
     private let cachedMeetingTTL: TimeInterval
@@ -67,6 +68,8 @@ final class BrowserMeetingActivityCollector {
             liveMeetings.append(context)
         }
 
+        // Refresh passes intentionally return only fresh probe results. Skipped
+        // probes preserve cache entries for later non-refresh passes.
         return liveMeetings
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -11,11 +11,20 @@ struct RunningAppSnapshot: Sendable {
 
 final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
-    // Keep a recently seen meeting URL across tab/app focus dropouts so the
-    // resolver does not churn from a room-specific Meet candidate to a generic
-    // browser-audio candidate while the same call is still active.
-    private let cachedMeetingTTL: TimeInterval = 120
+    private let cachedMeetingTTL: TimeInterval
+    private let focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)?
+    private let activeBrowserURLProvider: ((String) -> String?)?
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
+
+    init(
+        cachedMeetingTTL: TimeInterval = 30,
+        focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
+        activeBrowserURLProvider: ((String) -> String?)? = nil
+    ) {
+        self.cachedMeetingTTL = cachedMeetingTTL
+        self.focusedDocumentURLProvider = focusedDocumentURLProvider
+        self.activeBrowserURLProvider = activeBrowserURLProvider
+    }
 
     func collect(
         runningApps: [RunningAppSnapshot],
@@ -32,18 +41,12 @@ final class BrowserMeetingActivityCollector {
         }
 
         var liveMeetings: [BrowserMeetingContext] = []
-        let browsersToProbe = browserApps.filter { app in
-            app.isActive || cachedMeetings[app.bundleID] != nil
-        }
-
-        for app in browsersToProbe {
+        for app in browserApps {
             guard let normalized = await normalizedFocusedURL(
                 for: app,
                 shouldAttemptAppleScript: shouldAttemptAppleScript
             ) else {
-                if app.isActive {
-                    cachedMeetings.removeValue(forKey: app.bundleID)
-                }
+                cachedMeetings.removeValue(forKey: app.bundleID)
                 continue
             }
 
@@ -60,15 +63,7 @@ final class BrowserMeetingActivityCollector {
             liveMeetings.append(context)
         }
 
-        let liveBundleIDs = Set(liveMeetings.map(\.bundleID))
-
-        let cachedOnlyMeetings = cachedMeetings.values
-            .filter { !liveBundleIDs.contains($0.context.bundleID) }
-            .map { cached in
-                context(cached.context, runningApps: browserApps)
-            }
-
-        return liveMeetings + cachedOnlyMeetings
+        return liveMeetings
     }
 
     private func normalizedFocusedURL(
@@ -118,6 +113,10 @@ final class BrowserMeetingActivityCollector {
     }
 
     private func normalizedAXDocumentURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
+        if let rawURL = focusedDocumentURLProvider?(app) {
+            return MeetingURLNormalizer.normalize(rawURL)
+        }
+
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
         var windowRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, &windowRef) == .success,
@@ -138,18 +137,23 @@ final class BrowserMeetingActivityCollector {
 
     @MainActor
     private func activeBrowserURLViaAppleScript(bundleID: String) -> String? {
+        if let url = activeBrowserURLProvider?(bundleID) {
+            return url
+        }
+
+        let escapedBundleID = bundleID.replacingOccurrences(of: "\"", with: "\\\"")
         let source: String
         switch bundleID {
         case "com.apple.Safari":
             source = """
-            tell application id "\(bundleID)"
+            tell application id "\(escapedBundleID)"
                 if (count of windows) is 0 then return ""
                 return URL of current tab of front window
             end tell
             """
         case "com.google.Chrome", "com.brave.Browser", "company.thebrowser.Browser", "com.microsoft.edgemac":
             source = """
-            tell application id "\(bundleID)"
+            tell application id "\(escapedBundleID)"
                 if (count of windows) is 0 then return ""
                 return URL of active tab of front window
             end tell

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -42,11 +42,15 @@ final class BrowserMeetingActivityCollector {
 
         var liveMeetings: [BrowserMeetingContext] = []
         for app in browserApps {
-            guard let normalized = await normalizedFocusedURL(
+            let probeResult = await probeFocusedMeetingURL(
                 for: app,
                 shouldAttemptAppleScript: shouldAttemptAppleScript
-            ) else {
-                cachedMeetings.removeValue(forKey: app.bundleID)
+            )
+
+            guard case .meeting(let normalized) = probeResult else {
+                if case .noMeeting = probeResult {
+                    cachedMeetings.removeValue(forKey: app.bundleID)
+                }
                 continue
             }
 
@@ -66,22 +70,31 @@ final class BrowserMeetingActivityCollector {
         return liveMeetings
     }
 
-    private func normalizedFocusedURL(
+    private func probeFocusedMeetingURL(
         for app: RunningAppSnapshot,
         shouldAttemptAppleScript: (String) -> Bool
-    ) async -> NormalizedMeetingURL? {
-        if let normalized = normalizedAXDocumentURL(for: app) {
-            return normalized
+    ) async -> BrowserMeetingURLProbeResult {
+        if let focusedDocumentURLProvider {
+            guard let rawURL = focusedDocumentURLProvider(app) else {
+                return .noMeeting
+            }
+            return MeetingURLNormalizer.normalize(rawURL).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
+        }
+
+        if let rawURL = axDocumentURL(for: app) {
+            return MeetingURLNormalizer.normalize(rawURL).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
         }
 
         // Query the browser's active tab even after another app/overlay becomes
         // frontmost. Strict URL normalization plus resolver media checks keep
         // background meeting tabs from prompting by themselves.
-        guard shouldAttemptAppleScript(app.bundleID) else { return nil }
-        guard let url = await activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
-            return nil
+        guard shouldAttemptAppleScript(app.bundleID) else {
+            return .skipped
         }
-        return MeetingURLNormalizer.normalize(url)
+        guard let url = await activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
+            return .noMeeting
+        }
+        return MeetingURLNormalizer.normalize(url).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
     }
 
     private func pruneCache(runningBrowserIDs: Set<String>, now: Date) {
@@ -112,11 +125,7 @@ final class BrowserMeetingActivityCollector {
         )
     }
 
-    private func normalizedAXDocumentURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
-        if let rawURL = focusedDocumentURLProvider?(app) {
-            return MeetingURLNormalizer.normalize(rawURL)
-        }
-
+    private func axDocumentURL(for app: RunningAppSnapshot) -> String? {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
         var windowRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, &windowRef) == .success,
@@ -132,27 +141,40 @@ final class BrowserMeetingActivityCollector {
             return nil
         }
 
-        return MeetingURLNormalizer.normalize(rawURL)
+        return rawURL
     }
 
-    @MainActor
-    private func activeBrowserURLViaAppleScript(bundleID: String) -> String? {
-        if let url = activeBrowserURLProvider?(bundleID) {
-            return url
+    private func activeBrowserURLViaAppleScript(bundleID: String) async -> String? {
+        if let activeBrowserURLProvider {
+            return activeBrowserURLProvider(bundleID)
         }
 
+        guard let source = activeBrowserURLAppleScriptSource(bundleID: bundleID) else {
+            return nil
+        }
+
+        return await Task.detached(priority: .utility) {
+            var errorInfo: NSDictionary?
+            guard let output = NSAppleScript(source: source)?.executeAndReturnError(&errorInfo).stringValue,
+                  !output.isEmpty else {
+                return nil
+            }
+            return output
+        }.value
+    }
+
+    private func activeBrowserURLAppleScriptSource(bundleID: String) -> String? {
         let escapedBundleID = bundleID.replacingOccurrences(of: "\"", with: "\\\"")
-        let source: String
         switch bundleID {
         case "com.apple.Safari":
-            source = """
+            return """
             tell application id "\(escapedBundleID)"
                 if (count of windows) is 0 then return ""
                 return URL of current tab of front window
             end tell
             """
         case "com.google.Chrome", "com.brave.Browser", "company.thebrowser.Browser", "com.microsoft.edgemac":
-            source = """
+            return """
             tell application id "\(escapedBundleID)"
                 if (count of windows) is 0 then return ""
                 return URL of active tab of front window
@@ -161,14 +183,13 @@ final class BrowserMeetingActivityCollector {
         default:
             return nil
         }
-
-        var errorInfo: NSDictionary?
-        guard let output = NSAppleScript(source: source)?.executeAndReturnError(&errorInfo).stringValue,
-              !output.isEmpty else {
-            return nil
-        }
-        return output
     }
+}
+
+private enum BrowserMeetingURLProbeResult {
+    case meeting(NormalizedMeetingURL)
+    case noMeeting
+    case skipped
 }
 
 private struct CachedBrowserMeeting {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -11,17 +11,36 @@ struct RunningAppSnapshot: Sendable {
 
 final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
-    private let cachedMeetingTTL: TimeInterval = 8
+    // Keep a recently seen meeting URL across tab/app focus dropouts so the
+    // resolver does not churn from a room-specific Meet candidate to a generic
+    // browser-audio candidate while the same call is still active.
+    private let cachedMeetingTTL: TimeInterval = 120
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
-    func collect(runningApps: [RunningAppSnapshot]) async -> [BrowserMeetingContext] {
-        let now = Date()
+    func collect(
+        runningApps: [RunningAppSnapshot],
+        refresh: Bool,
+        now: Date = Date(),
+        shouldAttemptAppleScript: (String) -> Bool = { _ in true }
+    ) async -> [BrowserMeetingContext] {
         let browserApps = runningApps.filter { browserBundleIDs.contains($0.bundleID) }
         let runningBrowserIDs = Set(browserApps.map(\.bundleID))
 
+        pruneCache(runningBrowserIDs: runningBrowserIDs, now: now)
+        guard refresh else {
+            return cachedContexts(runningApps: browserApps)
+        }
+
         var liveMeetings: [BrowserMeetingContext] = []
-        for app in browserApps {
-            guard let normalized = await normalizedFocusedURL(for: app) else {
+        let browsersToProbe = browserApps.filter { app in
+            app.isActive || cachedMeetings[app.bundleID] != nil
+        }
+
+        for app in browsersToProbe {
+            guard let normalized = await normalizedFocusedURL(
+                for: app,
+                shouldAttemptAppleScript: shouldAttemptAppleScript
+            ) else {
                 if app.isActive {
                     cachedMeetings.removeValue(forKey: app.bundleID)
                 }
@@ -42,28 +61,20 @@ final class BrowserMeetingActivityCollector {
         }
 
         let liveBundleIDs = Set(liveMeetings.map(\.bundleID))
-        cachedMeetings = cachedMeetings.filter { bundleID, cached in
-            runningBrowserIDs.contains(bundleID) && now.timeIntervalSince(cached.observedAt) <= cachedMeetingTTL
-        }
 
         let cachedOnlyMeetings = cachedMeetings.values
             .filter { !liveBundleIDs.contains($0.context.bundleID) }
             .map { cached in
-                BrowserMeetingContext(
-                    bundleID: cached.context.bundleID,
-                    appName: cached.context.appName,
-                    pid: cached.context.pid,
-                    url: cached.context.url,
-                    normalizedID: cached.context.normalizedID,
-                    platform: cached.context.platform,
-                    isFocused: false
-                )
+                context(cached.context, runningApps: browserApps)
             }
 
         return liveMeetings + cachedOnlyMeetings
     }
 
-    private func normalizedFocusedURL(for app: RunningAppSnapshot) async -> NormalizedMeetingURL? {
+    private func normalizedFocusedURL(
+        for app: RunningAppSnapshot,
+        shouldAttemptAppleScript: (String) -> Bool
+    ) async -> NormalizedMeetingURL? {
         if let normalized = normalizedAXDocumentURL(for: app) {
             return normalized
         }
@@ -71,10 +82,39 @@ final class BrowserMeetingActivityCollector {
         // Query the browser's active tab even after another app/overlay becomes
         // frontmost. Strict URL normalization plus resolver media checks keep
         // background meeting tabs from prompting by themselves.
+        guard shouldAttemptAppleScript(app.bundleID) else { return nil }
         guard let url = await activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
             return nil
         }
         return MeetingURLNormalizer.normalize(url)
+    }
+
+    private func pruneCache(runningBrowserIDs: Set<String>, now: Date) {
+        cachedMeetings = cachedMeetings.filter { bundleID, cached in
+            runningBrowserIDs.contains(bundleID) && now.timeIntervalSince(cached.observedAt) <= cachedMeetingTTL
+        }
+    }
+
+    private func cachedContexts(runningApps: [RunningAppSnapshot]) -> [BrowserMeetingContext] {
+        cachedMeetings.values.map { cached in
+            context(cached.context, runningApps: runningApps)
+        }
+    }
+
+    private func context(
+        _ cached: BrowserMeetingContext,
+        runningApps: [RunningAppSnapshot]
+    ) -> BrowserMeetingContext {
+        let app = runningApps.first { $0.bundleID == cached.bundleID }
+        return BrowserMeetingContext(
+            bundleID: cached.bundleID,
+            appName: app?.appName ?? cached.appName,
+            pid: app?.processIdentifier ?? cached.pid,
+            url: cached.url,
+            normalizedID: cached.normalizedID,
+            platform: cached.platform,
+            isFocused: app?.isActive ?? false
+        )
     }
 
     private func normalizedAXDocumentURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMediaSessionTracker.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMediaSessionTracker.swift
@@ -26,7 +26,7 @@ actor MeetingMediaSessionTracker {
     ) -> MeetingCandidate? {
         pruneExpiredSessions(now: snapshot.now)
         guard let candidate else { return nil }
-        guard let key = sessionKey(for: candidate),
+        guard let key = sessionKey(for: candidate, now: snapshot.now),
               isMediaBacked(candidate, snapshot: snapshot) else {
             return candidate
         }
@@ -82,10 +82,15 @@ actor MeetingMediaSessionTracker {
         return session
     }
 
-    private func sessionKey(for candidate: MeetingCandidate) -> String? {
+    private func sessionKey(for candidate: MeetingCandidate, now: Date) -> String? {
         if let sourceBundleID = candidate.sourceBundleID {
             if MeetingCandidateResolver.browserApps[sourceBundleID] != nil {
-                return "browser:\(sourceBundleID)"
+                if let roomIdentity = roomIdentity(for: candidate) {
+                    return "browser:\(sourceBundleID):room:\(roomIdentity)"
+                }
+
+                return mostRecentBrowserSessionKey(for: sourceBundleID, now: now)
+                    ?? "browser:\(sourceBundleID):media"
             }
             return "app:\(sourceBundleID)"
         }
@@ -95,6 +100,27 @@ actor MeetingMediaSessionTracker {
         }
 
         return nil
+    }
+
+    private func roomIdentity(for candidate: MeetingCandidate) -> String? {
+        guard candidate.evidence.contains(.browserURL) else { return nil }
+        if let url = candidate.url, !url.isEmpty { return url }
+        if !candidate.id.hasPrefix("browser:"), !candidate.id.hasPrefix("app:") {
+            return candidate.id
+        }
+        return nil
+    }
+
+    private func mostRecentBrowserSessionKey(for bundleID: String, now: Date) -> String? {
+        let prefix = "browser:\(bundleID):"
+        return sessionsByKey.values
+            .filter { session in
+                session.key.hasPrefix(prefix)
+                    && now.timeIntervalSince(session.lastActiveAt) <= quietWindow
+            }
+            .sorted { lhs, rhs in lhs.lastActiveAt > rhs.lastActiveAt }
+            .first?
+            .key
     }
 
     private func isMediaBacked(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMediaSessionTracker.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMediaSessionTracker.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+actor MeetingMediaSessionTracker {
+    private struct Session {
+        let id: String
+        let key: String
+        let startedAt: Date
+        var lastActiveAt: Date
+        var platform: MeetingCandidate.Platform
+        var appName: String
+        var url: String?
+        var meetingTitle: String?
+        var evidence: Set<MeetingCandidate.Evidence>
+    }
+
+    private let quietWindow: TimeInterval
+    private var sessionsByKey: [String: Session] = [:]
+
+    init(quietWindow: TimeInterval = 30) {
+        self.quietWindow = quietWindow
+    }
+
+    func stabilize(
+        candidate: MeetingCandidate?,
+        snapshot: MeetingSignalSnapshot
+    ) -> MeetingCandidate? {
+        pruneExpiredSessions(now: snapshot.now)
+        guard let candidate else { return nil }
+        guard let key = sessionKey(for: candidate),
+              isMediaBacked(candidate, snapshot: snapshot) else {
+            return candidate
+        }
+
+        let session = updateSession(for: key, with: candidate, now: snapshot.now)
+        return MeetingCandidate(
+            id: session.id,
+            platform: session.platform,
+            appName: session.appName,
+            url: session.url,
+            evidence: session.evidence,
+            startedAt: session.startedAt,
+            meetingTitle: session.meetingTitle,
+            sourceBundleID: candidate.sourceBundleID,
+            sourcePID: candidate.sourcePID,
+            suppressionID: session.id
+        )
+    }
+
+    func reset() {
+        sessionsByKey = [:]
+    }
+
+    private func updateSession(
+        for key: String,
+        with candidate: MeetingCandidate,
+        now: Date
+    ) -> Session {
+        if var session = sessionsByKey[key],
+           now.timeIntervalSince(session.lastActiveAt) <= quietWindow {
+            session.lastActiveAt = now
+            session.platform = betterPlatform(current: candidate.platform, previous: session.platform)
+            session.appName = candidate.appName
+            session.url = candidate.url ?? session.url
+            session.meetingTitle = candidate.meetingTitle ?? session.meetingTitle
+            session.evidence.formUnion(candidate.evidence)
+            sessionsByKey[key] = session
+            return session
+        }
+
+        let session = Session(
+            id: "meeting-session:\(key):\(Int(now.timeIntervalSince1970))",
+            key: key,
+            startedAt: now,
+            lastActiveAt: now,
+            platform: candidate.platform,
+            appName: candidate.appName,
+            url: candidate.url,
+            meetingTitle: candidate.meetingTitle,
+            evidence: candidate.evidence
+        )
+        sessionsByKey[key] = session
+        return session
+    }
+
+    private func sessionKey(for candidate: MeetingCandidate) -> String? {
+        if let sourceBundleID = candidate.sourceBundleID {
+            if MeetingCandidateResolver.browserApps[sourceBundleID] != nil {
+                return "browser:\(sourceBundleID)"
+            }
+            return "app:\(sourceBundleID)"
+        }
+
+        if candidate.id.hasPrefix("browser:") || candidate.id.hasPrefix("app:") {
+            return candidate.id
+        }
+
+        return nil
+    }
+
+    private func isMediaBacked(
+        _ candidate: MeetingCandidate,
+        snapshot: MeetingSignalSnapshot
+    ) -> Bool {
+        if candidate.evidence.contains(.audioInputProcess)
+            || candidate.evidence.contains(.micActive)
+            || candidate.evidence.contains(.cameraActive) {
+            return true
+        }
+
+        guard let sourceBundleID = candidate.sourceBundleID else { return false }
+        return snapshot.audioInputProcesses.contains { process in
+            process.bundleID == sourceBundleID || process.bundleID.lowercased().hasPrefix("\(sourceBundleID.lowercased()).")
+        }
+    }
+
+    private func betterPlatform(
+        current: MeetingCandidate.Platform,
+        previous: MeetingCandidate.Platform
+    ) -> MeetingCandidate.Platform {
+        current == .unknown ? previous : current
+    }
+
+    private func pruneExpiredSessions(now: Date) {
+        sessionsByKey = sessionsByKey.filter { _, session in
+            now.timeIntervalSince(session.lastActiveAt) <= quietWindow
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -305,6 +305,7 @@ private actor MeetingDetectionService {
     private var lastSuppressionLogKey: String?
     private var signalRefreshState = MeetingSignalRefreshState()
     private var currentFallbackInterval: TimeInterval?
+    private var resetTask: Task<Void, Never>?
     private var latestLifecycleGeneration = 0
     private var isStarted = false
 
@@ -316,7 +317,11 @@ private actor MeetingDetectionService {
         self.promptHandler = promptHandler
     }
 
-    func start(generation: Int) {
+    func start(generation: Int) async {
+        if let resetTask {
+            await resetTask.value
+            self.resetTask = nil
+        }
         guard generation >= latestLifecycleGeneration else { return }
         latestLifecycleGeneration = generation
         guard !isStarted else { return }
@@ -325,13 +330,13 @@ private actor MeetingDetectionService {
         scheduleEvaluation(.startup)
     }
 
-    func stop(generation: Int) {
+    func stop(generation: Int) async {
         guard generation >= latestLifecycleGeneration else { return }
         latestLifecycleGeneration = generation
-        stop()
+        await performStop(generation: generation)
     }
 
-    private func stop() {
+    private func performStop(generation: Int) async {
         isStarted = false
         fallbackEvaluationTask?.cancel()
         fallbackEvaluationTask = nil
@@ -343,12 +348,14 @@ private actor MeetingDetectionService {
         pendingEvaluationTrigger = nil
         currentFallbackInterval = nil
         signalRefreshState = MeetingSignalRefreshState()
-        Task { [audioAttributionService] in
+        let resetTask = Task { [audioAttributionService, mediaSessionTracker] in
             await audioAttributionService.reset()
-        }
-        Task { [mediaSessionTracker] in
             await mediaSessionTracker.reset()
         }
+        self.resetTask = resetTask
+        await resetTask.value
+        guard latestLifecycleGeneration == generation else { return }
+        self.resetTask = nil
         promptState.resetVisiblePrompt()
         emitPromptUpdate(.hide)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -5,9 +5,6 @@ import os
 
 @MainActor
 final class MeetingMonitor {
-    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
-    private static let evaluationInterval: UInt64 = 3_000_000_000
-
     var calendarEventProvider: (() -> CalendarEventContext?)?
     var detectionEnabledProvider: (() -> Bool)?
     var isRecordingProvider: (() -> Bool)?
@@ -17,279 +14,153 @@ final class MeetingMonitor {
     var mutedDetectionBundleIDsProvider: (() -> Set<String>)?
     var onPromptCandidateChanged: ((MeetingCandidate?) -> Void)?
 
-    private let resolver = MeetingCandidateResolver()
-    private let signalCollector = MeetingSignalCollector()
+    private lazy var detectionService = MeetingDetectionService(
+        contextProvider: { [weak self] now in
+            self?.makeEvaluationContext(now: now) ?? .disabled
+        },
+        promptHandler: { [weak self] update in
+            self?.handlePromptUpdate(update)
+        }
+    )
+
     private let cameraMonitor = CameraActivityMonitor()
     private let sensorAttributionMonitor = ControlCenterSensorAttributionMonitor()
-    private let promptState = MeetingPromptStateMachine()
+    private let runningApplicationStore = RunningApplicationStore()
 
     private var micListenerDeviceID: AudioDeviceID = 0
     private var micListenerBlock: AudioObjectPropertyListenerBlock?
     private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
-    private var periodicEvaluationTask: Task<Void, Never>?
-    private var evaluationTask: Task<Void, Never>?
-    private var pendingEvaluation = false
-    private var workspaceObserver: NSObjectProtocol?
-    private var globalSuppressUntil: Date?
-    private var lastLoggedCandidateID: String?
-    private var lastSuppressionLogKey: String?
+    private var lifecycleGeneration = 0
+    private var isStarted = false
 
     func start() {
+        guard !isStarted else { return }
+        isStarted = true
+        lifecycleGeneration += 1
+        let generation = lifecycleGeneration
         installMicListener()
         installDeviceChangeListener()
-        installWorkspaceActivationObserver()
+        runningApplicationStore.onChanged = { [weak self] trigger in
+            self?.scheduleEvaluation(trigger)
+        }
+        runningApplicationStore.start()
 
         cameraMonitor.onCameraStateChanged = { [weak self] _ in
-            self?.scheduleEvaluation()
+            self?.scheduleEvaluation(.cameraChanged)
         }
         cameraMonitor.start()
 
         sensorAttributionMonitor.onAttributionsChanged = { [weak self] in
-            DispatchQueue.main.async { self?.scheduleEvaluation() }
+            DispatchQueue.main.async { self?.scheduleEvaluation(.sensorAttributionChanged) }
         }
         sensorAttributionMonitor.start()
 
-        installPeriodicEvaluationLoop()
-        scheduleEvaluation()
+        Task { [detectionService] in
+            await detectionService.start(generation: generation)
+        }
     }
 
     func stop() {
+        guard isStarted else { return }
+        isStarted = false
+        lifecycleGeneration += 1
+        let generation = lifecycleGeneration
         removeMicListener()
         removeDeviceChangeListener()
-        removeWorkspaceActivationObserver()
+        runningApplicationStore.stop()
+        runningApplicationStore.onChanged = nil
         cameraMonitor.stop()
         sensorAttributionMonitor.stop()
-        periodicEvaluationTask?.cancel()
-        periodicEvaluationTask = nil
-        evaluationTask?.cancel()
-        evaluationTask = nil
-        pendingEvaluation = false
+        Task { [detectionService] in
+            await detectionService.stop(generation: generation)
+        }
     }
 
-    func refreshState() {
-        scheduleEvaluation()
+    func refreshState(trigger: MeetingDetectionTrigger = .manualRefresh) {
+        scheduleEvaluation(trigger)
     }
 
     func suppress(for duration: TimeInterval = 120) {
-        globalSuppressUntil = Date().addingTimeInterval(duration)
-        dismissVisiblePromptForSuppression()
+        Task { [detectionService] in
+            await detectionService.suppress(for: duration)
+        }
     }
 
     func suppressWhileActive() {
-        globalSuppressUntil = .distantFuture
-        dismissVisiblePromptForSuppression()
+        Task { [detectionService] in
+            await detectionService.suppressWhileActive()
+        }
     }
 
     func resumeAfterCooldown() {
-        globalSuppressUntil = Date().addingTimeInterval(15)
+        Task { [detectionService] in
+            await detectionService.resumeAfterCooldown()
+        }
     }
 
     func markPromptShown(_ candidate: MeetingCandidate) {
-        promptState.markShown(candidate)
+        Task { [detectionService] in
+            await detectionService.markPromptShown(candidate)
+        }
     }
 
     func markPromptAutoDismissed(_ candidate: MeetingCandidate) {
-        promptState.markAutoDismissed(candidate)
-        log("prompt_auto_dismissed id=\(candidate.id)")
+        Task { [detectionService] in
+            await detectionService.markPromptAutoDismissed(candidate)
+        }
     }
 
     func markPromptUserDismissed(_ candidate: MeetingCandidate) {
-        promptState.markUserDismissed(candidate)
-        log("prompt_suppressed id=\(candidate.id) reason=user_dismissed")
+        Task { [detectionService] in
+            await detectionService.markPromptUserDismissed(candidate)
+        }
     }
 
     func markPromptClosed(_ candidate: MeetingCandidate) {
-        promptState.markClosed(candidate)
+        Task { [detectionService] in
+            await detectionService.markPromptClosed(candidate)
+        }
     }
 
     func markRecordingStarted(_ candidate: MeetingCandidate?) {
-        if let candidate {
-            log("recording_started id=\(candidate.id)")
-        } else {
-            log("recording_started")
+        Task { [detectionService] in
+            await detectionService.markRecordingStarted(candidate)
         }
     }
 
-    private func dismissVisiblePromptForSuppression() {
-        promptState.resetVisiblePrompt()
-        onPromptCandidateChanged?(nil)
-    }
-
-    private func scheduleEvaluation() {
-        guard detectionEnabledProvider?() ?? true else {
-            dismissVisiblePromptForSuppression()
-            return
-        }
-
-        if evaluationTask != nil {
-            pendingEvaluation = true
-            return
-        }
-
-        evaluationTask = Task { [weak self] in
-            await self?.runScheduledEvaluations()
+    private func scheduleEvaluation(_ trigger: MeetingDetectionTrigger) {
+        guard isStarted else { return }
+        Task { [detectionService] in
+            await detectionService.scheduleEvaluation(trigger)
         }
     }
 
-    private func runScheduledEvaluations() async {
-        repeat {
-            pendingEvaluation = false
-            await evaluateNow()
-        } while pendingEvaluation && !Task.isCancelled
-        evaluationTask = nil
+    private func handlePromptUpdate(_ update: MeetingPromptUpdate) {
+        switch update {
+        case .show(let candidate):
+            onPromptCandidateChanged?(candidate)
+        case .hide:
+            onPromptCandidateChanged?(nil)
+        }
     }
 
-    private func evaluateNow() async {
-        let now = Date()
-        let visibility = promptVisibilityProvider?() ?? MeetingPromptVisibility(isVisible: false, currentPromptID: nil, shownAt: nil)
-        cameraMonitor.refresh()
-        let sensorAttributions = sensorAttributionMonitor.snapshot(now: now)
-        let collectedSignals = await signalCollector.collect(micDeviceID: micListenerDeviceID)
-        guard !Task.isCancelled else { return }
-        let audioInputProcesses = mergedAudioInputProcesses(
-            collectedSignals.audioInputProcesses,
-            sensorAttributions: sensorAttributions,
-            runningProcessIDsByBundleID: collectedSignals.runningProcessIDsByBundleID
-        )
-        let micActive = collectedSignals.micActive || !audioInputProcesses.isEmpty || !sensorAttributions.micBundleIDs.isEmpty
-        let cameraActive = cameraMonitor.isCameraActive || !sensorAttributions.cameraBundleIDs.isEmpty
-
-        let snapshot = MeetingSignalSnapshot(
-            micActive: micActive,
-            cameraActive: cameraActive,
+    private func makeEvaluationContext(now: Date) -> MeetingDetectionEvaluationContext {
+        let runningApplicationState = runningApplicationStore.snapshot()
+        return MeetingDetectionEvaluationContext(
+            micDeviceID: micListenerDeviceID,
+            cameraActive: cameraMonitor.isCameraActive,
+            sensorAttributions: sensorAttributionMonitor.snapshot(now: now),
             calendarEvent: calendarEventProvider?(),
-            runningApps: collectedSignals.runningApps,
-            browserMeetings: collectedSignals.browserMeetings,
-            audioInputProcesses: audioInputProcesses,
-            foregroundBundleID: collectedSignals.foregroundBundleID,
-            now: now
-        )
-
-        let resolvedCandidate = isGloballySuppressed(now: now) ? nil : resolver.resolve(snapshot)
-        let candidate = isMuted(resolvedCandidate) ? nil : resolvedCandidate
-        logCandidateIfChanged(candidate)
-
-        let decision = promptState.evaluate(
-            candidate: candidate,
             detectionEnabled: detectionEnabledProvider?() ?? true,
             isRecording: isRecordingProvider?() ?? false,
             isStartingRecording: isStartingRecordingProvider?() ?? false,
             isCalendarNotificationVisible: isCalendarNotificationVisibleProvider?() ?? false,
-            visibility: visibility,
-            now: now
+            promptVisibility: promptVisibilityProvider?()
+                ?? MeetingPromptVisibility(isVisible: false, currentPromptID: nil, shownAt: nil),
+            mutedBundleIDs: mutedDetectionBundleIDsProvider?() ?? [],
+            runningApps: runningApplicationState.runningApps,
+            foregroundBundleID: runningApplicationState.foregroundBundleID
         )
-
-        switch decision.action {
-        case .show:
-            guard let candidate = decision.candidate else { return }
-            log("prompt_shown id=\(candidate.id) platform=\(candidate.platform.displayName) app=\(candidate.appName)")
-            onPromptCandidateChanged?(candidate)
-        case .hide:
-            onPromptCandidateChanged?(nil)
-        case .none:
-            logSuppressionIfNeeded(decision)
-        }
-    }
-
-    private func isGloballySuppressed(now: Date) -> Bool {
-        guard let until = globalSuppressUntil else { return false }
-        if now >= until {
-            globalSuppressUntil = nil
-            return false
-        }
-        return true
-    }
-
-    private func isMuted(_ candidate: MeetingCandidate?) -> Bool {
-        guard let sourceBundleID = candidate?.sourceBundleID else { return false }
-        return mutedDetectionBundleIDsProvider?().contains(sourceBundleID) ?? false
-    }
-
-    private func logCandidateIfChanged(_ candidate: MeetingCandidate?) {
-        guard candidate?.id != lastLoggedCandidateID else { return }
-        lastLoggedCandidateID = candidate?.id
-        if let candidate {
-            log("candidate_detected id=\(candidate.id) platform=\(candidate.platform.displayName) app=\(candidate.appName)")
-        }
-    }
-
-    private func logSuppressionIfNeeded(_ decision: MeetingPromptDecision) {
-        guard let candidate = decision.candidate else {
-            lastSuppressionLogKey = nil
-            return
-        }
-        let key = "\(candidate.id):\(decision.reason)"
-        guard key != lastSuppressionLogKey else { return }
-        lastSuppressionLogKey = key
-        switch decision.reason {
-        case .autoDismissedSuppression:
-            log("prompt_suppressed id=\(candidate.id) reason=auto_dismissed")
-        case .userDismissedSuppression:
-            log("prompt_suppressed id=\(candidate.id) reason=user_dismissed")
-        case .calendarNotificationVisible:
-            log("prompt_suppressed id=\(candidate.id) reason=calendar_notification_visible")
-        case .recording:
-            log("prompt_suppressed id=\(candidate.id) reason=recording")
-        default:
-            break
-        }
-    }
-
-    private func installPeriodicEvaluationLoop() {
-        periodicEvaluationTask?.cancel()
-        periodicEvaluationTask = Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: Self.evaluationInterval)
-                self?.scheduleEvaluation()
-            }
-        }
-    }
-
-    private func installWorkspaceActivationObserver() {
-        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didActivateApplicationNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.scheduleEvaluation()
-            }
-        }
-    }
-
-    private func removeWorkspaceActivationObserver() {
-        guard let workspaceObserver else { return }
-        NSWorkspace.shared.notificationCenter.removeObserver(workspaceObserver)
-        self.workspaceObserver = nil
-    }
-
-    private func mergedAudioInputProcesses(
-        _ coreAudioProcesses: [AudioProcessActivity],
-        sensorAttributions: SensorAttributionSnapshot,
-        runningProcessIDsByBundleID: [String: pid_t]
-    ) -> [AudioProcessActivity] {
-        var processes = coreAudioProcesses
-        let existingBundleIDs = Set(coreAudioProcesses.map(\.bundleID))
-
-        for bundleID in sensorAttributions.micBundleIDs.sorted() {
-            guard let appName = MeetingCandidateResolver.browserApps[bundleID] else { continue }
-            guard !existingBundleIDs.contains(bundleID),
-                  !existingBundleIDs.contains(where: { helperBundleID in
-                      helperBundleID.lowercased().hasPrefix("\(bundleID.lowercased()).")
-                  }) else {
-                continue
-            }
-
-            processes.append(AudioProcessActivity(
-                pid: runningProcessIDsByBundleID[bundleID] ?? 0,
-                bundleID: bundleID,
-                appName: appName,
-                isRunningInput: true,
-                isRunningOutput: false
-            ))
-        }
-
-        return processes
     }
 
     private func installMicListener() {
@@ -313,7 +184,7 @@ final class MeetingMonitor {
         micListenerDeviceID = deviceID
 
         let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            DispatchQueue.main.async { self?.scheduleEvaluation() }
+            DispatchQueue.main.async { self?.scheduleEvaluation(.micChanged) }
         }
         micListenerBlock = block
 
@@ -342,7 +213,7 @@ final class MeetingMonitor {
             DispatchQueue.main.async {
                 self?.removeMicListener()
                 self?.installMicListener()
-                self?.scheduleEvaluation()
+                self?.scheduleEvaluation(.micChanged)
             }
         }
         deviceChangeListenerBlock = block
@@ -375,6 +246,480 @@ final class MeetingMonitor {
         )
         deviceChangeListenerBlock = nil
     }
+}
+
+private enum MeetingPromptUpdate {
+    case show(MeetingCandidate)
+    case hide
+}
+
+private struct MeetingDetectionEvaluationContext {
+    let micDeviceID: AudioDeviceID
+    let cameraActive: Bool
+    let sensorAttributions: SensorAttributionSnapshot
+    let calendarEvent: CalendarEventContext?
+    let detectionEnabled: Bool
+    let isRecording: Bool
+    let isStartingRecording: Bool
+    let isCalendarNotificationVisible: Bool
+    let promptVisibility: MeetingPromptVisibility
+    let mutedBundleIDs: Set<String>
+    let runningApps: [RunningAppSnapshot]
+    let foregroundBundleID: String?
+
+    static let disabled = MeetingDetectionEvaluationContext(
+        micDeviceID: 0,
+        cameraActive: false,
+        sensorAttributions: .empty,
+        calendarEvent: nil,
+        detectionEnabled: false,
+        isRecording: false,
+        isStartingRecording: false,
+        isCalendarNotificationVisible: false,
+        promptVisibility: MeetingPromptVisibility(isVisible: false, currentPromptID: nil, shownAt: nil),
+        mutedBundleIDs: [],
+        runningApps: [],
+        foregroundBundleID: nil
+    )
+}
+
+private actor MeetingDetectionService {
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
+
+    private let contextProvider: @MainActor (Date) -> MeetingDetectionEvaluationContext
+    private let promptHandler: @MainActor (MeetingPromptUpdate) -> Void
+    private let resolver = MeetingCandidateResolver()
+    private let mediaSessionTracker = MeetingMediaSessionTracker()
+    private let signalCollector = MeetingSignalCollector()
+    private let audioAttributionService = AudioAttributionService()
+    private let promptState = MeetingPromptStateMachine()
+    private let refreshPolicy = MeetingSignalRefreshPolicy()
+
+    private var fallbackEvaluationTask: Task<Void, Never>?
+    private var debounceEvaluationTask: Task<Void, Never>?
+    private var evaluationTask: Task<Void, Never>?
+    private var scheduledTrigger: MeetingDetectionTrigger?
+    private var pendingEvaluationTrigger: MeetingDetectionTrigger?
+    private var globalSuppressUntil: Date?
+    private var lastLoggedCandidateID: String?
+    private var lastSuppressionLogKey: String?
+    private var signalRefreshState = MeetingSignalRefreshState()
+    private var currentFallbackInterval: TimeInterval?
+    private var latestLifecycleGeneration = 0
+    private var isStarted = false
+
+    init(
+        contextProvider: @escaping @MainActor (Date) -> MeetingDetectionEvaluationContext,
+        promptHandler: @escaping @MainActor (MeetingPromptUpdate) -> Void
+    ) {
+        self.contextProvider = contextProvider
+        self.promptHandler = promptHandler
+    }
+
+    func start(generation: Int) {
+        guard generation >= latestLifecycleGeneration else { return }
+        latestLifecycleGeneration = generation
+        guard !isStarted else { return }
+        isStarted = true
+        installFallbackEvaluationLoop(interval: refreshPolicy.idleFallbackInterval)
+        scheduleEvaluation(.startup)
+    }
+
+    func stop(generation: Int) {
+        guard generation >= latestLifecycleGeneration else { return }
+        latestLifecycleGeneration = generation
+        stop()
+    }
+
+    private func stop() {
+        isStarted = false
+        fallbackEvaluationTask?.cancel()
+        fallbackEvaluationTask = nil
+        debounceEvaluationTask?.cancel()
+        debounceEvaluationTask = nil
+        evaluationTask?.cancel()
+        evaluationTask = nil
+        scheduledTrigger = nil
+        pendingEvaluationTrigger = nil
+        currentFallbackInterval = nil
+        signalRefreshState = MeetingSignalRefreshState()
+        Task { [audioAttributionService] in
+            await audioAttributionService.reset()
+        }
+        Task { [mediaSessionTracker] in
+            await mediaSessionTracker.reset()
+        }
+        promptState.resetVisiblePrompt()
+        emitPromptUpdate(.hide)
+    }
+
+    func scheduleEvaluation(_ trigger: MeetingDetectionTrigger) {
+        guard isStarted else { return }
+        scheduledTrigger = mergeTrigger(scheduledTrigger, with: trigger)
+        debounceEvaluationTask?.cancel()
+
+        let delay = debounceDelay(for: trigger)
+        debounceEvaluationTask = Task { [weak self] in
+            if delay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+            await self?.startScheduledEvaluation()
+        }
+    }
+
+    func suppress(for duration: TimeInterval = 120) {
+        globalSuppressUntil = Date().addingTimeInterval(duration)
+        dismissVisiblePromptForSuppression()
+    }
+
+    func suppressWhileActive() {
+        globalSuppressUntil = .distantFuture
+        dismissVisiblePromptForSuppression()
+    }
+
+    func resumeAfterCooldown() {
+        globalSuppressUntil = Date().addingTimeInterval(15)
+        scheduleEvaluation(.promptStateChanged)
+    }
+
+    func markPromptShown(_ candidate: MeetingCandidate) {
+        promptState.markShown(candidate)
+        scheduleEvaluation(.promptStateChanged)
+    }
+
+    func markPromptAutoDismissed(_ candidate: MeetingCandidate) {
+        promptState.markAutoDismissed(candidate)
+        log("prompt_auto_dismissed id=\(candidate.id)")
+        scheduleEvaluation(.promptStateChanged)
+    }
+
+    func markPromptUserDismissed(_ candidate: MeetingCandidate) {
+        promptState.markUserDismissed(candidate)
+        log("prompt_suppressed id=\(candidate.id) reason=user_dismissed")
+        scheduleEvaluation(.promptStateChanged)
+    }
+
+    func markPromptClosed(_ candidate: MeetingCandidate) {
+        promptState.markClosed(candidate)
+        scheduleEvaluation(.promptStateChanged)
+    }
+
+    func markRecordingStarted(_ candidate: MeetingCandidate?) {
+        if let candidate {
+            log("recording_started id=\(candidate.id)")
+        } else {
+            log("recording_started")
+        }
+        scheduleEvaluation(.promptStateChanged)
+    }
+
+    private func startScheduledEvaluation() async {
+        guard isStarted else { return }
+        let trigger = scheduledTrigger ?? .manualRefresh
+        scheduledTrigger = nil
+
+        if evaluationTask != nil {
+            pendingEvaluationTrigger = mergeTrigger(pendingEvaluationTrigger, with: trigger)
+            return
+        }
+
+        evaluationTask = Task { [weak self] in
+            await self?.runScheduledEvaluations(initialTrigger: trigger)
+        }
+    }
+
+    private func runScheduledEvaluations(initialTrigger: MeetingDetectionTrigger) async {
+        var trigger: MeetingDetectionTrigger? = initialTrigger
+        repeat {
+            let currentTrigger = trigger ?? .manualRefresh
+            pendingEvaluationTrigger = nil
+            await evaluateNow(trigger: currentTrigger)
+            trigger = pendingEvaluationTrigger
+        } while trigger != nil && !Task.isCancelled
+        evaluationTask = nil
+    }
+
+    private func evaluateNow(trigger: MeetingDetectionTrigger) async {
+        let totalStart = Date()
+        let now = Date()
+        let context = await contextProvider(now)
+        guard isStarted else { return }
+        guard context.detectionEnabled else {
+            dismissVisiblePromptForSuppression()
+            return
+        }
+
+        signalRefreshState.hasMicOrCameraSignal = context.cameraActive
+            || !context.sensorAttributions.micBundleIDs.isEmpty
+            || !context.sensorAttributions.cameraBundleIDs.isEmpty
+        signalRefreshState.hasCalendarEvent = context.calendarEvent != nil
+        signalRefreshState.hasPromptVisible = context.promptVisibility.isVisible
+
+        let refreshDecision = refreshPolicy.decision(trigger: trigger, state: signalRefreshState, now: now)
+        async let audioAttributionResult = audioAttributionService.activeInputProcesses(
+            refresh: refreshDecision.refreshAudioAttribution
+        )
+        let collectedSignals = await signalCollector.collect(
+            micDeviceID: context.micDeviceID,
+            runningApps: context.runningApps,
+            foregroundBundleID: context.foregroundBundleID,
+            refreshBrowserMeetings: refreshDecision.refreshBrowserMeetings,
+            refreshPolicy: refreshPolicy,
+            refreshState: signalRefreshState,
+            now: now
+        )
+        let audioResult = await audioAttributionResult
+        guard !Task.isCancelled, isStarted else { return }
+        if refreshDecision.refreshAudioAttribution {
+            signalRefreshState.lastAudioAttributionRefreshAt = now
+        }
+        if refreshDecision.refreshBrowserMeetings {
+            signalRefreshState.lastBrowserRefreshAt = now
+        }
+        for bundleID in collectedSignals.appleScriptAttemptedBundleIDs {
+            signalRefreshState.lastAppleScriptAttemptAtByBundleID[bundleID] = now
+        }
+
+        let audioInputProcesses = mergedAudioInputProcesses(
+            audioResult.processes,
+            sensorAttributions: context.sensorAttributions,
+            runningProcessIDsByBundleID: collectedSignals.runningProcessIDsByBundleID
+        )
+        let micActive = collectedSignals.micActive
+            || !audioInputProcesses.isEmpty
+            || !context.sensorAttributions.micBundleIDs.isEmpty
+        let cameraActive = context.cameraActive || !context.sensorAttributions.cameraBundleIDs.isEmpty
+
+        let snapshot = MeetingSignalSnapshot(
+            micActive: micActive,
+            cameraActive: cameraActive,
+            calendarEvent: context.calendarEvent,
+            runningApps: collectedSignals.runningApps,
+            browserMeetings: collectedSignals.browserMeetings,
+            audioInputProcesses: audioInputProcesses,
+            foregroundBundleID: collectedSignals.foregroundBundleID,
+            now: now
+        )
+
+        let resolverStart = Date()
+        let resolvedCandidate = isGloballySuppressed(now: now) ? nil : resolver.resolve(snapshot)
+        let resolverDuration = Date().timeIntervalSince(resolverStart)
+        let unmutedCandidate = isMuted(resolvedCandidate, mutedBundleIDs: context.mutedBundleIDs) ? nil : resolvedCandidate
+        let candidate = await mediaSessionTracker.stabilize(
+            candidate: unmutedCandidate,
+            snapshot: snapshot
+        )
+        logCandidateIfChanged(candidate)
+        updateRefreshState(
+            trigger: trigger,
+            micActive: micActive,
+            cameraActive: cameraActive,
+            calendarEvent: context.calendarEvent,
+            browserMeetings: collectedSignals.browserMeetings,
+            foregroundBundleID: collectedSignals.foregroundBundleID,
+            visibility: context.promptVisibility,
+            candidate: candidate,
+            now: now
+        )
+
+        let decision = promptState.evaluate(
+            candidate: candidate,
+            detectionEnabled: context.detectionEnabled,
+            isRecording: context.isRecording,
+            isStartingRecording: context.isStartingRecording,
+            isCalendarNotificationVisible: context.isCalendarNotificationVisible,
+            visibility: context.promptVisibility,
+            now: now
+        )
+
+        switch decision.action {
+        case .show:
+            guard let candidate = decision.candidate else { return }
+            log("prompt_shown id=\(candidate.id) platform=\(candidate.platform.displayName) app=\(candidate.appName)")
+            emitPromptUpdate(.show(candidate))
+        case .hide:
+            emitPromptUpdate(.hide)
+        case .none:
+            logSuppressionIfNeeded(decision)
+        }
+
+        let nextDecision = refreshPolicy.decision(trigger: .fallbackTimer, state: signalRefreshState, now: now)
+        installFallbackEvaluationLoop(interval: nextDecision.fallbackInterval)
+        logEvaluation(
+            trigger: trigger,
+            decision: refreshDecision,
+            timings: MeetingCollectionTimings(
+                browserDuration: collectedSignals.timings.browserDuration,
+                audioAttributionDuration: audioResult.duration
+            ),
+            resolverDuration: resolverDuration,
+            totalDuration: Date().timeIntervalSince(totalStart)
+        )
+    }
+
+    private func dismissVisiblePromptForSuppression() {
+        promptState.resetVisiblePrompt()
+        emitPromptUpdate(.hide)
+    }
+
+    private func emitPromptUpdate(_ update: MeetingPromptUpdate) {
+        Task { @MainActor [promptHandler] in
+            promptHandler(update)
+        }
+    }
+
+    private func isGloballySuppressed(now: Date) -> Bool {
+        guard let until = globalSuppressUntil else { return false }
+        if now >= until {
+            globalSuppressUntil = nil
+            return false
+        }
+        return true
+    }
+
+    private func isMuted(_ candidate: MeetingCandidate?, mutedBundleIDs: Set<String>) -> Bool {
+        guard let sourceBundleID = candidate?.sourceBundleID else { return false }
+        return mutedBundleIDs.contains(sourceBundleID)
+    }
+
+    private func logCandidateIfChanged(_ candidate: MeetingCandidate?) {
+        guard candidate?.id != lastLoggedCandidateID else { return }
+        lastLoggedCandidateID = candidate?.id
+        if let candidate {
+            log("candidate_detected id=\(candidate.id) platform=\(candidate.platform.displayName) app=\(candidate.appName)")
+        }
+    }
+
+    private func logSuppressionIfNeeded(_ decision: MeetingPromptDecision) {
+        guard let candidate = decision.candidate else {
+            lastSuppressionLogKey = nil
+            return
+        }
+        let key = "\(candidate.id):\(decision.reason)"
+        guard key != lastSuppressionLogKey else { return }
+        lastSuppressionLogKey = key
+        switch decision.reason {
+        case .autoDismissedSuppression:
+            log("prompt_suppressed id=\(candidate.id) reason=auto_dismissed")
+        case .userDismissedSuppression:
+            log("prompt_suppressed id=\(candidate.id) reason=user_dismissed")
+        case .calendarNotificationVisible:
+            log("prompt_suppressed id=\(candidate.id) reason=calendar_notification_visible")
+        case .recording:
+            log("prompt_suppressed id=\(candidate.id) reason=recording")
+        default:
+            break
+        }
+    }
+
+    private func installFallbackEvaluationLoop(interval: TimeInterval) {
+        guard currentFallbackInterval != interval else { return }
+        currentFallbackInterval = interval
+        fallbackEvaluationTask?.cancel()
+        fallbackEvaluationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                await self?.scheduleEvaluation(.fallbackTimer)
+            }
+        }
+    }
+
+    private func mergedAudioInputProcesses(
+        _ coreAudioProcesses: [AudioProcessActivity],
+        sensorAttributions: SensorAttributionSnapshot,
+        runningProcessIDsByBundleID: [String: pid_t]
+    ) -> [AudioProcessActivity] {
+        var processes = coreAudioProcesses
+        let existingBundleIDs = Set(coreAudioProcesses.map(\.bundleID))
+
+        for bundleID in sensorAttributions.micBundleIDs.sorted() {
+            guard let appName = MeetingCandidateResolver.browserApps[bundleID] else { continue }
+            guard !existingBundleIDs.contains(bundleID),
+                  !existingBundleIDs.contains(where: { helperBundleID in
+                      helperBundleID.lowercased().hasPrefix("\(bundleID.lowercased()).")
+                  }) else {
+                continue
+            }
+
+            processes.append(AudioProcessActivity(
+                pid: runningProcessIDsByBundleID[bundleID] ?? 0,
+                bundleID: bundleID,
+                appName: appName,
+                isRunningInput: true,
+                isRunningOutput: false
+            ))
+        }
+
+        return processes
+    }
+
+    private func debounceDelay(for trigger: MeetingDetectionTrigger) -> TimeInterval {
+        switch trigger {
+        case .startup, .fallbackTimer:
+            return 0
+        case .micChanged, .cameraChanged, .sensorAttributionChanged, .workspaceActivated,
+             .calendarChanged, .promptStateChanged, .manualRefresh:
+            return refreshPolicy.debounceDelay
+        }
+    }
+
+    private func mergeTrigger(
+        _ existing: MeetingDetectionTrigger?,
+        with newTrigger: MeetingDetectionTrigger
+    ) -> MeetingDetectionTrigger {
+        guard let existing else { return newTrigger }
+        return triggerPriority(newTrigger) >= triggerPriority(existing) ? newTrigger : existing
+    }
+
+    private func triggerPriority(_ trigger: MeetingDetectionTrigger) -> Int {
+        switch trigger {
+        case .startup: return 9
+        case .micChanged, .sensorAttributionChanged, .cameraChanged: return 8
+        case .workspaceActivated, .calendarChanged: return 7
+        case .promptStateChanged, .manualRefresh: return 6
+        case .fallbackTimer: return 1
+        }
+    }
+
+    private func updateRefreshState(
+        trigger: MeetingDetectionTrigger,
+        micActive: Bool,
+        cameraActive: Bool,
+        calendarEvent: CalendarEventContext?,
+        browserMeetings: [BrowserMeetingContext],
+        foregroundBundleID: String?,
+        visibility: MeetingPromptVisibility,
+        candidate: MeetingCandidate?,
+        now: Date
+    ) {
+        signalRefreshState.hasMicOrCameraSignal = micActive || cameraActive
+        signalRefreshState.hasRecentBrowserMeeting = !browserMeetings.isEmpty
+        signalRefreshState.hasActiveCandidate = candidate != nil
+        signalRefreshState.hasPromptVisible = visibility.isVisible
+        signalRefreshState.hasCalendarEvent = calendarEvent != nil
+        signalRefreshState.foregroundIsMeetingCapableApp = foregroundBundleID.map { bundleID in
+            MeetingCandidateResolver.browserApps[bundleID] != nil
+                || MeetingCandidateResolver.dedicatedApps[bundleID] != nil
+        } ?? false
+        signalRefreshState.lastSuspicionAt = refreshPolicy.suspicionDate(
+            after: trigger,
+            state: signalRefreshState,
+            now: now,
+            resolvedCandidate: candidate
+        )
+    }
+
+    private func logEvaluation(
+        trigger: MeetingDetectionTrigger,
+        decision: MeetingSignalRefreshDecision,
+        timings: MeetingCollectionTimings,
+        resolverDuration: TimeInterval,
+        totalDuration: TimeInterval
+    ) {
+        Self.logger.notice(
+            "evaluation trigger=\(String(describing: trigger), privacy: .public) mode=\(String(describing: decision.mode), privacy: .public) browser_ms=\(timings.browserMilliseconds, privacy: .public) audio_ms=\(timings.audioAttributionMilliseconds, privacy: .public) resolver_ms=\(Int(resolverDuration * 1000), privacy: .public) total_ms=\(Int(totalDuration * 1000), privacy: .public) refresh_browser=\(decision.refreshBrowserMeetings, privacy: .public) refresh_audio=\(decision.refreshAudioAttribution, privacy: .public)"
+        )
+    }
 
     private func log(_ message: String) {
         Self.logger.notice("\(message, privacy: .public)")
@@ -386,41 +731,89 @@ private struct MeetingCollectedSignals {
     let micActive: Bool
     let runningApps: [RunningAppInfo]
     let browserMeetings: [BrowserMeetingContext]
-    let audioInputProcesses: [AudioProcessActivity]
     let foregroundBundleID: String?
     let runningProcessIDsByBundleID: [String: pid_t]
+    let appleScriptAttemptedBundleIDs: Set<String>
+    let timings: MeetingCollectionTimings
+}
+
+private struct MeetingCollectionTimings {
+    let browserDuration: TimeInterval
+    let audioAttributionDuration: TimeInterval
+
+    var browserMilliseconds: Int { Int(browserDuration * 1000) }
+    var audioAttributionMilliseconds: Int { Int(audioAttributionDuration * 1000) }
+}
+
+private struct AudioAttributionResult {
+    let processes: [AudioProcessActivity]
+    let duration: TimeInterval
+}
+
+private actor AudioAttributionService {
+    private let collector = AudioProcessAttributionCollector()
+    private var cachedInputProcesses: [AudioProcessActivity] = []
+
+    func activeInputProcesses(refresh: Bool) -> AudioAttributionResult {
+        guard refresh else {
+            return AudioAttributionResult(processes: cachedInputProcesses, duration: 0)
+        }
+
+        let start = Date()
+        let processes = collector.activeInputProcesses()
+        cachedInputProcesses = processes
+        return AudioAttributionResult(
+            processes: processes,
+            duration: Date().timeIntervalSince(start)
+        )
+    }
+
+    func reset() {
+        cachedInputProcesses = []
+    }
 }
 
 private actor MeetingSignalCollector {
     private let browserCollector = BrowserMeetingActivityCollector()
-    private let audioProcessCollector = AudioProcessAttributionCollector()
 
-    func collect(micDeviceID: AudioDeviceID) async -> MeetingCollectedSignals {
-        let runningAppSnapshots = currentRunningApps()
-        let browserMeetings = await browserCollector.collect(runningApps: runningAppSnapshots)
+    func collect(
+        micDeviceID: AudioDeviceID,
+        runningApps: [RunningAppSnapshot],
+        foregroundBundleID: String?,
+        refreshBrowserMeetings: Bool,
+        refreshPolicy: MeetingSignalRefreshPolicy,
+        refreshState: MeetingSignalRefreshState,
+        now: Date
+    ) async -> MeetingCollectedSignals {
+        var appleScriptAttemptedBundleIDs = Set<String>()
+        let browserStart = Date()
+        let browserMeetings = await browserCollector.collect(
+            runningApps: runningApps,
+            refresh: refreshBrowserMeetings,
+            now: now
+        ) { bundleID in
+            guard refreshPolicy.allowsAppleScript(for: bundleID, state: refreshState, now: now) else {
+                return false
+            }
+            appleScriptAttemptedBundleIDs.insert(bundleID)
+            return true
+        }
+        let browserDuration = Date().timeIntervalSince(browserStart)
 
         return MeetingCollectedSignals(
             micActive: isMicActive(deviceID: micDeviceID),
-            runningApps: runningAppSnapshots.map {
+            runningApps: runningApps.map {
                 RunningAppInfo(bundleID: $0.bundleID, isActive: $0.isActive)
             },
             browserMeetings: browserMeetings,
-            audioInputProcesses: audioProcessCollector.activeInputProcesses(),
-            foregroundBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
-            runningProcessIDsByBundleID: runningProcessIDsByBundleID(from: runningAppSnapshots)
-        )
-    }
-
-    private func currentRunningApps() -> [RunningAppSnapshot] {
-        NSWorkspace.shared.runningApplications.compactMap { app in
-            guard let bundleID = app.bundleIdentifier else { return nil }
-            return RunningAppSnapshot(
-                bundleID: bundleID,
-                appName: app.localizedName ?? MeetingCandidateResolver.browserApps[bundleID] ?? bundleID,
-                processIdentifier: app.processIdentifier,
-                isActive: app.isActive
+            foregroundBundleID: foregroundBundleID,
+            runningProcessIDsByBundleID: runningProcessIDsByBundleID(from: runningApps),
+            appleScriptAttemptedBundleIDs: appleScriptAttemptedBundleIDs,
+            timings: MeetingCollectionTimings(
+                browserDuration: browserDuration,
+                audioAttributionDuration: 0
             )
-        }
+        )
     }
 
     private func runningProcessIDsByBundleID(from apps: [RunningAppSnapshot]) -> [String: pid_t] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -134,6 +134,7 @@ final class MeetingNotificationController {
         dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.86)
         dismissButton.toolTip = "Dismiss"
         contentView.addSubview(dismissButton)
+        contentView.hoverFrames = [cardView.frame, dismissButton.frame]
 
         // Platform icon + text layout
         let textX: CGFloat
@@ -446,6 +447,8 @@ final class MeetingNotificationController {
 private final class HoverAwareView: NSView {
     var onMouseEntered: (() -> Void)?
     var onMouseExited: (() -> Void)?
+    var hoverFrames: [NSRect] = []
+    private var isHoveringActiveFrame = false
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
@@ -455,7 +458,7 @@ private final class HoverAwareView: NSView {
         addTrackingArea(
             NSTrackingArea(
                 rect: bounds,
-                options: [.activeAlways, .mouseEnteredAndExited, .inVisibleRect],
+                options: [.activeAlways, .mouseEnteredAndExited, .mouseMoved, .inVisibleRect],
                 owner: self,
                 userInfo: nil
             )
@@ -463,11 +466,30 @@ private final class HoverAwareView: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        onMouseEntered?()
+        updateHoverState(with: event)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        updateHoverState(with: event)
     }
 
     override func mouseExited(with event: NSEvent) {
-        onMouseExited?()
+        setHoveringActiveFrame(false)
+    }
+
+    private func updateHoverState(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        setHoveringActiveFrame(hoverFrames.contains { $0.contains(point) })
+    }
+
+    private func setHoveringActiveFrame(_ isHovering: Bool) {
+        guard isHovering != isHoveringActiveFrame else { return }
+        isHoveringActiveFrame = isHovering
+        if isHovering {
+            onMouseEntered?()
+        } else {
+            onMouseExited?()
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -57,8 +57,13 @@ final class MeetingNotificationController {
         let hasJoinButton = meetingURL != nil && onJoinAndRecord != nil
         let platform = explicitPlatform ?? meetingURL.flatMap { MeetingPlatform.detect(from: $0) }
 
-        let width: CGFloat = 344
-        let height: CGFloat = 60
+        let cardWidth: CGFloat = 344
+        let cardHeight: CGFloat = 60
+        let closeButtonSize: CGFloat = 22
+        let cardX = closeButtonSize / 2 + 1
+        let topGutter: CGFloat = closeButtonSize / 2 + 1
+        let width = cardWidth + cardX
+        let height = cardHeight + topGutter
         let margin: CGFloat = 16
         guard let frame = verifiedNotificationFrame(
             preferredScreen: preferredScreen,
@@ -90,34 +95,43 @@ final class MeetingNotificationController {
         contentView.onMouseEntered = { [weak self] in self?.pauseDismissCountdown() }
         contentView.onMouseExited = { [weak self] in self?.resumeDismissCountdown() }
         contentView.wantsLayer = true
-        contentView.layer?.cornerRadius = 10
-        contentView.layer?.masksToBounds = true
-        contentView.layer?.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.12, alpha: 0.97).cgColor
-        contentView.layer?.borderWidth = 1
-        contentView.layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+
+        let cardView = NSView(frame: NSRect(x: cardX, y: 0, width: cardWidth, height: cardHeight))
+        cardView.wantsLayer = true
+        cardView.layer?.cornerRadius = 10
+        cardView.layer?.masksToBounds = true
+        cardView.layer?.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.12, alpha: 0.97).cgColor
+        cardView.layer?.borderWidth = 1
+        cardView.layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        contentView.addSubview(cardView)
 
         // Countdown progress bar at bottom
         let progressBar = CALayer()
-        progressBar.frame = CGRect(x: 0, y: 0, width: width, height: 3)
+        progressBar.frame = CGRect(x: 0, y: 0, width: cardWidth, height: 3)
         progressBar.backgroundColor = NSColor(red: 0.3, green: 0.6, blue: 1.0, alpha: 0.8).cgColor
-        contentView.layer?.addSublayer(progressBar)
+        cardView.layer?.addSublayer(progressBar)
         self.progressLayer = progressBar
 
         progressBar.anchorPoint = CGPoint(x: 0, y: 0.5)
         progressBar.position = CGPoint(x: 0, y: 1.5)
 
         let dismissButton = NSButton(title: "×", target: self, action: #selector(handleDismiss))
-        dismissButton.font = .systemFont(ofSize: 13, weight: .medium)
-        dismissButton.frame = NSRect(x: 9, y: height - 27, width: 20, height: 20)
+        dismissButton.font = .systemFont(ofSize: 15, weight: .medium)
+        dismissButton.frame = NSRect(
+            x: cardX - closeButtonSize / 2,
+            y: cardHeight + topGutter - closeButtonSize,
+            width: closeButtonSize,
+            height: closeButtonSize
+        )
         dismissButton.wantsLayer = true
-        dismissButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.055).cgColor
+        dismissButton.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.70).cgColor
         dismissButton.layer?.borderWidth = 1
-        dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.14).cgColor
-        dismissButton.layer?.cornerRadius = 10
+        dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.55).cgColor
+        dismissButton.layer?.cornerRadius = closeButtonSize / 2
         dismissButton.alignment = .center
         dismissButton.focusRingType = .none
         dismissButton.isBordered = false
-        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.72)
+        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.86)
         dismissButton.toolTip = "Dismiss"
         contentView.addSubview(dismissButton)
 
@@ -127,11 +141,11 @@ final class MeetingNotificationController {
             let iconSize: CGFloat = 26
             let iconView = NSImageView(image: icon)
             iconView.imageScaling = .scaleProportionallyUpOrDown
-            iconView.frame = NSRect(x: 38, y: (height - iconSize) / 2 + 1, width: iconSize, height: iconSize)
-            contentView.addSubview(iconView)
-            textX = 38 + iconSize + 9
+            iconView.frame = NSRect(x: 14, y: (cardHeight - iconSize) / 2 + 1, width: iconSize, height: iconSize)
+            cardView.addSubview(iconView)
+            textX = 14 + iconSize + 9
         } else {
-            textX = 38
+            textX = 14
         }
 
         // Title label
@@ -139,21 +153,21 @@ final class MeetingNotificationController {
         titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
         titleLabel.textColor = .white
         titleLabel.frame = NSRect(x: textX, y: 32, width: 144, height: 18)
-        contentView.addSubview(titleLabel)
+        cardView.addSubview(titleLabel)
 
         // Subtitle label
         let subtitleLabel = NSTextField(labelWithString: subtitle)
         subtitleLabel.font = .systemFont(ofSize: 11)
         subtitleLabel.textColor = NSColor.white.withAlphaComponent(0.55)
         subtitleLabel.frame = NSRect(x: textX, y: 14, width: 144, height: 16)
-        contentView.addSubview(subtitleLabel)
+        cardView.addSubview(subtitleLabel)
 
         if hasJoinButton {
             // Split button: "Join & Record" (main) + chevron dropdown with "Join Only"
             let buttonWidth: CGFloat = 98
             let chevronWidth: CGFloat = 24
             let totalWidth = buttonWidth + chevronWidth
-            let buttonX = width - totalWidth - 12
+            let buttonX = cardWidth - totalWidth - 12
             let textMaxX = buttonX - 8
             let greenColor = NSColor(red: 0.20, green: 0.72, blue: 0.53, alpha: 1.0)
             let greenDarker = NSColor(red: 0.15, green: 0.58, blue: 0.42, alpha: 1.0)
@@ -172,7 +186,7 @@ final class MeetingNotificationController {
             joinButton.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             joinButton.isBordered = false
             joinButton.contentTintColor = .white
-            contentView.addSubview(joinButton)
+            cardView.addSubview(joinButton)
 
             // Chevron dropdown button
             let chevronButton = NSButton(title: "▾", target: self, action: #selector(handleChevronClick(_:)))
@@ -184,18 +198,18 @@ final class MeetingNotificationController {
             chevronButton.layer?.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             chevronButton.isBordered = false
             chevronButton.contentTintColor = NSColor.white.withAlphaComponent(0.8)
-            contentView.addSubview(chevronButton)
+            cardView.addSubview(chevronButton)
         } else {
             // Single "Start Recording" button
             let startButton = NSButton(title: actionLabel, target: self, action: #selector(handleStartRecording))
             startButton.font = .systemFont(ofSize: 12, weight: .medium)
-            startButton.frame = NSRect(x: width - 122, y: 15, width: 110, height: 30)
+            startButton.frame = NSRect(x: cardWidth - 122, y: 15, width: 110, height: 30)
             startButton.wantsLayer = true
             startButton.layer?.backgroundColor = NSColor(red: 0.2, green: 0.5, blue: 1.0, alpha: 1.0).cgColor
             startButton.layer?.cornerRadius = 6
             startButton.isBordered = false
             startButton.contentTintColor = .white
-            contentView.addSubview(startButton)
+            cardView.addSubview(startButton)
         }
 
         panel.contentView = contentView

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
@@ -166,6 +166,7 @@ final class MeetingPromptStateMachine {
     }
 
     private func autoDismissExpiry(for candidate: MeetingCandidate, now: Date) -> Date {
+        guard !candidate.suppressionID.hasPrefix("meeting-session:") else { return .distantFuture }
         guard candidate.evidence.contains(.browserURL) else { return .distantFuture }
         return now.addingTimeInterval(browserAutoDismissCooldown)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
@@ -35,7 +35,6 @@ struct MeetingSignalRefreshDecision: Equatable {
     let refreshAudioAttribution: Bool
     let refreshBrowserMeetings: Bool
     let fallbackInterval: TimeInterval
-    let debounceDelay: TimeInterval
 }
 
 struct MeetingSignalRefreshPolicy {
@@ -84,8 +83,7 @@ struct MeetingSignalRefreshPolicy {
             mode: mode,
             refreshAudioAttribution: shouldRefreshAudioAttribution(trigger: trigger, state: state, mode: mode, now: now),
             refreshBrowserMeetings: shouldRefreshBrowserMeetings(trigger: trigger, state: state, mode: mode, now: now),
-            fallbackInterval: fallbackInterval,
-            debounceDelay: shouldDebounce(trigger) ? debounceDelay : 0
+            fallbackInterval: fallbackInterval
         )
     }
 
@@ -173,16 +171,6 @@ struct MeetingSignalRefreshPolicy {
     private func isThrottleExpired(since date: Date?, throttle: TimeInterval, now: Date) -> Bool {
         guard let date else { return true }
         return now.timeIntervalSince(date) >= throttle
-    }
-
-    private func shouldDebounce(_ trigger: MeetingDetectionTrigger) -> Bool {
-        switch trigger {
-        case .fallbackTimer, .startup:
-            return false
-        case .micChanged, .cameraChanged, .sensorAttributionChanged, .workspaceActivated,
-             .calendarChanged, .promptStateChanged, .manualRefresh:
-            return true
-        }
     }
 
     private func isSuspicionTrigger(_ trigger: MeetingDetectionTrigger) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+enum MeetingDetectionTrigger: Equatable {
+    case startup
+    case fallbackTimer
+    case micChanged
+    case cameraChanged
+    case sensorAttributionChanged
+    case workspaceActivated
+    case calendarChanged
+    case promptStateChanged
+    case manualRefresh
+}
+
+enum MeetingDetectionMode: Equatable {
+    case idle
+    case suspicious
+}
+
+struct MeetingSignalRefreshState: Equatable {
+    var lastAudioAttributionRefreshAt: Date?
+    var lastBrowserRefreshAt: Date?
+    var lastAppleScriptAttemptAtByBundleID: [String: Date] = [:]
+    var lastSuspicionAt: Date?
+    var hasMicOrCameraSignal = false
+    var hasRecentBrowserMeeting = false
+    var hasActiveCandidate = false
+    var hasPromptVisible = false
+    var hasCalendarEvent = false
+    var foregroundIsMeetingCapableApp = false
+}
+
+struct MeetingSignalRefreshDecision: Equatable {
+    let mode: MeetingDetectionMode
+    let refreshAudioAttribution: Bool
+    let refreshBrowserMeetings: Bool
+    let fallbackInterval: TimeInterval
+    let debounceDelay: TimeInterval
+}
+
+struct MeetingSignalRefreshPolicy {
+    let idleFallbackInterval: TimeInterval
+    let suspiciousFallbackInterval: TimeInterval
+    let debounceDelay: TimeInterval
+    let suspicionTTL: TimeInterval
+    let audioSuspiciousThrottle: TimeInterval
+    let audioIdleThrottle: TimeInterval
+    let browserSuspiciousThrottle: TimeInterval
+    let browserIdleThrottle: TimeInterval
+    let appleScriptThrottle: TimeInterval
+
+    init(
+        idleFallbackInterval: TimeInterval = 120,
+        suspiciousFallbackInterval: TimeInterval = 3,
+        debounceDelay: TimeInterval = 0.5,
+        suspicionTTL: TimeInterval = 12,
+        audioSuspiciousThrottle: TimeInterval = 8,
+        audioIdleThrottle: TimeInterval = 120,
+        browserSuspiciousThrottle: TimeInterval = 3,
+        browserIdleThrottle: TimeInterval = 120,
+        appleScriptThrottle: TimeInterval = 15
+    ) {
+        self.idleFallbackInterval = idleFallbackInterval
+        self.suspiciousFallbackInterval = suspiciousFallbackInterval
+        self.debounceDelay = debounceDelay
+        self.suspicionTTL = suspicionTTL
+        self.audioSuspiciousThrottle = audioSuspiciousThrottle
+        self.audioIdleThrottle = audioIdleThrottle
+        self.browserSuspiciousThrottle = browserSuspiciousThrottle
+        self.browserIdleThrottle = browserIdleThrottle
+        self.appleScriptThrottle = appleScriptThrottle
+    }
+
+    func decision(
+        trigger: MeetingDetectionTrigger,
+        state: MeetingSignalRefreshState,
+        now: Date
+    ) -> MeetingSignalRefreshDecision {
+        let suspicious = isSuspicious(trigger: trigger, state: state, now: now)
+        let mode: MeetingDetectionMode = suspicious ? .suspicious : .idle
+        let fallbackInterval = suspicious ? suspiciousFallbackInterval : idleFallbackInterval
+
+        return MeetingSignalRefreshDecision(
+            mode: mode,
+            refreshAudioAttribution: shouldRefreshAudioAttribution(trigger: trigger, state: state, mode: mode, now: now),
+            refreshBrowserMeetings: shouldRefreshBrowserMeetings(trigger: trigger, state: state, mode: mode, now: now),
+            fallbackInterval: fallbackInterval,
+            debounceDelay: shouldDebounce(trigger) ? debounceDelay : 0
+        )
+    }
+
+    func allowsAppleScript(for bundleID: String, state: MeetingSignalRefreshState, now: Date) -> Bool {
+        guard let lastAttempt = state.lastAppleScriptAttemptAtByBundleID[bundleID] else { return true }
+        return now.timeIntervalSince(lastAttempt) >= appleScriptThrottle
+    }
+
+    func suspicionDate(
+        after trigger: MeetingDetectionTrigger,
+        state: MeetingSignalRefreshState,
+        now: Date,
+        resolvedCandidate: MeetingCandidate?
+    ) -> Date? {
+        if resolvedCandidate != nil
+            || state.hasMicOrCameraSignal
+            || state.hasRecentBrowserMeeting
+            || state.hasPromptVisible
+            || state.hasCalendarEvent
+            || state.foregroundIsMeetingCapableApp
+            || isSuspicionTrigger(trigger) {
+            return now
+        }
+
+        guard let lastSuspicionAt = state.lastSuspicionAt,
+              now.timeIntervalSince(lastSuspicionAt) <= suspicionTTL else {
+            return nil
+        }
+        return lastSuspicionAt
+    }
+
+    private func isSuspicious(
+        trigger: MeetingDetectionTrigger,
+        state: MeetingSignalRefreshState,
+        now: Date
+    ) -> Bool {
+        if state.hasMicOrCameraSignal
+            || state.hasRecentBrowserMeeting
+            || state.hasActiveCandidate
+            || state.hasPromptVisible
+            || state.hasCalendarEvent
+            || state.foregroundIsMeetingCapableApp
+            || isSuspicionTrigger(trigger) {
+            return true
+        }
+
+        guard let lastSuspicionAt = state.lastSuspicionAt else { return false }
+        return now.timeIntervalSince(lastSuspicionAt) <= suspicionTTL
+    }
+
+    private func shouldRefreshAudioAttribution(
+        trigger: MeetingDetectionTrigger,
+        state: MeetingSignalRefreshState,
+        mode: MeetingDetectionMode,
+        now: Date
+    ) -> Bool {
+        if trigger == .startup || trigger == .micChanged || trigger == .sensorAttributionChanged {
+            return isThrottleExpired(since: state.lastAudioAttributionRefreshAt, throttle: 0, now: now)
+        }
+
+        let throttle = mode == .suspicious ? audioSuspiciousThrottle : audioIdleThrottle
+        guard mode == .suspicious || trigger == .fallbackTimer || trigger == .manualRefresh else {
+            return false
+        }
+        return isThrottleExpired(since: state.lastAudioAttributionRefreshAt, throttle: throttle, now: now)
+    }
+
+    private func shouldRefreshBrowserMeetings(
+        trigger: MeetingDetectionTrigger,
+        state: MeetingSignalRefreshState,
+        mode: MeetingDetectionMode,
+        now: Date
+    ) -> Bool {
+        if trigger == .startup || trigger == .workspaceActivated || trigger == .calendarChanged {
+            return isThrottleExpired(since: state.lastBrowserRefreshAt, throttle: 0, now: now)
+        }
+
+        let throttle = mode == .suspicious ? browserSuspiciousThrottle : browserIdleThrottle
+        guard mode == .suspicious || trigger == .fallbackTimer || trigger == .manualRefresh else {
+            return false
+        }
+        return isThrottleExpired(since: state.lastBrowserRefreshAt, throttle: throttle, now: now)
+    }
+
+    private func isThrottleExpired(since date: Date?, throttle: TimeInterval, now: Date) -> Bool {
+        guard let date else { return true }
+        return now.timeIntervalSince(date) >= throttle
+    }
+
+    private func shouldDebounce(_ trigger: MeetingDetectionTrigger) -> Bool {
+        switch trigger {
+        case .fallbackTimer, .startup:
+            return false
+        case .micChanged, .cameraChanged, .sensorAttributionChanged, .workspaceActivated,
+             .calendarChanged, .promptStateChanged, .manualRefresh:
+            return true
+        }
+    }
+
+    private func isSuspicionTrigger(_ trigger: MeetingDetectionTrigger) -> Bool {
+        switch trigger {
+        case .micChanged, .cameraChanged, .sensorAttributionChanged, .calendarChanged:
+            return true
+        case .startup, .fallbackTimer, .workspaceActivated, .promptStateChanged, .manualRefresh:
+            return false
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -129,6 +129,8 @@ final class MuesliController: NSObject {
     private var calendarCheckTimer: Timer?
     private var meetingStartingNowTimers = [String: Timer]()
     private var notifiedUpcomingEventIDs = Set<String>()
+    private var meetingFeatureMonitorsAllowed = false
+    private var meetingDetectionMonitorStarted = false
 
     private var searchTask: Task<Void, Never>?
     private var onboardingModelPreparationTask: Task<Void, Never>?
@@ -259,6 +261,7 @@ final class MuesliController: NSObject {
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         let canRunMainApp = config.hasCompletedOnboarding
             && hasRequiredStartupPermissions(for: config.resolvedOnboardingUseCase)
+        meetingFeatureMonitorsAllowed = canRunMainApp
 
         // Defer permission-triggering monitors until after onboarding
         if canRunMainApp && config.resolvedOnboardingUseCase.includesPushToTalk {
@@ -368,7 +371,7 @@ final class MuesliController: NSObject {
         }
 
         // Defer permission-triggering monitors until after onboarding
-        if canRunMainApp && config.resolvedOnboardingUseCase.includesMeetings {
+        if canRunMainApp && shouldRunMeetingFeatureMonitors {
             startMeetingFeatureMonitors(includeMaraudersMap: true)
         }
 
@@ -436,7 +439,9 @@ final class MuesliController: NSObject {
         calendarMonitor.stop()
         meetingStartingNowTimers.values.forEach { $0.invalidate() }
         meetingStartingNowTimers.removeAll()
+        meetingFeatureMonitorsAllowed = false
         meetingMonitor.stop()
+        meetingDetectionMonitorStarted = false
         dismissPresentedMeetingDetection()
         meetingNotification.close()
         activeMeetingSession?.discard()
@@ -698,6 +703,7 @@ final class MuesliController: NSObject {
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
+        syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
     }
 
@@ -1085,6 +1091,7 @@ final class MuesliController: NSObject {
                 self.refreshAvailableEventKitCalendars()
                 await self.refreshUpcomingCalendarEvents()
                 self.checkUpcomingCalendarNotifications()
+                self.meetingMonitor.refreshState(trigger: .calendarChanged)
             }
         }
 
@@ -1100,6 +1107,7 @@ final class MuesliController: NSObject {
             Task { @MainActor in
                 await self.refreshUpcomingCalendarEvents()
                 self.checkUpcomingCalendarNotifications()
+                self.meetingMonitor.refreshState(trigger: .calendarChanged)
             }
         }
 
@@ -1108,6 +1116,7 @@ final class MuesliController: NSObject {
             self.refreshAvailableEventKitCalendars()
             await self.refreshUpcomingCalendarEvents()
             self.checkUpcomingCalendarNotifications()
+            self.meetingMonitor.refreshState(trigger: .calendarChanged)
         }
     }
 
@@ -1121,7 +1130,26 @@ final class MuesliController: NSObject {
         if includeMaraudersMap, config.maraudersMapUnlocked {
             startMaraudersMapMonitoring()
         }
-        meetingMonitor.start()
+        syncMeetingDetectionMonitor()
+    }
+
+    private var shouldRunMeetingFeatureMonitors: Bool {
+        config.showMeetingDetectionNotification
+            || config.showScheduledMeetingNotifications
+            || config.autoRecordMeetings
+    }
+
+    private func syncMeetingDetectionMonitor() {
+        let shouldRun = meetingFeatureMonitorsAllowed
+            && config.showMeetingDetectionNotification
+        if shouldRun && !meetingDetectionMonitorStarted {
+            meetingMonitor.start()
+            meetingDetectionMonitorStarted = true
+        } else if !shouldRun && meetingDetectionMonitorStarted {
+            meetingMonitor.stop()
+            meetingDetectionMonitorStarted = false
+            dismissPresentedMeetingDetection()
+        }
     }
 
     /// Check all upcoming calendar events (EventKit + Google) for events starting within 5 minutes.
@@ -1609,12 +1637,13 @@ final class MuesliController: NSObject {
         onboardingWindowController?.close()
         onboardingWindowController = nil
         if hasRequiredStartupPermissions(for: onboardingUseCase) {
+            meetingFeatureMonitorsAllowed = true
             if onboardingUseCase.includesPushToTalk {
                 hotkeyMonitor.start()
                 startComputerUseHotkeyMonitorIfNeeded()
             }
             // Start monitors that were deferred during onboarding
-            if onboardingUseCase.includesMeetings {
+            if shouldRunMeetingFeatureMonitors {
                 startMeetingFeatureMonitors(includeMaraudersMap: false)
             }
             TelemetryDeck.signal("onboarding.completed", parameters: [

--- a/native/MuesliNative/Sources/MuesliNativeApp/RunningApplicationStore.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RunningApplicationStore.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Foundation
+
+struct RunningApplicationState {
+    let runningApps: [RunningAppSnapshot]
+    let foregroundBundleID: String?
+}
+
+@MainActor
+final class RunningApplicationStore {
+    var onChanged: ((MeetingDetectionTrigger) -> Void)?
+
+    private var observers: [NSObjectProtocol] = []
+    private var runningApps: [RunningAppSnapshot] = []
+    private var foregroundBundleID: String?
+    private var isStarted = false
+
+    func start() {
+        guard !isStarted else { return }
+        isStarted = true
+        refreshState()
+
+        let notificationCenter = NSWorkspace.shared.notificationCenter
+        observers.append(notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshState()
+                self?.onChanged?(.workspaceActivated)
+            }
+        })
+
+        observers.append(notificationCenter.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshState()
+                self?.onChanged?(.workspaceActivated)
+            }
+        })
+
+        observers.append(notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshState()
+                self?.onChanged?(.workspaceActivated)
+            }
+        })
+    }
+
+    func stop() {
+        guard isStarted else { return }
+        isStarted = false
+        let notificationCenter = NSWorkspace.shared.notificationCenter
+        observers.forEach { notificationCenter.removeObserver($0) }
+        observers.removeAll()
+        runningApps.removeAll()
+        foregroundBundleID = nil
+    }
+
+    func snapshot() -> RunningApplicationState {
+        RunningApplicationState(
+            runningApps: runningApps,
+            foregroundBundleID: foregroundBundleID
+        )
+    }
+
+    private func refreshState() {
+        runningApps = NSWorkspace.shared.runningApplications.compactMap { app in
+            guard let bundleID = app.bundleIdentifier else { return nil }
+            return RunningAppSnapshot(
+                bundleID: bundleID,
+                appName: app.localizedName ?? MeetingCandidateResolver.browserApps[bundleID] ?? bundleID,
+                processIdentifier: app.processIdentifier,
+                isActive: app.isActive
+            )
+        }
+        foregroundBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("BrowserMeetingActivityCollector")
+struct BrowserMeetingActivityCollectorTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func chrome(isActive: Bool) -> RunningAppSnapshot {
+        RunningAppSnapshot(
+            bundleID: "com.google.Chrome",
+            appName: "Chrome",
+            processIdentifier: 1234,
+            isActive: isActive
+        )
+    }
+
+    @Test("refresh probes inactive uncached browsers")
+    func refreshProbesInactiveUncachedBrowsers() async {
+        let collector = BrowserMeetingActivityCollector(
+            focusedDocumentURLProvider: { app in
+                app.bundleID == "com.google.Chrome" ? "https://meet.google.com/pwm-txwq-txy" : nil
+            }
+        )
+
+        let meetings = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(meetings.first?.isFocused == false)
+    }
+
+    @Test("refresh clears stale cached room when browser no longer reports a meeting URL")
+    func refreshClearsStaleCachedRoom() async {
+        var focusedURL: String? = "https://meet.google.com/pwm-txwq-txy"
+        let collector = BrowserMeetingActivityCollector(
+            focusedDocumentURLProvider: { _ in focusedURL }
+        )
+
+        let first = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        focusedURL = nil
+        let second = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now.addingTimeInterval(1),
+            shouldAttemptAppleScript: { _ in false }
+        )
+        let cachedAfterFailedRefresh = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: false,
+            now: now.addingTimeInterval(2),
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        #expect(first.count == 1)
+        #expect(second.isEmpty)
+        #expect(cachedAfterFailedRefresh.isEmpty)
+    }
+
+    @Test("non-refresh pass can reuse recent cached browser room")
+    func nonRefreshPassCanReuseRecentCachedRoom() async {
+        var focusedURL: String? = "https://meet.google.com/pwm-txwq-txy"
+        let collector = BrowserMeetingActivityCollector(
+            focusedDocumentURLProvider: { _ in focusedURL }
+        )
+
+        _ = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        focusedURL = nil
+        let cached = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: false,
+            now: now.addingTimeInterval(1),
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        #expect(cached.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(cached.first?.isFocused == false)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -67,6 +67,72 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterFailedRefresh.isEmpty)
     }
 
+    @Test("refresh preserves cache when AppleScript probe is throttled")
+    func refreshPreservesCacheWhenAppleScriptProbeIsThrottled() async {
+        var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
+        let collector = BrowserMeetingActivityCollector(
+            activeBrowserURLProvider: { _ in activeTabURL }
+        )
+
+        let first = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in true }
+        )
+
+        activeTabURL = nil
+        let second = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now.addingTimeInterval(1),
+            shouldAttemptAppleScript: { _ in false }
+        )
+        let cachedAfterSkippedRefresh = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: false,
+            now: now.addingTimeInterval(2),
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        #expect(first.count == 1)
+        #expect(second.isEmpty)
+        #expect(cachedAfterSkippedRefresh.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+    }
+
+    @Test("refresh clears cache when AppleScript probe runs and finds no meeting URL")
+    func refreshClearsCacheWhenAppleScriptProbeFindsNoMeetingURL() async {
+        var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
+        let collector = BrowserMeetingActivityCollector(
+            activeBrowserURLProvider: { _ in activeTabURL }
+        )
+
+        let first = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in true }
+        )
+
+        activeTabURL = "https://example.com"
+        let second = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now.addingTimeInterval(1),
+            shouldAttemptAppleScript: { _ in true }
+        )
+        let cachedAfterFailedRefresh = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: false,
+            now: now.addingTimeInterval(2),
+            shouldAttemptAppleScript: { _ in false }
+        )
+
+        #expect(first.count == 1)
+        #expect(second.isEmpty)
+        #expect(cachedAfterFailedRefresh.isEmpty)
+    }
+
     @Test("non-refresh pass can reuse recent cached browser room")
     func nonRefreshPassCanReuseRecentCachedRoom() async {
         var focusedURL: String? = "https://meet.google.com/pwm-txwq-txy"

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMediaSessionTrackerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMediaSessionTrackerTests.swift
@@ -25,12 +25,16 @@ struct MeetingMediaSessionTrackerTests {
         )
     }
 
-    private func browserURLCandidate(now: Date) -> MeetingCandidate {
+    private func browserURLCandidate(
+        id: String = "googleMeet:meet.google.com/pwm-txwq-txy",
+        url: String = "meet.google.com/pwm-txwq-txy",
+        now: Date
+    ) -> MeetingCandidate {
         MeetingCandidate(
-            id: "googleMeet:meet.google.com/pwm-txwq-txy",
+            id: id,
             platform: .googleMeet,
             appName: "Chrome",
-            url: "meet.google.com/pwm-txwq-txy",
+            url: url,
             evidence: [.browserURL, .audioInputProcess],
             startedAt: now,
             meetingTitle: nil,
@@ -68,7 +72,7 @@ struct MeetingMediaSessionTrackerTests {
             snapshot: snapshot(now: now.addingTimeInterval(10))
         )
 
-        #expect(first?.id == "meeting-session:browser:com.google.Chrome:1800000000")
+        #expect(first?.id == "meeting-session:browser:com.google.Chrome:room:meet.google.com/pwm-txwq-txy:1800000000")
         #expect(second?.id == first?.id)
         #expect(second?.suppressionID == first?.suppressionID)
         #expect(second?.platform == .googleMeet)
@@ -89,9 +93,37 @@ struct MeetingMediaSessionTrackerTests {
             snapshot: snapshot(now: now.addingTimeInterval(45))
         )
 
-        #expect(first?.id == "meeting-session:browser:com.google.Chrome:1800000000")
-        #expect(later?.id == "meeting-session:browser:com.google.Chrome:1800000045")
+        #expect(first?.id == "meeting-session:browser:com.google.Chrome:room:meet.google.com/pwm-txwq-txy:1800000000")
+        #expect(later?.id == "meeting-session:browser:com.google.Chrome:room:meet.google.com/pwm-txwq-txy:1800000045")
         #expect(later?.id != first?.id)
+    }
+
+    @Test("different browser rooms in the quiet window get different media sessions")
+    func differentBrowserRoomsGetDifferentSessions() async {
+        let tracker = MeetingMediaSessionTracker(quietWindow: 30)
+
+        let first = await tracker.stabilize(
+            candidate: browserURLCandidate(now: now),
+            snapshot: snapshot(now: now)
+        )
+        let second = await tracker.stabilize(
+            candidate: browserURLCandidate(
+                id: "googleMeet:meet.google.com/abc-defg-hij",
+                url: "meet.google.com/abc-defg-hij",
+                now: now.addingTimeInterval(10)
+            ),
+            snapshot: snapshot(now: now.addingTimeInterval(10))
+        )
+        let genericAfterSecondRoom = await tracker.stabilize(
+            candidate: browserAudioCandidate(now: now.addingTimeInterval(11)),
+            snapshot: snapshot(now: now.addingTimeInterval(11))
+        )
+
+        #expect(first?.id == "meeting-session:browser:com.google.Chrome:room:meet.google.com/pwm-txwq-txy:1800000000")
+        #expect(second?.id == "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1800000010")
+        #expect(second?.id != first?.id)
+        #expect(genericAfterSecondRoom?.id == second?.id)
+        #expect(genericAfterSecondRoom?.url == "meet.google.com/abc-defg-hij")
     }
 
     @Test("non-media browser URL candidate keeps original identity")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMediaSessionTrackerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMediaSessionTrackerTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingMediaSessionTracker")
+struct MeetingMediaSessionTrackerTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func snapshot(
+        browserMeetings: [BrowserMeetingContext] = [],
+        audioInputProcesses: [AudioProcessActivity] = [],
+        now: Date
+    ) -> MeetingSignalSnapshot {
+        MeetingSignalSnapshot(
+            micActive: false,
+            cameraActive: false,
+            calendarEvent: nil,
+            runningApps: [
+                RunningAppInfo(bundleID: "com.google.Chrome", isActive: true),
+            ],
+            browserMeetings: browserMeetings,
+            audioInputProcesses: audioInputProcesses,
+            foregroundBundleID: "com.google.Chrome",
+            now: now
+        )
+    }
+
+    private func browserURLCandidate(now: Date) -> MeetingCandidate {
+        MeetingCandidate(
+            id: "googleMeet:meet.google.com/pwm-txwq-txy",
+            platform: .googleMeet,
+            appName: "Chrome",
+            url: "meet.google.com/pwm-txwq-txy",
+            evidence: [.browserURL, .audioInputProcess],
+            startedAt: now,
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 9876,
+            suppressionID: "browser:com.google.Chrome:session:1800000000"
+        )
+    }
+
+    private func browserAudioCandidate(now: Date) -> MeetingCandidate {
+        MeetingCandidate(
+            id: "browser:com.google.Chrome:session:\(Int(now.timeIntervalSince1970))",
+            platform: .unknown,
+            appName: "Chrome",
+            url: nil,
+            evidence: [.audioInputProcess],
+            startedAt: now,
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 9876,
+            suppressionID: "browser:com.google.Chrome:session:\(Int(now.timeIntervalSince1970))"
+        )
+    }
+
+    @Test("browser URL and generic browser audio candidates share a stable media session")
+    func browserURLAndGenericAudioShareSession() async {
+        let tracker = MeetingMediaSessionTracker(quietWindow: 30)
+
+        let first = await tracker.stabilize(
+            candidate: browserURLCandidate(now: now),
+            snapshot: snapshot(now: now)
+        )
+        let second = await tracker.stabilize(
+            candidate: browserAudioCandidate(now: now.addingTimeInterval(10)),
+            snapshot: snapshot(now: now.addingTimeInterval(10))
+        )
+
+        #expect(first?.id == "meeting-session:browser:com.google.Chrome:1800000000")
+        #expect(second?.id == first?.id)
+        #expect(second?.suppressionID == first?.suppressionID)
+        #expect(second?.platform == .googleMeet)
+        #expect(second?.url == "meet.google.com/pwm-txwq-txy")
+        #expect(second?.evidence.contains(.browserURL) == true)
+    }
+
+    @Test("browser media session expires after quiet window")
+    func browserSessionExpiresAfterQuietWindow() async {
+        let tracker = MeetingMediaSessionTracker(quietWindow: 30)
+
+        let first = await tracker.stabilize(
+            candidate: browserURLCandidate(now: now),
+            snapshot: snapshot(now: now)
+        )
+        let later = await tracker.stabilize(
+            candidate: browserURLCandidate(now: now.addingTimeInterval(45)),
+            snapshot: snapshot(now: now.addingTimeInterval(45))
+        )
+
+        #expect(first?.id == "meeting-session:browser:com.google.Chrome:1800000000")
+        #expect(later?.id == "meeting-session:browser:com.google.Chrome:1800000045")
+        #expect(later?.id != first?.id)
+    }
+
+    @Test("non-media browser URL candidate keeps original identity")
+    func nonMediaBrowserCandidateKeepsOriginalIdentity() async {
+        let tracker = MeetingMediaSessionTracker(quietWindow: 30)
+        let candidate = MeetingCandidate(
+            id: "googleMeet:meet.google.com/pwm-txwq-txy",
+            platform: .googleMeet,
+            appName: "Chrome",
+            url: "meet.google.com/pwm-txwq-txy",
+            evidence: [.browserURL, .foregroundApp],
+            startedAt: now,
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 9876
+        )
+
+        let result = await tracker.stabilize(
+            candidate: candidate,
+            snapshot: snapshot(now: now)
+        )
+
+        #expect(result?.id == candidate.id)
+        #expect(result?.suppressionID == candidate.id)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
@@ -217,6 +217,24 @@ struct MeetingPromptStateMachineTests {
         #expect(result.reason == .autoDismissedSuppression)
     }
 
+    @Test("browser media session auto-dismiss suppression does not expire while session is stable")
+    func browserMediaSessionAutoDismissSuppressionDoesNotExpire() {
+        let machine = immediateMachine()
+        let candidate = candidate(
+            "meeting-session:browser:com.google.Chrome:1800000000",
+            suppressionID: "meeting-session:browser:com.google.Chrome:1800000000",
+            evidence: [.micActive, .audioInputProcess, .browserURL]
+        )
+
+        machine.markShown(candidate)
+        machine.markAutoDismissed(candidate, now: now)
+
+        let result = decision(machine, candidate: candidate, now: now.addingTimeInterval(3_600))
+
+        #expect(result.action == .none)
+        #expect(result.reason == .autoDismissedSuppression)
+    }
+
     @Test("prompt does not show while recording or starting recording")
     func promptBlockedDuringRecordingStates() {
         let machine = immediateMachine()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingSignalRefreshPolicy")
+struct MeetingSignalRefreshPolicyTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("idle fallback skips expensive collectors")
+    func idleFallbackSkipsExpensiveCollectors() {
+        let policy = MeetingSignalRefreshPolicy()
+        let state = MeetingSignalRefreshState(
+            lastAudioAttributionRefreshAt: now.addingTimeInterval(-10),
+            lastBrowserRefreshAt: now.addingTimeInterval(-10)
+        )
+
+        let decision = policy.decision(trigger: .fallbackTimer, state: state, now: now)
+
+        #expect(decision.mode == .idle)
+        #expect(decision.fallbackInterval == 120)
+        #expect(decision.refreshAudioAttribution == false)
+        #expect(decision.refreshBrowserMeetings == false)
+    }
+
+    @Test("mic trigger enters suspicion and allows immediate audio attribution")
+    func micTriggerAllowsImmediateAudioAttribution() {
+        let policy = MeetingSignalRefreshPolicy()
+        let state = MeetingSignalRefreshState(
+            lastAudioAttributionRefreshAt: now,
+            lastBrowserRefreshAt: now
+        )
+
+        let decision = policy.decision(trigger: .micChanged, state: state, now: now)
+
+        #expect(decision.mode == .suspicious)
+        #expect(decision.fallbackInterval == 3)
+        #expect(decision.refreshAudioAttribution == true)
+    }
+
+    @Test("repeated suspicious fallback respects expensive collector throttle")
+    func repeatedSuspiciousFallbackRespectsThrottle() {
+        let policy = MeetingSignalRefreshPolicy()
+        let state = MeetingSignalRefreshState(
+            lastAudioAttributionRefreshAt: now.addingTimeInterval(-4),
+            lastBrowserRefreshAt: now.addingTimeInterval(-1),
+            lastSuspicionAt: now.addingTimeInterval(-2)
+        )
+
+        let decision = policy.decision(trigger: .fallbackTimer, state: state, now: now)
+
+        #expect(decision.mode == .suspicious)
+        #expect(decision.refreshAudioAttribution == false)
+        #expect(decision.refreshBrowserMeetings == false)
+    }
+
+    @Test("suspicious fallback refreshes collectors after throttle expires")
+    func suspiciousFallbackRefreshesAfterThrottle() {
+        let policy = MeetingSignalRefreshPolicy()
+        let state = MeetingSignalRefreshState(
+            lastAudioAttributionRefreshAt: now.addingTimeInterval(-9),
+            lastBrowserRefreshAt: now.addingTimeInterval(-4),
+            lastSuspicionAt: now.addingTimeInterval(-2)
+        )
+
+        let decision = policy.decision(trigger: .fallbackTimer, state: state, now: now)
+
+        #expect(decision.mode == .suspicious)
+        #expect(decision.refreshAudioAttribution == true)
+        #expect(decision.refreshBrowserMeetings == true)
+    }
+
+    @Test("AppleScript fallback is throttled per browser bundle")
+    func appleScriptFallbackIsThrottledPerBundle() {
+        let policy = MeetingSignalRefreshPolicy()
+        var state = MeetingSignalRefreshState()
+        state.lastAppleScriptAttemptAtByBundleID = [
+            "com.google.Chrome": now.addingTimeInterval(-10),
+            "com.apple.Safari": now.addingTimeInterval(-16),
+        ]
+
+        #expect(policy.allowsAppleScript(for: "com.google.Chrome", state: state, now: now) == false)
+        #expect(policy.allowsAppleScript(for: "com.apple.Safari", state: state, now: now) == true)
+        #expect(policy.allowsAppleScript(for: "com.brave.Browser", state: state, now: now) == true)
+    }
+
+    @Test("suspicion expires back to idle after TTL")
+    func suspicionExpiresBackToIdle() {
+        let policy = MeetingSignalRefreshPolicy()
+        let state = MeetingSignalRefreshState(
+            lastAudioAttributionRefreshAt: now.addingTimeInterval(-40),
+            lastBrowserRefreshAt: now.addingTimeInterval(-40),
+            lastSuspicionAt: now.addingTimeInterval(-13)
+        )
+
+        let decision = policy.decision(trigger: .fallbackTimer, state: state, now: now)
+
+        #expect(decision.mode == .idle)
+        #expect(decision.fallbackInterval == 120)
+    }
+
+    @Test("active candidate keeps suspicious mode")
+    func activeCandidateKeepsSuspiciousMode() {
+        let policy = MeetingSignalRefreshPolicy()
+        var state = MeetingSignalRefreshState()
+        state.hasActiveCandidate = true
+
+        let decision = policy.decision(trigger: .fallbackTimer, state: state, now: now)
+
+        #expect(decision.mode == .suspicious)
+        #expect(decision.fallbackInterval == 3)
+    }
+}


### PR DESCRIPTION
## Summary

Refactors meeting detection away from a fixed full-scan polling loop toward an adaptive, event-first monitor with stable media-session identity.

Key changes:
- Replaces the fixed 3s polling spine with adaptive trigger-based evaluation and idle/suspicious fallback intervals.
- Splits cheap cached signals from throttled expensive collectors for audio attribution and browser URL probing.
- Adds `MeetingSignalRefreshPolicy` to keep refresh decisions pure and testable.
- Adds `RunningApplicationStore` so running-app state is updated from workspace events instead of fetched on every pass.
- Adds `MeetingMediaSessionTracker` so media-backed detections keep a stable `meeting-session:...` identity across browser URL/focus churn.
- Keeps prompt dismissal/suppression attached to the stable meeting session, so dismissed Meet/Slack prompts do not reappear during the same active media session.
- Makes meeting detection lifecycle follow the meeting notification setting rather than requiring a meetings-specific onboarding path.
- Moves the meeting notification close button just outside the top-left card edge, matching the intended Zoom-like visual treatment.

## Why

The previous detector could do too much work on the app/UI path and could mutate candidate identity when browser URL context disappeared. For example, a Google Meet candidate could become a generic Chrome-audio candidate after focus/tab changes, causing prompt suppression to miss and the notification to reappear.

This change makes media ownership the stable backbone, then treats URL/title/calendar/app context as enrichment.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter 'Meeting(MediaSessionTracker|PromptStateMachine|CandidateResolver|SignalRefreshPolicy)'`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter 'MeetingNotificationController|MeetingMediaSessionTracker|MeetingPromptStateMachine'`
- `git diff --check`
- Rebuilt and launched `/Applications/MuesliDev.app` with `MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" ./scripts/dev-test.sh`

## Notes

This PR intentionally does not change transcription, recording, summarization, or calendar settings UI behavior.