### PR TITLE
feat: show green circle on menu bar icon during meeting recording and dictation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
@@ -19,19 +19,41 @@ enum MenuBarIconRenderer {
 
     /// Returns a menu bar icon for the given choice.
     /// "muesli" loads the bundled M logo; anything else renders an SF Symbol.
-    static func make(choice: String = "muesli") -> NSImage? {
+    static func make(choice: String = "muesli", recording: Bool = false) -> NSImage? {
+        let baseIcon: NSImage?
         if choice == "muesli" {
             if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
                let image = NSImage(contentsOf: url) {
                 image.isTemplate = true
                 image.size = NSSize(width: 18, height: 18)
-                return image
+                baseIcon = image
+            } else {
+                baseIcon = nil
             }
+        } else {
+            let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
+            let image = NSImage(systemSymbolName: choice, accessibilityDescription: "Muesli")?
+                .withSymbolConfiguration(config)
+            image?.isTemplate = true
+            baseIcon = image
         }
-        let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
-        let image = NSImage(systemSymbolName: choice, accessibilityDescription: "Muesli")?
-            .withSymbolConfiguration(config)
-        image?.isTemplate = true
-        return image
+
+        guard let baseIcon else { return nil }
+        guard recording else { return baseIcon }
+
+        let size = NSSize(width: 22, height: 22)
+        let result = NSImage(size: size, flipped: false) { rect in
+            NSColor.systemGreen.setFill()
+            NSBezierPath(ovalIn: rect).fill()
+            let iconRect = NSRect(
+                x: (rect.width - baseIcon.size.width) / 2,
+                y: (rect.height - baseIcon.size.height) / 2,
+                width: baseIcon.size.width, height: baseIcon.size.height
+            )
+            baseIcon.draw(in: iconRect, from: .zero, operation: .destinationOut, fraction: 1.0)
+            return true
+        }
+        result.isTemplate = false
+        return result
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2400,6 +2400,12 @@ final class MuesliController: NSObject {
         activeMeetingSession?.isRecording == true || isStoppingMeetingRecording
     }
 
+    func isMeetingActivelyCapturing() -> Bool {
+        activeMeetingSession?.isRecording == true
+            && activeMeetingSession?.isPaused != true
+            && !isStoppingMeetingRecording
+    }
+
     func isMeetingRecordingPaused() -> Bool {
         activeMeetingSession?.isPaused == true
     }
@@ -3182,6 +3188,7 @@ final class MuesliController: NSObject {
         case .transcribing: status = "Transcribing"
         }
         statusBarController?.setStatus(status)
+        statusBarController?.refreshIcon()
         if !isDictationTestMode {
             indicator.setState(state, config: config)
         }
@@ -3869,6 +3876,7 @@ final class MuesliController: NSObject {
             indicator.powerProvider = { [weak self] in
                 self?.recorder.currentPower() ?? -160
             }
+            setState(.recording)
             indicator.setToggleDictation(true, config: config)
         } catch {
             fputs("[muesli-native] toggle start failed: \(error)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -22,6 +22,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     func setStatus(_ text: String) {}
 
     func refresh() {
+        refreshIcon()
         rebuildMenu()
         updateMenuBarTitle()
     }
@@ -40,7 +41,9 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func refreshIcon() {
-        statusItem.button?.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon)
+        let isActivelyRecording = controller.appState.dictationState == .recording
+            || controller.isMeetingActivelyCapturing()
+        statusItem.button?.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon, recording: isActivelyRecording)
         updateMenuBarTitle()
     }
 


### PR DESCRIPTION
  ## Summary

  - Shows a green circle around the menu bar icon whenever the app is actively recording (meeting recording or dictation)
  - Uses `destinationOut` compositing to cut the icon shape out of the green circle, keeping it visually clean against any menu bar background
  - Icon reverts to normal template rendering when recording stops

  ## Changes

  - **MenuBarIconRenderer.swift**: Added `recording: Bool` parameter to `make()`. When true, renders the base icon inside a green circle using `destinationOut` blending and sets `isTemplate = false` for color display.
  - **StatusBarController.swift**: `refreshIcon()` now checks both `isMeetingRecording()` and `dictationState == .recording`. `refresh()` calls `refreshIcon()` so the icon updates on state changes.
  - **MuesliController.swift**: `setState()` calls `statusBarController?.refreshIcon()` so the icon updates immediately when dictation recording starts/stops.

  ## Test plan

  - [x] Start meeting recording → green circle appears on menu bar icon
  - [x] Stop meeting recording → icon reverts to normal
  - [x] Hold dictation hotkey → green circle appears while recording
  - [x] Release dictation hotkey → icon reverts to normal
  - [x] Custom menu bar icons (SF Symbols) also render correctly inside the green circle
  - [x] Verified on MuesliDev build