### PR TITLE
Add custom branding and refresh native workspace

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppBrandingAssets.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppBrandingAssets.swift
@@ -1,0 +1,97 @@
+import AppKit
+import Foundation
+
+enum AppBrandingAssets {
+    private static let directoryName = "Branding"
+    private static let logoFileName = "custom-logo.png"
+
+    static func importLogo(from sourceURL: URL, supportDirectory: URL = AppIdentity.supportDirectoryURL) throws -> String {
+        guard let image = NSImage(contentsOf: sourceURL) else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        let directory = supportDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let destination = directory.appendingPathComponent(logoFileName)
+        try pngData.write(to: destination, options: .atomic)
+        return destination.path
+    }
+
+    static func removeLogo(at path: String?) {
+        guard let path, !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    static func image(at path: String?) -> NSImage? {
+        guard let path, !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return NSImage(contentsOfFile: path)
+    }
+
+    static func accentedDefaultAppIcon(accentHex: String, fallbackURL: URL?) -> NSImage? {
+        let accent = NSColor.appBrandingColor(hex: accentHex)
+        let size = NSSize(width: 1024, height: 1024)
+        let image = NSImage(size: size)
+        let bounds = NSRect(origin: .zero, size: size)
+        let iconRect = bounds.insetBy(dx: 108, dy: 108)
+
+        image.lockFocus()
+        defer { image.unlockFocus() }
+
+        NSGraphicsContext.current?.imageInterpolation = .high
+        NSColor.clear.setFill()
+        bounds.fill()
+
+        let backgroundPath = NSBezierPath(roundedRect: iconRect, xRadius: 232, yRadius: 232)
+        NSGradient(
+            starting: accent.appBrandingHighlight,
+            ending: accent.appBrandingShadow
+        )?.draw(in: backgroundPath, angle: -45)
+
+        NSColor.white.withAlphaComponent(0.18).setStroke()
+        backgroundPath.lineWidth = 8
+        backgroundPath.stroke()
+
+        if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
+           let mark = NSImage(contentsOf: url) {
+            let markRect = bounds.insetBy(dx: 298, dy: 318)
+            mark.draw(in: markRect, from: .zero, operation: .sourceOver, fraction: 1)
+            NSColor.white.setFill()
+            markRect.fill(using: .sourceAtop)
+        } else if let fallbackURL,
+                  let fallback = NSImage(contentsOf: fallbackURL) {
+            fallback.draw(in: iconRect.insetBy(dx: 140, dy: 140), from: .zero, operation: .sourceOver, fraction: 1)
+        }
+
+        image.isTemplate = false
+        return image
+    }
+}
+
+private extension NSColor {
+    static func appBrandingColor(hex: String) -> NSColor {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        h = h.hasPrefix("#") ? String(h.dropFirst()) : h
+        guard h.count == 6, let value = UInt64(h, radix: 16) else {
+            return NSColor(red: 0.98, green: 0.38, blue: 0.0, alpha: 1.0)
+        }
+        return NSColor(
+            srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+
+    var appBrandingHighlight: NSColor {
+        blended(withFraction: 0.20, of: .white) ?? self
+    }
+
+    var appBrandingShadow: NSColor {
+        blended(withFraction: 0.16, of: .black) ?? self
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppIdentity.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppIdentity.swift
@@ -3,12 +3,17 @@ import MuesliCore
 
 enum AppIdentity {
     private static let defaultName = "Muesli"
+    private static var displayNameOverride: String?
 
     static var bundleName: String {
         stringValue(for: "CFBundleName") ?? defaultName
     }
 
     static var displayName: String {
+        displayNameOverride ?? bundleDisplayName
+    }
+
+    static var bundleDisplayName: String {
         stringValue(for: "CFBundleDisplayName") ?? bundleName
     }
 
@@ -18,6 +23,11 @@ enum AppIdentity {
 
     static var supportDirectoryURL: URL {
         MuesliPaths.defaultSupportDirectoryURL(appName: supportDirectoryName)
+    }
+
+    static func configureDisplayNameOverride(_ name: String?) {
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        displayNameOverride = trimmed.isEmpty ? nil : trimmed
     }
 
     private static func stringValue(for key: String) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppIdentity.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppIdentity.swift
@@ -18,7 +18,7 @@ enum AppIdentity {
     }
 
     static var supportDirectoryName: String {
-        stringValue(for: "MuesliSupportDirectoryName") ?? displayName
+        stringValue(for: "MuesliSupportDirectoryName") ?? bundleName
     }
 
     static var supportDirectoryURL: URL {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -117,7 +117,7 @@ final class AppState {
     var searchResultDictations: [DictationRecord] = []
     var searchResultMeetings: [MeetingRecord] = []
     var focusSearchField: Bool = false
-    var isSearchActive: Bool { !searchQuery.isEmpty }
+    var isSearchActive: Bool { !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
     // Navigation
     var selectedTab: DashboardTab = .dictations

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -6,50 +6,63 @@ struct DashboardRootView: View {
     let controller: MuesliController
 
     var body: some View {
-        NavigationSplitView {
+        HStack(spacing: 0) {
             SidebarView(appState: appState, controller: controller)
-            .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 300)
-        } detail: {
-            Group {
-                if appState.isSearchActive,
-                   case .document(let id) = appState.meetingsNavigationState {
-                    MeetingDetailView(
-                        meeting: appState.selectedMeeting,
-                        controller: controller,
-                        appState: appState,
-                        onBack: {
-                            appState.meetingsNavigationState = .browser
-                            appState.selectedMeetingID = nil
-                            appState.selectedMeetingRecord = nil
-                        },
-                        backLabel: "Back to Search"
-                    )
-                    .id(id)
-                } else if appState.isSearchActive {
-                    SearchResultsView(appState: appState, controller: controller)
-                } else {
-                    switch appState.selectedTab {
-                    case .dictations:
-                        DictationsView(appState: appState, controller: controller)
-                    case .meetings:
-                        MeetingsView(appState: appState, controller: controller)
-                    case .dictionary:
-                        DictionaryView(appState: appState, controller: controller)
-                    case .models:
-                        ModelsView(appState: appState, controller: controller)
-                    case .shortcuts:
-                        ShortcutsView(appState: appState, controller: controller)
-                    case .settings:
-                        SettingsView(appState: appState, controller: controller)
-                    case .about:
-                        AboutView(appState: appState, controller: controller)
-                    }
-                }
-            }
+                .frame(
+                    minWidth: MuesliTheme.sidebarMinWidth,
+                    idealWidth: MuesliTheme.sidebarIdealWidth,
+                    maxWidth: MuesliTheme.sidebarIdealWidth,
+                    maxHeight: .infinity
+                )
+
+            Rectangle()
+                .fill(MuesliTheme.surfaceBorder)
+                .frame(width: 1)
+
+            detailContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(MuesliTheme.backgroundBase)
         }
         .frame(minWidth: 900, minHeight: 600)
+        .background(MuesliTheme.backgroundBase)
         .preferredColorScheme(appState.config.darkMode ? .dark : .light)
+    }
+
+    @ViewBuilder
+    private var detailContent: some View {
+        if appState.isSearchActive,
+           case .document(let id) = appState.meetingsNavigationState {
+            MeetingDetailView(
+                meeting: appState.selectedMeeting,
+                controller: controller,
+                appState: appState,
+                onBack: {
+                    appState.meetingsNavigationState = .browser
+                    appState.selectedMeetingID = nil
+                    appState.selectedMeetingRecord = nil
+                },
+                backLabel: "Back to Search"
+            )
+            .id(id)
+        } else if appState.isSearchActive {
+            SearchResultsView(appState: appState, controller: controller)
+        } else {
+            switch appState.selectedTab {
+            case .dictations:
+                DictationsView(appState: appState, controller: controller)
+            case .meetings:
+                MeetingsView(appState: appState, controller: controller)
+            case .dictionary:
+                DictionaryView(appState: appState, controller: controller)
+            case .models:
+                ModelsView(appState: appState, controller: controller)
+            case .shortcuts:
+                ShortcutsView(appState: appState, controller: controller)
+            case .settings:
+                SettingsView(appState: appState, controller: controller)
+            case .about:
+                AboutView(appState: appState, controller: controller)
+            }
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -430,7 +430,10 @@ final class FloatingIndicatorController: NSObject {
         let config = configStore.load()
         let fallback = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
             .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)) ?? NSImage()
-        let newImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? fallback
+        let newImage = MenuBarIconRenderer.make(
+            choice: config.menuBarIcon,
+            customLogoPath: config.customLogoPath
+        ) ?? fallback
         newImage.isTemplate = false
         micIconView?.image = newImage
     }
@@ -1030,7 +1033,10 @@ final class FloatingIndicatorController: NSObject {
         let config = configStore.load()
         let fallbackImage = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
             .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)) ?? NSImage()
-        let idleImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? fallbackImage
+        let idleImage = MenuBarIconRenderer.make(
+            choice: config.menuBarIcon,
+            customLogoPath: config.customLogoPath
+        ) ?? fallbackImage
         idleImage.isTemplate = false // we tint manually via contentTintColor
         let micView = NSImageView(image: idleImage)
         micView.contentTintColor = .white

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
@@ -22,13 +22,13 @@ struct MeetingListItemView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-            HStack(alignment: .top) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
                 Text(record.title)
-                    .font(MuesliTheme.headline())
+                    .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(MuesliTheme.textPrimary)
                     .lineLimit(2)
 
-                Spacer(minLength: 4)
+                Spacer(minLength: MuesliTheme.spacing12)
 
                 HStack(spacing: 6) {
                     if !folders.isEmpty {
@@ -37,6 +37,10 @@ struct MeetingListItemView: View {
                     if onDelete != nil {
                         deleteButton
                     }
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 22, height: 22)
                 }
             }
 
@@ -71,17 +75,19 @@ struct MeetingListItemView: View {
                 .foregroundStyle(MuesliTheme.textTertiary)
                 .lineLimit(2)
         }
-        .padding(MuesliTheme.spacing16)
+        .padding(.horizontal, MuesliTheme.spacing20)
+        .padding(.vertical, MuesliTheme.spacing20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isSelected ? MuesliTheme.surfaceSelected : MuesliTheme.backgroundRaised)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerXL))
         .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerXL)
                 .strokeBorder(
-                    isSelected ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder,
+                    isSelected ? MuesliTheme.accent.opacity(0.28) : MuesliTheme.surfaceBorder,
                     lineWidth: 1
                 )
         )
+        .shadow(color: Color.black.opacity(isSelected ? 0.055 : 0.035), radius: 14, x: 0, y: 6)
         .contentShape(Rectangle())
         .onTapGesture(perform: onSelect)
         .onHover { isHovering = $0 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -198,7 +198,7 @@ struct MeetingsView: View {
     @ViewBuilder
     private var browserView: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing28) {
                 if !appState.upcomingCalendarEvents.isEmpty {
                     comingUpSection
                 }
@@ -240,10 +240,7 @@ struct MeetingsView: View {
                     }
                 }
             }
-            .frame(maxWidth: 960, alignment: .leading)
-            .padding(.horizontal, 40)
-            .padding(.vertical, 32)
-            .frame(maxWidth: .infinity, alignment: .center)
+            .muesliPageContent(maxWidth: 1080)
         }
     }
 
@@ -318,10 +315,10 @@ struct MeetingsView: View {
 
     @ViewBuilder
     private var comingUpSection: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Coming Up")
-                    .font(.custom("Cormorant Garamond", size: 22).weight(.medium))
+                    .font(.system(size: 20, weight: .semibold))
                     .foregroundStyle(MuesliTheme.textPrimary)
 
                 if appState.isGoogleCalendarAuthenticated {
@@ -341,42 +338,42 @@ struct MeetingsView: View {
                     .buttonStyle(.plain)
                 }
             }
-            .padding(.bottom, 4)
+            .padding(.bottom, 2)
 
             let groups = groupedUpcomingEvents
             let lastGroupId = groups.last?.id
             ForEach(groups) { group in
-                HStack(alignment: .top, spacing: 20) {
+                HStack(alignment: .top, spacing: 22) {
                     // Date column
                     VStack(alignment: .center, spacing: 2) {
                         Text(group.dayNumber)
-                            .font(.system(size: 24, weight: .light, design: .default))
+                            .font(.system(size: 28, weight: .regular, design: .default))
                             .foregroundStyle(group.isToday ? MuesliTheme.accent : MuesliTheme.textPrimary)
                         Text(group.dayLabel)
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(group.isToday ? MuesliTheme.accent : MuesliTheme.textSecondary)
                         Text(group.dayOfWeek)
-                            .font(.system(size: 10))
+                            .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(MuesliTheme.textSecondary)
                     }
-                    .frame(width: 60)
+                    .frame(width: 72)
 
                     // Events column
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 12) {
                         ForEach(group.events) { event in
-                            HStack(spacing: 8) {
-                                RoundedRectangle(cornerRadius: 1.5)
+                            HStack(spacing: 12) {
+                                RoundedRectangle(cornerRadius: 2)
                                     .fill(group.isToday ? MuesliTheme.accent : MuesliTheme.textSecondary.opacity(0.4))
-                                    .frame(width: 3, height: 36)
+                                    .frame(width: 4, height: 46)
 
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(event.title)
-                                        .font(.system(size: 13, weight: .medium))
+                                        .font(.system(size: 14, weight: .semibold))
                                         .foregroundStyle(MuesliTheme.textPrimary)
                                         .lineLimit(1)
 
                                     Text(formatTimeRange(event))
-                                        .font(.system(size: 11))
+                                        .font(.system(size: 13))
                                         .foregroundStyle(MuesliTheme.textSecondary)
                                 }
 
@@ -390,15 +387,19 @@ struct MeetingsView: View {
                                     } label: {
                                         HStack(spacing: 4) {
                                             Image(systemName: "video.fill")
-                                                .font(.system(size: 9))
+                                                .font(.system(size: 10, weight: .semibold))
                                             Text("Join & Record")
-                                                .font(.system(size: 10, weight: .medium))
+                                                .font(.system(size: 12, weight: .semibold))
                                         }
-                                        .foregroundStyle(.white)
-                                        .padding(.horizontal, 8)
-                                        .padding(.vertical, 4)
-                                        .background(Color(nsColor: NSColor(red: 0.20, green: 0.72, blue: 0.53, alpha: 1.0)))
-                                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                                        .foregroundStyle(Color(nsColor: NSColor(red: 0.16, green: 0.63, blue: 0.42, alpha: 1.0)))
+                                        .padding(.horizontal, 13)
+                                        .frame(height: 34)
+                                        .background(MuesliTheme.backgroundRaised)
+                                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                                                .strokeBorder(Color(nsColor: NSColor(red: 0.16, green: 0.63, blue: 0.42, alpha: 0.25)), lineWidth: 1)
+                                        )
                                     }
                                     .buttonStyle(.plain)
                                 }
@@ -415,16 +416,9 @@ struct MeetingsView: View {
                                     }
                                 } label: {
                                     Text("Add to folder")
-                                        .font(.system(size: 10, weight: .medium))
-                                        .foregroundStyle(MuesliTheme.textSecondary)
-                                        .padding(.horizontal, 8)
-                                        .padding(.vertical, 3)
-                                        .background(MuesliTheme.surfacePrimary)
-                                        .clipShape(RoundedRectangle(cornerRadius: 4))
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 0.5)
-                                        )
+                                        .font(.system(size: 12, weight: .medium))
+                                    .foregroundStyle(MuesliTheme.textSecondary)
+                                    .frame(height: 30)
                                 }
                                 .menuStyle(.borderlessButton)
                                 .fixedSize()
@@ -441,13 +435,14 @@ struct MeetingsView: View {
                 }
             }
         }
-        .padding(20)
+        .padding(24)
         .background(MuesliTheme.backgroundRaised)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerXL))
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerXL)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+        .shadow(color: Color.black.opacity(0.045), radius: 18, x: 0, y: 8)
     }
 
     private static let timeFormatter: DateFormatter = {
@@ -465,10 +460,10 @@ struct MeetingsView: View {
                 controller.hideCalendarEvent(event.id)
             }
         } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: 9, weight: .medium))
