### PR TITLE
feat: add custom command meeting summary backend

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -914,6 +914,9 @@ struct MeetingDetailView: View {
             return appState.isChatGPTAuthenticated
         } else if appState.selectedMeetingSummaryBackend == .openAI {
             return !config.openAIAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENAI_API_KEY"] != nil
+        } else if appState.selectedMeetingSummaryBackend == .ollama
+                    || appState.selectedMeetingSummaryBackend == .customCommand {
+            return true
         } else {
             return !config.openRouterAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -95,6 +95,18 @@ enum MeetingSummaryClient {
             )
             return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
         }
+        if backend == MeetingSummaryBackendOption.customCommand.backend {
+            generatedNotes = try await summarizeWithCustomCommand(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
         generatedNotes = try await summarizeWithOpenAI(
             transcript: transcript,
             meetingTitle: meetingTitle,
@@ -482,6 +494,149 @@ enum MeetingSummaryClient {
         }
     }
 
+    private static let customCommandTimeout: TimeInterval = 300
+
+    private static func summarizeWithCustomCommand(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil
+    ) async throws -> String {
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
+        let userPrompt = summaryUserPrompt(
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            visualContext: visualContext
+        )
+        let combinedPrompt = instructions + "\n\n" + userPrompt
+        return try await runCustomCommand(
+            command: config.customSummaryCommand,
+            input: combinedPrompt,
+            timeout: customCommandTimeout
+        )
+    }
+
+    private static func generateTitleWithCustomCommand(transcript: String, config: AppConfig) async -> String? {
+        let prompt = titleInstructions + "\n\n" + transcript
+        guard let result = try? await runCustomCommand(
+            command: config.customSummaryCommand,
+            input: prompt,
+            timeout: 60
+        ) else {
+            return nil
+        }
+        let title = result.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+        return title.isEmpty ? nil : title
+    }
+
+    private static func runCustomCommand(command: String, input: String, timeout: TimeInterval) async throws -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw MeetingSummaryError.backendFailed(
+                backend: "Custom Command", statusCode: nil,
+                message: "No command configured. Set a command in Settings → Meetings."
+            )
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", trimmed]
+
+        let stdinPipe = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        process.environment = ProcessInfo.processInfo.environment
+        if let path = process.environment?["PATH"] {
+            process.environment?["PATH"] = "\(NSHomeDirectory())/.local/bin:\(NSHomeDirectory())/.claude/local:/usr/local/bin:" + path
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            var stdoutData = Data()
+            var stderrData = Data()
+            let dataQueue = DispatchQueue(label: "com.muesli.custom-command-pipe")
+
+            stdout.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if !chunk.isEmpty {
+                    dataQueue.sync { stdoutData.append(chunk) }
+                }
+            }
+            stderr.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if !chunk.isEmpty {
+                    dataQueue.sync { stderrData.append(chunk) }
+                }
+            }
+
+            let timeoutSource = DispatchSource.makeTimerSource(queue: .global())
+            timeoutSource.schedule(deadline: .now() + timeout)
+            timeoutSource.setEventHandler {
+                process.terminate()
+                let pid = process.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGKILL)
+                }
+            }
+            timeoutSource.resume()
+
+            do {
+                try process.run()
+            } catch {
+                timeoutSource.cancel()
+                stdout.fileHandleForReading.readabilityHandler = nil
+                stderr.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(throwing: MeetingSummaryError.requestFailed(backend: "Custom Command", underlying: error))
+                return
+            }
+
+            if let data = input.data(using: .utf8) {
+                stdinPipe.fileHandleForWriting.write(data)
+            }
+            stdinPipe.fileHandleForWriting.closeFile()
+
+            process.terminationHandler = { proc in
+                timeoutSource.cancel()
+                stdout.fileHandleForReading.readabilityHandler = nil
+                stderr.fileHandleForReading.readabilityHandler = nil
+
+                let remainingOut = stdout.fileHandleForReading.readDataToEndOfFile()
+                let remainingErr = stderr.fileHandleForReading.readDataToEndOfFile()
+
+                var output = ""
+                var errOutput = ""
+                dataQueue.sync {
+                    if !remainingOut.isEmpty { stdoutData.append(remainingOut) }
+                    if !remainingErr.isEmpty { stderrData.append(remainingErr) }
+                    output = String(data: stdoutData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                    errOutput = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                }
+
+                if proc.terminationStatus != 0 {
+                    let message = errOutput.isEmpty ? "Process exited with code \(proc.terminationStatus)" : errOutput
+                    continuation.resume(throwing: MeetingSummaryError.backendFailed(
+                        backend: "Custom Command", statusCode: Int(proc.terminationStatus), message: message
+                    ))
+                    return
+                }
+
+                if output.isEmpty {
+                    continuation.resume(throwing: MeetingSummaryError.emptyResponse(backend: "Custom Command"))
+                    return
+                }
+
+                continuation.resume(returning: output)
+            }
+        }
+    }
     /// Call the WHAM streaming API and collect the full response text.
     private static func callWHAM(systemPrompt: String, userPrompt: String, model: String) async throws -> String? {
         let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
@@ -662,6 +817,10 @@ enum MeetingSummaryClient {
 
         if backend == MeetingSummaryBackendOption.ollama.backend {
             return await generateTitleWithOllama(transcript: excerpt, config: config)
+        }
+
+        if backend == MeetingSummaryBackendOption.customCommand.backend {
+            return await generateTitleWithCustomCommand(transcript: truncated, config: config)
         }
 
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -584,24 +584,14 @@ enum MeetingSummaryClient {
                 let pid = process.processIdentifier
                 if pid > 0 {
                     kill(pid, SIGKILL)
+                    // Kill child processes spawned by the shell
+                    let pgid = getpgid(pid)
+                    if pgid > 0 && pgid != getpgid(0) {
+                        killpg(pgid, SIGKILL)
+                    }
                 }
             }
             timeoutSource.resume()
-
-            do {
-                try process.run()
-            } catch {
-                timeoutSource.cancel()
-                stdout.fileHandleForReading.readabilityHandler = nil
-                stderr.fileHandleForReading.readabilityHandler = nil
-                continuation.resume(throwing: MeetingSummaryError.requestFailed(backend: "Custom Command", underlying: error))
-                return
-            }
-
-            if let data = input.data(using: .utf8) {
-                stdinPipe.fileHandleForWriting.write(data)
-            }
-            stdinPipe.fileHandleForWriting.closeFile()
 
             process.terminationHandler = { proc in
                 timeoutSource.cancel()
@@ -634,6 +624,23 @@ enum MeetingSummaryClient {
                 }
 
                 continuation.resume(returning: output)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                timeoutSource.cancel()
+                stdout.fileHandleForReading.readabilityHandler = nil
+                stderr.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(throwing: MeetingSummaryError.requestFailed(backend: "Custom Command", underlying: error))
+                return
+            }
+
+            DispatchQueue.global().async {
+                if let data = input.data(using: .utf8) {
+                    stdinPipe.fileHandleForWriting.write(data)
+                }
+                stdinPipe.fileHandleForWriting.closeFile()
             }
         }
     }
