### PR TITLE
[codex] Fix meeting helper preload for onboarding use cases

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -85,6 +85,8 @@ final class AppState {
     // Live status
     var isMeetingRecording: Bool = false
     var isMeetingRecordingPaused: Bool = false
+    var isMeetingStarting: Bool = false
+    var meetingStartStatus: String?
     var dictationState: DictationState = .idle
     var isVoiceNoteRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -69,14 +69,6 @@ struct MeetingDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     header(meeting)
 
-                    if appState.isMeetingStarting {
-                        MeetingPreparationBanner(status: appState.meetingStartStatus)
-                            .frame(maxWidth: 980, alignment: .leading)
-                            .padding(.horizontal, 40)
-                            .padding(.bottom, 20)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                    }
-
                     Divider()
                         .background(MuesliTheme.surfaceBorder)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -69,6 +69,14 @@ struct MeetingDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     header(meeting)
 
+                    if appState.isMeetingStarting {
+                        MeetingPreparationBanner(status: appState.meetingStartStatus)
+                            .frame(maxWidth: 980, alignment: .leading)
+                            .padding(.horizontal, 40)
+                            .padding(.bottom, 20)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+
                     Divider()
                         .background(MuesliTheme.surfaceBorder)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreparationBanner.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreparationBanner.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct MeetingPreparationBanner: View {
+    let status: String?
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 18, height: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Preparing meeting")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(status ?? "Loading transcription, VAD, and speaker diarization...")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: MuesliTheme.spacing12)
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreparationBanner.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreparationBanner.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MeetingPreparationBanner: View {
     let status: String?
+    let onCancel: () -> Void
 
     var body: some View {
         HStack(spacing: MuesliTheme.spacing12) {
@@ -20,6 +21,14 @@ struct MeetingPreparationBanner: View {
             }
 
             Spacer(minLength: MuesliTheme.spacing12)
+
+            Button(action: onCancel) {
+                Label("Cancel", systemImage: "xmark.circle")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .help("Cancel meeting preparation")
         }
         .padding(MuesliTheme.spacing12)
         .background(MuesliTheme.backgroundRaised)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreparationBanner.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreparationBanner.swift
@@ -9,6 +9,7 @@ struct MeetingPreparationBanner: View {
             ProgressView()
                 .controlSize(.small)
                 .frame(width: 18, height: 18)
+                .accessibilityLabel("Preparing meeting")
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Preparing meeting")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -203,6 +203,10 @@ struct MeetingsView: View {
                     comingUpSection
                 }
 
+                if appState.isMeetingStarting {
+                    MeetingPreparationBanner(status: appState.meetingStartStatus)
+                }
+
                 if let activeLiveMeeting {
                     activeMeetingBanner(activeLiveMeeting)
                 }
@@ -375,7 +379,9 @@ struct MeetingsView: View {
 
                                 Spacer()
 
-                                if let meetingURL = event.meetingURL, !appState.isMeetingRecording {
+                                if let meetingURL = event.meetingURL,
+                                   !appState.isMeetingRecording,
+                                   !appState.isMeetingStarting {
                                     Button {
                                         controller.joinAndRecord(title: event.title, meetingURL: meetingURL, endDate: event.endDate)
                                     } label: {
@@ -532,11 +538,11 @@ struct MeetingsView: View {
                 .foregroundStyle(MuesliTheme.backgroundBase)
                 .padding(.horizontal, MuesliTheme.spacing12)
                 .padding(.vertical, 8)
-                .background(appState.isMeetingRecording ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
+                .background(appState.isMeetingRecording || appState.isMeetingStarting ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
                 .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
             .buttonStyle(.plain)
-            .disabled(appState.isMeetingRecording)
+            .disabled(appState.isMeetingRecording || appState.isMeetingStarting)
             .help("Start a quick meeting note")
             .fixedSize()
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -204,7 +204,10 @@ struct MeetingsView: View {
                 }
 
                 if appState.isMeetingStarting {
-                    MeetingPreparationBanner(status: appState.meetingStartStatus)
+                    MeetingPreparationBanner(
+                        status: appState.meetingStartStatus,
+                        onCancel: { controller.cancelMeetingPreparation() }
+                    )
                 }
 
                 if let activeLiveMeeting {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -776,8 +776,10 @@ struct AppConfig: Codable {
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding
-        if c.contains(.onboardingUseCase) {
-            onboardingUseCase = OnboardingUseCase.resolved(try? c.decode(String.self, forKey: .onboardingUseCase)).rawValue
+        let decodedOnboardingUseCase = try? c.decode(String.self, forKey: .onboardingUseCase)
+        if let decodedOnboardingUseCase,
+           OnboardingUseCase(rawValue: decodedOnboardingUseCase) != nil {
+            onboardingUseCase = decodedOnboardingUseCase
         } else if hasCompletedOnboarding {
             onboardingUseCase = OnboardingUseCase.dictationAndMeetings.rawValue
         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -776,7 +776,13 @@ struct AppConfig: Codable {
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding
-        onboardingUseCase = OnboardingUseCase.resolved(try? c.decode(String.self, forKey: .onboardingUseCase)).rawValue
+        if c.contains(.onboardingUseCase) {
+            onboardingUseCase = OnboardingUseCase.resolved(try? c.decode(String.self, forKey: .onboardingUseCase)).rawValue
+        } else if hasCompletedOnboarding {
+            onboardingUseCase = OnboardingUseCase.dictationAndMeetings.rawValue
+        } else {
+            onboardingUseCase = defaults.onboardingUseCase
+        }
         userName = (try? c.decode(String.self, forKey: .userName)) ?? defaults.userName
         customMeetingTemplates = (try? c.decode([CustomMeetingTemplate].self, forKey: .customMeetingTemplates)) ?? defaults.customMeetingTemplates
         customWords = (try? c.decode([CustomWord].self, forKey: .customWords)) ?? defaults.customWords

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -184,6 +184,8 @@ final class MuesliController: NSObject {
     private var activeMeetingCalendarEndDate: Date?
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
+    private var meetingStartTask: Task<Void, Never>?
+    private var meetingStartMeetingID: Int64?
 
     init(
         runtime: RuntimePaths,
@@ -2482,6 +2484,9 @@ final class MuesliController: NSObject {
 
         activeMeetingSession?.discard()
         activeMeetingSession = nil
+        meetingStartTask?.cancel()
+        meetingStartTask = nil
+        meetingStartMeetingID = nil
         isStartingMeetingRecording = false
         isStoppingMeetingRecording = false
         endMeetingActivity()
@@ -2580,47 +2585,58 @@ final class MuesliController: NSObject {
             return false
         }
         isStartingMeetingRecording = true
+        meetingStartMeetingID = meetingID
         updateMeetingStartStatus("Preparing meeting transcription...")
         beginMeetingActivity(reason: "Recording and transcribing a meeting")
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
         updateMeetingNotificationVisibility()
 
-        Task { @MainActor [weak self] in
+        meetingStartTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
+                try Task.checkCancellation()
                 try await self.startMeetingRecordingWithSystemAudioRecovery(title: title, calendarEventID: calendarEventID, meetingID: meetingID)
+            } catch is CancellationError {
+                if self.meetingStartMeetingID == meetingID {
+                    self.resolveLiveMeetingAfterStartFailure(id: meetingID)
+                    self.meetingMonitor.resumeAfterCooldown()
+                    self.meetingMonitor.refreshState()
+                    self.statusBarController?.setStatus("Idle")
+                    self.statusBarController?.refresh()
+                    self.setState(.idle)
+                    self.endMeetingActivity()
+                }
             } catch {
-                fputs("[muesli-native] failed to start meeting: \(error)\n", stderr)
-                self.resolveLiveMeetingAfterStartFailure(id: meetingID)
-                self.meetingMonitor.resumeAfterCooldown()
-                self.meetingMonitor.refreshState()
-                self.statusBarController?.setStatus("Idle")
-                self.statusBarController?.refresh()
-                self.setState(.idle)
-                self.endMeetingActivity()
+                if self.meetingStartMeetingID == meetingID {
+                    fputs("[muesli-native] failed to start meeting: \(error)\n", stderr)
+                    self.resolveLiveMeetingAfterStartFailure(id: meetingID)
+                    self.meetingMonitor.resumeAfterCooldown()
+                    self.meetingMonitor.refreshState()
+                    self.statusBarController?.setStatus("Idle")
+                    self.statusBarController?.refresh()
+                    self.setState(.idle)
+                    self.endMeetingActivity()
 
-                let isSystemAudioError = error is CoreAudioSystemRecorder.RecorderError
-                let alert = NSAlert()
-                alert.alertStyle = .warning
-                if isSystemAudioError {
-                    alert.messageText = "System audio capture failed"
-                    alert.informativeText = "Could not start system audio recording. Open System Settings > Privacy & Security > Screen & System Audio Recording and enable \(AppIdentity.displayName) under \"System Audio Recording Only\".\n\nError: \(error.localizedDescription)"
-                    alert.addButton(withTitle: "Open System Settings")
-                    alert.addButton(withTitle: "OK")
-                    if alert.runModal() == .alertFirstButtonReturn {
-                        CoreAudioSystemRecorder.openSystemAudioSettings()
+                    let isSystemAudioError = error is CoreAudioSystemRecorder.RecorderError
+                    let alert = NSAlert()
+                    alert.alertStyle = .warning
+                    if isSystemAudioError {
+                        alert.messageText = "System audio capture failed"
+                        alert.informativeText = "Could not start system audio recording. Open System Settings > Privacy & Security > Screen & System Audio Recording and enable \(AppIdentity.displayName) under \"System Audio Recording Only\".\n\nError: \(error.localizedDescription)"
+                        alert.addButton(withTitle: "Open System Settings")
+                        alert.addButton(withTitle: "OK")
+                        if alert.runModal() == .alertFirstButtonReturn {
+                            CoreAudioSystemRecorder.openSystemAudioSettings()
+                        }
+                    } else {
+                        alert.messageText = "Meeting failed to start"
+                        alert.informativeText = error.localizedDescription
+                        alert.runModal()
                     }
-                } else {
-                    alert.messageText = "Meeting failed to start"
-                    alert.informativeText = error.localizedDescription
-                    alert.runModal()
                 }
             }
-            self.isStartingMeetingRecording = false
-            self.updateMeetingStartStatus(nil)
-            self.updateMeetingNotificationVisibility()
-            self.syncAppState()
+            self.finishMeetingStartAttempt(meetingID: meetingID)
         }
         return true
     }
@@ -2629,17 +2645,48 @@ final class MuesliController: NSObject {
         startForegroundMeetingRecording(title: "Meeting")
     }
 
+    func cancelMeetingPreparation() {
+        guard isStartingMeetingRecording,
+              activeMeetingSession == nil,
+              let meetingID = meetingStartMeetingID else {
+            return
+        }
+        meetingStartTask?.cancel()
+        updateMeetingStartStatus("Canceling meeting start...")
+        resolveLiveMeetingAfterStartFailure(id: meetingID)
+        meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
+        statusBarController?.setStatus("Idle")
+        statusBarController?.refresh()
+        setState(.idle)
+        endMeetingActivity()
+        finishMeetingStartAttempt(meetingID: meetingID)
+    }
+
+    private func finishMeetingStartAttempt(meetingID: Int64) {
+        guard meetingStartMeetingID == meetingID else { return }
+        meetingStartTask = nil
+        meetingStartMeetingID = nil
+        isStartingMeetingRecording = false
+        updateMeetingStartStatus(nil)
+        updateMeetingNotificationVisibility()
+        syncAppState()
+    }
+
     private func startMeetingRecordingWithSystemAudioRecovery(title: String, calendarEventID: String?, meetingID: Int64) async throws {
         var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
         statusBarController?.setStatus("Preparing meeting transcription...")
         statusBarController?.refresh()
+        try Task.checkCancellation()
         try await transcriptionCoordinator.preloadRequired(
             backend: selectedMeetingTranscriptionBackend,
             enablePostProcessor: false,
             includeMeetingHelpers: true
         )
+        try Task.checkCancellation()
 
         while true {
+            try Task.checkCancellation()
             let meetingSession = MeetingSession(
                 title: title,
                 calendarEventID: calendarEventID,
@@ -2663,6 +2710,10 @@ final class MuesliController: NSObject {
                     }
                 }
                 try await meetingSession.start()
+                if Task.isCancelled {
+                    meetingSession.discard()
+                    throw CancellationError()
+                }
                 activeMeetingSession = meetingSession
                 activeMeetingID = meetingID
                 meetingMonitor.suppressWhileActive()
@@ -2683,10 +2734,12 @@ final class MuesliController: NSObject {
 
                 shouldRetryAfterPermissionRequest = false
                 meetingSession.discard()
+                try Task.checkCancellation()
                 updateMeetingStartStatus("Requesting system audio permission...")
                 statusBarController?.setStatus("Requesting system audio permission...")
                 statusBarController?.refresh()
                 let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
+                try Task.checkCancellation()
                 if granted {
                     updateMeetingStartStatus("Retrying meeting start...")
                     statusBarController?.setStatus("Retrying meeting start...")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -177,6 +177,7 @@ final class MuesliController: NSObject {
     private var workspaceObserver: NSObjectProtocol?
     private var dataDidChangeObserver: NSObjectProtocol?
     private var isStartingMeetingRecording = false
+    private var meetingStartStatus: String?
     private var isShowingCalendarNotification = false
     private var presentedMeetingCandidate: MeetingCandidate?
     private var meetingEndTimer: Timer?
@@ -551,6 +552,8 @@ final class MuesliController: NSObject {
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
         appState.isMeetingRecordingPaused = isMeetingRecordingPaused()
+        appState.isMeetingStarting = isStartingMeetingRecording
+        appState.meetingStartStatus = meetingStartStatus
         indicator.setMeetingRecordingPaused(appState.isMeetingRecordingPaused, config: config)
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
@@ -2567,6 +2570,7 @@ final class MuesliController: NSObject {
             return
         }
         isStartingMeetingRecording = true
+        updateMeetingStartStatus("Preparing meeting transcription...")
         beginMeetingActivity(reason: "Recording and transcribing a meeting")
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
@@ -2606,7 +2610,9 @@ final class MuesliController: NSObject {
                 }
             }
             self.isStartingMeetingRecording = false
+            self.updateMeetingStartStatus(nil)
             self.updateMeetingNotificationVisibility()
+            self.syncAppState()
         }
     }
 
@@ -2616,6 +2622,14 @@ final class MuesliController: NSObject {
 
     private func startMeetingRecordingWithSystemAudioRecovery(title: String, calendarEventID: String?, meetingID: Int64) async throws {
         var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
+        updateMeetingStartStatus("Preparing meeting transcription...")
+        statusBarController?.setStatus("Preparing meeting transcription...")
+        statusBarController?.refresh()
+        try await transcriptionCoordinator.preloadRequired(
+            backend: selectedMeetingTranscriptionBackend,
+            enablePostProcessor: false,
+            includeMeetingHelpers: true
+        )
 
         while true {
             let meetingSession = MeetingSession(
@@ -2661,10 +2675,12 @@ final class MuesliController: NSObject {
 
                 shouldRetryAfterPermissionRequest = false
                 meetingSession.discard()
+                updateMeetingStartStatus("Requesting system audio permission...")
                 statusBarController?.setStatus("Requesting system audio permission...")
                 statusBarController?.refresh()
                 let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
                 if granted {
+                    updateMeetingStartStatus("Retrying meeting start...")
                     statusBarController?.setStatus("Retrying meeting start...")
                     statusBarController?.refresh()
                     continue
@@ -3258,6 +3274,12 @@ final class MuesliController: NSObject {
             ],
             reason: reason
         )
+    }
+
+    private func updateMeetingStartStatus(_ status: String?) {
+        meetingStartStatus = status
+        appState.isMeetingStarting = isStartingMeetingRecording
+        appState.meetingStartStatus = status
     }
 
     private func endMeetingActivity() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2562,7 +2562,7 @@ final class MuesliController: NSObject {
     @discardableResult
     func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
-        guard normalizeMeetingTranscriptionSelectionForAvailability() != nil else {
+        guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
             presentErrorAlert(
                 title: "Meeting failed to start",
                 message: "Download a transcription model before recording a meeting."
@@ -2603,7 +2603,12 @@ final class MuesliController: NSObject {
             guard let self else { return }
             do {
                 try Task.checkCancellation()
-                try await self.startMeetingRecordingWithSystemAudioRecovery(title: title, calendarEventID: calendarEventID, meetingID: meetingID)
+                try await self.startMeetingRecordingWithSystemAudioRecovery(
+                    title: title,
+                    calendarEventID: calendarEventID,
+                    meetingID: meetingID,
+                    backend: meetingBackend
+                )
             } catch is CancellationError {
                 if self.meetingStartMeetingID == meetingID {
                     self.resolveLiveMeetingAfterStartFailure(id: meetingID)
@@ -2686,13 +2691,18 @@ final class MuesliController: NSObject {
         syncAppState()
     }
 
-    private func startMeetingRecordingWithSystemAudioRecovery(title: String, calendarEventID: String?, meetingID: Int64) async throws {
+    private func startMeetingRecordingWithSystemAudioRecovery(
+        title: String,
+        calendarEventID: String?,
+        meetingID: Int64,
+        backend: BackendOption
+    ) async throws {
         var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
         statusBarController?.setStatus("Preparing meeting transcription...")
         statusBarController?.refresh()
         try Task.checkCancellation()
         try await transcriptionCoordinator.preloadRequired(
-            backend: selectedMeetingTranscriptionBackend,
+            backend: backend,
             enablePostProcessor: false,
             includeMeetingHelpers: true
         )
@@ -2705,7 +2715,7 @@ final class MuesliController: NSObject {
             let meetingSession = MeetingSession(
                 title: title,
                 calendarEventID: calendarEventID,
-                backend: selectedMeetingTranscriptionBackend,
+                backend: backend,
                 runtime: runtime,
                 config: config,
                 transcriptionCoordinator: transcriptionCoordinator

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2536,6 +2536,11 @@ final class MuesliController: NSObject {
     @discardableResult
     func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
+        if isMeetingRecording() {
+            presentHistoryWindow(tab: .meetings)
+            return false
+        }
+        guard !isStartingMeetingRecording else { return false }
         let didStart = startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true)
         guard didStart else { return false }
         presentHistoryWindow(tab: .meetings)
@@ -2580,8 +2585,6 @@ final class MuesliController: NSObject {
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
         updateMeetingNotificationVisibility()
-        statusBarController?.setStatus("Starting meeting: \(title)")
-        statusBarController?.refresh()
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -3330,9 +3333,12 @@ final class MuesliController: NSObject {
             platform: MeetingPlatform(candidate.platform),
             onStartRecording: { [weak self] in
                 guard let self else { return }
-                self.meetingMonitor.markRecordingStarted(candidate)
-                self.presentedMeetingCandidate = nil
-                self.startForegroundMeetingRecording(title: title)
+                if self.startForegroundMeetingRecording(title: title) {
+                    self.meetingMonitor.markRecordingStarted(candidate)
+                    self.presentedMeetingCandidate = nil
+                } else {
+                    self.meetingMonitor.refreshState()
+                }
             },
             onDismiss: { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1233,8 +1233,9 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID)
-                self.scheduleMeetingEndNotification(endDate: endDate, title: title)
+                if self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID) {
+                    self.scheduleMeetingEndNotification(endDate: endDate, title: title)
+                }
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -2532,20 +2533,24 @@ final class MuesliController: NSObject {
         startForegroundMeetingRecording(title: title)
     }
 
-    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil) {
-        guard ensureBasicDictationPermissionsBeforeDashboard() else { return }
-        startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true)
+    @discardableResult
+    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil) -> Bool {
+        guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
+        let didStart = startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true)
+        guard didStart else { return false }
         presentHistoryWindow(tab: .meetings)
+        return true
     }
 
-    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) {
-        guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+    @discardableResult
+    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) -> Bool {
+        guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
         guard normalizeMeetingTranscriptionSelectionForAvailability() != nil else {
             presentErrorAlert(
                 title: "Meeting failed to start",
                 message: "Download a transcription model before recording a meeting."
             )
-            return
+            return false
         }
         let templateSnapshot = defaultMeetingTemplate()
         let meetingID: Int64
@@ -2567,7 +2572,7 @@ final class MuesliController: NSObject {
         } catch {
             fputs("[muesli-native] failed to create live meeting: \(error)\n", stderr)
             presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
-            return
+            return false
         }
         isStartingMeetingRecording = true
         updateMeetingStartStatus("Preparing meeting transcription...")
@@ -2614,6 +2619,7 @@ final class MuesliController: NSObject {
             self.updateMeetingNotificationVisibility()
             self.syncAppState()
         }
+        return true
     }
 
     func startQuickNoteMeeting() {
@@ -2622,7 +2628,6 @@ final class MuesliController: NSObject {
 
     private func startMeetingRecordingWithSystemAudioRecovery(title: String, calendarEventID: String?, meetingID: Int64) async throws {
         var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
-        updateMeetingStartStatus("Preparing meeting transcription...")
         statusBarController?.setStatus("Preparing meeting transcription...")
         statusBarController?.refresh()
         try await transcriptionCoordinator.preloadRequired(
@@ -2694,8 +2699,9 @@ final class MuesliController: NSObject {
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
     func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
         NSWorkspace.shared.open(meetingURL)
-        startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID)
-        scheduleMeetingEndNotification(endDate: endDate, title: title)
+        if startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID) {
+            scheduleMeetingEndNotification(endDate: endDate, title: title)
+        }
     }
 
     /// Open meeting URL and suppress detection for the event duration.
@@ -4216,8 +4222,9 @@ final class MuesliController: NSObject {
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
 
         if config.autoRecordMeetings, !isMeetingRecording() {
-            startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true)
-            scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
+            if startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true) {
+                scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
+            }
             return
         }
 
@@ -4247,8 +4254,9 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(title: title, calendarEventID: event.id)
-                self.scheduleMeetingEndNotification(endDate: calendarEndDate, title: title)
+                if self.startForegroundMeetingRecording(title: title, calendarEventID: event.id) {
+                    self.scheduleMeetingEndNotification(endDate: calendarEndDate, title: title)
+                }
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -186,6 +186,7 @@ final class MuesliController: NSObject {
     private var isStoppingMeetingRecording = false
     private var meetingStartTask: Task<Void, Never>?
     private var meetingStartMeetingID: Int64?
+    private var canceledMeetingStartIDs = Set<Int64>()
 
     init(
         runtime: RuntimePaths,
@@ -2484,12 +2485,18 @@ final class MuesliController: NSObject {
 
         activeMeetingSession?.discard()
         activeMeetingSession = nil
+        if let meetingStartMeetingID {
+            canceledMeetingStartIDs.insert(meetingStartMeetingID)
+        }
         meetingStartTask?.cancel()
         meetingStartTask = nil
         meetingStartMeetingID = nil
         isStartingMeetingRecording = false
         isStoppingMeetingRecording = false
+        updateMeetingStartStatus(nil)
+        updateMeetingNotificationVisibility()
         endMeetingActivity()
+        syncAppState()
         return true
     }
 
@@ -2651,8 +2658,8 @@ final class MuesliController: NSObject {
               let meetingID = meetingStartMeetingID else {
             return
         }
+        canceledMeetingStartIDs.insert(meetingID)
         meetingStartTask?.cancel()
-        updateMeetingStartStatus("Canceling meeting start...")
         resolveLiveMeetingAfterStartFailure(id: meetingID)
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
@@ -2660,10 +2667,16 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         setState(.idle)
         endMeetingActivity()
-        finishMeetingStartAttempt(meetingID: meetingID)
+        meetingStartTask = nil
+        meetingStartMeetingID = nil
+        isStartingMeetingRecording = false
+        updateMeetingStartStatus(nil)
+        updateMeetingNotificationVisibility()
+        syncAppState()
     }
 
     private func finishMeetingStartAttempt(meetingID: Int64) {
+        canceledMeetingStartIDs.remove(meetingID)
         guard meetingStartMeetingID == meetingID else { return }
         meetingStartTask = nil
         meetingStartMeetingID = nil
@@ -2684,9 +2697,11 @@ final class MuesliController: NSObject {
             includeMeetingHelpers: true
         )
         try Task.checkCancellation()
+        try checkMeetingStartStillCurrent(meetingID)
 
         while true {
             try Task.checkCancellation()
+            try checkMeetingStartStillCurrent(meetingID)
             let meetingSession = MeetingSession(
                 title: title,
                 calendarEventID: calendarEventID,
@@ -2710,7 +2725,7 @@ final class MuesliController: NSObject {
                     }
                 }
                 try await meetingSession.start()
-                if Task.isCancelled {
+                if Task.isCancelled || canceledMeetingStartIDs.contains(meetingID) {
                     meetingSession.discard()
                     throw CancellationError()
                 }
@@ -2735,11 +2750,13 @@ final class MuesliController: NSObject {
                 shouldRetryAfterPermissionRequest = false
                 meetingSession.discard()
                 try Task.checkCancellation()
+                try checkMeetingStartStillCurrent(meetingID)
                 updateMeetingStartStatus("Requesting system audio permission...")
                 statusBarController?.setStatus("Requesting system audio permission...")
                 statusBarController?.refresh()
                 let granted = await CoreAudioSystemRecorder.requestSystemAudioAccess()
                 try Task.checkCancellation()
+                try checkMeetingStartStillCurrent(meetingID)
                 if granted {
                     updateMeetingStartStatus("Retrying meeting start...")
                     statusBarController?.setStatus("Retrying meeting start...")
@@ -2748,6 +2765,12 @@ final class MuesliController: NSObject {
                 }
                 throw error
             }
+        }
+    }
+
+    private func checkMeetingStartStillCurrent(_ meetingID: Int64) throws {
+        if canceledMeetingStartIDs.contains(meetingID) || meetingStartMeetingID != meetingID {
+            throw CancellationError()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1236,9 +1236,7 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                if self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID) {
-                    self.scheduleMeetingEndNotification(endDate: endDate, title: title)
-                }
+                self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID, endDate: endDate)
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -2487,6 +2485,7 @@ final class MuesliController: NSObject {
         activeMeetingSession = nil
         if let meetingStartMeetingID {
             canceledMeetingStartIDs.insert(meetingStartMeetingID)
+            resolveLiveMeetingAfterStartFailure(id: meetingStartMeetingID)
         }
         meetingStartTask?.cancel()
         meetingStartTask = nil
@@ -2546,21 +2545,21 @@ final class MuesliController: NSObject {
     }
 
     @discardableResult
-    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil) -> Bool {
+    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, endDate: Date? = nil) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
         if isMeetingRecording() {
             presentHistoryWindow(tab: .meetings)
             return false
         }
         guard !isStartingMeetingRecording else { return false }
-        let didStart = startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true)
+        let didStart = startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true, endDate: endDate)
         guard didStart else { return false }
         presentHistoryWindow(tab: .meetings)
         return true
     }
 
     @discardableResult
-    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false) -> Bool {
+    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false, endDate: Date? = nil) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
         guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
             presentErrorAlert(
@@ -2607,7 +2606,8 @@ final class MuesliController: NSObject {
                     title: title,
                     calendarEventID: calendarEventID,
                     meetingID: meetingID,
-                    backend: meetingBackend
+                    backend: meetingBackend,
+                    endDate: endDate
                 )
             } catch is CancellationError {
                 if self.meetingStartMeetingID == meetingID {
@@ -2681,8 +2681,8 @@ final class MuesliController: NSObject {
     }
 
     private func finishMeetingStartAttempt(meetingID: Int64) {
-        canceledMeetingStartIDs.remove(meetingID)
         guard meetingStartMeetingID == meetingID else { return }
+        canceledMeetingStartIDs.remove(meetingID)
         meetingStartTask = nil
         meetingStartMeetingID = nil
         isStartingMeetingRecording = false
@@ -2695,7 +2695,8 @@ final class MuesliController: NSObject {
         title: String,
         calendarEventID: String?,
         meetingID: Int64,
-        backend: BackendOption
+        backend: BackendOption,
+        endDate: Date?
     ) async throws {
         var shouldRetryAfterPermissionRequest = config.useCoreAudioTap
         statusBarController?.setStatus("Preparing meeting transcription...")
@@ -2750,6 +2751,7 @@ final class MuesliController: NSObject {
                 indicator.setMeetingRecording(true, config: config)
                 statusBarController?.refresh()
                 syncAppState()
+                scheduleMeetingEndNotification(endDate: endDate, title: title)
                 return
             } catch {
                 guard shouldRetryAfterPermissionRequest,
@@ -2788,9 +2790,7 @@ final class MuesliController: NSObject {
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
     func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
         NSWorkspace.shared.open(meetingURL)
-        if startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID) {
-            scheduleMeetingEndNotification(endDate: endDate, title: title)
-        }
+        startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID, endDate: endDate)
     }
 
     /// Open meeting URL and suppress detection for the event duration.
@@ -4314,9 +4314,7 @@ final class MuesliController: NSObject {
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
 
         if config.autoRecordMeetings, !isMeetingRecording() {
-            if startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true) {
-                scheduleMeetingEndNotification(endDate: calendarEndDate, title: event.title)
-            }
+            startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true, endDate: calendarEndDate)
             return
         }
 
@@ -4346,9 +4344,7 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                if self.startForegroundMeetingRecording(title: title, calendarEventID: event.id) {
-                    self.scheduleMeetingEndNotification(endDate: calendarEndDate, title: title)
-                }
+                self.startForegroundMeetingRecording(title: title, calendarEventID: event.id, endDate: calendarEndDate)
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -4378,23 +4374,30 @@ final class MuesliController: NSObject {
         guard let endDate else { return }
 
         let delay = endDate.timeIntervalSinceNow
-        guard delay > 0 else { return }
+        guard delay > 0 else {
+            showMeetingEndNotification(title: title)
+            return
+        }
 
         meetingEndTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             DispatchQueue.main.async { [weak self] in
-                guard let self, self.isMeetingRecording() else { return }
-                self.meetingNotification.show(
-                    title: "Meeting ended",
-                    subtitle: "\(title) · scheduled time is over",
-                    actionLabel: "Stop Recording",
-                    dismissAfter: 45,
-                    onStartRecording: { [weak self] in
-                        self?.stopMeetingRecording()
-                    },
-                    onDismiss: nil
-                )
+                self?.showMeetingEndNotification(title: title)
             }
         }
+    }
+
+    private func showMeetingEndNotification(title: String) {
+        guard isMeetingRecording() else { return }
+        meetingNotification.show(
+            title: "Meeting ended",
+            subtitle: "\(title) · scheduled time is over",
+            actionLabel: "Stop Recording",
+            dismissAfter: 45,
+            onStartRecording: { [weak self] in
+                self?.stopMeetingRecording()
+            },
+            onDismiss: nil
+        )
     }
 
     func serializedCustomWords() -> [[String: Any]] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -153,7 +153,7 @@ actor TranscriptionCoordinator {
         activeBackend = backend.backend
 
         if includeMeetingHelpers {
-            // Meeting helpers are intentionally skipped for dictation-only onboarding.
+            // Meeting helpers are intentionally loaded only when the caller needs meeting behavior.
             if vadManager == nil {
                 do {
                     vadManager = try await VadManager()

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -549,6 +549,39 @@ struct AppConfigTests {
         #expect(config.meetingHookTimeoutSeconds == 30)
     }
 
+    @Test("legacy completed onboarding enables meetings when use case is missing")
+    func legacyCompletedOnboardingEnablesMeetingsWhenUseCaseMissing() throws {
+        let json = """
+        {
+          "has_completed_onboarding": true,
+          "stt_backend": "fluidaudio",
+          "stt_model": "FluidInference/parakeet-tdt-0.6b-v3-coreml"
+        }
+        """
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.hasCompletedOnboarding)
+        #expect(config.resolvedOnboardingUseCase == .dictationAndMeetings)
+        #expect(config.resolvedOnboardingUseCase.includesMeetings)
+    }
+
+    @Test("explicit completed dictation-only onboarding remains dictation-only")
+    func explicitCompletedDictationOnlyOnboardingRemainsDictationOnly() throws {
+        let json = """
+        {
+          "has_completed_onboarding": true,
+          "onboarding_use_case": "dictation"
+        }
+        """
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.hasCompletedOnboarding)
+        #expect(config.resolvedOnboardingUseCase == .dictation)
+        #expect(!config.resolvedOnboardingUseCase.includesMeetings)
+    }
+
     @Test("computer use default avoids existing right command dictation hotkey")
     func computerUseDefaultAvoidsExistingRightCommandDictationHotkey() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -566,6 +566,38 @@ struct AppConfigTests {
         #expect(config.resolvedOnboardingUseCase.includesMeetings)
     }
 
+    @Test("legacy completed onboarding enables meetings when use case is malformed")
+    func legacyCompletedOnboardingEnablesMeetingsWhenUseCaseMalformed() throws {
+        let jsonCases = [
+            """
+            {
+              "has_completed_onboarding": true,
+              "onboarding_use_case": null
+            }
+            """,
+            """
+            {
+              "has_completed_onboarding": true,
+              "onboarding_use_case": 7
+            }
+            """,
+            """
+            {
+              "has_completed_onboarding": true,
+              "onboarding_use_case": "future-meeting-mode"
+            }
+            """
+        ]
+
+        for json in jsonCases {
+            let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+            #expect(config.hasCompletedOnboarding)
+            #expect(config.resolvedOnboardingUseCase == .dictationAndMeetings)
+            #expect(config.resolvedOnboardingUseCase.includesMeetings)
+        }
+    }
+
     @Test("explicit completed dictation-only onboarding remains dictation-only")
     func explicitCompletedDictationOnlyOnboardingRemainsDictationOnly() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -598,6 +598,37 @@ struct AppConfigTests {
         }
     }
 
+    @Test("incomplete onboarding defaults malformed use case to dictation")
+    func incompleteOnboardingDefaultsMalformedUseCaseToDictation() throws {
+        let jsonCases = [
+            """
+            {
+              "has_completed_onboarding": false
+            }
+            """,
+            """
+            {
+              "has_completed_onboarding": false,
+              "onboarding_use_case": null
+            }
+            """,
+            """
+            {
+              "has_completed_onboarding": false,
+              "onboarding_use_case": "future-meeting-mode"
+            }
+            """
+        ]
+
+        for json in jsonCases {
+            let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+            #expect(!config.hasCompletedOnboarding)
+            #expect(config.resolvedOnboardingUseCase == .dictation)
+            #expect(!config.resolvedOnboardingUseCase.includesMeetings)
+        }
+    }
+
     @Test("explicit completed dictation-only onboarding remains dictation-only")
     func explicitCompletedDictationOnlyOnboardingRemainsDictationOnly() throws {
         let json = """


### PR DESCRIPTION
## Summary

Fixes #123.

This PR fixes a meeting transcript regression for users whose configs were affected by the new onboarding use-case flag. Legacy completed users without `onboarding_use_case` no longer get treated as dictation-only, and meeting recording now prepares meeting-critical helpers when the feature is actually used.

## Root Cause

`OnboardingUseCase.resolved(nil)` defaults to `.dictation`. After v0.6.6 introduced `onboarding_use_case`, legacy configs could have `has_completed_onboarding: true` but no use-case key. Those users skipped meeting helper preload at startup, so live meetings could run without VAD/chunking/diarization and produce huge one-line mic/system transcript blocks.

A related first-use path also existed for users who originally chose dictation but later explored Meetings: live meeting start did not force-load VAD and diarization helpers before creating `MeetingSession`.

## Changes

- Backfill missing `onboarding_use_case` to `dictation_and_meetings` for completed legacy configs.
- Preserve explicit dictation-only onboarding selections.
- Preload the selected meeting transcription backend with `includeMeetingHelpers: true` immediately before live meeting start.
- Add an in-app meeting preparation banner while meeting transcription/VAD/diarization are warming up.
- Disable duplicate meeting start actions while preparation is in progress.
- Add AppConfig regression coverage for legacy completed configs and explicit dictation-only configs.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-c403-issue123" --filter AppConfigTests`
- `git diff --check`