-                .foregroundStyle(MuesliTheme.textSecondary.opacity(0.6))
-                .frame(width: 20, height: 20)
+            Image(systemName: "ellipsis")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textSecondary.opacity(0.8))
+                .frame(width: 28, height: 28)
         }
         .buttonStyle(.plain)
         .help("Hide from Coming Up")
@@ -535,14 +530,14 @@ struct MeetingsView: View {
                     Image(systemName: "plus")
                         .font(.system(size: 11, weight: .semibold))
                     Text("Quick Note")
-                        .font(.system(size: 12, weight: .semibold))
-                        .lineLimit(1)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
                 }
                 .foregroundStyle(MuesliTheme.backgroundBase)
-                .padding(.horizontal, MuesliTheme.spacing12)
-                .padding(.vertical, 8)
+                .padding(.horizontal, MuesliTheme.spacing16)
+                .frame(height: 38)
                 .background(appState.isMeetingRecording || appState.isMeetingStarting ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
             }
             .buttonStyle(.plain)
             .disabled(appState.isMeetingRecording || appState.isMeetingStarting)
@@ -563,12 +558,12 @@ struct MeetingsView: View {
                         .lineLimit(1)
                 }
                 .foregroundStyle(MuesliTheme.textPrimary)
-                .padding(.horizontal, MuesliTheme.spacing12)
-                .padding(.vertical, 8)
+                .padding(.horizontal, MuesliTheme.spacing16)
+                .frame(height: 38)
                 .background(MuesliTheme.surfacePrimary)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
                 .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
                         .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
                 )
             }
@@ -696,13 +691,19 @@ struct MeetingsView: View {
                 Image(systemName: "arrow.up.arrow.down")
                     .font(.system(size: 11))
                 Text(selectedSort.label)
-                    .font(.system(size: 11))
+                    .font(.system(size: 12, weight: .medium))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
             }
             .foregroundStyle(selectedSort != .newestFirst ? MuesliTheme.accent : MuesliTheme.textSecondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(selectedSort != .newestFirst ? MuesliTheme.accent.opacity(0.12) : MuesliTheme.surfacePrimary.opacity(0.5))
-            .clipShape(Capsule())
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .frame(height: 38)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
@@ -729,14 +730,20 @@ struct MeetingsView: View {
                     .font(.system(size: 11))
                 if selectedFilter != .all {
                     Text(selectedFilter.label)
-                        .font(.system(size: 11))
+                        .font(.system(size: 12, weight: .medium))
                 }
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
             }
             .foregroundStyle(selectedFilter != .all ? MuesliTheme.accent : MuesliTheme.textTertiary)
-            .padding(.horizontal, selectedFilter != .all ? 8 : 0)
-            .padding(.vertical, 3)
-            .background(selectedFilter != .all ? MuesliTheme.accent.opacity(0.12) : Color.clear)
-            .clipShape(Capsule())
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .frame(height: 38)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
         }
         .menuStyle(.borderlessButton)
         .fixedSize()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
