### PR TITLE
Import Granola meetings and enrich meeting list metadata

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -281,9 +281,9 @@ public final class DictationStore {
 
         var sql: String
         if folderID != nil {
-            sql = "SELECT \(Self.meetingColumns) FROM meetings WHERE folder_id = ? ORDER BY id DESC"
+            sql = "SELECT \(Self.meetingColumns) FROM meetings WHERE folder_id = ? ORDER BY start_time DESC, id DESC"
         } else {
-            sql = "SELECT \(Self.meetingColumns) FROM meetings ORDER BY id DESC"
+            sql = "SELECT \(Self.meetingColumns) FROM meetings ORDER BY start_time DESC, id DESC"
         }
         if limit != nil { sql += " LIMIT ?" }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -135,7 +135,8 @@ final class CalendarMonitor {
                 isAllDay: false,
                 source: .eventKit,
                 calendarID: event.calendar?.calendarIdentifier,
-                meetingURL: Self.extractMeetingURL(from: event)
+                meetingURL: Self.extractMeetingURL(from: event),
+                attendees: Self.extractAttendees(from: event)
             )
         }
         return UnifiedCalendarEvent
@@ -217,6 +218,40 @@ final class CalendarMonitor {
         }
 
         return nil
+    }
+
+    static func extractAttendees(from event: EKEvent) -> [CalendarEventAttendee] {
+        guard let participants = event.attendees else { return [] }
+        var attendees: [CalendarEventAttendee] = []
+        var seen = Set<String>()
+
+        for participant in participants where participant.participantType != .resource {
+            let attendee = CalendarEventAttendee(
+                name: participant.name,
+                email: emailAddress(from: participant.url)
+            )
+            let key = (attendee.email ?? attendee.name ?? attendee.markdownLabel).lowercased()
+            guard !key.isEmpty, !seen.contains(key) else { continue }
+            seen.insert(key)
+            attendees.append(attendee)
+        }
+
+        return attendees
+    }
+
+    private static func emailAddress(from url: URL?) -> String? {
+        guard let url else { return nil }
+        if url.scheme?.lowercased() == "mailto" {
+            let raw = url.absoluteString.dropFirst("mailto:".count)
+            let address = raw.split(separator: "?", maxSplits: 1).first.map(String.init) ?? String(raw)
+            return address.removingPercentEncoding
+        }
+        let raw = url.absoluteString.removingPercentEncoding ?? url.absoluteString
+        guard let range = raw.range(
+            of: #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) else { return nil }
+        return String(raw[range])
     }
 
     private static func isMeetingURL(_ url: URL) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -14,6 +14,7 @@ struct UnifiedCalendarEvent: Identifiable, Equatable {
     /// Optional because legacy events deserialized from older state may not have it.
     var calendarID: String? = nil
     var meetingURL: URL? = nil
+    var attendees: [CalendarEventAttendee] = []
 
     enum CalendarSource: String {
         case eventKit
@@ -31,6 +32,24 @@ struct UnifiedCalendarEvent: Identifiable, Equatable {
             guard let id = event.calendarID else { return true }
             return !disabledCalendarIDs.contains(id)
         }
+    }
+}
+
+struct CalendarEventAttendee: Equatable {
+    let name: String?
+    let email: String?
+
+    init(name: String?, email: String?) {
+        let cleanName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanEmail = email?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.name = cleanName?.isEmpty == false ? cleanName : nil
+        self.email = cleanEmail?.isEmpty == false ? cleanEmail : nil
+    }
+
+    var markdownLabel: String {
+        if let name, let email { return "\(name) <\(email)>" }
+        if let name { return name }
+        return email ?? ""
     }
 }
 
@@ -375,8 +394,34 @@ final class GoogleCalendarClient {
             isAllDay: isAllDay,
             source: .googleCalendar,
             calendarID: calendarID,
-            meetingURL: meetingURL
+            meetingURL: meetingURL,
+            attendees: Self.parseAttendees(from: item)
         )
+    }
+
+    static func parseAttendees(from item: [String: Any]) -> [CalendarEventAttendee] {
+        var attendees: [CalendarEventAttendee] = []
+        var seen = Set<String>()
+
+        func append(name: String?, email: String?) {
+            let attendee = CalendarEventAttendee(name: name, email: email)
+            let key = (attendee.email ?? attendee.name ?? attendee.markdownLabel).lowercased()
+            guard !key.isEmpty, !seen.contains(key) else { return }
+            seen.insert(key)
+            attendees.append(attendee)
+        }
+
+        if let organizer = item["organizer"] as? [String: Any] {
+            append(name: organizer["displayName"] as? String, email: organizer["email"] as? String)
+        }
+        if let entries = item["attendees"] as? [[String: Any]] {
+            for entry in entries {
+                if entry["resource"] as? Bool == true { continue }
+                append(name: entry["displayName"] as? String, email: entry["email"] as? String)
+            }
+        }
+
+        return attendees
     }
 
     // MARK: - Merge & Deduplicate
