### PR TITLE
Fix meeting auto-stop and background transcription blocking

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct MeetingAutoStopSource: Equatable {
+    let candidateID: String?
+    let suppressionID: String?
+    let normalizedURL: String?
+    let sourceBundleID: String?
+
+    private init(
+        candidateID: String?,
+        suppressionID: String?,
+        normalizedURL: String?,
+        sourceBundleID: String?
+    ) {
+        self.candidateID = candidateID
+        self.suppressionID = suppressionID
+        self.normalizedURL = normalizedURL
+        self.sourceBundleID = sourceBundleID
+    }
+
+    init(candidate: MeetingCandidate) {
+        self.candidateID = candidate.id
+        self.suppressionID = candidate.suppressionID
+        self.normalizedURL = candidate.url
+        self.sourceBundleID = candidate.sourceBundleID
+    }
+
+    init?(meetingURL: URL) {
+        guard let normalized = MeetingURLNormalizer.normalize(meetingURL.absoluteString) else {
+            return nil
+        }
+        self.candidateID = normalized.id
+        self.suppressionID = normalized.id
+        self.normalizedURL = normalized.url
+        self.sourceBundleID = nil
+    }
+
+    func refined(with candidate: MeetingCandidate) -> MeetingAutoStopSource {
+        MeetingAutoStopSource(
+            candidateID: candidateID ?? candidate.id,
+            suppressionID: candidate.suppressionID,
+            normalizedURL: normalizedURL ?? candidate.url,
+            sourceBundleID: sourceBundleID ?? candidate.sourceBundleID
+        )
+    }
+}
+
+enum MeetingAutoStopPolicy {
+    static func matches(candidate: MeetingCandidate, source: MeetingAutoStopSource) -> Bool {
+        if let candidateID = source.candidateID, candidate.id == candidateID {
+            return true
+        }
+
+        if let suppressionID = source.suppressionID, candidate.suppressionID == suppressionID {
+            return true
+        }
+
+        if let normalizedURL = source.normalizedURL, candidate.url == normalizedURL {
+            return true
+        }
+
+        if let sourceBundleID = source.sourceBundleID,
+           candidate.sourceBundleID == sourceBundleID,
+           candidate.evidence.contains(.audioInputProcess) {
+            return true
+        }
+
+        return false
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -12,11 +12,15 @@ final class MeetingMonitor {
     var isCalendarNotificationVisibleProvider: (() -> Bool)?
     var promptVisibilityProvider: (() -> MeetingPromptVisibility)?
     var mutedDetectionBundleIDsProvider: (() -> Set<String>)?
+    var onActivityCandidateChanged: ((MeetingCandidate?) -> Void)?
     var onPromptCandidateChanged: ((MeetingCandidate?) -> Void)?
 
     private lazy var detectionService = MeetingDetectionService(
         contextProvider: { [weak self] now in
             self?.makeEvaluationContext(now: now) ?? .disabled
+        },
+        activityHandler: { [weak self] candidate in
+            self?.onActivityCandidateChanged?(candidate)
         },
         promptHandler: { [weak self] update in
             self?.handlePromptUpdate(update)
@@ -287,6 +291,7 @@ private actor MeetingDetectionService {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
 
     private let contextProvider: @MainActor (Date) -> MeetingDetectionEvaluationContext
+    private let activityHandler: @MainActor (MeetingCandidate?) -> Void
     private let promptHandler: @MainActor (MeetingPromptUpdate) -> Void
     private let resolver = MeetingCandidateResolver()
     private let mediaSessionTracker = MeetingMediaSessionTracker()
@@ -311,9 +316,11 @@ private actor MeetingDetectionService {
 
     init(
         contextProvider: @escaping @MainActor (Date) -> MeetingDetectionEvaluationContext,
+        activityHandler: @escaping @MainActor (MeetingCandidate?) -> Void,
         promptHandler: @escaping @MainActor (MeetingPromptUpdate) -> Void
     ) {
         self.contextProvider = contextProvider
+        self.activityHandler = activityHandler
         self.promptHandler = promptHandler
     }
 
@@ -509,13 +516,18 @@ private actor MeetingDetectionService {
         )
 
         let resolverStart = Date()
-        let resolvedCandidate = isGloballySuppressed(now: now) ? nil : resolver.resolve(snapshot)
+        let resolvedActivityCandidate = resolver.resolve(snapshot)
         let resolverDuration = Date().timeIntervalSince(resolverStart)
-        let unmutedCandidate = isMuted(resolvedCandidate, mutedBundleIDs: context.mutedBundleIDs) ? nil : resolvedCandidate
-        let candidate = await mediaSessionTracker.stabilize(
-            candidate: unmutedCandidate,
+        let unmutedActivityCandidate = isMuted(
+            resolvedActivityCandidate,
+            mutedBundleIDs: context.mutedBundleIDs
+        ) ? nil : resolvedActivityCandidate
+        let activityCandidate = await mediaSessionTracker.stabilize(
+            candidate: unmutedActivityCandidate,
             snapshot: snapshot
         )
+        emitActivityUpdate(activityCandidate)
+        let candidate = isGloballySuppressed(now: now) ? nil : activityCandidate
         logCandidateIfChanged(candidate)
         updateRefreshState(
             trigger: trigger,
@@ -525,7 +537,8 @@ private actor MeetingDetectionService {
             browserMeetings: collectedSignals.browserMeetings,
             foregroundBundleID: collectedSignals.foregroundBundleID,
             visibility: context.promptVisibility,
-            candidate: candidate,
+            candidate: activityCandidate,
+            keepSuspicious: context.isRecording || context.isStartingRecording,
             now: now
         )
 
@@ -572,6 +585,12 @@ private actor MeetingDetectionService {
     private func emitPromptUpdate(_ update: MeetingPromptUpdate) {
         Task { @MainActor [promptHandler] in
             promptHandler(update)
+        }
+    }
+
+    private func emitActivityUpdate(_ candidate: MeetingCandidate?) {
+        Task { @MainActor [activityHandler] in
+            activityHandler(candidate)
         }
     }
 
@@ -697,11 +716,12 @@ private actor MeetingDetectionService {
         foregroundBundleID: String?,
         visibility: MeetingPromptVisibility,
         candidate: MeetingCandidate?,
+        keepSuspicious: Bool = false,
         now: Date
     ) {
         signalRefreshState.hasMicOrCameraSignal = micActive || cameraActive
         signalRefreshState.hasRecentBrowserMeeting = !browserMeetings.isEmpty
-        signalRefreshState.hasActiveCandidate = candidate != nil
+        signalRefreshState.hasActiveCandidate = candidate != nil || keepSuspicious
         signalRefreshState.hasPromptVisible = visibility.isVisible
         signalRefreshState.hasCalendarEvent = calendarEvent != nil
         signalRefreshState.foregroundIsMeetingCapableApp = foregroundBundleID.map { bundleID in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -182,6 +182,11 @@ final class MuesliController: NSObject {
     private var presentedMeetingCandidate: MeetingCandidate?
     private var meetingEndTimer: Timer?
     private var activeMeetingCalendarEndDate: Date?
+    private var latestMeetingActivityCandidate: MeetingCandidate?
+    private var latestMeetingActivityCandidateObservedAt: Date?
+    private var activeMeetingAutoStopSource: MeetingAutoStopSource?
+    private var activeMeetingAutoStopLastSeenAt: Date?
+    private let meetingAutoStopGracePeriod: TimeInterval = 20
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
     private var meetingStartTask: Task<Void, Never>?
@@ -340,7 +345,9 @@ final class MuesliController: NSObject {
             self?.currentOrNearbyCachedCalendarEvent()
         }
         meetingMonitor.detectionEnabledProvider = { [weak self] in
-            self?.config.showMeetingDetectionNotification ?? false
+            guard let self else { return false }
+            return self.config.showMeetingDetectionNotification
+                || self.activeMeetingAutoStopSource != nil
         }
         meetingMonitor.mutedDetectionBundleIDsProvider = { [weak self] in
             Set(self?.config.mutedMeetingDetectionAppBundleIDs ?? [])
@@ -364,6 +371,9 @@ final class MuesliController: NSObject {
                 currentPromptID: self.meetingNotification.currentPromptID,
                 shownAt: self.meetingNotification.shownAt
             )
+        }
+        meetingMonitor.onActivityCandidateChanged = { [weak self] candidate in
+            self?.handleMeetingActivityCandidate(candidate)
         }
         meetingMonitor.onPromptCandidateChanged = { [weak self] candidate in
             guard let self else { return }
@@ -444,6 +454,7 @@ final class MuesliController: NSObject {
         meetingStartingNowTimers.values.forEach { $0.invalidate() }
         meetingStartingNowTimers.removeAll()
         meetingFeatureMonitorsAllowed = false
+        disarmMeetingAutoStop()
         meetingMonitor.stop()
         meetingDetectionMonitorStarted = false
         dismissPresentedMeetingDetection()
@@ -1227,6 +1238,7 @@ final class MuesliController: NSObject {
               !isMeetingRecording(),
               !isStartingMeetingRecording else { return }
         isShowingCalendarNotification = true
+        let autoStopSource = meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
 
         meetingNotification.show(
             title: "Meeting starting now",
@@ -1236,7 +1248,12 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID, endDate: endDate)
+                self.startForegroundMeetingRecording(
+                    title: title,
+                    calendarEventID: calendarEventID,
+                    endDate: endDate,
+                    autoStopSource: autoStopSource
+                )
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -2434,6 +2451,10 @@ final class MuesliController: NSObject {
         activeMeetingSession?.isRecording == true || isStoppingMeetingRecording
     }
 
+    private var isMeetingCapturingAudio: Bool {
+        activeMeetingSession?.isRecording == true || isStartingMeetingRecording
+    }
+
     func isMeetingRecordingPaused() -> Bool {
         activeMeetingSession?.isPaused == true
     }
@@ -2483,6 +2504,7 @@ final class MuesliController: NSObject {
 
         activeMeetingSession?.discard()
         activeMeetingSession = nil
+        disarmMeetingAutoStop()
         if let meetingStartMeetingID {
             canceledMeetingStartIDs.insert(meetingStartMeetingID)
             resolveLiveMeetingAfterStartFailure(id: meetingStartMeetingID)
@@ -2545,21 +2567,38 @@ final class MuesliController: NSObject {
     }
 
     @discardableResult
-    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, endDate: Date? = nil) -> Bool {
+    func startForegroundMeetingRecording(
+        title: String = "Meeting",
+        calendarEventID: String? = nil,
+        endDate: Date? = nil,
+        autoStopSource: MeetingAutoStopSource? = nil
+    ) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
         if isMeetingRecording() {
             presentHistoryWindow(tab: .meetings)
             return false
         }
         guard !isStartingMeetingRecording else { return false }
-        let didStart = startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true, endDate: endDate)
+        let didStart = startMeetingRecording(
+            title: title,
+            calendarEventID: calendarEventID,
+            openDocument: true,
+            endDate: endDate,
+            autoStopSource: autoStopSource
+        )
         guard didStart else { return false }
         presentHistoryWindow(tab: .meetings)
         return true
     }
 
     @discardableResult
-    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false, endDate: Date? = nil) -> Bool {
+    func startMeetingRecording(
+        title: String = "Meeting",
+        calendarEventID: String? = nil,
+        openDocument: Bool = false,
+        endDate: Date? = nil,
+        autoStopSource: MeetingAutoStopSource? = nil
+    ) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
         guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
             presentErrorAlert(
@@ -2590,6 +2629,7 @@ final class MuesliController: NSObject {
             presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
             return false
         }
+        armMeetingAutoStop(source: autoStopSource ?? recentMeetingAutoStopSource())
         isStartingMeetingRecording = true
         meetingStartMeetingID = meetingID
         updateMeetingStartStatus("Preparing meeting transcription...")
@@ -2611,6 +2651,7 @@ final class MuesliController: NSObject {
                 )
             } catch is CancellationError {
                 if self.meetingStartMeetingID == meetingID {
+                    self.disarmMeetingAutoStop()
                     self.resolveLiveMeetingAfterStartFailure(id: meetingID)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.meetingMonitor.refreshState()
@@ -2622,6 +2663,7 @@ final class MuesliController: NSObject {
             } catch {
                 if self.meetingStartMeetingID == meetingID {
                     fputs("[muesli-native] failed to start meeting: \(error)\n", stderr)
+                    self.disarmMeetingAutoStop()
                     self.resolveLiveMeetingAfterStartFailure(id: meetingID)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.meetingMonitor.refreshState()
@@ -2672,6 +2714,7 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         setState(.idle)
         endMeetingActivity()
+        disarmMeetingAutoStop()
         meetingStartTask = nil
         meetingStartMeetingID = nil
         isStartingMeetingRecording = false
@@ -2790,7 +2833,12 @@ final class MuesliController: NSObject {
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
     func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
         NSWorkspace.shared.open(meetingURL)
-        startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID, endDate: endDate)
+        startForegroundMeetingRecording(
+            title: title,
+            calendarEventID: calendarEventID,
+            endDate: endDate,
+            autoStopSource: MeetingAutoStopSource(meetingURL: meetingURL)
+        )
     }
 
     /// Open meeting URL and suppress detection for the event duration.
@@ -2865,6 +2913,7 @@ final class MuesliController: NSObject {
         guard let sessionToDiscard = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
+            disarmMeetingAutoStop()
             indicator.setMeetingRecording(false, config: config)
             if let activeMeetingID {
                 resolveLiveMeetingAfterDiscard(id: activeMeetingID)
@@ -2876,6 +2925,7 @@ final class MuesliController: NSObject {
             return
         }
         sessionToDiscard.discard()
+        disarmMeetingAutoStop()
         self.activeMeetingSession = nil
         indicator.setMeetingRecording(false, config: config)
         if let activeMeetingID {
@@ -2983,6 +3033,7 @@ final class MuesliController: NSObject {
         guard let sessionToStop = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
+            disarmMeetingAutoStop()
             if let activeMeetingID {
                 resolveLiveMeetingAfterStopFailure(id: activeMeetingID)
                 self.activeMeetingID = nil
@@ -2994,6 +3045,7 @@ final class MuesliController: NSObject {
             return
         }
         isStoppingMeetingRecording = true
+        disarmMeetingAutoStop()
         meetingEndTimer?.invalidate()
         meetingEndTimer = nil
         meetingNotification.close()
@@ -3004,8 +3056,7 @@ final class MuesliController: NSObject {
             syncAppState()
         }
         indicator.setMeetingRecording(false, config: config)
-        indicator.setTranscribingTitle("Transcribing", config: config)
-        setState(.transcribing)
+        setMeetingProcessingStatus("Meeting: Transcribing")
         sessionToStop.onProgress = { [weak self] stage in
             Task { @MainActor [weak self] in
                 self?.setMeetingProcessingStage(stage)
@@ -3054,7 +3105,9 @@ final class MuesliController: NSObject {
                 self.activeMeetingID = nil
                 self.isStoppingMeetingRecording = false
                 self.endMeetingActivity()
-                self.setState(.idle)
+                if !self.isDictationActivityInProgress {
+                    self.setState(.idle)
+                }
                 self.meetingMonitor.resumeAfterCooldown()
                 self.meetingMonitor.refreshState()
                 self.statusBarController?.refresh()
@@ -3397,6 +3450,63 @@ final class MuesliController: NSObject {
         meetingMonitor.refreshState()
     }
 
+    private func armMeetingAutoStop(source: MeetingAutoStopSource?) {
+        activeMeetingAutoStopSource = source
+        activeMeetingAutoStopLastSeenAt = source == nil ? nil : Date()
+    }
+
+    private func recentMeetingAutoStopSource() -> MeetingAutoStopSource? {
+        guard let candidate = latestMeetingActivityCandidate,
+              let observedAt = latestMeetingActivityCandidateObservedAt,
+              Date().timeIntervalSince(observedAt) <= 15 else {
+            return nil
+        }
+        return MeetingAutoStopSource(candidate: candidate)
+    }
+
+    private func disarmMeetingAutoStop() {
+        activeMeetingAutoStopSource = nil
+        activeMeetingAutoStopLastSeenAt = nil
+        latestMeetingActivityCandidate = nil
+        latestMeetingActivityCandidateObservedAt = nil
+    }
+
+    private func handleMeetingActivityCandidate(_ candidate: MeetingCandidate?) {
+        if activeMeetingAutoStopSource == nil,
+           !isMeetingRecording(),
+           !isStartingMeetingRecording {
+            if let candidate {
+                latestMeetingActivityCandidate = candidate
+                latestMeetingActivityCandidateObservedAt = Date()
+            } else {
+                latestMeetingActivityCandidate = nil
+                latestMeetingActivityCandidateObservedAt = nil
+            }
+        }
+
+        guard let source = activeMeetingAutoStopSource,
+              activeMeetingSession?.isRecording == true,
+              !isStoppingMeetingRecording else {
+            return
+        }
+
+        let now = Date()
+        if let candidate,
+           MeetingAutoStopPolicy.matches(candidate: candidate, source: source) {
+            activeMeetingAutoStopSource = source.refined(with: candidate)
+            activeMeetingAutoStopLastSeenAt = now
+            return
+        }
+
+        guard let lastSeenAt = activeMeetingAutoStopLastSeenAt,
+              now.timeIntervalSince(lastSeenAt) >= meetingAutoStopGracePeriod else {
+            return
+        }
+
+        fputs("[meeting] auto-stopping recording after meeting source disappeared\n", stderr)
+        stopMeetingRecording()
+    }
+
     private func presentMeetingDetection(_ candidate: MeetingCandidate) {
         guard config.showMeetingDetectionNotification,
               !isShowingCalendarNotification,
@@ -3419,7 +3529,10 @@ final class MuesliController: NSObject {
             platform: MeetingPlatform(candidate.platform),
             onStartRecording: { [weak self] in
                 guard let self else { return }
-                if self.startForegroundMeetingRecording(title: title) {
+                if self.startForegroundMeetingRecording(
+                    title: title,
+                    autoStopSource: MeetingAutoStopSource(candidate: candidate)
+                ) {
                     self.meetingMonitor.markRecordingStarted(candidate)
                     self.presentedMeetingCandidate = nil
                 } else {
@@ -3623,7 +3736,7 @@ final class MuesliController: NSObject {
     }
 
     private var canPrepareComputerUseCommand: Bool {
-        !isMeetingRecording()
+        !isMeetingCapturingAudio
             && !isDictationTestMode
             && dictationStartedAt == nil
             && computerUseCommandStartedAt == nil
@@ -3632,7 +3745,7 @@ final class MuesliController: NSObject {
     }
 
     private var canStartComputerUseCommand: Bool {
-        !isMeetingRecording()
+        !isMeetingCapturingAudio
             && !isDictationTestMode
             && dictationStartedAt == nil
             && computerUseCommandStartedAt == nil
@@ -3861,7 +3974,7 @@ final class MuesliController: NSObject {
     }
 
     private func handlePrepare() {
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         fputs("[muesli-native] prepare\n", stderr)
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
@@ -3891,7 +4004,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleStart() {
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
 
         // Nemotron is handsfree-only — block hold-to-talk and show a hint
         if selectedBackend.backend == "nemotron" {
@@ -3964,7 +4077,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleCancel() {
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         fputs("[muesli-native] cancel\n", stderr)
         resetDictationOutputMode()
 
@@ -3985,7 +4098,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         meetingMonitor.suppressWhileActive()
         beginDictationOutput(mode: outputMode)
@@ -4043,7 +4156,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleStop() {
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         fputs("[muesli-native] stop\n", stderr)
         let startedAt = dictationStartedAt ?? Date()
         dictationStartedAt = nil
@@ -4312,9 +4425,16 @@ final class MuesliController: NSObject {
             .first(where: { $0.id == event.id })
         let calendarEndDate = calendarEvent?.endDate
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
+        let autoStopSource = meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
 
         if config.autoRecordMeetings, !isMeetingRecording() {
-            startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true, endDate: calendarEndDate)
+            startMeetingRecording(
+                title: event.title,
+                calendarEventID: event.id,
+                openDocument: true,
+                endDate: calendarEndDate,
+                autoStopSource: autoStopSource
+            )
             return
         }
 
@@ -4344,7 +4464,12 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(title: title, calendarEventID: event.id, endDate: calendarEndDate)
+                self.startForegroundMeetingRecording(
+                    title: title,
+                    calendarEventID: event.id,
+                    endDate: calendarEndDate,
+                    autoStopSource: autoStopSource
+                )
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting auto-stop policy")
+struct MeetingAutoStopPolicyTests {
+    @Test("matches the original browser meeting candidate")
+    func matchesOriginalBrowserMeetingCandidate() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+
+        #expect(MeetingAutoStopPolicy.matches(
+            candidate: googleMeetCandidate(),
+            source: source
+        ))
+    }
+
+    @Test("matches calendar-wrapped candidate by normalized URL")
+    func matchesCalendarWrappedCandidateByURL() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let calendarCandidate = MeetingCandidate(
+            id: "cal:event-1:googleMeet:meet.google.com/aaa-bbbb-ccc",
+            platform: .googleMeet,
+            appName: "Chrome",
+            url: "meet.google.com/aaa-bbbb-ccc",
+            evidence: [.browserURL, .calendarEvent],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            meetingTitle: "Team sync",
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 1234
+        )
+
+        #expect(MeetingAutoStopPolicy.matches(candidate: calendarCandidate, source: source))
+    }
+
+    @Test("matches browser audio fallback by suppression session")
+    func matchesBrowserAudioFallbackBySuppressionSession() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let audioFallback = MeetingCandidate(
+            id: "browser:com.google.Chrome:session:1800000000",
+            platform: .unknown,
+            appName: "Chrome",
+            url: nil,
+            evidence: [.audioInputProcess],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_005),
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 9876,
+            suppressionID: "browser:com.google.Chrome:session:1800000000"
+        )
+
+        #expect(MeetingAutoStopPolicy.matches(candidate: audioFallback, source: source))
+    }
+
+    @Test("ignores unrelated calendar-only activity")
+    func ignoresUnrelatedCalendarOnlyActivity() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let calendarOnly = MeetingCandidate(
+            id: "cal:event-2",
+            platform: .unknown,
+            appName: "Meeting",
+            url: nil,
+            evidence: [.calendarEvent, .micActive],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_010),
+            meetingTitle: "Later meeting"
+        )
+
+        #expect(!MeetingAutoStopPolicy.matches(candidate: calendarOnly, source: source))
+    }
+
+    @Test("creates source from supported meeting URL")
+    func createsSourceFromSupportedMeetingURL() throws {
+        let url = try #require(URL(string: "https://meet.google.com/aaa-bbbb-ccc?authuser=0"))
+        let source = try #require(MeetingAutoStopSource(meetingURL: url))
+
+        #expect(source.candidateID == "googleMeet:meet.google.com/aaa-bbbb-ccc")
+        #expect(source.normalizedURL == "meet.google.com/aaa-bbbb-ccc")
+    }
+
+    @Test("refines URL-only source with observed browser source")
+    func refinesURLOnlySourceWithObservedBrowserSource() throws {
+        let url = try #require(URL(string: "https://meet.google.com/aaa-bbbb-ccc"))
+        let source = try #require(MeetingAutoStopSource(meetingURL: url))
+
+        let refined = source.refined(with: googleMeetCandidate())
+
+        #expect(refined.sourceBundleID == "com.google.Chrome")
+        #expect(refined.suppressionID == "browser:com.google.Chrome:session:1800000000")
+    }
+
+    private func googleMeetCandidate() -> MeetingCandidate {
+        MeetingCandidate(
+            id: "googleMeet:meet.google.com/aaa-bbbb-ccc",
+            platform: .googleMeet,
+            appName: "Chrome",
+            url: "meet.google.com/aaa-bbbb-ccc",
+            evidence: [.browserURL, .audioInputProcess],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 1234,
+            suppressionID: "browser:com.google.Chrome:session:1800000000"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Track meeting activity separately from prompt suppression so active recordings can auto-stop when the meeting source disappears.
- Carry the auto-stop source through detected, scheduled, auto-recorded, and join-and-record meeting starts.
- Allow dictation and computer-use commands while a stopped meeting is transcribing in the background, while still blocking them during active meeting audio capture.

## Testing
- Manually verified with `MuesliDev`: leaving/closing a Google Meet auto-stops recording, and dictation works while meeting transcription continues.
- `env -u OPENAI_API_KEY -u OPENROUTER_API_KEY swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"`