@@ -19,8 +19,12 @@ enum MenuBarIconRenderer {
 
     /// Returns a menu bar icon for the given choice.
     /// "muesli" loads the bundled M logo; anything else renders an SF Symbol.
-    static func make(choice: String = "muesli") -> NSImage? {
-        if choice == "muesli" {
+    static func make(choice: String = "muesli", customLogoPath: String? = nil) -> NSImage? {
+        if let customLogo = AppBrandingAssets.image(at: customLogoPath) {
+            customLogo.isTemplate = false
+            customLogo.size = NSSize(width: 18, height: 18)
+            return customLogo
+        } else if choice == "muesli" {
             if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
                let image = NSImage(contentsOf: url) {
                 image.isTemplate = true
@@ -28,6 +32,7 @@ enum MenuBarIconRenderer {
                 return image
             }
         }
+
         let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
         let image = NSImage(systemSymbolName: choice, accessibilityDescription: "Muesli")?
             .withSymbolConfiguration(config)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
@@ -20,11 +20,12 @@ enum MenuBarIconRenderer {
     /// Returns a menu bar icon for the given choice.
     /// "muesli" loads the bundled M logo; anything else renders an SF Symbol.
     static func make(choice: String = "muesli", customLogoPath: String? = nil) -> NSImage? {
-        if let customLogo = AppBrandingAssets.image(at: customLogoPath) {
-            customLogo.isTemplate = false
-            customLogo.size = NSSize(width: 18, height: 18)
-            return customLogo
-        } else if choice == "muesli" {
+        if choice == "muesli" {
+            if let customLogo = AppBrandingAssets.image(at: customLogoPath) {
+                customLogo.isTemplate = false
+                customLogo.size = NSSize(width: 18, height: 18)
+                return customLogo
+            }
             if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
                let image = NSImage(contentsOf: url) {
                 image.isTemplate = true

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -643,6 +643,8 @@ struct AppConfig: Codable {
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
+    var appDisplayName: String = ""
+    var customLogoPath: String?
     var menuBarIcon: String = "muesli"
     var showNextMeetingInMenuBar: Bool = true
     var maraudersMapUnlocked: Bool = false
@@ -706,6 +708,8 @@ struct AppConfig: Codable {
         case folderOrder = "folder_order"
         case soundEnabled = "sound_enabled"
         case recordingColorHex = "recording_color_hex"
+        case appDisplayName = "app_display_name"
+        case customLogoPath = "custom_logo_path"
         case menuBarIcon = "menu_bar_icon"
         case showNextMeetingInMenuBar = "show_next_meeting_in_menu_bar"
         case maraudersMapUnlocked = "marauders_map_unlocked"
@@ -791,6 +795,8 @@ struct AppConfig: Codable {
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
+        appDisplayName = (try? c.decode(String.self, forKey: .appDisplayName)) ?? defaults.appDisplayName
+        customLogoPath = try? c.decode(String.self, forKey: .customLogoPath)
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
         showNextMeetingInMenuBar = (try? c.decode(Bool.self, forKey: .showNextMeetingInMenuBar)) ?? defaults.showNextMeetingInMenuBar
         maraudersMapUnlocked = (try? c.decode(Bool.self, forKey: .maraudersMapUnlocked)) ?? defaults.maraudersMapUnlocked
@@ -814,6 +820,11 @@ struct AppConfig: Codable {
 
     var resolvedOnboardingUseCase: OnboardingUseCase {
         OnboardingUseCase.resolved(onboardingUseCase)
+    }
+
+    var resolvedDisplayName: String {
+        let trimmed = appDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? AppIdentity.bundleDisplayName : trimmed
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -616,7 +616,7 @@ final class MuesliController: NSObject {
     func performSearch(query: String) {
         searchTask?.cancel()
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        appState.searchQuery = trimmed
+        appState.searchQuery = query
         guard !trimmed.isEmpty else {
             appState.searchResultDictations = []
             appState.searchResultMeetings = []

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -195,6 +195,7 @@ final class MuesliController: NSObject {
         launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager()
     ) {
         let loadedConfig = configStore.load()
+        AppIdentity.configureDisplayNameOverride(loadedConfig.appDisplayName)
         self.runtime = runtime
         self.dictationStore = dictationStore ?? DictationStore(
             databaseURL: MuesliPaths.defaultDatabaseURL(appName: AppIdentity.supportDirectoryName)
@@ -223,6 +224,7 @@ final class MuesliController: NSObject {
         self.indicator = FloatingIndicatorController(configStore: configStore)
         ComputerUseCursorOverlay.shared.attachIndicator(self.indicator)
         super.init()
+        applyApplicationBranding()
     }
 
     func start() {
@@ -507,7 +509,23 @@ final class MuesliController: NSObject {
         }
     }
 
+    private func applyApplicationBranding() {
+        if let customLogo = AppBrandingAssets.image(at: config.customLogoPath) {
+            NSApplication.shared.applicationIconImage = customLogo
+        } else if let image = AppBrandingAssets.accentedDefaultAppIcon(
+            accentHex: config.recordingColorHex,
+            fallbackURL: runtime.appIcon
+        ) {
+            NSApplication.shared.applicationIconImage = image
+        }
+
+        if let quitItem = NSApplication.shared.mainMenu?.items.first?.submenu?.items.first {
+            quitItem.title = "Quit \(AppIdentity.displayName)"
+        }
+    }
+
     func refreshUI() {
+        applyApplicationBranding()
         statusBarController?.setStatus("Idle")
         statusBarController?.refresh()
         historyWindowController?.updateBackendLabel()
@@ -682,8 +700,11 @@ final class MuesliController: NSObject {
 
     func updateConfig(_ mutate: (inout AppConfig) -> Void) {
         mutate(&config)
+        config.appDisplayName = config.appDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
         configStore.save(config)
+        AppIdentity.configureDisplayNameOverride(config.appDisplayName)
         MuesliTheme.accentOverrideHex = config.recordingColorHex == "1e1e2e" ? nil : config.recordingColorHex
+        applyApplicationBranding()
         selectedBackend = BackendOption.all.first(where: {
             $0.backend == config.sttBackend && $0.model == config.sttModel
         }) ?? .whisper

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -616,7 +616,7 @@ final class MuesliController: NSObject {
     func performSearch(query: String) {
         searchTask?.cancel()
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        appState.searchQuery = query
+        appState.searchQuery = trimmed
         guard !trimmed.isEmpty else {
             appState.searchResultDictations = []
             appState.searchResultMeetings = []

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliTheme.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliTheme.swift
@@ -4,15 +4,15 @@ import MuesliCore
 enum MuesliTheme {
     // MARK: - Colors — Backgrounds (layered)
 
-    static let backgroundDeep   = Color.adaptive(dark: 0x111214, light: 0xF5F5F7)
-    static let backgroundBase   = Color.adaptive(dark: 0x161719, light: 0xFFFFFF)
-    static let backgroundRaised = Color.adaptive(dark: 0x1C1D20, light: 0xF0F0F2)
-    static let backgroundHover  = Color.adaptive(dark: 0x232528, light: 0xE8E8EC)
+    static let backgroundDeep   = Color.adaptive(dark: 0x101114, light: 0xF7F8FA)
+    static let backgroundBase   = Color.adaptive(dark: 0x15161A, light: 0xF8F9FB)
+    static let backgroundRaised = Color.adaptive(dark: 0x1D1F24, light: 0xFFFFFF)
+    static let backgroundHover  = Color.adaptive(dark: 0x262932, light: 0xF1F3F6)
 
     // MARK: - Surfaces (interactive elements)
 
-    static let surfacePrimary   = Color.adaptive(dark: 0x262830, light: 0xE5E5EA)
-    static let surfaceSelected  = Color.adaptive(dark: 0x2E3340, light: 0xD6DFFE)
+    static let surfacePrimary   = Color.adaptive(dark: 0x292C34, light: 0xF3F5F7)
+    static let surfaceSelected  = Color.adaptive(dark: 0x2A3140, light: 0xFFF3EA)
     static let surfaceBorder    = Color.adaptiveAlpha(
         dark: .white, darkAlpha: 0.07,
         light: .black, lightAlpha: 0.08
@@ -36,7 +36,7 @@ enum MuesliTheme {
     // MARK: - Accent
 
     static let defaultAccentDarkHex = 0x6BA3F7
-    static let defaultAccentLightHex = 0x2563EB
+    static let defaultAccentLightHex = 0xF97316
     static let defaultAccent    = Color.adaptive(dark: defaultAccentDarkHex, light: defaultAccentLightHex)
     static var accentOverrideHex: String?
     static var accent: Color {
@@ -73,14 +73,39 @@ enum MuesliTheme {
     static let spacing16: CGFloat = 16
     static let spacing20: CGFloat = 20
     static let spacing24: CGFloat = 24
+    static let spacing28: CGFloat = 28
     static let spacing32: CGFloat = 32
+    static let spacing40: CGFloat = 40
+
+    // MARK: - Layout
+
+    static let pageMaxWidth: CGFloat = 1080
+    static let pageHorizontalPadding: CGFloat = 42
+    static let pageVerticalPadding: CGFloat = 36
+    static let sectionSpacing: CGFloat = 24
+    static let cardPadding: CGFloat = 20
+    static let rowMinHeight: CGFloat = 44
+    static let sidebarMinWidth: CGFloat = 244
+    static let sidebarIdealWidth: CGFloat = 260
+    static let sidebarMaxWidth: CGFloat = 288
+    static let sidebarRowHeight: CGFloat = 40
+    static let sidebarChildRowHeight: CGFloat = 32
 
     // MARK: - Corner radii
 
     static let cornerSmall: CGFloat = 6
-    static let cornerMedium: CGFloat = 10
-    static let cornerLarge: CGFloat = 14
-    static let cornerXL: CGFloat = 20
+    static let cornerMedium: CGFloat = 8
+    static let cornerLarge: CGFloat = 12
+    static let cornerXL: CGFloat = 16
+}
+
+extension View {
+    func muesliPageContent(maxWidth: CGFloat = MuesliTheme.pageMaxWidth) -> some View {
+        frame(maxWidth: maxWidth, alignment: .leading)
+            .padding(.horizontal, MuesliTheme.pageHorizontalPadding)
+            .padding(.vertical, MuesliTheme.pageVerticalPadding)
+            .frame(maxWidth: .infinity, alignment: .top)
+    }
 }
 
 // MARK: - Color Helpers

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -39,6 +39,7 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
     }
 
     func updateBackendLabel() {
+        window?.title = AppIdentity.displayName
         controller.syncAppState()
     }
 
@@ -52,8 +53,8 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
 
     private func buildWindow() {
         let window = NSWindow(
-            contentRect: NSRect(x: 180, y: 140, width: 1120, height: 790),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            contentRect: NSRect(x: 140, y: 110, width: 1280, height: 840),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -62,7 +63,8 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         window.delegate = self
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
-        window.backgroundColor = NSColor(red: 0.067, green: 0.071, blue: 0.078, alpha: 1) // #111214
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = NSColor.windowBackgroundColor
 
         let rootView = DashboardRootView(
             appState: controller.appState,

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -30,6 +30,7 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
     }
 
     func reload() {
+        window?.title = AppIdentity.displayName
         controller.syncAppState()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
@@ -10,7 +10,7 @@ struct SearchResultsView: View {
     let appState: AppState
     let controller: MuesliController
 
-    @State private var selectedTab: SearchTab = .dictations
+    @State private var selectedTab: SearchTab = .meetings
 
     private var totalCount: Int {
         appState.searchResultDictations.count + appState.searchResultMeetings.count

--- a/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
@@ -16,6 +16,20 @@ struct SearchResultsView: View {
         appState.searchResultDictations.count + appState.searchResultMeetings.count
     }
 
+    private var activeTab: SearchTab {
+        if selectedTab == .meetings,
+           appState.searchResultMeetings.isEmpty,
+           !appState.searchResultDictations.isEmpty {
+            return .dictations
+        }
+        if selectedTab == .dictations,
+           appState.searchResultDictations.isEmpty,
+           !appState.searchResultMeetings.isEmpty {
+            return .meetings
+        }
+        return selectedTab
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
@@ -53,7 +67,7 @@ struct SearchResultsView: View {
 
     @ViewBuilder
     private func tabButton(_ tab: SearchTab, count: Int) -> some View {
-        let isSelected = selectedTab == tab
+        let isSelected = activeTab == tab
         Button {
             withAnimation(.easeInOut(duration: 0.15)) { selectedTab = tab }
         } label: {
@@ -81,7 +95,7 @@ struct SearchResultsView: View {
 
     @ViewBuilder
     private var tabContent: some View {
-        switch selectedTab {
+        switch activeTab {
         case .dictations:
             if appState.searchResultDictations.isEmpty {
                 noResultsForTab("dictations")

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -459,53 +459,6 @@ struct SettingsView: View {
                             .foregroundStyle(MuesliTheme.textPrimary)
                     }
                 }
-                Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Voice feedback", controlWidth: meetingControlWidth) {
-                    settingsSwitch(isOn: appState.config.enableComputerUseVoiceFeedback) { newValue in
-                        controller.updateConfig { $0.enableComputerUseVoiceFeedback = newValue }
-                    }
-                }
-                Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Voice model", controlWidth: meetingControlWidth) {
-                    settingsMenu(
-                        selection: ComputerUseTTSModelOption.resolve(appState.config.computerUseTTSModel).label,
-                        options: ComputerUseTTSModelOption.labels
-                    ) { label in
-                        controller.updateConfig {
-                            $0.computerUseTTSModel = ComputerUseTTSModelOption.option(forLabel: label).rawValue
-                        }
-                    }
-                }
-                Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Voice", controlWidth: meetingControlWidth) {
-                    settingsMenu(
-                        selection: ComputerUseTTSVoiceOption.resolve(appState.config.computerUseTTSVoice).label,
-                        options: ComputerUseTTSVoiceOption.labels
-                    ) { label in
-                        controller.updateConfig {
-                            $0.computerUseTTSVoice = ComputerUseTTSVoiceOption.option(forLabel: label).rawValue
-                        }
-                    }
-                }
-                Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Voice speed", controlWidth: meetingControlWidth) {
-                    Stepper(
-                        value: Binding(
-                            get: { min(max(appState.config.computerUseTTSSpeed, 0.5), 2.0) },
-                            set: { newValue in
-                                controller.updateConfig {
-                                    $0.computerUseTTSSpeed = min(max(newValue, 0.5), 2.0)
-                                }
-                            }
-                        ),
-                        in: 0.5...2.0,
-                        step: 0.05
-                    ) {
-                        Text("\(appState.config.computerUseTTSSpeed.formatted(.number.precision(.fractionLength(2))))x")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                    }
-                }
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import SwiftUI
+import UniformTypeIdentifiers
 import MuesliCore
 
 private struct MeetingDetectionAppOption: Identifiable {
@@ -87,10 +88,11 @@ struct SettingsView: View {
     @State private var openRouterFreeModels: [SummaryModelPreset] = []
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
+    @State private var appDisplayNameDraft = ""
 
     // Uniform width for all right-side controls
-    private let controlWidth: CGFloat = 220
-    private let meetingControlWidth: CGFloat = 275
+    private let controlWidth: CGFloat = 240
+    private let meetingControlWidth: CGFloat = 300
     private let screenContextGrantIntentTimeout: TimeInterval = 15 * 60
     private let meetingDetectionAppOptions: [MeetingDetectionAppOption] = [
         MeetingDetectionAppOption(bundleID: "com.google.Chrome", name: "Chrome", icon: "globe"),
@@ -126,7 +128,7 @@ struct SettingsView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            VStack(alignment: .leading, spacing: MuesliTheme.sectionSpacing) {
                 Text("Settings")
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
@@ -134,10 +136,11 @@ struct SettingsView: View {
                 settingsPanePicker
                 paneContent
             }
-            .padding(MuesliTheme.spacing32)
+            .muesliPageContent(maxWidth: 1080)
         }
         .background(MuesliTheme.backgroundBase)
         .onAppear {
+            appDisplayNameDraft = appState.config.appDisplayName
             refreshDownloadedModelOptions()
             startPermissionPolling()
             if appState.selectedMeetingSummaryBackend == .openRouter {
@@ -164,6 +167,11 @@ struct SettingsView: View {
         .onChange(of: appState.selectedMeetingSummaryBackend) { _, backend in
             if backend == .openRouter {
                 loadOpenRouterFreeModelsIfNeeded()
+            }
+        }
+        .onChange(of: appState.config.appDisplayName) { _, name in
+            if appDisplayNameDraft != name {
+                appDisplayNameDraft = name
             }
         }
         .alert(
@@ -226,7 +234,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func screenContextRow(_ title: String, controlWidth rowControlWidth: CGFloat? = nil) -> some View {
         let width = rowControlWidth ?? controlWidth
-        HStack(alignment: .top, spacing: 20) {
+        HStack(alignment: .top, spacing: MuesliTheme.spacing16) {
             VStack(alignment: .leading, spacing: 6) {
                 Text(title)
                     .font(MuesliTheme.body())
@@ -239,21 +247,20 @@ struct SettingsView: View {
             }
             .layoutPriority(1)
 
-            Spacer(minLength: 20)
+            Spacer(minLength: MuesliTheme.spacing20)
 
             ZStack(alignment: .trailing) {
                 Color.clear.frame(width: width, height: 1)
                 screenContextControl(width: width)
             }
         }
-        .frame(minHeight: 52)
+        .frame(minHeight: MuesliTheme.rowMinHeight + MuesliTheme.spacing8)
     }
 
     private let customIndicatorPositionLabel = "Custom (drag to reposition)"
 
     private var settingsPanePicker: some View {
         HStack {
-            Spacer()
             Picker("", selection: $selectedPane) {
                 ForEach(SettingsPane.allCases) { pane in
                     Text(pane.title).tag(pane)
@@ -261,8 +268,8 @@ struct SettingsView: View {
             }
             .labelsHidden()
             .pickerStyle(.segmented)
-            .frame(width: 680)
-            Spacer()
+            .controlSize(.large)
+            .frame(maxWidth: .infinity)
         }
     }
 
@@ -305,7 +312,8 @@ struct SettingsView: View {
 
             permissionsSection
 
-            settingsSection("Data") {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                settingsSectionLabel("Data")
                 HStack(spacing: MuesliTheme.spacing12) {
                     actionButton("Clear dictation history", role: .destructive) {
                         pendingDataDestruction = .dictations
@@ -316,6 +324,7 @@ struct SettingsView: View {
                     .disabled(controller.isMeetingRecording())
                     .help("Stop the current meeting recording before clearing meeting history.")
                 }
+                .frame(maxWidth: .infinity)
             }
         }
     }
@@ -450,6 +459,53 @@ struct SettingsView: View {
                             .foregroundStyle(MuesliTheme.textPrimary)
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Voice feedback", controlWidth: meetingControlWidth) {
+                    settingsSwitch(isOn: appState.config.enableComputerUseVoiceFeedback) { newValue in
+                        controller.updateConfig { $0.enableComputerUseVoiceFeedback = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Voice model", controlWidth: meetingControlWidth) {
+                    settingsMenu(
+                        selection: ComputerUseTTSModelOption.resolve(appState.config.computerUseTTSModel).label,
+                        options: ComputerUseTTSModelOption.labels
+                    ) { label in
+                        controller.updateConfig {
+                            $0.computerUseTTSModel = ComputerUseTTSModelOption.option(forLabel: label).rawValue
+                        }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Voice", controlWidth: meetingControlWidth) {
+                    settingsMenu(
+                        selection: ComputerUseTTSVoiceOption.resolve(appState.config.computerUseTTSVoice).label,
+                        options: ComputerUseTTSVoiceOption.labels
+                    ) { label in
+                        controller.updateConfig {
+                            $0.computerUseTTSVoice = ComputerUseTTSVoiceOption.option(forLabel: label).rawValue
+                        }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Voice speed", controlWidth: meetingControlWidth) {
+                    Stepper(
+                        value: Binding(
+                            get: { min(max(appState.config.computerUseTTSSpeed, 0.5), 2.0) },
+                            set: { newValue in
+                                controller.updateConfig {
+                                    $0.computerUseTTSSpeed = min(max(newValue, 0.5), 2.0)
+                                }
+                            }
+                        ),
+                        in: 0.5...2.0,
+                        step: 0.05
+                    ) {
+                        Text("\(appState.config.computerUseTTSSpeed.formatted(.number.precision(.fractionLength(2))))x")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                    }
+                }
             }
         }
     }
@@ -522,7 +578,7 @@ struct SettingsView: View {
                             placeholder: "sk-...",
                             onChange: { val in controller.updateConfig { $0.openAIAPIKey = val } }
                         )
-                        .frame(height: 22)
+                        .frame(height: 26)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Model", controlWidth: meetingControlWidth) {
@@ -539,7 +595,7 @@ struct SettingsView: View {
                             placeholder: "http://localhost:11434",
                             onChange: { val in controller.updateConfig { $0.ollamaURL = val } }
                         )
-                        .frame(height: 22)
+                        .frame(height: 26)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Model", controlWidth: meetingControlWidth) {
@@ -555,7 +611,7 @@ struct SettingsView: View {
                             placeholder: "sk-or-...",
                             onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
                         )
-                        .frame(height: 22)
+                        .frame(height: 26)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Free model", controlWidth: meetingControlWidth) {
@@ -704,6 +760,20 @@ struct SettingsView: View {
             }
 
             settingsSection("Appearance") {
+                settingsRow("App name", controlWidth: 260) {
+                    settingsTextField(
+                        text: appDisplayNameDraft,
+                        placeholder: AppIdentity.bundleDisplayName
+                    ) { value in
+                        appDisplayNameDraft = value
+                        controller.updateConfig { $0.appDisplayName = value }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Logo", controlWidth: 260) {
+                    customLogoPicker
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Dark mode") {
                     settingsSwitch(isOn: appState.config.darkMode) { newValue in
                         controller.updateConfig { $0.darkMode = newValue }
@@ -755,7 +825,7 @@ struct SettingsView: View {
     }
 
     private var glassTintPicker: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
             ForEach(Self.accentPresets, id: \.hex) { preset in
                 let isSelected = appState.config.recordingColorHex.lowercased() == preset.hex
                 Button {
@@ -774,7 +844,85 @@ struct SettingsView: View {
                 .buttonStyle(.plain)
                 .help(preset.name)
             }
+
+            CompactColorWell(
+                color: .muesliHex(appState.config.recordingColorHex),
+                onChange: { color in
+                    if let hex = color.toHexString() {
+                        controller.updateConfig { $0.recordingColorHex = hex }
+                    }
+                }
+            )
+            .frame(width: 24, height: 24)
+            .clipShape(Circle())
+            .overlay(
+                Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+            .help("Choose any accent color")
         }
+    }
+
+    private var customLogoPicker: some View {
+        HStack(spacing: 6) {
+            logoPreview
+
+            Button {
+                pickCustomLogo()
+            } label: {
+                Image(systemName: "photo")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .help("Upload logo")
+
+            if appState.config.customLogoPath != nil {
+                Button {
+                    let oldPath = appState.config.customLogoPath
+                    controller.updateConfig { $0.customLogoPath = nil }
+                    AppBrandingAssets.removeLogo(at: oldPath)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .help("Remove custom logo")
+            }
+        }
+        .frame(width: 260, alignment: .trailing)
+    }
+
+    private var logoPreview: some View {
+        Group {
+            if let img = MenuBarIconRenderer.make(
+                choice: appState.config.menuBarIcon,
+                customLogoPath: appState.config.customLogoPath
+            ) {
+                Image(nsImage: img)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(systemName: "app")
+                    .font(.system(size: 13))
+            }
+        }
+        .frame(width: 20, height: 20)
+        .padding(4)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
     }
 
     private var menuBarIconPicker: some View {
@@ -1048,6 +1196,32 @@ struct SettingsView: View {
         }
     }
 
+    private func pickCustomLogo() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a logo"
+        panel.prompt = "Choose Logo"
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        presentOpenPanel(panel) { url in
+            do {
+                let previousPath = appState.config.customLogoPath
+                let importedPath = try AppBrandingAssets.importLogo(from: url)
+                controller.updateConfig {
+                    $0.customLogoPath = importedPath
+                    $0.menuBarIcon = "muesli"
+                }
+                if previousPath != importedPath {
+                    AppBrandingAssets.removeLogo(at: previousPath)
+                }
+            } catch {
+                fputs("[muesli-native] Failed to import custom logo: \(error)\n", stderr)
+            }
+        }
+    }
+
     private func pickMeetingHookFile() {
         let panel = NSOpenPanel()
         panel.title = "Choose a hook script"
@@ -1304,19 +1478,24 @@ struct SettingsView: View {
 
     // MARK: - Layout Primitives
 
+    private func settingsSectionLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(MuesliTheme.textTertiary)
+            .textCase(.uppercase)
+            .padding(.leading, 2)
+    }
+
     @ViewBuilder
     private func settingsSection(_ title: String, @ViewBuilder content: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-            Text(title)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(MuesliTheme.textTertiary)
-                .textCase(.uppercase)
-                .padding(.leading, 2)
+            settingsSectionLabel(title)
 
             VStack(alignment: .leading, spacing: 0) {
                 content()
             }
-            .padding(MuesliTheme.spacing16)
+            .padding(.horizontal, MuesliTheme.cardPadding)
+            .padding(.vertical, MuesliTheme.spacing4)
             .background(MuesliTheme.backgroundRaised)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
             .overlay(
@@ -1331,12 +1510,12 @@ struct SettingsView: View {
     @ViewBuilder
     private func settingsRow(_ label: String, controlWidth rowControlWidth: CGFloat? = nil, @ViewBuilder control: () -> some View) -> some View {
         let width = rowControlWidth ?? controlWidth
-        HStack(alignment: .center) {
+        HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
             Text(label)
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textPrimary)
                 .layoutPriority(1)
-            Spacer(minLength: 20)
+            Spacer(minLength: MuesliTheme.spacing20)
             ZStack(alignment: .trailing) {
                 // Invisible spacer forces the ZStack to exactly controlWidth
                 Color.clear.frame(width: width, height: 1)
@@ -1344,14 +1523,14 @@ struct SettingsView: View {
                     .frame(maxWidth: width)
             }
         }
-        .frame(minHeight: 32)
+        .frame(minHeight: MuesliTheme.rowMinHeight)
     }
 
     private func settingsDescription(_ text: String) -> some View {
         Text(text)
             .font(MuesliTheme.caption())
             .foregroundStyle(MuesliTheme.textTertiary)
-            .padding(.horizontal, MuesliTheme.spacing16)
+            .padding(.trailing, MuesliTheme.spacing16)
             .padding(.top, -4)
             .padding(.bottom, MuesliTheme.spacing8)
     }
@@ -1372,7 +1551,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
         FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
-            .frame(height: 24)
+            .frame(height: 28)
     }
 
     private var mutedMeetingDetectionAppsControl: some View {
@@ -1755,7 +1934,7 @@ struct SettingsView: View {
                 onChange(allItems[index].id)
             }
         )
-        .frame(height: 24)
+        .frame(height: 28)
     }
 
     @ViewBuilder
@@ -1772,7 +1951,7 @@ struct SettingsView: View {
                 onChange(selectedId == presets.first?.id ? "" : selectedId)
             }
         )
-        .frame(height: 24)
+        .frame(height: 28)
     }
 
     @ViewBuilder
@@ -1784,7 +1963,17 @@ struct SettingsView: View {
                 onChange(value.trimmingCharacters(in: .whitespacesAndNewlines))
             }
         )
-        .frame(height: 22)
+        .frame(height: 26)
+    }
+
+    @ViewBuilder
+    private func settingsTextField(text: String, placeholder: String, onChange: @escaping (String) -> Void) -> some View {
+        PastableTextField(
+            text: text,
+            placeholder: placeholder,
+            onChange: onChange
+        )
+        .frame(height: 24)
     }
 
     @ViewBuilder
@@ -2014,25 +2203,33 @@ struct PastableSecureField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: EditableNSSecureTextField, context: Context) {
+        context.coordinator.onChange = onChange
         if nsView.stringValue != text {
+            guard nsView.currentEditor() == nil else { return }
             nsView.stringValue = text
+            context.coordinator.lastValue = text
         }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onChange: onChange)
+        Coordinator(initialValue: text, onChange: onChange)
     }
 
     class Coordinator: NSObject, NSTextFieldDelegate {
-        let onChange: (String) -> Void
+        var lastValue: String
+        var onChange: (String) -> Void
 
-        init(onChange: @escaping (String) -> Void) {
+        init(initialValue: String, onChange: @escaping (String) -> Void) {
+            self.lastValue = initialValue
             self.onChange = onChange
         }
 
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
-            onChange(field.stringValue)
+            let value = field.stringValue
+            guard value != lastValue else { return }
+            lastValue = value
+            onChange(value)
         }
     }
 }
@@ -2056,8 +2253,55 @@ struct PastableTextField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: EditableNSTextField, context: Context) {
+        context.coordinator.onChange = onChange
         if nsView.stringValue != text {
+            guard nsView.currentEditor() == nil else { return }
             nsView.stringValue = text
+            context.coordinator.lastValue = text
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(initialValue: text, onChange: onChange)
+    }
+
+    class Coordinator: NSObject, NSTextFieldDelegate {
+        var lastValue: String
+        var onChange: (String) -> Void
+
+        init(initialValue: String, onChange: @escaping (String) -> Void) {
+            self.lastValue = initialValue
+            self.onChange = onChange
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            let value = field.stringValue
+            guard value != lastValue else { return }
+            lastValue = value
+            onChange(value)
+        }
+    }
+}
+
+struct CompactColorWell: NSViewRepresentable {
+    let color: NSColor
+    let onChange: (NSColor) -> Void
+
+    func makeNSView(context: Context) -> CompactColorWellButton {
+        let button = CompactColorWellButton(frame: NSRect(x: 0, y: 0, width: 24, height: 24))
+        button.swatchColor = color
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.openColorPanel(_:))
+        context.coordinator.button = button
+        return button
+    }
+
+    func updateNSView(_ nsView: CompactColorWellButton, context: Context) {
+        context.coordinator.onChange = onChange
+        context.coordinator.button = nsView
+        if !nsView.swatchColor.isEqual(color) {
+            nsView.swatchColor = color
         }
     }
 
@@ -2065,17 +2309,88 @@ struct PastableTextField: NSViewRepresentable {
         Coordinator(onChange: onChange)
     }
 
-    class Coordinator: NSObject, NSTextFieldDelegate {
-        let onChange: (String) -> Void
+    class Coordinator: NSObject {
+        var onChange: (NSColor) -> Void
+        weak var button: CompactColorWellButton?
+        private var panelObserver: NSObjectProtocol?
 
-        init(onChange: @escaping (String) -> Void) {
+        init(onChange: @escaping (NSColor) -> Void) {
             self.onChange = onChange
         }
 
-        func controlTextDidChange(_ obj: Notification) {
-            guard let field = obj.object as? NSTextField else { return }
-            onChange(field.stringValue)
+        deinit {
+            if let panelObserver {
+                NotificationCenter.default.removeObserver(panelObserver)
+            }
         }
+
+        @objc func openColorPanel(_ sender: CompactColorWellButton) {
+            let panel = NSColorPanel.shared
+            panel.showsAlpha = false
+            panel.color = sender.swatchColor
+            observe(panel)
+            panel.makeKeyAndOrderFront(nil)
+        }
+
+        private func observe(_ panel: NSColorPanel) {
+            if let panelObserver {
+                NotificationCenter.default.removeObserver(panelObserver)
+            }
+            panelObserver = NotificationCenter.default.addObserver(
+                forName: NSColorPanel.colorDidChangeNotification,
+                object: panel,
+                queue: .main
+            ) { [weak self] notification in
+                guard let self, let panel = notification.object as? NSColorPanel else { return }
+                button?.swatchColor = panel.color
+                onChange(panel.color)
+            }
+        }
+    }
+}
+
+final class CompactColorWellButton: NSButton {
+    var swatchColor: NSColor = .controlAccentColor {
+        didSet { needsDisplay = true }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        title = ""
+        isBordered = false
+        bezelStyle = .regularSquare
+        setButtonType(.momentaryPushIn)
+        focusRingType = .none
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        title = ""
+        isBordered = false
+        focusRingType = .none
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 24, height: 24)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.clear.setFill()
+        dirtyRect.fill()
+
+        let circleRect = bounds.insetBy(dx: 2, dy: 2)
+        let path = NSBezierPath(ovalIn: circleRect)
+        swatchColor.setFill()
+        path.fill()
+
+        NSColor.white.withAlphaComponent(isHighlighted ? 0.95 : 0.7).setStroke()
+        path.lineWidth = 1.5
+        path.stroke()
+
+        NSColor.separatorColor.withAlphaComponent(0.8).setStroke()
+        let border = NSBezierPath(ovalIn: circleRect.insetBy(dx: -0.5, dy: -0.5))
+        border.lineWidth = 1
+        border.stroke()
     }
 }
 
@@ -2095,6 +2410,20 @@ private extension Color {
 }
 
 private extension NSColor {
+    static func muesliHex(_ hex: String) -> NSColor {
+        var h = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        h = h.hasPrefix("#") ? String(h.dropFirst()) : h
+        guard h.count == 6, let value = UInt64(h, radix: 16) else {
+            return .controlAccentColor
+        }
+        return NSColor(
+            srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+
     func toHexString() -> String? {
         guard let rgb = usingColorSpace(.sRGB) else { return nil }
         let r = Int((rgb.redComponent   * 255).rounded())

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -157,8 +157,12 @@ struct SidebarView: View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             HStack(spacing: MuesliTheme.spacing12) {
                 Group {
-                    if appState.config.menuBarIcon == "muesli",
-                       let img = MenuBarIconRenderer.make(choice: "muesli") {
+                    if let img = AppBrandingAssets.image(at: appState.config.customLogoPath) {
+                        Image(nsImage: img)
+                            .resizable()
+                            .scaledToFit()
+                    } else if appState.config.menuBarIcon == "muesli",
+                              let img = MenuBarIconRenderer.make(choice: "muesli") {
                         Image(nsImage: img)
                             .resizable()
                             .scaledToFit()
@@ -168,7 +172,7 @@ struct SidebarView: View {
                 }
                 .frame(width: 22, height: 22)
                 .foregroundStyle(MuesliTheme.accent)
-                Text("muesli")
+                Text(appState.config.resolvedDisplayName)
                     .font(MuesliTheme.title2())
                     .foregroundStyle(MuesliTheme.textPrimary)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -2,10 +2,15 @@ import SwiftUI
 import MuesliCore
 
 struct SidebarView: View {
-    private let sidebarIconColumnWidth: CGFloat = 20
-    private let meetingsTrailingColumnWidth: CGFloat = 24
-    private let sidebarRowHorizontalPadding: CGFloat = 16
-    private let sidebarRowOuterPadding: CGFloat = 8
+    private let sidebarIconColumnWidth: CGFloat = 22
+    private let meetingsTrailingColumnWidth: CGFloat = 22
+    private let sidebarRowHorizontalPadding: CGFloat = 14
+    private let sidebarRowOuterPadding: CGFloat = 24
+    private let sidebarHeaderTopPadding: CGFloat = 36
+
+    private var sidebarChildLabelLeadingPadding: CGFloat {
+        sidebarRowHorizontalPadding + sidebarIconColumnWidth + MuesliTheme.spacing12
+    }
 
     let appState: AppState
     let controller: MuesliController
@@ -17,12 +22,13 @@ struct SidebarView: View {
     @State private var showDeleteConfirmation = false
     @State private var draggingFolderID: Int64?
     @State private var dragOrderedFolders: [MeetingFolder]?
+    @State private var searchText = ""
     @FocusState private var isSearchFieldFocused: Bool
 
     private var searchTextBinding: Binding<String> {
         Binding(
-            get: { appState.searchQuery },
-            set: { controller.performSearch(query: $0) }
+            get: { searchText },
+            set: { searchText = $0 }
         )
     }
 
@@ -96,23 +102,23 @@ struct SidebarView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+        VStack(alignment: .leading, spacing: 0) {
             sidebarHeader
             searchBar
 
-            sidebarItem(tab: .dictations, icon: "mic.fill", label: "Dictations")
-            meetingsSection
-            sidebarItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
-            sidebarItem(tab: .models, icon: "square.and.arrow.down", label: "Models")
-            sidebarItem(tab: .shortcuts, icon: "keyboard", label: "Shortcuts")
+            VStack(alignment: .leading, spacing: 4) {
+                sidebarItem(tab: .dictations, icon: "mic.fill", label: "Dictations")
+                meetingsSection
+                sidebarItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
+                sidebarItem(tab: .models, icon: "cube", label: "Models")
+                sidebarItem(tab: .shortcuts, icon: "keyboard", label: "Shortcuts")
+            }
+            .padding(.top, MuesliTheme.spacing12)
 
             Spacer()
 
             modelPreparationStatus
-            sidebarItem(tab: .settings, icon: "gearshape", label: "Settings")
-            sidebarItem(tab: .about, icon: "info.circle", label: "About", updateCTA: pendingUpdateCTA)
-            darkModeToggle
-                .padding(.bottom, MuesliTheme.spacing16)
+            sidebarFooter
         }
         .frame(maxHeight: .infinity)
         .background(MuesliTheme.backgroundDeep)
@@ -154,53 +160,37 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var sidebarHeader: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-            HStack(spacing: MuesliTheme.spacing12) {
-                Group {
-                    if let img = AppBrandingAssets.image(at: appState.config.customLogoPath) {
-                        Image(nsImage: img)
-                            .resizable()
-                            .scaledToFit()
-                    } else if appState.config.menuBarIcon == "muesli",
-                              let img = MenuBarIconRenderer.make(choice: "muesli") {
-                        Image(nsImage: img)
-                            .resizable()
-                            .scaledToFit()
-                    } else {
-                        Image(systemName: appState.config.menuBarIcon)
-                    }
-                }
-                .frame(width: 22, height: 22)
-                .foregroundStyle(MuesliTheme.accent)
-                Text(appState.config.resolvedDisplayName)
-                    .font(MuesliTheme.title2())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-            }
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Text(appState.config.resolvedDisplayName)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
             if !userName.isEmpty {
                 Text("Hi, \(userName)")
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
-                    .padding(.leading, 34)
             }
         }
-        .padding(.horizontal, MuesliTheme.spacing16)
-        .padding(.top, MuesliTheme.spacing24)
-        .padding(.bottom, MuesliTheme.spacing20)
+        .padding(.horizontal, sidebarRowOuterPadding + sidebarRowHorizontalPadding)
+        .padding(.top, sidebarHeaderTopPadding)
+        .padding(.bottom, MuesliTheme.spacing24)
     }
 
     @ViewBuilder
     private var searchBar: some View {
         HStack(spacing: MuesliTheme.spacing8) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 12))
+                .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(MuesliTheme.textTertiary)
-            TextField("Search...", text: searchTextBinding)
+            TextField("Search", text: searchTextBinding)
                 .textFieldStyle(.plain)
                 .font(MuesliTheme.callout())
                 .foregroundStyle(MuesliTheme.textPrimary)
                 .focused($isSearchFieldFocused)
-            if !appState.searchQuery.isEmpty {
+            if !searchText.isEmpty {
                 Button {
+                    searchText = ""
                     controller.clearSearch()
                     isSearchFieldFocused = false
                 } label: {
@@ -209,18 +199,37 @@ struct SidebarView: View {
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
                 .buttonStyle(.plain)
+            } else {
+                Text("⌘K")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.horizontal, 6)
+                    .frame(height: 22)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
+        .padding(.horizontal, MuesliTheme.spacing12)
+        .frame(height: 42)
         .background(MuesliTheme.backgroundRaised)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
         .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
         .padding(.horizontal, sidebarRowOuterPadding)
-        .padding(.bottom, MuesliTheme.spacing8)
+        .shadow(color: Color.black.opacity(0.025), radius: 8, x: 0, y: 2)
+        .onAppear {
+            searchText = appState.searchQuery
+        }
+        .onChange(of: searchText) { _, newValue in
+            controller.performSearch(query: newValue)
+        }
+        .onChange(of: appState.searchQuery) { _, newValue in
+            if newValue.isEmpty || !isSearchFieldFocused {
+                searchText = newValue
+            }
+        }
         .onChange(of: appState.focusSearchField) { _, shouldFocus in
             if shouldFocus {
                 isSearchFieldFocused = true
@@ -233,7 +242,7 @@ struct SidebarView: View {
     private var meetingsSection: some View {
         VStack(alignment: .leading, spacing: 2) {
             let isSelected = appState.selectedTab == .meetings
-            HStack(spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing8) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.15)) {
                         meetingsExpanded = true
@@ -242,9 +251,9 @@ struct SidebarView: View {
                 } label: {
                     HStack(spacing: MuesliTheme.spacing12) {
                         Image(systemName: "person.2.fill")
-                            .font(.system(size: 14, weight: .medium))
+                            .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
-                            .frame(width: sidebarIconColumnWidth)
+                            .frame(width: sidebarIconColumnWidth, height: sidebarIconColumnWidth)
                         Text("Meetings")
                             .font(MuesliTheme.headline())
                             .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
@@ -276,17 +285,20 @@ struct SidebarView: View {
                 .help("New Meeting Folder")
             }
             .padding(.horizontal, sidebarRowHorizontalPadding)
-            .padding(.vertical, MuesliTheme.spacing8)
+            .frame(height: MuesliTheme.sidebarRowHeight)
             .background(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                    .fill(isSelected ? MuesliTheme.accent.opacity(0.10) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                    .strokeBorder(isSelected ? MuesliTheme.accent.opacity(0.18) : Color.clear, lineWidth: 1)
             )
             .padding(.horizontal, sidebarRowOuterPadding)
 
             if meetingsExpanded {
                 VStack(alignment: .leading, spacing: 2) {
                     meetingFilterRow(
-                        icon: "tray.2",
                         label: "All Meetings",
                         count: appState.totalMeetingCount,
                         isSelected: appState.selectedTab == .meetings && appState.selectedFolderID == nil
@@ -375,18 +387,35 @@ struct SidebarView: View {
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, sidebarRowHorizontalPadding)
-            .padding(.vertical, MuesliTheme.spacing8)
+            .frame(minHeight: MuesliTheme.sidebarRowHeight)
             .background(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
                     .fill(MuesliTheme.backgroundRaised)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
             .padding(.horizontal, sidebarRowOuterPadding)
             .padding(.bottom, MuesliTheme.spacing4)
         }
+    }
+
+    @ViewBuilder
+    private var sidebarFooter: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Rectangle()
+                .fill(MuesliTheme.surfaceBorder)
+                .frame(height: 1)
+                .padding(.horizontal, sidebarRowOuterPadding)
+                .padding(.bottom, MuesliTheme.spacing12)
+
+            sidebarItem(tab: .settings, icon: "gearshape", label: "Settings")
+            sidebarItem(tab: .about, icon: "info.circle", label: "About", updateCTA: pendingUpdateCTA)
+            darkModeToggle
+                .padding(.top, MuesliTheme.spacing12)
+        }
+        .padding(.bottom, MuesliTheme.spacing28)
     }
 
     @ViewBuilder
@@ -399,10 +428,9 @@ struct SidebarView: View {
         } label: {
             HStack(spacing: MuesliTheme.spacing12) {
                 Image(systemName: icon)
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.system(size: 15, weight: .medium))
                     .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
                     .frame(width: sidebarIconColumnWidth, height: sidebarIconColumnWidth, alignment: .center)
-                    .offset(y: icon == "square.and.arrow.down" ? -1 : 0)
                 Text(label)
                     .font(MuesliTheme.headline())
                     .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
@@ -427,10 +455,14 @@ struct SidebarView: View {
                 }
             }
             .padding(.horizontal, sidebarRowHorizontalPadding)
-            .padding(.vertical, MuesliTheme.spacing8)
+            .frame(height: MuesliTheme.sidebarRowHeight)
             .background(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                    .fill(isSelected ? MuesliTheme.accent.opacity(0.10) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                    .strokeBorder(isSelected ? MuesliTheme.accent.opacity(0.18) : Color.clear, lineWidth: 1)
             )
         }
         .buttonStyle(.plain)
@@ -440,19 +472,19 @@ struct SidebarView: View {
     @ViewBuilder
     private var darkModeToggle: some View {
         let isDark = appState.config.darkMode
-        HStack(spacing: 2) {
+        HStack(spacing: 0) {
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     controller.updateConfig { $0.darkMode = false }
                 }
             } label: {
                 Image(systemName: "sun.max.fill")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(!isDark ? MuesliTheme.accent : MuesliTheme.textTertiary)
-                    .frame(width: 28, height: 22)
+                    .frame(width: 42, height: 30)
                     .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(!isDark ? MuesliTheme.surfaceSelected : Color.clear)
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                            .fill(!isDark ? MuesliTheme.backgroundRaised : Color.clear)
                     )
             }
             .buttonStyle(.plain)
@@ -463,55 +495,70 @@ struct SidebarView: View {
                 }
             } label: {
                 Image(systemName: "moon.fill")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(isDark ? MuesliTheme.accent : MuesliTheme.textTertiary)
-                    .frame(width: 28, height: 22)
+                    .frame(width: 42, height: 30)
                     .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(isDark ? MuesliTheme.surfaceSelected : Color.clear)
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                            .fill(isDark ? MuesliTheme.backgroundRaised : Color.clear)
                     )
             }
             .buttonStyle(.plain)
         }
-        .padding(2)
+        .padding(3)
         .background(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                .fill(MuesliTheme.backgroundRaised)
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                .fill(MuesliTheme.surfacePrimary)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
         .padding(.horizontal, sidebarRowOuterPadding)
         .padding(.leading, sidebarRowHorizontalPadding)
-        .padding(.bottom, MuesliTheme.spacing4)
     }
 
     @ViewBuilder
     private func meetingFilterRow(
-        icon: String,
+        icon: String? = nil,
         label: String,
         count: Int,
         isSelected: Bool,
         action: @escaping () -> Void
     ) -> some View {
+        let childIconWidth: CGFloat = icon == nil ? 0 : 16
+        let leadingPadding = icon == nil
+            ? sidebarChildLabelLeadingPadding
+            : max(0, sidebarChildLabelLeadingPadding - childIconWidth - MuesliTheme.spacing8)
+
         HStack(spacing: MuesliTheme.spacing8) {
-            Image(systemName: icon)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textTertiary)
-                .frame(width: sidebarIconColumnWidth)
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textTertiary)
+                    .frame(width: childIconWidth)
+            }
             Text(label)
                 .font(MuesliTheme.callout())
                 .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
                 .lineLimit(1)
             Spacer()
             Text(formattedCount(count))
-                .font(MuesliTheme.caption())
+                .font(.system(size: 11, weight: .medium, design: .rounded))
                 .monospacedDigit()
                 .foregroundStyle(MuesliTheme.textTertiary)
-                .frame(minWidth: meetingsTrailingColumnWidth, alignment: .center)
+                .frame(minWidth: 20, alignment: .center)
+                .padding(.horizontal, 5)
+                .frame(height: 20)
+                .background(MuesliTheme.surfacePrimary)
+                .clipShape(Capsule())
         }
-        .padding(.horizontal, sidebarRowHorizontalPadding)
-        .padding(.vertical, 6)
+        .padding(.leading, leadingPadding)
+        .padding(.trailing, sidebarRowHorizontalPadding)
+        .frame(height: MuesliTheme.sidebarChildRowHeight)
         .background(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                .fill(isSelected ? MuesliTheme.surfaceSelected.opacity(0.6) : Color.clear)
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .fill(isSelected ? MuesliTheme.backgroundRaised : Color.clear)
         )
         .contentShape(Rectangle())
         .onTapGesture(perform: action)
@@ -523,7 +570,7 @@ struct SidebarView: View {
             Image(systemName: "folder")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(MuesliTheme.accent)
-                .frame(width: sidebarIconColumnWidth)
+                .frame(width: 16)
             TextField("Folder name", text: $renamingFolderName)
                 .font(MuesliTheme.callout())
                 .textFieldStyle(.plain)
@@ -535,11 +582,12 @@ struct SidebarView: View {
                     renamingFolderID = nil
                 }
         }
-        .padding(.horizontal, sidebarRowHorizontalPadding)
-        .padding(.vertical, 6)
+        .padding(.leading, max(0, sidebarChildLabelLeadingPadding - 16 - MuesliTheme.spacing8))
+        .padding(.trailing, sidebarRowHorizontalPadding)
+        .frame(height: MuesliTheme.sidebarChildRowHeight)
         .background(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                .fill(MuesliTheme.surfaceSelected.opacity(0.6))
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .fill(MuesliTheme.backgroundRaised)
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -40,7 +40,11 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func refreshIcon() {
-        statusItem.button?.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon)
+        statusItem.button?.image = MenuBarIconRenderer.make(
+            choice: controller.config.menuBarIcon,
+            customLogoPath: controller.config.customLogoPath
+        )
+        statusItem.button?.toolTip = AppIdentity.displayName
         updateMenuBarTitle()
     }
 
@@ -78,7 +82,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     private func build() {
         if let button = statusItem.button {
-            button.image = MenuBarIconRenderer.make(choice: controller.config.menuBarIcon)
+            button.image = MenuBarIconRenderer.make(
+                choice: controller.config.menuBarIcon,
+                customLogoPath: controller.config.customLogoPath
+            )
             button.imageScaling = .scaleProportionallyDown
             button.toolTip = AppIdentity.displayName
         }

--- a/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
@@ -50,3 +50,18 @@ struct MenuBarIconRendererTests {
         #expect((image?.size.height ?? 0) > 0)
     }
 }
+
+@Suite("AppBrandingAssets")
+struct AppBrandingAssetsTests {
+
+    @Test("accented default app icon renders from accent color")
+    func accentedDefaultAppIconRenders() throws {
+        let image = try #require(AppBrandingAssets.accentedDefaultAppIcon(
+            accentHex: "fb6100",
+            fallbackURL: nil
+        ))
+        #expect(image.isTemplate == false)
+        #expect(image.size.width == 1024)
+        #expect(image.size.height == 1024)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
@@ -49,6 +49,33 @@ struct MenuBarIconRendererTests {
         #expect((image?.size.width ?? 0) > 0)
         #expect((image?.size.height ?? 0) > 0)
     }
+
+    @Test("custom logo only replaces the logo icon choice")
+    func customLogoOnlyReplacesLogoChoice() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-menu-logo-\(UUID().uuidString).png")
+        try writeTestImage(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let logo = MenuBarIconRenderer.make(choice: "muesli", customLogoPath: url.path)
+        let symbol = MenuBarIconRenderer.make(choice: "mic.fill", customLogoPath: url.path)
+
+        #expect(logo?.isTemplate == false)
+        #expect(symbol?.isTemplate == true)
+    }
+
+    private func writeTestImage(to url: URL) throws {
+        let image = NSImage(size: NSSize(width: 18, height: 18))
+        image.lockFocus()
+        NSColor.systemOrange.setFill()
+        NSRect(x: 0, y: 0, width: 18, height: 18).fill()
+        image.unlockFocus()
+
+        let data = try #require(image.tiffRepresentation)
+        let bitmap = try #require(NSBitmapImageRep(data: data))
+        let png = try #require(bitmap.representation(using: .png, properties: [:]))
+        try png.write(to: url)
+    }
 }
 
 @Suite("AppBrandingAssets")
@@ -63,5 +90,20 @@ struct AppBrandingAssetsTests {
         #expect(image.isTemplate == false)
         #expect(image.size.width == 1024)
         #expect(image.size.height == 1024)
+    }
+}
+
+@Suite("AppIdentity")
+struct AppIdentityTests {
+
+    @Test("custom display name does not change support directory identity")
+    func customDisplayNameDoesNotChangeSupportDirectoryIdentity() {
+        AppIdentity.configureDisplayNameOverride(nil)
+        let originalSupportDirectoryName = AppIdentity.supportDirectoryName
+        AppIdentity.configureDisplayNameOverride("Runpoint Partners")
+        defer { AppIdentity.configureDisplayNameOverride(nil) }
+
+        #expect(AppIdentity.displayName == "Runpoint Partners")
+        #expect(AppIdentity.supportDirectoryName == originalSupportDirectoryName)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1225,6 +1225,17 @@ struct AppConfigAppearanceTests {
         #expect(decoded.recordingColorHex == "303446")
     }
 
+    @Test("branding fields round-trip through JSON")
+    func brandingFieldsRoundTrip() throws {
+        var config = AppConfig()
+        config.appDisplayName = "Acme Notes"
+        config.customLogoPath = "/tmp/acme-logo.png"
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.appDisplayName == "Acme Notes")
+        #expect(decoded.customLogoPath == "/tmp/acme-logo.png")
+    }
+
     @Test("unknown JSON keys are ignored — soundEnabled falls back to default")
     func soundEnabledFallsBackOnMissingKey() throws {
         let json = Data("{}".utf8)
@@ -1237,6 +1248,14 @@ struct AppConfigAppearanceTests {
         let json = Data("{}".utf8)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
         #expect(decoded.recordingColorHex == "1e1e2e")
+    }
+
+    @Test("branding fields fall back when missing")
+    func brandingFieldsFallBackOnMissingKey() throws {
+        let json = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(decoded.appDisplayName == "")
+        #expect(decoded.customLogoPath == nil)
     }
 
     @Test("soundEnabled CodingKey is sound_enabled")
@@ -1255,5 +1274,16 @@ struct AppConfigAppearanceTests {
         let data = try JSONEncoder().encode(config)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(json?["recording_color_hex"] as? String == "eff1f5")
+    }
+
+    @Test("branding CodingKeys are snake case")
+    func brandingCodingKeys() throws {
+        var config = AppConfig()
+        config.appDisplayName = "Acme Notes"
+        config.customLogoPath = "/tmp/acme-logo.png"
+        let data = try JSONEncoder().encode(config)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["app_display_name"] as? String == "Acme Notes")
+        #expect(json?["custom_logo_path"] as? String == "/tmp/acme-logo.png")
     }
 }


### PR DESCRIPTION
## Summary
- add configurable app name and custom logo support across the app, menu bar, floating indicator, window titles, and app identity
- make the accent color drive the generated default app icon and replace the oversized color picker with a compact color well
- refresh the native desktop shell, sidebar alignment, bottom footer group, theme toggle, Coming Up card, and meeting list cards for the premium SaaS-style workspace
- stabilize search and app-name text editing so SwiftUI/AppKit refreshes do not duplicate typed characters

## Existing PR context
- Extends/supersedes the earlier visual polish in #136 with the branding-aware native shell and sidebar changes.
- Kept unrelated open PR behavior out of this branch while resolving conflicts against current `main`.

## Validation
- `env -u OPENAI_API_KEY -u OPENROUTER_API_KEY swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/pr-custom-branding"`
- Result: 728 tests in 97 suites passed.