@@ -399,6 +444,9 @@ final class GoogleCalendarClient {
                 // Prefer Google Calendar's meetingURL when EventKit doesn't have one
                 if merged[idx].meetingURL == nil, gEvent.meetingURL != nil {
                     merged[idx].meetingURL = gEvent.meetingURL
+                }
+                if merged[idx].attendees.isEmpty, !gEvent.attendees.isEmpty {
+                    merged[idx].attendees = gEvent.attendees
                 }
             } else {
                 merged.append(gEvent)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemMetadata.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemMetadata.swift
@@ -102,14 +102,21 @@ enum MeetingListItemMetadata {
     }
 
     private static func participant(from rawLine: String) -> MeetingListParticipant? {
+        let hasListMarker = rawLine.range(
+            of: #"^\s*(?:[-+*]|\d+[.)]|\[[ xX]\])\s+"#,
+            options: .regularExpression
+        ) != nil
+        let email = firstEmail(in: rawLine)
+        guard hasListMarker || email != nil else { return nil }
+
         let line = rawLine
             .replacingOccurrences(of: #"^\s*(?:[-+*]|\d+[.)])\s+"#, with: "", options: .regularExpression)
             .replacingOccurrences(of: #"^\s*\[[ xX]\]\s+"#, with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !line.isEmpty else { return nil }
+        guard !isParticipantPlaceholder(line) else { return nil }
 
-        let email = firstEmail(in: line)
         var name = line
         if let email {
             name = name.replacingOccurrences(of: email, with: "")
@@ -120,6 +127,24 @@ enum MeetingListItemMetadata {
 
         if name.isEmpty, email == nil { return nil }
         return MeetingListParticipant(name: name.isEmpty ? nil : name, email: email)
+    }
+
+    private static func isParticipantPlaceholder(_ line: String) -> Bool {
+        let normalized = line
+            .lowercased()
+            .replacingOccurrences(of: #"[^a-z0-9 ]+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return [
+            "none",
+            "na",
+            "no attendees",
+            "no attendees captured",
+            "no participants",
+            "no participants captured",
+            "no invitees",
+            "no invitees captured"
+        ].contains(normalized)
     }
 
     private static func firstEmail(in line: String) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemMetadata.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemMetadata.swift
@@ -1,0 +1,213 @@
+import Foundation
+import MuesliCore
+
+struct MeetingListParticipant: Equatable {
+    let name: String?
+    let email: String?
+
+    var listLabel: String {
+        let cleanName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanEmail = email?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let cleanName, !cleanName.isEmpty, let cleanEmail, !cleanEmail.isEmpty {
+            return "\(cleanName) <\(cleanEmail)>"
+        }
+        if let cleanName, !cleanName.isEmpty { return cleanName }
+        return cleanEmail ?? ""
+    }
+}
+
+enum MeetingListItemMetadata {
+    static func friendlyDate(
+        _ raw: String,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> String {
+        guard let date = parseStoredTimestamp(raw, timeZone: calendar.timeZone) else {
+            return fallbackDate(raw)
+        }
+
+        let day: String
+        if calendar.isDate(date, inSameDayAs: now) {
+            day = "Today"
+        } else if let yesterday = calendar.date(byAdding: .day, value: -1, to: now),
+                  calendar.isDate(date, inSameDayAs: yesterday) {
+            day = "Yesterday"
+        } else if calendar.isDate(date, equalTo: now, toGranularity: .year) {
+            day = monthDayFormatter(calendar: calendar).string(from: date)
+        } else {
+            day = monthDayYearFormatter(calendar: calendar).string(from: date)
+        }
+
+        return "\(day), \(timeFormatter(calendar: calendar).string(from: date))"
+    }
+
+    static func participantLine(from record: MeetingRecord, limit: Int = 2) -> String? {
+        let participants = participants(from: record.formattedNotes)
+        guard !participants.isEmpty else { return nil }
+
+        let shown = participants.prefix(limit).map(\.listLabel).filter { !$0.isEmpty }
+        guard !shown.isEmpty else { return nil }
+
+        let remaining = participants.count - shown.count
+        if remaining > 0 {
+            return "\(shown.joined(separator: ", ")) +\(remaining) more"
+        }
+        return shown.joined(separator: ", ")
+    }
+
+    static func fullParticipantLine(from record: MeetingRecord) -> String? {
+        let participants = participants(from: record.formattedNotes)
+        let labels = participants.map(\.listLabel).filter { !$0.isEmpty }
+        return labels.isEmpty ? nil : labels.joined(separator: ", ")
+    }
+
+    static func participants(from markdown: String) -> [MeetingListParticipant] {
+        var results: [MeetingListParticipant] = []
+        var seen = Set<String>()
+        var isInParticipantSection = false
+
+        for rawLine in markdown.normalizedMarkdownLines {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            if let heading = headingTitle(from: trimmed) {
+                let normalized = normalizedHeading(heading)
+                isInParticipantSection = ["attendees", "participants", "invitees", "people"].contains(normalized)
+                continue
+            }
+
+            guard isInParticipantSection else { continue }
+            guard let participant = participant(from: trimmed) else { continue }
+
+            let key = (participant.email ?? participant.name ?? participant.listLabel).lowercased()
+            guard !key.isEmpty, !seen.contains(key) else { continue }
+
+            seen.insert(key)
+            results.append(participant)
+        }
+
+        return results
+    }
+
+    static func notesPreview(from record: MeetingRecord, limit: Int = 112) -> String {
+        let source: String
+        if !record.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           record.status != .completed {
+            source = record.manualNotes
+        } else {
+            source = record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
+        }
+        return MeetingPreviewText.noteSnippet(from: source, limit: limit)
+    }
+
+    private static func participant(from rawLine: String) -> MeetingListParticipant? {
+        let line = rawLine
+            .replacingOccurrences(of: #"^\s*(?:[-+*]|\d+[.)])\s+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"^\s*\[[ xX]\]\s+"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !line.isEmpty else { return nil }
+
+        let email = firstEmail(in: line)
+        var name = line
+        if let email {
+            name = name.replacingOccurrences(of: email, with: "")
+        }
+        name = name
+            .replacingOccurrences(of: #"[<>]"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: " \t-–—:;,."))
+
+        if name.isEmpty, email == nil { return nil }
+        return MeetingListParticipant(name: name.isEmpty ? nil : name, email: email)
+    }
+
+    private static func firstEmail(in line: String) -> String? {
+        let pattern = #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#
+        guard let range = line.range(of: pattern, options: [.regularExpression, .caseInsensitive]) else {
+            return nil
+        }
+        return String(line[range])
+    }
+
+    private static func headingTitle(from line: String) -> String? {
+        guard line.range(of: #"^\s{0,3}#{1,6}\s+"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        return line.replacingOccurrences(
+            of: #"^\s{0,3}#{1,6}\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func normalizedHeading(_ heading: String) -> String {
+        heading
+            .lowercased()
+            .replacingOccurrences(of: #"[^a-z0-9 ]+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func fallbackDate(_ raw: String) -> String {
+        let clean = raw
+            .replacingOccurrences(of: "T", with: " ")
+            .replacingOccurrences(of: "Z", with: "")
+        return clean.count > 16 ? String(clean.prefix(16)) : clean
+    }
+
+    private static func parseStoredTimestamp(_ raw: String, timeZone: TimeZone) -> Date? {
+        isoParsers.lazy.compactMap { $0.date(from: raw) }.first
+            ?? localParsers(timeZone: timeZone).lazy.compactMap { $0.date(from: raw) }.first
+    }
+
+    private static let isoParsers: [ISO8601DateFormatter] = {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let wholeSeconds = ISO8601DateFormatter()
+        wholeSeconds.formatOptions = [.withInternetDateTime]
+        return [fractional, wholeSeconds]
+    }()
+
+    private static func localParsers(timeZone: TimeZone) -> [DateFormatter] {
+        [
+            formatter(calendar: .current, dateFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSSSS", timeZone: timeZone),
+            formatter(calendar: .current, dateFormat: "yyyy-MM-dd'T'HH:mm:ss", timeZone: timeZone),
+        ]
+    }
+
+    private static func timeFormatter(calendar: Calendar) -> DateFormatter {
+        formatter(calendar: calendar, dateFormat: "h:mm a")
+    }
+
+    private static func monthDayFormatter(calendar: Calendar) -> DateFormatter {
+        formatter(calendar: calendar, dateFormat: "MMM d")
+    }
+
+    private static func monthDayYearFormatter(calendar: Calendar) -> DateFormatter {
+        formatter(calendar: calendar, dateFormat: "MMM d, yyyy")
+    }
+
+    private static func formatter(calendar: Calendar, dateFormat: String) -> DateFormatter {
+        formatter(calendar: calendar, dateFormat: dateFormat, timeZone: calendar.timeZone)
+    }
+
+    private static func formatter(calendar: Calendar, dateFormat: String, timeZone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = calendar
+        formatter.timeZone = timeZone
+        formatter.dateFormat = dateFormat
+        return formatter
+    }
+}
+
+private extension String {
+    var normalizedMarkdownLines: [String] {
+        replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
@@ -66,10 +66,27 @@ struct MeetingListItemView: View {
                 }
             }
 
-            Text(previewText())
-                .font(MuesliTheme.caption())
-                .foregroundStyle(MuesliTheme.textTertiary)
-                .lineLimit(2)
+            if let participantLine = MeetingListItemMetadata.participantLine(from: record) {
+                HStack(spacing: 5) {
+                    Image(systemName: "person.2.fill")
+                        .font(.system(size: 10, weight: .medium))
+                    Text(participantLine)
+                        .font(MuesliTheme.caption())
+                        .lineLimit(1)
+                }
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .help(MeetingListItemMetadata.fullParticipantLine(from: record) ?? participantLine)
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Image(systemName: "text.alignleft")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                Text(MeetingListItemMetadata.notesPreview(from: record))
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .lineLimit(2)
+            }
         }
         .padding(MuesliTheme.spacing16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -206,17 +223,9 @@ struct MeetingListItemView: View {
     }
 
     private func formatMeta() -> String {
-        let time = formatTime(record.startTime)
+        let time = MeetingListItemMetadata.friendlyDate(record.startTime)
         let duration = formatDuration(record.durationSeconds)
         return "\(time)  \u{2022}  \(duration)"
-    }
-
-    private func formatTime(_ raw: String) -> String {
-        let clean = raw.replacingOccurrences(of: "T", with: " ")
-        if clean.count > 16 {
-            return String(clean.prefix(16))
-        }
-        return clean
     }
 
     private func formatDuration(_ seconds: Double) -> String {
@@ -230,17 +239,6 @@ struct MeetingListItemView: View {
             return s == 0 ? "\(m)m" : "\(m)m \(s)s"
         }
         return "\(rounded)s"
-    }
-
-    private func previewText() -> String {
-        let source: String
-        if !record.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           record.status != .completed {
-            source = record.manualNotes
-        } else {
-            source = record.formattedNotes.isEmpty ? record.rawTranscript : record.formattedNotes
-        }
-        return MeetingPreviewText.snippet(from: source)
     }
 
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
@@ -96,7 +96,7 @@ enum MeetingPreviewText {
     static func notePlainText(from markdown: String) -> String {
         var lines: [String] = []
         var isInsideFence = false
-        var isInsideSkippedSection = false
+        var skippedSectionHeading: String?
 
         for rawLine in markdown
             .replacingOccurrences(of: "\r\n", with: "\n")
@@ -118,12 +118,15 @@ enum MeetingPreviewText {
 
             if let heading = headingTitle(from: line) {
                 let normalized = MeetingListItemMetadata.normalizedHeading(heading)
-                isInsideSkippedSection = skippedSectionHeadings.contains(normalized)
-                if isInsideSkippedSection || genericNoteHeadings.contains(normalized) {
+                skippedSectionHeading = skippedSectionHeadings.contains(normalized) ? normalized : nil
+                if skippedSectionHeading != nil || genericNoteHeadings.contains(normalized) {
                     continue
                 }
-            } else if isInsideSkippedSection {
-                continue
+            } else if let section = skippedSectionHeading {
+                if isMetadataLine(line, inSection: section) {
+                    continue
+                }
+                skippedSectionHeading = nil
             }
 
             line = line.replacingOccurrences(
@@ -204,6 +207,31 @@ enum MeetingPreviewText {
         "source",
         "source trail"
     ]
+
+    private static func isMetadataLine(_ line: String, inSection section: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stripped = trimmed
+            .replacingOccurrences(of: #"^\s*(?:[-+*]|\d+[.)])\s+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"^\s*\[[ xX]\]\s+"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = stripped.lowercased()
+
+        if ["none", "n/a", "no attendees", "no attendees captured", "no participants", "no invitees"].contains(normalized) {
+            return true
+        }
+
+        if section == "source" || section == "source trail" {
+            return trimmed.range(of: #"^\s*(?:[-+*]|\d+[.)])\s+"#, options: .regularExpression) != nil ||
+                normalized.contains("granola") ||
+                normalized.contains("calendar event") ||
+                normalized.contains("source") ||
+                normalized.contains("http://") ||
+                normalized.contains("https://")
+        }
+
+        return trimmed.range(of: #"^\s*(?:[-+*]|\d+[.)])\s+"#, options: .regularExpression) != nil ||
+            stripped.range(of: #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#, options: [.regularExpression, .caseInsensitive]) != nil
+    }
 
     private static func stripMarkdownDelimiters(from text: String) -> String {
         var result = text

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPreviewText.swift
@@ -13,6 +13,18 @@ enum MeetingPreviewText {
         return String(compact.prefix(prefixCount)) + "..."
     }
 
+    static func noteSnippet(from source: String, limit: Int = 112) -> String {
+        let compact = notePlainText(from: source)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+
+        guard !compact.isEmpty else { return "No notes yet" }
+        guard compact.count > limit else { return compact }
+
+        let prefixCount = max(0, limit - 3)
+        return String(compact.prefix(prefixCount)) + "..."
+    }
+
     static func plainText(from markdown: String) -> String {
         var lines: [String] = []
         var isInsideFence = false
@@ -80,6 +92,118 @@ enum MeetingPreviewText {
 
         return lines.joined(separator: " ")
     }
+
+    static func notePlainText(from markdown: String) -> String {
+        var lines: [String] = []
+        var isInsideFence = false
+        var isInsideSkippedSection = false
+
+        for rawLine in markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false) {
+            var line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if line.hasPrefix("```") || line.hasPrefix("~~~") {
+                isInsideFence.toggle()
+                continue
+            }
+            guard !isInsideFence else { continue }
+
+            if line.range(of: #"^\s{0,3}[-*_]{3,}\s*$"#, options: .regularExpression) != nil ||
+                line.range(of: #"^\s{0,3}[=-]{3,}\s*$"#, options: .regularExpression) != nil {
+                continue
+            }
+
+            if let heading = headingTitle(from: line) {
+                let normalized = MeetingListItemMetadata.normalizedHeading(heading)
+                isInsideSkippedSection = skippedSectionHeadings.contains(normalized)
+                if isInsideSkippedSection || genericNoteHeadings.contains(normalized) {
+                    continue
+                }
+            } else if isInsideSkippedSection {
+                continue
+            }
+
+            line = line.replacingOccurrences(
+                of: #"^\s{0,3}#{1,6}\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"^\s*>+\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"^\s*(?:[-+*]|\d+[.)])\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"^\s*\[[ xX]\]\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"!\[([^\]]*)\]\([^)]+\)"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"\[([^\]]+)\]\([^)]+\)"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            line = line.replacingOccurrences(
+                of: #"`([^`\n]+)`"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            line = stripMarkdownDelimiters(from: line)
+            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !line.isEmpty {
+                lines.append(line)
+            }
+        }
+
+        return lines.joined(separator: " ")
+    }
+
+    private static func headingTitle(from line: String) -> String? {
+        guard line.range(of: #"^\s{0,3}#{1,6}\s+"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        return line.replacingOccurrences(
+            of: #"^\s{0,3}#{1,6}\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static let genericNoteHeadings: Set<String> = [
+        "meeting summary",
+        "summary",
+        "key discussion points",
+        "discussion points",
+        "decisions",
+        "decisions made",
+        "action items",
+        "notable quotes",
+        "raw transcript"
+    ]
+
+    private static let skippedSectionHeadings: Set<String> = [
+        "attendees",
+        "participants",
+        "invitees",
+        "people",
+        "source",
+        "source trail"
+    ]
 
     private static func stripMarkdownDelimiters(from text: String) -> String {
         var result = text

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -153,6 +153,21 @@ struct MeetingsView: View {
         return appState.folders.first(where: { $0.id == folderID })?.name ?? "All Meetings"
     }
 
+    private var browserMeetingCountText: String {
+        let visibleCount = filteredMeetings.count
+        let totalCount: Int
+        if let folderID = appState.selectedFolderID {
+            totalCount = appState.meetingCountsByFolder[folderID] ?? visibleCount
+        } else {
+            totalCount = appState.totalMeetingCount
+        }
+
+        guard selectedFilter == .all, totalCount > visibleCount else {
+            return "\(visibleCount) meeting\(visibleCount == 1 ? "" : "s")"
+        }
+        return "Showing \(visibleCount) of \(totalCount) meetings"
+    }
+
     private var currentDocumentMeeting: MeetingRecord? {
         guard case let .document(id) = appState.meetingsNavigationState else { return nil }
         if appState.selectedMeetingID == id, let selectedMeeting = appState.selectedMeeting {
@@ -508,7 +523,7 @@ struct MeetingsView: View {
     @ViewBuilder
     private var browserHeaderMeta: some View {
         HStack(spacing: MuesliTheme.spacing8) {
-            Text("\(filteredMeetings.count) meeting\(filteredMeetings.count == 1 ? "" : "s")")
+            Text(browserMeetingCountText)
                 .font(MuesliTheme.callout())
                 .foregroundStyle(MuesliTheme.textSecondary)
                 .fixedSize()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -29,6 +29,23 @@ enum MeetingBrowserSort: Hashable {
 }
 
 enum MeetingBrowserLogic {
+    static func countText(
+        visibleCount: Int,
+        loadedCount: Int,
+        totalCount: Int,
+        filter: MeetingBrowserFilter
+    ) -> String {
+        guard totalCount > loadedCount else {
+            return "\(visibleCount) meeting\(visibleCount == 1 ? "" : "s")"
+        }
+
+        if filter == .all {
+            return "Showing \(visibleCount) of \(totalCount) meetings"
+        }
+
+        return "Showing \(visibleCount) filtered from newest \(loadedCount) of \(totalCount) meetings"
+    }
+
     static func availableFilters(
         for meetings: [MeetingRecord],
         now: Date = Date(),
@@ -155,6 +172,7 @@ struct MeetingsView: View {
 
     private var browserMeetingCountText: String {
         let visibleCount = filteredMeetings.count
+        let loadedCount = scopedMeetings.count
         let totalCount: Int
         if let folderID = appState.selectedFolderID {
             totalCount = appState.meetingCountsByFolder[folderID] ?? visibleCount
@@ -162,10 +180,12 @@ struct MeetingsView: View {
             totalCount = appState.totalMeetingCount
         }
 
-        guard selectedFilter == .all, totalCount > visibleCount else {
-            return "\(visibleCount) meeting\(visibleCount == 1 ? "" : "s")"
-        }
-        return "Showing \(visibleCount) of \(totalCount) meetings"
+        return MeetingBrowserLogic.countText(
+            visibleCount: visibleCount,
+            loadedCount: loadedCount,
+            totalCount: totalCount,
+            filter: selectedFilter
+        )
     }
 
     private var currentDocumentMeeting: MeetingRecord? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -152,6 +152,7 @@ final class MuesliController: NSObject {
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
     private var liveMeetingTitleCache: [Int64: String] = [:]
+    private var liveMeetingCalendarAttendees: [Int64: [CalendarEventAttendee]] = [:]
     private var liveManualNotesCache: [Int64: String] = [:]
     private var liveManualNotesLastPersistedAt: [Int64: Date] = [:]
     private var liveManualNotesLastPersistedValue: [Int64: String] = [:]
@@ -2195,6 +2196,11 @@ final class MuesliController: NSObject {
 
     private func clearCachedMeetingTitle(id: Int64) {
         liveMeetingTitleCache[id] = nil
+        clearCachedMeetingCalendarAttendees(id: id)
+    }
+
+    private func clearCachedMeetingCalendarAttendees(id: Int64) {
+        liveMeetingCalendarAttendees[id] = nil
     }
 
     private func flushCachedMeetingTitle(id: Int64) {
@@ -2217,6 +2223,10 @@ final class MuesliController: NSObject {
 
     private func clearAllCachedMeetingTitles() {
         liveMeetingTitleCache.removeAll()
+    }
+
+    private func clearAllCachedMeetingCalendarAttendees() {
+        liveMeetingCalendarAttendees.removeAll()
     }
 
     private func manualNotesForLiveMeeting(id: Int64) -> String {
@@ -2283,7 +2293,7 @@ final class MuesliController: NSObject {
                 startTime: event.startDate,
                 endTime: event.endDate,
                 rawTranscript: "",
-                formattedNotes: "",
+                formattedNotes: Self.calendarAttendeesMarkdown(event.attendees),
                 micAudioPath: nil,
                 systemAudioPath: nil
             )
@@ -2295,6 +2305,59 @@ final class MuesliController: NSObject {
         } catch {
             fputs("[muesli-native] failed to create meeting from calendar event: \(error)\n", stderr)
         }
+    }
+
+    private func formattedNotesWithCalendarAttendees(
+        _ formattedNotes: String,
+        calendarEventID: String?,
+        meetingID: Int64? = nil
+    ) -> String {
+        if let meetingID, let attendees = liveMeetingCalendarAttendees[meetingID] {
+            return Self.appendCalendarAttendees(attendees, to: formattedNotes)
+        }
+
+        guard let event = calendarEvent(matching: calendarEventID) else { return formattedNotes }
+        return Self.appendCalendarAttendees(event.attendees, to: formattedNotes)
+    }
+
+    private func calendarEvent(matching calendarEventID: String?) -> UnifiedCalendarEvent? {
+        guard let calendarEventID = calendarEventID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !calendarEventID.isEmpty else { return nil }
+
+        if let exact = appState.upcomingCalendarEvents.first(where: { $0.id == calendarEventID }) {
+            return exact
+        }
+
+        let baseID = calendarEventID.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: true)
+            .first
+            .map(String.init)
+        guard let baseID, baseID != calendarEventID else { return nil }
+        return appState.upcomingCalendarEvents.first(where: { $0.id == baseID })
+    }
+
+    private static func appendCalendarAttendees(
+        _ attendees: [CalendarEventAttendee],
+        to formattedNotes: String
+    ) -> String {
+        guard !attendees.isEmpty,
+              MeetingListItemMetadata.participants(from: formattedNotes).isEmpty else {
+            return formattedNotes
+        }
+
+        let attendeeSection = calendarAttendeesMarkdown(attendees)
+        guard !attendeeSection.isEmpty else { return formattedNotes }
+
+        let trimmedNotes = formattedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedNotes.isEmpty else { return attendeeSection }
+        return "\(trimmedNotes)\n\n\(attendeeSection)"
+    }
+
+    private static func calendarAttendeesMarkdown(_ attendees: [CalendarEventAttendee]) -> String {
+        let lines = attendees
+            .map(\.markdownLabel)
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard !lines.isEmpty else { return "" }
+        return "## Attendees\n" + lines.map { "- \($0)" }.joined(separator: "\n")
     }
 
     func moveMeeting(id: Int64, toFolder folderID: Int64?) {
@@ -2422,6 +2485,7 @@ final class MuesliController: NSObject {
         try? dictationStore.clearMeetings()
         clearAllCachedMeetingManualNotes()
         clearAllCachedMeetingTitles()
+        clearAllCachedMeetingCalendarAttendees()
         appState.selectedMeetingID = nil
         appState.selectedMeetingRecord = nil
         appState.meetingsNavigationState = .browser
@@ -2581,6 +2645,11 @@ final class MuesliController: NSObject {
                 selectedTemplatePrompt: templateSnapshot.prompt
             )
             activeMeetingID = meetingID
+            if let event = calendarEvent(matching: calendarEventID), !event.attendees.isEmpty {
+                liveMeetingCalendarAttendees[meetingID] = event.attendees
+            } else {
+                liveMeetingCalendarAttendees[meetingID] = nil
+            }
             syncAppState()
             if openDocument {
                 showMeetingDocument(id: meetingID)
@@ -3192,6 +3261,11 @@ final class MuesliController: NSObject {
 
         if let existingMeetingID {
             let persistedTitle = completedLiveMeetingTitle(for: result, existingMeetingID: existingMeetingID)
+            let formattedNotes = formattedNotesWithCalendarAttendees(
+                result.formattedNotes,
+                calendarEventID: result.calendarEventID,
+                meetingID: existingMeetingID
+            )
             try dictationStore.completeLiveMeeting(
                 id: existingMeetingID,
                 title: persistedTitle,
@@ -3199,7 +3273,7 @@ final class MuesliController: NSObject {
                 startTime: result.startTime,
                 endTime: result.endTime,
                 rawTranscript: result.rawTranscript,
-                formattedNotes: result.formattedNotes,
+                formattedNotes: formattedNotes,
                 micAudioPath: nil,
                 systemAudioPath: nil,
                 savedRecordingPath: savedRecordingPath,
@@ -3212,13 +3286,17 @@ final class MuesliController: NSObject {
             clearCachedMeetingManualNotes(id: existingMeetingID)
             clearCachedMeetingTitle(id: existingMeetingID)
         } else {
+            let formattedNotes = formattedNotesWithCalendarAttendees(
+                result.formattedNotes,
+                calendarEventID: result.calendarEventID
+            )
             meetingID = try dictationStore.insertMeeting(
                 title: result.title,
                 calendarEventID: result.calendarEventID,
                 startTime: result.startTime,
                 endTime: result.endTime,
                 rawTranscript: result.rawTranscript,
-                formattedNotes: result.formattedNotes,
+                formattedNotes: formattedNotes,
                 micAudioPath: nil,
                 systemAudioPath: nil,
                 savedRecordingPath: savedRecordingPath,

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -670,6 +670,51 @@ struct DictationStoreTests {
         #expect(remaining.first?.title == "Keep Me")
     }
 
+    @Test("recent meetings sort by meeting start time rather than insertion order")
+    func recentMeetingsSortByStartTime() throws {
+        let store = try makeStore()
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try store.insertMeeting(
+            title: "Newest Inserted First",
+            calendarEventID: nil,
+            startTime: base.addingTimeInterval(3_600),
+            endTime: base.addingTimeInterval(3_900),
+            rawTranscript: "newest",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        try store.insertMeeting(
+            title: "Oldest Inserted Second",
+            calendarEventID: nil,
+            startTime: base,
+            endTime: base.addingTimeInterval(300),
+            rawTranscript: "oldest",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        try store.insertMeeting(
+            title: "Middle Inserted Last",
+            calendarEventID: nil,
+            startTime: base.addingTimeInterval(1_800),
+            endTime: base.addingTimeInterval(2_100),
+            rawTranscript: "middle",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+
+        let meetings = try store.recentMeetings(limit: 3)
+
+        #expect(meetings.map(\.title) == [
+            "Newest Inserted First",
+            "Middle Inserted Last",
+            "Oldest Inserted Second"
+        ])
+    }
+
     @Test("recent dictations respects limit")
     func limitRespected() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -149,6 +149,28 @@ struct GoogleCalendarTests {
         #expect(event?.meetingURL == nil)
     }
 
+    @Test("parses organizer and attendee emails from Google Calendar event")
+    func parsesEventAttendees() {
+        let item: [String: Any] = [
+            "id": "attendees1",
+            "summary": "Client Call",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T15:00:00Z"],
+            "organizer": ["displayName": "Sam Gaddis", "email": "sam@runpoint.ai"],
+            "attendees": [
+                ["displayName": "Pat Prospect", "email": "pat@example.com"],
+                ["displayName": "Conference Room", "email": "room@example.com", "resource": true],
+                ["displayName": "Sam Gaddis", "email": "sam@runpoint.ai"],
+            ],
+        ]
+
+        let event = GoogleCalendarClient().parseEvent(item, calendarID: "primary")
+        #expect(event?.attendees.map(\.markdownLabel) == [
+            "Sam Gaddis <sam@runpoint.ai>",
+            "Pat Prospect <pat@example.com>",
+        ])
+    }
+
     @Test("CalendarMonitor extracts Zoom URL from text")
     func extractsZoomURL() {
         let url = CalendarMonitor.findMeetingURL(in: "Join at https://us02web.zoom.us/j/123456789?pwd=abc please")
@@ -196,6 +218,28 @@ struct GoogleCalendarTests {
         let merged = GoogleCalendarClient.mergeEvents(eventKit: ek, google: google)
         #expect(merged.count == 1)
         #expect(merged[0].source == .eventKit)
+    }
+
+    @Test("dedupe preserves Google attendees when EventKit has none")
+    func dedupePreservesGoogleAttendees() {
+        let ek = [
+            UnifiedCalendarEvent(id: "ek1", title: "Sprint Planning", startDate: date("2026-04-10T14:00:00Z"), endDate: date("2026-04-10T15:00:00Z"), isAllDay: false, source: .eventKit),
+        ]
+        let google = [
+            UnifiedCalendarEvent(
+                id: "g1",
+                title: "Sprint Planning",
+                startDate: date("2026-04-10T14:02:00Z"),
+                endDate: date("2026-04-10T15:00:00Z"),
+                isAllDay: false,
+                source: .googleCalendar,
+                attendees: [CalendarEventAttendee(name: "Pat Prospect", email: "pat@example.com")]
+            ),
+        ]
+
+        let merged = GoogleCalendarClient.mergeEvents(eventKit: ek, google: google)
+        #expect(merged.count == 1)
+        #expect(merged[0].attendees.map(\.markdownLabel) == ["Pat Prospect <pat@example.com>"])
     }
 
     @Test("keeps events with same title but different times")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingListItemMetadataTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingListItemMetadataTests.swift
@@ -50,6 +50,19 @@ struct MeetingListItemMetadataTests {
         #expect(MeetingListItemMetadata.fullParticipantLine(from: meeting) == "Sam Gaddis <sam@runpoint.ai>, Jonathan Layton <jonathan.layton@runpoint.ai>, ops@example.com")
     }
 
+    @Test("participant extraction ignores prose placeholders")
+    func participantExtractionIgnoresProsePlaceholders() {
+        let meeting = makeMeeting(formattedNotes: """
+        ## Attendees
+
+        No attendees captured
+        The discussion focused on pipeline progress.
+        - Sam Gaddis <sam@runpoint.ai>
+        """)
+
+        #expect(MeetingListItemMetadata.fullParticipantLine(from: meeting) == "Sam Gaddis <sam@runpoint.ai>")
+    }
+
     @Test("notes preview skips generic headings and attendee/source sections")
     func notesPreviewSkipsMetadataSections() {
         let meeting = makeMeeting(formattedNotes: """

--- a/native/MuesliNative/Tests/MuesliTests/MeetingListItemMetadataTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingListItemMetadataTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Meeting list item metadata")
+struct MeetingListItemMetadataTests {
+    @Test("friendly date uses relative day labels and local-style time")
+    func friendlyDateLabels() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-05-14T21:00:00Z"))
+
+        #expect(MeetingListItemMetadata.friendlyDate(
+            "2026-05-14T17:40:17Z",
+            now: now,
+            calendar: calendar
+        ) == "Today, 5:40 PM")
+        #expect(MeetingListItemMetadata.friendlyDate(
+            "2026-05-13T15:00:00Z",
+            now: now,
+            calendar: calendar
+        ) == "Yesterday, 3:00 PM")
+        #expect(MeetingListItemMetadata.friendlyDate(
+            "2025-11-05T16:00:00Z",
+            now: now,
+            calendar: calendar
+        ) == "Nov 5, 2025, 4:00 PM")
+    }
+
+    @Test("participant line extracts attendee names and emails from notes")
+    func participantLine() {
+        let meeting = makeMeeting(formattedNotes: """
+        ## Summary
+
+        Discussed the rollout.
+
+        ## Attendees
+
+        - Sam Gaddis <sam@runpoint.ai>
+        - Jonathan Layton <jonathan.layton@runpoint.ai>
+        - ops@example.com
+
+        ## Source
+
+        - Granola note ID: `not_123`
+        """)
+
+        #expect(MeetingListItemMetadata.participantLine(from: meeting) == "Sam Gaddis <sam@runpoint.ai>, Jonathan Layton <jonathan.layton@runpoint.ai> +1 more")
+        #expect(MeetingListItemMetadata.fullParticipantLine(from: meeting) == "Sam Gaddis <sam@runpoint.ai>, Jonathan Layton <jonathan.layton@runpoint.ai>, ops@example.com")
+    }
+
+    @Test("notes preview skips generic headings and attendee/source sections")
+    func notesPreviewSkipsMetadataSections() {
+        let meeting = makeMeeting(formattedNotes: """
+        ## Meeting Summary
+
+        The team reviewed import progress and next steps.
+
+        ## Attendees
+
+        - Sam <sam@runpoint.ai>
+
+        ## Source
+
+        - Granola note ID: `not_123`
+        """)
+
+        #expect(MeetingListItemMetadata.notesPreview(from: meeting, limit: 120) == "The team reviewed import progress and next steps.")
+    }
+
+    private func makeMeeting(formattedNotes: String) -> MeetingRecord {
+        MeetingRecord(
+            id: 1,
+            title: "Test Meeting",
+            startTime: "2026-05-14T17:40:17Z",
+            durationSeconds: 1800,
+            rawTranscript: "Transcript",
+            formattedNotes: formattedNotes,
+            wordCount: 2,
+            folderID: nil
+        )
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPreviewTextTests.swift
@@ -38,4 +38,17 @@ struct MeetingPreviewTextTests {
 
         #expect(preview == "No notes yet")
     }
+
+    @Test("note preview resumes after metadata section when prose follows")
+    func notePreviewResumesAfterMetadataSection() {
+        let preview = MeetingPreviewText.noteSnippet(from: """
+        ## Attendees
+
+        No attendees captured
+
+        The team reviewed pipeline progress and next steps.
+        """, limit: 120)
+
+        #expect(preview == "The team reviewed pipeline progress and next steps.")
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -687,6 +687,30 @@ struct MeetingBrowserLogicTests {
         #expect(filtered.map(\.id) == [12, 11, 10])
     }
 
+    @Test("count text discloses capped filtered data")
+    func countTextDisclosesCappedFilteredData() {
+        #expect(MeetingBrowserLogic.countText(
+            visibleCount: 200,
+            loadedCount: 200,
+            totalCount: 559,
+            filter: .all
+        ) == "Showing 200 of 559 meetings")
+
+        #expect(MeetingBrowserLogic.countText(
+            visibleCount: 8,
+            loadedCount: 200,
+            totalCount: 559,
+            filter: .lastWeek
+        ) == "Showing 8 filtered from newest 200 of 559 meetings")
+
+        #expect(MeetingBrowserLogic.countText(
+            visibleCount: 1,
+            loadedCount: 20,
+            totalCount: 20,
+            filter: .lastWeek
+        ) == "1 meeting")
+    }
+
     private static func isoDate(daysAgo: Int, now: Date, calendar: Calendar) -> String {
         let date = calendar.date(byAdding: .day, value: -daysAgo, to: now) ?? now
         let formatter = ISO8601DateFormatter()

--- a/scripts/import_granola_to_muesli.py
+++ b/scripts/import_granola_to_muesli.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+API_BASE = "https://public-api.granola.ai/v1"
+
+
+@dataclass
+class ImportStats:
+    fetched: int = 0
+    with_transcript: int = 0
+    created: int = 0
+    skipped_existing: int = 0
+    skipped_missing_transcript: int = 0
+    failed: int = 0
+
+
+def parse_args() -> argparse.Namespace:
+    default_db = Path.home() / "Library/Application Support/Muesli/muesli.db"
+    parser = argparse.ArgumentParser(description="Import Granola note transcripts into the local Muesli database.")
+    parser.add_argument("--db-path", default=str(default_db), help="Path to the Muesli SQLite database.")
+    parser.add_argument("--api-key-env", default="GRANOLA_API_KEY", help="Environment variable containing the Granola API key.")
+    parser.add_argument("--page-size", type=int, default=30, help="Granola list page size. API maximum is 30.")
+    parser.add_argument("--created-after", help="Optional ISO date or datetime lower bound passed to Granola.")
+    parser.add_argument("--created-before", help="Optional ISO date or datetime upper bound passed to Granola.")
+    parser.add_argument("--limit", type=int, help="Optional maximum number of notes to fetch for testing.")
+    parser.add_argument("--export-json", help="Optional path to write fetched Granola note JSON.")
+    parser.add_argument("--input-json", help="Import from a previously exported JSON file instead of calling Granola.")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch and parse data without writing to Muesli.")
+    parser.add_argument("--no-backup", action="store_true", help="Do not create a timestamped database backup before writing.")
+    return parser.parse_args()
+
+
+def request_json(path: str, api_key: str, params: dict[str, Any] | None = None, retries: int = 4) -> dict[str, Any]:
+    query = f"?{urlencode(params)}" if params else ""
+    request = Request(
+        f"{API_BASE}{path}{query}",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+            "User-Agent": "muesli-granola-import/1.0",
+        },
+    )
+
+    for attempt in range(retries + 1):
+        try:
+            with urlopen(request, timeout=45) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            if error.code == 429 and attempt < retries:
+                retry_after = error.headers.get("Retry-After")
+                delay = float(retry_after) if retry_after else min(8, 1.5 * (attempt + 1))
+                time.sleep(delay)
+                continue
+            body = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Granola API returned HTTP {error.code} for {path}: {body}") from error
+        except URLError as error:
+            if attempt < retries:
+                time.sleep(min(8, 1.5 * (attempt + 1)))
+                continue
+            raise RuntimeError(f"Granola API request failed for {path}: {error}") from error
+
+    raise RuntimeError(f"Granola API request failed for {path}")
+
+
+def fetch_notes(api_key: str, page_size: int, created_after: str | None, created_before: str | None, limit: int | None) -> list[dict[str, Any]]:
+    notes: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        params: dict[str, Any] = {"page_size": min(max(page_size, 1), 30)}
+        if cursor:
+            params["cursor"] = cursor
+        if created_after:
+            params["created_after"] = created_after
+        if created_before:
+            params["created_before"] = created_before
+
+        page = request_json("/notes", api_key, params)
+        for note in page.get("notes") or []:
+            note_id = note.get("id")
+            if not isinstance(note_id, str) or not note_id:
+                continue
+            detail = request_json(f"/notes/{note_id}", api_key, {"include": "transcript"})
+            notes.append(detail)
+            if limit and len(notes) >= limit:
+                return notes
+
+        if not page.get("hasMore"):
+            return notes
+        cursor = page.get("cursor")
+        if not cursor:
+            return notes
+
+
+def load_notes(path: str) -> list[dict[str, Any]]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("notes"), list):
+        return payload["notes"]
+    raise SystemExit("Expected input JSON to be an array of Granola notes or an object with { notes: [...] }.")
+
+
+def parse_date(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def iso_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def note_start(note: dict[str, Any]) -> datetime:
+    calendar_event = note.get("calendar_event") if isinstance(note.get("calendar_event"), dict) else {}
+    transcript = note.get("transcript") if isinstance(note.get("transcript"), list) else []
+    candidates = [
+        calendar_event.get("scheduled_start_time"),
+        first_transcript_time(transcript, "start_time"),
+        note.get("created_at"),
+        note.get("updated_at"),
+    ]
+    for candidate in candidates:
+        parsed = parse_date(candidate)
+        if parsed:
+            return parsed
+    return datetime.now(timezone.utc)
+
+
+def note_end(note: dict[str, Any], start: datetime) -> datetime:
+    calendar_event = note.get("calendar_event") if isinstance(note.get("calendar_event"), dict) else {}
+    transcript = note.get("transcript") if isinstance(note.get("transcript"), list) else []
+    candidates = [
+        calendar_event.get("scheduled_end_time"),
+        last_transcript_time(transcript, "end_time"),
+        last_transcript_time(transcript, "start_time"),
+    ]
+    for candidate in candidates:
+        parsed = parse_date(candidate)
+        if parsed and parsed >= start:
+            return parsed
+    return start
+
+
+def first_transcript_time(transcript: list[Any], key: str) -> Any:
+    for item in transcript:
+        if isinstance(item, dict) and item.get(key):
+            return item.get(key)
+    return None
+
+
+def last_transcript_time(transcript: list[Any], key: str) -> Any:
+    for item in reversed(transcript):
+        if isinstance(item, dict) and item.get(key):
+            return item.get(key)
+    return None
+
+
+def speaker_label(item: dict[str, Any]) -> str:
+    speaker = item.get("speaker") if isinstance(item.get("speaker"), dict) else {}
+    diarization = speaker.get("diarization_label")
+    if isinstance(diarization, str) and diarization.strip():
+        return diarization.strip()
+
+    source = speaker.get("source")
+    if source == "microphone":
+        return "Microphone"
+    if source == "speaker":
+        return "Speaker"
+    if isinstance(source, str) and source.strip():
+        return source.strip().replace("_", " ").title()
+    return "Speaker"
+
+
+def format_offset(timestamp: datetime | None, start: datetime) -> str:
+    if not timestamp:
+        return "00:00:00"
+    seconds = max(int((timestamp - start).total_seconds()), 0)
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def transcript_text(note: dict[str, Any], start: datetime) -> str:
+    transcript = note.get("transcript")
+    if not isinstance(transcript, list):
+        return ""
+
+    lines: list[str] = []
+    for item in transcript:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        started_at = parse_date(item.get("start_time"))
+        offset = format_offset(started_at, start)
+        lines.append(f"[{offset}] {speaker_label(item)}: {text.strip()}")
+    return "\n".join(lines)
+
+
+def plain_word_count(value: str) -> int:
+    return len(re.findall(r"\b[\w']+\b", value))
+
+
+def attendee_lines(note: dict[str, Any]) -> list[str]:
+    attendees = note.get("attendees")
+    if not isinstance(attendees, list):
+        return []
+    lines: list[str] = []
+    for attendee in attendees:
+        if not isinstance(attendee, dict):
+            continue
+        name = attendee.get("name")
+        email = attendee.get("email")
+        if isinstance(name, str) and name.strip() and isinstance(email, str) and email.strip():
+            lines.append(f"- {name.strip()} <{email.strip()}>")
+        elif isinstance(name, str) and name.strip():
+            lines.append(f"- {name.strip()}")
+        elif isinstance(email, str) and email.strip():
+            lines.append(f"- {email.strip()}")
+    return lines
+
+
+def formatted_notes(note: dict[str, Any]) -> str:
+    note_id = str(note.get("id") or "")
+    parts: list[str] = []
+    summary = note.get("summary_markdown") or note.get("summary_text")
+    if isinstance(summary, str) and summary.strip():
+        parts.append(summary.strip())
+    else:
+        parts.append("## Imported From Granola\n\nNo generated summary was returned by the Granola API.")
+
+    attendees = attendee_lines(note)
+    if attendees:
+        parts.append("## Attendees\n\n" + "\n".join(attendees))
+
+    calendar_event = note.get("calendar_event") if isinstance(note.get("calendar_event"), dict) else {}
+    source_lines = [f"- Granola note ID: `{note_id}`"]
+    web_url = note.get("web_url")
+    if isinstance(web_url, str) and web_url.strip():
+        source_lines.append(f"- Granola URL: {web_url.strip()}")
+    calendar_id = calendar_event.get("calendar_event_id")
+    if isinstance(calendar_id, str) and calendar_id.strip():
+        source_lines.append(f"- Calendar event ID: `{calendar_id.strip()}`")
+    parts.append("## Source\n\n" + "\n".join(source_lines))
+    return "\n\n".join(parts).strip() + "\n"
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(str(db_path))
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def ensure_meetings_schema(connection: sqlite3.Connection) -> None:
+    row = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'meetings'"
+    ).fetchone()
+    if not row:
+        raise RuntimeError("Muesli meetings table does not exist. Launch Muesli once before importing.")
+
+
+def backup_database(db_path: Path) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = db_path.with_name(f"{db_path.name}.backup-before-granola-{timestamp}")
+    shutil.copy2(db_path, backup_path)
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(f"{db_path}{suffix}")
+        if sidecar.exists():
+            shutil.copy2(sidecar, Path(f"{backup_path}{suffix}"))
+    return backup_path
+
+
+def import_notes(connection: sqlite3.Connection, notes: list[dict[str, Any]], dry_run: bool) -> ImportStats:
+    stats = ImportStats(fetched=len(notes))
+    for note in notes:
+        note_id = note.get("id")
+        if not isinstance(note_id, str) or not note_id.strip():
+            stats.failed += 1
+            continue
+
+        start = note_start(note)
+        raw_transcript = transcript_text(note, start)
+        if not raw_transcript.strip():
+            stats.skipped_missing_transcript += 1
+            continue
+        stats.with_transcript += 1
+
+        external_id = f"granola:{note_id.strip()}"
+        existing = connection.execute(
+            "SELECT id FROM meetings WHERE calendar_event_id = ? LIMIT 1",
+            (external_id,),
+        ).fetchone()
+        if existing:
+            stats.skipped_existing += 1
+            continue
+
+        end = note_end(note, start)
+        duration_seconds = max((end - start).total_seconds(), 0)
+        title = note.get("title") if isinstance(note.get("title"), str) and note.get("title").strip() else "Granola meeting"
+        notes_markdown = formatted_notes(note)
+        word_count = plain_word_count(raw_transcript)
+
+        if not dry_run:
+            connection.execute(
+                """
+                INSERT INTO meetings
+                (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes,
+                 mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, word_count,
+                 selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source)
+                VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, 'completed', '', ?, 'granola-import', 'Granola Import', 'builtin', NULL, 'granola')
+                """,
+                (
+                    title.strip(),
+                    external_id,
+                    iso_z(start),
+                    iso_z(end),
+                    duration_seconds,
+                    raw_transcript,
+                    notes_markdown,
+                    word_count,
+                ),
+            )
+        stats.created += 1
+
+    if not dry_run:
+        connection.commit()
+    return stats
+
+
+def main() -> int:
+    args = parse_args()
+    db_path = Path(args.db_path).expanduser()
+    if not db_path.exists():
+        print(f"Muesli database not found: {db_path}", file=sys.stderr)
+        return 2
+
+    if args.input_json:
+        notes = load_notes(args.input_json)
+    else:
+        api_key = os.environ.get(args.api_key_env)
+        if not api_key:
+            print(f"Set {args.api_key_env} to a Granola API key.", file=sys.stderr)
+            return 2
+        notes = fetch_notes(api_key, args.page_size, args.created_after, args.created_before, args.limit)
+
+    if args.export_json:
+        Path(args.export_json).expanduser().write_text(
+            json.dumps({"notes": notes}, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    backup_path: Path | None = None
+    if not args.dry_run and not args.no_backup:
+        backup_path = backup_database(db_path)
+
+    with connect(db_path) as connection:
+        ensure_meetings_schema(connection)
+        stats = import_notes(connection, notes, args.dry_run)
+
+    output = {
+        "ok": True,
+        "dryRun": args.dry_run,
+        "dbPath": str(db_path),
+        "backupPath": str(backup_path) if backup_path else None,
+        "stats": stats.__dict__,
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_granola_to_muesli.py
+++ b/scripts/import_granola_to_muesli.py
@@ -325,8 +325,9 @@ def import_notes(connection: sqlite3.Connection, notes: list[dict[str, Any]], dr
         stats.with_transcript += 1
 
         external_id = f"granola:{note_id.strip()}"
+        calendar_id = calendar_event_id(note)
         duplicate_ids = [external_id]
-        if calendar_id := calendar_event_id(note):
+        if calendar_id:
             duplicate_ids.append(calendar_id)
         existing = connection.execute(
             f"SELECT id FROM meetings WHERE calendar_event_id IN ({','.join('?' for _ in duplicate_ids)}) LIMIT 1",
@@ -353,7 +354,7 @@ def import_notes(connection: sqlite3.Connection, notes: list[dict[str, Any]], dr
                 """,
                 (
                     title.strip(),
-                    external_id,
+                calendar_id or external_id,
                     iso_z(start),
                     iso_z(end),
                     duration_seconds,

--- a/scripts/import_granola_to_muesli.py
+++ b/scripts/import_granola_to_muesli.py
@@ -161,11 +161,12 @@ def note_end(note: dict[str, Any], start: datetime) -> datetime:
         last_transcript_time(transcript, "end_time"),
         last_transcript_time(transcript, "start_time"),
     ]
+    parsed_candidates: list[datetime] = []
     for candidate in candidates:
         parsed = parse_date(candidate)
         if parsed and parsed >= start:
-            return parsed
-    return start
+            parsed_candidates.append(parsed)
+    return max(parsed_candidates) if parsed_candidates else start
 
 
 def first_transcript_time(transcript: list[Any], key: str) -> Any:
@@ -274,6 +275,14 @@ def formatted_notes(note: dict[str, Any]) -> str:
     return "\n\n".join(parts).strip() + "\n"
 
 
+def calendar_event_id(note: dict[str, Any]) -> str | None:
+    calendar_event = note.get("calendar_event") if isinstance(note.get("calendar_event"), dict) else {}
+    value = calendar_event.get("calendar_event_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def connect(db_path: Path) -> sqlite3.Connection:
     connection = sqlite3.connect(str(db_path))
     connection.row_factory = sqlite3.Row
@@ -316,9 +325,12 @@ def import_notes(connection: sqlite3.Connection, notes: list[dict[str, Any]], dr
         stats.with_transcript += 1
 
         external_id = f"granola:{note_id.strip()}"
+        duplicate_ids = [external_id]
+        if calendar_id := calendar_event_id(note):
+            duplicate_ids.append(calendar_id)
         existing = connection.execute(
-            "SELECT id FROM meetings WHERE calendar_event_id = ? LIMIT 1",
-            (external_id,),
+            f"SELECT id FROM meetings WHERE calendar_event_id IN ({','.join('?' for _ in duplicate_ids)}) LIMIT 1",
+            duplicate_ids,
         ).fetchone()
         if existing:
             stats.skipped_existing += 1


### PR DESCRIPTION
## Summary
- add a Granola import script that brings raw transcripts, notes, titles, timestamps, and source metadata into the local Muesli database
- preserve and surface calendar attendee/organizer information so meeting rows can show participant names and emails when available
- make meeting rows easier to scan with friendly relative dates, participant lines, and cleaner notes previews
- show capped meeting counts as `Showing 200 of 559 meetings` when the browser is limited

## Existing PR context
- This is separate from the branding/native-shell work in #141.
- It no longer depends on the separate timestamp-formatting PR; the new meeting-list metadata helper parses stored timestamps directly.

## Validation
- `env -u OPENAI_API_KEY -u OPENROUTER_API_KEY swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/pr-granola-import"`
- Result: 730 tests in 97 suites passed.