### PR TITLE
Auto-stop meeting recording when source disappears

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -51,6 +51,48 @@ struct MeetingAutoStopSource: Equatable {
     }
 }
 
+struct MeetingAutoStopTracker: Equatable {
+    private(set) var source: MeetingAutoStopSource?
+    private(set) var lastSeenAt: Date?
+
+    var isArmed: Bool {
+        source != nil
+    }
+
+    mutating func arm(source: MeetingAutoStopSource?) {
+        self.source = source
+        lastSeenAt = nil
+    }
+
+    mutating func disarm() {
+        source = nil
+        lastSeenAt = nil
+    }
+
+    mutating func observe(
+        candidate: MeetingCandidate?,
+        now: Date,
+        gracePeriod: TimeInterval
+    ) -> Bool {
+        guard let currentSource = source else {
+            return false
+        }
+
+        if let candidate,
+           MeetingAutoStopPolicy.matches(candidate: candidate, source: currentSource) {
+            source = currentSource.refined(with: candidate)
+            lastSeenAt = now
+            return false
+        }
+
+        guard let lastSeenAt else {
+            return false
+        }
+
+        return now.timeIntervalSince(lastSeenAt) >= gracePeriod
+    }
+}
+
 enum MeetingAutoStopPolicy {
     static func matches(candidate: MeetingCandidate, source: MeetingAutoStopSource) -> Bool {
         if let candidateID = source.candidateID, candidate.id == candidateID {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -54,6 +54,7 @@ struct MeetingAutoStopSource: Equatable {
 struct MeetingAutoStopTracker: Equatable {
     private(set) var source: MeetingAutoStopSource?
     private(set) var lastSeenAt: Date?
+    private var observedBeforeRecordingStarted = false
 
     var isArmed: Bool {
         source != nil
@@ -62,11 +63,29 @@ struct MeetingAutoStopTracker: Equatable {
     mutating func arm(source: MeetingAutoStopSource?) {
         self.source = source
         lastSeenAt = nil
+        observedBeforeRecordingStarted = false
     }
 
     mutating func disarm() {
         source = nil
         lastSeenAt = nil
+        observedBeforeRecordingStarted = false
+    }
+
+    mutating func observeBeforeRecordingStarted(candidate: MeetingCandidate?) {
+        guard let currentSource = source,
+              let candidate,
+              MeetingAutoStopPolicy.matches(candidate: candidate, source: currentSource) else {
+            return
+        }
+        source = currentSource.refined(with: candidate)
+        observedBeforeRecordingStarted = true
+    }
+
+    mutating func markRecordingStarted(now: Date) {
+        guard observedBeforeRecordingStarted, lastSeenAt == nil else { return }
+        lastSeenAt = now
+        observedBeforeRecordingStarted = false
     }
 
     mutating func observe(
@@ -105,6 +124,12 @@ enum MeetingAutoStopPolicy {
 
         if let normalizedURL = source.normalizedURL, candidate.url == normalizedURL {
             return true
+        }
+
+        guard source.candidateID == nil,
+              source.suppressionID == nil,
+              source.normalizedURL == nil else {
+            return false
         }
 
         if let sourceBundleID = source.sourceBundleID,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct MeetingAutoStopSource: Equatable {
+    let candidateID: String?
+    let suppressionID: String?
+    let normalizedURL: String?
+    let sourceBundleID: String?
+
+    private init(
+        candidateID: String?,
+        suppressionID: String?,
+        normalizedURL: String?,
+        sourceBundleID: String?
+    ) {
+        self.candidateID = candidateID
+        self.suppressionID = suppressionID
+        self.normalizedURL = normalizedURL
+        self.sourceBundleID = sourceBundleID
+    }
+
+    init(candidate: MeetingCandidate) {
+        self.candidateID = candidate.id
+        self.suppressionID = candidate.suppressionID
+        self.normalizedURL = candidate.url
+        self.sourceBundleID = candidate.sourceBundleID
+    }
+
+    init?(meetingURL: URL) {
+        guard let normalized = MeetingURLNormalizer.normalize(meetingURL.absoluteString) else {
+            return nil
+        }
+        self.candidateID = normalized.id
+        self.suppressionID = normalized.id
+        self.normalizedURL = normalized.url
+        self.sourceBundleID = nil
+    }
+
+    func refined(with candidate: MeetingCandidate) -> MeetingAutoStopSource {
+        MeetingAutoStopSource(
+            candidateID: candidateID ?? candidate.id,
+            suppressionID: candidate.suppressionID,
+            normalizedURL: normalizedURL ?? candidate.url,
+            sourceBundleID: sourceBundleID ?? candidate.sourceBundleID
+        )
+    }
+}
+
+enum MeetingAutoStopPolicy {
+    static func matches(candidate: MeetingCandidate, source: MeetingAutoStopSource) -> Bool {
+        if let candidateID = source.candidateID, candidate.id == candidateID {
+            return true
+        }
+
+        if let suppressionID = source.suppressionID, candidate.suppressionID == suppressionID {
+            return true
+        }
+
+        if let normalizedURL = source.normalizedURL, candidate.url == normalizedURL {
+            return true
+        }
+
+        if let sourceBundleID = source.sourceBundleID,
+           candidate.sourceBundleID == sourceBundleID,
+           candidate.evidence.contains(.audioInputProcess) {
+            return true
+        }
+
+        return false
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -5,17 +5,20 @@ struct MeetingAutoStopSource: Equatable {
     let suppressionID: String?
     let normalizedURL: String?
     let sourceBundleID: String?
+    let hasObservedCandidate: Bool
 
     private init(
         candidateID: String?,
         suppressionID: String?,
         normalizedURL: String?,
-        sourceBundleID: String?
+        sourceBundleID: String?,
+        hasObservedCandidate: Bool
     ) {
         self.candidateID = candidateID
         self.suppressionID = suppressionID
         self.normalizedURL = normalizedURL
         self.sourceBundleID = sourceBundleID
+        self.hasObservedCandidate = hasObservedCandidate
     }
 
     init(candidate: MeetingCandidate) {
@@ -23,6 +26,7 @@ struct MeetingAutoStopSource: Equatable {
         self.suppressionID = candidate.suppressionID
         self.normalizedURL = candidate.url
         self.sourceBundleID = candidate.sourceBundleID
+        self.hasObservedCandidate = true
     }
 
     init?(meetingURL: URL) {
@@ -33,6 +37,7 @@ struct MeetingAutoStopSource: Equatable {
         self.suppressionID = normalized.id
         self.normalizedURL = normalized.url
         self.sourceBundleID = nil
+        self.hasObservedCandidate = false
     }
 
     func refined(with candidate: MeetingCandidate) -> MeetingAutoStopSource {
@@ -40,7 +45,8 @@ struct MeetingAutoStopSource: Equatable {
             candidateID: candidateID ?? candidate.id,
             suppressionID: candidate.suppressionID,
             normalizedURL: normalizedURL ?? candidate.url,
-            sourceBundleID: sourceBundleID ?? candidate.sourceBundleID
+            sourceBundleID: sourceBundleID ?? candidate.sourceBundleID,
+            hasObservedCandidate: true
         )
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -12,11 +12,15 @@ final class MeetingMonitor {
     var isCalendarNotificationVisibleProvider: (() -> Bool)?
     var promptVisibilityProvider: (() -> MeetingPromptVisibility)?
     var mutedDetectionBundleIDsProvider: (() -> Set<String>)?
+    var onActivityCandidateChanged: ((MeetingCandidate?) -> Void)?
     var onPromptCandidateChanged: ((MeetingCandidate?) -> Void)?
 
     private lazy var detectionService = MeetingDetectionService(
         contextProvider: { [weak self] now in
             self?.makeEvaluationContext(now: now) ?? .disabled
+        },
+        activityHandler: { [weak self] candidate in
+            self?.onActivityCandidateChanged?(candidate)
         },
         promptHandler: { [weak self] update in
             self?.handlePromptUpdate(update)
@@ -287,6 +291,7 @@ private actor MeetingDetectionService {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
 
     private let contextProvider: @MainActor (Date) -> MeetingDetectionEvaluationContext
+    private let activityHandler: @MainActor (MeetingCandidate?) -> Void
     private let promptHandler: @MainActor (MeetingPromptUpdate) -> Void
     private let resolver = MeetingCandidateResolver()
     private let mediaSessionTracker = MeetingMediaSessionTracker()
@@ -311,9 +316,11 @@ private actor MeetingDetectionService {
 
     init(
         contextProvider: @escaping @MainActor (Date) -> MeetingDetectionEvaluationContext,
+        activityHandler: @escaping @MainActor (MeetingCandidate?) -> Void,
         promptHandler: @escaping @MainActor (MeetingPromptUpdate) -> Void
     ) {
         self.contextProvider = contextProvider
+        self.activityHandler = activityHandler
         self.promptHandler = promptHandler
     }
 
@@ -509,13 +516,18 @@ private actor MeetingDetectionService {
         )
 
         let resolverStart = Date()
-        let resolvedCandidate = isGloballySuppressed(now: now) ? nil : resolver.resolve(snapshot)
+        let resolvedActivityCandidate = resolver.resolve(snapshot)
         let resolverDuration = Date().timeIntervalSince(resolverStart)
-        let unmutedCandidate = isMuted(resolvedCandidate, mutedBundleIDs: context.mutedBundleIDs) ? nil : resolvedCandidate
-        let candidate = await mediaSessionTracker.stabilize(
-            candidate: unmutedCandidate,
+        let unmutedActivityCandidate = isMuted(
+            resolvedActivityCandidate,
+            mutedBundleIDs: context.mutedBundleIDs
+        ) ? nil : resolvedActivityCandidate
+        let activityCandidate = await mediaSessionTracker.stabilize(
+            candidate: unmutedActivityCandidate,
             snapshot: snapshot
         )
+        emitActivityUpdate(activityCandidate)
+        let candidate = isGloballySuppressed(now: now) ? nil : activityCandidate
         logCandidateIfChanged(candidate)
         updateRefreshState(
             trigger: trigger,
@@ -525,7 +537,8 @@ private actor MeetingDetectionService {
             browserMeetings: collectedSignals.browserMeetings,
             foregroundBundleID: collectedSignals.foregroundBundleID,
             visibility: context.promptVisibility,
-            candidate: candidate,
+            candidate: activityCandidate,
+            keepSuspicious: context.isRecording || context.isStartingRecording,
             now: now
         )
 
@@ -572,6 +585,12 @@ private actor MeetingDetectionService {
     private func emitPromptUpdate(_ update: MeetingPromptUpdate) {
         Task { @MainActor [promptHandler] in
             promptHandler(update)
+        }
+    }
+
+    private func emitActivityUpdate(_ candidate: MeetingCandidate?) {
+        Task { @MainActor [activityHandler] in
+            activityHandler(candidate)
         }
     }
 
@@ -697,11 +716,12 @@ private actor MeetingDetectionService {
         foregroundBundleID: String?,
         visibility: MeetingPromptVisibility,
         candidate: MeetingCandidate?,
+        keepSuspicious: Bool = false,
         now: Date
     ) {
         signalRefreshState.hasMicOrCameraSignal = micActive || cameraActive
         signalRefreshState.hasRecentBrowserMeeting = !browserMeetings.isEmpty
-        signalRefreshState.hasActiveCandidate = candidate != nil
+        signalRefreshState.hasActiveCandidate = candidate != nil || keepSuspicious
         signalRefreshState.hasPromptVisible = visibility.isVisible
         signalRefreshState.hasCalendarEvent = calendarEvent != nil
         signalRefreshState.foregroundIsMeetingCapableApp = foregroundBundleID.map { bundleID in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -518,16 +518,16 @@ private actor MeetingDetectionService {
         let resolverStart = Date()
         let resolvedActivityCandidate = resolver.resolve(snapshot)
         let resolverDuration = Date().timeIntervalSince(resolverStart)
-        let unmutedActivityCandidate = isMuted(
-            resolvedActivityCandidate,
-            mutedBundleIDs: context.mutedBundleIDs
-        ) ? nil : resolvedActivityCandidate
         let activityCandidate = await mediaSessionTracker.stabilize(
-            candidate: unmutedActivityCandidate,
+            candidate: resolvedActivityCandidate,
             snapshot: snapshot
         )
         emitActivityUpdate(activityCandidate)
-        let candidate = isGloballySuppressed(now: now) ? nil : activityCandidate
+        let unmutedActivityCandidate = isMuted(
+            activityCandidate,
+            mutedBundleIDs: context.mutedBundleIDs
+        ) ? nil : activityCandidate
+        let candidate = isGloballySuppressed(now: now) ? nil : unmutedActivityCandidate
         logCandidateIfChanged(candidate)
         updateRefreshState(
             trigger: trigger,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -353,7 +353,7 @@ final class MuesliController: NSObject {
         }
         meetingMonitor.isRecordingProvider = { [weak self] in
             guard let self else { return false }
-            return self.isMeetingRecording() || self.isDictationActivityInProgress
+            return self.isMeetingRecording()
         }
         meetingMonitor.isStartingRecordingProvider = { [weak self] in
             self?.isStartingMeetingRecording ?? false
@@ -2780,6 +2780,7 @@ final class MuesliController: NSObject {
                 }
                 activeMeetingSession = meetingSession
                 activeMeetingID = meetingID
+                activeMeetingAutoStop.markRecordingStarted(now: Date())
                 meetingMonitor.suppressWhileActive()
                 meetingMonitor.refreshState()
                 statusBarController?.setStatus("Meeting: \(title)")
@@ -3476,6 +3477,13 @@ final class MuesliController: NSObject {
                 latestMeetingActivityCandidate = nil
                 latestMeetingActivityCandidateObservedAt = nil
             }
+        }
+
+        if activeMeetingAutoStop.isArmed,
+           isStartingMeetingRecording,
+           !isStoppingMeetingRecording {
+            activeMeetingAutoStop.observeBeforeRecordingStarted(candidate: candidate)
+            return
         }
 
         guard activeMeetingAutoStop.isArmed,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -184,8 +184,7 @@ final class MuesliController: NSObject {
     private var activeMeetingCalendarEndDate: Date?
     private var latestMeetingActivityCandidate: MeetingCandidate?
     private var latestMeetingActivityCandidateObservedAt: Date?
-    private var activeMeetingAutoStopSource: MeetingAutoStopSource?
-    private var activeMeetingAutoStopLastSeenAt: Date?
+    private var activeMeetingAutoStop = MeetingAutoStopTracker()
     private let meetingAutoStopGracePeriod: TimeInterval = 20
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
@@ -347,7 +346,7 @@ final class MuesliController: NSObject {
         meetingMonitor.detectionEnabledProvider = { [weak self] in
             guard let self else { return false }
             return self.config.showMeetingDetectionNotification
-                || self.activeMeetingAutoStopSource != nil
+                || self.activeMeetingAutoStop.isArmed
         }
         meetingMonitor.mutedDetectionBundleIDsProvider = { [weak self] in
             Set(self?.config.mutedMeetingDetectionAppBundleIDs ?? [])
@@ -1158,7 +1157,7 @@ final class MuesliController: NSObject {
 
     private func syncMeetingDetectionMonitor() {
         let shouldRun = meetingFeatureMonitorsAllowed
-            && (config.showMeetingDetectionNotification || activeMeetingAutoStopSource != nil)
+            && (config.showMeetingDetectionNotification || activeMeetingAutoStop.isArmed)
         if shouldRun && !meetingDetectionMonitorStarted {
             meetingMonitor.start()
             meetingDetectionMonitorStarted = true
@@ -3446,8 +3445,7 @@ final class MuesliController: NSObject {
     }
 
     private func armMeetingAutoStop(source: MeetingAutoStopSource?) {
-        activeMeetingAutoStopSource = source
-        activeMeetingAutoStopLastSeenAt = source?.hasObservedCandidate == true ? Date() : nil
+        activeMeetingAutoStop.arm(source: source)
         syncMeetingDetectionMonitor()
     }
 
@@ -3461,15 +3459,14 @@ final class MuesliController: NSObject {
     }
 
     private func disarmMeetingAutoStop() {
-        activeMeetingAutoStopSource = nil
-        activeMeetingAutoStopLastSeenAt = nil
+        activeMeetingAutoStop.disarm()
         latestMeetingActivityCandidate = nil
         latestMeetingActivityCandidateObservedAt = nil
         syncMeetingDetectionMonitor()
     }
 
     private func handleMeetingActivityCandidate(_ candidate: MeetingCandidate?) {
-        if activeMeetingAutoStopSource == nil,
+        if !activeMeetingAutoStop.isArmed,
            !isMeetingRecording(),
            !isStartingMeetingRecording {
             if let candidate {
@@ -3481,27 +3478,21 @@ final class MuesliController: NSObject {
             }
         }
 
-        guard let source = activeMeetingAutoStopSource,
+        guard activeMeetingAutoStop.isArmed,
               activeMeetingSession?.isRecording == true,
               !isStoppingMeetingRecording else {
             return
         }
 
         let now = Date()
-        if let candidate,
-           MeetingAutoStopPolicy.matches(candidate: candidate, source: source) {
-            activeMeetingAutoStopSource = source.refined(with: candidate)
-            activeMeetingAutoStopLastSeenAt = now
-            return
+        if activeMeetingAutoStop.observe(
+            candidate: candidate,
+            now: now,
+            gracePeriod: meetingAutoStopGracePeriod
+        ) {
+            fputs("[meeting] auto-stopping recording after meeting source disappeared\n", stderr)
+            stopMeetingRecording()
         }
-
-        guard let lastSeenAt = activeMeetingAutoStopLastSeenAt,
-              now.timeIntervalSince(lastSeenAt) >= meetingAutoStopGracePeriod else {
-            return
-        }
-
-        fputs("[meeting] auto-stopping recording after meeting source disappeared\n", stderr)
-        stopMeetingRecording()
     }
 
     private func presentMeetingDetection(_ candidate: MeetingCandidate) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1158,7 +1158,7 @@ final class MuesliController: NSObject {
 
     private func syncMeetingDetectionMonitor() {
         let shouldRun = meetingFeatureMonitorsAllowed
-            && config.showMeetingDetectionNotification
+            && (config.showMeetingDetectionNotification || activeMeetingAutoStopSource != nil)
         if shouldRun && !meetingDetectionMonitorStarted {
             meetingMonitor.start()
             meetingDetectionMonitorStarted = true
@@ -3447,7 +3447,8 @@ final class MuesliController: NSObject {
 
     private func armMeetingAutoStop(source: MeetingAutoStopSource?) {
         activeMeetingAutoStopSource = source
-        activeMeetingAutoStopLastSeenAt = source == nil ? nil : Date()
+        activeMeetingAutoStopLastSeenAt = source?.hasObservedCandidate == true ? Date() : nil
+        syncMeetingDetectionMonitor()
     }
 
     private func recentMeetingAutoStopSource() -> MeetingAutoStopSource? {
@@ -3464,6 +3465,7 @@ final class MuesliController: NSObject {
         activeMeetingAutoStopLastSeenAt = nil
         latestMeetingActivityCandidate = nil
         latestMeetingActivityCandidateObservedAt = nil
+        syncMeetingDetectionMonitor()
     }
 
     private func handleMeetingActivityCandidate(_ candidate: MeetingCandidate?) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -182,6 +182,11 @@ final class MuesliController: NSObject {
     private var presentedMeetingCandidate: MeetingCandidate?
     private var meetingEndTimer: Timer?
     private var activeMeetingCalendarEndDate: Date?
+    private var latestMeetingActivityCandidate: MeetingCandidate?
+    private var latestMeetingActivityCandidateObservedAt: Date?
+    private var activeMeetingAutoStopSource: MeetingAutoStopSource?
+    private var activeMeetingAutoStopLastSeenAt: Date?
+    private let meetingAutoStopGracePeriod: TimeInterval = 20
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
     private var meetingStartTask: Task<Void, Never>?
@@ -340,7 +345,9 @@ final class MuesliController: NSObject {
             self?.currentOrNearbyCachedCalendarEvent()
         }
         meetingMonitor.detectionEnabledProvider = { [weak self] in
-            self?.config.showMeetingDetectionNotification ?? false
+            guard let self else { return false }
+            return self.config.showMeetingDetectionNotification
+                || self.activeMeetingAutoStopSource != nil
         }
         meetingMonitor.mutedDetectionBundleIDsProvider = { [weak self] in
             Set(self?.config.mutedMeetingDetectionAppBundleIDs ?? [])
@@ -364,6 +371,9 @@ final class MuesliController: NSObject {
                 currentPromptID: self.meetingNotification.currentPromptID,
                 shownAt: self.meetingNotification.shownAt
             )
+        }
+        meetingMonitor.onActivityCandidateChanged = { [weak self] candidate in
+            self?.handleMeetingActivityCandidate(candidate)
         }
         meetingMonitor.onPromptCandidateChanged = { [weak self] candidate in
             guard let self else { return }
@@ -444,6 +454,7 @@ final class MuesliController: NSObject {
         meetingStartingNowTimers.values.forEach { $0.invalidate() }
         meetingStartingNowTimers.removeAll()
         meetingFeatureMonitorsAllowed = false
+        disarmMeetingAutoStop()
         meetingMonitor.stop()
         meetingDetectionMonitorStarted = false
         dismissPresentedMeetingDetection()
@@ -1227,6 +1238,7 @@ final class MuesliController: NSObject {
               !isMeetingRecording(),
               !isStartingMeetingRecording else { return }
         isShowingCalendarNotification = true
+        let autoStopSource = meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
 
         meetingNotification.show(
             title: "Meeting starting now",
@@ -1236,7 +1248,12 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID, endDate: endDate)
+                self.startForegroundMeetingRecording(
+                    title: title,
+                    calendarEventID: calendarEventID,
+                    endDate: endDate,
+                    autoStopSource: autoStopSource
+                )
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -2483,6 +2500,7 @@ final class MuesliController: NSObject {
 
         activeMeetingSession?.discard()
         activeMeetingSession = nil
+        disarmMeetingAutoStop()
         if let meetingStartMeetingID {
             canceledMeetingStartIDs.insert(meetingStartMeetingID)
             resolveLiveMeetingAfterStartFailure(id: meetingStartMeetingID)
@@ -2545,21 +2563,38 @@ final class MuesliController: NSObject {
     }
 
     @discardableResult
-    func startForegroundMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, endDate: Date? = nil) -> Bool {
+    func startForegroundMeetingRecording(
+        title: String = "Meeting",
+        calendarEventID: String? = nil,
+        endDate: Date? = nil,
+        autoStopSource: MeetingAutoStopSource? = nil
+    ) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
         if isMeetingRecording() {
             presentHistoryWindow(tab: .meetings)
             return false
         }
         guard !isStartingMeetingRecording else { return false }
-        let didStart = startMeetingRecording(title: title, calendarEventID: calendarEventID, openDocument: true, endDate: endDate)
+        let didStart = startMeetingRecording(
+            title: title,
+            calendarEventID: calendarEventID,
+            openDocument: true,
+            endDate: endDate,
+            autoStopSource: autoStopSource
+        )
         guard didStart else { return false }
         presentHistoryWindow(tab: .meetings)
         return true
     }
 
     @discardableResult
-    func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false, endDate: Date? = nil) -> Bool {
+    func startMeetingRecording(
+        title: String = "Meeting",
+        calendarEventID: String? = nil,
+        openDocument: Bool = false,
+        endDate: Date? = nil,
+        autoStopSource: MeetingAutoStopSource? = nil
+    ) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
         guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
             presentErrorAlert(
@@ -2590,6 +2625,7 @@ final class MuesliController: NSObject {
             presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
             return false
         }
+        armMeetingAutoStop(source: autoStopSource ?? recentMeetingAutoStopSource())
         isStartingMeetingRecording = true
         meetingStartMeetingID = meetingID
         updateMeetingStartStatus("Preparing meeting transcription...")
@@ -2611,6 +2647,7 @@ final class MuesliController: NSObject {
                 )
             } catch is CancellationError {
                 if self.meetingStartMeetingID == meetingID {
+                    self.disarmMeetingAutoStop()
                     self.resolveLiveMeetingAfterStartFailure(id: meetingID)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.meetingMonitor.refreshState()
@@ -2622,6 +2659,7 @@ final class MuesliController: NSObject {
             } catch {
                 if self.meetingStartMeetingID == meetingID {
                     fputs("[muesli-native] failed to start meeting: \(error)\n", stderr)
+                    self.disarmMeetingAutoStop()
                     self.resolveLiveMeetingAfterStartFailure(id: meetingID)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.meetingMonitor.refreshState()
@@ -2672,6 +2710,7 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         setState(.idle)
         endMeetingActivity()
+        disarmMeetingAutoStop()
         meetingStartTask = nil
         meetingStartMeetingID = nil
         isStartingMeetingRecording = false
@@ -2790,7 +2829,12 @@ final class MuesliController: NSObject {
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
     func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
         NSWorkspace.shared.open(meetingURL)
-        startForegroundMeetingRecording(title: title, calendarEventID: calendarEventID, endDate: endDate)
+        startForegroundMeetingRecording(
+            title: title,
+            calendarEventID: calendarEventID,
+            endDate: endDate,
+            autoStopSource: MeetingAutoStopSource(meetingURL: meetingURL)
+        )
     }
 
     /// Open meeting URL and suppress detection for the event duration.
@@ -2865,6 +2909,7 @@ final class MuesliController: NSObject {
         guard let sessionToDiscard = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
+            disarmMeetingAutoStop()
             indicator.setMeetingRecording(false, config: config)
             if let activeMeetingID {
                 resolveLiveMeetingAfterDiscard(id: activeMeetingID)
@@ -2876,6 +2921,7 @@ final class MuesliController: NSObject {
             return
         }
         sessionToDiscard.discard()
+        disarmMeetingAutoStop()
         self.activeMeetingSession = nil
         indicator.setMeetingRecording(false, config: config)
         if let activeMeetingID {
@@ -2983,6 +3029,7 @@ final class MuesliController: NSObject {
         guard let sessionToStop = activeMeetingSession else {
             // Fallback recovery: reset indicator if session is nil
             guard !isStartingMeetingRecording else { return }
+            disarmMeetingAutoStop()
             if let activeMeetingID {
                 resolveLiveMeetingAfterStopFailure(id: activeMeetingID)
                 self.activeMeetingID = nil
@@ -2994,6 +3041,7 @@ final class MuesliController: NSObject {
             return
         }
         isStoppingMeetingRecording = true
+        disarmMeetingAutoStop()
         meetingEndTimer?.invalidate()
         meetingEndTimer = nil
         meetingNotification.close()
@@ -3397,6 +3445,63 @@ final class MuesliController: NSObject {
         meetingMonitor.refreshState()
     }
 
+    private func armMeetingAutoStop(source: MeetingAutoStopSource?) {
+        activeMeetingAutoStopSource = source
+        activeMeetingAutoStopLastSeenAt = source == nil ? nil : Date()
+    }
+
+    private func recentMeetingAutoStopSource() -> MeetingAutoStopSource? {
+        guard let candidate = latestMeetingActivityCandidate,
+              let observedAt = latestMeetingActivityCandidateObservedAt,
+              Date().timeIntervalSince(observedAt) <= 15 else {
+            return nil
+        }
+        return MeetingAutoStopSource(candidate: candidate)
+    }
+
+    private func disarmMeetingAutoStop() {
+        activeMeetingAutoStopSource = nil
+        activeMeetingAutoStopLastSeenAt = nil
+        latestMeetingActivityCandidate = nil
+        latestMeetingActivityCandidateObservedAt = nil
+    }
+
+    private func handleMeetingActivityCandidate(_ candidate: MeetingCandidate?) {
+        if activeMeetingAutoStopSource == nil,
+           !isMeetingRecording(),
+           !isStartingMeetingRecording {
+            if let candidate {
+                latestMeetingActivityCandidate = candidate
+                latestMeetingActivityCandidateObservedAt = Date()
+            } else {
+                latestMeetingActivityCandidate = nil
+                latestMeetingActivityCandidateObservedAt = nil
+            }
+        }
+
+        guard let source = activeMeetingAutoStopSource,
+              activeMeetingSession?.isRecording == true,
+              !isStoppingMeetingRecording else {
+            return
+        }
+
+        let now = Date()
+        if let candidate,
+           MeetingAutoStopPolicy.matches(candidate: candidate, source: source) {
+            activeMeetingAutoStopSource = source.refined(with: candidate)
+            activeMeetingAutoStopLastSeenAt = now
+            return
+        }
+
+        guard let lastSeenAt = activeMeetingAutoStopLastSeenAt,
+              now.timeIntervalSince(lastSeenAt) >= meetingAutoStopGracePeriod else {
+            return
+        }
+
+        fputs("[meeting] auto-stopping recording after meeting source disappeared\n", stderr)
+        stopMeetingRecording()
+    }
+
     private func presentMeetingDetection(_ candidate: MeetingCandidate) {
         guard config.showMeetingDetectionNotification,
               !isShowingCalendarNotification,
@@ -3419,7 +3524,10 @@ final class MuesliController: NSObject {
             platform: MeetingPlatform(candidate.platform),
             onStartRecording: { [weak self] in
                 guard let self else { return }
-                if self.startForegroundMeetingRecording(title: title) {
+                if self.startForegroundMeetingRecording(
+                    title: title,
+                    autoStopSource: MeetingAutoStopSource(candidate: candidate)
+                ) {
                     self.meetingMonitor.markRecordingStarted(candidate)
                     self.presentedMeetingCandidate = nil
                 } else {
@@ -4312,9 +4420,16 @@ final class MuesliController: NSObject {
             .first(where: { $0.id == event.id })
         let calendarEndDate = calendarEvent?.endDate
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
+        let autoStopSource = meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
 
         if config.autoRecordMeetings, !isMeetingRecording() {
-            startMeetingRecording(title: event.title, calendarEventID: event.id, openDocument: true, endDate: calendarEndDate)
+            startMeetingRecording(
+                title: event.title,
+                calendarEventID: event.id,
+                openDocument: true,
+                endDate: calendarEndDate,
+                autoStopSource: autoStopSource
+            )
             return
         }
 
@@ -4344,7 +4459,12 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(title: title, calendarEventID: event.id, endDate: calendarEndDate)
+                self.startForegroundMeetingRecording(
+                    title: title,
+                    calendarEventID: event.id,
+                    endDate: calendarEndDate,
+                    autoStopSource: autoStopSource
+                )
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -51,6 +51,25 @@ struct MeetingAutoStopPolicyTests {
         #expect(MeetingAutoStopPolicy.matches(candidate: audioFallback, source: source))
     }
 
+    @Test("ignores unrelated browser audio in the same browser")
+    func ignoresUnrelatedBrowserAudioInSameBrowser() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let otherTabAudio = MeetingCandidate(
+            id: "browser:com.google.Chrome:session:1800000999",
+            platform: .unknown,
+            appName: "Chrome",
+            url: nil,
+            evidence: [.audioInputProcess],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_005),
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 9876,
+            suppressionID: "browser:com.google.Chrome:session:1800000999"
+        )
+
+        #expect(!MeetingAutoStopPolicy.matches(candidate: otherTabAudio, source: source))
+    }
+
     @Test("ignores unrelated calendar-only activity")
     func ignoresUnrelatedCalendarOnlyActivity() {
         let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
@@ -163,6 +182,31 @@ struct MeetingAutoStopPolicyTests {
         #expect(!shouldStopWhileVisible)
         #expect(tracker.source?.sourceBundleID == "com.google.Chrome")
         #expect(tracker.source?.hasObservedCandidate == true)
+        #expect(shouldStopAfterGrace)
+    }
+
+    @Test("tracker starts disappearance grace at recording start after startup observation")
+    func trackerStartsGraceAtRecordingStartAfterStartupObservation() throws {
+        let url = try #require(URL(string: "https://meet.google.com/aaa-bbbb-ccc"))
+        var tracker = MeetingAutoStopTracker()
+        tracker.arm(source: MeetingAutoStopSource(meetingURL: url))
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        tracker.observeBeforeRecordingStarted(candidate: googleMeetCandidate())
+        tracker.markRecordingStarted(now: now.addingTimeInterval(10))
+        let shouldStopBeforeGrace = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(29),
+            gracePeriod: 20
+        )
+        let shouldStopAfterGrace = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(31),
+            gracePeriod: 20
+        )
+
+        #expect(tracker.source?.sourceBundleID == "com.google.Chrome")
+        #expect(!shouldStopBeforeGrace)
         #expect(shouldStopAfterGrace)
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -96,6 +96,76 @@ struct MeetingAutoStopPolicyTests {
         #expect(source.hasObservedCandidate)
     }
 
+    @Test("tracker waits for a recording-time observation before auto-stopping")
+    func trackerWaitsForRecordingTimeObservationBeforeAutoStopping() {
+        var tracker = MeetingAutoStopTracker()
+        tracker.arm(source: MeetingAutoStopSource(candidate: googleMeetCandidate()))
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let shouldStop = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(25),
+            gracePeriod: 20
+        )
+
+        #expect(!shouldStop)
+        #expect(tracker.lastSeenAt == nil)
+    }
+
+    @Test("tracker stops after a confirmed recording-time source disappears")
+    func trackerStopsAfterConfirmedRecordingTimeSourceDisappears() {
+        var tracker = MeetingAutoStopTracker()
+        tracker.arm(source: MeetingAutoStopSource(candidate: googleMeetCandidate()))
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let shouldStopWhileVisible = tracker.observe(
+            candidate: googleMeetCandidate(),
+            now: now,
+            gracePeriod: 20
+        )
+        let shouldStopBeforeGrace = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(19),
+            gracePeriod: 20
+        )
+        let shouldStopAfterGrace = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(21),
+            gracePeriod: 20
+        )
+
+        #expect(!shouldStopWhileVisible)
+        #expect(!shouldStopBeforeGrace)
+        #expect(shouldStopAfterGrace)
+    }
+
+    @Test("tracker refines URL source before disappearing")
+    func trackerRefinesURLSourceBeforeDisappearing() throws {
+        let url = try #require(URL(string: "https://meet.google.com/aaa-bbbb-ccc"))
+        var tracker = MeetingAutoStopTracker()
+        tracker.arm(source: MeetingAutoStopSource(meetingURL: url))
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let shouldStopBeforeObservation = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(25),
+            gracePeriod: 20
+        )
+        let shouldStopWhileVisible = tracker.observe(
+            candidate: googleMeetCandidate(),
+            now: now.addingTimeInterval(30),
+            gracePeriod: 20
+        )
+        let shouldStopAfterGrace = tracker.observe(
+            candidate: nil,
+            now: now.addingTimeInterval(51),
+            gracePeriod: 20
+        )
+
+        #expect(!shouldStopBeforeObservation)
+        #expect(!shouldStopWhileVisible)
+        #expect(tracker.source?.sourceBundleID == "com.google.Chrome")
+        #expect(tracker.source?.hasObservedCandidate == true)
+        #expect(shouldStopAfterGrace)
+    }
+
     private func googleMeetCandidate() -> MeetingCandidate {
         MeetingCandidate(
             id: "googleMeet:meet.google.com/aaa-bbbb-ccc",

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -74,6 +74,7 @@ struct MeetingAutoStopPolicyTests {
 
         #expect(source.candidateID == "googleMeet:meet.google.com/aaa-bbbb-ccc")
         #expect(source.normalizedURL == "meet.google.com/aaa-bbbb-ccc")
+        #expect(source.hasObservedCandidate == false)
     }
 
     @Test("refines URL-only source with observed browser source")
@@ -85,6 +86,14 @@ struct MeetingAutoStopPolicyTests {
 
         #expect(refined.sourceBundleID == "com.google.Chrome")
         #expect(refined.suppressionID == "browser:com.google.Chrome:session:1800000000")
+        #expect(refined.hasObservedCandidate)
+    }
+
+    @Test("candidate source starts as observed")
+    func candidateSourceStartsObserved() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+
+        #expect(source.hasObservedCandidate)
     }
 
     private func googleMeetCandidate() -> MeetingCandidate {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting auto-stop policy")
+struct MeetingAutoStopPolicyTests {
+    @Test("matches the original browser meeting candidate")
+    func matchesOriginalBrowserMeetingCandidate() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+
+        #expect(MeetingAutoStopPolicy.matches(
+            candidate: googleMeetCandidate(),
+            source: source
+        ))
+    }
+
+    @Test("matches calendar-wrapped candidate by normalized URL")
+    func matchesCalendarWrappedCandidateByURL() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let calendarCandidate = MeetingCandidate(
+            id: "cal:event-1:googleMeet:meet.google.com/aaa-bbbb-ccc",
+            platform: .googleMeet,
+            appName: "Chrome",
+            url: "meet.google.com/aaa-bbbb-ccc",
+            evidence: [.browserURL, .calendarEvent],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            meetingTitle: "Team sync",
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 1234
+        )
+
+        #expect(MeetingAutoStopPolicy.matches(candidate: calendarCandidate, source: source))
+    }
+
+    @Test("matches browser audio fallback by suppression session")
+    func matchesBrowserAudioFallbackBySuppressionSession() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let audioFallback = MeetingCandidate(
+            id: "browser:com.google.Chrome:session:1800000000",
+            platform: .unknown,
+            appName: "Chrome",
+            url: nil,
+            evidence: [.audioInputProcess],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_005),
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 9876,
+            suppressionID: "browser:com.google.Chrome:session:1800000000"
+        )
+
+        #expect(MeetingAutoStopPolicy.matches(candidate: audioFallback, source: source))
+    }
+
+    @Test("ignores unrelated calendar-only activity")
+    func ignoresUnrelatedCalendarOnlyActivity() {
+        let source = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let calendarOnly = MeetingCandidate(
+            id: "cal:event-2",
+            platform: .unknown,
+            appName: "Meeting",
+            url: nil,
+            evidence: [.calendarEvent, .micActive],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_010),
+            meetingTitle: "Later meeting"
+        )
+
+        #expect(!MeetingAutoStopPolicy.matches(candidate: calendarOnly, source: source))
+    }
+
+    @Test("creates source from supported meeting URL")
+    func createsSourceFromSupportedMeetingURL() throws {
+        let url = try #require(URL(string: "https://meet.google.com/aaa-bbbb-ccc?authuser=0"))
+        let source = try #require(MeetingAutoStopSource(meetingURL: url))
+
+        #expect(source.candidateID == "googleMeet:meet.google.com/aaa-bbbb-ccc")
+        #expect(source.normalizedURL == "meet.google.com/aaa-bbbb-ccc")
+    }
+
+    @Test("refines URL-only source with observed browser source")
+    func refinesURLOnlySourceWithObservedBrowserSource() throws {
+        let url = try #require(URL(string: "https://meet.google.com/aaa-bbbb-ccc"))
+        let source = try #require(MeetingAutoStopSource(meetingURL: url))
+
+        let refined = source.refined(with: googleMeetCandidate())
+
+        #expect(refined.sourceBundleID == "com.google.Chrome")
+        #expect(refined.suppressionID == "browser:com.google.Chrome:session:1800000000")
+    }
+
+    private func googleMeetCandidate() -> MeetingCandidate {
+        MeetingCandidate(
+            id: "googleMeet:meet.google.com/aaa-bbbb-ccc",
+            platform: .googleMeet,
+            appName: "Chrome",
+            url: "meet.google.com/aaa-bbbb-ccc",
+            evidence: [.browserURL, .audioInputProcess],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            meetingTitle: nil,
+            sourceBundleID: "com.google.Chrome",
+            sourcePID: 1234,
+            suppressionID: "browser:com.google.Chrome:session:1800000000"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Track meeting activity separately from prompt visibility so active recordings can keep observing the underlying meeting source while prompts are suppressed.
- Arm recordings with an auto-stop source from detected meetings, calendar notifications, auto-recording, and join-and-record flows.
- Stop the active meeting recording after the source disappears for a short grace period.

## Testing
- Manually verified with `MuesliDev`: leaving/closing a Google Meet auto-stops recording.
- `env -u OPENAI_API_KEY -u OPENROUTER_API_KEY swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"`