@@ -820,7 +827,7 @@ enum MeetingSummaryClient {
         }
 
         if backend == MeetingSummaryBackendOption.customCommand.backend {
-            return await generateTitleWithCustomCommand(transcript: truncated, config: config)
+            return await generateTitleWithCustomCommand(transcript: excerpt, config: config)
         }
 
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -343,7 +343,12 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "Ollama"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama]
+    static let customCommand = MeetingSummaryBackendOption(
+        backend: "custom-command",
+        label: "Custom Command"
+    )
+
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .customCommand]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
@@ -632,6 +637,7 @@ struct AppConfig: Codable {
     var chatGPTModel: String = ""
     var ollamaURL: String = "http://localhost:11434"
     var ollamaModel: String = "qwen3.5"
+    var customSummaryCommand: String = "claude -p"
     var summaryModel: String = ""
     var meetingSummaryModel: String = ""
     var hasCompletedOnboarding: Bool = false
@@ -700,6 +706,7 @@ struct AppConfig: Codable {
         case chatGPTModel = "chatgpt_model"
         case ollamaURL = "ollama_url"
         case ollamaModel = "ollama_model"
+        case customSummaryCommand = "custom_summary_command"
         case summaryModel = "summary_model"
         case meetingSummaryModel = "meeting_summary_model"
         case hasCompletedOnboarding = "has_completed_onboarding"
@@ -782,6 +789,7 @@ struct AppConfig: Codable {
         chatGPTModel = (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
         ollamaURL = (try? c.decode(String.self, forKey: .ollamaURL)) ?? defaults.ollamaURL
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
+        customSummaryCommand = (try? c.decode(String.self, forKey: .customSummaryCommand)) ?? defaults.customSummaryCommand
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -569,6 +569,19 @@ struct SettingsView: View {
                             placeholder: "qwen3.5"
                         ) { val in controller.updateConfig { $0.ollamaModel = val } }
                     }
+                } else if appState.selectedMeetingSummaryBackend == .customCommand {
+                    settingsRow("Command", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.customSummaryCommand,
+                            placeholder: "claude -p",
+                            onChange: { val in controller.updateConfig { $0.customSummaryCommand = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Text("The prompt is piped to stdin. Stdout is captured as the summary.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .padding(.horizontal, MuesliTheme.spacing16)
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -368,11 +368,12 @@ struct MeetingSummaryBackendTests {
 
     @Test("all options listed")
     func allOptions() {
-        #expect(MeetingSummaryBackendOption.all.count == 4)
+        #expect(MeetingSummaryBackendOption.all.count == 5)
         #expect(MeetingSummaryBackendOption.all.contains(.openAI))
         #expect(MeetingSummaryBackendOption.all.contains(.openRouter))
         #expect(MeetingSummaryBackendOption.all.contains(.chatGPT))
         #expect(MeetingSummaryBackendOption.all.contains(.ollama))
+        #expect(MeetingSummaryBackendOption.all.contains(.customCommand))
     }
 
     @Test("backend strings are lowercase")


### PR DESCRIPTION
  ## Summary

  Adds "Custom Command" as a new meeting summarization backend, addressing #131. The user specifies any shell command that reads a prompt from stdin and writes the summary to stdout.

  - Default command: `claude -p` (Claude Code CLI)
  - Also works with `aifx agent run claude -p`, local LLM wrappers, or any stdin→stdout CLI
  - Settings shows a single "Command" field — no API key or model configuration needed
  - Inherits the same prompt structure (system instructions + transcript) used by all other backends
  - 5-minute timeout for summaries, 60s for titles
  - PATH is extended with common CLI install locations (`~/.local/bin`, `~/.claude/local`, `/usr/local/bin`)

  ## Changes

  - **Models.swift**: Added `.customCommand` backend option + `customSummaryCommand` config field (default: `"claude -p"`)
  - **MeetingSummaryClient.swift**: Added `summarizeWithCustomCommand`, `generateTitleWithCustomCommand`, and `runCustomCommand` (generic subprocess via `/bin/sh -c`)
  - **SettingsView.swift**: Shows command text field + helper text when Custom Command backend is selected

  ## Test plan

  - [x] Build succeeds
  - [x] Select "Custom Command" in menu bar → Settings shows command field, no API key/model fields
  - [x] Record a meeting with `claude -p` as command → summary generated correctly
  - [x] Test with empty command → clear error message
  - [x] Test with failing command → error includes stderr output

Closes #131