### PR TITLE
[codex] Allow editing meeting transcripts

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -727,6 +727,28 @@ public final class DictationStore {
         }
     }
 
+    public func updateMeetingTranscript(id: Int64, rawTranscript: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let manualNotes = try manualNotesForMeeting(id: id, db: db)
+        let wordCount = Self.countWords(in: rawTranscript) + Self.countWords(in: manualNotes)
+        let sql = "UPDATE meetings SET raw_transcript = ?, word_count = ? WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (rawTranscript as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(statement, 2, Int32(wordCount))
+        sqlite3_bind_int64(statement, 3, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+        guard sqlite3_changes(db) > 0 else {
+            throw DictationStoreError.meetingNotFound(id: id)
+        }
+    }
+
     public func updateMeetingManualNotes(id: Int64, manualNotes: String) throws {
         let db = try openDatabase()
         defer { sqlite3_close(db) }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -1088,6 +1088,7 @@ struct MeetingDetailView: View {
         if meetingChanged {
             editableManualNotes = meeting?.manualNotes ?? ""
             manualNotesSaveStatus = .saved
+            transcriptResummaryPromptMeetingID = nil
             transcriptEditOriginalTranscript = nil
             transcriptEditHadStructuredNotes = false
         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -396,6 +396,7 @@ struct MeetingDetailView: View {
                 controller.updateMeetingNotes(id: meeting.id, notes: editableNotes)
                 isEditingNotes = false
             } else if isEditingTranscript {
+                guard !isRetranscribing else { return }
                 transcriptSaveTask?.cancel()
                 transcriptSaveTask = nil
                 let shouldPromptForResummary = Self.shouldPromptForTranscriptResummary(
@@ -1355,9 +1356,14 @@ struct TranscriptChatMessage: Identifiable, Equatable {
 
 private struct MeetingTranscriptView: View {
     let transcript: String
+    @State private var messages: [TranscriptChatMessage]
+
+    init(transcript: String) {
+        self.transcript = transcript
+        _messages = State(initialValue: TranscriptChatMessage.messages(from: transcript))
+    }
 
     var body: some View {
-        let messages = TranscriptChatMessage.messages(from: transcript)
         ScrollView {
             LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                 if messages.isEmpty {
@@ -1376,6 +1382,9 @@ private struct MeetingTranscriptView: View {
             .padding(.horizontal, MuesliTheme.spacing24)
             .padding(.vertical, MuesliTheme.spacing16)
             .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .onChange(of: transcript) { _, newTranscript in
+            messages = TranscriptChatMessage.messages(from: newTranscript)
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -44,6 +44,7 @@ struct MeetingDetailView: View {
     @State private var summaryErrorMessage: String?
     @State private var retranscriptionErrorMessage: String?
     @State private var showDeleteConfirmation = false
+    @State private var transcriptResummaryPromptMeetingID: Int64?
 
     init(
         meeting: MeetingRecord?,
@@ -117,6 +118,16 @@ struct MeetingDetailView: View {
             }
         } message: {
             Text(retranscriptionErrorMessage ?? "The saved recording could not be re-transcribed.")
+        }
+        .alert("Re-summarize Notes?", isPresented: transcriptResummaryPromptBinding) {
+            Button("Re-summarize") {
+                resummarizeAfterTranscriptEdit()
+            }
+            Button("Not Now", role: .cancel) {
+                transcriptResummaryPromptMeetingID = nil
+            }
+        } message: {
+            Text("Your transcript edits may change the generated notes. Re-summarize now to update them from the edited transcript.")
         }
         .alert("Delete Meeting", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
@@ -365,8 +376,15 @@ struct MeetingDetailView: View {
             } else if isEditingTranscript {
                 transcriptSaveTask?.cancel()
                 transcriptSaveTask = nil
+                let shouldPromptForResummary = Self.shouldPromptForTranscriptResummary(
+                    meeting: meeting,
+                    editedTranscript: editableTranscript
+                )
                 controller.updateMeetingTranscript(id: meeting.id, transcript: editableTranscript)
                 isEditingTranscript = false
+                if shouldPromptForResummary {
+                    transcriptResummaryPromptMeetingID = meeting.id
+                }
             } else if documentMode == .transcript {
                 editableTranscript = meeting.rawTranscript
                 isEditingTranscript = true
@@ -965,6 +983,40 @@ struct MeetingDetailView: View {
                 }
             }
         )
+    }
+
+    private var transcriptResummaryPromptBinding: Binding<Bool> {
+        Binding(
+            get: { transcriptResummaryPromptMeetingID != nil },
+            set: { isPresented in
+                if !isPresented {
+                    transcriptResummaryPromptMeetingID = nil
+                }
+            }
+        )
+    }
+
+    private static func shouldPromptForTranscriptResummary(meeting: MeetingRecord, editedTranscript: String) -> Bool {
+        guard meeting.notesState == .structuredNotes else { return false }
+        return meeting.rawTranscript != editedTranscript
+    }
+
+    private func resummarizeAfterTranscriptEdit() {
+        guard let meetingID = transcriptResummaryPromptMeetingID else { return }
+        transcriptResummaryPromptMeetingID = nil
+        guard let updatedMeeting = controller.meeting(id: meetingID) else { return }
+        isSummarizing = true
+        controller.resummarize(meeting: updatedMeeting) { [meetingID] result in
+            isSummarizing = false
+            switch result {
+            case .success:
+                if let refreshed = controller.meeting(id: meetingID) {
+                    syncLocalState(with: refreshed)
+                }
+            case .failure(let error):
+                summaryErrorMessage = error.localizedDescription
+            }
+        }
     }
 
     private func resolvedPendingTemplateDefinition(for meeting: MeetingRecord) -> MeetingTemplateDefinition {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -421,6 +421,7 @@ struct MeetingDetailView: View {
                 isEditingNotes = true
             }
         }
+        .disabled(isRetranscribing && !isEditingNotes && !isEditingTranscript)
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -27,8 +27,10 @@ struct MeetingDetailView: View {
     @State private var isSummarizing = false
     @State private var isRetranscribing = false
     @State private var isEditingNotes = false
+    @State private var isEditingTranscript = false
     @State private var editableTitle: String
     @State private var editableNotes: String
+    @State private var editableTranscript: String
     @State private var editableManualNotes: String
     @State private var loadedMeetingID: Int64?
     @State private var manualNotesSaveStatus: ManualNotesSaveStatus = .saved
@@ -37,6 +39,7 @@ struct MeetingDetailView: View {
     @State private var documentMode: MeetingDocumentMode
     @State private var titleSaveTask: DispatchWorkItem?
     @State private var notesSaveTask: DispatchWorkItem?
+    @State private var transcriptSaveTask: DispatchWorkItem?
     @State private var manualNotesSaveStatusTask: DispatchWorkItem?
     @State private var summaryErrorMessage: String?
     @State private var retranscriptionErrorMessage: String?
@@ -57,6 +60,7 @@ struct MeetingDetailView: View {
         let initialTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         _editableTitle = State(initialValue: meeting?.title ?? "")
         _editableNotes = State(initialValue: meeting.map { Self.notesContent(for: $0) } ?? "")
+        _editableTranscript = State(initialValue: meeting?.rawTranscript ?? "")
         _editableManualNotes = State(initialValue: meeting?.manualNotes ?? "")
         _loadedMeetingID = State(initialValue: meeting?.id)
         _pendingTemplateID = State(initialValue: initialTemplateID)
@@ -145,16 +149,15 @@ struct MeetingDetailView: View {
 
             HStack(alignment: .top, spacing: MuesliTheme.spacing24) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                    TextField("Meeting Title", text: $editableTitle)
-                        .font(.system(size: 30, weight: .bold))
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                        .textFieldStyle(.plain)
-                        .onSubmit {
+                    MarqueeTitleTextField(
+                        text: $editableTitle,
+                        onSubmit: {
                             controller.updateMeetingTitle(id: meeting.id, title: editableTitle)
-                        }
-                        .onChange(of: editableTitle) { _, _ in
+                        },
+                        onTextChange: {
                             debounceSaveTitle(meetingID: meeting.id)
                         }
+                    )
 
                     HStack(spacing: MuesliTheme.spacing8) {
                         Text(formatMeta(meeting))
@@ -172,31 +175,16 @@ struct MeetingDetailView: View {
                     } else {
                         documentModePicker
 
-                        ViewThatFits(in: .horizontal) {
-                            HStack(spacing: MuesliTheme.spacing8) {
-                                templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                                recordingAction(for: meeting)
-                                summaryAction(for: meeting)
-                                editButton(for: meeting)
-                                if controller.canDeleteMeeting(meeting) {
-                                    deleteButton
-                                }
-                            }
-
-                            VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
-                                HStack(spacing: MuesliTheme.spacing8) {
-                                    templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                                    recordingAction(for: meeting)
-                                    summaryAction(for: meeting)
-                                }
-                                HStack(spacing: MuesliTheme.spacing8) {
-                                    editButton(for: meeting)
-                                    if controller.canDeleteMeeting(meeting) {
-                                        deleteButton
-                                    }
-                                }
+                        HStack(spacing: MuesliTheme.spacing8) {
+                            templateMenu(for: meeting, appliedTemplate: appliedTemplate)
+                            recordingAction(for: meeting)
+                            summaryAction(for: meeting)
+                            editButton(for: meeting)
+                            if controller.canDeleteMeeting(meeting) {
+                                deleteButton
                             }
                         }
+                        .fixedSize(horizontal: true, vertical: false)
                     }
                 }
             }
@@ -260,6 +248,25 @@ struct MeetingDetailView: View {
             .padding(.top, 12)
             .padding(.bottom, 24)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        } else if isEditingTranscript {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                contentToolbar(for: meeting)
+
+                TextEditor(text: $editableTranscript)
+                    .font(.system(size: 14))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .padding(MuesliTheme.spacing24)
+                    .background(MuesliTheme.backgroundBase)
+                    .frame(maxWidth: 980, maxHeight: .infinity, alignment: .topLeading)
+                    .onChange(of: editableTranscript) { _, _ in
+                        debounceSaveTranscript(meetingID: meeting.id)
+                    }
+            }
+            .padding(.horizontal, 40)
+            .padding(.top, 12)
+            .padding(.bottom, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         } else {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 contentToolbar(for: meeting)
@@ -291,7 +298,7 @@ struct MeetingDetailView: View {
         .pickerStyle(.segmented)
         .tint(MuesliTheme.accent)
         .frame(width: 220)
-        .disabled(isEditingNotes)
+        .disabled(isEditingNotes || isEditingTranscript)
     }
 
     private func showsManualNotesEditor(for meeting: MeetingRecord) -> Bool {
@@ -347,17 +354,27 @@ struct MeetingDetailView: View {
     @ViewBuilder
     private func editButton(for meeting: MeetingRecord) -> some View {
         iconButton(
-            isEditingNotes ? "checkmark.circle" : "pencil",
-            label: isEditingNotes ? "Done" : "Edit"
+            isEditingNotes || isEditingTranscript ? "checkmark.circle" : "pencil",
+            label: editButtonLabel
         ) {
             if isEditingNotes {
                 notesSaveTask?.cancel()
+                notesSaveTask = nil
                 controller.updateMeetingNotes(id: meeting.id, notes: editableNotes)
+                isEditingNotes = false
+            } else if isEditingTranscript {
+                transcriptSaveTask?.cancel()
+                transcriptSaveTask = nil
+                controller.updateMeetingTranscript(id: meeting.id, transcript: editableTranscript)
+                isEditingTranscript = false
+            } else if documentMode == .transcript {
+                editableTranscript = meeting.rawTranscript
+                isEditingTranscript = true
             } else {
                 documentMode = .notes
                 editableNotes = Self.notesContent(for: meeting)
+                isEditingNotes = true
             }
-            isEditingNotes.toggle()
         }
     }
 
@@ -644,7 +661,7 @@ struct MeetingDetailView: View {
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
-        .disabled(isEditingNotes)
+        .disabled(isEditingNotes || isEditingTranscript)
     }
 
     private func templateMenuItem(title: String, systemImage: String, isSelected: Bool) -> some View {
@@ -802,6 +819,13 @@ struct MeetingDetailView: View {
         "Copy"
     }
 
+    private var editButtonLabel: String {
+        if isEditingNotes || isEditingTranscript {
+            return "Done"
+        }
+        return documentMode == .transcript ? "Edit Transcript" : "Edit Notes"
+    }
+
     private func primarySummaryActionLabel(for meeting: MeetingRecord) -> String {
         hasPendingTemplateChange(for: meeting) ? "Apply Template" : "Re-summarize"
     }
@@ -811,7 +835,7 @@ struct MeetingDetailView: View {
         case .notes:
             return isEditingNotes ? editableNotes : Self.notesContent(for: meeting)
         case .transcript:
-            return meeting.rawTranscript
+            return isEditingTranscript ? editableTranscript : meeting.rawTranscript
         }
     }
 
@@ -893,6 +917,15 @@ struct MeetingDetailView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
     }
 
+    private func debounceSaveTranscript(meetingID: Int64) {
+        transcriptSaveTask?.cancel()
+        let transcript = editableTranscript
+        let c = controller
+        let item = DispatchWorkItem { c.updateMeetingTranscript(id: meetingID, transcript: transcript) }
+        transcriptSaveTask = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: item)
+    }
+
     private func saveManualNotes(meetingID: Int64, notes: String) {
         manualNotesSaveStatus = .saving
         controller.cacheMeetingManualNotes(id: meetingID, notes: notes)
@@ -963,6 +996,7 @@ struct MeetingDetailView: View {
         loadedMeetingID = meeting?.id
         editableTitle = meeting?.title ?? ""
         editableNotes = meeting.map { Self.notesContent(for: $0) } ?? ""
+        editableTranscript = meeting?.rawTranscript ?? ""
         if previousMeetingID != meeting?.id {
             editableManualNotes = meeting?.manualNotes ?? ""
             manualNotesSaveStatus = .saved
@@ -971,6 +1005,8 @@ struct MeetingDetailView: View {
         }
         pendingTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
+        isEditingNotes = false
+        isEditingTranscript = false
     }
 
     private func syncManualNotesState(with meeting: MeetingRecord?) {
@@ -1022,18 +1058,279 @@ private extension View {
     }
 }
 
+private struct MarqueeTitleTextField: View {
+    @Binding var text: String
+    let onSubmit: () -> Void
+    let onTextChange: () -> Void
+
+    @State private var isHovering = false
+    @State private var contentWidth: CGFloat = 0
+    @State private var containerWidth: CGFloat = 0
+    @State private var marqueeOffset: CGFloat = 0
+    @State private var marqueeRunID = UUID()
+
+    private let titleFont = Font.system(size: 30, weight: .bold)
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            TextField("Meeting Title", text: $text)
+                .font(titleFont)
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .textFieldStyle(.plain)
+                .lineLimit(1)
+                .opacity(shouldShowMarquee ? 0 : 1)
+                .allowsHitTesting(!shouldShowMarquee)
+                .onSubmit(onSubmit)
+                .onChange(of: text) { _, _ in
+                    onTextChange()
+                    restartMarqueeIfNeeded()
+                }
+
+            Text(text.isEmpty ? "Meeting Title" : text)
+                .font(titleFont)
+                .fontWeight(.bold)
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .offset(x: marqueeOffset)
+                .opacity(shouldShowMarquee ? 1 : 0)
+                .allowsHitTesting(false)
+        }
+        .frame(maxWidth: .infinity, minHeight: 38, alignment: .leading)
+        .clipped()
+        .contentShape(Rectangle())
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: TitleContainerWidthPreferenceKey.self, value: proxy.size.width)
+            }
+        )
+        .overlay(
+            Text(text.isEmpty ? "Meeting Title" : text)
+                .font(titleFont)
+                .fontWeight(.bold)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .hidden()
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(key: TitleContentWidthPreferenceKey.self, value: proxy.size.width)
+                    }
+                )
+        )
+        .onPreferenceChange(TitleContainerWidthPreferenceKey.self) { width in
+            containerWidth = width
+            restartMarqueeIfNeeded()
+        }
+        .onPreferenceChange(TitleContentWidthPreferenceKey.self) { width in
+            contentWidth = width
+            restartMarqueeIfNeeded()
+        }
+        .onHover { hovering in
+            isHovering = hovering
+            restartMarqueeIfNeeded()
+        }
+    }
+
+    private var overflowDistance: CGFloat {
+        max(contentWidth - containerWidth, 0)
+    }
+
+    private var shouldShowMarquee: Bool {
+        isHovering && overflowDistance > 8
+    }
+
+    private func restartMarqueeIfNeeded() {
+        let runID = UUID()
+        marqueeRunID = runID
+        guard shouldShowMarquee else {
+            withAnimation(.easeOut(duration: 0.18)) {
+                marqueeOffset = 0
+            }
+            return
+        }
+
+        marqueeOffset = 0
+        let distance = overflowDistance + 28
+        let duration = min(max(Double(distance) / 42.0, 3.0), 12.0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            guard marqueeRunID == runID, shouldShowMarquee else { return }
+            withAnimation(.linear(duration: duration).repeatForever(autoreverses: false)) {
+                marqueeOffset = -distance
+            }
+        }
+    }
+}
+
+private struct TitleContainerWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct TitleContentWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+struct TranscriptChatMessage: Identifiable, Equatable {
+    let id: Int
+    let timestamp: String?
+    let speaker: String?
+    let text: String
+
+    var isUser: Bool {
+        speaker?.localizedCaseInsensitiveCompare("You") == .orderedSame
+    }
+
+    static func messages(from transcript: String) -> [TranscriptChatMessage] {
+        let normalized = transcript.replacingOccurrences(of: "\r\n", with: "\n")
+        let rawLines = normalized
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+
+        var messages: [TranscriptChatMessage] = []
+        for rawLine in rawLines {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            let parsed = parseLine(line, id: messages.count)
+            messages.append(parsed)
+        }
+
+        return messages
+    }
+
+    private static func parseLine(_ line: String, id: Int) -> TranscriptChatMessage {
+        if line.hasPrefix("["),
+           let timestampEnd = line.firstIndex(of: "]") {
+            let timestamp = String(line[line.index(after: line.startIndex)..<timestampEnd])
+            let remainderStart = line.index(after: timestampEnd)
+            let remainder = line[remainderStart...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let speakerText = splitSpeakerAndText(remainder)
+            return TranscriptChatMessage(
+                id: id,
+                timestamp: timestamp.isEmpty ? nil : timestamp,
+                speaker: speakerText.speaker,
+                text: speakerText.text
+            )
+        }
+
+        let speakerText = splitSpeakerAndText(line)
+        return TranscriptChatMessage(
+            id: id,
+            timestamp: nil,
+            speaker: speakerText.speaker,
+            text: speakerText.text
+        )
+    }
+
+    private static func splitSpeakerAndText(_ text: String) -> (speaker: String?, text: String) {
+        guard let separator = text.firstIndex(of: ":") else {
+            return (nil, text)
+        }
+
+        let candidate = text[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isLikelySpeakerLabel(candidate) else {
+            return (nil, text)
+        }
+
+        let bodyStart = text.index(after: separator)
+        let body = text[bodyStart...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (candidate, body.isEmpty ? text : body)
+    }
+
+    private static func isLikelySpeakerLabel(_ label: String) -> Bool {
+        guard !label.isEmpty, label.count <= 32 else { return false }
+        if label.localizedCaseInsensitiveCompare("You") == .orderedSame { return true }
+        if label.localizedCaseInsensitiveCompare("Others") == .orderedSame { return true }
+        if label.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil {
+            return true
+        }
+        return false
+    }
+}
+
 private struct MeetingTranscriptView: View {
     let transcript: String
 
     var body: some View {
+        let messages = TranscriptChatMessage.messages(from: transcript)
         ScrollView {
-            Text(transcript)
-                .font(.system(size: 13, design: .monospaced))
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .frame(maxWidth: 860, alignment: .leading)
-                .textSelection(.enabled)
-                .padding(MuesliTheme.spacing24)
-                .frame(maxWidth: .infinity, alignment: .center)
+            LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                if messages.isEmpty {
+                    Text("No transcript available")
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(maxWidth: 860, alignment: .leading)
+                        .padding(MuesliTheme.spacing24)
+                } else {
+                    ForEach(messages) { message in
+                        TranscriptChatBubble(message: message)
+                    }
+                }
+            }
+            .frame(maxWidth: 860, alignment: .leading)
+            .padding(.horizontal, MuesliTheme.spacing24)
+            .padding(.vertical, MuesliTheme.spacing16)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+}
+
+private struct TranscriptChatBubble: View {
+    let message: TranscriptChatMessage
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: MuesliTheme.spacing8) {
+            if message.isUser {
+                Spacer(minLength: 80)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                if let metadata = metadata {
+                    Text(metadata)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .textSelection(.enabled)
+                }
+                Text(message.text)
+                    .font(.system(size: 14))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .lineSpacing(2)
+                    .textSelection(.enabled)
+            }
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, 8)
+            .background(message.isUser ? MuesliTheme.accent.opacity(0.18) : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(message.isUser ? MuesliTheme.accent.opacity(0.25) : MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+            .frame(maxWidth: 680, alignment: message.isUser ? .trailing : .leading)
+
+            if !message.isUser {
+                Spacer(minLength: 80)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: message.isUser ? .trailing : .leading)
+    }
+
+    private var metadata: String? {
+        switch (message.speaker, message.timestamp) {
+        case let (speaker?, timestamp?):
+            return "\(speaker) \(timestamp)"
+        case let (speaker?, nil):
+            return speaker
+        case let (nil, timestamp?):
+            return timestamp
+        case (nil, nil):
+            return nil
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -188,16 +188,7 @@ struct MeetingDetailView: View {
                     } else {
                         documentModePicker
 
-                        HStack(spacing: MuesliTheme.spacing8) {
-                            templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                            recordingAction(for: meeting)
-                            summaryAction(for: meeting)
-                            editButton(for: meeting)
-                            if controller.canDeleteMeeting(meeting) {
-                                deleteButton
-                            }
-                        }
-                        .fixedSize(horizontal: true, vertical: false)
+                        headerActions(for: meeting, appliedTemplate: appliedTemplate)
                     }
                 }
             }
@@ -328,6 +319,35 @@ struct MeetingDetailView: View {
     }
 
     @ViewBuilder
+    private func headerActions(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                templateMenu(for: meeting, appliedTemplate: appliedTemplate)
+                recordingAction(for: meeting)
+                summaryAction(for: meeting)
+                editButton(for: meeting)
+                if controller.canDeleteMeeting(meeting) {
+                    deleteButton
+                }
+            }
+
+            VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    templateMenu(for: meeting, appliedTemplate: appliedTemplate)
+                    recordingAction(for: meeting)
+                    summaryAction(for: meeting)
+                }
+                HStack(spacing: MuesliTheme.spacing8) {
+                    editButton(for: meeting)
+                    if controller.canDeleteMeeting(meeting) {
+                        deleteButton
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
     private func summaryAction(for meeting: MeetingRecord) -> some View {
         if isSummarizing {
             HStack(spacing: 6) {
@@ -439,7 +459,7 @@ struct MeetingDetailView: View {
                         }
                     }
                 }
-                .disabled(meeting.status == .recording || meeting.status == .processing)
+                .disabled(meeting.status == .recording || meeting.status == .processing || isEditingNotes || isEditingTranscript)
             }
         }
     }
@@ -1140,6 +1160,7 @@ private struct MarqueeTitleTextField: View {
     @State private var containerWidth: CGFloat = 0
     @State private var marqueeOffset: CGFloat = 0
     @State private var marqueeRunID = UUID()
+    @FocusState private var isTitleFocused: Bool
 
     private let titleFont = Font.system(size: 30, weight: .bold)
 
@@ -1151,10 +1172,13 @@ private struct MarqueeTitleTextField: View {
                 .textFieldStyle(.plain)
                 .lineLimit(1)
                 .opacity(shouldShowMarquee ? 0 : 1)
-                .allowsHitTesting(!shouldShowMarquee)
+                .focused($isTitleFocused)
                 .onSubmit(onSubmit)
                 .onChange(of: text) { _, _ in
                     onTextChange()
+                    restartMarqueeIfNeeded()
+                }
+                .onChange(of: isTitleFocused) { _, _ in
                     restartMarqueeIfNeeded()
                 }
 
@@ -1208,7 +1232,7 @@ private struct MarqueeTitleTextField: View {
     }
 
     private var shouldShowMarquee: Bool {
-        isHovering && overflowDistance > 8
+        isHovering && !isTitleFocused && overflowDistance > 8
     }
 
     private func restartMarqueeIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -45,6 +45,8 @@ struct MeetingDetailView: View {
     @State private var retranscriptionErrorMessage: String?
     @State private var showDeleteConfirmation = false
     @State private var transcriptResummaryPromptMeetingID: Int64?
+    @State private var transcriptEditOriginalTranscript: String?
+    @State private var transcriptEditHadStructuredNotes = false
 
     init(
         meeting: MeetingRecord?,
@@ -377,16 +379,21 @@ struct MeetingDetailView: View {
                 transcriptSaveTask?.cancel()
                 transcriptSaveTask = nil
                 let shouldPromptForResummary = Self.shouldPromptForTranscriptResummary(
-                    meeting: meeting,
+                    hadStructuredNotes: transcriptEditHadStructuredNotes,
+                    originalTranscript: transcriptEditOriginalTranscript,
                     editedTranscript: editableTranscript
                 )
                 controller.updateMeetingTranscript(id: meeting.id, transcript: editableTranscript)
                 isEditingTranscript = false
+                transcriptEditOriginalTranscript = nil
+                transcriptEditHadStructuredNotes = false
                 if shouldPromptForResummary {
                     transcriptResummaryPromptMeetingID = meeting.id
                 }
             } else if documentMode == .transcript {
                 editableTranscript = meeting.rawTranscript
+                transcriptEditOriginalTranscript = meeting.rawTranscript
+                transcriptEditHadStructuredNotes = meeting.notesState == .structuredNotes
                 isEditingTranscript = true
             } else {
                 documentMode = .notes
@@ -996,9 +1003,13 @@ struct MeetingDetailView: View {
         )
     }
 
-    private static func shouldPromptForTranscriptResummary(meeting: MeetingRecord, editedTranscript: String) -> Bool {
-        guard meeting.notesState == .structuredNotes else { return false }
-        return meeting.rawTranscript != editedTranscript
+    private static func shouldPromptForTranscriptResummary(
+        hadStructuredNotes: Bool,
+        originalTranscript: String?,
+        editedTranscript: String
+    ) -> Bool {
+        guard hadStructuredNotes, let originalTranscript else { return false }
+        return originalTranscript != editedTranscript
     }
 
     private func resummarizeAfterTranscriptEdit() {
@@ -1045,20 +1056,29 @@ struct MeetingDetailView: View {
 
     private func syncLocalState(with meeting: MeetingRecord?) {
         let previousMeetingID = loadedMeetingID
+        let meetingChanged = previousMeetingID != meeting?.id
         loadedMeetingID = meeting?.id
         editableTitle = meeting?.title ?? ""
-        editableNotes = meeting.map { Self.notesContent(for: $0) } ?? ""
-        editableTranscript = meeting?.rawTranscript ?? ""
-        if previousMeetingID != meeting?.id {
+        if meetingChanged || !isEditingNotes {
+            editableNotes = meeting.map { Self.notesContent(for: $0) } ?? ""
+        }
+        if meetingChanged || !isEditingTranscript {
+            editableTranscript = meeting?.rawTranscript ?? ""
+        }
+        if meetingChanged {
             editableManualNotes = meeting?.manualNotes ?? ""
             manualNotesSaveStatus = .saved
+            transcriptEditOriginalTranscript = nil
+            transcriptEditHadStructuredNotes = false
         } else {
             syncManualNotesState(with: meeting)
         }
         pendingTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
-        documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
-        isEditingNotes = false
-        isEditingTranscript = false
+        if meetingChanged {
+            documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
+            isEditingNotes = false
+            isEditingTranscript = false
+        }
     }
 
     private func syncManualNotesState(with meeting: MeetingRecord?) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2106,6 +2106,15 @@ final class MuesliController: NSObject {
         syncAppState()
     }
 
+    func updateMeetingTranscript(id: Int64, transcript: String) {
+        do {
+            try dictationStore.updateMeetingTranscript(id: id, rawTranscript: transcript)
+        } catch {
+            fputs("[muesli-native] failed to update meeting transcript \(id): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
     func updateMeetingManualNotes(id: Int64, notes: String) {
         liveManualNotesPersistWorkItems[id]?.cancel()
         liveManualNotesPersistWorkItems[id] = nil

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -448,6 +448,35 @@ struct DictationStoreTests {
         #expect(updated.manualNotes == "Manual note")
     }
 
+    @Test("update meeting transcript preserves notes and refreshes word count")
+    func updateMeetingTranscript() throws {
+        let store = try makeStore()
+
+        let start = Date()
+        let meetingID = try store.insertMeeting(
+            title: "Editable Transcript",
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(60),
+            rawTranscript: "Original words",
+            formattedNotes: "## Summary\nExisting notes",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        try store.updateMeetingManualNotes(id: meetingID, manualNotes: "Manual note")
+
+        try store.updateMeetingTranscript(
+            id: meetingID,
+            rawTranscript: "[10:00:00] You: Edited transcript words"
+        )
+
+        let updated = try #require(try store.meeting(id: meetingID))
+        #expect(updated.rawTranscript == "[10:00:00] You: Edited transcript words")
+        #expect(updated.formattedNotes == "## Summary\nExisting notes")
+        #expect(updated.manualNotes == "Manual note")
+        #expect(updated.wordCount == 7)
+    }
+
     @Test("fetch dictation by id returns the full record")
     func fetchDictationByID() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptChatMessageTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptChatMessageTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Transcript chat message parsing")
+struct TranscriptChatMessageTests {
+    @Test("timestamped speaker lines become chat messages")
+    func timestampedSpeakerLinesBecomeChatMessages() {
+        let messages = TranscriptChatMessage.messages(from: """
+        [10:00:00] You: Hello there.
+        [10:00:04] Speaker 1: Hi back.
+        """)
+
+        #expect(messages.count == 2)
+        #expect(messages[0].timestamp == "10:00:00")
+        #expect(messages[0].speaker == "You")
+        #expect(messages[0].text == "Hello there.")
+        #expect(messages[0].isUser)
+        #expect(messages[1].speaker == "Speaker 1")
+        #expect(messages[1].text == "Hi back.")
+        #expect(!messages[1].isUser)
+    }
+
+    @Test("plain transcript lines are preserved")
+    func plainTranscriptLinesArePreserved() {
+        let messages = TranscriptChatMessage.messages(from: """
+        Product: launch timeline changed.
+
+        This line has no speaker.
+        """)
+
+        #expect(messages.count == 2)
+        #expect(messages[0].speaker == nil)
+        #expect(messages[0].text == "Product: launch timeline changed.")
+        #expect(messages[1].text == "This line has no speaker.")
+    }
+}


### PR DESCRIPTION
## Summary

- Add an editable transcript mode to meeting detail pages.
- Render saved transcripts as chat-style bubbles instead of a monospaced text block.
- Persist transcript edits to `raw_transcript` and refresh meeting word counts.
- Keep the meeting header action row stable across Notes and Transcript, with a hover marquee for long titles.

Closes #121

## Validation

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-edit-transcript" --filter TranscriptChatMessageTests`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-edit-transcript" --filter 'DictationStoreTests/updateMeetingTranscript'`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-edit-transcript" --filter MeetingsNavigationTests`
- `MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" ./scripts/dev-test.sh`
