### PR TITLE
Fix discard modal for live meeting notes

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2802,29 +2802,46 @@ final class MuesliController: NSObject {
         NSWorkspace.shared.open(meetingURL)
     }
 
+    private enum MeetingDiscardResolution {
+        case discard
+        case keepManualNotes
+        case deleteDraft
+    }
+
     @objc func discardMeetingWithConfirmation() {
         NSApp.activate(ignoringOtherApps: true)
 
         let alert = NSAlert()
+        let hasManualNotes = activeMeetingID.map { id in
+            !manualNotesForLiveMeeting(id: id).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        } ?? false
         alert.messageText = "Discard recording?"
-        alert.informativeText = "This will stop the meeting recording and delete all captured audio. This cannot be undone."
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Discard")
-        alert.addButton(withTitle: "Cancel")
-        alert.buttons.first?.hasDestructiveAction = true
-        presentDiscardMeetingAlert(alert)
+        if hasManualNotes {
+            alert.informativeText = "This will stop the meeting recording and delete all captured audio. This meeting also has manually written notes."
+            alert.addButton(withTitle: "Keep Notes")
+            alert.addButton(withTitle: "Delete Draft")
+            alert.addButton(withTitle: "Cancel")
+            alert.buttons.dropFirst().first?.hasDestructiveAction = true
+        } else {
+            alert.informativeText = "This will stop the meeting recording and delete all captured audio. This cannot be undone."
+            alert.addButton(withTitle: "Discard")
+            alert.addButton(withTitle: "Cancel")
+            alert.buttons.first?.hasDestructiveAction = true
+        }
+        presentDiscardMeetingAlert(alert, hasManualNotes: hasManualNotes)
     }
 
-    private func presentDiscardMeetingAlert(_ alert: NSAlert, attempt: Int = 0) {
+    private func presentDiscardMeetingAlert(_ alert: NSAlert, hasManualNotes: Bool, attempt: Int = 0) {
         if let window = confirmationAnchorWindow() {
-            beginDiscardMeetingAlert(alert, for: window)
+            beginDiscardMeetingAlert(alert, for: window, hasManualNotes: hasManualNotes)
             return
         }
 
         showActiveMeetingDocumentIfNeeded()
         historyWindowController?.show()
         if let window = confirmationAnchorWindow() {
-            beginDiscardMeetingAlert(alert, for: window)
+            beginDiscardMeetingAlert(alert, for: window, hasManualNotes: hasManualNotes)
             return
         }
 
@@ -2835,17 +2852,31 @@ final class MuesliController: NSObject {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self, alert] in
-            self?.presentDiscardMeetingAlert(alert, attempt: attempt + 1)
+            self?.presentDiscardMeetingAlert(alert, hasManualNotes: hasManualNotes, attempt: attempt + 1)
         }
     }
 
