### PR TITLE
Add LM Studio summarization support

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -26,6 +26,7 @@ enum MeetingSummaryClient {
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
+    private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
     private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
     private static let defaultChatGPTModel = "gpt-5.4-mini"
@@ -33,6 +34,8 @@ enum MeetingSummaryClient {
     private static let defaultSummaryMaxOutputTokens = 2500
     private static let ollamaSummaryTimeout: TimeInterval = 300
     private static let ollamaTitleTimeout: TimeInterval = 120
+    private static let lmStudioSummaryTimeout: TimeInterval = 300
+    private static let lmStudioTitleTimeout: TimeInterval = 120
 
     private static let titleInstructions = """
     Generate a short, descriptive meeting title (3-7 words) from this transcript. \
@@ -84,6 +87,18 @@ enum MeetingSummaryClient {
         }
         if backend == MeetingSummaryBackendOption.ollama.backend {
             generatedNotes = try await summarizeWithOllama(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
+        if backend == MeetingSummaryBackendOption.lmStudio.backend {
+            generatedNotes = try await summarizeWithLMStudio(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -481,6 +496,70 @@ enum MeetingSummaryClient {
         }
     }
 
+    private static func summarizeWithLMStudio(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil
+    ) async throws -> String {
+        let baseURLString = config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL: URL
+        if baseURLString.isEmpty {
+            baseURL = defaultLMStudioBaseURL
+        } else {
+            guard let url = URL(string: baseURLString) else {
+                throw MeetingSummaryError.backendFailed(backend: "LM Studio", statusCode: nil, message: "Invalid LM Studio URL: \(baseURLString)")
+            }
+            baseURL = url
+        }
+        let chatURL = baseURL.appendingPathComponent("v1/chat/completions")
+
+        let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
+        let userPrompt = summaryUserPrompt(
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            visualContext: visualContext
+        )
+        let body: [String: Any] = [
+            "model": configuredModel,
+            "messages": [
+                ["role": "system", "content": instructions],
+                ["role": "user", "content": userPrompt],
+            ],
+            "max_tokens": defaultSummaryMaxOutputTokens,
+        ]
+
+        var request = URLRequest(url: chatURL)
+        request.timeoutInterval = lmStudioSummaryTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "LM Studio")
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let text = extractOpenRouterText(from: json),
+                !text.isEmpty
+            else {
+                if let message = extractErrorMessage(from: data) {
+                    throw MeetingSummaryError.backendFailed(backend: "LM Studio", statusCode: nil, message: message)
+                }
+                throw MeetingSummaryError.emptyResponse(backend: "LM Studio")
+            }
+            return text
+        } catch {
+            throw summaryRequestError(backend: "LM Studio", error: error)
+        }
+    }
+
     /// Call the WHAM streaming API and collect the full response text.
     private static func callWHAM(systemPrompt: String, userPrompt: String, model: String) async throws -> String? {
         let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
@@ -664,6 +743,10 @@ enum MeetingSummaryClient {
             return await generateTitleWithOllama(transcript: truncated, config: config)
         }
 
+        if backend == MeetingSummaryBackendOption.lmStudio.backend {
+            return await generateTitleWithLMStudio(transcript: truncated, config: config)
+        }
+
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey
         guard !apiKey.isEmpty else { return nil }
         let model = config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel
@@ -803,6 +886,61 @@ enum MeetingSummaryClient {
             return nil
         } catch {
             fputs("[summary] Ollama title generation failed: \(error)\n", stderr)
+            return nil
+        }
+    }
+
+    private static func generateTitleWithLMStudio(transcript: String, config: AppConfig) async -> String? {
+        let baseURLString = config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL: URL
+        if baseURLString.isEmpty {
+            baseURL = defaultLMStudioBaseURL
+        } else {
+            guard let url = URL(string: baseURLString) else {
+                fputs("[summary] LM Studio title generation: invalid URL \(baseURLString)\n", stderr)
+                return nil
+            }
+            baseURL = url
+        }
+        let chatURL = baseURL.appendingPathComponent("v1/chat/completions")
+        let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let body: [String: Any] = [
+            "model": configuredModel,
+            "messages": [
+                ["role": "system", "content": titleInstructions],
+                ["role": "user", "content": transcript],
+            ],
+            "max_tokens": 100,
+        ]
+
+        var request = URLRequest(url: chatURL)
+        request.timeoutInterval = lmStudioTitleTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "LM Studio")
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let text = extractOpenRouterText(from: json),
+                  !text.isEmpty else {
+                fputs("[summary] LM Studio title generation: empty or invalid response\n", stderr)
+                return nil
+            }
+            let title = text.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+            guard !title.isEmpty else {
+                fputs("[summary] LM Studio title generation: trimmed response is empty\n", stderr)
+                return nil
+            }
+            fputs("[summary] LM Studio generated title: \(title)\n", stderr)
+            return title
+        } catch let error as MeetingSummaryError {
+            fputs("[summary] LM Studio title generation failed: \(error.localizedDescription)\n", stderr)
+            return nil
+        } catch {
+            fputs("[summary] LM Studio title generation failed: \(error)\n", stderr)
             return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -343,7 +343,12 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "Ollama"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama]
+    static let lmStudio = MeetingSummaryBackendOption(
+        backend: "lmstudio",
+        label: "LM Studio"
+    )
+
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .lmStudio]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
@@ -631,6 +636,8 @@ struct AppConfig: Codable {
     var chatGPTModel: String = ""
     var ollamaURL: String = "http://localhost:11434"
     var ollamaModel: String = "qwen3.5"
+    var lmStudioURL: String = "http://localhost:1234"
+    var lmStudioModel: String = ""
     var summaryModel: String = ""
     var meetingSummaryModel: String = ""
     var hasCompletedOnboarding: Bool = false
@@ -696,6 +703,8 @@ struct AppConfig: Codable {
         case chatGPTModel = "chatgpt_model"
         case ollamaURL = "ollama_url"
         case ollamaModel = "ollama_model"
+        case lmStudioURL = "lmstudio_url"
+        case lmStudioModel = "lmstudio_model"
         case summaryModel = "summary_model"
         case meetingSummaryModel = "meeting_summary_model"
         case hasCompletedOnboarding = "has_completed_onboarding"
@@ -773,6 +782,8 @@ struct AppConfig: Codable {
         chatGPTModel = (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
         ollamaURL = (try? c.decode(String.self, forKey: .ollamaURL)) ?? defaults.ollamaURL
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
+        lmStudioURL = (try? c.decode(String.self, forKey: .lmStudioURL)) ?? defaults.lmStudioURL
+        lmStudioModel = (try? c.decode(String.self, forKey: .lmStudioModel)) ?? defaults.lmStudioModel
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1419,6 +1419,10 @@ struct OnboardingView: View {
                     summaryBackend = .ollama
                     apiKey = ""
                 }
+                providerTab("LM Studio", selected: summaryBackend == .lmStudio) {
+                    summaryBackend = .lmStudio
+                    apiKey = ""
+                }
             }
             .background(MuesliTheme.backgroundRaised)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
@@ -1426,7 +1430,7 @@ struct OnboardingView: View {
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
-            .frame(width: 320)
+            .frame(width: 400)
 
             if summaryBackend == .chatGPT {
                 Text("Use your ChatGPT Plus or Pro subscription.")
@@ -1495,6 +1499,26 @@ struct OnboardingView: View {
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                     Text("Ollama is served by default at http://localhost:11434")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(MuesliTheme.success)
+                            .frame(width: 6, height: 6)
+                        Text("No authentication required")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuesliTheme.success)
+                    }
+                }
+            } else if summaryBackend == .lmStudio {
+                Text("Run AI models locally with LM Studio.\nNo API key needed — just start the LM Studio server.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                    Text("LM Studio is served by default at http://localhost:1234")
                         .font(.system(size: 11))
                         .foregroundStyle(MuesliTheme.textTertiary)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -548,6 +548,22 @@ struct SettingsView: View {
                             placeholder: "qwen3.5"
                         ) { val in controller.updateConfig { $0.ollamaModel = val } }
                     }
+                } else if appState.selectedMeetingSummaryBackend == .lmStudio {
+                    settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.lmStudioURL,
+                            placeholder: "http://localhost:1234",
+                            onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model", controlWidth: meetingControlWidth) {
+                        settingsModelTextField(
+                            currentModel: appState.config.lmStudioModel,
+                            placeholder: "model-name"
+                        ) { val in controller.updateConfig { $0.lmStudioModel = val } }
+                    }
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -358,4 +358,56 @@ struct MeetingSummaryClientTests {
             #expect(summaryError != nil)
         }
     }
+
+    @Test("summarize routes to LM Studio when configured")
+    func routesToLMStudio() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "http://localhost:1" // invalid port to force connection failure
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            let summaryError = error as? MeetingSummaryError
+            #expect(summaryError != nil)
+            if case .requestFailed(let backend, _) = summaryError! {
+                #expect(backend == "LM Studio")
+            } else {
+                #expect(Bool(false), "Expected requestFailed error, got \(String(describing: error))")
+            }
+        }
+    }
+
+    @Test("generateTitle returns nil for LM Studio when unreachable")
+    func titleLMStudioUnreachable() async {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "http://localhost:1"
+
+        let title = await MeetingSummaryClient.generateTitle(
+            transcript: "Sprint planning discussion",
+            config: config
+        )
+
+        #expect(title == nil)
+    }
+
+    @Test("generateTitle returns nil for LM Studio with invalid URL")
+    func titleLMStudioInvalidURL() async {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "not a valid url"
+
+        let title = await MeetingSummaryClient.generateTitle(
+            transcript: "Sprint planning discussion",
+            config: config
+        )
+
+        #expect(title == nil)
+    }
 }


### PR DESCRIPTION
## Summary
Add LM Studio as a new meeting summarization backend, enabling users to use local LM Studio models for AI-powered meeting notes without requiring an API key.

## Changes
- **Models.swift**: Add `lmStudio` backend option and config fields (`lmStudioURL`, `lmStudioModel`)
- **MeetingSummaryClient.swift**: Implement `summarizeWithLMStudio` and `generateTitleWithLMStudio` functions
- **SettingsView.swift**: Add UI for LM Studio URL and model configuration in meeting summaries settings
- **OnboardingView.swift**: Add LM Studio tab to meeting summary onboarding with provider-specific info
- **MeetingSummaryClientTests.swift**: Add tests for LM Studio routing, title generation, and error handling

## Implementation Details
LM Studio uses the OpenAI-compatible `/v1/chat/completions` endpoint at `http://localhost:1234` by default. No authentication is required, similar to the existing Ollama integration.

The implementation follows the same pattern as Ollama:
- Validates URL and constructs the chat completions endpoint
- Sends messages array with system instructions and user prompt
- Uses `max_tokens` for output limiting
- Parses response using the existing `extractOpenRouterText` helper
- Includes proper error handling and timeout configuration

## Testing
Added 3 new tests in `MeetingSummaryClientTests.swift`:
- `routesToLMStudio`: Verifies backend routing and error handling
- `titleLMStudioUnreachable`: Tests connection failure scenarios
- `titleLMStudioInvalidURL`: Tests malformed URL handling

All 26 tests pass.

## Configuration
- Default URL: `http://localhost:1234`
- Model: User-configurable (empty by default, allowing LM Studio's model selection)
- Timeout: 300s for summaries, 120s for title generation