### PR TITLE
feat: support key combinations (e.g. ⌘⇧R) in hotkey system

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -13,6 +13,14 @@ final class HotkeyMonitor {
     var targetKeyCode: UInt16 = 55
     var doubleTapEnabled: Bool = true
 
+    // Combination mode (e.g. Cmd+Shift+R)
+    var combinationModifiers: NSEvent.ModifierFlags?
+    var combinationKeyCode: UInt16?
+
+    var isCombinationMode: Bool {
+        combinationModifiers != nil && combinationKeyCode != nil
+    }
+
     private var globalMonitor: Any?
     private var localMonitor: Any?
     private var prepareWorkItem: DispatchWorkItem?
@@ -57,7 +65,8 @@ final class HotkeyMonitor {
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { [weak self] event in
             guard let self else { return event }
             if self.shouldHandleLocalEvent(event) {
-                self.handle(event)
+                let consumed = self.handle(event)
+                if consumed { return nil }
             }
             return event
         }
@@ -87,9 +96,27 @@ final class HotkeyMonitor {
     }
 
     func configure(keyCode: UInt16) {
+        combinationModifiers = nil
+        combinationKeyCode = nil
         targetKeyCode = keyCode
-        if isRunning {
-            restart()
+        if isRunning { restart() }
+    }
+
+    func configure(combination config: HotkeyConfig) {
+        guard config.isCombination,
+              let mods = config.resolvedCombinationModifiers,
+              let kc = config.combinationKeyCode else { return }
+        targetKeyCode = UInt16.max
+        combinationModifiers = mods
+        combinationKeyCode = kc
+        if isRunning { restart() }
+    }
+
+    func configure(_ config: HotkeyConfig) {
+        if config.isCombination {
+            configure(combination: config)
+        } else {
+            configure(keyCode: config.keyCode)
         }
     }
 
@@ -123,7 +150,11 @@ final class HotkeyMonitor {
         toggleActive
     }
 
-    private func handle(_ event: NSEvent) {
+    @discardableResult
+    private func handle(_ event: NSEvent) -> Bool {
+        if isCombinationMode {
+            return handleCombination(event)
+        }
         switch event.type {
         case .flagsChanged:
             handleFlagsChanged(keyCode: event.keyCode, flags: event.modifierFlags)
@@ -132,6 +163,36 @@ final class HotkeyMonitor {
         default:
             break
         }
+        return false
+    }
+
+    @discardableResult
+    private func handleCombination(_ event: NSEvent) -> Bool {
+        if event.type == .keyDown && event.keyCode == 53 && toggleActive {
+            toggleActive = false
+            fputs("[hotkey] escape → cancel combination toggle\n", stderr)
+            onCancel?()
+            return true
+        }
+
+        guard event.type == .keyDown,
+              !event.isARepeat,
+              let targetMods = combinationModifiers,
+              let targetKey = combinationKeyCode,
+              event.keyCode == targetKey,
+              event.modifierFlags.intersection(.deviceIndependentFlagsMask) == targetMods
+        else { return false }
+
+        if toggleActive {
+            fputs("[hotkey] combination → toggle stop\n", stderr)
+            toggleActive = false
+            onToggleStop?()
+        } else {
+            fputs("[hotkey] combination → toggle start\n", stderr)
+            toggleActive = true
+            onToggleStart?()
+        }
+        return true
     }
 
     private func shouldHandleLocalEvent(_ event: NSEvent) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import MuesliCore
 
@@ -537,6 +538,16 @@ struct HotkeyConfig: Codable, Equatable {
     var keyCode: UInt16 = 61
     var label: String = "Right Option"
 
+    // Key combination support (e.g. Cmd+Shift+R).
+    // When set, the hotkey fires on keyDown with these modifiers held.
+    // When nil, the hotkey is a single modifier key (existing behavior).
+    var combinationModifiers: UInt? = nil
+    var combinationKeyCode: UInt16? = nil
+
+    var isCombination: Bool {
+        combinationModifiers != nil && combinationKeyCode != nil
+    }
+
     static func label(for keyCode: UInt16) -> String? {
         switch keyCode {
         case 55: return "Left Cmd"
@@ -550,6 +561,41 @@ struct HotkeyConfig: Codable, Equatable {
         case 60: return "Right Shift"
         default: return nil
         }
+    }
+
+    static func letterLabel(for keyCode: UInt16) -> String? {
+        let letters: [UInt16: String] = [
+            0: "A", 1: "S", 2: "D", 3: "F", 4: "H", 5: "G", 6: "Z", 7: "X",
+            8: "C", 9: "V", 11: "B", 12: "Q", 13: "W", 14: "E", 15: "R",
+            16: "Y", 17: "T", 31: "O", 32: "U", 34: "I", 35: "P", 37: "L",
+            38: "J", 40: "K", 45: "N", 46: "M",
+        ]
+        return letters[keyCode]
+    }
+
+    static func combinationLabel(modifiers: NSEvent.ModifierFlags, keyCode: UInt16) -> String {
+        var parts: [String] = []
+        if modifiers.contains(.control) { parts.append("⌃") }
+        if modifiers.contains(.option) { parts.append("⌥") }
+        if modifiers.contains(.shift) { parts.append("⇧") }
+        if modifiers.contains(.command) { parts.append("⌘") }
+        parts.append(letterLabel(for: keyCode) ?? "?")
+        return parts.joined()
+    }
+
+    static func combination(modifiers: NSEvent.ModifierFlags, keyCode: UInt16) -> HotkeyConfig {
+        let lbl = combinationLabel(modifiers: modifiers, keyCode: keyCode)
+        return HotkeyConfig(
+            keyCode: UInt16.max,
+            label: lbl,
+            combinationModifiers: UInt(modifiers.rawValue),
+            combinationKeyCode: keyCode
+        )
+    }
+
+    var resolvedCombinationModifiers: NSEvent.ModifierFlags? {
+        guard let raw = combinationModifiers else { return nil }
+        return NSEvent.ModifierFlags(rawValue: raw)
     }
 
     static let `default` = HotkeyConfig()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -262,7 +262,7 @@ final class MuesliController: NSObject {
 
         // Defer permission-triggering monitors until after onboarding
         if canRunMainApp && config.resolvedOnboardingUseCase.includesPushToTalk {
-            hotkeyMonitor.targetKeyCode = config.dictationHotkey.keyCode
+            hotkeyMonitor.configure(config.dictationHotkey)
             hotkeyMonitor.start()
             startComputerUseHotkeyMonitorIfNeeded()
         }
@@ -1253,7 +1253,7 @@ final class MuesliController: NSObject {
             return result
         }
         updateConfig { $0.dictationHotkey = hotkey }
-        hotkeyMonitor.configure(keyCode: hotkey.keyCode)
+        hotkeyMonitor.configure(hotkey)
         configureComputerUseHotkeyMonitor()
         return result
     }
@@ -1299,7 +1299,7 @@ final class MuesliController: NSObject {
             config.computerUseHotkey = .computerUseDefault
             config.enableComputerUseHotkey = false
         }
-        hotkeyMonitor.configure(keyCode: HotkeyConfig.default.keyCode)
+        hotkeyMonitor.configure(.default)
         configureComputerUseHotkeyMonitor()
     }
 
@@ -3196,7 +3196,7 @@ final class MuesliController: NSObject {
             computerUseHotkeyMonitor.stop()
             return
         }
-        computerUseHotkeyMonitor.configure(keyCode: config.computerUseHotkey.keyCode)
+        computerUseHotkeyMonitor.configure(config.computerUseHotkey)
         startComputerUseHotkeyMonitorIfNeeded()
     }
 
@@ -3209,13 +3209,13 @@ final class MuesliController: NSObject {
             computerUseHotkeyMonitor.stop()
             return
         }
-        guard config.computerUseHotkey.keyCode != config.dictationHotkey.keyCode else {
+        guard !ShortcutHotkeyPolicy.hotkeysConflict(config.computerUseHotkey, config.dictationHotkey) else {
             computerUseHotkeyMonitor.stop()
             fputs("[cua] computer use hotkey disabled because it matches dictation hotkey\n", stderr)
             return
         }
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
-        computerUseHotkeyMonitor.targetKeyCode = config.computerUseHotkey.keyCode
+        computerUseHotkeyMonitor.configure(config.computerUseHotkey)
         computerUseHotkeyMonitor.start()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutHotkeyPolicy.swift
@@ -28,12 +28,21 @@ enum ShortcutHotkeyUpdateResult: Equatable {
 struct ShortcutHotkeyPolicy {
     static let conflictMessage = "Push to Talk and Computer Use Command need different keys."
 
+    static func hotkeysConflict(_ a: HotkeyConfig, _ b: HotkeyConfig) -> Bool {
+        if a.isCombination != b.isCombination { return false }
+        if a.isCombination {
+            return a.combinationModifiers == b.combinationModifiers
+                && a.combinationKeyCode == b.combinationKeyCode
+        }
+        return a.keyCode == b.keyCode
+    }
+
     static func validateDictationHotkey(
         _ hotkey: HotkeyConfig,
         computerUseHotkey: HotkeyConfig,
         isComputerUseEnabled: Bool
     ) -> ShortcutHotkeyUpdateResult {
-        guard !isComputerUseEnabled || hotkey.keyCode != computerUseHotkey.keyCode else {
+        guard !isComputerUseEnabled || !hotkeysConflict(hotkey, computerUseHotkey) else {
             return .conflict(message: conflictMessage)
         }
         return .updated
@@ -44,7 +53,7 @@ struct ShortcutHotkeyPolicy {
         dictationHotkey: HotkeyConfig,
         isComputerUseEnabled: Bool
     ) -> ShortcutHotkeyUpdateResult {
-        guard !isComputerUseEnabled || hotkey.keyCode != dictationHotkey.keyCode else {
+        guard !isComputerUseEnabled || !hotkeysConflict(hotkey, dictationHotkey) else {
             return .conflict(message: conflictMessage)
         }
         return .updated
@@ -54,7 +63,7 @@ struct ShortcutHotkeyPolicy {
         currentHotkey: HotkeyConfig,
         dictationHotkey: HotkeyConfig
     ) -> (hotkey: HotkeyConfig, result: ShortcutHotkeyUpdateResult) {
-        guard currentHotkey.keyCode == dictationHotkey.keyCode else {
+        guard hotkeysConflict(currentHotkey, dictationHotkey) else {
             return (currentHotkey, .updated)
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -113,7 +113,7 @@ struct ShortcutsView: View {
             }
 
             if appState.config.enableComputerUseHotkey,
-               appState.config.computerUseHotkey.keyCode == appState.config.dictationHotkey.keyCode {
+               ShortcutHotkeyPolicy.hotkeysConflict(appState.config.computerUseHotkey, appState.config.dictationHotkey) {
                 shortcutMessage(ShortcutHotkeyPolicy.conflictMessage)
             } else if let computerUseShortcutMessage {
                 shortcutMessage(computerUseShortcutMessage)
@@ -156,7 +156,7 @@ struct ShortcutsView: View {
                 startRecording(target)
             }
         } label: {
-            Text(recordingTarget == target ? "Press a modifier key..." : "Change Shortcut")
+            Text(recordingTarget == target ? "Press a key or modifier..." : "Change Shortcut")
                 .font(MuesliTheme.body())
                 .foregroundStyle(recordingTarget == target ? MuesliTheme.accent : MuesliTheme.textPrimary)
         }
@@ -225,7 +225,31 @@ struct ShortcutsView: View {
         stopRecording()
         clearShortcutMessage(for: target)
         recordingTarget = target
-        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [self] event in
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { [self] event in
+            if event.type == .keyDown {
+                if event.keyCode == 53 {
+                    stopRecording()
+                    return nil
+                }
+                let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                let hasModifiers = mods.contains(.command) || mods.contains(.control)
+                    || mods.contains(.option)
+                guard hasModifiers, HotkeyConfig.letterLabel(for: event.keyCode) != nil else {
+                    return event
+                }
+                let newConfig = HotkeyConfig.combination(modifiers: mods, keyCode: event.keyCode)
+                let result: ShortcutHotkeyUpdateResult
+                switch target {
+                case .dictation:
+                    result = controller.updateDictationHotkey(newConfig)
+                case .computerUse:
+                    result = controller.updateComputerUseHotkey(newConfig)
+                }
+                setShortcutMessage(result.message, for: target)
+                stopRecording()
+                return nil
+            }
+
             let keyCode = event.keyCode
             if let label = HotkeyConfig.label(for: keyCode) {
                 let newConfig = HotkeyConfig(keyCode: keyCode, label: label)
@@ -238,6 +262,7 @@ struct ShortcutsView: View {
                 }
                 setShortcutMessage(result.message, for: target)
                 stopRecording()
+                return nil
             }
             return event
         }


### PR DESCRIPTION
  ## Summary

  - Extends `HotkeyConfig` to represent modifier+letter key combinations (e.g. ⌘⇧R) alongside existing single-modifier hotkeys
  - Extends `HotkeyMonitor` with combination mode — detects keyDown with required modifiers held, fires toggle callbacks
  - Updates shortcut capture UI to accept both single modifiers (press and release) and combinations (hold modifiers, press letter)
  - Updates conflict detection to use structural equality so combinations and single-modifier keys don't falsely conflict

  Single-modifier hotkeys are completely unchanged. Combination hotkeys use simple toggle semantics (press to start, press again to stop). No new dependencies. Backward compatible.

  ## Test plan

  - [x] Existing single-modifier hotkeys still work identically
  - [x] "Change Shortcut" captures Cmd+Shift+R as ⌘⇧R
  - [x] Single modifier press-and-release still captures correctly
  - [x] Key repeat doesn't fire multiple toggles
  - [x] Escape cancels combination toggle mode