-    private func beginDiscardMeetingAlert(_ alert: NSAlert, for window: NSWindow) {
+    private func beginDiscardMeetingAlert(_ alert: NSAlert, for window: NSWindow, hasManualNotes: Bool) {
         alert.beginSheetModal(for: window) { [weak self] response in
-            guard response == .alertFirstButtonReturn else { return }
+            guard let resolution = Self.discardResolution(for: response, hasManualNotes: hasManualNotes) else { return }
             Task { @MainActor [weak self] in
-                self?.discardMeetingRecording()
+                self?.discardMeetingRecording(resolution: resolution)
             }
         }
+    }
+
+    private static func discardResolution(for response: NSApplication.ModalResponse, hasManualNotes: Bool) -> MeetingDiscardResolution? {
+        if hasManualNotes {
+            switch response {
+            case .alertFirstButtonReturn:
+                return .keepManualNotes
+            case .alertSecondButtonReturn:
+                return .deleteDraft
+            default:
+                return nil
+            }
+        }
+        return response == .alertFirstButtonReturn ? .discard : nil
     }
 
     private func confirmationAnchorWindow() -> NSWindow? {
@@ -2861,16 +2892,14 @@ final class MuesliController: NSObject {
         }
     }
 
-    func discardMeetingRecording() {
+    private func discardMeetingRecording(resolution: MeetingDiscardResolution = .discard) {
         guard let sessionToDiscard = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
             indicator.setMeetingRecording(false, config: config)
             if let meetingID = activeMeetingID {
                 activeMeetingID = nil
-                resolveLiveMeetingAfterDiscard(id: meetingID) { [weak self] in
-                    self?.finishDiscardMeetingRecording()
-                }
+                resolveLiveMeetingAfterDiscard(id: meetingID, resolution: resolution)
             } else {
                 finishDiscardMeetingRecording()
             }
@@ -2881,9 +2910,7 @@ final class MuesliController: NSObject {
         indicator.setMeetingRecording(false, config: config)
         if let meetingID = activeMeetingID {
             activeMeetingID = nil
-            resolveLiveMeetingAfterDiscard(id: meetingID) { [weak self] in
-                self?.finishDiscardMeetingRecording()
-            }
+            resolveLiveMeetingAfterDiscard(id: meetingID, resolution: resolution)
         } else {
             finishDiscardMeetingRecording()
         }
@@ -2900,58 +2927,21 @@ final class MuesliController: NSObject {
         updateMeetingNotificationVisibility()
     }
 
-    private func resolveLiveMeetingAfterDiscard(id: Int64, completion: @escaping () -> Void) {
-        let manualNotes = manualNotesForLiveMeeting(id: id)
-        if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            try? dictationStore.deleteMeeting(id: id)
-            clearCachedMeetingManualNotes(id: id)
-            clearCachedMeetingTitle(id: id)
-            if appState.selectedMeetingID == id {
-                appState.selectedMeetingID = nil
-                appState.selectedMeetingRecord = nil
-                appState.meetingsNavigationState = .browser
-            }
-            syncAppState()
-            completion()
-            return
-        }
-
-        DispatchQueue.main.async { [weak self] in
-            self?.presentManualNotesDiscardResolution(id: id, completion: completion)
-        }
-    }
-
-    private func presentManualNotesDiscardResolution(id: Int64, completion: @escaping () -> Void) {
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = "Keep manual notes?"
-        alert.informativeText = "This recording will be discarded, but this meeting has manually written notes. Keep them as a note-only meeting or delete the draft?"
-        alert.addButton(withTitle: "Keep Notes")
-        alert.addButton(withTitle: "Delete Draft")
-        alert.buttons.dropFirst().first?.hasDestructiveAction = true
-        guard let window = confirmationAnchorWindow() else {
+    private func resolveLiveMeetingAfterDiscard(id: Int64, resolution: MeetingDiscardResolution) {
+        switch resolution {
+        case .keepManualNotes:
             keepManualNotesAfterDiscard(id: id)
-            completion()
-            return
-        }
-        alert.beginSheetModal(for: window) { [weak self] response in
-            guard let self else { return }
-            if response == .alertFirstButtonReturn {
-                self.keepManualNotesAfterDiscard(id: id)
+        case .deleteDraft:
+            deleteManualNotesDraftAfterDiscard(id: id)
+        case .discard:
+            let manualNotes = manualNotesForLiveMeeting(id: id)
+            if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                deleteManualNotesDraftAfterDiscard(id: id)
             } else {
-                self.deleteManualNotesDraftAfterDiscard(id: id)
+                keepManualNotesAfterDiscard(id: id)
             }
-            completion()
         }
-    }
-
-    private func keepManualNotesAfterDiscard(id: Int64) {
-        flushCachedMeetingTitle(id: id)
-        flushCachedMeetingManualNotes(id: id, sync: false)
-        try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
-        clearCachedMeetingManualNotes(id: id)
-        clearCachedMeetingTitle(id: id)
-        syncAppState()
+        finishDiscardMeetingRecording()
     }
 
     private func deleteManualNotesDraftAfterDiscard(id: Int64) {
@@ -2963,7 +2953,14 @@ final class MuesliController: NSObject {
             appState.selectedMeetingRecord = nil
             appState.meetingsNavigationState = .browser
         }
-        syncAppState()
+    }
+
+    private func keepManualNotesAfterDiscard(id: Int64) {
+        flushCachedMeetingTitle(id: id)
+        flushCachedMeetingManualNotes(id: id, sync: false)
+        try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
+        clearCachedMeetingManualNotes(id: id)
+        clearCachedMeetingTitle(id: id)
     }
 
     private func resolveLiveMeetingAfterStartFailure(id: Int64) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2802,10 +2802,15 @@ final class MuesliController: NSObject {
         NSWorkspace.shared.open(meetingURL)
     }
 
-    private enum MeetingDiscardResolution {
+    enum MeetingDiscardResolution: Equatable {
         case discardRecording
         case keepManualNotes
         case deleteDraft
+    }
+
+    private struct MeetingDiscardAccessory {
+        let view: NSView
+        let manualNotesCheckbox: NSButton
     }
 
     @objc func discardMeetingWithConfirmation() {
@@ -2817,31 +2822,55 @@ final class MuesliController: NSObject {
         } ?? false
         alert.messageText = "Discard recording?"
         alert.alertStyle = .warning
+        var manualNotesCheckbox: NSButton?
         if hasManualNotes {
-            alert.informativeText = "This will stop the meeting recording and delete all captured audio. This meeting also has manually written notes."
-            alert.addButton(withTitle: "Keep Notes")
-            alert.addButton(withTitle: "Delete Draft")
+            alert.informativeText = "This will stop the meeting recording. Select what should be deleted."
+            let accessory = Self.makeDiscardMeetingAccessoryView()
+            manualNotesCheckbox = accessory.manualNotesCheckbox
+            alert.accessoryView = accessory.view
+            alert.addButton(withTitle: "Discard")
             alert.addButton(withTitle: "Cancel")
-            alert.buttons.dropFirst().first?.hasDestructiveAction = true
+            alert.buttons.first?.hasDestructiveAction = true
         } else {
             alert.informativeText = "This will stop the meeting recording and delete all captured audio. This cannot be undone."
             alert.addButton(withTitle: "Discard")
             alert.addButton(withTitle: "Cancel")
             alert.buttons.first?.hasDestructiveAction = true
         }
-        presentDiscardMeetingAlert(alert, hasManualNotes: hasManualNotes)
+        presentDiscardMeetingAlert(alert, manualNotesCheckbox: manualNotesCheckbox)
     }
 
-    private func presentDiscardMeetingAlert(_ alert: NSAlert, hasManualNotes: Bool, attempt: Int = 0) {
+    private static func makeDiscardMeetingAccessoryView() -> MeetingDiscardAccessory {
+        let label = NSTextField(labelWithString: "Delete")
+        label.font = .systemFont(ofSize: NSFont.systemFontSize)
+        label.textColor = .secondaryLabelColor
+
+        let recordingCheckbox = NSButton(checkboxWithTitle: "Recording audio", target: nil, action: nil)
+        recordingCheckbox.state = .on
+        recordingCheckbox.isEnabled = false
+
+        let notesCheckbox = NSButton(checkboxWithTitle: "Manual notes", target: nil, action: nil)
+        notesCheckbox.state = .off
+
+        let stack = NSStackView(views: [label, recordingCheckbox, notesCheckbox])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.widthAnchor.constraint(greaterThanOrEqualToConstant: 260).isActive = true
+        return MeetingDiscardAccessory(view: stack, manualNotesCheckbox: notesCheckbox)
+    }
+
+    private func presentDiscardMeetingAlert(_ alert: NSAlert, manualNotesCheckbox: NSButton?, attempt: Int = 0) {
         if let window = confirmationAnchorWindow() {
-            beginDiscardMeetingAlert(alert, for: window, hasManualNotes: hasManualNotes)
+            beginDiscardMeetingAlert(alert, for: window, manualNotesCheckbox: manualNotesCheckbox)
             return
         }
 
         showActiveMeetingDocumentIfNeeded()
         historyWindowController?.show()
         if let window = confirmationAnchorWindow() {
-            beginDiscardMeetingAlert(alert, for: window, hasManualNotes: hasManualNotes)
+            beginDiscardMeetingAlert(alert, for: window, manualNotesCheckbox: manualNotesCheckbox)
             return
         }
 
@@ -2852,31 +2881,28 @@ final class MuesliController: NSObject {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self, alert] in
-            self?.presentDiscardMeetingAlert(alert, hasManualNotes: hasManualNotes, attempt: attempt + 1)
+            self?.presentDiscardMeetingAlert(alert, manualNotesCheckbox: manualNotesCheckbox, attempt: attempt + 1)
         }
     }
 
-    private func beginDiscardMeetingAlert(_ alert: NSAlert, for window: NSWindow, hasManualNotes: Bool) {
+    private func beginDiscardMeetingAlert(_ alert: NSAlert, for window: NSWindow, manualNotesCheckbox: NSButton?) {
         alert.beginSheetModal(for: window) { [weak self] response in
-            guard let resolution = Self.discardResolution(for: response, hasManualNotes: hasManualNotes) else { return }
+            guard let resolution = Self.discardResolution(
+                for: response,
+                deleteManualNotes: manualNotesCheckbox?.state == .on
+            ) else { return }
             Task { @MainActor [weak self] in
                 self?.discardMeetingRecording(resolution: resolution)
             }
         }
     }
 
-    private static func discardResolution(for response: NSApplication.ModalResponse, hasManualNotes: Bool) -> MeetingDiscardResolution? {
-        if hasManualNotes {
-            switch response {
-            case .alertFirstButtonReturn:
-                return .keepManualNotes
-            case .alertSecondButtonReturn:
-                return .deleteDraft
-            default:
-                return nil
-            }
+    static func discardResolution(for response: NSApplication.ModalResponse, deleteManualNotes: Bool?) -> MeetingDiscardResolution? {
+        guard response == .alertFirstButtonReturn else { return nil }
+        if let deleteManualNotes {
+            return deleteManualNotes ? .deleteDraft : .keepManualNotes
         }
-        return response == .alertFirstButtonReturn ? .discardRecording : nil
+        return .discardRecording
     }
 
     private func confirmationAnchorWindow() -> NSWindow? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2755,22 +2755,30 @@ final class MuesliController: NSObject {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
             indicator.setMeetingRecording(false, config: config)
-            if let activeMeetingID {
-                resolveLiveMeetingAfterDiscard(id: activeMeetingID)
-                self.activeMeetingID = nil
+            if let meetingID = activeMeetingID {
+                activeMeetingID = nil
+                resolveLiveMeetingAfterDiscard(id: meetingID) { [weak self] in
+                    self?.finishDiscardMeetingRecording()
+                }
+            } else {
+                finishDiscardMeetingRecording()
             }
-            isStoppingMeetingRecording = false
-            endMeetingActivity()
-            setState(.idle)
             return
         }
         sessionToDiscard.discard()
         self.activeMeetingSession = nil
         indicator.setMeetingRecording(false, config: config)
-        if let activeMeetingID {
-            resolveLiveMeetingAfterDiscard(id: activeMeetingID)
-            self.activeMeetingID = nil
+        if let meetingID = activeMeetingID {
+            activeMeetingID = nil
+            resolveLiveMeetingAfterDiscard(id: meetingID) { [weak self] in
+                self?.finishDiscardMeetingRecording()
+            }
+        } else {
+            finishDiscardMeetingRecording()
         }
+    }
+
+    private func finishDiscardMeetingRecording() {
         isStoppingMeetingRecording = false
         endMeetingActivity()
         meetingMonitor.resumeAfterCooldown()
@@ -2781,7 +2789,7 @@ final class MuesliController: NSObject {
         updateMeetingNotificationVisibility()
     }
 
-    private func resolveLiveMeetingAfterDiscard(id: Int64) {
+    private func resolveLiveMeetingAfterDiscard(id: Int64, completion: @escaping () -> Void) {
         let manualNotes = manualNotesForLiveMeeting(id: id)
         if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             try? dictationStore.deleteMeeting(id: id)
@@ -2793,9 +2801,16 @@ final class MuesliController: NSObject {
                 appState.meetingsNavigationState = .browser
             }
             syncAppState()
+            completion()
             return
         }
 
+        DispatchQueue.main.async { [weak self] in
+            self?.presentManualNotesDiscardResolution(id: id, completion: completion)
+        }
+    }
+
+    private func presentManualNotesDiscardResolution(id: Int64, completion: @escaping () -> Void) {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Keep manual notes?"
@@ -2803,21 +2818,39 @@ final class MuesliController: NSObject {
         alert.addButton(withTitle: "Keep Notes")
         alert.addButton(withTitle: "Delete Draft")
         alert.buttons.dropFirst().first?.hasDestructiveAction = true
-        if alert.runModal() == .alertFirstButtonReturn {
-            flushCachedMeetingTitle(id: id)
-            flushCachedMeetingManualNotes(id: id, sync: false)
-            try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
-            clearCachedMeetingManualNotes(id: id)
-            clearCachedMeetingTitle(id: id)
-        } else {
-            try? dictationStore.deleteMeeting(id: id)
-            clearCachedMeetingManualNotes(id: id)
-            clearCachedMeetingTitle(id: id)
-            if appState.selectedMeetingID == id {
-                appState.selectedMeetingID = nil
-                appState.selectedMeetingRecord = nil
-                appState.meetingsNavigationState = .browser
+        guard let window = confirmationAnchorWindow() else {
+            keepManualNotesAfterDiscard(id: id)
+            completion()
+            return
+        }
+        alert.beginSheetModal(for: window) { [weak self] response in
+            guard let self else { return }
+            if response == .alertFirstButtonReturn {
+                self.keepManualNotesAfterDiscard(id: id)
+            } else {
+                self.deleteManualNotesDraftAfterDiscard(id: id)
             }
+            completion()
+        }
+    }
+
+    private func keepManualNotesAfterDiscard(id: Int64) {
+        flushCachedMeetingTitle(id: id)
+        flushCachedMeetingManualNotes(id: id, sync: false)
+        try? dictationStore.updateMeetingStatus(id: id, status: .noteOnly)
+        clearCachedMeetingManualNotes(id: id)
+        clearCachedMeetingTitle(id: id)
+        syncAppState()
+    }
+
+    private func deleteManualNotesDraftAfterDiscard(id: Int64) {
+        try? dictationStore.deleteMeeting(id: id)
+        clearCachedMeetingManualNotes(id: id)
+        clearCachedMeetingTitle(id: id)
+        if appState.selectedMeetingID == id {
+            appState.selectedMeetingID = nil
+            appState.selectedMeetingRecord = nil
+            appState.meetingsNavigationState = .browser
         }
         syncAppState()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2828,7 +2828,7 @@ final class MuesliController: NSObject {
             let accessory = Self.makeDiscardMeetingAccessoryView()
             manualNotesCheckbox = accessory.manualNotesCheckbox
             alert.accessoryView = accessory.view
-            alert.addButton(withTitle: "Discard")
+            alert.addButton(withTitle: "Discard Recording")
             alert.addButton(withTitle: "Cancel")
             alert.buttons.first?.hasDestructiveAction = true
         } else {
@@ -2889,7 +2889,7 @@ final class MuesliController: NSObject {
         alert.beginSheetModal(for: window) { [weak self] response in
             guard let resolution = Self.discardResolution(
                 for: response,
-                deleteManualNotes: manualNotesCheckbox?.state == .on
+                deleteManualNotes: manualNotesCheckbox.map { $0.state == .on }
             ) else { return }
             Task { @MainActor [weak self] in
                 self?.discardMeetingRecording(resolution: resolution)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2813,6 +2813,22 @@ final class MuesliController: NSObject {
         let manualNotesCheckbox: NSButton
     }
 
+    private final class MeetingDiscardAccessoryView: NSView {
+        var titleUpdater: AnyObject?
+    }
+
+    private final class MeetingDiscardButtonTitleUpdater: NSObject {
+        weak var discardButton: NSButton?
+
+        init(discardButton: NSButton?) {
+            self.discardButton = discardButton
+        }
+
+        @MainActor @objc func manualNotesCheckboxChanged(_ sender: NSButton) {
+            discardButton?.title = sender.state == .on ? "Discard" : "Discard Recording"
+        }
+    }
+
     @objc func discardMeetingWithConfirmation() {
         NSApp.activate(ignoringOtherApps: true)
 
@@ -2831,6 +2847,10 @@ final class MuesliController: NSObject {
             alert.addButton(withTitle: "Discard Recording")
             alert.addButton(withTitle: "Cancel")
             alert.buttons.first?.hasDestructiveAction = true
+            let titleUpdater = MeetingDiscardButtonTitleUpdater(discardButton: alert.buttons.first)
+            manualNotesCheckbox?.target = titleUpdater
+            manualNotesCheckbox?.action = #selector(MeetingDiscardButtonTitleUpdater.manualNotesCheckboxChanged(_:))
+            (accessory.view as? MeetingDiscardAccessoryView)?.titleUpdater = titleUpdater
         } else {
             alert.informativeText = "This will stop the meeting recording and delete all captured audio. This cannot be undone."
             alert.addButton(withTitle: "Discard")
@@ -2852,7 +2872,7 @@ final class MuesliController: NSObject {
         let notesCheckbox = NSButton(checkboxWithTitle: "Manual notes", target: nil, action: nil)
         notesCheckbox.state = .off
 
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 230, height: 76))
+        let container = MeetingDiscardAccessoryView(frame: NSRect(x: 0, y: 0, width: 230, height: 76))
         let stack = NSStackView(views: [label, recordingCheckbox, notesCheckbox])
         stack.frame = container.bounds
         stack.orientation = .vertical

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2803,7 +2803,7 @@ final class MuesliController: NSObject {
     }
 
     private enum MeetingDiscardResolution {
-        case discard
+        case discardRecording
         case keepManualNotes
         case deleteDraft
     }
@@ -2876,7 +2876,7 @@ final class MuesliController: NSObject {
                 return nil
             }
         }
-        return response == .alertFirstButtonReturn ? .discard : nil
+        return response == .alertFirstButtonReturn ? .discardRecording : nil
     }
 
     private func confirmationAnchorWindow() -> NSWindow? {
@@ -2892,7 +2892,7 @@ final class MuesliController: NSObject {
         }
     }
 
-    private func discardMeetingRecording(resolution: MeetingDiscardResolution = .discard) {
+    private func discardMeetingRecording(resolution: MeetingDiscardResolution = .discardRecording) {
         guard let sessionToDiscard = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
@@ -2933,11 +2933,14 @@ final class MuesliController: NSObject {
             keepManualNotesAfterDiscard(id: id)
         case .deleteDraft:
             deleteManualNotesDraftAfterDiscard(id: id)
-        case .discard:
+        case .discardRecording:
             let manualNotes = manualNotesForLiveMeeting(id: id)
             if manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 deleteManualNotesDraftAfterDiscard(id: id)
             } else {
+                // Defensive fallback: the UI routes manual-note meetings through
+                // explicit Keep Notes/Delete Draft choices. If notes appear after
+                // the simpler discard alert was built, preserve user-written text.
                 keepManualNotesAfterDiscard(id: id)
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2824,7 +2824,7 @@ final class MuesliController: NSObject {
         alert.alertStyle = .warning
         var manualNotesCheckbox: NSButton?
         if hasManualNotes {
-            alert.informativeText = "This will stop the meeting recording. Select what should be deleted."
+            alert.informativeText = "This will stop the meeting. Choose whether to delete the written notes too."
             let accessory = Self.makeDiscardMeetingAccessoryView()
             manualNotesCheckbox = accessory.manualNotesCheckbox
             alert.accessoryView = accessory.view
@@ -2841,7 +2841,7 @@ final class MuesliController: NSObject {
     }
 
     private static func makeDiscardMeetingAccessoryView() -> MeetingDiscardAccessory {
-        let label = NSTextField(labelWithString: "Delete")
+        let label = NSTextField(labelWithString: "Will delete:")
         label.font = .systemFont(ofSize: NSFont.systemFontSize)
         label.textColor = .secondaryLabelColor
 
@@ -2852,13 +2852,15 @@ final class MuesliController: NSObject {
         let notesCheckbox = NSButton(checkboxWithTitle: "Manual notes", target: nil, action: nil)
         notesCheckbox.state = .off
 
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 230, height: 76))
         let stack = NSStackView(views: [label, recordingCheckbox, notesCheckbox])
+        stack.frame = container.bounds
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 6
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.widthAnchor.constraint(greaterThanOrEqualToConstant: 260).isActive = true
-        return MeetingDiscardAccessory(view: stack, manualNotesCheckbox: notesCheckbox)
+        stack.autoresizingMask = [.width, .height]
+        container.addSubview(stack)
+        return MeetingDiscardAccessory(view: container, manualNotesCheckbox: notesCheckbox)
     }
 
     private func presentDiscardMeetingAlert(_ alert: NSAlert, manualNotesCheckbox: NSButton?, attempt: Int = 0) {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import AppKit
 import Foundation
 import MuesliCore
 @testable import MuesliNativeApp
@@ -32,6 +33,34 @@ struct MeetingsNavigationTests {
 
         #expect(appState.meetingsNavigationState == .browser)
         #expect(appState.selectedMeeting == nil)
+    }
+
+    @Test("discard confirmation maps checkbox selections to meeting discard resolutions")
+    func discardConfirmationResolutionMapping() {
+        #expect(
+            MuesliController.discardResolution(
+                for: .alertFirstButtonReturn,
+                deleteManualNotes: nil
+            ) == .discardRecording
+        )
+        #expect(
+            MuesliController.discardResolution(
+                for: .alertFirstButtonReturn,
+                deleteManualNotes: false
+            ) == .keepManualNotes
+        )
+        #expect(
+            MuesliController.discardResolution(
+                for: .alertFirstButtonReturn,
+                deleteManualNotes: true
+            ) == .deleteDraft
+        )
+        #expect(
+            MuesliController.discardResolution(
+                for: .alertSecondButtonReturn,
+                deleteManualNotes: false
+            ) == nil
+        )
     }
 
     @Test("selectedMeeting resolves the selected row only")


### PR DESCRIPTION
## Summary
- Fixes the live-meeting discard flow when manual notes are present.
- Presents the “Keep manual notes?” choice as a sheet instead of opening a nested modal alert from the discard confirmation callback.
- Keeps the preserved-note path unchanged: manual notes can still be saved as a note-only meeting.

## Root Cause
Discarding a live meeting with manual notes opened `NSAlert.runModal()` from inside the discard confirmation sheet callback. That nested modal could become invisible or non-interactive, making the app appear frozen.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-c403-discard-modal" --filter MeetingsNavigationTests`
- `git diff --check`
