### PR TITLE
[codex] Exclude dictation mic from meeting detection

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -283,6 +283,68 @@ private struct MeetingDetectionEvaluationContext {
     )
 }
 
+struct MeetingMediaSignals: Equatable {
+    let micActive: Bool
+    let cameraActive: Bool
+    let audioInputProcesses: [AudioProcessActivity]
+
+    var hasMicOrCameraSignal: Bool {
+        micActive || cameraActive
+    }
+}
+
+enum MeetingMediaSignalFilter {
+    static func apply(
+        deviceMicActive: Bool,
+        cameraActive: Bool,
+        audioInputProcesses: [AudioProcessActivity],
+        sensorAttributions: SensorAttributionSnapshot,
+        selfBundleID: String
+    ) -> MeetingMediaSignals {
+        let externalAudioInputProcesses = audioInputProcesses.filter {
+            !isSelfBundleID($0.bundleID, selfBundleID: selfBundleID)
+        }
+        let selfMicAttributed = audioInputProcesses.contains {
+            isSelfBundleID($0.bundleID, selfBundleID: selfBundleID)
+        } || sensorAttributions.micBundleIDs.contains {
+            isSelfBundleID($0, selfBundleID: selfBundleID)
+        }
+        let hasExternalMicAttribution = !externalAudioInputProcesses.isEmpty
+            || sensorAttributions.micBundleIDs.contains {
+                !isSelfBundleID($0, selfBundleID: selfBundleID)
+            }
+        let externalCameraActive = cameraActive
+            || sensorAttributions.cameraBundleIDs.contains {
+                !isSelfBundleID($0, selfBundleID: selfBundleID)
+            }
+
+        return MeetingMediaSignals(
+            micActive: hasExternalMicAttribution || (deviceMicActive && !selfMicAttributed),
+            cameraActive: externalCameraActive,
+            audioInputProcesses: externalAudioInputProcesses
+        )
+    }
+
+    static func hasExternalSensorAttribution(
+        _ sensorAttributions: SensorAttributionSnapshot,
+        selfBundleID: String
+    ) -> Bool {
+        sensorAttributions.micBundleIDs.contains {
+            !isSelfBundleID($0, selfBundleID: selfBundleID)
+        } || sensorAttributions.cameraBundleIDs.contains {
+            !isSelfBundleID($0, selfBundleID: selfBundleID)
+        }
+    }
+
+    private static func isSelfBundleID(_ bundleID: String, selfBundleID: String) -> Bool {
+        guard !selfBundleID.isEmpty else { return false }
+        let normalizedBundleID = bundleID.lowercased()
+        let normalizedSelfBundleID = selfBundleID.lowercased()
+        return normalizedBundleID == normalizedSelfBundleID
+            || normalizedBundleID.hasPrefix("\(normalizedSelfBundleID).")
+    }
+}
+
 private actor MeetingDetectionService {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingDetection")
 
@@ -457,8 +519,10 @@ private actor MeetingDetectionService {
         }
 
         signalRefreshState.hasMicOrCameraSignal = context.cameraActive
-            || !context.sensorAttributions.micBundleIDs.isEmpty
-            || !context.sensorAttributions.cameraBundleIDs.isEmpty
+            || MeetingMediaSignalFilter.hasExternalSensorAttribution(
+                context.sensorAttributions,
+                selfBundleID: resolver.selfBundleID
+            )
         signalRefreshState.hasCalendarEvent = context.calendarEvent != nil
         signalRefreshState.hasPromptVisible = context.promptVisibility.isVisible
 
@@ -487,23 +551,26 @@ private actor MeetingDetectionService {
             signalRefreshState.lastAppleScriptAttemptAtByBundleID[bundleID] = now
         }
 
-        let audioInputProcesses = mergedAudioInputProcesses(
+        let rawAudioInputProcesses = mergedAudioInputProcesses(
             audioResult.processes,
             sensorAttributions: context.sensorAttributions,
             runningProcessIDsByBundleID: collectedSignals.runningProcessIDsByBundleID
         )
-        let micActive = collectedSignals.micActive
-            || !audioInputProcesses.isEmpty
-            || !context.sensorAttributions.micBundleIDs.isEmpty
-        let cameraActive = context.cameraActive || !context.sensorAttributions.cameraBundleIDs.isEmpty
+        let mediaSignals = MeetingMediaSignalFilter.apply(
+            deviceMicActive: collectedSignals.micActive,
+            cameraActive: context.cameraActive,
+            audioInputProcesses: rawAudioInputProcesses,
+            sensorAttributions: context.sensorAttributions,
+            selfBundleID: resolver.selfBundleID
+        )
 
         let snapshot = MeetingSignalSnapshot(
-            micActive: micActive,
-            cameraActive: cameraActive,
+            micActive: mediaSignals.micActive,
+            cameraActive: mediaSignals.cameraActive,
             calendarEvent: context.calendarEvent,
             runningApps: collectedSignals.runningApps,
             browserMeetings: collectedSignals.browserMeetings,
-            audioInputProcesses: audioInputProcesses,
+            audioInputProcesses: mediaSignals.audioInputProcesses,
             foregroundBundleID: collectedSignals.foregroundBundleID,
             now: now
         )
@@ -519,8 +586,8 @@ private actor MeetingDetectionService {
         logCandidateIfChanged(candidate)
         updateRefreshState(
             trigger: trigger,
-            micActive: micActive,
-            cameraActive: cameraActive,
+            micActive: mediaSignals.micActive,
+            cameraActive: mediaSignals.cameraActive,
             calendarEvent: context.calendarEvent,
             browserMeetings: collectedSignals.browserMeetings,
             foregroundBundleID: collectedSignals.foregroundBundleID,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -313,14 +313,16 @@ enum MeetingMediaSignalFilter {
             || sensorAttributions.micBundleIDs.contains {
                 !isSelfBundleID($0, selfBundleID: selfBundleID)
             }
-        let externalCameraActive = cameraActive
-            || sensorAttributions.cameraBundleIDs.contains {
-                !isSelfBundleID($0, selfBundleID: selfBundleID)
-            }
+        let selfCameraAttributed = sensorAttributions.cameraBundleIDs.contains {
+            isSelfBundleID($0, selfBundleID: selfBundleID)
+        }
+        let hasExternalCameraAttribution = sensorAttributions.cameraBundleIDs.contains {
+            !isSelfBundleID($0, selfBundleID: selfBundleID)
+        }
 
         return MeetingMediaSignals(
             micActive: hasExternalMicAttribution || (deviceMicActive && !selfMicAttributed),
-            cameraActive: externalCameraActive,
+            cameraActive: hasExternalCameraAttribution || (cameraActive && !selfCameraAttributed),
             audioInputProcesses: externalAudioInputProcesses
         )
     }
@@ -518,11 +520,13 @@ private actor MeetingDetectionService {
             return
         }
 
-        signalRefreshState.hasMicOrCameraSignal = context.cameraActive
-            || MeetingMediaSignalFilter.hasExternalSensorAttribution(
-                context.sensorAttributions,
-                selfBundleID: resolver.selfBundleID
-            )
+        signalRefreshState.hasMicOrCameraSignal = MeetingMediaSignalFilter.apply(
+            deviceMicActive: false,
+            cameraActive: context.cameraActive,
+            audioInputProcesses: [],
+            sensorAttributions: context.sensorAttributions,
+            selfBundleID: resolver.selfBundleID
+        ).hasMicOrCameraSignal
         signalRefreshState.hasCalendarEvent = context.calendarEvent != nil
         signalRefreshState.hasPromptVisible = context.promptVisibility.isVisible
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMediaSignalFilterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMediaSignalFilterTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingMediaSignalFilter")
+struct MeetingMediaSignalFilterTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private let selfBundleID = "com.muesli.app"
+
+    private func audioProcess(
+        bundleID: String,
+        appName: String,
+        isRunningOutput: Bool = false
+    ) -> AudioProcessActivity {
+        AudioProcessActivity(
+            pid: 1234,
+            bundleID: bundleID,
+            appName: appName,
+            isRunningInput: true,
+            isRunningOutput: isRunningOutput
+        )
+    }
+
+    private func sensorAttributions(
+        micBundleIDs: Set<String> = [],
+        cameraBundleIDs: Set<String> = []
+    ) -> SensorAttributionSnapshot {
+        SensorAttributionSnapshot(
+            micBundleIDs: micBundleIDs,
+            cameraBundleIDs: cameraBundleIDs,
+            observedAt: now
+        )
+    }
+
+    private func resolver() -> MeetingCandidateResolver {
+        let resolver = MeetingCandidateResolver()
+        resolver.selfBundleID = selfBundleID
+        return resolver
+    }
+
+    @Test("Muesli dictation mic does not satisfy calendar meeting activity")
+    func muesliDictationMicDoesNotSatisfyCalendarMeetingActivity() {
+        let media = MeetingMediaSignalFilter.apply(
+            deviceMicActive: true,
+            cameraActive: false,
+            audioInputProcesses: [
+                audioProcess(bundleID: selfBundleID, appName: "Muesli"),
+            ],
+            sensorAttributions: sensorAttributions(micBundleIDs: [selfBundleID]),
+            selfBundleID: selfBundleID
+        )
+
+        #expect(media.micActive == false)
+        #expect(media.audioInputProcesses.isEmpty)
+        #expect(media.hasMicOrCameraSignal == false)
+
+        let candidate = resolver().resolve(MeetingSignalSnapshot(
+            micActive: media.micActive,
+            cameraActive: media.cameraActive,
+            calendarEvent: CalendarEventContext(id: "evt-standup", title: "Standup"),
+            runningApps: [
+                RunningAppInfo(bundleID: "us.zoom.xos", isActive: false),
+            ],
+            browserMeetings: [],
+            audioInputProcesses: media.audioInputProcesses,
+            foregroundBundleID: nil,
+            now: now
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("external meeting mic still counts when Muesli is also using input")
+    func externalMeetingMicStillCountsWhenMuesliIsAlsoUsingInput() {
+        let media = MeetingMediaSignalFilter.apply(
+            deviceMicActive: true,
+            cameraActive: false,
+            audioInputProcesses: [
+                audioProcess(bundleID: selfBundleID, appName: "Muesli"),
+                audioProcess(bundleID: "com.microsoft.teams2", appName: "Teams"),
+            ],
+            sensorAttributions: sensorAttributions(micBundleIDs: [selfBundleID, "com.microsoft.teams2"]),
+            selfBundleID: selfBundleID
+        )
+
+        #expect(media.micActive == true)
+        #expect(media.audioInputProcesses.map(\.bundleID) == ["com.microsoft.teams2"])
+
+        let candidate = resolver().resolve(MeetingSignalSnapshot(
+            micActive: media.micActive,
+            cameraActive: media.cameraActive,
+            calendarEvent: CalendarEventContext(id: "evt-standup", title: "Standup"),
+            runningApps: [
+                RunningAppInfo(bundleID: "com.microsoft.teams2", isActive: false),
+            ],
+            browserMeetings: [],
+            audioInputProcesses: media.audioInputProcesses,
+            foregroundBundleID: nil,
+            now: now
+        ))
+
+        #expect(candidate?.platform == .teams)
+        #expect(candidate?.sourceBundleID == "com.microsoft.teams2")
+    }
+
+    @Test("legacy global mic signal is preserved without self attribution")
+    func legacyGlobalMicSignalIsPreservedWithoutSelfAttribution() {
+        let media = MeetingMediaSignalFilter.apply(
+            deviceMicActive: true,
+            cameraActive: false,
+            audioInputProcesses: [],
+            sensorAttributions: sensorAttributions(),
+            selfBundleID: selfBundleID
+        )
+
+        #expect(media.micActive == true)
+        #expect(media.audioInputProcesses.isEmpty)
+    }
+
+    @Test("self helper audio input is treated as Muesli")
+    func selfHelperAudioInputIsTreatedAsMuesli() {
+        let media = MeetingMediaSignalFilter.apply(
+            deviceMicActive: true,
+            cameraActive: false,
+            audioInputProcesses: [
+                audioProcess(bundleID: "\(selfBundleID).helper", appName: "Muesli Helper"),
+            ],
+            sensorAttributions: sensorAttributions(),
+            selfBundleID: selfBundleID
+        )
+
+        #expect(media.micActive == false)
+        #expect(media.audioInputProcesses.isEmpty)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMediaSignalFilterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMediaSignalFilterTests.swift
@@ -103,6 +103,49 @@ struct MeetingMediaSignalFilterTests {
         #expect(candidate?.sourceBundleID == "com.microsoft.teams2")
     }
 
+    @Test("Muesli camera does not satisfy calendar meeting activity")
+    func muesliCameraDoesNotSatisfyCalendarMeetingActivity() {
+        let media = MeetingMediaSignalFilter.apply(
+            deviceMicActive: false,
+            cameraActive: true,
+            audioInputProcesses: [],
+            sensorAttributions: sensorAttributions(cameraBundleIDs: [selfBundleID]),
+            selfBundleID: selfBundleID
+        )
+
+        #expect(media.cameraActive == false)
+        #expect(media.hasMicOrCameraSignal == false)
+
+        let candidate = resolver().resolve(MeetingSignalSnapshot(
+            micActive: media.micActive,
+            cameraActive: media.cameraActive,
+            calendarEvent: CalendarEventContext(id: "evt-standup", title: "Standup"),
+            runningApps: [
+                RunningAppInfo(bundleID: "us.zoom.xos", isActive: false),
+            ],
+            browserMeetings: [],
+            audioInputProcesses: media.audioInputProcesses,
+            foregroundBundleID: nil,
+            now: now
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("external camera attribution still counts")
+    func externalCameraAttributionStillCounts() {
+        let media = MeetingMediaSignalFilter.apply(
+            deviceMicActive: false,
+            cameraActive: true,
+            audioInputProcesses: [],
+            sensorAttributions: sensorAttributions(cameraBundleIDs: [selfBundleID, "us.zoom.xos"]),
+            selfBundleID: selfBundleID
+        )
+
+        #expect(media.cameraActive == true)
+        #expect(media.hasMicOrCameraSignal == true)
+    }
+
     @Test("legacy global mic signal is preserved without self attribution")
     func legacyGlobalMicSignalIsPreservedWithoutSelfAttribution() {
         let media = MeetingMediaSignalFilter.apply(


### PR DESCRIPTION
## Summary

- Filter Muesli-owned mic/audio attribution before resolving meeting detection candidates.
- Keep external meeting-app media signals eligible, including cases where Muesli is also using input.
- Add regression coverage for dictation during an active calendar window so it does not create a meeting candidate.

## Root Cause

Meeting detection treated the global mic device as meeting evidence even when Muesli itself was the only attributed mic owner. During a current or nearby calendar event, using dictation could therefore satisfy `calendar + mic` and surface a false meeting detection prompt.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter MeetingMediaSignalFilter`
- `env -u OPENAI_API_KEY -u OPENROUTER_API_KEY swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"`