### PR TITLE
[codex] Add dictation audio ducking and AirPods route handling

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -64,6 +64,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     private var duckingEnabledForSession = false
     private var snapshots: [AudioObjectID: DeviceSnapshot] = [:]
     private var restoreGeneration = 0
+    private var isRestorePending = false
 
     init(
         client: AudioDuckingDeviceClient = CoreAudioDuckingDeviceClient(),
@@ -84,7 +85,7 @@ final class AudioDuckingController: AudioDuckingManaging {
                 self.restoreLocked()
                 return
             }
-            self.restoreGeneration += 1
+            self.cancelPendingRestoreLocked()
             self.duckingEnabledForSession = true
             guard self.shouldDuckCurrentOutput() else { return }
             self.duckCurrentDefaultDevice()
@@ -154,10 +155,17 @@ final class AudioDuckingController: AudioDuckingManaging {
 
     private func restoreLocked() {
         restoreGeneration += 1
+        isRestorePending = true
         scheduleRestoreAfterCodecStabilizationLocked(
             generation: restoreGeneration,
             deadline: Date().addingTimeInterval(stabilizationTimeout)
         )
+    }
+
+    private func cancelPendingRestoreLocked() {
+        guard isRestorePending else { return }
+        restoreGeneration += 1
+        isRestorePending = false
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {
@@ -176,6 +184,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         let pendingSnapshots = snapshots.values
         snapshots.removeAll()
         duckingEnabledForSession = false
+        isRestorePending = false
 
         for snapshot in pendingSnapshots {
             guard client.isDeviceAvailable(snapshot.deviceID) else { continue }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -63,6 +63,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     private let stabilizationPollInterval: TimeInterval
     private var duckingEnabledForSession = false
     private var snapshots: [AudioObjectID: DeviceSnapshot] = [:]
+    private var restoreGeneration = 0
 
     init(
         client: AudioDuckingDeviceClient = CoreAudioDuckingDeviceClient(),
@@ -83,6 +84,7 @@ final class AudioDuckingController: AudioDuckingManaging {
                 self.restoreLocked()
                 return
             }
+            self.restoreGeneration += 1
             self.duckingEnabledForSession = true
             guard self.shouldDuckCurrentOutput() else { return }
             self.duckCurrentDefaultDevice()
@@ -151,7 +153,26 @@ final class AudioDuckingController: AudioDuckingManaging {
     }
 
     private func restoreLocked() {
-        waitForCodecStabilization()
+        restoreGeneration += 1
+        scheduleRestoreAfterCodecStabilizationLocked(
+            generation: restoreGeneration,
+            deadline: Date().addingTimeInterval(stabilizationTimeout)
+        )
+    }
+
+    private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {
+        guard generation == restoreGeneration else { return }
+        guard shouldWaitForCodecStabilizationLocked(until: deadline) else {
+            applyRestoreLocked(generation: generation)
+            return
+        }
+        queue.asyncAfter(deadline: .now() + stabilizationPollInterval) { [self] in
+            scheduleRestoreAfterCodecStabilizationLocked(generation: generation, deadline: deadline)
+        }
+    }
+
+    private func applyRestoreLocked(generation: Int) {
+        guard generation == restoreGeneration else { return }
         let pendingSnapshots = snapshots.values
         snapshots.removeAll()
         duckingEnabledForSession = false
@@ -174,19 +195,16 @@ final class AudioDuckingController: AudioDuckingManaging {
         }
     }
 
-    private func waitForCodecStabilization() {
-        guard stabilizationTimeout > 0, stabilizationPollInterval > 0 else { return }
-        let deadline = Date().addingTimeInterval(stabilizationTimeout)
-        while Date() < deadline {
-            guard let defaultDeviceID = client.defaultOutputDeviceID(),
-                  let snapshot = snapshots[defaultDeviceID],
-                  let previousSampleRate = snapshot.sampleRate,
-                  let currentSampleRate = client.nominalSampleRate(for: defaultDeviceID),
-                  abs(currentSampleRate - previousSampleRate) > 0.5 else {
-                return
-            }
-            Thread.sleep(forTimeInterval: stabilizationPollInterval)
+    private func shouldWaitForCodecStabilizationLocked(until deadline: Date) -> Bool {
+        guard stabilizationTimeout > 0, stabilizationPollInterval > 0, Date() < deadline else { return false }
+        guard let defaultDeviceID = client.defaultOutputDeviceID(),
+              let snapshot = snapshots[defaultDeviceID],
+              let previousSampleRate = snapshot.sampleRate,
+              let currentSampleRate = client.nominalSampleRate(for: defaultDeviceID),
+              abs(currentSampleRate - previousSampleRate) > 0.5 else {
+            return false
         }
+        return true
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -7,14 +7,23 @@ protocol AudioDuckingManaging: AnyObject {
     func restoreDictationDucking()
 }
 
-enum AudioOutputActivityStatus: Equatable {
+enum AudioOutputActivityStatus: Equatable, CustomStringConvertible {
     case active
     case inactive
     case unknown
+
+    var description: String {
+        switch self {
+        case .active: return "active"
+        case .inactive: return "inactive"
+        case .unknown: return "unknown"
+        }
+    }
 }
 
 protocol AudioDuckingDeviceClient {
     func outputActivityStatus() -> AudioOutputActivityStatus
+    func defaultOutputRouteKind() -> AudioOutputRouteKind
     func defaultOutputDeviceID() -> AudioObjectID?
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool
     func nominalSampleRate(for deviceID: AudioObjectID) -> Double?
@@ -69,19 +78,19 @@ final class AudioDuckingController: AudioDuckingManaging {
     }
 
     func beginDictationDucking(enabled: Bool) {
-        queue.sync {
-            restoreWorkItem?.cancel()
-            restoreWorkItem = nil
-            duckingEnabledForSession = enabled
-            guard enabled, shouldDuckCurrentOutput() else { return }
-            duckCurrentDefaultDevice()
+        queue.async { [self] in
+            self.restoreWorkItem?.cancel()
+            self.restoreWorkItem = nil
+            self.duckingEnabledForSession = enabled
+            guard enabled, self.shouldDuckCurrentOutput() else { return }
+            self.duckCurrentDefaultDevice()
         }
     }
 
     func ensureCurrentDefaultDucked() {
-        queue.sync {
-            guard duckingEnabledForSession, shouldDuckCurrentOutput() else { return }
-            duckCurrentDefaultDevice()
+        queue.async { [self] in
+            guard self.duckingEnabledForSession, self.shouldDuckCurrentOutput() else { return }
+            self.duckCurrentDefaultDevice()
         }
     }
 
@@ -101,6 +110,9 @@ final class AudioDuckingController: AudioDuckingManaging {
     }
 
     private func shouldDuckCurrentOutput() -> Bool {
+        guard client.defaultOutputRouteKind() != .headphoneLike else {
+            return false
+        }
         switch client.outputActivityStatus() {
         case .active, .unknown:
             return true
@@ -183,6 +195,11 @@ final class AudioDuckingController: AudioDuckingManaging {
 
 final class CoreAudioDuckingDeviceClient: AudioDuckingDeviceClient {
     private let currentProcessID = ProcessInfo.processInfo.processIdentifier
+    private let inspector: CoreAudioDeviceInspector
+
+    init(inspector: CoreAudioDeviceInspector = CoreAudioDeviceInspector()) {
+        self.inspector = inspector
+    }
 
     func outputActivityStatus() -> AudioOutputActivityStatus {
         guard let processIDs = processObjectIDs() else { return .unknown }
@@ -196,48 +213,21 @@ final class CoreAudioDuckingDeviceClient: AudioDuckingDeviceClient {
         return .inactive
     }
 
+    func defaultOutputRouteKind() -> AudioOutputRouteKind {
+        guard let deviceID = defaultOutputDeviceID() else { return .unknown }
+        return inspector.outputRouteKind(for: deviceID)
+    }
+
     func defaultOutputDeviceID() -> AudioObjectID? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var deviceID = AudioObjectID(kAudioObjectUnknown)
-        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
-        guard AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address,
-            0,
-            nil,
-            &dataSize,
-            &deviceID
-        ) == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
-            return nil
-        }
-        return deviceID
+        inspector.defaultOutputDeviceID()
     }
 
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {
-        deviceID != AudioObjectID(kAudioObjectUnknown) && hasProperty(
-            kAudioObjectPropertyName,
-            objectID: deviceID,
-            scope: kAudioObjectPropertyScopeGlobal,
-            element: kAudioObjectPropertyElementMain
-        )
+        inspector.isDeviceAvailable(deviceID)
     }
 
     func nominalSampleRate(for deviceID: AudioObjectID) -> Double? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyNominalSampleRate,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var sampleRate = Float64(0)
-        var dataSize = UInt32(MemoryLayout<Float64>.size)
-        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &sampleRate) == noErr else {
-            return nil
-        }
-        return sampleRate
+        inspector.nominalSampleRate(for: deviceID)
     }
 
     func muteElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -63,7 +63,6 @@ final class AudioDuckingController: AudioDuckingManaging {
     private let stabilizationPollInterval: TimeInterval
     private var duckingEnabledForSession = false
     private var snapshots: [AudioObjectID: DeviceSnapshot] = [:]
-    private var restoreWorkItem: DispatchWorkItem?
 
     init(
         client: AudioDuckingDeviceClient = CoreAudioDuckingDeviceClient(),
@@ -79,8 +78,6 @@ final class AudioDuckingController: AudioDuckingManaging {
 
     func beginDictationDucking(enabled: Bool) {
         queue.async { [self] in
-            self.restoreWorkItem?.cancel()
-            self.restoreWorkItem = nil
             guard enabled else {
                 self.duckingEnabledForSession = false
                 self.restoreLocked()
@@ -100,14 +97,9 @@ final class AudioDuckingController: AudioDuckingManaging {
     }
 
     func restoreDictationDucking() {
-        let workItem = DispatchWorkItem { [weak self] in
-            self?.restoreLocked()
+        queue.async { [self] in
+            restoreLocked()
         }
-        queue.sync {
-            restoreWorkItem?.cancel()
-            restoreWorkItem = workItem
-        }
-        queue.async(execute: workItem)
     }
 
     func waitForIdle() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -340,6 +340,8 @@ final class CoreAudioDuckingDeviceClient: AudioDuckingDeviceClient {
         deviceID: AudioObjectID,
         scope: AudioObjectPropertyScope
     ) -> [AudioObjectPropertyElement] {
+        // Dictation ducking only needs the main and common stereo elements.
+        // Aggregate/surround channel-specific ducking is intentionally out of scope.
         let candidates = [
             kAudioObjectPropertyElementMain,
             AudioObjectPropertyElement(1),

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -176,7 +176,9 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
-        // Preserve completions until a real restore happens; a new dictation keeps output ducked.
+        let completions = restoreCompletions
+        restoreCompletions.removeAll()
+        completions.forEach { $0() }
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -1,0 +1,438 @@
+import CoreAudio
+import Foundation
+
+protocol AudioDuckingManaging: AnyObject {
+    func beginDictationDucking(enabled: Bool)
+    func ensureCurrentDefaultDucked()
+    func restoreDictationDucking()
+}
+
+enum AudioOutputActivityStatus: Equatable {
+    case active
+    case inactive
+    case unknown
+}
+
+protocol AudioDuckingDeviceClient {
+    func outputActivityStatus() -> AudioOutputActivityStatus
+    func defaultOutputDeviceID() -> AudioObjectID?
+    func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool
+    func nominalSampleRate(for deviceID: AudioObjectID) -> Double?
+    func muteElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement]
+    func isMuted(deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool?
+    func setMuted(_ muted: Bool, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool
+    func volumeElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement]
+    func volume(deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Float32?
+    func setVolume(_ volume: Float32, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool
+}
+
+final class AudioDuckingController: AudioDuckingManaging {
+    private struct MuteMutation {
+        let element: AudioObjectPropertyElement
+        let previousValue: Bool
+    }
+
+    private struct VolumeMutation {
+        let element: AudioObjectPropertyElement
+        let previousValue: Float32
+    }
+
+    private struct DeviceSnapshot {
+        let deviceID: AudioObjectID
+        let sampleRate: Double?
+        var muteMutations: [MuteMutation] = []
+        var volumeMutations: [VolumeMutation] = []
+
+        var hasMutations: Bool {
+            !muteMutations.isEmpty || !volumeMutations.isEmpty
+        }
+    }
+
+    private let client: AudioDuckingDeviceClient
+    private let queue: DispatchQueue
+    private let stabilizationTimeout: TimeInterval
+    private let stabilizationPollInterval: TimeInterval
+    private var duckingEnabledForSession = false
+    private var snapshots: [AudioObjectID: DeviceSnapshot] = [:]
+    private var restoreWorkItem: DispatchWorkItem?
+
+    init(
+        client: AudioDuckingDeviceClient = CoreAudioDuckingDeviceClient(),
+        queue: DispatchQueue = DispatchQueue(label: "com.muesli.audio-ducking"),
+        stabilizationTimeout: TimeInterval = 0.5,
+        stabilizationPollInterval: TimeInterval = 0.05
+    ) {
+        self.client = client
+        self.queue = queue
+        self.stabilizationTimeout = stabilizationTimeout
+        self.stabilizationPollInterval = stabilizationPollInterval
+    }
+
+    func beginDictationDucking(enabled: Bool) {
+        queue.sync {
+            restoreWorkItem?.cancel()
+            restoreWorkItem = nil
+            duckingEnabledForSession = enabled
+            guard enabled, shouldDuckCurrentOutput() else { return }
+            duckCurrentDefaultDevice()
+        }
+    }
+
+    func ensureCurrentDefaultDucked() {
+        queue.sync {
+            guard duckingEnabledForSession, shouldDuckCurrentOutput() else { return }
+            duckCurrentDefaultDevice()
+        }
+    }
+
+    func restoreDictationDucking() {
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.restoreLocked()
+        }
+        queue.sync {
+            restoreWorkItem?.cancel()
+            restoreWorkItem = workItem
+        }
+        queue.async(execute: workItem)
+    }
+
+    func waitForIdle() {
+        queue.sync {}
+    }
+
+    private func shouldDuckCurrentOutput() -> Bool {
+        switch client.outputActivityStatus() {
+        case .active, .unknown:
+            return true
+        case .inactive:
+            return false
+        }
+    }
+
+    private func duckCurrentDefaultDevice() {
+        guard let deviceID = client.defaultOutputDeviceID(),
+              client.isDeviceAvailable(deviceID),
+              snapshots[deviceID] == nil else { return }
+
+        let sampleRate = client.nominalSampleRate(for: deviceID)
+        var snapshot = DeviceSnapshot(deviceID: deviceID, sampleRate: sampleRate)
+
+        let muteElements = client.muteElements(for: deviceID)
+        for element in muteElements {
+            guard let isMuted = client.isMuted(deviceID: deviceID, element: element),
+                  !isMuted else { continue }
+            if client.setMuted(true, deviceID: deviceID, element: element) {
+                snapshot.muteMutations.append(MuteMutation(element: element, previousValue: isMuted))
+            }
+        }
+
+        if snapshot.muteMutations.isEmpty {
+            for element in client.volumeElements(for: deviceID) {
+                guard let volume = client.volume(deviceID: deviceID, element: element),
+                      volume > 0.0001 else { continue }
+                if client.setVolume(0, deviceID: deviceID, element: element) {
+                    snapshot.volumeMutations.append(VolumeMutation(element: element, previousValue: volume))
+                }
+            }
+        }
+
+        if snapshot.hasMutations {
+            snapshots[deviceID] = snapshot
+        }
+    }
+
+    private func restoreLocked() {
+        waitForCodecStabilization()
+        let pendingSnapshots = snapshots.values
+        snapshots.removeAll()
+        duckingEnabledForSession = false
+
+        for snapshot in pendingSnapshots {
+            guard client.isDeviceAvailable(snapshot.deviceID) else { continue }
+            for mutation in snapshot.muteMutations {
+                guard client.isMuted(deviceID: snapshot.deviceID, element: mutation.element) == true else {
+                    continue
+                }
+                _ = client.setMuted(mutation.previousValue, deviceID: snapshot.deviceID, element: mutation.element)
+            }
+            for mutation in snapshot.volumeMutations {
+                guard let current = client.volume(deviceID: snapshot.deviceID, element: mutation.element),
+                      abs(current) <= 0.0001 else {
+                    continue
+                }
+                _ = client.setVolume(mutation.previousValue, deviceID: snapshot.deviceID, element: mutation.element)
+            }
+        }
+    }
+
+    private func waitForCodecStabilization() {
+        guard stabilizationTimeout > 0, stabilizationPollInterval > 0 else { return }
+        let deadline = Date().addingTimeInterval(stabilizationTimeout)
+        while Date() < deadline {
+            guard let defaultDeviceID = client.defaultOutputDeviceID(),
+                  let snapshot = snapshots[defaultDeviceID],
+                  let previousSampleRate = snapshot.sampleRate,
+                  let currentSampleRate = client.nominalSampleRate(for: defaultDeviceID),
+                  abs(currentSampleRate - previousSampleRate) > 0.5 else {
+                return
+            }
+            Thread.sleep(forTimeInterval: stabilizationPollInterval)
+        }
+    }
+}
+
+final class CoreAudioDuckingDeviceClient: AudioDuckingDeviceClient {
+    private let currentProcessID = ProcessInfo.processInfo.processIdentifier
+
+    func outputActivityStatus() -> AudioOutputActivityStatus {
+        guard let processIDs = processObjectIDs() else { return .unknown }
+        for processObjectID in processIDs {
+            guard boolProperty(kAudioProcessPropertyIsRunningOutput, objectID: processObjectID),
+                  let pid = pidProperty(objectID: processObjectID),
+                  pid > 0,
+                  pid != currentProcessID else { continue }
+            return .active
+        }
+        return .inactive
+    }
+
+    func defaultOutputDeviceID() -> AudioObjectID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &deviceID
+        ) == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
+            return nil
+        }
+        return deviceID
+    }
+
+    func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {
+        deviceID != AudioObjectID(kAudioObjectUnknown) && hasProperty(
+            kAudioObjectPropertyName,
+            objectID: deviceID,
+            scope: kAudioObjectPropertyScopeGlobal,
+            element: kAudioObjectPropertyElementMain
+        )
+    }
+
+    func nominalSampleRate(for deviceID: AudioObjectID) -> Double? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var sampleRate = Float64(0)
+        var dataSize = UInt32(MemoryLayout<Float64>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &sampleRate) == noErr else {
+            return nil
+        }
+        return sampleRate
+    }
+
+    func muteElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement] {
+        supportedElements(
+            for: kAudioDevicePropertyMute,
+            deviceID: deviceID,
+            scope: kAudioDevicePropertyScopeOutput
+        )
+    }
+
+    func isMuted(deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool? {
+        var value: UInt32 = 0
+        guard getUInt32(
+            kAudioDevicePropertyMute,
+            objectID: deviceID,
+            scope: kAudioDevicePropertyScopeOutput,
+            element: element,
+            value: &value
+        ) else {
+            return nil
+        }
+        return value != 0
+    }
+
+    func setMuted(_ muted: Bool, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool {
+        var value: UInt32 = muted ? 1 : 0
+        return setUInt32(
+            kAudioDevicePropertyMute,
+            objectID: deviceID,
+            scope: kAudioDevicePropertyScopeOutput,
+            element: element,
+            value: &value
+        )
+    }
+
+    func volumeElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement] {
+        supportedElements(
+            for: kAudioDevicePropertyVolumeScalar,
+            deviceID: deviceID,
+            scope: kAudioDevicePropertyScopeOutput
+        )
+    }
+
+    func volume(deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Float32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: element
+        )
+        var value = Float32(0)
+        var dataSize = UInt32(MemoryLayout<Float32>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &value) == noErr else {
+            return nil
+        }
+        return value
+    }
+
+    func setVolume(_ volume: Float32, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: element
+        )
+        var value = volume
+        let dataSize = UInt32(MemoryLayout<Float32>.size)
+        return AudioObjectSetPropertyData(deviceID, &address, 0, nil, dataSize, &value) == noErr
+    }
+
+    private func supportedElements(
+        for selector: AudioObjectPropertySelector,
+        deviceID: AudioObjectID,
+        scope: AudioObjectPropertyScope
+    ) -> [AudioObjectPropertyElement] {
+        let candidates = [
+            kAudioObjectPropertyElementMain,
+            AudioObjectPropertyElement(1),
+            AudioObjectPropertyElement(2),
+        ]
+        return candidates.filter {
+            hasProperty(selector, objectID: deviceID, scope: scope, element: $0)
+        }
+    }
+
+    private func processObjectIDs() -> [AudioObjectID]? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize
+        ) == noErr else {
+            return nil
+        }
+        guard dataSize > 0 else { return [] }
+
+        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+        var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &ids
+        ) == noErr else {
+            return nil
+        }
+        return ids.filter { $0 != AudioObjectID(kAudioObjectUnknown) }
+    }
+
+    private func pidProperty(objectID: AudioObjectID) -> pid_t? {
+        var pid = pid_t(0)
+        guard getPid(kAudioProcessPropertyPID, objectID: objectID, value: &pid) else {
+            return nil
+        }
+        return pid
+    }
+
+    private func boolProperty(_ selector: AudioObjectPropertySelector, objectID: AudioObjectID) -> Bool {
+        var value: UInt32 = 0
+        guard getUInt32(
+            selector,
+            objectID: objectID,
+            scope: kAudioObjectPropertyScopeGlobal,
+            element: kAudioObjectPropertyElementMain,
+            value: &value
+        ) else {
+            return false
+        }
+        return value != 0
+    }
+
+    private func hasProperty(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        return AudioObjectHasProperty(objectID, &address)
+    }
+
+    private func getUInt32(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+        value: inout UInt32
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
+    }
+
+    private func setUInt32(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+        value: inout UInt32
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        let dataSize = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectSetPropertyData(objectID, &address, 0, nil, dataSize, &value) == noErr
+    }
+
+    private func getPid(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        value: inout pid_t
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize = UInt32(MemoryLayout<pid_t>.size)
+        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -176,9 +176,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
-        let completions = restoreCompletions
-        restoreCompletions.removeAll()
-        completions.forEach { $0() }
+        // Preserve completions until a real restore happens; a new dictation keeps output ducked.
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -88,6 +88,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     func beginDictationDucking(enabled: Bool) {
         queue.async { [self] in
             guard enabled else {
+                self.cancelPendingRestoreLocked()
                 self.duckingEnabledForSession = false
                 self.restoreLocked(completion: nil)
                 return

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -81,8 +81,13 @@ final class AudioDuckingController: AudioDuckingManaging {
         queue.async { [self] in
             self.restoreWorkItem?.cancel()
             self.restoreWorkItem = nil
-            self.duckingEnabledForSession = enabled
-            guard enabled, self.shouldDuckCurrentOutput() else { return }
+            guard enabled else {
+                self.duckingEnabledForSession = false
+                self.restoreLocked()
+                return
+            }
+            self.duckingEnabledForSession = true
+            guard self.shouldDuckCurrentOutput() else { return }
             self.duckCurrentDefaultDevice()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -177,9 +177,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
-        let completions = restoreCompletions
         restoreCompletions.removeAll()
-        completions.forEach { $0() }
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -177,7 +177,9 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
+        let completions = restoreCompletions
         restoreCompletions.removeAll()
+        completions.forEach { $0() }
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -176,9 +176,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
-        let completions = restoreCompletions
         restoreCompletions.removeAll()
-        completions.forEach { $0() }
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -4,7 +4,13 @@ import Foundation
 protocol AudioDuckingManaging: AnyObject {
     func beginDictationDucking(enabled: Bool)
     func ensureCurrentDefaultDucked()
-    func restoreDictationDucking()
+    func restoreDictationDucking(completion: (() -> Void)?)
+}
+
+extension AudioDuckingManaging {
+    func restoreDictationDucking() {
+        restoreDictationDucking(completion: nil)
+    }
 }
 
 enum AudioOutputActivityStatus: Equatable, CustomStringConvertible {
@@ -65,6 +71,7 @@ final class AudioDuckingController: AudioDuckingManaging {
     private var snapshots: [AudioObjectID: DeviceSnapshot] = [:]
     private var restoreGeneration = 0
     private var isRestorePending = false
+    private var restoreCompletions: [() -> Void] = []
 
     init(
         client: AudioDuckingDeviceClient = CoreAudioDuckingDeviceClient(),
@@ -82,7 +89,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         queue.async { [self] in
             guard enabled else {
                 self.duckingEnabledForSession = false
-                self.restoreLocked()
+                self.restoreLocked(completion: nil)
                 return
             }
             self.cancelPendingRestoreLocked()
@@ -99,9 +106,9 @@ final class AudioDuckingController: AudioDuckingManaging {
         }
     }
 
-    func restoreDictationDucking() {
+    func restoreDictationDucking(completion: (() -> Void)? = nil) {
         queue.async { [self] in
-            restoreLocked()
+            restoreLocked(completion: completion)
         }
     }
 
@@ -153,7 +160,10 @@ final class AudioDuckingController: AudioDuckingManaging {
         }
     }
 
-    private func restoreLocked() {
+    private func restoreLocked(completion: (() -> Void)?) {
+        if let completion {
+            restoreCompletions.append(completion)
+        }
         restoreGeneration += 1
         isRestorePending = true
         scheduleRestoreAfterCodecStabilizationLocked(
@@ -166,6 +176,7 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
+        restoreCompletions.removeAll()
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {
@@ -185,6 +196,8 @@ final class AudioDuckingController: AudioDuckingManaging {
         snapshots.removeAll()
         duckingEnabledForSession = false
         isRestorePending = false
+        let completions = restoreCompletions
+        restoreCompletions.removeAll()
 
         for snapshot in pendingSnapshots {
             guard client.isDeviceAvailable(snapshot.deviceID) else { continue }
@@ -202,6 +215,7 @@ final class AudioDuckingController: AudioDuckingManaging {
                 _ = client.setVolume(mutation.previousValue, deviceID: snapshot.deviceID, element: mutation.element)
             }
         }
+        completions.forEach { $0() }
     }
 
     private func shouldWaitForCodecStabilizationLocked(until deadline: Date) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -88,12 +88,12 @@ final class AudioDuckingController: AudioDuckingManaging {
     func beginDictationDucking(enabled: Bool) {
         queue.async { [self] in
             guard enabled else {
-                self.cancelPendingRestoreLocked()
+                self.cancelPendingRestoreLocked(preserveCompletions: true)
                 self.duckingEnabledForSession = false
                 self.restoreLocked(completion: nil)
                 return
             }
-            self.cancelPendingRestoreLocked()
+            self.cancelPendingRestoreLocked(preserveCompletions: false)
             self.duckingEnabledForSession = true
             guard self.shouldDuckCurrentOutput() else { return }
             self.duckCurrentDefaultDevice()
@@ -173,11 +173,13 @@ final class AudioDuckingController: AudioDuckingManaging {
         )
     }
 
-    private func cancelPendingRestoreLocked() {
+    private func cancelPendingRestoreLocked(preserveCompletions: Bool) {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
-        restoreCompletions.removeAll()
+        if !preserveCompletions {
+            restoreCompletions.removeAll()
+        }
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioDuckingController.swift
@@ -176,7 +176,9 @@ final class AudioDuckingController: AudioDuckingManaging {
         guard isRestorePending else { return }
         restoreGeneration += 1
         isRestorePending = false
+        let completions = restoreCompletions
         restoreCompletions.removeAll()
+        completions.forEach { $0() }
     }
 
     private func scheduleRestoreAfterCodecStabilizationLocked(generation: Int, deadline: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -46,6 +46,18 @@ struct AudioOutputDeviceDescription: Equatable {
 }
 
 enum AudioRouteClassifier {
+    struct Classification: Equatable {
+        let kind: AudioOutputRouteKind
+        let isAmbiguousBluetooth: Bool
+    }
+
+    static func outputRouteClassification(for device: AudioOutputDeviceDescription) -> Classification {
+        Classification(
+            kind: outputRouteKind(for: device),
+            isAmbiguousBluetooth: isAmbiguousBluetoothWithoutRouteMetadata(device)
+        )
+    }
+
     static func outputRouteKind(for device: AudioOutputDeviceDescription) -> AudioOutputRouteKind {
         guard device.hasOutputStreams else { return .unknown }
 
@@ -81,6 +93,13 @@ enum AudioRouteClassifier {
         kAudioStreamTerminalTypeLFESpeaker,
         kAudioStreamTerminalTypeReceiverSpeaker,
     ]
+
+    private static func isAmbiguousBluetoothWithoutRouteMetadata(_ device: AudioOutputDeviceDescription) -> Bool {
+        guard device.hasOutputStreams, device.hasInputStreams else { return false }
+        guard device.transportType == kAudioDeviceTransportTypeBluetooth
+            || device.transportType == kAudioDeviceTransportTypeBluetoothLE else { return false }
+        return device.outputTerminalTypes.union(device.outputDataSourceKinds).isEmpty
+    }
 }
 
 protocol DictationAudioRouting: AnyObject {
@@ -98,6 +117,7 @@ protocol DictationAudioRouting: AnyObject {
 final class DictationAudioRouteController: DictationAudioRouting {
     private struct RouteSnapshot {
         var outputRouteKind: AudioOutputRouteKind = .unknown
+        var outputIsAmbiguousBluetooth: Bool = false
         var builtInInputDeviceID: AudioObjectID?
     }
 
@@ -118,10 +138,12 @@ final class DictationAudioRouteController: DictationAudioRouting {
         self.inspector = inspector
         self.queue = queue
         self.queue.setSpecific(key: queueKey, value: ())
+        let initialOutputClassification = inspector.defaultOutputDeviceID().map {
+            inspector.outputRouteClassification(for: $0)
+        }
         self.snapshot = RouteSnapshot(
-            outputRouteKind: inspector.defaultOutputDeviceID().map {
-                inspector.outputRouteKind(for: $0)
-            } ?? .unknown,
+            outputRouteKind: initialOutputClassification?.kind ?? .unknown,
+            outputIsAmbiguousBluetooth: initialOutputClassification?.isAmbiguousBluetooth ?? false,
             builtInInputDeviceID: inspector.builtInInputDeviceID()
         )
         if observesDefaultOutputChanges {
@@ -223,20 +245,30 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
-        guard snapshot.outputRouteKind != .speakerLike else { return nil }
-        return snapshot.builtInInputDeviceID
+        switch snapshot.outputRouteKind {
+        case .headphoneLike:
+            return snapshot.builtInInputDeviceID
+        case .speakerLike:
+            return nil
+        case .unknown:
+            return snapshot.outputIsAmbiguousBluetooth ? snapshot.builtInInputDeviceID : nil
+        }
     }
 
     private func makeRouteSnapshot() -> RouteSnapshot {
-        RouteSnapshot(
-            outputRouteKind: currentOutputRouteKind(),
+        let outputClassification = currentOutputRouteClassification()
+        return RouteSnapshot(
+            outputRouteKind: outputClassification.kind,
+            outputIsAmbiguousBluetooth: outputClassification.isAmbiguousBluetooth,
             builtInInputDeviceID: inspector.builtInInputDeviceID()
         )
     }
 
-    private func currentOutputRouteKind() -> AudioOutputRouteKind {
-        guard let outputDeviceID = inspector.defaultOutputDeviceID() else { return .unknown }
-        return inspector.outputRouteKind(for: outputDeviceID)
+    private func currentOutputRouteClassification() -> AudioRouteClassifier.Classification {
+        guard let outputDeviceID = inspector.defaultOutputDeviceID() else {
+            return AudioRouteClassifier.Classification(kind: .unknown, isAmbiguousBluetooth: false)
+        }
+        return inspector.outputRouteClassification(for: outputDeviceID)
     }
 
     private func installDefaultOutputListener() {
@@ -294,7 +326,7 @@ protocol CoreAudioDeviceInspecting {
     func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool
     func nominalSampleRate(for deviceID: AudioObjectID) -> Double?
-    func outputRouteKind(for deviceID: AudioObjectID) -> AudioOutputRouteKind
+    func outputRouteClassification(for deviceID: AudioObjectID) -> AudioRouteClassifier.Classification
     func builtInInputDeviceID() -> AudioObjectID?
 }
 
@@ -349,17 +381,23 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
         return sampleRate
     }
 
+    func outputRouteClassification(for deviceID: AudioObjectID) -> AudioRouteClassifier.Classification {
+        AudioRouteClassifier.outputRouteClassification(for: outputDeviceDescription(for: deviceID))
+    }
+
     func outputRouteKind(for deviceID: AudioObjectID) -> AudioOutputRouteKind {
-        AudioRouteClassifier.outputRouteKind(
-            for: AudioOutputDeviceDescription(
-                name: deviceName(for: deviceID),
-                transportType: transportType(for: deviceID),
-                hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput),
-                hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput),
-                outputTerminalTypes: outputTerminalTypes(for: deviceID),
-                outputDataSourceKinds: outputDataSourceKinds(for: deviceID),
-                nominalSampleRate: nominalSampleRate(for: deviceID)
-            )
+        outputRouteClassification(for: deviceID).kind
+    }
+
+    private func outputDeviceDescription(for deviceID: AudioObjectID) -> AudioOutputDeviceDescription {
+        AudioOutputDeviceDescription(
+            name: deviceName(for: deviceID),
+            transportType: transportType(for: deviceID),
+            hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput),
+            hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput),
+            outputTerminalTypes: outputTerminalTypes(for: deviceID),
+            outputDataSourceKinds: outputDataSourceKinds(for: deviceID),
+            nominalSampleRate: nominalSampleRate(for: deviceID)
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -43,11 +43,11 @@ enum AudioRouteClassifier {
     static func outputRouteKind(for device: AudioOutputDeviceDescription) -> AudioOutputRouteKind {
         guard device.hasOutputStreams else { return .unknown }
 
-        if device.outputTerminalTypes.contains(kAudioStreamTerminalTypeHeadphones) {
-            return .headphoneLike
-        }
         if !device.outputTerminalTypes.isDisjoint(with: speakerTerminalTypes) {
             return .speakerLike
+        }
+        if device.outputTerminalTypes.contains(kAudioStreamTerminalTypeHeadphones) {
+            return .headphoneLike
         }
 
         if device.transportType == kAudioDeviceTransportTypeBluetooth
@@ -57,6 +57,12 @@ enum AudioRouteClassifier {
             return device.hasInputStreams ? .headphoneLike : .speakerLike
         }
 
+        if let transportType = device.transportType,
+           inputCapableWiredTransports.contains(transportType),
+           device.hasInputStreams {
+            return .headphoneLike
+        }
+
         return .speakerLike
     }
 
@@ -64,6 +70,11 @@ enum AudioRouteClassifier {
         kAudioStreamTerminalTypeSpeaker,
         kAudioStreamTerminalTypeLFESpeaker,
         kAudioStreamTerminalTypeReceiverSpeaker,
+    ]
+
+    private static let inputCapableWiredTransports: Set<UInt32> = [
+        kAudioDeviceTransportTypeUSB,
+        kAudioDeviceTransportTypeThunderbolt,
     ]
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -463,7 +463,7 @@ enum AudioInputDeviceSelection {
         to engine: AVAudioEngine,
         logPrefix: String
     ) {
-        guard var deviceID = preferredInputDeviceID ?? CoreAudioDeviceInspector().defaultInputDeviceID() else {
+        guard var deviceID = preferredInputDeviceID else {
             return
         }
         guard let audioUnit = engine.inputNode.audioUnit else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -128,7 +128,15 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private var snapshot = RouteSnapshot()
     private var defaultOutputListener: AudioObjectPropertyListenerBlock?
     private var defaultInputListener: AudioObjectPropertyListenerBlock?
-    var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
+    private var onPreferredInputDeviceChangedStorage: ((AudioObjectID?) -> Void)?
+    var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)? {
+        get {
+            lock.withLock { onPreferredInputDeviceChangedStorage }
+        }
+        set {
+            lock.withLock { onPreferredInputDeviceChangedStorage = newValue }
+        }
+    }
 
     init(
         inspector: CoreAudioDeviceInspecting = CoreAudioDeviceInspector(),
@@ -189,7 +197,8 @@ final class DictationAudioRouteController: DictationAudioRouting {
             }
             let preferredInputDeviceID = Self.preferredInputDeviceID(for: next)
             if notifyEvenIfPreferredUnchanged || previousPreferredInputDeviceID != preferredInputDeviceID {
-                self.onPreferredInputDeviceChanged?(preferredInputDeviceID)
+                let handler = self.onPreferredInputDeviceChanged
+                handler?(preferredInputDeviceID)
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -64,6 +64,9 @@ enum AudioRouteClassifier {
             // If CoreAudio only exposes generic Bluetooth metadata, a high-rate
             // output with an input stream is more likely a speakerphone/soundbar
             // profile than a headset microphone profile.
+            // Known limitation: low-rate Bluetooth speakers with embedded mics
+            // can look headset-like when CoreAudio omits terminal/data-source
+            // metadata.
             if device.hasInputStreams,
                let sampleRate = device.nominalSampleRate,
                sampleRate > 24_000 {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -1,0 +1,484 @@
+import AudioToolbox
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+
+enum AudioOutputRouteKind: Equatable, CustomStringConvertible {
+    case speakerLike
+    case headphoneLike
+    case unknown
+
+    var description: String {
+        switch self {
+        case .speakerLike: return "speaker-like"
+        case .headphoneLike: return "headphone-like"
+        case .unknown: return "unknown"
+        }
+    }
+}
+
+struct AudioOutputDeviceDescription: Equatable {
+    let name: String?
+    let transportType: UInt32?
+    let hasOutputStreams: Bool
+}
+
+enum AudioRouteClassifier {
+    static func outputRouteKind(for device: AudioOutputDeviceDescription) -> AudioOutputRouteKind {
+        guard device.hasOutputStreams else { return .unknown }
+
+        let normalizedName = (device.name ?? "").lowercased()
+        if containsAny(normalizedName, keywords: headphoneKeywords) {
+            return .headphoneLike
+        }
+
+        if device.transportType == kAudioDeviceTransportTypeBluetooth
+            || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
+            return containsAny(normalizedName, keywords: bluetoothSpeakerKeywords)
+                ? .speakerLike
+                : .headphoneLike
+        }
+
+        return .speakerLike
+    }
+
+    private static let headphoneKeywords = [
+        "airpods",
+        "earpods",
+        "earbuds",
+        "headphone",
+        "headphones",
+        "headset",
+        "buds",
+        "beats",
+        "wh-",
+        "wf-",
+        "xm3",
+        "xm4",
+        "xm5",
+        "bose qc",
+        "quietcomfort",
+        "jabra",
+        "elite",
+        "galaxy buds",
+        "pixel buds",
+    ]
+
+    private static let bluetoothSpeakerKeywords = [
+        "speaker",
+        "soundbar",
+        "sonos",
+        "homepod",
+        "jbl",
+        "flip",
+        "charge",
+        "boom",
+        "echo",
+        "nest audio",
+    ]
+
+    private static func containsAny(_ value: String, keywords: [String]) -> Bool {
+        keywords.contains { value.contains($0) }
+    }
+}
+
+protocol DictationAudioRouting: AnyObject {
+    var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)? { get set }
+
+    func refreshRouteCache()
+    func preferredInputDeviceIDForDictation() -> AudioObjectID?
+    func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID?
+    func isDefaultOutputHeadphoneLike() -> Bool
+    func currentOutputRouteKindForDebug() -> AudioOutputRouteKind
+    func currentRouteDebugDescription() -> String
+    func beginDictationInputOverride()
+    func restoreDictationInputOverride()
+}
+
+final class DictationAudioRouteController: DictationAudioRouting {
+    private struct RouteSnapshot {
+        var outputRouteKind: AudioOutputRouteKind = .unknown
+        var builtInInputDeviceID: AudioObjectID?
+    }
+
+    private let inspector: CoreAudioDeviceInspector
+    private let queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<Void>()
+    private let lock = NSLock()
+    private var snapshot = RouteSnapshot()
+    private var defaultOutputListener: AudioObjectPropertyListenerBlock?
+    var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
+
+    init(
+        inspector: CoreAudioDeviceInspector = CoreAudioDeviceInspector(),
+        queue: DispatchQueue = DispatchQueue(label: "com.muesli.dictation-audio-route")
+    ) {
+        self.inspector = inspector
+        self.queue = queue
+        self.queue.setSpecific(key: queueKey, value: ())
+        self.snapshot = RouteSnapshot(
+            outputRouteKind: inspector.defaultOutputDeviceID().map {
+                inspector.outputRouteKind(for: $0)
+            } ?? .unknown,
+            builtInInputDeviceID: inspector.builtInInputDeviceID()
+        )
+        installDefaultOutputListener()
+        refreshRouteCache()
+    }
+
+    deinit {
+        guard let defaultOutputListener else { return }
+        var address = Self.defaultOutputDeviceAddress()
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            queue,
+            defaultOutputListener
+        )
+    }
+
+    func refreshRouteCache() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let next = self.makeRouteSnapshot()
+            let previousPreferredInputDeviceID = self.lock.withLock { () -> AudioObjectID? in
+                let previous = self.snapshot
+                self.snapshot = next
+                return Self.preferredInputDeviceID(for: previous)
+            }
+            let preferredInputDeviceID = Self.preferredInputDeviceID(for: next)
+            if previousPreferredInputDeviceID != preferredInputDeviceID {
+                self.onPreferredInputDeviceChanged?(preferredInputDeviceID)
+            }
+        }
+    }
+
+    func preferredInputDeviceIDForDictation() -> AudioObjectID? {
+        syncOnRouteQueue {
+            let next = makeRouteSnapshot()
+            lock.withLock {
+                snapshot = next
+            }
+        }
+        return Self.preferredInputDeviceID(for: lock.withLock { snapshot })
+    }
+
+    func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID? {
+        Self.preferredInputDeviceID(for: lock.withLock { snapshot })
+    }
+
+    func isDefaultOutputHeadphoneLike() -> Bool {
+        lock.withLock { snapshot.outputRouteKind != .speakerLike }
+    }
+
+    func currentOutputRouteKindForDebug() -> AudioOutputRouteKind {
+        lock.withLock { snapshot.outputRouteKind }
+    }
+
+    func currentRouteDebugDescription() -> String {
+        let current = lock.withLock { snapshot }
+        let preferredInput = Self.preferredInputDeviceID(for: current)
+            .map(String.init) ?? "default"
+        return "output=\(current.outputRouteKind.description) preferredInput=\(preferredInput)"
+    }
+
+    func beginDictationInputOverride() {
+        syncOnRouteQueue {
+            let current = makeRouteSnapshot()
+            lock.withLock {
+                snapshot = current
+            }
+        }
+    }
+
+    func restoreDictationInputOverride() {
+        syncOnRouteQueue {
+            let current = makeRouteSnapshot()
+            lock.withLock {
+                snapshot = current
+            }
+        }
+    }
+
+    private func syncOnRouteQueue(_ work: () -> Void) {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            work()
+        } else {
+            queue.sync(execute: work)
+        }
+    }
+
+    private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
+        switch snapshot.outputRouteKind {
+        case .headphoneLike, .unknown:
+            return snapshot.builtInInputDeviceID
+        case .speakerLike:
+            return nil
+        }
+    }
+
+    private func makeRouteSnapshot() -> RouteSnapshot {
+        RouteSnapshot(
+            outputRouteKind: currentOutputRouteKind(),
+            builtInInputDeviceID: inspector.builtInInputDeviceID()
+        )
+    }
+
+    private func currentOutputRouteKind() -> AudioOutputRouteKind {
+        guard let outputDeviceID = inspector.defaultOutputDeviceID() else { return .unknown }
+        return inspector.outputRouteKind(for: outputDeviceID)
+    }
+
+    private func installDefaultOutputListener() {
+        var address = Self.defaultOutputDeviceAddress()
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.refreshRouteCache()
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            queue,
+            listener
+        )
+        if status == noErr {
+            defaultOutputListener = listener
+        }
+    }
+
+    private static func defaultOutputDeviceAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+}
+
+final class CoreAudioDeviceInspector {
+    func defaultOutputDeviceID() -> AudioObjectID? {
+        defaultDeviceID(selector: kAudioHardwarePropertyDefaultOutputDevice)
+    }
+
+    func defaultInputDeviceID() -> AudioObjectID? {
+        defaultDeviceID(selector: kAudioHardwarePropertyDefaultInputDevice)
+    }
+
+    func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var mutableDeviceID = deviceID
+        let dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        return AudioObjectSetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            dataSize,
+            &mutableDeviceID
+        ) == noErr
+    }
+
+    func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {
+        deviceID != AudioObjectID(kAudioObjectUnknown)
+            && hasProperty(
+                kAudioObjectPropertyName,
+                objectID: deviceID,
+                scope: kAudioObjectPropertyScopeGlobal,
+                element: kAudioObjectPropertyElementMain
+            )
+    }
+
+    func nominalSampleRate(for deviceID: AudioObjectID) -> Double? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var sampleRate = Float64(0)
+        var dataSize = UInt32(MemoryLayout<Float64>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &sampleRate) == noErr else {
+            return nil
+        }
+        return sampleRate
+    }
+
+    func outputRouteKind(for deviceID: AudioObjectID) -> AudioOutputRouteKind {
+        AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: deviceName(for: deviceID),
+                transportType: transportType(for: deviceID),
+                hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput)
+            )
+        )
+    }
+
+    func builtInInputDeviceID() -> AudioObjectID? {
+        let builtInInputs = allDeviceIDs().filter {
+            transportType(for: $0) == kAudioDeviceTransportTypeBuiltIn
+                && hasStreams(deviceID: $0, scope: kAudioDevicePropertyScopeInput)
+        }
+        return builtInInputs.sorted { inputDeviceSortKey($0) < inputDeviceSortKey($1) }.first
+    }
+
+    private func inputDeviceSortKey(_ deviceID: AudioObjectID) -> String {
+        let name = (deviceName(for: deviceID) ?? "").lowercased()
+        if name.contains("microphone") { return "0-\(name)" }
+        if name.contains("macbook") { return "1-\(name)" }
+        if name.contains("built-in") { return "2-\(name)" }
+        return "9-\(name)"
+    }
+
+    private func allDeviceIDs() -> [AudioObjectID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize
+        ) == noErr, dataSize > 0 else {
+            return []
+        }
+
+        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+        var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &ids
+        ) == noErr else {
+            return []
+        }
+        return ids.filter { $0 != AudioObjectID(kAudioObjectUnknown) }
+    }
+
+    private func defaultDeviceID(selector: AudioObjectPropertySelector) -> AudioObjectID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &deviceID
+        ) == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
+            return nil
+        }
+        return deviceID
+    }
+
+    private func deviceName(for deviceID: AudioObjectID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var name: Unmanaged<CFString>?
+        var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &name) == noErr,
+              let name else {
+            return nil
+        }
+        return name.takeRetainedValue() as String
+    }
+
+    private func transportType(for deviceID: AudioObjectID) -> UInt32? {
+        var transportType = UInt32(0)
+        guard getUInt32(
+            kAudioDevicePropertyTransportType,
+            objectID: deviceID,
+            scope: kAudioObjectPropertyScopeGlobal,
+            element: kAudioObjectPropertyElementMain,
+            value: &transportType
+        ) else {
+            return nil
+        }
+        return transportType
+    }
+
+    private func hasStreams(deviceID: AudioObjectID, scope: AudioObjectPropertyScope) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        return AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr
+            && dataSize >= MemoryLayout<AudioObjectID>.size
+    }
+
+    private func hasProperty(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        return AudioObjectHasProperty(objectID, &address)
+    }
+
+    private func getUInt32(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+        value: inout UInt32
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
+    }
+}
+
+enum AudioInputDeviceSelection {
+    static func applyPreferredInputDeviceID(
+        _ preferredInputDeviceID: AudioObjectID?,
+        to engine: AVAudioEngine,
+        logPrefix: String
+    ) {
+        guard var deviceID = preferredInputDeviceID ?? CoreAudioDeviceInspector().defaultInputDeviceID() else {
+            return
+        }
+        guard let audioUnit = engine.inputNode.audioUnit else {
+            fputs("[\(logPrefix)] no audio unit available for preferred input routing\n", stderr)
+            return
+        }
+
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            UInt32(MemoryLayout<AudioObjectID>.size)
+        )
+        if status != noErr {
+            fputs("[\(logPrefix)] failed to set preferred input device \(deviceID): \(status)\n", stderr)
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -91,8 +91,7 @@ protocol DictationAudioRouting: AnyObject {
     func isDefaultOutputHeadphoneLike() -> Bool
     func currentOutputRouteKindForDebug() -> AudioOutputRouteKind
     func currentRouteDebugDescription() -> String
-    func beginDictationInputOverride()
-    func restoreDictationInputOverride()
+    func refreshRouteAfterDictationSession()
 }
 
 final class DictationAudioRouteController: DictationAudioRouting {
@@ -171,6 +170,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     func isDefaultOutputHeadphoneLike() -> Bool {
+        // Unknown outputs are treated as non-speaker for lifecycle sounds so we
+        // avoid playing cues into headphones during CoreAudio route transitions.
+        // Ducking uses RouteSnapshot.shouldDuck and still fails open for unknown.
         lock.withLock { snapshot.outputRouteKind != .speakerLike }
     }
 
@@ -185,16 +187,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         return "output=\(current.outputRouteKind.description) preferredInput=\(preferredInput)"
     }
 
-    func beginDictationInputOverride() {
-        syncOnRouteQueue {
-            let current = makeRouteSnapshot()
-            lock.withLock {
-                snapshot = current
-            }
-        }
-    }
-
-    func restoreDictationInputOverride() {
+    func refreshRouteAfterDictationSession() {
         syncOnRouteQueue {
             let current = makeRouteSnapshot()
             lock.withLock {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -23,19 +23,22 @@ struct AudioOutputDeviceDescription: Equatable {
     let hasOutputStreams: Bool
     let hasInputStreams: Bool
     let outputTerminalTypes: Set<UInt32>
+    let outputDataSourceKinds: Set<UInt32>
 
     init(
         name: String?,
         transportType: UInt32?,
         hasOutputStreams: Bool,
         hasInputStreams: Bool,
-        outputTerminalTypes: Set<UInt32> = []
+        outputTerminalTypes: Set<UInt32> = [],
+        outputDataSourceKinds: Set<UInt32> = []
     ) {
         self.name = name
         self.transportType = transportType
         self.hasOutputStreams = hasOutputStreams
         self.hasInputStreams = hasInputStreams
         self.outputTerminalTypes = outputTerminalTypes
+        self.outputDataSourceKinds = outputDataSourceKinds
     }
 }
 
@@ -43,10 +46,11 @@ enum AudioRouteClassifier {
     static func outputRouteKind(for device: AudioOutputDeviceDescription) -> AudioOutputRouteKind {
         guard device.hasOutputStreams else { return .unknown }
 
-        if !device.outputTerminalTypes.isDisjoint(with: speakerTerminalTypes) {
+        let routeKinds = device.outputTerminalTypes.union(device.outputDataSourceKinds)
+        if !routeKinds.isDisjoint(with: speakerTerminalTypes) {
             return .speakerLike
         }
-        if device.outputTerminalTypes.contains(kAudioStreamTerminalTypeHeadphones) {
+        if routeKinds.contains(kAudioStreamTerminalTypeHeadphones) {
             return .headphoneLike
         }
 
@@ -57,12 +61,6 @@ enum AudioRouteClassifier {
             return device.hasInputStreams ? .headphoneLike : .speakerLike
         }
 
-        if let transportType = device.transportType,
-           inputCapableWiredTransports.contains(transportType),
-           device.hasInputStreams {
-            return .headphoneLike
-        }
-
         return .speakerLike
     }
 
@@ -70,11 +68,6 @@ enum AudioRouteClassifier {
         kAudioStreamTerminalTypeSpeaker,
         kAudioStreamTerminalTypeLFESpeaker,
         kAudioStreamTerminalTypeReceiverSpeaker,
-    ]
-
-    private static let inputCapableWiredTransports: Set<UInt32> = [
-        kAudioDeviceTransportTypeUSB,
-        kAudioDeviceTransportTypeThunderbolt,
     ]
 }
 
@@ -350,7 +343,8 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
                 transportType: transportType(for: deviceID),
                 hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput),
                 hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput),
-                outputTerminalTypes: outputTerminalTypes(for: deviceID)
+                outputTerminalTypes: outputTerminalTypes(for: deviceID),
+                outputDataSourceKinds: outputDataSourceKinds(for: deviceID)
             )
         )
     }
@@ -464,6 +458,13 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
         )
     }
 
+    private func outputDataSourceKinds(for deviceID: AudioObjectID) -> Set<UInt32> {
+        Set(
+            currentDataSourceIDs(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput)
+                .compactMap { sourceID in dataSourceKind(for: sourceID, deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput) }
+        )
+    }
+
     private func streamIDs(deviceID: AudioObjectID, scope: AudioObjectPropertyScope) -> [AudioObjectID] {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyStreams,
@@ -495,6 +496,58 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
             return nil
         }
         return terminalType
+    }
+
+    private func currentDataSourceIDs(deviceID: AudioObjectID, scope: AudioObjectPropertyScope) -> [UInt32] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDataSource,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr,
+              dataSize >= MemoryLayout<UInt32>.size else {
+            return []
+        }
+        let count = Int(dataSize) / MemoryLayout<UInt32>.size
+        var ids = [UInt32](repeating: 0, count: count)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &ids) == noErr else {
+            return []
+        }
+        return ids
+    }
+
+    private func dataSourceKind(
+        for sourceID: UInt32,
+        deviceID: AudioObjectID,
+        scope: AudioObjectPropertyScope
+    ) -> UInt32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDataSourceKindForID,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var source = sourceID
+        var kind = UInt32(0)
+        let sourceSize = UInt32(MemoryLayout<UInt32>.size)
+        let kindSize = UInt32(MemoryLayout<UInt32>.size)
+        var result: UInt32?
+        withUnsafeMutablePointer(to: &source) { sourcePointer in
+            withUnsafeMutablePointer(to: &kind) { kindPointer in
+                var translation = AudioValueTranslation(
+                    mInputData: sourcePointer,
+                    mInputDataSize: sourceSize,
+                    mOutputData: kindPointer,
+                    mOutputDataSize: kindSize
+                )
+                var dataSize = UInt32(MemoryLayout<AudioValueTranslation>.size)
+                guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &translation) == noErr else {
+                    return
+                }
+                result = kindPointer.pointee
+            }
+        }
+        return result
     }
 
     private func hasProperty(

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -27,58 +27,12 @@ enum AudioRouteClassifier {
     static func outputRouteKind(for device: AudioOutputDeviceDescription) -> AudioOutputRouteKind {
         guard device.hasOutputStreams else { return .unknown }
 
-        let normalizedName = (device.name ?? "").lowercased()
-        if containsAny(normalizedName, keywords: headphoneKeywords) {
+        if device.transportType == kAudioDeviceTransportTypeBluetooth
+            || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
             return .headphoneLike
         }
 
-        if device.transportType == kAudioDeviceTransportTypeBluetooth
-            || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
-            return containsAny(normalizedName, keywords: bluetoothSpeakerKeywords)
-                ? .speakerLike
-                : .headphoneLike
-        }
-
         return .speakerLike
-    }
-
-    private static let headphoneKeywords = [
-        "airpods",
-        "earpods",
-        "earbuds",
-        "headphone",
-        "headphones",
-        "headset",
-        "buds",
-        "beats",
-        "wh-",
-        "wf-",
-        "xm3",
-        "xm4",
-        "xm5",
-        "bose qc",
-        "quietcomfort",
-        "jabra",
-        "elite",
-        "galaxy buds",
-        "pixel buds",
-    ]
-
-    private static let bluetoothSpeakerKeywords = [
-        "speaker",
-        "soundbar",
-        "sonos",
-        "homepod",
-        "jbl",
-        "flip",
-        "charge",
-        "boom",
-        "echo",
-        "nest audio",
-    ]
-
-    private static func containsAny(_ value: String, keywords: [String]) -> Bool {
-        keywords.contains { value.contains($0) }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -104,10 +104,12 @@ enum AudioRouteClassifier {
     private static func isLikelyPersonalWiredOutput(_ device: AudioOutputDeviceDescription) -> Bool {
         guard let transportType = device.transportType else { return false }
         switch transportType {
-        case kAudioDeviceTransportTypeBuiltIn,
-             kAudioDeviceTransportTypeUSB,
+        case kAudioDeviceTransportTypeUSB,
              kAudioDeviceTransportTypeThunderbolt:
-            return true
+            // Missing terminal metadata leaves USB/TB ambiguous. Only
+            // bidirectional devices can plausibly be headsets; pure outputs
+            // stay speaker-like so ducking remains available.
+            return device.hasInputStreams
         default:
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -106,6 +106,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private let lock = NSLock()
     private var snapshot = RouteSnapshot()
     private var defaultOutputListener: AudioObjectPropertyListenerBlock?
+    private var defaultInputListener: AudioObjectPropertyListenerBlock?
     var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
 
     init(
@@ -124,22 +125,37 @@ final class DictationAudioRouteController: DictationAudioRouting {
         )
         if observesDefaultOutputChanges {
             installDefaultOutputListener()
+            installDefaultInputListener()
         }
         refreshRouteCache()
     }
 
     deinit {
-        guard let defaultOutputListener else { return }
-        var address = Self.defaultOutputDeviceAddress()
-        AudioObjectRemovePropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address,
-            queue,
-            defaultOutputListener
-        )
+        if let defaultOutputListener {
+            var address = Self.defaultOutputDeviceAddress()
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                queue,
+                defaultOutputListener
+            )
+        }
+        if let defaultInputListener {
+            var address = Self.defaultInputDeviceAddress()
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                queue,
+                defaultInputListener
+            )
+        }
     }
 
     func refreshRouteCache() {
+        refreshRouteCache(notifyEvenIfPreferredUnchanged: false)
+    }
+
+    private func refreshRouteCache(notifyEvenIfPreferredUnchanged: Bool) {
         queue.async { [weak self] in
             guard let self else { return }
             let next = self.makeRouteSnapshot()
@@ -149,7 +165,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
                 return Self.preferredInputDeviceID(for: previous)
             }
             let preferredInputDeviceID = Self.preferredInputDeviceID(for: next)
-            if previousPreferredInputDeviceID != preferredInputDeviceID {
+            if notifyEvenIfPreferredUnchanged || previousPreferredInputDeviceID != preferredInputDeviceID {
                 self.onPreferredInputDeviceChanged?(preferredInputDeviceID)
             }
         }
@@ -237,9 +253,33 @@ final class DictationAudioRouteController: DictationAudioRouting {
         }
     }
 
+    private func installDefaultInputListener() {
+        var address = Self.defaultInputDeviceAddress()
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            queue,
+            listener
+        )
+        if status == noErr {
+            defaultInputListener = listener
+        }
+    }
+
     private static func defaultOutputDeviceAddress() -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+
+    private static func defaultInputDeviceAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -22,11 +22,33 @@ struct AudioOutputDeviceDescription: Equatable {
     let transportType: UInt32?
     let hasOutputStreams: Bool
     let hasInputStreams: Bool
+    let outputTerminalTypes: Set<UInt32>
+
+    init(
+        name: String?,
+        transportType: UInt32?,
+        hasOutputStreams: Bool,
+        hasInputStreams: Bool,
+        outputTerminalTypes: Set<UInt32> = []
+    ) {
+        self.name = name
+        self.transportType = transportType
+        self.hasOutputStreams = hasOutputStreams
+        self.hasInputStreams = hasInputStreams
+        self.outputTerminalTypes = outputTerminalTypes
+    }
 }
 
 enum AudioRouteClassifier {
     static func outputRouteKind(for device: AudioOutputDeviceDescription) -> AudioOutputRouteKind {
         guard device.hasOutputStreams else { return .unknown }
+
+        if device.outputTerminalTypes.contains(kAudioStreamTerminalTypeHeadphones) {
+            return .headphoneLike
+        }
+        if !device.outputTerminalTypes.isDisjoint(with: speakerTerminalTypes) {
+            return .speakerLike
+        }
 
         if device.transportType == kAudioDeviceTransportTypeBluetooth
             || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
@@ -37,6 +59,12 @@ enum AudioRouteClassifier {
 
         return .speakerLike
     }
+
+    private static let speakerTerminalTypes: Set<UInt32> = [
+        kAudioStreamTerminalTypeSpeaker,
+        kAudioStreamTerminalTypeLFESpeaker,
+        kAudioStreamTerminalTypeReceiverSpeaker,
+    ]
 }
 
 protocol DictationAudioRouting: AnyObject {
@@ -310,7 +338,8 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
                 name: deviceName(for: deviceID),
                 transportType: transportType(for: deviceID),
                 hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput),
-                hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput)
+                hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput),
+                outputTerminalTypes: outputTerminalTypes(for: deviceID)
             )
         )
     }
@@ -414,14 +443,47 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     private func hasStreams(deviceID: AudioObjectID, scope: AudioObjectPropertyScope) -> Bool {
+        !streamIDs(deviceID: deviceID, scope: scope).isEmpty
+    }
+
+    private func outputTerminalTypes(for deviceID: AudioObjectID) -> Set<UInt32> {
+        Set(
+            streamIDs(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput)
+                .compactMap { streamID in terminalType(for: streamID) }
+        )
+    }
+
+    private func streamIDs(deviceID: AudioObjectID, scope: AudioObjectPropertyScope) -> [AudioObjectID] {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyStreams,
             mScope: scope,
             mElement: kAudioObjectPropertyElementMain
         )
         var dataSize: UInt32 = 0
-        return AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr
-            && dataSize >= MemoryLayout<AudioObjectID>.size
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize) == noErr,
+              dataSize >= MemoryLayout<AudioObjectID>.size else {
+            return []
+        }
+        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+        var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &ids) == noErr else {
+            return []
+        }
+        return ids.filter { $0 != AudioObjectID(kAudioObjectUnknown) }
+    }
+
+    private func terminalType(for streamID: AudioObjectID) -> UInt32? {
+        var terminalType = UInt32(0)
+        guard getUInt32(
+            kAudioStreamPropertyTerminalType,
+            objectID: streamID,
+            scope: kAudioObjectPropertyScopeGlobal,
+            element: kAudioObjectPropertyElementMain,
+            value: &terminalType
+        ) else {
+            return nil
+        }
+        return terminalType
     }
 
     private func hasProperty(

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -299,7 +299,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private func installDefaultInputListener() {
         var address = Self.defaultInputDeviceAddress()
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            self?.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+            self?.refreshRouteCache()
         }
         let status = AudioObjectAddPropertyListenerBlock(
             AudioObjectID(kAudioObjectSystemObject),

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -210,9 +210,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
 
     private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
         switch snapshot.outputRouteKind {
-        case .headphoneLike, .unknown:
+        case .headphoneLike:
             return snapshot.builtInInputDeviceID
-        case .speakerLike:
+        case .speakerLike, .unknown:
             return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -96,7 +96,8 @@ enum AudioRouteClassifier {
 
     private static func isAmbiguousBluetoothWithoutRouteMetadata(_ device: AudioOutputDeviceDescription) -> Bool {
         guard device.hasOutputStreams, device.hasInputStreams else { return false }
-        guard device.transportType == kAudioDeviceTransportTypeBluetoothLE else { return false }
+        guard device.transportType == kAudioDeviceTransportTypeBluetooth
+            || device.transportType == kAudioDeviceTransportTypeBluetoothLE else { return false }
         return device.outputTerminalTypes.union(device.outputDataSourceKinds).isEmpty
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -183,7 +183,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         refreshRouteCache(notifyEvenIfPreferredUnchanged: false)
     }
 
-    private func refreshRouteCache(notifyEvenIfPreferredUnchanged: Bool) {
+    func refreshRouteCache(notifyEvenIfPreferredUnchanged: Bool) {
         queue.async { [weak self] in
             guard let self else { return }
             let next = self.makeRouteSnapshot()
@@ -296,7 +296,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private func installDefaultInputListener() {
         var address = Self.defaultInputDeviceAddress()
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            self?.refreshRouteCache()
+            self?.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
         }
         let status = AudioObjectAddPropertyListenerBlock(
             AudioObjectID(kAudioObjectSystemObject),

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -212,7 +212,8 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
-        snapshot.builtInInputDeviceID
+        guard snapshot.outputRouteKind == .headphoneLike else { return nil }
+        return snapshot.builtInInputDeviceID
     }
 
     private func makeRouteSnapshot() -> RouteSnapshot {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -59,15 +59,14 @@ enum AudioRouteClassifier {
 
         if device.transportType == kAudioDeviceTransportTypeBluetooth
             || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
-            // Avoid brand/product-name heuristics. Bluetooth headsets expose input
-            // streams; output-only Bluetooth routes behave like external speakers.
-            // CoreAudio can expose AirPods and similar devices as high-rate generic
-            // Bluetooth outputs, so sample rate is not a reliable speaker signal.
-            // Only apply the headset fallback when CoreAudio gives us no terminal
-            // or data-source signal at all. Unknown Bluetooth devices with any
-            // non-headphone metadata stay speaker-like so opt-in ducking still
-            // protects against external speaker bleed.
-            return device.hasInputStreams && routeKinds.isEmpty ? .headphoneLike : .speakerLike
+            // Avoid brand/product-name heuristics. If CoreAudio does not expose
+            // terminal or data-source metadata, a bidirectional Bluetooth device
+            // could be either headphones or a speakerphone. Keep that ambiguous
+            // instead of skipping ducking for possible external speaker bleed.
+            guard !routeKinds.isEmpty else {
+                return device.hasInputStreams ? .unknown : .speakerLike
+            }
+            return .speakerLike
         }
 
         // Conservative fallback: wired headphones, USB headsets, or DACs that

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -96,8 +96,7 @@ enum AudioRouteClassifier {
 
     private static func isAmbiguousBluetoothWithoutRouteMetadata(_ device: AudioOutputDeviceDescription) -> Bool {
         guard device.hasOutputStreams, device.hasInputStreams else { return false }
-        guard device.transportType == kAudioDeviceTransportTypeBluetooth
-            || device.transportType == kAudioDeviceTransportTypeBluetoothLE else { return false }
+        guard device.transportType == kAudioDeviceTransportTypeBluetoothLE else { return false }
         return device.outputTerminalTypes.union(device.outputDataSourceKinds).isEmpty
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -101,7 +101,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         var builtInInputDeviceID: AudioObjectID?
     }
 
-    private let inspector: CoreAudioDeviceInspector
+    private let inspector: CoreAudioDeviceInspecting
     private let queue: DispatchQueue
     private let queueKey = DispatchSpecificKey<Void>()
     private let lock = NSLock()
@@ -110,8 +110,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
     var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
 
     init(
-        inspector: CoreAudioDeviceInspector = CoreAudioDeviceInspector(),
-        queue: DispatchQueue = DispatchQueue(label: "com.muesli.dictation-audio-route")
+        inspector: CoreAudioDeviceInspecting = CoreAudioDeviceInspector(),
+        queue: DispatchQueue = DispatchQueue(label: "com.muesli.dictation-audio-route"),
+        observesDefaultOutputChanges: Bool = true
     ) {
         self.inspector = inspector
         self.queue = queue
@@ -122,7 +123,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
             } ?? .unknown,
             builtInInputDeviceID: inspector.builtInInputDeviceID()
         )
-        installDefaultOutputListener()
+        if observesDefaultOutputChanges {
+            installDefaultOutputListener()
+        }
         refreshRouteCache()
     }
 
@@ -209,12 +212,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
-        switch snapshot.outputRouteKind {
-        case .headphoneLike:
-            return snapshot.builtInInputDeviceID
-        case .speakerLike, .unknown:
-            return nil
-        }
+        snapshot.builtInInputDeviceID
     }
 
     private func makeRouteSnapshot() -> RouteSnapshot {
@@ -254,7 +252,17 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 }
 
-final class CoreAudioDeviceInspector {
+protocol CoreAudioDeviceInspecting {
+    func defaultOutputDeviceID() -> AudioObjectID?
+    func defaultInputDeviceID() -> AudioObjectID?
+    func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool
+    func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool
+    func nominalSampleRate(for deviceID: AudioObjectID) -> Double?
+    func outputRouteKind(for deviceID: AudioObjectID) -> AudioOutputRouteKind
+    func builtInInputDeviceID() -> AudioObjectID?
+}
+
+final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     func defaultOutputDeviceID() -> AudioObjectID? {
         defaultDeviceID(selector: kAudioHardwarePropertyDefaultOutputDevice)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -195,7 +195,8 @@ final class DictationAudioRouteController: DictationAudioRouting {
     func isDefaultOutputHeadphoneLike() -> Bool {
         // Unknown outputs are treated as non-speaker for lifecycle sounds so we
         // avoid playing cues into headphones during CoreAudio route transitions.
-        // Dictation ducking is also limited to known speaker-like route snapshots.
+        // Dictation ducking is stricter: when enabled, it ducks any route that
+        // is not confirmed headphone-like to avoid speaker bleed.
         lock.withLock { snapshot.outputRouteKind != .speakerLike }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -24,6 +24,7 @@ struct AudioOutputDeviceDescription: Equatable {
     let hasInputStreams: Bool
     let outputTerminalTypes: Set<UInt32>
     let outputDataSourceKinds: Set<UInt32>
+    let nominalSampleRate: Double?
 
     init(
         name: String?,
@@ -31,7 +32,8 @@ struct AudioOutputDeviceDescription: Equatable {
         hasOutputStreams: Bool,
         hasInputStreams: Bool,
         outputTerminalTypes: Set<UInt32> = [],
-        outputDataSourceKinds: Set<UInt32> = []
+        outputDataSourceKinds: Set<UInt32> = [],
+        nominalSampleRate: Double? = nil
     ) {
         self.name = name
         self.transportType = transportType
@@ -39,6 +41,7 @@ struct AudioOutputDeviceDescription: Equatable {
         self.hasInputStreams = hasInputStreams
         self.outputTerminalTypes = outputTerminalTypes
         self.outputDataSourceKinds = outputDataSourceKinds
+        self.nominalSampleRate = nominalSampleRate
     }
 }
 
@@ -58,6 +61,14 @@ enum AudioRouteClassifier {
             || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
             // Avoid brand/product-name heuristics. Bluetooth headsets expose input
             // streams; output-only Bluetooth routes behave like external speakers.
+            // If CoreAudio only exposes generic Bluetooth metadata, a high-rate
+            // output with an input stream is more likely a speakerphone/soundbar
+            // profile than a headset microphone profile.
+            if device.hasInputStreams,
+               let sampleRate = device.nominalSampleRate,
+               sampleRate > 24_000 {
+                return .speakerLike
+            }
             return device.hasInputStreams ? .headphoneLike : .speakerLike
         }
 
@@ -344,7 +355,8 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
                 hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput),
                 hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput),
                 outputTerminalTypes: outputTerminalTypes(for: deviceID),
-                outputDataSourceKinds: outputDataSourceKinds(for: deviceID)
+                outputDataSourceKinds: outputDataSourceKinds(for: deviceID),
+                nominalSampleRate: nominalSampleRate(for: deviceID)
             )
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -81,10 +81,10 @@ enum AudioRouteClassifier {
             return .speakerLike
         }
 
-        // Conservative fallback: wired headphones, USB headsets, or DACs that
-        // omit headphone terminal/data-source metadata are treated as speaker-like.
-        // Extend this when we have a reliable public CoreAudio signal for those
-        // devices; do not add product-name matching.
+        if routeKinds.isEmpty, isLikelyPersonalWiredOutput(device) {
+            return .headphoneLike
+        }
+
         return .speakerLike
     }
 
@@ -99,6 +99,18 @@ enum AudioRouteClassifier {
         guard device.transportType == kAudioDeviceTransportTypeBluetooth
             || device.transportType == kAudioDeviceTransportTypeBluetoothLE else { return false }
         return device.outputTerminalTypes.union(device.outputDataSourceKinds).isEmpty
+    }
+
+    private static func isLikelyPersonalWiredOutput(_ device: AudioOutputDeviceDescription) -> Bool {
+        guard let transportType = device.transportType else { return false }
+        switch transportType {
+        case kAudioDeviceTransportTypeBuiltIn,
+             kAudioDeviceTransportTypeUSB,
+             kAudioDeviceTransportTypeThunderbolt:
+            return true
+        default:
+            return false
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -81,10 +81,6 @@ enum AudioRouteClassifier {
             return .speakerLike
         }
 
-        if routeKinds.isEmpty, isLikelyPersonalWiredOutput(device) {
-            return .headphoneLike
-        }
-
         return .speakerLike
     }
 
@@ -101,19 +97,6 @@ enum AudioRouteClassifier {
         return device.outputTerminalTypes.union(device.outputDataSourceKinds).isEmpty
     }
 
-    private static func isLikelyPersonalWiredOutput(_ device: AudioOutputDeviceDescription) -> Bool {
-        guard let transportType = device.transportType else { return false }
-        switch transportType {
-        case kAudioDeviceTransportTypeUSB,
-             kAudioDeviceTransportTypeThunderbolt:
-            // Missing terminal metadata leaves USB/TB ambiguous. Only
-            // bidirectional devices can plausibly be headsets; pure outputs
-            // stay speaker-like so ducking remains available.
-            return device.hasInputStreams
-        default:
-            return false
-        }
-    }
 }
 
 protocol DictationAudioRouting: AnyObject {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -75,6 +75,10 @@ enum AudioRouteClassifier {
             return device.hasInputStreams ? .headphoneLike : .speakerLike
         }
 
+        // Conservative fallback: wired headphones, USB headsets, or DACs that
+        // omit headphone terminal/data-source metadata are treated as speaker-like.
+        // Extend this when we have a reliable public CoreAudio signal for those
+        // devices; do not add product-name matching.
         return .speakerLike
     }
 
@@ -191,7 +195,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     func isDefaultOutputHeadphoneLike() -> Bool {
         // Unknown outputs are treated as non-speaker for lifecycle sounds so we
         // avoid playing cues into headphones during CoreAudio route transitions.
-        // Ducking uses RouteSnapshot.shouldDuck and still fails open for unknown.
+        // Dictation ducking is also limited to known speaker-like route snapshots.
         lock.withLock { snapshot.outputRouteKind != .speakerLike }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -21,6 +21,7 @@ struct AudioOutputDeviceDescription: Equatable {
     let name: String?
     let transportType: UInt32?
     let hasOutputStreams: Bool
+    let hasInputStreams: Bool
 }
 
 enum AudioRouteClassifier {
@@ -29,7 +30,9 @@ enum AudioRouteClassifier {
 
         if device.transportType == kAudioDeviceTransportTypeBluetooth
             || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
-            return .headphoneLike
+            // Avoid brand/product-name heuristics. Bluetooth headsets expose input
+            // streams; output-only Bluetooth routes behave like external speakers.
+            return device.hasInputStreams ? .headphoneLike : .speakerLike
         }
 
         return .speakerLike
@@ -306,7 +309,8 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
             for: AudioOutputDeviceDescription(
                 name: deviceName(for: deviceID),
                 transportType: transportType(for: deviceID),
-                hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput)
+                hasOutputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeOutput),
+                hasInputStreams: hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput)
             )
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -64,15 +64,16 @@ enum AudioRouteClassifier {
             // If CoreAudio only exposes generic Bluetooth metadata, a high-rate
             // output with an input stream is more likely a speakerphone/soundbar
             // profile than a headset microphone profile.
-            // Known limitation: low-rate Bluetooth speakers with embedded mics
-            // can look headset-like when CoreAudio omits terminal/data-source
-            // metadata.
             if device.hasInputStreams,
                let sampleRate = device.nominalSampleRate,
                sampleRate > 24_000 {
                 return .speakerLike
             }
-            return device.hasInputStreams ? .headphoneLike : .speakerLike
+            // Only apply the headset fallback when CoreAudio gives us no
+            // terminal/data-source signal at all. Unknown Bluetooth devices
+            // with any non-headphone metadata stay speaker-like so opt-in
+            // ducking still protects against external speaker bleed.
+            return device.hasInputStreams && routeKinds.isEmpty ? .headphoneLike : .speakerLike
         }
 
         // Conservative fallback: wired headphones, USB headsets, or DACs that

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -223,7 +223,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
-        guard snapshot.outputRouteKind == .headphoneLike else { return nil }
+        guard snapshot.outputRouteKind != .speakerLike else { return nil }
         return snapshot.builtInInputDeviceID
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -61,18 +61,12 @@ enum AudioRouteClassifier {
             || device.transportType == kAudioDeviceTransportTypeBluetoothLE {
             // Avoid brand/product-name heuristics. Bluetooth headsets expose input
             // streams; output-only Bluetooth routes behave like external speakers.
-            // If CoreAudio only exposes generic Bluetooth metadata, a high-rate
-            // output with an input stream is more likely a speakerphone/soundbar
-            // profile than a headset microphone profile.
-            if device.hasInputStreams,
-               let sampleRate = device.nominalSampleRate,
-               sampleRate > 24_000 {
-                return .speakerLike
-            }
-            // Only apply the headset fallback when CoreAudio gives us no
-            // terminal/data-source signal at all. Unknown Bluetooth devices
-            // with any non-headphone metadata stay speaker-like so opt-in
-            // ducking still protects against external speaker bleed.
+            // CoreAudio can expose AirPods and similar devices as high-rate generic
+            // Bluetooth outputs, so sample rate is not a reliable speaker signal.
+            // Only apply the headset fallback when CoreAudio gives us no terminal
+            // or data-source signal at all. Unknown Bluetooth devices with any
+            // non-headphone metadata stay speaker-like so opt-in ducking still
+            // protects against external speaker bleed.
             return device.hasInputStreams && routeKinds.isEmpty ? .headphoneLike : .speakerLike
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -1,0 +1,350 @@
+import CoreAudio
+import Foundation
+
+enum DictationAudioSessionState: Equatable {
+    case idle
+    case armed(UUID)
+    case acquiringAudio(UUID)
+    case streamActive(UUID)
+    case speechDetected(UUID)
+
+    var sessionID: UUID? {
+        switch self {
+        case .idle:
+            return nil
+        case .armed(let id), .acquiringAudio(let id), .streamActive(let id), .speechDetected(let id):
+            return id
+        }
+    }
+}
+
+enum DictationAudioSessionEvent {
+    case armed(UUID, source: String)
+    case acquiringAudio(UUID)
+    case streamActive(UUID, capturedAt: Date)
+    case speechDetected(UUID, capturedAt: Date)
+    case noAudioTimeout(UUID, at: Date)
+    case stopped(UUID?, wavURL: URL?)
+    case cancelled(UUID?, reason: String)
+    case failed(UUID?, error: Error)
+    case latency(String, Date)
+}
+
+protocol DictationAudioRecording: AnyObject {
+    var preferredInputDeviceID: AudioObjectID? { get set }
+    var keepsAudioGraphWarm: Bool { get set }
+    var onFirstCapturedAudioBuffer: ((Date) -> Void)? { get set }
+    var onFirstSpeechDetected: ((Date) -> Void)? { get set }
+    var onNoAudioTimeout: ((Date) -> Void)? { get set }
+
+    func prepare() throws
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws
+    func coolDown()
+    func start() throws
+    func stop() -> URL?
+    func cancel()
+    func currentPower() -> Float
+}
+
+extension MicrophoneRecorder: DictationAudioRecording {}
+
+final class DictationAudioSessionManager: @unchecked Sendable {
+    private struct RouteSnapshot {
+        let routeKind: AudioOutputRouteKind
+        let preferredInputDeviceID: AudioObjectID?
+        let debugDescription: String
+
+        var shouldDuck: Bool {
+            routeKind != .headphoneLike
+        }
+    }
+
+    private let recorder: DictationAudioRecording
+    private let duckingController: AudioDuckingManaging
+    private let routingController: DictationAudioRouting
+    private let queue: DispatchQueue
+    private let eventQueue: DispatchQueue
+
+    private var stateStorage: DictationAudioSessionState = .idle
+    private var routeSnapshot: RouteSnapshot
+    private var duckingEnabledForSession = false
+    private var externalSessionActive = false
+
+    var onEvent: ((DictationAudioSessionEvent) -> Void)?
+
+    init(
+        recorder: DictationAudioRecording,
+        duckingController: AudioDuckingManaging,
+        routingController: DictationAudioRouting,
+        queue: DispatchQueue = DispatchQueue(label: "com.muesli.dictation-audio-session-manager"),
+        eventQueue: DispatchQueue = .main
+    ) {
+        self.recorder = recorder
+        self.duckingController = duckingController
+        self.routingController = routingController
+        self.queue = queue
+        self.eventQueue = eventQueue
+        self.routeSnapshot = RouteSnapshot(
+            routeKind: routingController.currentOutputRouteKindForDebug(),
+            preferredInputDeviceID: routingController.cachedPreferredInputDeviceIDForDictation(),
+            debugDescription: routingController.currentRouteDebugDescription()
+        )
+
+        recorder.onFirstCapturedAudioBuffer = { [weak self] capturedAt in
+            self?.handleFirstAudioBuffer(capturedAt: capturedAt)
+        }
+        recorder.onFirstSpeechDetected = { [weak self] capturedAt in
+            self?.handleFirstSpeech(capturedAt: capturedAt)
+        }
+        recorder.onNoAudioTimeout = { [weak self] at in
+            self?.handleNoAudioTimeout(at: at)
+        }
+    }
+
+    var currentState: DictationAudioSessionState {
+        queue.sync { stateStorage }
+    }
+
+    var currentSessionID: UUID? {
+        currentState.sessionID
+    }
+
+    var hasActiveSession: Bool {
+        queue.sync {
+            stateStorage.sessionID != nil || externalSessionActive
+        }
+    }
+
+    func currentPower() -> Float {
+        recorder.currentPower()
+    }
+
+    func arm(source: String, duckingEnabled: Bool) {
+        let sessionID = ensureSession()
+        emit(.armed(sessionID, source: source))
+        emitLatency("ui_armed")
+        queue.async { [self] in
+            guard self.isCurrent(sessionID) else { return }
+            self.stateStorage = .armed(sessionID)
+            self.routeSnapshot = self.makeRouteSnapshot()
+            self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
+            self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+            self.recorder.keepsAudioGraphWarm = true
+            do {
+                self.emitLatency("activation_begin:\(source)")
+                try self.recorder.activateWarmEngine(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
+                self.emitLatency("activation_end:\(source)")
+                fputs("[dictation-session] armed source=\(source) \(self.routeSnapshot.debugDescription)\n", stderr)
+            } catch {
+                self.emitLatency("activation_failed:\(source)")
+                self.failCurrentSession(error: error)
+            }
+        }
+    }
+
+    func beginRecording(mode: String, duckingEnabled: Bool) {
+        let sessionID = ensureSession()
+        queue.async { [self] in
+            guard self.isCurrent(sessionID) else { return }
+            switch self.stateStorage {
+            case .acquiringAudio, .streamActive, .speechDetected:
+                self.emitLatency("activation_reused:\(mode)")
+                return
+            default:
+                break
+            }
+            self.stateStorage = .acquiringAudio(sessionID)
+            self.emit(.acquiringAudio(sessionID))
+            self.emitLatency("threshold_met:\(mode)")
+            self.routeSnapshot = self.makeRouteSnapshot()
+            self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+            self.duckingController.ensureCurrentDefaultDucked()
+            self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
+            self.recorder.keepsAudioGraphWarm = true
+            do {
+                self.emitLatency("engine_prepare_begin")
+                try self.recorder.prepare()
+                self.emitLatency("engine_prepare_end")
+                self.emitLatency("activation_begin:\(mode)")
+                try self.recorder.start()
+                self.emitLatency("activation_end:\(mode)")
+                fputs("[dictation-session] recording mode=\(mode) \(self.routeSnapshot.debugDescription)\n", stderr)
+            } catch {
+                self.emitLatency("activation_failed:\(mode)")
+                self.recorder.cancel()
+                self.failCurrentSession(error: error)
+            }
+        }
+    }
+
+    func beginExternalSession(source: String, duckingEnabled: Bool) {
+        queue.async { [self] in
+            self.externalSessionActive = true
+            self.routeSnapshot = self.makeRouteSnapshot()
+            self.emitLatency("external_begin:\(source)")
+            self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+            self.duckingController.ensureCurrentDefaultDucked()
+        }
+    }
+
+    func endExternalSession(reason: String) {
+        queue.async { [self] in
+            guard self.externalSessionActive else { return }
+            self.externalSessionActive = false
+            self.emitLatency("external_end:\(reason)")
+            self.restoreSessionAudioState()
+        }
+    }
+
+    func stop() {
+        queue.async { [self] in
+            let sessionID = self.stateStorage.sessionID
+            guard sessionID != nil else {
+                self.restoreSessionAudioState()
+                self.emit(.stopped(nil, wavURL: nil))
+                return
+            }
+            self.emitLatency("stop")
+            let wavURL = self.recorder.stop()
+            self.recorder.preferredInputDeviceID = nil
+            self.stateStorage = .idle
+            self.restoreSessionAudioState()
+            self.emit(.stopped(sessionID, wavURL: wavURL))
+        }
+    }
+
+    func cancel(reason: String) {
+        queue.async { [self] in
+            let sessionID = self.stateStorage.sessionID
+            self.recorder.cancel()
+            self.recorder.preferredInputDeviceID = nil
+            self.stateStorage = .idle
+            self.externalSessionActive = false
+            self.restoreSessionAudioState()
+            self.emitLatency("cancelled:\(reason)")
+            self.emit(.cancelled(sessionID, reason: reason))
+        }
+    }
+
+    func refreshRoute(reason: String, delay: TimeInterval = 0, canWarmUp: Bool) {
+        routingController.refreshRouteCache()
+        queue.async { [self] in
+            if delay > 0 {
+                Thread.sleep(forTimeInterval: delay)
+            }
+            self.routeSnapshot = self.makeRouteSnapshot()
+            self.emitLatency("route_refresh:\(reason) \(self.routeSnapshot.debugDescription)")
+            guard self.stateStorage == .idle, !self.externalSessionActive else { return }
+            guard canWarmUp else {
+                self.recorder.keepsAudioGraphWarm = false
+                self.recorder.coolDown()
+                return
+            }
+            self.recorder.keepsAudioGraphWarm = true
+            do {
+                self.emitLatency("engine_prepare_begin:warmup:\(reason)")
+                try self.recorder.warmUp(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
+                self.emitLatency("engine_prepare_end:warmup:\(reason)")
+                fputs("[dictation-session] warmed reason=\(reason) \(self.routeSnapshot.debugDescription)\n", stderr)
+            } catch {
+                self.emitLatency("engine_prepare_failed:warmup:\(reason)")
+                fputs("[dictation-session] warmup failed reason=\(reason) error=\(error)\n", stderr)
+            }
+        }
+    }
+
+    func coolDown(reason: String) {
+        queue.async { [self] in
+            guard self.stateStorage == .idle, !self.externalSessionActive else { return }
+            self.recorder.keepsAudioGraphWarm = false
+            self.recorder.coolDown()
+            self.emitLatency("cool_down:\(reason)")
+        }
+    }
+
+    private func ensureSession() -> UUID {
+        queue.sync {
+            if let current = stateStorage.sessionID {
+                return current
+            }
+            let id = UUID()
+            stateStorage = .armed(id)
+            return id
+        }
+    }
+
+    private func isCurrent(_ sessionID: UUID) -> Bool {
+        stateStorage.sessionID == sessionID
+    }
+
+    private func beginDuckingIfNeeded(duckingEnabled: Bool) {
+        duckingEnabledForSession = duckingEnabled && routeSnapshot.shouldDuck
+        emitLatency(duckingEnabledForSession ? "duck_begin" : "duck_skip")
+        duckingController.beginDictationDucking(enabled: duckingEnabledForSession)
+    }
+
+    private func restoreSessionAudioState() {
+        duckingController.restoreDictationDucking()
+        routingController.restoreDictationInputOverride()
+        duckingEnabledForSession = false
+    }
+
+    private func makeRouteSnapshot() -> RouteSnapshot {
+        RouteSnapshot(
+            routeKind: routingController.currentOutputRouteKindForDebug(),
+            preferredInputDeviceID: routingController.cachedPreferredInputDeviceIDForDictation(),
+            debugDescription: routingController.currentRouteDebugDescription()
+        )
+    }
+
+    private func failCurrentSession(error: Error) {
+        let sessionID = stateStorage.sessionID
+        stateStorage = .idle
+        recorder.preferredInputDeviceID = nil
+        restoreSessionAudioState()
+        emit(.failed(sessionID, error: error))
+    }
+
+    private func handleFirstAudioBuffer(capturedAt: Date) {
+        queue.async { [self] in
+            guard let sessionID = self.stateStorage.sessionID else { return }
+            switch self.stateStorage {
+            case .acquiringAudio(let id) where id == sessionID,
+                 .armed(let id) where id == sessionID:
+                self.stateStorage = .streamActive(sessionID)
+            default:
+                break
+            }
+            self.emitLatency("first_buffer", at: capturedAt)
+            self.emit(.streamActive(sessionID, capturedAt: capturedAt))
+        }
+    }
+
+    private func handleFirstSpeech(capturedAt: Date) {
+        queue.async { [self] in
+            guard let sessionID = self.stateStorage.sessionID else { return }
+            self.stateStorage = .speechDetected(sessionID)
+            self.emitLatency("first_speech", at: capturedAt)
+            self.emit(.speechDetected(sessionID, capturedAt: capturedAt))
+        }
+    }
+
+    private func handleNoAudioTimeout(at: Date) {
+        queue.async { [self] in
+            guard let sessionID = self.stateStorage.sessionID else { return }
+            self.emitLatency("no_audio_timeout", at: at)
+            self.emit(.noAudioTimeout(sessionID, at: at))
+        }
+    }
+
+    private func emitLatency(_ event: String, at date: Date = Date()) {
+        emit(.latency(event, date))
+    }
+
+    private func emit(_ event: DictationAudioSessionEvent) {
+        eventQueue.async { [weak self] in
+            self?.onEvent?(event)
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -146,26 +146,21 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     func beginRecording(mode: String, duckingEnabled: Bool) {
-        let hadExistingSession = currentSessionID != nil
         let sessionID = ensureSession()
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
             guard self.isCurrent(sessionID) else { return }
-            let canUseArmedRouteSnapshot: Bool
             switch self.stateStorage {
             case .acquiringAudio, .streamActive, .speechDetected:
                 self.emitLatency("activation_reused:\(mode)")
                 return
-            case .armed(let id) where id == sessionID && hadExistingSession:
-                canUseArmedRouteSnapshot = true
             default:
-                canUseArmedRouteSnapshot = false
                 break
             }
             self.stateStorage = .acquiringAudio(sessionID)
             self.emit(.acquiringAudio(sessionID))
             self.emitLatency("threshold_met:\(mode)")
-            self.routeSnapshot = self.makeRouteSnapshot(refreshInput: !canUseArmedRouteSnapshot)
+            self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
             self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -369,9 +369,11 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     private func restoreSessionAudioState(completion: (() -> Void)? = nil) {
-        mediaPlaybackController.restoreDictationMediaPause()
-        duckingController.restoreDictationDucking(completion: completion)
-        routingController.refreshRouteAfterDictationSession()
+        duckingController.restoreDictationDucking { [self] in
+            self.mediaPlaybackController.restoreDictationMediaPause()
+            self.routingController.refreshRouteAfterDictationSession()
+            completion?()
+        }
         duckingEnabledForSession = false
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -212,7 +212,6 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         queue.async { [self] in
             let sessionID = self.stateStorage.sessionID
             guard sessionID != nil else {
-                self.emit(.stopped(nil, wavURL: nil))
                 self.restoreSessionAudioState(completion: nil)
                 return
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -308,7 +308,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
 
     private func restoreSessionAudioState() {
         duckingController.restoreDictationDucking()
-        routingController.restoreDictationInputOverride()
+        routingController.refreshRouteAfterDictationSession()
         duckingEnabledForSession = false
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -129,7 +129,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.cancelPendingRouteRefreshLocked()
             guard self.isCurrent(sessionID) else { return }
             self.stateStorage = .armed(sessionID)
-            self.routeSnapshot = self.makeRouteSnapshot()
+            self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
             self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
             self.recorder.keepsAudioGraphWarm = true
@@ -146,21 +146,26 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     func beginRecording(mode: String, duckingEnabled: Bool) {
+        let hadExistingSession = currentSessionID != nil
         let sessionID = ensureSession()
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
             guard self.isCurrent(sessionID) else { return }
+            let canUseArmedRouteSnapshot: Bool
             switch self.stateStorage {
             case .acquiringAudio, .streamActive, .speechDetected:
                 self.emitLatency("activation_reused:\(mode)")
                 return
+            case .armed(let id) where id == sessionID && hadExistingSession:
+                canUseArmedRouteSnapshot = true
             default:
+                canUseArmedRouteSnapshot = false
                 break
             }
             self.stateStorage = .acquiringAudio(sessionID)
             self.emit(.acquiringAudio(sessionID))
             self.emitLatency("threshold_met:\(mode)")
-            self.routeSnapshot = self.makeRouteSnapshot()
+            self.routeSnapshot = self.makeRouteSnapshot(refreshInput: !canUseArmedRouteSnapshot)
             self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
             self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
@@ -280,7 +285,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             emitLatency("route_refresh_cancelled:\(reason)")
             return
         }
-        routeSnapshot = makeRouteSnapshot()
+        routeSnapshot = makeRouteSnapshot(refreshInput: false)
         emitLatency("route_refresh:\(reason) \(routeSnapshot.debugDescription)")
         guard stateStorage == .idle, !externalSessionActive else { return }
         guard canWarmUp else {
@@ -312,10 +317,13 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         duckingEnabledForSession = false
     }
 
-    private func makeRouteSnapshot() -> RouteSnapshot {
-        RouteSnapshot(
+    private func makeRouteSnapshot(refreshInput: Bool = false) -> RouteSnapshot {
+        let preferredInputDeviceID = refreshInput
+            ? routingController.preferredInputDeviceIDForDictation()
+            : routingController.cachedPreferredInputDeviceIDForDictation()
+        return RouteSnapshot(
             routeKind: routingController.currentOutputRouteKindForDebug(),
-            preferredInputDeviceID: routingController.cachedPreferredInputDeviceIDForDictation(),
+            preferredInputDeviceID: preferredInputDeviceID,
             debugDescription: routingController.currentRouteDebugDescription()
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -70,6 +70,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private var routeSnapshot: RouteSnapshot
     private var duckingEnabledForSession = false
     private var externalSessionActive = false
+    private var routeRefreshGeneration = 0
 
     var onEvent: ((DictationAudioSessionEvent) -> Void)?
 
@@ -125,6 +126,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         emit(.armed(sessionID, source: source))
         emitLatency("ui_armed")
         queue.async { [self] in
+            self.cancelPendingRouteRefreshLocked()
             guard self.isCurrent(sessionID) else { return }
             self.stateStorage = .armed(sessionID)
             self.routeSnapshot = self.makeRouteSnapshot()
@@ -146,6 +148,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     func beginRecording(mode: String, duckingEnabled: Bool) {
         let sessionID = ensureSession()
         queue.async { [self] in
+            self.cancelPendingRouteRefreshLocked()
             guard self.isCurrent(sessionID) else { return }
             switch self.stateStorage {
             case .acquiringAudio, .streamActive, .speechDetected:
@@ -180,6 +183,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
 
     func beginExternalSession(source: String, duckingEnabled: Bool) {
         queue.async { [self] in
+            self.cancelPendingRouteRefreshLocked()
             self.externalSessionActive = true
             self.routeSnapshot = self.makeRouteSnapshot()
             self.emitLatency("external_begin:\(source)")
@@ -230,26 +234,15 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     func refreshRoute(reason: String, delay: TimeInterval = 0, canWarmUp: Bool) {
         routingController.refreshRouteCache()
         queue.async { [self] in
-            if delay > 0 {
-                Thread.sleep(forTimeInterval: delay)
-            }
-            self.routeSnapshot = self.makeRouteSnapshot()
-            self.emitLatency("route_refresh:\(reason) \(self.routeSnapshot.debugDescription)")
-            guard self.stateStorage == .idle, !self.externalSessionActive else { return }
-            guard canWarmUp else {
-                self.recorder.keepsAudioGraphWarm = false
-                self.recorder.coolDown()
+            self.routeRefreshGeneration += 1
+            let generation = self.routeRefreshGeneration
+            guard delay > 0 else {
+                self.performRouteRefreshLocked(reason: reason, canWarmUp: canWarmUp, generation: generation)
                 return
             }
-            self.recorder.keepsAudioGraphWarm = true
-            do {
-                self.emitLatency("engine_prepare_begin:warmup:\(reason)")
-                try self.recorder.warmUp(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
-                self.emitLatency("engine_prepare_end:warmup:\(reason)")
-                fputs("[dictation-session] warmed reason=\(reason) \(self.routeSnapshot.debugDescription)\n", stderr)
-            } catch {
-                self.emitLatency("engine_prepare_failed:warmup:\(reason)")
-                fputs("[dictation-session] warmup failed reason=\(reason) error=\(error)\n", stderr)
+            self.emitLatency("route_refresh_deferred:\(reason)")
+            self.queue.asyncAfter(deadline: .now() + delay) { [self] in
+                self.performRouteRefreshLocked(reason: reason, canWarmUp: canWarmUp, generation: generation)
             }
         }
     }
@@ -276,6 +269,35 @@ final class DictationAudioSessionManager: @unchecked Sendable {
 
     private func isCurrent(_ sessionID: UUID) -> Bool {
         stateStorage.sessionID == sessionID
+    }
+
+    private func cancelPendingRouteRefreshLocked() {
+        routeRefreshGeneration += 1
+    }
+
+    private func performRouteRefreshLocked(reason: String, canWarmUp: Bool, generation: Int) {
+        guard routeRefreshGeneration == generation else {
+            emitLatency("route_refresh_cancelled:\(reason)")
+            return
+        }
+        routeSnapshot = makeRouteSnapshot()
+        emitLatency("route_refresh:\(reason) \(routeSnapshot.debugDescription)")
+        guard stateStorage == .idle, !externalSessionActive else { return }
+        guard canWarmUp else {
+            recorder.keepsAudioGraphWarm = false
+            recorder.coolDown()
+            return
+        }
+        recorder.keepsAudioGraphWarm = true
+        do {
+            emitLatency("engine_prepare_begin:warmup:\(reason)")
+            try recorder.warmUp(preferredInputDeviceID: routeSnapshot.preferredInputDeviceID)
+            emitLatency("engine_prepare_end:warmup:\(reason)")
+            fputs("[dictation-session] warmed reason=\(reason) \(routeSnapshot.debugDescription)\n", stderr)
+        } catch {
+            emitLatency("engine_prepare_failed:warmup:\(reason)")
+            fputs("[dictation-session] warmup failed reason=\(reason) error=\(error)\n", stderr)
+        }
     }
 
     private func beginDuckingIfNeeded(duckingEnabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -371,9 +371,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private func restoreSessionAudioState(completion: (() -> Void)? = nil) {
         duckingController.restoreDictationDucking { [self] in
             self.mediaPlaybackController.restoreDictationMediaPause()
-            self.routingController.refreshRouteAfterDictationSession()
             completion?()
         }
+        routingController.refreshRouteAfterDictationSession()
         duckingEnabledForSession = false
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -128,7 +128,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         recorder.currentPower()
     }
 
-    func arm(source: String, duckingEnabled: Bool, mediaPauseEnabled: Bool) {
+    func arm(source: String) {
         let sessionID = ensureSession()
         emit(.armed(sessionID, source: source))
         emitLatency("ui_armed")

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -71,6 +71,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private var duckingEnabledForSession = false
     private var externalSessionActive = false
     private var routeRefreshGeneration = 0
+    private let sessionHintLock = NSLock()
+    private var sessionHint: UUID?
+    private var externalSessionHint = false
 
     var onEvent: ((DictationAudioSessionEvent) -> Void)?
 
@@ -108,13 +111,11 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     var currentSessionID: UUID? {
-        currentState.sessionID
+        sessionHintLock.withLock { sessionHint }
     }
 
     var hasActiveSession: Bool {
-        queue.sync {
-            stateStorage.sessionID != nil || externalSessionActive
-        }
+        sessionHintLock.withLock { sessionHint != nil || externalSessionHint }
     }
 
     func currentPower() -> Float {
@@ -127,6 +128,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         emitLatency("ui_armed")
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
+            self.ensureSessionStateLocked(sessionID)
             guard self.isCurrent(sessionID) else { return }
             self.stateStorage = .armed(sessionID)
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
@@ -149,6 +151,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         let sessionID = ensureSession()
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
+            self.ensureSessionStateLocked(sessionID)
             guard self.isCurrent(sessionID) else { return }
             switch self.stateStorage {
             case .acquiringAudio, .streamActive, .speechDetected:
@@ -182,6 +185,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     func beginExternalSession(source: String, duckingEnabled: Bool) {
+        setExternalSessionHint(true)
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
             self.externalSessionActive = true
@@ -193,6 +197,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     func endExternalSession(reason: String) {
+        setExternalSessionHint(false)
         queue.async { [self] in
             guard self.externalSessionActive else { return }
             self.externalSessionActive = false
@@ -213,6 +218,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             let wavURL = self.recorder.stop()
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
+            self.clearSessionHint(sessionID)
             self.restoreSessionAudioState()
             self.emit(.stopped(sessionID, wavURL: wavURL))
         }
@@ -225,6 +231,8 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
             self.externalSessionActive = false
+            self.clearSessionHint(sessionID)
+            self.setExternalSessionHint(false)
             self.restoreSessionAudioState()
             self.emitLatency("cancelled:\(reason)")
             self.emit(.cancelled(sessionID, reason: reason))
@@ -257,13 +265,32 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     private func ensureSession() -> UUID {
-        queue.sync {
-            if let current = stateStorage.sessionID {
+        sessionHintLock.withLock {
+            if let current = sessionHint {
                 return current
             }
             let id = UUID()
-            stateStorage = .armed(id)
+            sessionHint = id
             return id
+        }
+    }
+
+    private func ensureSessionStateLocked(_ sessionID: UUID) {
+        if stateStorage.sessionID == nil {
+            stateStorage = .armed(sessionID)
+        }
+    }
+
+    private func clearSessionHint(_ sessionID: UUID?) {
+        sessionHintLock.withLock {
+            guard self.sessionHint == sessionID || sessionID == nil else { return }
+            self.sessionHint = nil
+        }
+    }
+
+    private func setExternalSessionHint(_ active: Bool) {
+        sessionHintLock.withLock {
+            externalSessionHint = active
         }
     }
 
@@ -327,6 +354,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         let sessionID = stateStorage.sessionID
         stateStorage = .idle
         recorder.preferredInputDeviceID = nil
+        clearSessionHint(sessionID)
         restoreSessionAudioState()
         emit(.failed(sessionID, error: error))
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -57,6 +57,8 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         let debugDescription: String
 
         var shouldDuck: Bool {
+            // Unknown routes are ducked to avoid speaker bleed during route
+            // transitions. Lifecycle sounds separately avoid unknown outputs.
             routeKind != .headphoneLike
         }
     }
@@ -177,12 +179,19 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.emit(.acquiringAudio(sessionID))
             self.emitLatency("threshold_met:\(mode)")
             if case .armed = previousState {
+                let armedRouteSnapshot = self.routeSnapshot
+                // arm() already refreshed the preferred input; keep threshold
+                // transition on the cached hotkey path.
                 self.routeSnapshot = self.makeRouteSnapshot(refreshInput: false)
                 self.emitLatency("route_snapshot_cached:\(mode) \(self.routeSnapshot.debugDescription)")
+                if armedRouteSnapshot.routeKind != self.routeSnapshot.routeKind
+                    || armedRouteSnapshot.preferredInputDeviceID != self.routeSnapshot.preferredInputDeviceID {
+                    self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
+                }
             } else {
                 self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
+                self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             }
-            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
             self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
             self.recorder.keepsAudioGraphWarm = true

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -56,7 +56,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         let debugDescription: String
 
         var shouldDuck: Bool {
-            routeKind != .headphoneLike
+            routeKind == .speakerLike
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -56,7 +56,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         let debugDescription: String
 
         var shouldDuck: Bool {
-            routeKind == .speakerLike
+            routeKind != .headphoneLike
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -191,7 +191,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
             self.externalSessionActive = true
-            self.routeSnapshot = self.makeRouteSnapshot()
+            self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("external_begin:\(source)")
             self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
             self.duckingController.ensureCurrentDefaultDucked()

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -25,6 +25,7 @@ enum DictationAudioSessionEvent {
     case speechDetected(UUID, capturedAt: Date)
     case noAudioTimeout(UUID, at: Date)
     case stopped(UUID?, wavURL: URL?)
+    case audioRestored(UUID?)
     case cancelled(UUID?, reason: String)
     case failed(UUID?, error: Error)
     case latency(String, Date)
@@ -211,8 +212,8 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         queue.async { [self] in
             let sessionID = self.stateStorage.sessionID
             guard sessionID != nil else {
-                self.restoreSessionAudioState()
                 self.emit(.stopped(nil, wavURL: nil))
+                self.restoreSessionAudioState(completion: nil)
                 return
             }
             self.emitLatency("stop")
@@ -220,8 +221,10 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
             self.clearSessionHint(sessionID)
-            self.restoreSessionAudioState()
             self.emit(.stopped(sessionID, wavURL: wavURL))
+            self.restoreSessionAudioState {
+                self.emit(.audioRestored(sessionID))
+            }
         }
     }
 
@@ -317,6 +320,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             return
         }
         recorder.keepsAudioGraphWarm = true
+        recorder.coolDown()
         do {
             emitLatency("engine_prepare_begin:warmup:\(reason)")
             try recorder.warmUp(preferredInputDeviceID: routeSnapshot.preferredInputDeviceID)
@@ -334,8 +338,8 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         duckingController.beginDictationDucking(enabled: duckingEnabledForSession)
     }
 
-    private func restoreSessionAudioState() {
-        duckingController.restoreDictationDucking()
+    private func restoreSessionAudioState(completion: (() -> Void)? = nil) {
+        duckingController.restoreDictationDucking(completion: completion)
         routingController.refreshRouteAfterDictationSession()
         duckingEnabledForSession = false
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -169,10 +169,11 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
             self.recorder.keepsAudioGraphWarm = true
             do {
+                self.emitLatency("activation_begin:\(mode)")
+                try self.recorder.activateWarmEngine(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
                 self.emitLatency("engine_prepare_begin")
                 try self.recorder.prepare()
                 self.emitLatency("engine_prepare_end")
-                self.emitLatency("activation_begin:\(mode)")
                 try self.recorder.start()
                 self.emitLatency("activation_end:\(mode)")
                 fputs("[dictation-session] recording mode=\(mode) \(self.routeSnapshot.debugDescription)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -247,6 +247,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     func cancel(reason: String) {
         queue.async { [self] in
             let sessionID = self.stateStorage.sessionID
+            self.recorder.keepsAudioGraphWarm = false
             self.recorder.cancel()
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -143,7 +143,6 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.stateStorage = .armed(sessionID)
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
-            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.recorder.keepsAudioGraphWarm = true
             do {
                 self.emitLatency("activation_begin:\(source)")
@@ -179,19 +178,14 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.emit(.acquiringAudio(sessionID))
             self.emitLatency("threshold_met:\(mode)")
             if case .armed = previousState {
-                let armedRouteSnapshot = self.routeSnapshot
                 // arm() already refreshed the preferred input; keep threshold
                 // transition on the cached hotkey path.
                 self.routeSnapshot = self.makeRouteSnapshot(refreshInput: false)
                 self.emitLatency("route_snapshot_cached:\(mode) \(self.routeSnapshot.debugDescription)")
-                if armedRouteSnapshot.routeKind != self.routeSnapshot.routeKind
-                    || armedRouteSnapshot.preferredInputDeviceID != self.routeSnapshot.preferredInputDeviceID {
-                    self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
-                }
             } else {
                 self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
-                self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             }
+            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
             self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
             self.recorder.keepsAudioGraphWarm = true

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -63,6 +63,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
 
     private let recorder: DictationAudioRecording
     private let duckingController: AudioDuckingManaging
+    private let mediaPlaybackController: MediaPlaybackManaging
     private let routingController: DictationAudioRouting
     private let queue: DispatchQueue
     private let eventQueue: DispatchQueue
@@ -81,12 +82,14 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     init(
         recorder: DictationAudioRecording,
         duckingController: AudioDuckingManaging,
+        mediaPlaybackController: MediaPlaybackManaging = MediaPlaybackController(),
         routingController: DictationAudioRouting,
         queue: DispatchQueue = DispatchQueue(label: "com.muesli.dictation-audio-session-manager"),
         eventQueue: DispatchQueue = .main
     ) {
         self.recorder = recorder
         self.duckingController = duckingController
+        self.mediaPlaybackController = mediaPlaybackController
         self.routingController = routingController
         self.queue = queue
         self.eventQueue = eventQueue
@@ -123,18 +126,22 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         recorder.currentPower()
     }
 
-    func arm(source: String, duckingEnabled: Bool) {
+    func arm(source: String, duckingEnabled: Bool, mediaPauseEnabled: Bool) {
         let sessionID = ensureSession()
         emit(.armed(sessionID, source: source))
         emitLatency("ui_armed")
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
+            guard self.sessionHintMatches(sessionID) else {
+                self.emitLatency("stale_session_ignored:\(source)")
+                return
+            }
             self.ensureSessionStateLocked(sessionID)
             guard self.isCurrent(sessionID) else { return }
             self.stateStorage = .armed(sessionID)
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
-            self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.recorder.keepsAudioGraphWarm = true
             do {
                 self.emitLatency("activation_begin:\(source)")
@@ -148,13 +155,18 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
-    func beginRecording(mode: String, duckingEnabled: Bool) {
+    func beginRecording(mode: String, duckingEnabled: Bool, mediaPauseEnabled: Bool) {
         let sessionID = ensureSession()
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
+            guard self.sessionHintMatches(sessionID) else {
+                self.emitLatency("stale_session_ignored:\(mode)")
+                return
+            }
+            let previousState = self.stateStorage
             self.ensureSessionStateLocked(sessionID)
             guard self.isCurrent(sessionID) else { return }
-            switch self.stateStorage {
+            switch previousState {
             case .acquiringAudio, .streamActive, .speechDetected:
                 self.emitLatency("activation_reused:\(mode)")
                 return
@@ -164,8 +176,13 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.stateStorage = .acquiringAudio(sessionID)
             self.emit(.acquiringAudio(sessionID))
             self.emitLatency("threshold_met:\(mode)")
-            self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
-            self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+            if case .armed = previousState {
+                self.routeSnapshot = self.makeRouteSnapshot(refreshInput: false)
+                self.emitLatency("route_snapshot_cached:\(mode) \(self.routeSnapshot.debugDescription)")
+            } else {
+                self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
+            }
+            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
             self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
             self.recorder.keepsAudioGraphWarm = true
@@ -186,14 +203,14 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
-    func beginExternalSession(source: String, duckingEnabled: Bool) {
+    func beginExternalSession(source: String, duckingEnabled: Bool, mediaPauseEnabled: Bool) {
         setExternalSessionHint(true)
         queue.async { [self] in
             self.cancelPendingRouteRefreshLocked()
             self.externalSessionActive = true
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("external_begin:\(source)")
-            self.beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+            self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
         }
     }
@@ -291,6 +308,12 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
+    private func sessionHintMatches(_ sessionID: UUID) -> Bool {
+        sessionHintLock.withLock {
+            self.sessionHint == sessionID
+        }
+    }
+
     private func setExternalSessionHint(_ active: Bool) {
         sessionHintLock.withLock {
             externalSessionHint = active
@@ -331,6 +354,14 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
+    private func beginSessionAudioControls(duckingEnabled: Bool, mediaPauseEnabled: Bool) {
+        mediaPlaybackController.beginDictationMediaPause(
+            enabled: mediaPauseEnabled,
+            routeKind: routeSnapshot.routeKind
+        )
+        beginDuckingIfNeeded(duckingEnabled: duckingEnabled)
+    }
+
     private func beginDuckingIfNeeded(duckingEnabled: Bool) {
         duckingEnabledForSession = duckingEnabled && routeSnapshot.shouldDuck
         emitLatency(duckingEnabledForSession ? "duck_begin" : "duck_skip")
@@ -338,6 +369,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     private func restoreSessionAudioState(completion: (() -> Void)? = nil) {
+        mediaPlaybackController.restoreDictationMediaPause()
         duckingController.restoreDictationDucking(completion: completion)
         routingController.refreshRouteAfterDictationSession()
         duckingEnabledForSession = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -90,6 +90,8 @@ final class FloatingIndicatorController: NSObject {
     private var barLayers: [CALayer] = []
     private var amplitudeTimer: Timer?
     private var smoothedAmplitude: CGFloat = 0
+    private var waveformAnimationMode: WaveformAnimationMode = .level
+    private var waveformAnimationStartedAt = Date()
     fileprivate var isDragging = false
     var powerProvider: (() -> Float)?
     var onStopMeeting: (() -> Void)?
@@ -105,6 +107,11 @@ final class FloatingIndicatorController: NSObject {
     private var isShowingLoading = false
     private var isComputerUseCursorMode = false
     private var computerUseCursorReturnFrame: NSRect?
+
+    private enum WaveformAnimationMode {
+        case level
+        case waiting
+    }
 
     init(configStore: ConfigStore) {
         self.configStore = configStore
@@ -244,7 +251,7 @@ final class FloatingIndicatorController: NSObject {
         }
         guard let panel, let contentView, let iconLabel, let textLabel else { return }
 
-        if previousState == .recording && state != .recording {
+        if (previousState == .recording || previousState == .preparing) && state != previousState {
             stopWaveformAnimation()
         }
 
@@ -333,7 +340,7 @@ final class FloatingIndicatorController: NSObject {
         switch state {
         case .recording:
             setupWaveformBars(in: targetFrame.size)
-            startWaveformAnimation()
+            startWaveformAnimation(mode: .level)
             addStopLayer(in: targetFrame.size)
         case .transcribing:
             if #available(macOS 15, *) {
@@ -343,13 +350,8 @@ final class FloatingIndicatorController: NSObject {
                 )
             }
         case .preparing:
-            if #available(macOS 15, *) {
-                micIconView?.addSymbolEffect(
-                    .pulse,
-                    options: .repeating,
-                    animated: true
-                )
-            }
+            setupWaveformBars(in: targetFrame.size)
+            startWaveformAnimation(mode: .waiting)
         default:
             break
         }
@@ -681,6 +683,7 @@ final class FloatingIndicatorController: NSObject {
         barLayers.forEach { $0.removeFromSuperlayer() }
         barLayers.removeAll()
         smoothedAmplitude = 0
+        waveformAnimationMode = .level
         powerProvider = nil
         contentView?.layer?.transform = CATransform3DIdentity
         removeStopLayer()
@@ -709,8 +712,10 @@ final class FloatingIndicatorController: NSObject {
         }
     }
 
-    private func startWaveformAnimation() {
+    private func startWaveformAnimation(mode: WaveformAnimationMode) {
         amplitudeTimer?.invalidate()
+        waveformAnimationMode = mode
+        waveformAnimationStartedAt = Date()
         amplitudeTimer = Timer.scheduledTimer(
             timeInterval: 1.0 / 30.0,
             target: self,
@@ -725,16 +730,33 @@ final class FloatingIndicatorController: NSObject {
         let multipliers: [CGFloat] = [0.6, 0.85, 1.0, 0.85, 0.6]
         let minHeight: CGFloat = 3
         let maxHeight: CGFloat = 14
-        let dB = CGFloat(powerProvider?() ?? -160)
-        let raw = max(0, min(1, (dB + 50) / 50))
-        smoothedAmplitude = 0.35 * raw + 0.65 * smoothedAmplitude
         let pillHeight = contentView.frame.height
+        let elapsed = CGFloat(Date().timeIntervalSince(waveformAnimationStartedAt))
+        let levelAmplitude: CGFloat
+        if waveformAnimationMode == .level {
+            let dB = CGFloat(powerProvider?() ?? -160)
+            let raw = max(0, min(1, (dB + 50) / 50))
+            smoothedAmplitude = 0.35 * raw + 0.65 * smoothedAmplitude
+            levelAmplitude = smoothedAmplitude
+        } else {
+            levelAmplitude = 0
+        }
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         for (i, bar) in barLayers.enumerated() {
             let m = i < multipliers.count ? multipliers[i] : 1.0
-            let h = minHeight + (maxHeight - minHeight) * smoothedAmplitude * m
+            let amplitude: CGFloat
+            switch waveformAnimationMode {
+            case .level:
+                amplitude = levelAmplitude * m
+                bar.opacity = 0.85
+            case .waiting:
+                let phase = elapsed * 5.8 + CGFloat(i) * 0.72
+                amplitude = 0.28 + (sin(phase) + 1) * 0.22 * m
+                bar.opacity = Float(0.38 + (sin(phase) + 1) * 0.18)
+            }
+            let h = minHeight + (maxHeight - minHeight) * amplitude
             bar.frame.size.height = h
             bar.frame.origin.y = (pillHeight - h) / 2
         }
@@ -833,16 +855,7 @@ final class FloatingIndicatorController: NSObject {
         case .preparing:
             wandIconView?.isHidden = true
             iconLabel?.isHidden = true
-            micIconView?.isHidden = false
-            if let mic = micIconView {
-                mic.alphaValue = 0.86
-                mic.frame = NSRect(
-                    x: (frameSize.width - iconSize.width) / 2,
-                    y: (frameSize.height - iconSize.height) / 2,
-                    width: iconSize.width,
-                    height: iconSize.height
-                )
-            }
+            micIconView?.isHidden = true
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -91,6 +91,7 @@ final class FloatingIndicatorController: NSObject {
     private var amplitudeTimer: Timer?
     private var smoothedAmplitude: CGFloat = 0
     private var waveformAnimationMode: WaveformAnimationMode = .level
+    private var recordingWaveformMode: WaveformAnimationMode = .level
     private var waveformAnimationStartedAt = Date()
     fileprivate var isDragging = false
     var powerProvider: (() -> Float)?
@@ -197,6 +198,7 @@ final class FloatingIndicatorController: NSObject {
 
     func setMeetingRecording(_ recording: Bool, config: AppConfig) {
         isMeetingRecording = recording
+        recordingWaveformMode = .level
         if !recording {
             isMeetingRecordingPaused = false
         }
@@ -204,6 +206,27 @@ final class FloatingIndicatorController: NSObject {
             setState(.recording, config: config)
         } else {
             setState(.idle, config: config)
+        }
+    }
+
+    func setRecordingWaveformWaiting(config: AppConfig) {
+        recordingWaveformMode = .waiting
+        guard state == .recording else { return }
+        if let panel {
+            setupWaveformBars(in: panel.frame.size)
+            startWaveformAnimation(mode: .waiting)
+        }
+    }
+
+    func setRecordingWaveformLevel(config: AppConfig) {
+        recordingWaveformMode = .level
+        guard state == .recording else {
+            setState(.recording, config: config)
+            return
+        }
+        if let panel {
+            setupWaveformBars(in: panel.frame.size)
+            startWaveformAnimation(mode: .level)
         }
     }
 
@@ -238,6 +261,9 @@ final class FloatingIndicatorController: NSObject {
         if state != .transcribing {
             transcribingTitle = "Transcribing"
             computerUseTranscriptText = nil
+        }
+        if state != .recording {
+            recordingWaveformMode = .level
         }
         if state != .idle {
             isHovered = false
@@ -340,7 +366,7 @@ final class FloatingIndicatorController: NSObject {
         switch state {
         case .recording:
             setupWaveformBars(in: targetFrame.size)
-            startWaveformAnimation(mode: .level)
+            startWaveformAnimation(mode: recordingWaveformMode)
             addStopLayer(in: targetFrame.size)
         case .transcribing:
             if #available(macOS 15, *) {
@@ -716,13 +742,15 @@ final class FloatingIndicatorController: NSObject {
         amplitudeTimer?.invalidate()
         waveformAnimationMode = mode
         waveformAnimationStartedAt = Date()
-        amplitudeTimer = Timer.scheduledTimer(
+        let timer = Timer(
             timeInterval: 1.0 / 30.0,
             target: self,
             selector: #selector(waveformTimerFired(_:)),
             userInfo: nil,
             repeats: true
         )
+        RunLoop.main.add(timer, forMode: .common)
+        amplitudeTimer = timer
     }
 
     @objc private func waveformTimerFired(_ timer: Timer) {
@@ -735,8 +763,8 @@ final class FloatingIndicatorController: NSObject {
         let levelAmplitude: CGFloat
         if waveformAnimationMode == .level {
             let dB = CGFloat(powerProvider?() ?? -160)
-            let raw = max(0, min(1, (dB + 50) / 50))
-            smoothedAmplitude = 0.35 * raw + 0.65 * smoothedAmplitude
+            let raw = max(0, min(1, (dB + 68) / 38))
+            smoothedAmplitude = 0.48 * raw + 0.52 * smoothedAmplitude
             levelAmplitude = smoothedAmplitude
         } else {
             levelAmplitude = 0

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -347,6 +347,10 @@ final class FloatingIndicatorController: NSObject {
         }
 
         panel.orderFrontRegardless()
+        if state == .preparing {
+            contentView.displayIfNeeded()
+            panel.displayIfNeeded()
+        }
     }
 
     func showComputerUseCursor(at quartzPoint: CGPoint, label rawLabel: String?) {
@@ -770,6 +774,7 @@ final class FloatingIndicatorController: NSObject {
             iconLabel?.isHidden = true
             micIconView?.isHidden = false
             if let mic = micIconView {
+                mic.alphaValue = 1
                 if isHovered {
                     mic.frame = NSRect(x: 12, y: (frameSize.height - iconSize.height) / 2,
                                       width: iconSize.width, height: iconSize.height)
@@ -819,8 +824,17 @@ final class FloatingIndicatorController: NSObject {
 
         case .preparing:
             wandIconView?.isHidden = true
-            micIconView?.isHidden = true
-            iconLabel?.isHidden = false
+            iconLabel?.isHidden = true
+            micIconView?.isHidden = false
+            if let mic = micIconView {
+                mic.alphaValue = 0.86
+                mic.frame = NSRect(
+                    x: (frameSize.width - iconSize.width) / 2,
+                    y: (frameSize.height - iconSize.height) / 2,
+                    width: iconSize.width,
+                    height: iconSize.height
+                )
+            }
         }
     }
 
@@ -1113,7 +1127,7 @@ final class FloatingIndicatorController: NSObject {
         switch state {
         case .idle:
             size = isHovered ? NSSize(width: 220, height: 36) : NSSize(width: 44, height: 28)
-        case .preparing: size = NSSize(width: 44, height: 28)
+        case .preparing: size = NSSize(width: 76, height: 22)
         case .recording: size = NSSize(width: 76, height: 22)
         case .transcribing:
             if let transcript = computerUseTranscriptText {
@@ -1182,6 +1196,12 @@ final class FloatingIndicatorController: NSObject {
     }
 
     private func transitionDuration(from oldState: DictationState, to newState: DictationState, wasHovered: Bool, isHovered: Bool) -> TimeInterval {
+        if newState == .preparing {
+            return 0
+        }
+        if oldState == .preparing, newState == .recording {
+            return 0
+        }
         if oldState == .idle, newState == .idle, wasHovered != isHovered {
             return isHovered ? 0.24 : 0.2
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -213,8 +213,7 @@ final class FloatingIndicatorController: NSObject {
         recordingWaveformMode = .waiting
         guard state == .recording else { return }
         if let panel {
-            setupWaveformBars(in: panel.frame.size)
-            startWaveformAnimation(mode: .waiting)
+            ensureWaveformAnimation(in: panel.frame.size, mode: .waiting)
         }
     }
 
@@ -225,8 +224,7 @@ final class FloatingIndicatorController: NSObject {
             return
         }
         if let panel {
-            setupWaveformBars(in: panel.frame.size)
-            startWaveformAnimation(mode: .level)
+            ensureWaveformAnimation(in: panel.frame.size, mode: .level)
         }
     }
 
@@ -277,7 +275,10 @@ final class FloatingIndicatorController: NSObject {
         }
         guard let panel, let contentView, let iconLabel, let textLabel else { return }
 
-        if (previousState == .recording || previousState == .preparing) && state != previousState {
+        let preservesWaveformAcrossTransition = previousState == .preparing && state == .recording
+        if (previousState == .recording || previousState == .preparing)
+            && state != previousState
+            && !preservesWaveformAcrossTransition {
             stopWaveformAnimation()
         }
 
@@ -365,8 +366,7 @@ final class FloatingIndicatorController: NSObject {
 
         switch state {
         case .recording:
-            setupWaveformBars(in: targetFrame.size)
-            startWaveformAnimation(mode: recordingWaveformMode)
+            ensureWaveformAnimation(in: targetFrame.size, mode: recordingWaveformMode)
             addStopLayer(in: targetFrame.size)
         case .transcribing:
             if #available(macOS 15, *) {
@@ -376,8 +376,7 @@ final class FloatingIndicatorController: NSObject {
                 )
             }
         case .preparing:
-            setupWaveformBars(in: targetFrame.size)
-            startWaveformAnimation(mode: .waiting)
+            ensureWaveformAnimation(in: targetFrame.size, mode: .waiting)
         default:
             break
         }
@@ -736,6 +735,43 @@ final class FloatingIndicatorController: NSObject {
             layer.addSublayer(bar)
             barLayers.append(bar)
         }
+    }
+
+    private func updateWaveformBarsLayout(in frameSize: NSSize) {
+        guard !barLayers.isEmpty else { return }
+        let barWidth: CGFloat = 3
+        let barSpacing: CGFloat = 3
+        let totalWidth = CGFloat(barLayers.count) * barWidth + CGFloat(max(0, barLayers.count - 1)) * barSpacing
+        let startX = (frameSize.width - totalWidth) / 2
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for (i, bar) in barLayers.enumerated() {
+            var frame = bar.frame
+            frame.origin.x = startX + CGFloat(i) * (barWidth + barSpacing)
+            frame.origin.y = (frameSize.height - frame.height) / 2
+            frame.size.width = barWidth
+            bar.frame = frame
+            bar.cornerRadius = barWidth / 2
+        }
+        CATransaction.commit()
+    }
+
+    private func ensureWaveformAnimation(in frameSize: NSSize, mode: WaveformAnimationMode) {
+        if barLayers.isEmpty {
+            setupWaveformBars(in: frameSize)
+        } else {
+            updateWaveformBarsLayout(in: frameSize)
+        }
+        setWaveformAnimationMode(mode)
+        if amplitudeTimer == nil {
+            startWaveformAnimation(mode: mode)
+        }
+    }
+
+    private func setWaveformAnimationMode(_ mode: WaveformAnimationMode) {
+        guard waveformAnimationMode != mode else { return }
+        waveformAnimationMode = mode
+        waveformAnimationStartedAt = Date()
     }
 
     private func startWaveformAnimation(mode: WaveformAnimationMode) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -342,6 +342,14 @@ final class FloatingIndicatorController: NSObject {
                     options: .repeating, animated: true
                 )
             }
+        case .preparing:
+            if #available(macOS 15, *) {
+                micIconView?.addSymbolEffect(
+                    .pulse,
+                    options: .repeating,
+                    animated: true
+                )
+            }
         default:
             break
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -119,6 +119,7 @@ final class HotkeyMonitor {
     }
 
     func configure(keyCode: UInt16) {
+        finishActiveSessionBeforeReconfigure()
         targetKeyCode = keyCode
         if isRunning {
             restart()
@@ -133,6 +134,32 @@ final class HotkeyMonitor {
     private func restartIfRunning() {
         if isRunning {
             restart()
+        }
+    }
+
+    private func finishActiveSessionBeforeReconfigure() {
+        guard targetKeyDown || armed || prepared || active || toggleActive else { return }
+
+        let wasToggleActive = toggleActive
+        let wasActive = active
+        let wasPreparedOrArmed = prepared || armed
+
+        targetKeyDown = false
+        otherKeyPressed = false
+        armed = false
+        prepared = false
+        active = false
+        toggleActive = false
+        lastTapWasShort = false
+        lastTapUpTime = nil
+        cancelTimers()
+
+        if wasToggleActive {
+            onToggleStop?()
+        } else if wasActive {
+            onStop?()
+        } else if wasPreparedOrArmed {
+            onCancel?()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -3,7 +3,28 @@ import ApplicationServices
 import Foundation
 import MuesliCore
 
+enum HotkeyTriggerTiming {
+    static let defaultThresholdMilliseconds = 250
+    static let minThresholdMilliseconds = 50
+    static let maxThresholdMilliseconds = 600
+    static let doubleTapTapGuardDelay: TimeInterval = 0.18
+
+    static func clampedMilliseconds(_ value: Int) -> Int {
+        min(max(value, minThresholdMilliseconds), maxThresholdMilliseconds)
+    }
+
+    static func startDelay(forThresholdMilliseconds value: Int) -> TimeInterval {
+        TimeInterval(clampedMilliseconds(value)) / 1000
+    }
+
+    static func prepareDelay(forThresholdMilliseconds value: Int) -> TimeInterval {
+        let startDelay = startDelay(forThresholdMilliseconds: value)
+        return min(0.15, max(0, startDelay - 0.10))
+    }
+}
+
 final class HotkeyMonitor {
+    var onArm: (() -> Void)?
     var onPrepare: (() -> Void)?
     var onStart: (() -> Void)?
     var onStop: (() -> Void)?
@@ -17,8 +38,10 @@ final class HotkeyMonitor {
     private var localMonitor: Any?
     private var prepareWorkItem: DispatchWorkItem?
     private var startWorkItem: DispatchWorkItem?
+    private var armCancelWorkItem: DispatchWorkItem?
     private var targetKeyDown = false
     private var otherKeyPressed = false
+    private var armed = false
     private var prepared = false
     private var active = false
 
@@ -27,9 +50,9 @@ final class HotkeyMonitor {
     private var lastTapWasShort = false
     private var toggleActive = false
 
-    private let prepareDelay: TimeInterval
-    private let startDelay: TimeInterval
-    private let doubleTapWindow: TimeInterval
+    private var prepareDelay: TimeInterval
+    private var startDelay: TimeInterval
+    private var doubleTapWindow: TimeInterval
 
     init(
         prepareDelay: TimeInterval = 0.15,
@@ -39,6 +62,12 @@ final class HotkeyMonitor {
         self.prepareDelay = prepareDelay
         self.startDelay = startDelay
         self.doubleTapWindow = doubleTapWindow
+    }
+
+    func configureTriggerThreshold(milliseconds: Int) {
+        prepareDelay = HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: milliseconds)
+        startDelay = HotkeyTriggerTiming.startDelay(forThresholdMilliseconds: milliseconds)
+        restartIfRunning()
     }
 
     func start() {
@@ -81,6 +110,7 @@ final class HotkeyMonitor {
         localMonitor = nil
         targetKeyDown = false
         otherKeyPressed = false
+        armed = false
         prepared = false
         active = false
         toggleActive = false
@@ -96,6 +126,12 @@ final class HotkeyMonitor {
     func restart() {
         stop()
         start()
+    }
+
+    private func restartIfRunning() {
+        if isRunning {
+            restart()
+        }
     }
 
     /// Call externally to stop toggle mode (e.g., from floating indicator click)
@@ -152,7 +188,7 @@ final class HotkeyMonitor {
 
         // Text editing owns fresh hotkey starts, but an already-armed hotkey
         // session must still receive key-up/Escape cleanup events.
-        if targetKeyDown || prepared || active || toggleActive {
+        if targetKeyDown || armed || prepared || active || toggleActive {
             return true
         }
 
@@ -164,6 +200,8 @@ final class HotkeyMonitor {
             let isDown = isModifierDown(keyCode: targetKeyCode, flags: flags)
             if isDown {
                 if !targetKeyDown {
+                    armCancelWorkItem?.cancel()
+                    armCancelWorkItem = nil
                     targetKeyDown = true
                     otherKeyPressed = false
                     prepared = false
@@ -192,13 +230,19 @@ final class HotkeyMonitor {
                         return
                     }
 
+                    if let onArm {
+                        armed = true
+                        onArm()
+                    }
                     fputs("[hotkey] target key \(targetKeyCode) down\n", stderr)
                     scheduleTimers()
                 }
             } else {
                 fputs("[hotkey] target key \(targetKeyCode) up\n", stderr)
                 let wasDown = targetKeyDown
+                let wasArmed = armed
                 targetKeyDown = false
+                armed = false
                 cancelTimers()
 
                 if toggleActive {
@@ -206,9 +250,10 @@ final class HotkeyMonitor {
                     return
                 }
 
-                // Track tap timing for double-tap detection
-                if wasDown && !active && !prepared && !otherKeyPressed {
-                    // This was a short tap (released before prepareDelay)
+                // Track tap timing for double-tap detection. Low trigger thresholds can
+                // enter the prepared state quickly, but a release before recording starts
+                // should still count as a tap.
+                if wasDown && !active && !otherKeyPressed {
                     lastTapWasShort = true
                     lastTapUpTime = Date()
                 } else {
@@ -221,18 +266,28 @@ final class HotkeyMonitor {
                 } else if prepared {
                     prepared = false
                     onCancel?()
+                } else if wasArmed {
+                    if doubleTapEnabled, lastTapWasShort {
+                        scheduleArmCancel()
+                    } else {
+                        onCancel?()
+                    }
                 }
             }
         } else if targetKeyDown && !toggleActive {
             fputs("[hotkey] canceled by other modifier key \(keyCode)\n", stderr)
             otherKeyPressed = true
             lastTapWasShort = false
+            let wasArmed = armed
+            armed = false
             cancelTimers()
             if active {
                 active = false
                 onStop?()
             } else if prepared {
                 prepared = false
+                onCancel?()
+            } else if wasArmed {
                 onCancel?()
             }
         }
@@ -263,6 +318,16 @@ final class HotkeyMonitor {
                 fputs("[hotkey] escape → cancel hold\n", stderr)
                 active = false
                 targetKeyDown = false
+                armed = false
+                cancelTimers()
+                onCancel?()
+                return
+            }
+            if armed || prepared {
+                fputs("[hotkey] escape → cancel armed hold\n", stderr)
+                targetKeyDown = false
+                armed = false
+                prepared = false
                 cancelTimers()
                 onCancel?()
             }
@@ -274,6 +339,8 @@ final class HotkeyMonitor {
                 fputs("[hotkey] canceled by other key\n", stderr)
                 otherKeyPressed = true
                 lastTapWasShort = false
+                let wasArmed = armed
+                armed = false
                 cancelTimers()
                 if active {
                     active = false
@@ -281,36 +348,81 @@ final class HotkeyMonitor {
                 } else if prepared {
                     prepared = false
                     onCancel?()
+                } else if wasArmed {
+                    onCancel?()
                 }
             }
         }
     }
 
     private func scheduleTimers() {
+        let delays = timerDelays()
         let prepare = DispatchWorkItem { [weak self] in
-            guard let self, self.targetKeyDown, !self.otherKeyPressed, !self.prepared else { return }
+            guard let self, self.targetKeyDown, !self.otherKeyPressed, !self.prepared, !self.active else { return }
+            self.armCancelWorkItem?.cancel()
+            self.armCancelWorkItem = nil
             self.prepared = true
+            self.armed = false
             self.lastTapWasShort = false // Held long enough — not a tap
             fputs("[hotkey] prepared\n", stderr)
             self.onPrepare?()
         }
         let start = DispatchWorkItem { [weak self] in
             guard let self, self.targetKeyDown, !self.otherKeyPressed, !self.active else { return }
+            self.armCancelWorkItem?.cancel()
+            self.armCancelWorkItem = nil
+            if !self.prepared {
+                self.prepared = true
+                self.armed = false
+                self.lastTapWasShort = false
+                fputs("[hotkey] prepared\n", stderr)
+                self.onPrepare?()
+            }
             self.active = true
             fputs("[hotkey] start\n", stderr)
             self.onStart?()
         }
         prepareWorkItem = prepare
         startWorkItem = start
-        DispatchQueue.main.asyncAfter(deadline: .now() + prepareDelay, execute: prepare)
-        DispatchQueue.main.asyncAfter(deadline: .now() + startDelay, execute: start)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delays.prepare, execute: prepare)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delays.start, execute: start)
+    }
+
+    private func scheduleArmCancel() {
+        armCancelWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            guard let self,
+                  !self.targetKeyDown,
+                  !self.toggleActive,
+                  !self.prepared,
+                  !self.active
+            else { return }
+            self.armCancelWorkItem = nil
+            self.onCancel?()
+        }
+        armCancelWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + doubleTapWindow, execute: item)
+    }
+
+    private func timerDelays() -> (prepare: TimeInterval, start: TimeInterval) {
+        guard doubleTapEnabled else {
+            return (prepareDelay, startDelay)
+        }
+        let guardedStartDelay = max(startDelay, HotkeyTriggerTiming.doubleTapTapGuardDelay)
+        let guardedPrepareDelay = max(
+            HotkeyTriggerTiming.doubleTapTapGuardDelay,
+            min(0.15, max(0, guardedStartDelay - 0.10))
+        )
+        return (min(guardedPrepareDelay, guardedStartDelay), guardedStartDelay)
     }
 
     private func cancelTimers() {
         prepareWorkItem?.cancel()
         startWorkItem?.cancel()
+        armCancelWorkItem?.cancel()
         prepareWorkItem = nil
         startWorkItem = nil
+        armCancelWorkItem = nil
     }
 
     func setHoldRecordingActiveForTests() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -67,7 +67,7 @@ final class HotkeyMonitor {
     func configureTriggerThreshold(milliseconds: Int) {
         prepareDelay = HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: milliseconds)
         startDelay = HotkeyTriggerTiming.startDelay(forThresholdMilliseconds: milliseconds)
-        if isRunning && !targetKeyDown && !armed && !prepared && !active && !toggleActive {
+        if isRunning && !targetKeyDown && !armed && !prepared && !active && !toggleActive && armCancelWorkItem == nil {
             restart()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -102,6 +102,7 @@ final class HotkeyMonitor {
     }
 
     func stop() {
+        finishActiveSessionBeforeReconfigure()
         cancelTimers()
         if let globalMonitor {
             NSEvent.removeMonitor(globalMonitor)

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -67,7 +67,9 @@ final class HotkeyMonitor {
     func configureTriggerThreshold(milliseconds: Int) {
         prepareDelay = HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: milliseconds)
         startDelay = HotkeyTriggerTiming.startDelay(forThresholdMilliseconds: milliseconds)
-        restartIfRunning()
+        if isRunning && !targetKeyDown && !armed && !prepared && !active && !toggleActive {
+            restart()
+        }
     }
 
     func start() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -65,6 +65,7 @@ final class HotkeyMonitor {
     }
 
     func configureTriggerThreshold(milliseconds: Int) {
+        finishActiveSessionBeforeReconfigure()
         prepareDelay = HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: milliseconds)
         startDelay = HotkeyTriggerTiming.startDelay(forThresholdMilliseconds: milliseconds)
         if isRunning && !targetKeyDown && !armed && !prepared && !active && !toggleActive && armCancelWorkItem == nil {

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -68,7 +68,7 @@ final class HotkeyMonitor {
         finishActiveSessionBeforeReconfigure()
         prepareDelay = HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: milliseconds)
         startDelay = HotkeyTriggerTiming.startDelay(forThresholdMilliseconds: milliseconds)
-        if isRunning && !targetKeyDown && !armed && !prepared && !active && !toggleActive && armCancelWorkItem == nil {
+        if isRunning && !targetKeyDown && !armed && !prepared && !active && !toggleActive {
             restart()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -138,11 +138,11 @@ final class HotkeyMonitor {
     }
 
     private func finishActiveSessionBeforeReconfigure() {
-        guard targetKeyDown || armed || prepared || active || toggleActive else { return }
+        guard targetKeyDown || armed || prepared || active || toggleActive || armCancelWorkItem != nil else { return }
 
         let wasToggleActive = toggleActive
         let wasActive = active
-        let wasPreparedOrArmed = prepared || armed
+        let shouldCancel = prepared || armed || armCancelWorkItem != nil
 
         targetKeyDown = false
         otherKeyPressed = false
@@ -158,7 +158,7 @@ final class HotkeyMonitor {
             onToggleStop?()
         } else if wasActive {
             onStop?()
-        } else if wasPreparedOrArmed {
+        } else if shouldCancel {
             onCancel?()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -292,6 +292,7 @@ final class HotkeyMonitor {
 
                 if active {
                     active = false
+                    prepared = false
                     onStop?()
                 } else if prepared {
                     prepared = false
@@ -313,6 +314,7 @@ final class HotkeyMonitor {
             cancelTimers()
             if active {
                 active = false
+                prepared = false
                 onStop?()
             } else if prepared {
                 prepared = false
@@ -347,6 +349,7 @@ final class HotkeyMonitor {
             if active {
                 fputs("[hotkey] escape → cancel hold\n", stderr)
                 active = false
+                prepared = false
                 targetKeyDown = false
                 armed = false
                 cancelTimers()
@@ -374,6 +377,7 @@ final class HotkeyMonitor {
                 cancelTimers()
                 if active {
                     active = false
+                    prepared = false
                     onStop?()
                 } else if prepared {
                     prepared = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -42,8 +42,10 @@ final class MediaPlaybackController: MediaPlaybackManaging {
             pausedForSession = false
             // macOS exposes a reliable public media key toggle, not a global
             // "resume only what I paused" API. Resume only when output still
-            // looks inactive so we do not pause user-started playback.
-            guard client.outputActivityStatus() == .inactive else { return }
+            // does not look active so we do not pause user-started playback.
+            // If activity is unknown, prefer restoring media we know Muesli
+            // paused over leaving playback stranded.
+            guard client.outputActivityStatus() != .active else { return }
             client.sendMediaPlayPauseToggle()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -1,0 +1,180 @@
+import AppKit
+import CoreAudio
+import Foundation
+
+protocol MediaPlaybackManaging: AnyObject {
+    func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind)
+    func restoreDictationMediaPause()
+}
+
+protocol MediaPlaybackClient {
+    func outputActivityStatus() -> AudioOutputActivityStatus
+    func sendMediaPlayPauseToggle()
+}
+
+final class MediaPlaybackController: MediaPlaybackManaging {
+    private let client: MediaPlaybackClient
+    private let queue: DispatchQueue
+    private var pausedForSession = false
+
+    init(
+        client: MediaPlaybackClient = SystemMediaPlaybackClient(),
+        queue: DispatchQueue = DispatchQueue(label: "com.muesli.media-playback")
+    ) {
+        self.client = client
+        self.queue = queue
+    }
+
+    func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind) {
+        queue.async { [self] in
+            guard enabled else { return }
+            guard !pausedForSession else { return }
+            guard routeKind == .speakerLike else { return }
+            guard client.outputActivityStatus() == .active else { return }
+            client.sendMediaPlayPauseToggle()
+            pausedForSession = true
+        }
+    }
+
+    func restoreDictationMediaPause() {
+        queue.async { [self] in
+            guard pausedForSession else { return }
+            pausedForSession = false
+            // macOS exposes a reliable public media key toggle, not a global
+            // "resume only what I paused" API. Resume only when output still
+            // looks inactive so we do not pause user-started playback.
+            guard client.outputActivityStatus() == .inactive else { return }
+            client.sendMediaPlayPauseToggle()
+        }
+    }
+
+    func waitForIdle() {
+        queue.sync {}
+    }
+}
+
+final class SystemMediaPlaybackClient: MediaPlaybackClient {
+    private let currentProcessID = ProcessInfo.processInfo.processIdentifier
+
+    func outputActivityStatus() -> AudioOutputActivityStatus {
+        guard let processIDs = processObjectIDs() else { return .unknown }
+        for processObjectID in processIDs {
+            guard boolProperty(kAudioProcessPropertyIsRunningOutput, objectID: processObjectID),
+                  let pid = pidProperty(objectID: processObjectID),
+                  pid > 0,
+                  pid != currentProcessID else { continue }
+            return .active
+        }
+        return .inactive
+    }
+
+    func sendMediaPlayPauseToggle() {
+        postAuxKey(keyCode: 16)
+    }
+
+    private func postAuxKey(keyCode: Int) {
+        postAuxKeyEvent(keyCode: keyCode, keyState: 0xA)
+        postAuxKeyEvent(keyCode: keyCode, keyState: 0xB)
+    }
+
+    private func postAuxKeyEvent(keyCode: Int, keyState: Int) {
+        let data1 = (keyCode << 16) | (keyState << 8)
+        guard let event = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: NSEvent.ModifierFlags(rawValue: UInt(keyState << 8)),
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: 8,
+            data1: data1,
+            data2: -1
+        )?.cgEvent else { return }
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func processObjectIDs() -> [AudioObjectID]? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize
+        ) == noErr else {
+            return nil
+        }
+        guard dataSize > 0 else { return [] }
+
+        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+        var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &ids
+        ) == noErr else {
+            return nil
+        }
+        return ids.filter { $0 != AudioObjectID(kAudioObjectUnknown) }
+    }
+
+    private func pidProperty(objectID: AudioObjectID) -> pid_t? {
+        var pid = pid_t(0)
+        guard getPid(kAudioProcessPropertyPID, objectID: objectID, value: &pid) else {
+            return nil
+        }
+        return pid
+    }
+
+    private func boolProperty(_ selector: AudioObjectPropertySelector, objectID: AudioObjectID) -> Bool {
+        var value: UInt32 = 0
+        guard getUInt32(
+            selector,
+            objectID: objectID,
+            scope: kAudioObjectPropertyScopeGlobal,
+            element: kAudioObjectPropertyElementMain,
+            value: &value
+        ) else {
+            return false
+        }
+        return value != 0
+    }
+
+    private func getPid(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        value: inout pid_t
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize = UInt32(MemoryLayout<pid_t>.size)
+        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
+    }
+
+    private func getUInt32(
+        _ selector: AudioObjectPropertySelector,
+        objectID: AudioObjectID,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+        value: inout UInt32
+    ) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
@@ -29,7 +29,11 @@ final class MeetingMicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
 
     func start() throws {
         try prepare()
-        recorder?.record()
+        guard recorder?.record() == true else {
+            throw NSError(domain: "MeetingMicrophoneRecorder", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Could not start full-session meeting microphone recording",
+            ])
+        }
     }
 
     func stop() -> URL? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
@@ -30,6 +30,7 @@ final class MeetingMicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
     func start() throws {
         try prepare()
         guard recorder?.record() == true else {
+            cancel()
             throw NSError(domain: "MeetingMicrophoneRecorder", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Could not start full-session meeting microphone recording",
             ])

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
@@ -29,7 +29,7 @@ final class MeetingMicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
 
     func start() throws {
         try prepare()
-        guard recorder?.record() == true else {
+        guard let recorder, recorder.record() else {
             cancel()
             throw NSError(domain: "MeetingMicrophoneRecorder", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Could not start full-session meeting microphone recording",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicrophoneRecorder.swift
@@ -1,0 +1,60 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+final class MeetingMicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
+    private var recorder: AVAudioRecorder?
+    private var preparedURL: URL?
+
+    func prepare() throws {
+        if recorder != nil { return }
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-native", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: 16_000,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+        let recorder = try AVAudioRecorder(url: fileURL, settings: settings)
+        recorder.delegate = self
+        recorder.isMeteringEnabled = true
+        recorder.prepareToRecord()
+        self.preparedURL = fileURL
+        self.recorder = recorder
+    }
+
+    func start() throws {
+        try prepare()
+        recorder?.record()
+    }
+
+    func stop() -> URL? {
+        guard let recorder else { return nil }
+        recorder.stop()
+        let url = preparedURL
+        self.recorder = nil
+        self.preparedURL = nil
+        return url
+    }
+
+    func pause() {
+        recorder?.pause()
+    }
+
+    func resume() {
+        recorder?.record()
+    }
+
+    func cancel() {
+        recorder?.stop()
+        if let url = preparedURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        recorder = nil
+        preparedURL = nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -720,6 +720,7 @@ final class MeetingSession {
         if let vadManager {
             let controller = StreamingVadController(vadManager: vadManager)
             controller.onChunkBoundary = { [weak self] in
+                // Streaming VAD callbacks can arrive off-main; serialize chunk rotation explicitly.
                 self?.chunkRotationQueue.async { [weak self] in
                     self?.rotateChunkOnQueue()
                 }
@@ -729,6 +730,7 @@ final class MeetingSession {
 
             let systemController = StreamingVadController(vadManager: vadManager)
             systemController.onChunkBoundary = { [weak self] in
+                // Streaming VAD callbacks can arrive off-main; serialize chunk rotation explicitly.
                 self?.chunkRotationQueue.async { [weak self] in
                     self?.rotateSystemChunkOnQueue()
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -720,14 +720,18 @@ final class MeetingSession {
         if let vadManager {
             let controller = StreamingVadController(vadManager: vadManager)
             controller.onChunkBoundary = { [weak self] in
-                self?.rotateChunk()
+                self?.chunkRotationQueue.async { [weak self] in
+                    self?.rotateChunkOnQueue()
+                }
             }
             controller.start()
             vadController = controller
 
             let systemController = StreamingVadController(vadManager: vadManager)
             systemController.onChunkBoundary = { [weak self] in
-                self?.rotateSystemChunk()
+                self?.chunkRotationQueue.async { [weak self] in
+                    self?.rotateSystemChunkOnQueue()
+                }
             }
             systemController.start()
             systemVadController = systemController

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -757,11 +757,6 @@ final class MeetingSession {
 
             let floatSamples = rawSamples.map { Float($0) / 32767.0 }
 
-            // VAD always sees raw audio for reliable speech boundary detection
-            if let vadController = self.vadController {
-                vadController.processAudio(floatSamples)
-            }
-
             // AEC: clean mic using position-aligned system reference
             let cleanedFloat = self.neuralAec.processStreamingMic(floatSamples)
             if !cleanedFloat.isEmpty {
@@ -769,6 +764,12 @@ final class MeetingSession {
                     Int16(max(-1.0, min(1.0, sample)) * 32767)
                 }
                 self.rawMicChunkRecorder?.append(cleanedInt16)
+            }
+
+            // VAD sees raw audio, but only after the cleaned samples for this
+            // buffer have been appended so boundary rotation stays ordered.
+            if let vadController = self.vadController {
+                vadController.processAudio(floatSamples)
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -91,7 +91,7 @@ final class MeetingSession {
     private let config: AppConfig
     private let transcriptionCoordinator: TranscriptionCoordinator
     private let systemAudioRecorder: SystemAudioCapturing
-    private let fullSessionMicRecorder = MicrophoneRecorder()
+    private let fullSessionMicRecorder = MeetingMicrophoneRecorder()
     private let neuralAec = MeetingNeuralAec()
 
     /// Streaming mic recorder with real-time buffer access (AVAudioEngine)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -7,6 +7,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
     var preferredInputDeviceID: AudioObjectID?
     var keepsAudioGraphWarm = false
     var onFirstCapturedAudioBuffer: ((Date) -> Void)?
+    var onFirstSpeechDetected: ((Date) -> Void)?
+    var onNoAudioTimeout: ((Date) -> Void)?
 
     private struct FileState {
         var fileHandle: FileHandle?
@@ -16,20 +18,26 @@ final class MicrophoneRecorder: @unchecked Sendable {
         var isPaused = false
         var isCapturing = false
         var hasReceivedFirstAudioBuffer = false
+        var hasDetectedSpeech = false
+        var hasReportedNoAudioTimeout = false
     }
 
     private static let sampleRate: Double = 16_000
-    private static let bufferSize: AVAudioFrameCount = 1024
+    private static let bufferSize: AVAudioFrameCount = 640
+    private static let speechThresholdDB: Float = -58
+    private static let noAudioTimeout: TimeInterval = 1.5
 
     private let engine = AVAudioEngine()
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
     private let lifecycleLock = NSRecursiveLock()
     private let writerQueue = DispatchQueue(label: "com.muesli.microphone-recorder-writer")
+    private let timeoutQueue = DispatchQueue(label: "com.muesli.microphone-recorder-timeout")
     private var isPrepared = false
     private var isRunning = false
     private var isGraphPrepared = false
     private var tapInstalled = false
     private var preparedInputDeviceID: AudioObjectID?
+    private var noAudioTimeoutWorkItem: DispatchWorkItem?
 
     func prepare() throws {
         lifecycleLock.lock()
@@ -158,6 +166,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
                     state.isPaused = false
                     state.latestPowerDB = -160
                     state.hasReceivedFirstAudioBuffer = false
+                    state.hasDetectedSpeech = false
+                    state.hasReportedNoAudioTimeout = false
                 }
                 try engine.start()
             } else {
@@ -166,15 +176,19 @@ final class MicrophoneRecorder: @unchecked Sendable {
                     state.isPaused = false
                     state.latestPowerDB = -160
                     state.hasReceivedFirstAudioBuffer = false
+                    state.hasDetectedSpeech = false
+                    state.hasReportedNoAudioTimeout = false
                 }
             }
             isRunning = true
+            scheduleNoAudioTimeout()
         } catch {
             isRunning = false
             lock.withLock { state in
                 state.isCapturing = false
                 state.latestPowerDB = -160
             }
+            cancelNoAudioTimeout()
             stopWarmGraphLocked()
             throw error
         }
@@ -186,6 +200,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
 
         guard isPrepared else { return nil }
         isRunning = false
+        cancelNoAudioTimeout()
 
         let finalState = lock.withLock { state -> FileState in
             let old = state
@@ -235,6 +250,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
 
         isRunning = false
         isPrepared = false
+        cancelNoAudioTimeout()
 
         let state = lock.withLock { state -> FileState in
             let old = state
@@ -312,18 +328,22 @@ final class MicrophoneRecorder: @unchecked Sendable {
         let pcmByteCount = pcmData.count
         let dataToWrite = pcmData
 
-        let writeTarget = lock.withLock { state -> (FileHandle?, Bool) in
+        let writeTarget = lock.withLock { state -> (FileHandle?, Bool, Bool) in
             guard state.isCapturing, !state.isPaused else {
                 state.latestPowerDB = -160
-                return (nil, false)
+                return (nil, false, false)
             }
             let shouldNotifyFirstBuffer = !state.hasReceivedFirstAudioBuffer
             if !state.hasReceivedFirstAudioBuffer {
                 state.hasReceivedFirstAudioBuffer = true
             }
+            let shouldNotifySpeech = !state.hasDetectedSpeech && powerDB >= Self.speechThresholdDB
+            if shouldNotifySpeech {
+                state.hasDetectedSpeech = true
+            }
             state.bytesWritten += pcmByteCount
             state.latestPowerDB = powerDB
-            return (state.fileHandle, shouldNotifyFirstBuffer)
+            return (state.fileHandle, shouldNotifyFirstBuffer, shouldNotifySpeech)
         }
         if let handle = writeTarget.0 {
             writerQueue.async { [dataToWrite] in
@@ -332,6 +352,9 @@ final class MicrophoneRecorder: @unchecked Sendable {
         }
         if writeTarget.1 {
             onFirstCapturedAudioBuffer?(capturedAt)
+        }
+        if writeTarget.2 {
+            onFirstSpeechDetected?(capturedAt)
         }
     }
 
@@ -365,6 +388,32 @@ final class MicrophoneRecorder: @unchecked Sendable {
 
     private func waitForPendingWrites() {
         writerQueue.sync {}
+    }
+
+    private func scheduleNoAudioTimeout() {
+        cancelNoAudioTimeout()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let shouldNotify = self.lock.withLock { state -> Bool in
+                guard state.isCapturing,
+                      !state.hasDetectedSpeech,
+                      !state.hasReportedNoAudioTimeout else {
+                    return false
+                }
+                state.hasReportedNoAudioTimeout = true
+                return true
+            }
+            if shouldNotify {
+                self.onNoAudioTimeout?(Date())
+            }
+        }
+        noAudioTimeoutWorkItem = workItem
+        timeoutQueue.asyncAfter(deadline: .now() + Self.noAudioTimeout, execute: workItem)
+    }
+
+    private func cancelNoAudioTimeout() {
+        noAudioTimeoutWorkItem?.cancel()
+        noAudioTimeoutWorkItem = nil
     }
 
     private func removeTapIfNeeded() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -224,6 +224,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
         // callbacks that already reached the dispatch group.
         tapCallbackGroup.wait()
         waitForPendingWrites()
+        waitForPendingWrites()
         if keepsAudioGraphWarm {
             lock.withLock { $0.latestPowerDB = -160 }
         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -314,7 +314,13 @@ final class MicrophoneRecorder: @unchecked Sendable {
                 return
             }
             var error: NSError?
+            var didProvideInput = false
             let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+                guard !didProvideInput else {
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+                didProvideInput = true
                 outStatus.pointee = .haveData
                 return buffer
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -167,6 +167,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
         try prepare()
 
         do {
+            // The preferred input can refresh between prepare/warmup and start
+            // after a route change, so keep this re-check on the start path.
             try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
             if !engine.isRunning {
                 lock.withLock { state in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -1,64 +1,376 @@
 @preconcurrency import AVFoundation
+import CoreAudio
 import Foundation
+import os
 
-final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate {
-    private var recorder: AVAudioRecorder?
-    private var preparedURL: URL?
+final class MicrophoneRecorder: @unchecked Sendable {
+    var preferredInputDeviceID: AudioObjectID?
+    var keepsAudioGraphWarm = false
+    var onFirstCapturedAudioBuffer: ((Date) -> Void)?
+
+    private struct FileState {
+        var fileHandle: FileHandle?
+        var fileURL: URL?
+        var bytesWritten: Int = 0
+        var latestPowerDB: Float = -160
+        var isPaused = false
+        var isCapturing = false
+        var hasReceivedFirstAudioBuffer = false
+    }
+
+    private static let sampleRate: Double = 16_000
+    private static let bufferSize: AVAudioFrameCount = 1024
+
+    private let engine = AVAudioEngine()
+    private let lock = OSAllocatedUnfairLock(initialState: FileState())
+    private let lifecycleLock = NSRecursiveLock()
+    private let writerQueue = DispatchQueue(label: "com.muesli.microphone-recorder-writer")
+    private var isPrepared = false
+    private var isRunning = false
+    private var isGraphPrepared = false
+    private var tapInstalled = false
+    private var preparedInputDeviceID: AudioObjectID?
 
     func prepare() throws {
-        if recorder != nil { return }
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("muesli-native", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let fileURL = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
-        let settings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
-            AVSampleRateKey: 16_000,
-            AVNumberOfChannelsKey: 1,
-            AVLinearPCMBitDepthKey: 16,
-            AVLinearPCMIsFloatKey: false,
-            AVLinearPCMIsBigEndianKey: false,
-        ]
-        let recorder = try AVAudioRecorder(url: fileURL, settings: settings)
-        recorder.delegate = self
-        recorder.isMeteringEnabled = true
-        recorder.prepareToRecord()
-        self.preparedURL = fileURL
-        self.recorder = recorder
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        guard !isPrepared else { return }
+        try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
+
+        let fileState = try createNewFile()
+        lock.withLock { $0 = fileState }
+        isPrepared = true
+    }
+
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        self.preferredInputDeviceID = preferredInputDeviceID
+        guard !isPrepared && !isRunning else {
+            fputs("[mic-recorder] warmup deferred while capture is active\n", stderr)
+            return
+        }
+        try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
+    }
+
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        self.preferredInputDeviceID = preferredInputDeviceID
+        guard !isPrepared && !isRunning else {
+            fputs("[mic-recorder] activation deferred while capture is active\n", stderr)
+            return
+        }
+        try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
+        guard !engine.isRunning else { return }
+        lock.withLock { state in
+            state.isCapturing = false
+            state.isPaused = false
+            state.latestPowerDB = -160
+            state.hasReceivedFirstAudioBuffer = false
+        }
+        try engine.start()
+        fputs(
+            "[mic-recorder] warm engine activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n",
+            stderr
+        )
+    }
+
+    func coolDown() {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        guard !isPrepared && !isRunning else { return }
+        stopWarmGraphLocked()
+    }
+
+    private func ensurePreparedGraphLocked(preferredInputDeviceID: AudioObjectID?) throws {
+        if isGraphPrepared, preparedInputDeviceID == preferredInputDeviceID {
+            return
+        }
+        if isRunning {
+            return
+        }
+
+        stopWarmGraphLocked()
+
+        AudioInputDeviceSelection.applyPreferredInputDeviceID(
+            preferredInputDeviceID,
+            to: engine,
+            logPrefix: "mic-recorder"
+        )
+
+        let inputNode = engine.inputNode
+        let hwFormat = inputNode.outputFormat(forBus: 0)
+        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+            throw NSError(domain: "MicrophoneRecorder", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "No audio input available",
+            ])
+        }
+
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.sampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw NSError(domain: "MicrophoneRecorder", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Could not create target audio format",
+            ])
+        }
+
+        let needsConversion = hwFormat.sampleRate != Self.sampleRate || hwFormat.channelCount != 1
+        let converter = needsConversion ? AVAudioConverter(from: hwFormat, to: targetFormat) : nil
+
+        fputs(
+            "[mic-recorder] preparing graph preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default") hwRate=\(Int(hwFormat.sampleRate)) channels=\(hwFormat.channelCount)\n",
+            stderr
+        )
+        inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
+            self?.handleAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
+        }
+        tapInstalled = true
+        engine.prepare()
+        isGraphPrepared = true
+        preparedInputDeviceID = preferredInputDeviceID
     }
 
     func start() throws {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        guard !isRunning else { return }
         try prepare()
-        recorder?.record()
+
+        do {
+            if !engine.isRunning {
+                try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
+                lock.withLock { state in
+                    state.isCapturing = true
+                    state.isPaused = false
+                    state.latestPowerDB = -160
+                    state.hasReceivedFirstAudioBuffer = false
+                }
+                try engine.start()
+            } else {
+                lock.withLock { state in
+                    state.isCapturing = true
+                    state.isPaused = false
+                    state.latestPowerDB = -160
+                    state.hasReceivedFirstAudioBuffer = false
+                }
+            }
+            isRunning = true
+        } catch {
+            isRunning = false
+            lock.withLock { state in
+                state.isCapturing = false
+                state.latestPowerDB = -160
+            }
+            throw error
+        }
     }
 
     func stop() -> URL? {
-        guard let recorder else { return nil }
-        recorder.stop()
-        let url = preparedURL
-        self.recorder = nil
-        self.preparedURL = nil
-        return url
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        guard isPrepared else { return nil }
+        isRunning = false
+
+        let finalState = lock.withLock { state -> FileState in
+            let old = state
+            state = FileState()
+            return old
+        }
+        isPrepared = false
+        engine.stop()
+        waitForPendingWrites()
+        if keepsAudioGraphWarm {
+            lock.withLock { $0.latestPowerDB = -160 }
+        } else {
+            stopWarmGraphLocked()
+        }
+
+        return finalizeFile(finalState)
     }
 
     func pause() {
-        recorder?.pause()
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        guard isPrepared else { return }
+        lock.withLock { state in
+            state.isPaused = true
+            state.latestPowerDB = -160
+        }
     }
 
     func resume() {
-        recorder?.record()
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        guard isPrepared else { return }
+        lock.withLock { state in
+            state.isPaused = false
+        }
     }
 
     func currentPower() -> Float {
-        recorder?.updateMeters()
-        return recorder?.averagePower(forChannel: 0) ?? -160
+        lock.withLock { $0.latestPowerDB }
     }
 
     func cancel() {
-        recorder?.stop()
-        if let url = preparedURL {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
+        isRunning = false
+        isPrepared = false
+
+        let state = lock.withLock { state -> FileState in
+            let old = state
+            state = FileState()
+            return old
+        }
+        engine.stop()
+        waitForPendingWrites()
+        state.fileHandle?.closeFile()
+        if let url = state.fileURL {
             try? FileManager.default.removeItem(at: url)
         }
-        recorder = nil
-        preparedURL = nil
+        if keepsAudioGraphWarm {
+            lock.withLock { $0.latestPowerDB = -160 }
+        } else {
+            stopWarmGraphLocked()
+        }
+    }
+
+    private func handleAudioBuffer(
+        _ buffer: AVAudioPCMBuffer,
+        converter: AVAudioConverter?,
+        targetFormat: AVAudioFormat
+    ) {
+        let capturedAt = Date()
+        let shouldCapture = lock.withLock { state -> Bool in
+            guard state.isCapturing, !state.isPaused else {
+                state.latestPowerDB = -160
+                return false
+            }
+            return true
+        }
+        guard shouldCapture else { return }
+
+        let monoBuffer: AVAudioPCMBuffer
+        if let converter {
+            let frameCapacity = max(
+                1,
+                AVAudioFrameCount(Double(buffer.frameLength) * Self.sampleRate / buffer.format.sampleRate)
+            )
+            guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else {
+                return
+            }
+            var error: NSError?
+            let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+                outStatus.pointee = .haveData
+                return buffer
+            }
+            converter.convert(to: converted, error: &error, withInputFrom: inputBlock)
+            guard error == nil else { return }
+            monoBuffer = converted
+        } else {
+            monoBuffer = buffer
+        }
+
+        guard let floatData = monoBuffer.floatChannelData?[0] else { return }
+        let frameCount = Int(monoBuffer.frameLength)
+        guard frameCount > 0 else { return }
+
+        var sumSquares: Float = 0
+        var pcmData = Data(count: frameCount * MemoryLayout<Int16>.size)
+        pcmData.withUnsafeMutableBytes { rawBuffer in
+            guard let output = rawBuffer.bindMemory(to: Int16.self).baseAddress else { return }
+            for i in 0..<frameCount {
+                let sample = floatData[i]
+                let clamped = max(-1.0, min(1.0, sample))
+                output[i] = Int16(clamped * 32767)
+                sumSquares += sample * sample
+            }
+        }
+
+        let rms = sqrt(sumSquares / Float(frameCount))
+        let rawDB = rms > 0.000_001 ? 20 * log10(rms) : -160
+        let powerDB = max(-160, min(0, rawDB))
+        let pcmByteCount = pcmData.count
+        let dataToWrite = pcmData
+
+        let writeTarget = lock.withLock { state -> (FileHandle?, Bool) in
+            guard state.isCapturing, !state.isPaused else {
+                state.latestPowerDB = -160
+                return (nil, false)
+            }
+            let shouldNotifyFirstBuffer = !state.hasReceivedFirstAudioBuffer
+            if !state.hasReceivedFirstAudioBuffer {
+                state.hasReceivedFirstAudioBuffer = true
+            }
+            state.bytesWritten += pcmByteCount
+            state.latestPowerDB = powerDB
+            return (state.fileHandle, shouldNotifyFirstBuffer)
+        }
+        if let handle = writeTarget.0 {
+            writerQueue.async { [dataToWrite] in
+                handle.write(dataToWrite)
+            }
+        }
+        if writeTarget.1 {
+            onFirstCapturedAudioBuffer?(capturedAt)
+        }
+    }
+
+    private func createNewFile() throws -> FileState {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-native", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        guard let handle = FileHandle(forWritingAtPath: url.path) else {
+            throw NSError(domain: "MicrophoneRecorder", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Could not open file for writing",
+            ])
+        }
+        handle.write(WavWriter.header(dataSize: 0))
+        return FileState(fileHandle: handle, fileURL: url)
+    }
+
+    private func finalizeFile(_ state: FileState) -> URL? {
+        guard let handle = state.fileHandle, let url = state.fileURL else { return nil }
+        handle.seek(toFileOffset: 0)
+        handle.write(WavWriter.header(dataSize: UInt32(state.bytesWritten)))
+        handle.closeFile()
+
+        if state.bytesWritten == 0 {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        return url
+    }
+
+    private func waitForPendingWrites() {
+        writerQueue.sync {}
+    }
+
+    private func removeTapIfNeeded() {
+        guard tapInstalled else { return }
+        engine.inputNode.removeTap(onBus: 0)
+        tapInstalled = false
+    }
+
+    private func stopWarmGraphLocked() {
+        removeTapIfNeeded()
+        engine.stop()
+        isGraphPrepared = false
+        preparedInputDeviceID = nil
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -224,6 +224,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
         // callbacks that already reached the dispatch group.
         tapCallbackGroup.wait()
         waitForPendingWrites()
+        // Second drain is defensive if future write work ever enqueues another
+        // writerQueue block before the WAV header is finalized.
         waitForPendingWrites()
         if keepsAudioGraphWarm {
             lock.withLock { $0.latestPowerDB = -160 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -219,6 +219,9 @@ final class MicrophoneRecorder: @unchecked Sendable {
         }
         isPrepared = false
         engine.stop()
+        // AVAudioEngine.stop() must happen before waiting here: after it returns,
+        // CoreAudio will not enter new tap callbacks, so this wait only drains
+        // callbacks that already reached the dispatch group.
         tapCallbackGroup.wait()
         waitForPendingWrites()
         if keepsAudioGraphWarm {
@@ -269,6 +272,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
             return old
         }
         engine.stop()
+        // See stop(): engine.stop() closes the door on new tap callbacks before
+        // we wait for callbacks that were already in flight.
         tapCallbackGroup.wait()
         waitForPendingWrites()
         state.fileHandle?.closeFile()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -32,6 +32,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
     private let lifecycleLock = NSRecursiveLock()
     private let writerQueue = DispatchQueue(label: "com.muesli.microphone-recorder-writer")
     private let timeoutQueue = DispatchQueue(label: "com.muesli.microphone-recorder-timeout")
+    private let tapCallbackGroup = DispatchGroup()
     private var isPrepared = false
     private var isRunning = false
     private var isGraphPrepared = false
@@ -209,6 +210,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
         }
         isPrepared = false
         engine.stop()
+        tapCallbackGroup.wait()
         waitForPendingWrites()
         if keepsAudioGraphWarm {
             lock.withLock { $0.latestPowerDB = -160 }
@@ -258,6 +260,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
             return old
         }
         engine.stop()
+        tapCallbackGroup.wait()
         waitForPendingWrites()
         state.fileHandle?.closeFile()
         if let url = state.fileURL {
@@ -284,6 +287,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
             return true
         }
         guard shouldCapture else { return }
+        tapCallbackGroup.enter()
+        defer { tapCallbackGroup.leave() }
 
         let monoBuffer: AVAudioPCMBuffer
         if let converter {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -295,6 +295,9 @@ final class MicrophoneRecorder: @unchecked Sendable {
         targetFormat: AVAudioFormat
     ) {
         let capturedAt = Date()
+        tapCallbackGroup.enter()
+        defer { tapCallbackGroup.leave() }
+
         let shouldCapture = lock.withLock { state -> Bool in
             guard state.isCapturing, !state.isPaused else {
                 state.latestPowerDB = -160
@@ -303,8 +306,6 @@ final class MicrophoneRecorder: @unchecked Sendable {
             return true
         }
         guard shouldCapture else { return }
-        tapCallbackGroup.enter()
-        defer { tapCallbackGroup.leave() }
 
         let monoBuffer: AVAudioPCMBuffer
         if let converter {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -160,8 +160,8 @@ final class MicrophoneRecorder: @unchecked Sendable {
         try prepare()
 
         do {
+            try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
             if !engine.isRunning {
-                try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
                 lock.withLock { state in
                     state.isCapturing = true
                     state.isPaused = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -72,7 +72,12 @@ final class MicrophoneRecorder: @unchecked Sendable {
             state.latestPowerDB = -160
             state.hasReceivedFirstAudioBuffer = false
         }
-        try engine.start()
+        do {
+            try engine.start()
+        } catch {
+            stopWarmGraphLocked()
+            throw error
+        }
         fputs(
             "[mic-recorder] warm engine activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n",
             stderr
@@ -170,6 +175,7 @@ final class MicrophoneRecorder: @unchecked Sendable {
                 state.isCapturing = false
                 state.latestPowerDB = -160
             }
+            stopWarmGraphLocked()
             throw error
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -226,9 +226,6 @@ final class MicrophoneRecorder: @unchecked Sendable {
             fputs("[audio-recorder] timed out waiting for tap callbacks during stop\n", stderr)
         }
         waitForPendingWrites()
-        // Second drain is defensive if future write work ever enqueues another
-        // writerQueue block before the WAV header is finalized.
-        waitForPendingWrites()
         if keepsAudioGraphWarm {
             lock.withLock { $0.latestPowerDB = -160 }
         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -73,6 +73,13 @@ final class MicrophoneRecorder: @unchecked Sendable {
             fputs("[mic-recorder] activation deferred while capture is active\n", stderr)
             return
         }
+        if engine.isRunning, preparedInputDeviceID != preferredInputDeviceID {
+            fputs(
+                "[mic-recorder] rebuilding warm engine for preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n",
+                stderr
+            )
+            stopWarmGraphLocked()
+        }
         try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
         guard !engine.isRunning else { return }
         lock.withLock { state in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -276,7 +276,9 @@ final class MicrophoneRecorder: @unchecked Sendable {
         engine.stop()
         // See stop(): engine.stop() closes the door on new tap callbacks before
         // we wait for callbacks that were already in flight.
-        tapCallbackGroup.wait()
+        if tapCallbackGroup.wait(timeout: .now() + 2.0) == .timedOut {
+            fputs("[audio-recorder] timed out waiting for tap callbacks during cancel\n", stderr)
+        }
         waitForPendingWrites()
         state.fileHandle?.closeFile()
         if let url = state.fileURL {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -222,7 +222,9 @@ final class MicrophoneRecorder: @unchecked Sendable {
         // AVAudioEngine.stop() must happen before waiting here: after it returns,
         // CoreAudio will not enter new tap callbacks, so this wait only drains
         // callbacks that already reached the dispatch group.
-        tapCallbackGroup.wait()
+        if tapCallbackGroup.wait(timeout: .now() + 2.0) == .timedOut {
+            fputs("[audio-recorder] timed out waiting for tap callbacks during stop\n", stderr)
+        }
         waitForPendingWrites()
         // Second drain is defensive if future write work ever enqueues another
         // writerQueue block before the WAV header is finalized.

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -618,6 +618,7 @@ struct AppConfig: Codable {
     var meetingRecordingSavePolicy: MeetingRecordingSavePolicy = .never
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
+    var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
     var launchAtLogin: Bool = false
     var openDashboardOnLaunch: Bool = true
     var showFloatingIndicator: Bool = true
@@ -684,6 +685,7 @@ struct AppConfig: Codable {
         case meetingRecordingSavePolicy = "meeting_recording_save_policy"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
+        case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
         case launchAtLogin = "launch_at_login"
         case openDashboardOnLaunch = "open_dashboard_on_launch"
         case showFloatingIndicator = "show_floating_indicator"
@@ -761,6 +763,9 @@ struct AppConfig: Codable {
         meetingRecordingSavePolicy = (try? c.decode(MeetingRecordingSavePolicy.self, forKey: .meetingRecordingSavePolicy)) ?? defaults.meetingRecordingSavePolicy
         darkMode = (try? c.decode(Bool.self, forKey: .darkMode)) ?? defaults.darkMode
         enableDoubleTapDictation = (try? c.decode(Bool.self, forKey: .enableDoubleTapDictation)) ?? defaults.enableDoubleTapDictation
+        hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(
+            (try? c.decode(Int.self, forKey: .hotkeyTriggerThresholdMS)) ?? defaults.hotkeyTriggerThresholdMS
+        )
         launchAtLogin = (try? c.decode(Bool.self, forKey: .launchAtLogin)) ?? defaults.launchAtLogin
         openDashboardOnLaunch = (try? c.decode(Bool.self, forKey: .openDashboardOnLaunch)) ?? defaults.openDashboardOnLaunch
         showFloatingIndicator = (try? c.decode(Bool.self, forKey: .showFloatingIndicator)) ?? defaults.showFloatingIndicator

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -642,6 +642,7 @@ struct AppConfig: Codable {
     ]
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
+    var muteSystemAudioDuringDictation: Bool = false
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
     var menuBarIcon: String = "muesli"
     var showNextMeetingInMenuBar: Bool = true
@@ -705,6 +706,7 @@ struct AppConfig: Codable {
         case customWords = "custom_words"
         case folderOrder = "folder_order"
         case soundEnabled = "sound_enabled"
+        case muteSystemAudioDuringDictation = "mute_system_audio_during_dictation"
         case recordingColorHex = "recording_color_hex"
         case menuBarIcon = "menu_bar_icon"
         case showNextMeetingInMenuBar = "show_next_meeting_in_menu_bar"
@@ -790,6 +792,7 @@ struct AppConfig: Codable {
         customWords = (try? c.decode([CustomWord].self, forKey: .customWords)) ?? defaults.customWords
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
+        muteSystemAudioDuringDictation = (try? c.decode(Bool.self, forKey: .muteSystemAudioDuringDictation)) ?? defaults.muteSystemAudioDuringDictation
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
         showNextMeetingInMenuBar = (try? c.decode(Bool.self, forKey: .showNextMeetingInMenuBar)) ?? defaults.showNextMeetingInMenuBar

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -643,6 +643,7 @@ struct AppConfig: Codable {
     ]
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
+    var pauseMediaDuringDictation: Bool = false
     var muteSystemAudioDuringDictation: Bool = false
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
     var menuBarIcon: String = "muesli"
@@ -708,6 +709,7 @@ struct AppConfig: Codable {
         case customWords = "custom_words"
         case folderOrder = "folder_order"
         case soundEnabled = "sound_enabled"
+        case pauseMediaDuringDictation = "pause_media_during_dictation"
         case muteSystemAudioDuringDictation = "mute_system_audio_during_dictation"
         case recordingColorHex = "recording_color_hex"
         case menuBarIcon = "menu_bar_icon"
@@ -797,6 +799,7 @@ struct AppConfig: Codable {
         customWords = (try? c.decode([CustomWord].self, forKey: .customWords)) ?? defaults.customWords
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
+        pauseMediaDuringDictation = (try? c.decode(Bool.self, forKey: .pauseMediaDuringDictation)) ?? defaults.pauseMediaDuringDictation
         muteSystemAudioDuringDictation = (try? c.decode(Bool.self, forKey: .muteSystemAudioDuringDictation)) ?? defaults.muteSystemAudioDuringDictation
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -179,6 +179,7 @@ final class MuesliController: NSObject {
     private var dictationLatencyTraceStartedAt: Date?
     private var currentDictationOutputMode: DictationOutputMode = .paste
     private var pendingDictationStopStartedAt: Date?
+    private var pendingDictationStopSessionID: UUID?
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
@@ -188,6 +189,7 @@ final class MuesliController: NSObject {
     private let computerUseFloatingStatusMinimumDwell: TimeInterval = 0.85
     private var _streamingDictationController: Any?  // StreamingDictationController (macOS 15+)
     private var isNemotronStreaming = false
+    private var nemotronStreamingSessionID: UUID?
     private var previousStreamText = ""
     private var openWindowCount = 0
     private var lastExternalApp: NSRunningApplication?
@@ -4169,8 +4171,25 @@ final class MuesliController: NSObject {
             handleDictationSpeechDetected(capturedAt: capturedAt)
         case .noAudioTimeout:
             statusBarController?.setStatus("Mic waiting for speech")
-        case .stopped(_, let wavURL):
+        case .stopped(let eventSessionID, let wavURL):
+            guard pendingDictationStopSessionID == eventSessionID else {
+                fputs("[muesli-native] ignoring stale stopped event\n", stderr)
+                if let wavURL {
+                    try? FileManager.default.removeItem(at: wavURL)
+                }
+                break
+            }
+            guard dictationAudioSessionManager.currentSessionID == nil else {
+                fputs("[muesli-native] ignoring stopped event while a new session is active\n", stderr)
+                pendingDictationStopSessionID = nil
+                pendingDictationStopStartedAt = nil
+                if let wavURL {
+                    try? FileManager.default.removeItem(at: wavURL)
+                }
+                break
+            }
             let startedAt = pendingDictationStopStartedAt ?? dictationStartedAt ?? Date()
+            pendingDictationStopSessionID = nil
             pendingDictationStopStartedAt = nil
             finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt)
         case .cancelled:
@@ -4179,6 +4198,7 @@ final class MuesliController: NSObject {
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
             resetDictationOutputMode()
             dictationStartedAt = nil
+            pendingDictationStopSessionID = nil
             pendingDictationStopStartedAt = nil
             capturedDictationContext = nil
             setState(.idle)
@@ -4286,7 +4306,10 @@ final class MuesliController: NSObject {
     }
 
     @available(macOS 15, *)
-    private func startNemotronStreamingAsync(preferredInputDeviceID: AudioObjectID?) {
+    private func startNemotronStreamingAsync(
+        preferredInputDeviceID: AudioObjectID?,
+        sessionID: UUID
+    ) {
         Task {
             let transcriber = await transcriptionCoordinator.getNemotronTranscriber()
             fputs("[muesli-native] got Nemotron transcriber\n", stderr)
@@ -4297,11 +4320,13 @@ final class MuesliController: NSObject {
             )
             controller.onPartialText = { [weak self] fullText in
                 guard let self else { return }
+                guard self.nemotronStreamingSessionID == sessionID else { return }
                 let delta = String(fullText.dropFirst(self.previousStreamText.count))
                 fputs("[muesli-native] streaming partial: +\"\(delta)\" (total \(fullText.count) chars)\n", stderr)
                 if !delta.isEmpty {
                     self.previousStreamText = fullText
                     DispatchQueue.main.async {
+                        guard self.nemotronStreamingSessionID == sessionID else { return }
                         if self.currentDictationOutputMode != .voiceNote {
                             PasteController.typeText(delta)
                         }
@@ -4310,7 +4335,7 @@ final class MuesliController: NSObject {
             }
 
             await MainActor.run {
-                guard self.isNemotronStreaming else {
+                guard self.isNemotronStreaming, self.nemotronStreamingSessionID == sessionID else {
                     fputs("[muesli-native] Nemotron session cancelled before transcriber ready\n", stderr)
                     return
                 }
@@ -4329,6 +4354,7 @@ final class MuesliController: NSObject {
         fputs("[muesli-native] Nemotron streaming controller failed to start\n", stderr)
         isNemotronStreaming = false
         _streamingDictationController = nil
+        nemotronStreamingSessionID = nil
         previousStreamText = ""
         dictationStartedAt = nil
         dictationAudioSessionManager.endExternalSession(reason: "nemotron-start-failed")
@@ -4348,15 +4374,17 @@ final class MuesliController: NSObject {
         if isNemotronStreaming {
             isNemotronStreaming = false
             if #available(macOS 15, *), let sdc = _streamingDictationController as? StreamingDictationController {
-                let _ = sdc.stop()
+                sdc.cancel()
             }
             _streamingDictationController = nil
+            nemotronStreamingSessionID = nil
             previousStreamText = ""
         }
 
         dictationAudioSessionManager.cancel(reason: "user-cancel")
         capturedDictationContext = nil
         dictationStartedAt = nil
+        pendingDictationStopSessionID = nil
         pendingDictationStopStartedAt = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
@@ -4380,7 +4408,9 @@ final class MuesliController: NSObject {
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
             if #available(macOS 15, *) {
+                let sessionID = UUID()
                 isNemotronStreaming = true
+                nemotronStreamingSessionID = sessionID
                 previousStreamText = ""
                 dictationStartedAt = Date()
                 setState(.recording)
@@ -4390,7 +4420,10 @@ final class MuesliController: NSObject {
                     duckingEnabled: config.muteSystemAudioDuringDictation
                 )
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
-                startNemotronStreamingAsync(preferredInputDeviceID: preferredInputDeviceID)
+                startNemotronStreamingAsync(
+                    preferredInputDeviceID: preferredInputDeviceID,
+                    sessionID: sessionID
+                )
                 return
             }
         }
@@ -4423,46 +4456,72 @@ final class MuesliController: NSObject {
 
         // Nemotron streaming: text already typed — just finalize and store
         if isNemotronStreaming {
+            let sessionID = nemotronStreamingSessionID
             isNemotronStreaming = false
-            var finalText = ""
             if #available(macOS 15, *), let controller = _streamingDictationController as? StreamingDictationController {
-                finalText = controller.stop()
-                fputs("[muesli-native] Nemotron streaming stop, got \(finalText.count) chars\n", stderr)
+                controller.stop { [weak self] finalText in
+                    DispatchQueue.main.async {
+                        self?.finishNemotronStreamingStop(
+                            finalText: finalText,
+                            startedAt: startedAt,
+                            sessionID: sessionID
+                        )
+                    }
+                }
             } else {
                 fputs("[muesli-native] Nemotron streaming stop, controller not ready (short press)\n", stderr)
-            }
-            dictationAudioSessionManager.endExternalSession(reason: "nemotron-stop")
-            _streamingDictationController = nil
-            previousStreamText = ""
-
-            let duration = max(Date().timeIntervalSince(startedAt), 0)
-            let cleaned = FillerWordFilter.apply(finalText)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-
-            if !config.maraudersMapUnlocked { checkMaraudersMapActivation(cleaned) }
-
-            if !cleaned.isEmpty {
-                _ = try? dictationStore.insertDictation(
-                    text: cleaned,
-                    durationSeconds: duration,
+                finishNemotronStreamingStop(
+                    finalText: "",
                     startedAt: startedAt,
-                    endedAt: Date()
+                    sessionID: sessionID
                 )
             }
-
-            statusBarController?.refresh()
-            historyWindowController?.reload()
-            syncAppState()
-            resetDictationOutputMode()
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
-            finishDictationLatencyTrace("nemotron_stop")
+            dictationAudioSessionManager.endExternalSession(reason: "nemotron-stop")
+            setState(.transcribing)
             return
         }
 
+        pendingDictationStopSessionID = dictationAudioSessionManager.currentSessionID
         pendingDictationStopStartedAt = startedAt
         dictationAudioSessionManager.stop()
+    }
+
+    private func finishNemotronStreamingStop(
+        finalText: String,
+        startedAt: Date,
+        sessionID: UUID?
+    ) {
+        guard nemotronStreamingSessionID == sessionID else {
+            fputs("[muesli-native] ignoring stale Nemotron stop completion\n", stderr)
+            return
+        }
+        _streamingDictationController = nil
+        nemotronStreamingSessionID = nil
+        previousStreamText = ""
+        let duration = max(Date().timeIntervalSince(startedAt), 0)
+        fputs("[muesli-native] Nemotron streaming stop, got \(finalText.count) chars\n", stderr)
+        let cleaned = FillerWordFilter.apply(finalText)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !config.maraudersMapUnlocked { checkMaraudersMapActivation(cleaned) }
+
+        if !cleaned.isEmpty {
+            _ = try? dictationStore.insertDictation(
+                text: cleaned,
+                durationSeconds: duration,
+                startedAt: startedAt,
+                endedAt: Date()
+            )
+        }
+
+        statusBarController?.refresh()
+        historyWindowController?.reload()
+        syncAppState()
+        resetDictationOutputMode()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
+        finishDictationLatencyTrace("nemotron_stop")
     }
 
     private func finishStandardDictationStop(wavURL stoppedWavURL: URL?, startedAt: Date) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4400,6 +4400,7 @@ final class MuesliController: NSObject {
         resetDictationOutputMode()
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
         finishDictationLatencyTrace("nemotron_start_failed")
         syncDictationRecorderWarmup(reason: "nemotron-start-failed")
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -111,45 +111,6 @@ struct CompletedMeetingPersistenceResult {
     let recordingSaveError: MeetingLifecycleError?
 }
 
-private final class DictationAudioSessionTracker: @unchecked Sendable {
-    private let lock = NSLock()
-    private var currentSessionID: UUID?
-
-    func begin() -> UUID {
-        let sessionID = UUID()
-        lock.lock()
-        currentSessionID = sessionID
-        lock.unlock()
-        return sessionID
-    }
-
-    func current() -> UUID? {
-        lock.lock()
-        defer { lock.unlock() }
-        return currentSessionID
-    }
-
-    func isCurrent(_ sessionID: UUID) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return currentSessionID == sessionID
-    }
-
-    func finish(_ sessionID: UUID) {
-        lock.lock()
-        if currentSessionID == sessionID {
-            currentSessionID = nil
-        }
-        lock.unlock()
-    }
-
-    func finishAll() {
-        lock.lock()
-        currentSessionID = nil
-        lock.unlock()
-    }
-}
-
 @MainActor
 final class MuesliController: NSObject {
     private let runtime: RuntimePaths
@@ -161,10 +122,13 @@ final class MuesliController: NSObject {
     private let hotkeyMonitor = HotkeyMonitor()
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let recorder = MicrophoneRecorder()
-    private let dictationAudioQueue = DispatchQueue(label: "com.muesli.dictation-audio-session")
-    private let dictationAudioSessionTracker = DictationAudioSessionTracker()
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
+    private lazy var dictationAudioSessionManager = DictationAudioSessionManager(
+        recorder: recorder,
+        duckingController: audioDuckingController,
+        routingController: dictationAudioRoutingController
+    )
     private let dictationLatencyLogQueue = DispatchQueue(label: "com.muesli.dictation-latency-log")
     private let dictationLatencyLogURL = AppIdentity.supportDirectoryURL.appendingPathComponent("dictation-latency.log")
     private let dictationLatencyTimestampFormatter = ISO8601DateFormatter()
@@ -213,9 +177,8 @@ final class MuesliController: NSObject {
     private var dictationStartedAt: Date?
     private var dictationLatencyTraceID: UUID?
     private var dictationLatencyTraceStartedAt: Date?
-    private var dictationAudioRouteStabilizingUntil: Date?
-    private var dictationAwaitingFirstAudioSessionID: UUID?
     private var currentDictationOutputMode: DictationOutputMode = .paste
+    private var pendingDictationStopStartedAt: Date?
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
@@ -283,28 +246,18 @@ final class MuesliController: NSObject {
         self.indicator = FloatingIndicatorController(configStore: configStore)
         ComputerUseCursorOverlay.shared.attachIndicator(self.indicator)
         super.init()
-        recorder.onFirstCapturedAudioBuffer = { [weak self] capturedAt in
+        dictationAudioSessionManager.onEvent = { [weak self] event in
             Task { @MainActor [weak self] in
-                self?.handleFirstDictationAudioBuffer(capturedAt: capturedAt)
+                self?.handleDictationAudioSessionEvent(event)
             }
         }
         dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] preferredInputDeviceID in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.dictationAudioRouteStabilizingUntil = Date()
-                    .addingTimeInterval(DictationAudioRouteTiming.stabilizationDelay)
-                self.coolDownDictationRecorder(reason: "route-change")
-                if self.dictationState == .preparing {
-                    self.primeDictationRecorderForHotkey(
-                        reason: "route-change",
-                        preferredInputDeviceID: preferredInputDeviceID
-                    )
-                } else {
-                    self.syncDictationRecorderWarmup(
-                        reason: "route-change",
-                        delay: DictationAudioRouteTiming.stabilizationDelay
-                    )
-                }
+                self.syncDictationRecorderWarmup(
+                    reason: "route-change",
+                    delay: DictationAudioRouteTiming.stabilizationDelay
+                )
             }
         }
     }
@@ -318,6 +271,7 @@ final class MuesliController: NSObject {
         }
         recoverStaleLiveMeetings()
         normalizeMeetingTranscriptionSelectionForAvailability()
+        SoundController.prewarmLifecycleSounds()
 
         // Clean up phantom aggregate devices left by a previous crash
         CoreAudioSystemRecorder.cleanupStaleDevices()
@@ -4067,12 +4021,9 @@ final class MuesliController: NSObject {
         guard selectedBackend.backend != "nemotron" else {
             return
         }
-        let sessionID = dictationAudioSessionTracker.begin()
-        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
-        beginDictationAudioDucking()
-        prepareDictationRecorderAsync(
-            sessionID: sessionID,
-            preferredInputDeviceID: preferredInputDeviceID
+        dictationAudioSessionManager.beginRecording(
+            mode: "hold-prepare",
+            duckingEnabled: config.muteSystemAudioDuringDictation
         )
     }
 
@@ -4081,10 +4032,13 @@ final class MuesliController: NSObject {
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "hotkey")
         }
-        markDictationLatency("ui_armed")
         setState(.preparing)
-        beginDictationAudioDucking()
-        primeDictationRecorderForHotkey(reason: "hotkey-arm")
+        if selectedBackend.backend != "nemotron" {
+            dictationAudioSessionManager.arm(
+                source: "hotkey_arm",
+                duckingEnabled: config.muteSystemAudioDuringDictation
+            )
+        }
     }
 
     private var defaultDictationOutputMode: DictationOutputMode {
@@ -4112,78 +4066,15 @@ final class MuesliController: NSObject {
     }
 
     private func coolDownDictationRecorder(reason: String) {
-        recorder.keepsAudioGraphWarm = false
-        let recorder = self.recorder
-        dictationAudioQueue.async {
-            recorder.coolDown()
-            fputs("[dictation-prime] cooled reason=\(reason)\n", stderr)
-        }
+        dictationAudioSessionManager.coolDown(reason: reason)
     }
 
     private func syncDictationRecorderWarmup(reason: String, delay: TimeInterval = 0) {
-        guard canPrimeDictationRecorder, selectedBackend.backend != "nemotron" else {
-            coolDownDictationRecorder(reason: reason)
-            return
-        }
-
-        recorder.keepsAudioGraphWarm = true
-        let recorder = self.recorder
-        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
-        dictationAudioQueue.async { [route = dictationAudioRoutingController.currentRouteDebugDescription()] in
-            if delay > 0 {
-                Thread.sleep(forTimeInterval: delay)
-            }
-            do {
-                try recorder.warmUp(preferredInputDeviceID: preferredInputDeviceID)
-                fputs("[dictation-prime] warmed-idle reason=\(reason) \(route)\n", stderr)
-            } catch {
-                fputs("[dictation-prime] idle-warmup failed reason=\(reason) \(route) error=\(error)\n", stderr)
-            }
-        }
-    }
-
-    private func primeDictationRecorderForHotkey(reason: String) {
-        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
-        primeDictationRecorderForHotkey(reason: reason, preferredInputDeviceID: preferredInputDeviceID)
-    }
-
-    private func primeDictationRecorderForHotkey(reason: String, preferredInputDeviceID: AudioObjectID?) {
-        guard canPrimeDictationRecorder, selectedBackend.backend != "nemotron" else { return }
-        recorder.keepsAudioGraphWarm = true
-        let recorder = self.recorder
-        let routeStabilizationDelay = dictationAudioRouteStabilizationDelay()
-        markDictationLatency("prime_enqueue:\(reason)")
-        let markLatency: @Sendable (String) -> Void = { [weak self] event in
-            DispatchQueue.main.async { [weak self] in
-                self?.markDictationLatency(event)
-            }
-        }
-        dictationAudioQueue.async { [route = dictationAudioRoutingController.currentRouteDebugDescription(), markLatency] in
-            do {
-                if routeStabilizationDelay > 0 {
-                    markLatency("route_stabilization_wait_begin:\(reason)")
-                    Thread.sleep(forTimeInterval: routeStabilizationDelay)
-                    markLatency("route_stabilization_wait_end:\(reason)")
-                }
-                markLatency("activation_begin:\(reason)")
-                try recorder.activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
-                markLatency("activation_end:\(reason)")
-                fputs("[dictation-prime] activated reason=\(reason) \(route)\n", stderr)
-            } catch {
-                markLatency("activation_failed:\(reason)")
-                fputs("[dictation-prime] activation failed reason=\(reason) \(route) error=\(error)\n", stderr)
-            }
-        }
-    }
-
-    private func dictationAudioRouteStabilizationDelay() -> TimeInterval {
-        guard let stabilizingUntil = dictationAudioRouteStabilizingUntil else { return 0 }
-        let delay = stabilizingUntil.timeIntervalSinceNow
-        if delay <= 0 {
-            dictationAudioRouteStabilizingUntil = nil
-            return 0
-        }
-        return delay
+        dictationAudioSessionManager.refreshRoute(
+            reason: reason,
+            delay: delay,
+            canWarmUp: canPrimeDictationRecorder && selectedBackend.backend != "nemotron"
+        )
     }
 
     private func beginDictationLatencyTrace(reason: String) {
@@ -4248,223 +4139,112 @@ final class MuesliController: NSObject {
         dictationLatencyTraceStartedAt = nil
     }
 
-    private func configureDictationInputRoute() {
-        recorder.preferredInputDeviceID = dictationAudioRoutingController.preferredInputDeviceIDForDictation()
-        dictationAudioRoutingController.refreshRouteCache()
-    }
-
-    private func preferredDictationInputDeviceID() -> AudioObjectID? {
-        dictationAudioRoutingController.preferredInputDeviceIDForDictation()
-    }
-
     private func cachedPreferredDictationInputDeviceID() -> AudioObjectID? {
         dictationAudioRoutingController.cachedPreferredInputDeviceIDForDictation()
-    }
-
-    private func resetDictationInputRoute() {
-        recorder.preferredInputDeviceID = nil
-    }
-
-    private func beginDictationInputOverride() {
-        dictationAudioRoutingController.beginDictationInputOverride()
-    }
-
-    private func restoreDictationInputOverride() {
-        dictationAudioRoutingController.restoreDictationInputOverride()
     }
 
     private var shouldPlayDictationLifecycleSounds: Bool {
         config.soundEnabled && !dictationAudioRoutingController.isDefaultOutputHeadphoneLike()
     }
 
-    private func beginDictationAudioDucking() {
-        audioDuckingController.beginDictationDucking(enabled: config.muteSystemAudioDuringDictation)
-    }
-
-    private func ensureDictationAudioDucked() {
-        audioDuckingController.ensureCurrentDefaultDucked()
-    }
-
-    private func restoreDictationAudioDucking() {
-        audioDuckingController.restoreDictationDucking()
-    }
-
-    private func prepareDictationRecorderAsync(
-        sessionID: UUID,
-        preferredInputDeviceID: AudioObjectID?
-    ) {
-        let recorder = self.recorder
-        let tracker = dictationAudioSessionTracker
-        let routeStabilizationDelay = dictationAudioRouteStabilizationDelay()
-        let markLatency: @Sendable (String) -> Void = { [weak self] event in
-            DispatchQueue.main.async { [weak self] in
-                self?.markDictationLatency(event)
-            }
-        }
-        dictationAudioQueue.async { [recorder, tracker, markLatency] in
-            guard tracker.isCurrent(sessionID) else { return }
-            recorder.preferredInputDeviceID = preferredInputDeviceID
-            do {
-                if routeStabilizationDelay > 0 {
-                    markLatency("route_stabilization_wait_begin:prepare")
-                    Thread.sleep(forTimeInterval: routeStabilizationDelay)
-                    markLatency("route_stabilization_wait_end:prepare")
-                }
-                markLatency("prepare_begin")
-                try recorder.prepare()
-                markLatency("prepare_end")
-                DispatchQueue.main.async { [weak self] in
-                    self?.handleDictationPrepareFinished(sessionID: sessionID, error: nil)
-                }
-            } catch {
-                recorder.cancel()
-                let shouldReportFailure = tracker.isCurrent(sessionID)
-                if shouldReportFailure {
-                    tracker.finish(sessionID)
-                }
-                DispatchQueue.main.async { [weak self] in
-                    self?.handleDictationPrepareFinished(
-                        sessionID: sessionID,
-                        error: error,
-                        shouldReportFailure: shouldReportFailure
-                    )
-                }
-            }
-        }
-    }
-
-    private func handleDictationPrepareFinished(
-        sessionID: UUID,
-        error: Error?,
-        shouldReportFailure: Bool = false
-    ) {
-        guard let error else { return }
-        guard shouldReportFailure else { return }
-        fputs("[muesli-native] recorder prepare failed: \(error)\n", stderr)
-        restoreDictationAudioDucking()
-        restoreDictationInputOverride()
-        resetDictationInputRoute()
-        dictationAwaitingFirstAudioSessionID = nil
-        setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
-        meetingMonitor.refreshState()
-        finishDictationLatencyTrace("prepare_failed")
-        syncDictationRecorderWarmup(reason: "prepare-failed")
-    }
-
-    private func startDictationRecorderAsync(sessionID: UUID) {
-        let recorder = self.recorder
-        let tracker = dictationAudioSessionTracker
-        let markLatency: @Sendable (String) -> Void = { [weak self] event in
-            DispatchQueue.main.async { [weak self] in
-                self?.markDictationLatency(event)
-            }
-        }
-        dictationAudioQueue.async { [recorder, tracker, markLatency] in
-            guard tracker.isCurrent(sessionID) else { return }
-            do {
-                markLatency("start_begin")
-                try recorder.start()
-                markLatency("start_end")
-                DispatchQueue.main.async { [weak self] in
-                    self?.handleDictationStartFinished(sessionID: sessionID, error: nil)
-                }
-            } catch {
-                recorder.cancel()
-                tracker.finish(sessionID)
-                DispatchQueue.main.async { [weak self] in
-                    self?.handleDictationStartFinished(sessionID: sessionID, error: error)
-                }
-            }
-        }
-    }
-
-    private func handleDictationStartFinished(sessionID: UUID, error: Error?) {
-        if let error {
+    private func handleDictationAudioSessionEvent(_ event: DictationAudioSessionEvent) {
+        switch event {
+        case .armed:
+            break
+        case .acquiringAudio:
+            markDictationLatency("acquiring_audio")
+        case .streamActive(_, let capturedAt):
+            handleDictationStreamActive(capturedAt: capturedAt)
+        case .speechDetected(_, let capturedAt):
+            handleDictationSpeechDetected(capturedAt: capturedAt)
+        case .noAudioTimeout:
+            statusBarController?.setStatus("Mic waiting for speech")
+        case .stopped(_, let wavURL):
+            let startedAt = pendingDictationStopStartedAt ?? dictationStartedAt ?? Date()
+            pendingDictationStopStartedAt = nil
+            finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt)
+        case .cancelled:
+            break
+        case .failed(_, let error):
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
-            restoreDictationAudioDucking()
-            restoreDictationInputOverride()
-            resetDictationInputRoute()
             resetDictationOutputMode()
-            dictationAwaitingFirstAudioSessionID = nil
             dictationStartedAt = nil
+            pendingDictationStopStartedAt = nil
+            capturedDictationContext = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
-            finishDictationLatencyTrace("start_failed")
-            syncDictationRecorderWarmup(reason: "start-failed")
-            return
-        }
-
-        guard dictationAudioSessionTracker.isCurrent(sessionID) else { return }
-        markDictationLatency("start_success")
-        if !isDictationTestMode {
-            indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
-            }
+            finishDictationLatencyTrace("audio_session_failed")
+            syncDictationRecorderWarmup(reason: "audio-session-failed")
+        case .latency(let event, let date):
+            markDictationLatency(event, at: date)
         }
     }
 
-    private func handleFirstDictationAudioBuffer(capturedAt: Date) {
-        markDictationLatency("first_audio_buffer", at: capturedAt)
-        guard let sessionID = dictationAudioSessionTracker.current(),
-              dictationAwaitingFirstAudioSessionID == sessionID else {
-            return
-        }
-
-        dictationAwaitingFirstAudioSessionID = nil
+    private func handleDictationStreamActive(capturedAt: Date) {
         if dictationStartedAt == nil {
             dictationStartedAt = capturedAt
         }
         capturedDictationContext = nil
-        if !isDictationTestMode {
-            indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
-            }
-        }
         if hotkeyMonitor.isToggleRecording {
             indicator.setToggleDictation(true, config: config)
+            indicator.setRecordingWaveformLevel(config: config)
         } else {
             setState(.recording)
+            indicator.setRecordingWaveformLevel(config: config)
         }
-        markDictationLatency("ui_recording")
+        if !isDictationTestMode {
+            indicator.powerProvider = { [weak self] in
+                self?.dictationAudioSessionManager.currentPower() ?? -160
+            }
+        }
+        markDictationLatency("ui_stream_active")
+        logDictationPowerSample(label: "ui_power_sample_350ms", delay: 0.35)
+        logDictationPowerSample(label: "ui_power_sample_1000ms", delay: 1.0)
         if isDictationTestMode {
             dictationTestRecordingStarted?()
         }
         SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
 
-        if config.enableScreenContext
-            && CGPreflightScreenCaptureAccess()
-            && config.enablePostProcessor
-            && !isDictationTestMode {
-            capturedDictationContext = DictationContextCapture.capture()
+        if shouldCaptureDictationContext {
+            captureDictationContextAsync()
         }
     }
 
-    private func stopDictationRecorderAsync(sessionID: UUID, startedAt: Date) {
-        let recorder = self.recorder
-        let tracker = dictationAudioSessionTracker
-        dictationAudioQueue.async { [recorder, tracker] in
-            let wavURL: URL?
-            if tracker.isCurrent(sessionID) {
-                wavURL = recorder.stop()
-                recorder.preferredInputDeviceID = nil
-                tracker.finish(sessionID)
-            } else {
-                wavURL = nil
-            }
-            DispatchQueue.main.async { [weak self] in
-                self?.finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt)
-            }
+    private func handleDictationSpeechDetected(capturedAt: Date) {
+        markDictationLatency("ui_speech_active", at: capturedAt)
+    }
+
+    private func logDictationPowerSample(label: String, delay: TimeInterval) {
+        let traceID = dictationLatencyTraceID
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, traceID] in
+            guard let self,
+                  self.dictationLatencyTraceID == traceID,
+                  self.dictationState == .recording else { return }
+            let power = Int(self.dictationAudioSessionManager.currentPower().rounded())
+            self.markDictationLatency("\(label)_db:\(power)")
         }
     }
 
-    private func cancelDictationRecorderAsync() {
-        let recorder = self.recorder
-        dictationAudioSessionTracker.finishAll()
-        dictationAudioQueue.async { [recorder] in
-            recorder.cancel()
-            recorder.preferredInputDeviceID = nil
+    private var shouldCaptureDictationContext: Bool {
+        config.enableScreenContext && config.enablePostProcessor && !isDictationTestMode
+    }
+
+    private func captureDictationContextAsync() {
+        guard shouldCaptureDictationContext else { return }
+        let traceID = dictationLatencyTraceID
+        markDictationLatency("context_capture_enqueue")
+        DispatchQueue.global(qos: .utility).async { [weak self, traceID] in
+            guard CGPreflightScreenCaptureAccess() else { return }
+            let context = DictationContextCapture.capture()
+            DispatchQueue.main.async { [weak self, traceID] in
+                guard let self,
+                      self.dictationLatencyTraceID == traceID,
+                      self.shouldCaptureDictationContext,
+                      self.dictationState == .recording else { return }
+                self.capturedDictationContext = context
+                self.markDictationLatency("context_capture_ready")
+            }
         }
     }
 
@@ -4473,10 +4253,7 @@ final class MuesliController: NSObject {
 
         // Nemotron is handsfree-only — block hold-to-talk and show a hint
         if selectedBackend.backend == "nemotron" {
-            recorder.cancel()
-            restoreDictationAudioDucking()
-            restoreDictationInputOverride()
-            resetDictationInputRoute()
+            dictationAudioSessionManager.cancel(reason: "nemotron-hold-blocked")
             fputs("[muesli-native] hold-to-talk blocked for Nemotron, showing warning\n", stderr)
             indicator.showWarning("Double-tap for Nemotron handsfree mode", icon: "⚡")
             finishDictationLatencyTrace("nemotron_hold_blocked")
@@ -4485,22 +4262,14 @@ final class MuesliController: NSObject {
 
         fputs("[muesli-native] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
-        guard let sessionID = dictationAudioSessionTracker.current() else {
-            finishDictationLatencyTrace("start_without_session")
-            return
-        }
         beginDictationOutput()
         dictationStartedAt = nil
-        dictationAwaitingFirstAudioSessionID = sessionID
         capturedDictationContext = nil
-        if !isDictationTestMode {
-            indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
-            }
-        }
         setState(.preparing)
-        ensureDictationAudioDucked()
-        startDictationRecorderAsync(sessionID: sessionID)
+        dictationAudioSessionManager.beginRecording(
+            mode: "hold-start",
+            duckingEnabled: config.muteSystemAudioDuringDictation
+        )
     }
 
     @available(macOS 15, *)
@@ -4549,13 +4318,10 @@ final class MuesliController: NSObject {
             previousStreamText = ""
         }
 
-        cancelDictationRecorderAsync()
-        restoreDictationAudioDucking()
-        restoreDictationInputOverride()
-        resetDictationInputRoute()
+        dictationAudioSessionManager.cancel(reason: "user-cancel")
         capturedDictationContext = nil
-        dictationAwaitingFirstAudioSessionID = nil
         dictationStartedAt = nil
+        pendingDictationStopStartedAt = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
         finishDictationLatencyTrace("cancelled")
@@ -4571,14 +4337,8 @@ final class MuesliController: NSObject {
         markDictationLatency("toggle_start")
         meetingMonitor.suppressWhileActive()
         let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
-        beginDictationAudioDucking()
         beginDictationOutput(mode: outputMode)
         dictationStartedAt = nil
-        if !isDictationTestMode {
-            indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
-            }
-        }
         setState(.preparing)
 
         // Nemotron streaming: live text at cursor in handsfree mode too
@@ -4589,21 +4349,20 @@ final class MuesliController: NSObject {
                 dictationStartedAt = Date()
                 setState(.recording)
                 indicator.setToggleDictation(true, config: config)
-                ensureDictationAudioDucked()
+                dictationAudioSessionManager.beginExternalSession(
+                    source: "nemotron-toggle",
+                    duckingEnabled: config.muteSystemAudioDuringDictation
+                )
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
                 startNemotronStreamingAsync(preferredInputDeviceID: preferredInputDeviceID)
                 return
             }
         }
 
-        let sessionID = dictationAudioSessionTracker.begin()
-        dictationAwaitingFirstAudioSessionID = sessionID
-        prepareDictationRecorderAsync(
-            sessionID: sessionID,
-            preferredInputDeviceID: preferredInputDeviceID
+        dictationAudioSessionManager.beginRecording(
+            mode: "toggle",
+            duckingEnabled: config.muteSystemAudioDuringDictation
         )
-        ensureDictationAudioDucked()
-        startDictationRecorderAsync(sessionID: sessionID)
     }
 
     private func handleToggleStop() {
@@ -4613,7 +4372,7 @@ final class MuesliController: NSObject {
     }
 
     func toggleVoiceNoteRecording() {
-        if dictationStartedAt != nil || dictationAudioSessionTracker.current() != nil || isNemotronStreaming {
+        if dictationStartedAt != nil || dictationAudioSessionManager.hasActiveSession || isNemotronStreaming {
             handleToggleStop()
         } else if dictationState == .idle {
             handleToggleStart(outputMode: .voiceNote)
@@ -4636,12 +4395,9 @@ final class MuesliController: NSObject {
             } else {
                 fputs("[muesli-native] Nemotron streaming stop, controller not ready (short press)\n", stderr)
             }
-            restoreDictationAudioDucking()
-            restoreDictationInputOverride()
-            resetDictationInputRoute()
+            dictationAudioSessionManager.endExternalSession(reason: "nemotron-stop")
             _streamingDictationController = nil
             previousStreamText = ""
-            dictationAwaitingFirstAudioSessionID = nil
 
             let duration = max(Date().timeIntervalSince(startedAt), 0)
             let cleaned = FillerWordFilter.apply(finalText)
@@ -4669,26 +4425,11 @@ final class MuesliController: NSObject {
             return
         }
 
-        guard let sessionID = dictationAudioSessionTracker.current() else {
-            restoreDictationAudioDucking()
-            restoreDictationInputOverride()
-            resetDictationInputRoute()
-            resetDictationOutputMode()
-            dictationAwaitingFirstAudioSessionID = nil
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            finishDictationLatencyTrace("stop_without_session")
-            syncDictationRecorderWarmup(reason: "stop-without-session")
-            return
-        }
-        dictationAwaitingFirstAudioSessionID = nil
-        restoreDictationAudioDucking()
-        stopDictationRecorderAsync(sessionID: sessionID, startedAt: startedAt)
+        pendingDictationStopStartedAt = startedAt
+        dictationAudioSessionManager.stop()
     }
 
     private func finishStandardDictationStop(wavURL stoppedWavURL: URL?, startedAt: Date) {
-        restoreDictationInputOverride()
-        resetDictationInputRoute()
         markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
             fputs("[muesli-native] stop without wav\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4516,7 +4516,10 @@ final class MuesliController: NSObject {
     }
 
     private func handleStop() {
-        if isMeetingRecording() { return }
+        if isMeetingRecording() {
+            cancelDictationAudioSessionForMeetingRecordingIfNeeded()
+            return
+        }
         fputs("[muesli-native] stop\n", stderr)
         let startedAt = dictationStartedAt ?? Date()
         dictationStartedAt = nil
@@ -4554,6 +4557,21 @@ final class MuesliController: NSObject {
             : nil
         pendingDictationStopStartedAt = startedAt
         dictationAudioSessionManager.stop()
+    }
+
+    private func cancelDictationAudioSessionForMeetingRecordingIfNeeded() {
+        guard dictationAudioSessionManager.hasActiveSession else { return }
+        fputs("[muesli-native] cancelling dictation audio session because meeting is active\n", stderr)
+        dictationAudioSessionManager.cancel(reason: "meeting-active")
+        dictationStartedAt = nil
+        capturedDictationContext = nil
+        pendingDictationStopSessionID = nil
+        pendingDictationStopStartedAt = nil
+        pendingReleaseSoundSessionID = nil
+        resetDictationOutputMode()
+        setState(.idle)
+        finishDictationLatencyTrace("meeting_active_cancel")
+        syncDictationRecorderWarmup(reason: "meeting-active")
     }
 
     private func finishNemotronStreamingStop(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4585,7 +4585,11 @@ final class MuesliController: NSObject {
         pendingReleaseSoundSessionID = nil
         resetDictationOutputMode()
         setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
+        if activeMeetingID != nil || isStartingMeetingRecording || isMeetingRecording() {
+            meetingMonitor.suppressWhileActive()
+        } else {
+            meetingMonitor.resumeAfterCooldown()
+        }
         meetingMonitor.refreshState()
         finishDictationLatencyTrace("meeting_active_cancel")
         syncDictationRecorderWarmup(reason: "meeting-active")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4541,6 +4541,9 @@ final class MuesliController: NSObject {
         }
 
         markDictationLatency("sound_release_requested:stop")
+        // This cue is intentionally key-up feedback, not a transcription-success
+        // signal. Keeping it off the network/transcription path preserves the
+        // lower perceived release latency of dictation.
         SoundController.playDictationInsert(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         pendingDictationStopSessionID = dictationAudioSessionManager.currentSessionID
         pendingDictationStopStartedAt = startedAt

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4250,6 +4250,7 @@ final class MuesliController: NSObject {
         }
         capturedDictationContext = nil
         if hotkeyMonitor.isToggleRecording {
+            setState(.recording)
             indicator.setToggleDictation(true, config: config)
             indicator.setRecordingWaveformLevel(config: config)
         } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -132,12 +132,12 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
                 }
                 try Self.trimIfNeeded(at: url)
                 let data = Data((line + "\n").utf8)
-                if FileManager.default.fileExists(atPath: url.path) {
+                do {
                     let handle = try FileHandle(forWritingTo: url)
                     defer { try? handle.close() }
                     try handle.seekToEnd()
                     try handle.write(contentsOf: data)
-                } else {
+                } catch {
                     try data.write(to: url, options: .atomic)
                 }
             } catch {
@@ -4080,9 +4080,11 @@ final class MuesliController: NSObject {
         guard selectedBackend.backend != "nemotron" else {
             return
         }
-        meetingMonitor.suppressWhileActive()
-        meetingMonitor.refreshState()
-        setState(.preparing)
+        if !dictationAudioSessionManager.hasActiveSession {
+            meetingMonitor.suppressWhileActive()
+            meetingMonitor.refreshState()
+            setState(.preparing)
+        }
     }
 
     private func handleArm() {
@@ -4364,6 +4366,11 @@ final class MuesliController: NSObject {
                     }
                 }
             }
+            controller.onFailure = { [weak self] error in
+                DispatchQueue.main.async {
+                    self?.handleNemotronStreamingRuntimeFailure(error: error, sessionID: sessionID)
+                }
+            }
 
             await MainActor.run {
                 guard self.isNemotronStreaming, self.nemotronStreamingSessionID == sessionID else {
@@ -4395,6 +4402,25 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
         finishDictationLatencyTrace("nemotron_start_failed")
         syncDictationRecorderWarmup(reason: "nemotron-start-failed")
+    }
+
+    @MainActor
+    private func handleNemotronStreamingRuntimeFailure(error: Error, sessionID: UUID) {
+        guard isNemotronStreaming, nemotronStreamingSessionID == sessionID else { return }
+        fputs("[muesli-native] Nemotron streaming failed after mic start: \(error)\n", stderr)
+        isNemotronStreaming = false
+        _streamingDictationController = nil
+        nemotronStreamingSessionID = nil
+        previousStreamText = ""
+        dictationStartedAt = nil
+        dictationAudioSessionManager.endExternalSession(reason: "nemotron-runtime-failed")
+        indicator.setToggleDictation(false, config: config)
+        resetDictationOutputMode()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
+        finishDictationLatencyTrace("nemotron_runtime_failed")
+        syncDictationRecorderWarmup(reason: "nemotron-runtime-failed")
     }
 
     private func handleCancel() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -111,6 +111,56 @@ struct CompletedMeetingPersistenceResult {
     let recordingSaveError: MeetingLifecycleError?
 }
 
+private final class DictationLatencyLogWriter: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.muesli.dictation-latency-log")
+    private let url: URL
+    private var hasCreatedDirectory = false
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    func append(_ line: String) {
+        queue.async { [self] in
+            do {
+                if !hasCreatedDirectory {
+                    try FileManager.default.createDirectory(
+                        at: url.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    hasCreatedDirectory = true
+                }
+                try Self.trimIfNeeded(at: url)
+                let data = Data((line + "\n").utf8)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    let handle = try FileHandle(forWritingTo: url)
+                    try handle.seekToEnd()
+                    try handle.write(contentsOf: data)
+                    try handle.close()
+                } else {
+                    try data.write(to: url, options: .atomic)
+                }
+            } catch {
+                fputs("[dictation-latency] failed to append log: \(error)\n", stderr)
+            }
+        }
+    }
+
+    private static func trimIfNeeded(at url: URL) throws {
+        let maxBytes: UInt64 = 2 * 1024 * 1024
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        guard let fileSize = attributes?[.size] as? UInt64,
+              fileSize > maxBytes else { return }
+
+        let data = try Data(contentsOf: url)
+        let keepCount = min(data.count, Int(maxBytes / 2))
+        let tail = data.suffix(keepCount)
+        let newlineIndex = tail.firstIndex(of: UInt8(ascii: "\n"))
+        let trimmed = newlineIndex.map { tail[tail.index(after: $0)...] } ?? tail[...]
+        try Data(trimmed).write(to: url, options: .atomic)
+    }
+}
+
 @MainActor
 final class MuesliController: NSObject {
     private let runtime: RuntimePaths
@@ -129,8 +179,9 @@ final class MuesliController: NSObject {
         duckingController: audioDuckingController,
         routingController: dictationAudioRoutingController
     )
-    private let dictationLatencyLogQueue = DispatchQueue(label: "com.muesli.dictation-latency-log")
-    private let dictationLatencyLogURL = AppIdentity.supportDirectoryURL.appendingPathComponent("dictation-latency.log")
+    private let dictationLatencyLogWriter = DictationLatencyLogWriter(
+        url: AppIdentity.supportDirectoryURL.appendingPathComponent("dictation-latency.log")
+    )
     private let dictationLatencyTimestampFormatter = ISO8601DateFormatter()
     private let indicator: FloatingIndicatorController
     private let calendarMonitor = CalendarMonitor()
@@ -4039,8 +4090,8 @@ final class MuesliController: NSObject {
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "hotkey")
         }
-        setState(.preparing)
         if selectedBackend.backend != "nemotron" {
+            setState(.preparing)
             meetingMonitor.suppressWhileActive()
             meetingMonitor.refreshState()
             dictationAudioSessionManager.arm(
@@ -4122,41 +4173,7 @@ final class MuesliController: NSObject {
     }
 
     private func appendDictationLatencyLog(_ line: String) {
-        let url = dictationLatencyLogURL
-        dictationLatencyLogQueue.async {
-            do {
-                try FileManager.default.createDirectory(
-                    at: url.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                try Self.trimDictationLatencyLogIfNeeded(at: url)
-                let data = Data((line + "\n").utf8)
-                if FileManager.default.fileExists(atPath: url.path) {
-                    let handle = try FileHandle(forWritingTo: url)
-                    try handle.seekToEnd()
-                    try handle.write(contentsOf: data)
-                    try handle.close()
-                } else {
-                    try data.write(to: url, options: .atomic)
-                }
-            } catch {
-                fputs("[dictation-latency] failed to append log: \(error)\n", stderr)
-            }
-        }
-    }
-
-    private nonisolated static func trimDictationLatencyLogIfNeeded(at url: URL) throws {
-        let maxBytes: UInt64 = 2 * 1024 * 1024
-        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
-        guard let fileSize = attributes?[.size] as? UInt64,
-              fileSize > maxBytes else { return }
-
-        let data = try Data(contentsOf: url)
-        let keepCount = min(data.count, Int(maxBytes / 2))
-        let tail = data.suffix(keepCount)
-        let newlineIndex = tail.firstIndex(of: UInt8(ascii: "\n"))
-        let trimmed = newlineIndex.map { tail[tail.index(after: $0)...] } ?? tail[...]
-        try Data(trimmed).write(to: url, options: .atomic)
+        dictationLatencyLogWriter.append(line)
     }
 
     private func finishDictationLatencyTrace(_ event: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2674,6 +2674,7 @@ final class MuesliController: NSObject {
     @discardableResult
     func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false, endDate: Date? = nil) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
+        cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
             presentErrorAlert(
                 title: "Meeting failed to start",
@@ -4230,7 +4231,9 @@ final class MuesliController: NSObject {
             guard pendingReleaseSoundSessionID == eventSessionID else { break }
             pendingReleaseSoundSessionID = nil
             guard dictationAudioSessionManager.currentSessionID == nil else { break }
-            SoundController.playDictationInsert(enabled: true)
+            // Reuse the insert cue as the hotkey-release cue once ducked audio has
+            // been restored; waiting for transcription would make release feedback lag.
+            SoundController.playDictationInsert(enabled: shouldPlayDictationLifecycleSounds)
         case .cancelled:
             break
         case .failed(_, let error):

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import AVFoundation
+import CoreAudio
 import Foundation
 import Sparkle
 import TelemetryDeck
@@ -106,6 +107,45 @@ struct CompletedMeetingPersistenceResult {
     let recordingSaveError: MeetingLifecycleError?
 }
 
+private final class DictationAudioSessionTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentSessionID: UUID?
+
+    func begin() -> UUID {
+        let sessionID = UUID()
+        lock.lock()
+        currentSessionID = sessionID
+        lock.unlock()
+        return sessionID
+    }
+
+    func current() -> UUID? {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentSessionID
+    }
+
+    func isCurrent(_ sessionID: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentSessionID == sessionID
+    }
+
+    func finish(_ sessionID: UUID) {
+        lock.lock()
+        if currentSessionID == sessionID {
+            currentSessionID = nil
+        }
+        lock.unlock()
+    }
+
+    func finishAll() {
+        lock.lock()
+        currentSessionID = nil
+        lock.unlock()
+    }
+}
+
 @MainActor
 final class MuesliController: NSObject {
     private let runtime: RuntimePaths
@@ -117,7 +157,13 @@ final class MuesliController: NSObject {
     private let hotkeyMonitor = HotkeyMonitor()
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let recorder = MicrophoneRecorder()
+    private let dictationAudioQueue = DispatchQueue(label: "com.muesli.dictation-audio-session")
+    private let dictationAudioSessionTracker = DictationAudioSessionTracker()
     private let audioDuckingController: AudioDuckingManaging
+    private let dictationAudioRoutingController: DictationAudioRouting
+    private let dictationLatencyLogQueue = DispatchQueue(label: "com.muesli.dictation-latency-log")
+    private let dictationLatencyLogURL = AppIdentity.supportDirectoryURL.appendingPathComponent("dictation-latency.log")
+    private let dictationLatencyTimestampFormatter = ISO8601DateFormatter()
     private let indicator: FloatingIndicatorController
     private let calendarMonitor = CalendarMonitor()
     private let meetingMonitor = MeetingMonitor()
@@ -161,6 +207,8 @@ final class MuesliController: NSObject {
     private var staleLiveMeetingRecoveryFailures = Set<Int64>()
     private var dictationState: DictationState = .idle
     private var dictationStartedAt: Date?
+    private var dictationLatencyTraceID: UUID?
+    private var dictationLatencyTraceStartedAt: Date?
     private var currentDictationOutputMode: DictationOutputMode = .paste
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
@@ -188,13 +236,15 @@ final class MuesliController: NSObject {
     private var meetingStartTask: Task<Void, Never>?
     private var meetingStartMeetingID: Int64?
     private var canceledMeetingStartIDs = Set<Int64>()
+    private var hasStarted = false
 
     init(
         runtime: RuntimePaths,
         dictationStore: DictationStore? = nil,
         meetingHookDispatcher: MeetingHookDispatching = MeetingHookRunner(),
         launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager(),
-        audioDuckingController: AudioDuckingManaging = AudioDuckingController()
+        audioDuckingController: AudioDuckingManaging = AudioDuckingController(),
+        dictationAudioRoutingController: DictationAudioRouting = DictationAudioRouteController()
     ) {
         let loadedConfig = configStore.load()
         self.runtime = runtime
@@ -204,6 +254,7 @@ final class MuesliController: NSObject {
         self.meetingHookDispatcher = meetingHookDispatcher
         self.launchAtLoginCoordinator = LaunchAtLoginCoordinator(manager: launchAtLoginManager)
         self.audioDuckingController = audioDuckingController
+        self.dictationAudioRoutingController = dictationAudioRoutingController
         self.config = loadedConfig
         if loadedConfig.recordingColorHex != "1e1e2e" {
             MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
@@ -226,9 +277,28 @@ final class MuesliController: NSObject {
         self.indicator = FloatingIndicatorController(configStore: configStore)
         ComputerUseCursorOverlay.shared.attachIndicator(self.indicator)
         super.init()
+        recorder.onFirstCapturedAudioBuffer = { [weak self] capturedAt in
+            Task { @MainActor [weak self] in
+                self?.markDictationLatency("first_audio_buffer", at: capturedAt)
+            }
+        }
+        dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] preferredInputDeviceID in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if self.dictationState == .preparing {
+                    self.primeDictationRecorderForHotkey(
+                        reason: "route-change",
+                        preferredInputDeviceID: preferredInputDeviceID
+                    )
+                } else {
+                    self.syncDictationRecorderWarmup(reason: "route-change")
+                }
+            }
+        }
     }
 
     func start() {
+        hasStarted = true
         do {
             try dictationStore.migrateIfNeeded()
         } catch {
@@ -252,6 +322,7 @@ final class MuesliController: NSObject {
             logDescription: "leftover temp meeting recording files"
         )
 
+        hotkeyMonitor.onArm = { [weak self] in self?.handleArm() }
         hotkeyMonitor.onPrepare = { [weak self] in self?.handlePrepare() }
         hotkeyMonitor.onStart = { [weak self] in self?.handleStart() }
         hotkeyMonitor.onStop = { [weak self] in self?.handleStop() }
@@ -259,6 +330,7 @@ final class MuesliController: NSObject {
         hotkeyMonitor.onToggleStart = { [weak self] in self?.handleToggleStart() }
         hotkeyMonitor.onToggleStop = { [weak self] in self?.handleToggleStop() }
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        configureHotkeyMonitorTiming()
         computerUseHotkeyMonitor.onPrepare = { [weak self] in self?.handleComputerUsePrepare() }
         computerUseHotkeyMonitor.onStart = { [weak self] in self?.handleComputerUseStart() }
         computerUseHotkeyMonitor.onStop = { [weak self] in self?.handleComputerUseStop() }
@@ -276,6 +348,7 @@ final class MuesliController: NSObject {
             hotkeyMonitor.start()
             startComputerUseHotkeyMonitorIfNeeded()
         }
+        syncDictationRecorderWarmup(reason: "startup")
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
         indicator.onToggleMeetingPause = { [weak self] in self?.toggleMeetingRecordingPause() }
@@ -684,7 +757,10 @@ final class MuesliController: NSObject {
     }
 
     func updateConfig(_ mutate: (inout AppConfig) -> Void) {
+        let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         mutate(&config)
+        config.hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.hotkeyTriggerThresholdMS)
+        let hotkeyTriggerThresholdChanged = config.hotkeyTriggerThresholdMS != previousHotkeyTriggerThresholdMS
         configStore.save(config)
         MuesliTheme.accentOverrideHex = config.recordingColorHex == "1e1e2e" ? nil : config.recordingColorHex
         selectedBackend = BackendOption.all.first(where: {
@@ -701,6 +777,9 @@ final class MuesliController: NSObject {
         indicator.refreshIcon()
         hotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
         computerUseHotkeyMonitor.doubleTapEnabled = config.enableDoubleTapDictation
+        if hotkeyTriggerThresholdChanged {
+            configureHotkeyMonitorTiming()
+        }
         historyWindowController?.updateBackendLabel()
         if config.showFloatingIndicator {
             indicator.ensureVisible(config: config)
@@ -714,6 +793,7 @@ final class MuesliController: NSObject {
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
+        syncDictationRecorderWarmup(reason: "config")
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -1728,6 +1808,7 @@ final class MuesliController: NSObject {
         hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
         hotkeyMonitor.start()
         startComputerUseHotkeyMonitorIfNeeded()
+        syncDictationRecorderWarmup(reason: "permissions-ready")
         TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
             "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
             "to_use_case": OnboardingUseCase.dictation.rawValue,
@@ -2594,6 +2675,7 @@ final class MuesliController: NSObject {
             return false
         }
         isStartingMeetingRecording = true
+        syncDictationRecorderWarmup(reason: "meeting-start")
         meetingStartMeetingID = meetingID
         updateMeetingStartStatus("Preparing meeting transcription...")
         beginMeetingActivity(reason: "Recording and transcribing a meeting")
@@ -2621,6 +2703,7 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.setState(.idle)
                     self.endMeetingActivity()
+                    self.syncDictationRecorderWarmup(reason: "meeting-start-cancelled")
                 }
             } catch {
                 if self.meetingStartMeetingID == meetingID {
@@ -2632,6 +2715,7 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.setState(.idle)
                     self.endMeetingActivity()
+                    self.syncDictationRecorderWarmup(reason: "meeting-start-failed")
 
                     let isSystemAudioError = error is CoreAudioSystemRecorder.RecorderError
                     let alert = NSAlert()
@@ -2681,6 +2765,7 @@ final class MuesliController: NSObject {
         updateMeetingStartStatus(nil)
         updateMeetingNotificationVisibility()
         syncAppState()
+        syncDictationRecorderWarmup(reason: "meeting-start-cancelled")
     }
 
     private func finishMeetingStartAttempt(meetingID: Int64) {
@@ -2692,6 +2777,7 @@ final class MuesliController: NSObject {
         updateMeetingStartStatus(nil)
         updateMeetingNotificationVisibility()
         syncAppState()
+        syncDictationRecorderWarmup(reason: "meeting-start-finished")
     }
 
     private func startMeetingRecordingWithSystemAudioRecovery(
@@ -2976,6 +3062,7 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         syncAppState()
         updateMeetingNotificationVisibility()
+        syncDictationRecorderWarmup(reason: "meeting-discard")
     }
 
     private func resolveLiveMeetingAfterDiscard(id: Int64, resolution: MeetingDiscardResolution) {
@@ -3144,6 +3231,7 @@ final class MuesliController: NSObject {
                 self.statusBarController?.refresh()
                 self.historyWindowController?.reload()
                 self.syncAppState()
+                self.syncDictationRecorderWarmup(reason: "meeting-stop")
                 if let meetingResult {
                     self.cleanupTemporaryMeetingAudioFiles(for: meetingResult)
                 }
@@ -3424,6 +3512,12 @@ final class MuesliController: NSObject {
         startComputerUseHotkeyMonitorIfNeeded()
     }
 
+    private func configureHotkeyMonitorTiming() {
+        let threshold = config.hotkeyTriggerThresholdMS
+        hotkeyMonitor.configureTriggerThreshold(milliseconds: threshold)
+        computerUseHotkeyMonitor.configureTriggerThreshold(milliseconds: threshold)
+    }
+
     private func startComputerUseHotkeyMonitorIfNeeded() {
         guard config.enableComputerUseHotkey else {
             computerUseHotkeyMonitor.stop()
@@ -3563,11 +3657,13 @@ final class MuesliController: NSObject {
         fputs("[cua] prepare\n", stderr)
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
+        recorder.preferredInputDeviceID = nil
+        setState(.preparing)
         do {
             try recorder.prepare()
-            setState(.preparing)
         } catch {
             fputs("[cua] recorder prepare failed: \(error)\n", stderr)
+            recorder.cancel()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
@@ -3578,6 +3674,7 @@ final class MuesliController: NSObject {
         guard canStartComputerUseCommand else { return }
         fputs("[cua] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
+        recorder.preferredInputDeviceID = nil
         do {
             try recorder.start()
             computerUseCommandStartedAt = Date()
@@ -3585,9 +3682,10 @@ final class MuesliController: NSObject {
                 self?.recorder.currentPower() ?? -160
             }
             setState(.recording)
-            SoundController.playDictationStart(enabled: config.soundEnabled && !isDictationTestMode)
+            SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         } catch {
             fputs("[cua] recorder start failed: \(error)\n", stderr)
+            recorder.cancel()
             computerUseCommandStartedAt = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -3947,21 +4045,34 @@ final class MuesliController: NSObject {
     private func handlePrepare() {
         if isMeetingRecording() { return }
         fputs("[muesli-native] prepare\n", stderr)
+        if dictationLatencyTraceID == nil {
+            beginDictationLatencyTrace(reason: "prepare")
+        }
+        markDictationLatency("prepare_requested")
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
-        if selectedBackend.backend != "nemotron" {
-            beginDictationAudioDucking()
+        setState(.preparing)
+        guard selectedBackend.backend != "nemotron" else {
+            return
         }
-        do {
-            try recorder.prepare()
-            setState(.preparing)
-        } catch {
-            fputs("[muesli-native] recorder prepare failed: \(error)\n", stderr)
-            restoreDictationAudioDucking()
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
+        let sessionID = dictationAudioSessionTracker.begin()
+        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
+        beginDictationAudioDucking()
+        prepareDictationRecorderAsync(
+            sessionID: sessionID,
+            preferredInputDeviceID: preferredInputDeviceID
+        )
+    }
+
+    private func handleArm() {
+        if isMeetingRecording() { return }
+        if dictationLatencyTraceID == nil {
+            beginDictationLatencyTrace(reason: "hotkey")
         }
+        markDictationLatency("ui_armed")
+        setState(.preparing)
+        beginDictationAudioDucking()
+        primeDictationRecorderForHotkey(reason: "hotkey-arm")
     }
 
     private var defaultDictationOutputMode: DictationOutputMode {
@@ -3978,6 +4089,159 @@ final class MuesliController: NSObject {
         appState.isVoiceNoteRecording = false
     }
 
+    private var canPrimeDictationRecorder: Bool {
+        config.hasCompletedOnboarding
+            && hasStarted
+            && config.resolvedOnboardingUseCase.includesPushToTalk
+            && AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+            && !isMeetingRecording()
+            && !isStartingMeetingRecording
+            && !isStoppingMeetingRecording
+    }
+
+    private func syncDictationRecorderWarmup(reason: String) {
+        guard canPrimeDictationRecorder, selectedBackend.backend != "nemotron" else {
+            recorder.keepsAudioGraphWarm = false
+            let recorder = self.recorder
+            dictationAudioQueue.async {
+                recorder.coolDown()
+                fputs("[dictation-prime] cooled reason=\(reason)\n", stderr)
+            }
+            return
+        }
+
+        recorder.keepsAudioGraphWarm = true
+        let recorder = self.recorder
+        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
+        dictationAudioQueue.async { [route = dictationAudioRoutingController.currentRouteDebugDescription()] in
+            do {
+                try recorder.warmUp(preferredInputDeviceID: preferredInputDeviceID)
+                fputs("[dictation-prime] warmed-idle reason=\(reason) \(route)\n", stderr)
+            } catch {
+                fputs("[dictation-prime] idle-warmup failed reason=\(reason) \(route) error=\(error)\n", stderr)
+            }
+        }
+    }
+
+    private func primeDictationRecorderForHotkey(reason: String) {
+        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
+        primeDictationRecorderForHotkey(reason: reason, preferredInputDeviceID: preferredInputDeviceID)
+    }
+
+    private func primeDictationRecorderForHotkey(reason: String, preferredInputDeviceID: AudioObjectID?) {
+        guard canPrimeDictationRecorder, selectedBackend.backend != "nemotron" else { return }
+        recorder.keepsAudioGraphWarm = true
+        let recorder = self.recorder
+        markDictationLatency("prime_enqueue:\(reason)")
+        let markLatency: @Sendable (String) -> Void = { [weak self] event in
+            DispatchQueue.main.async { [weak self] in
+                self?.markDictationLatency(event)
+            }
+        }
+        dictationAudioQueue.async { [route = dictationAudioRoutingController.currentRouteDebugDescription(), markLatency] in
+            do {
+                markLatency("activation_begin:\(reason)")
+                try recorder.activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
+                markLatency("activation_end:\(reason)")
+                fputs("[dictation-prime] activated reason=\(reason) \(route)\n", stderr)
+            } catch {
+                markLatency("activation_failed:\(reason)")
+                fputs("[dictation-prime] activation failed reason=\(reason) \(route) error=\(error)\n", stderr)
+            }
+        }
+    }
+
+    private func beginDictationLatencyTrace(reason: String) {
+        dictationLatencyTraceID = UUID()
+        dictationLatencyTraceStartedAt = Date()
+        markDictationLatency("trace_begin:\(reason)")
+    }
+
+    private func markDictationLatency(_ event: String) {
+        markDictationLatency(event, at: Date())
+    }
+
+    private func markDictationLatency(_ event: String, at date: Date) {
+        guard let traceID = dictationLatencyTraceID,
+              let startedAt = dictationLatencyTraceStartedAt else { return }
+        let elapsedMS = Int(date.timeIntervalSince(startedAt) * 1000)
+        let timestamp = dictationLatencyTimestampFormatter.string(from: date)
+        let routeKind = dictationAudioRoutingController.currentOutputRouteKindForDebug()
+        let routeDescription = dictationAudioRoutingController.currentRouteDebugDescription()
+        let line = "[dictation-latency] ts=\(timestamp) id=\(traceID.uuidString) event=\(event) elapsed_ms=\(elapsedMS) profile=\(dictationLatencyProfile(routeKind: routeKind)) \(routeDescription)"
+        fputs("\(line)\n", stderr)
+        appendDictationLatencyLog(line)
+    }
+
+    private func dictationLatencyProfile(routeKind: AudioOutputRouteKind) -> String {
+        switch routeKind {
+        case .speakerLike:
+            return "speaker"
+        case .headphoneLike:
+            return "headphone"
+        case .unknown:
+            return "unknown"
+        }
+    }
+
+    private func appendDictationLatencyLog(_ line: String) {
+        let url = dictationLatencyLogURL
+        dictationLatencyLogQueue.async {
+            do {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                let data = Data((line + "\n").utf8)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    let handle = try FileHandle(forWritingTo: url)
+                    try handle.seekToEnd()
+                    try handle.write(contentsOf: data)
+                    try handle.close()
+                } else {
+                    try data.write(to: url, options: .atomic)
+                }
+            } catch {
+                fputs("[dictation-latency] failed to append log: \(error)\n", stderr)
+            }
+        }
+    }
+
+    private func finishDictationLatencyTrace(_ event: String) {
+        markDictationLatency(event)
+        dictationLatencyTraceID = nil
+        dictationLatencyTraceStartedAt = nil
+    }
+
+    private func configureDictationInputRoute() {
+        recorder.preferredInputDeviceID = dictationAudioRoutingController.preferredInputDeviceIDForDictation()
+        dictationAudioRoutingController.refreshRouteCache()
+    }
+
+    private func preferredDictationInputDeviceID() -> AudioObjectID? {
+        dictationAudioRoutingController.preferredInputDeviceIDForDictation()
+    }
+
+    private func cachedPreferredDictationInputDeviceID() -> AudioObjectID? {
+        dictationAudioRoutingController.cachedPreferredInputDeviceIDForDictation()
+    }
+
+    private func resetDictationInputRoute() {
+        recorder.preferredInputDeviceID = nil
+    }
+
+    private func beginDictationInputOverride() {
+        dictationAudioRoutingController.beginDictationInputOverride()
+    }
+
+    private func restoreDictationInputOverride() {
+        dictationAudioRoutingController.restoreDictationInputOverride()
+    }
+
+    private var shouldPlayDictationLifecycleSounds: Bool {
+        config.soundEnabled && !dictationAudioRoutingController.isDefaultOutputHeadphoneLike()
+    }
+
     private func beginDictationAudioDucking() {
         audioDuckingController.beginDictationDucking(enabled: config.muteSystemAudioDuringDictation)
     }
@@ -3990,6 +4254,161 @@ final class MuesliController: NSObject {
         audioDuckingController.restoreDictationDucking()
     }
 
+    private func prepareDictationRecorderAsync(
+        sessionID: UUID,
+        preferredInputDeviceID: AudioObjectID?
+    ) {
+        let recorder = self.recorder
+        let tracker = dictationAudioSessionTracker
+        let markLatency: @Sendable (String) -> Void = { [weak self] event in
+            DispatchQueue.main.async { [weak self] in
+                self?.markDictationLatency(event)
+            }
+        }
+        dictationAudioQueue.async { [recorder, tracker, markLatency] in
+            guard tracker.isCurrent(sessionID) else { return }
+            recorder.preferredInputDeviceID = preferredInputDeviceID
+            do {
+                markLatency("prepare_begin")
+                try recorder.prepare()
+                markLatency("prepare_end")
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleDictationPrepareFinished(sessionID: sessionID, error: nil)
+                }
+            } catch {
+                recorder.cancel()
+                let shouldReportFailure = tracker.isCurrent(sessionID)
+                if shouldReportFailure {
+                    tracker.finish(sessionID)
+                }
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleDictationPrepareFinished(
+                        sessionID: sessionID,
+                        error: error,
+                        shouldReportFailure: shouldReportFailure
+                    )
+                }
+            }
+        }
+    }
+
+    private func handleDictationPrepareFinished(
+        sessionID: UUID,
+        error: Error?,
+        shouldReportFailure: Bool = false
+    ) {
+        guard let error else { return }
+        guard shouldReportFailure else { return }
+        fputs("[muesli-native] recorder prepare failed: \(error)\n", stderr)
+        restoreDictationAudioDucking()
+        restoreDictationInputOverride()
+        resetDictationInputRoute()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
+        finishDictationLatencyTrace("prepare_failed")
+        syncDictationRecorderWarmup(reason: "prepare-failed")
+    }
+
+    private func startDictationRecorderAsync(sessionID: UUID) {
+        let recorder = self.recorder
+        let tracker = dictationAudioSessionTracker
+        let markLatency: @Sendable (String) -> Void = { [weak self] event in
+            DispatchQueue.main.async { [weak self] in
+                self?.markDictationLatency(event)
+            }
+        }
+        dictationAudioQueue.async { [recorder, tracker, markLatency] in
+            guard tracker.isCurrent(sessionID) else { return }
+            do {
+                markLatency("start_begin")
+                try recorder.start()
+                markLatency("start_end")
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleDictationStartFinished(sessionID: sessionID, error: nil)
+                }
+            } catch {
+                recorder.cancel()
+                tracker.finish(sessionID)
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleDictationStartFinished(sessionID: sessionID, error: error)
+                }
+            }
+        }
+    }
+
+    private func handleDictationStartFinished(sessionID: UUID, error: Error?) {
+        if let error {
+            fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
+            restoreDictationAudioDucking()
+            restoreDictationInputOverride()
+            resetDictationInputRoute()
+            resetDictationOutputMode()
+            dictationStartedAt = nil
+            setState(.idle)
+            meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
+            finishDictationLatencyTrace("start_failed")
+            syncDictationRecorderWarmup(reason: "start-failed")
+            return
+        }
+
+        guard dictationAudioSessionTracker.isCurrent(sessionID) else { return }
+        markDictationLatency("start_success")
+        if dictationStartedAt == nil {
+            dictationStartedAt = Date()
+        }
+        capturedDictationContext = nil
+        if !isDictationTestMode {
+            indicator.powerProvider = { [weak self] in
+                self?.recorder.currentPower() ?? -160
+            }
+        }
+        if hotkeyMonitor.isToggleRecording {
+            indicator.setToggleDictation(true, config: config)
+        } else {
+            setState(.recording)
+        }
+        if isDictationTestMode {
+            dictationTestRecordingStarted?()
+        }
+        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
+
+        if config.enableScreenContext
+            && CGPreflightScreenCaptureAccess()
+            && config.enablePostProcessor
+            && !isDictationTestMode {
+            capturedDictationContext = DictationContextCapture.capture()
+        }
+    }
+
+    private func stopDictationRecorderAsync(sessionID: UUID, startedAt: Date) {
+        let recorder = self.recorder
+        let tracker = dictationAudioSessionTracker
+        dictationAudioQueue.async { [recorder, tracker] in
+            let wavURL: URL?
+            if tracker.isCurrent(sessionID) {
+                wavURL = recorder.stop()
+                recorder.preferredInputDeviceID = nil
+                tracker.finish(sessionID)
+            } else {
+                wavURL = nil
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt)
+            }
+        }
+    }
+
+    private func cancelDictationRecorderAsync() {
+        let recorder = self.recorder
+        dictationAudioSessionTracker.finishAll()
+        dictationAudioQueue.async { [recorder] in
+            recorder.cancel()
+            recorder.preferredInputDeviceID = nil
+        }
+    }
+
     private func handleStart() {
         if isMeetingRecording() { return }
 
@@ -3997,53 +4416,44 @@ final class MuesliController: NSObject {
         if selectedBackend.backend == "nemotron" {
             recorder.cancel()
             restoreDictationAudioDucking()
+            restoreDictationInputOverride()
+            resetDictationInputRoute()
             fputs("[muesli-native] hold-to-talk blocked for Nemotron, showing warning\n", stderr)
             indicator.showWarning("Double-tap for Nemotron handsfree mode", icon: "⚡")
+            finishDictationLatencyTrace("nemotron_hold_blocked")
             return
         }
 
         fputs("[muesli-native] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
-        beginDictationOutput()
-
-        do {
-            ensureDictationAudioDucked()
-            try recorder.start()
-            dictationStartedAt = Date()
-            capturedDictationContext = nil
-            if config.enableScreenContext
-                && CGPreflightScreenCaptureAccess()
-                && config.enablePostProcessor
-                && !isDictationTestMode {
-                capturedDictationContext = DictationContextCapture.capture()
-            }
-            if !isDictationTestMode {
-                indicator.powerProvider = { [weak self] in
-                    self?.recorder.currentPower() ?? -160
-                }
-            }
-            setState(.recording)
-            if isDictationTestMode {
-                dictationTestRecordingStarted?()
-            }
-            SoundController.playDictationStart(enabled: config.soundEnabled && !isDictationTestMode)
-        } catch {
-            fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
-            restoreDictationAudioDucking()
-            resetDictationOutputMode()
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
+        guard let sessionID = dictationAudioSessionTracker.current() else {
+            finishDictationLatencyTrace("start_without_session")
+            return
         }
+        beginDictationOutput()
+        dictationStartedAt = Date()
+        capturedDictationContext = nil
+        if !isDictationTestMode {
+            indicator.powerProvider = { [weak self] in
+                self?.recorder.currentPower() ?? -160
+            }
+        }
+        setState(.recording)
+        markDictationLatency("ui_recording")
+        ensureDictationAudioDucked()
+        startDictationRecorderAsync(sessionID: sessionID)
     }
 
     @available(macOS 15, *)
-    private func startNemotronStreamingAsync() {
+    private func startNemotronStreamingAsync(preferredInputDeviceID: AudioObjectID?) {
         Task {
             let transcriber = await transcriptionCoordinator.getNemotronTranscriber()
             fputs("[muesli-native] got Nemotron transcriber\n", stderr)
 
-            let controller = StreamingDictationController(transcriber: transcriber)
+            let controller = StreamingDictationController(
+                transcriber: transcriber,
+                preferredInputDeviceID: preferredInputDeviceID
+            )
             controller.onPartialText = { [weak self] fullText in
                 guard let self else { return }
                 let delta = String(fullText.dropFirst(self.previousStreamText.count))
@@ -4080,20 +4490,37 @@ final class MuesliController: NSObject {
             previousStreamText = ""
         }
 
-        recorder.cancel()
+        cancelDictationRecorderAsync()
         restoreDictationAudioDucking()
+        restoreDictationInputOverride()
+        resetDictationInputRoute()
         capturedDictationContext = nil
         dictationStartedAt = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
+        finishDictationLatencyTrace("cancelled")
+        syncDictationRecorderWarmup(reason: "cancel")
     }
 
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
         if isMeetingRecording() { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)
+        if dictationLatencyTraceID == nil {
+            beginDictationLatencyTrace(reason: "toggle")
+        }
+        markDictationLatency("toggle_start")
         meetingMonitor.suppressWhileActive()
+        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
         beginDictationAudioDucking()
         beginDictationOutput(mode: outputMode)
+        dictationStartedAt = Date()
+        if !isDictationTestMode {
+            indicator.powerProvider = { [weak self] in
+                self?.recorder.currentPower() ?? -160
+            }
+        }
+        indicator.setToggleDictation(true, config: config)
+        markDictationLatency("ui_recording")
 
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
@@ -4105,35 +4532,18 @@ final class MuesliController: NSObject {
                 indicator.setToggleDictation(true, config: config)
                 ensureDictationAudioDucked()
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
-                startNemotronStreamingAsync()
+                startNemotronStreamingAsync(preferredInputDeviceID: preferredInputDeviceID)
                 return
             }
         }
 
-        do {
-            try recorder.prepare()
-            ensureDictationAudioDucked()
-            try recorder.start()
-            dictationStartedAt = Date()
-            capturedDictationContext = nil
-            if config.enableScreenContext
-                && CGPreflightScreenCaptureAccess()
-                && config.enablePostProcessor
-                && !isDictationTestMode {
-                capturedDictationContext = DictationContextCapture.capture()
-            }
-            indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
-            }
-            indicator.setToggleDictation(true, config: config)
-        } catch {
-            fputs("[muesli-native] toggle start failed: \(error)\n", stderr)
-            restoreDictationAudioDucking()
-            resetDictationOutputMode()
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
-        }
+        let sessionID = dictationAudioSessionTracker.begin()
+        prepareDictationRecorderAsync(
+            sessionID: sessionID,
+            preferredInputDeviceID: preferredInputDeviceID
+        )
+        ensureDictationAudioDucked()
+        startDictationRecorderAsync(sessionID: sessionID)
     }
 
     private func handleToggleStop() {
@@ -4167,6 +4577,8 @@ final class MuesliController: NSObject {
                 fputs("[muesli-native] Nemotron streaming stop, controller not ready (short press)\n", stderr)
             }
             restoreDictationAudioDucking()
+            restoreDictationInputOverride()
+            resetDictationInputRoute()
             _streamingDictationController = nil
             previousStreamText = ""
 
@@ -4192,17 +4604,36 @@ final class MuesliController: NSObject {
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
+            finishDictationLatencyTrace("nemotron_stop")
             return
         }
 
-        // Standard path: stop recording → transcribe → paste
-        let stoppedWavURL = recorder.stop()
+        guard let sessionID = dictationAudioSessionTracker.current() else {
+            restoreDictationAudioDucking()
+            restoreDictationInputOverride()
+            resetDictationInputRoute()
+            resetDictationOutputMode()
+            setState(.idle)
+            meetingMonitor.resumeAfterCooldown()
+            finishDictationLatencyTrace("stop_without_session")
+            syncDictationRecorderWarmup(reason: "stop-without-session")
+            return
+        }
         restoreDictationAudioDucking()
+        stopDictationRecorderAsync(sessionID: sessionID, startedAt: startedAt)
+    }
+
+    private func finishStandardDictationStop(wavURL stoppedWavURL: URL?, startedAt: Date) {
+        restoreDictationInputOverride()
+        resetDictationInputRoute()
+        markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
             fputs("[muesli-native] stop without wav\n", stderr)
             resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
+            finishDictationLatencyTrace("stop_without_wav")
+            syncDictationRecorderWarmup(reason: "stop-without-wav")
             return
         }
         let duration = max(Date().timeIntervalSince(startedAt), 0)
@@ -4215,10 +4646,14 @@ final class MuesliController: NSObject {
             resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
+            finishDictationLatencyTrace("short_recording")
+            syncDictationRecorderWarmup(reason: "short-recording")
             return
         }
 
         setState(.transcribing)
+        finishDictationLatencyTrace("ready_for_transcription")
+        syncDictationRecorderWarmup(reason: "dictation-stop")
         let isTestMode = isDictationTestMode
         let outputMode = currentDictationOutputMode
         let transcriptionBackend = isTestMode ? (dictationTestBackend ?? selectedBackend) : selectedBackend
@@ -4278,10 +4713,10 @@ final class MuesliController: NSObject {
                     self.historyWindowController?.reload()
                     self.syncAppState()
                     if outputMode == .voiceNote {
-                        SoundController.playDictationInsert(enabled: self.config.soundEnabled)
+                        SoundController.playDictationInsert(enabled: self.shouldPlayDictationLifecycleSounds)
                     } else {
                         PasteController.paste(text: text)
-                        SoundController.playDictationInsert(enabled: self.config.soundEnabled)
+                        SoundController.playDictationInsert(enabled: self.shouldPlayDictationLifecycleSounds)
                     }
                     self.resetDictationOutputMode()
                     self.setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2703,8 +2703,8 @@ final class MuesliController: NSObject {
             presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
             return false
         }
-        cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         isStartingMeetingRecording = true
+        cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         syncDictationRecorderWarmup(reason: "meeting-start")
         meetingStartMeetingID = meetingID
         updateMeetingStartStatus("Preparing meeting transcription...")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4130,6 +4130,7 @@ final class MuesliController: NSObject {
                     at: url.deletingLastPathComponent(),
                     withIntermediateDirectories: true
                 )
+                try Self.trimDictationLatencyLogIfNeeded(at: url)
                 let data = Data((line + "\n").utf8)
                 if FileManager.default.fileExists(atPath: url.path) {
                     let handle = try FileHandle(forWritingTo: url)
@@ -4143,6 +4144,20 @@ final class MuesliController: NSObject {
                 fputs("[dictation-latency] failed to append log: \(error)\n", stderr)
             }
         }
+    }
+
+    private nonisolated static func trimDictationLatencyLogIfNeeded(at url: URL) throws {
+        let maxBytes: UInt64 = 2 * 1024 * 1024
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        guard let fileSize = attributes?[.size] as? UInt64,
+              fileSize > maxBytes else { return }
+
+        let data = try Data(contentsOf: url)
+        let keepCount = min(data.count, Int(maxBytes / 2))
+        let tail = data.suffix(keepCount)
+        let newlineIndex = tail.firstIndex(of: UInt8(ascii: "\n"))
+        let trimmed = newlineIndex.map { tail[tail.index(after: $0)...] } ?? tail[...]
+        try Data(trimmed).write(to: url, options: .atomic)
     }
 
     private func finishDictationLatencyTrace(_ event: String) {
@@ -4400,7 +4415,6 @@ final class MuesliController: NSObject {
         }
         markDictationLatency("toggle_start")
         meetingMonitor.suppressWhileActive()
-        let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
         beginDictationOutput(mode: outputMode)
         dictationStartedAt = nil
         setState(.preparing)
@@ -4408,6 +4422,7 @@ final class MuesliController: NSObject {
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
             if #available(macOS 15, *) {
+                let preferredInputDeviceID = dictationAudioRoutingController.preferredInputDeviceIDForDictation()
                 let sessionID = UUID()
                 isNemotronStreaming = true
                 nemotronStreamingSessionID = sessionID

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4216,8 +4216,6 @@ final class MuesliController: NSObject {
             }
             guard dictationAudioSessionManager.currentSessionID == nil else {
                 fputs("[muesli-native] ignoring stopped event while a new session is active\n", stderr)
-                pendingDictationStopSessionID = nil
-                pendingDictationStopStartedAt = nil
                 if let wavURL {
                     try? FileManager.default.removeItem(at: wavURL)
                 }
@@ -4490,6 +4488,7 @@ final class MuesliController: NSObject {
                     source: "nemotron-toggle",
                     duckingEnabled: config.muteSystemAudioDuringDictation
                 )
+                meetingMonitor.refreshState()
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
                 startNemotronStreamingAsync(
                     sessionID: sessionID

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -134,9 +134,9 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
                 let data = Data((line + "\n").utf8)
                 if FileManager.default.fileExists(atPath: url.path) {
                     let handle = try FileHandle(forWritingTo: url)
+                    defer { try? handle.close() }
                     try handle.seekToEnd()
                     try handle.write(contentsOf: data)
-                    try handle.close()
                 } else {
                     try data.write(to: url, options: .atomic)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4100,11 +4100,7 @@ final class MuesliController: NSObject {
             setState(.preparing)
             meetingMonitor.suppressWhileActive()
             meetingMonitor.refreshState()
-            dictationAudioSessionManager.arm(
-                source: "hotkey_arm",
-                duckingEnabled: config.muteSystemAudioDuringDictation,
-                mediaPauseEnabled: config.pauseMediaDuringDictation
-            )
+            dictationAudioSessionManager.arm(source: "hotkey_arm")
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -117,6 +117,7 @@ final class MuesliController: NSObject {
     private let hotkeyMonitor = HotkeyMonitor()
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let recorder = MicrophoneRecorder()
+    private let audioDuckingController: AudioDuckingManaging
     private let indicator: FloatingIndicatorController
     private let calendarMonitor = CalendarMonitor()
     private let meetingMonitor = MeetingMonitor()
@@ -192,7 +193,8 @@ final class MuesliController: NSObject {
         runtime: RuntimePaths,
         dictationStore: DictationStore? = nil,
         meetingHookDispatcher: MeetingHookDispatching = MeetingHookRunner(),
-        launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager()
+        launchAtLoginManager: LaunchAtLoginManaging = SystemLaunchAtLoginManager(),
+        audioDuckingController: AudioDuckingManaging = AudioDuckingController()
     ) {
         let loadedConfig = configStore.load()
         self.runtime = runtime
@@ -201,6 +203,7 @@ final class MuesliController: NSObject {
         )
         self.meetingHookDispatcher = meetingHookDispatcher
         self.launchAtLoginCoordinator = LaunchAtLoginCoordinator(manager: launchAtLoginManager)
+        self.audioDuckingController = audioDuckingController
         self.config = loadedConfig
         if loadedConfig.recordingColorHex != "1e1e2e" {
             MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
@@ -3946,11 +3949,15 @@ final class MuesliController: NSObject {
         fputs("[muesli-native] prepare\n", stderr)
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
+        if selectedBackend.backend != "nemotron" {
+            beginDictationAudioDucking()
+        }
         do {
             try recorder.prepare()
             setState(.preparing)
         } catch {
             fputs("[muesli-native] recorder prepare failed: \(error)\n", stderr)
+            restoreDictationAudioDucking()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
@@ -3971,12 +3978,25 @@ final class MuesliController: NSObject {
         appState.isVoiceNoteRecording = false
     }
 
+    private func beginDictationAudioDucking() {
+        audioDuckingController.beginDictationDucking(enabled: config.muteSystemAudioDuringDictation)
+    }
+
+    private func ensureDictationAudioDucked() {
+        audioDuckingController.ensureCurrentDefaultDucked()
+    }
+
+    private func restoreDictationAudioDucking() {
+        audioDuckingController.restoreDictationDucking()
+    }
+
     private func handleStart() {
         if isMeetingRecording() { return }
 
         // Nemotron is handsfree-only — block hold-to-talk and show a hint
         if selectedBackend.backend == "nemotron" {
             recorder.cancel()
+            restoreDictationAudioDucking()
             fputs("[muesli-native] hold-to-talk blocked for Nemotron, showing warning\n", stderr)
             indicator.showWarning("Double-tap for Nemotron handsfree mode", icon: "⚡")
             return
@@ -3987,6 +4007,7 @@ final class MuesliController: NSObject {
         beginDictationOutput()
 
         do {
+            ensureDictationAudioDucked()
             try recorder.start()
             dictationStartedAt = Date()
             capturedDictationContext = nil
@@ -4008,6 +4029,7 @@ final class MuesliController: NSObject {
             SoundController.playDictationStart(enabled: config.soundEnabled && !isDictationTestMode)
         } catch {
             fputs("[muesli-native] recorder start failed: \(error)\n", stderr)
+            restoreDictationAudioDucking()
             resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -4059,6 +4081,7 @@ final class MuesliController: NSObject {
         }
 
         recorder.cancel()
+        restoreDictationAudioDucking()
         capturedDictationContext = nil
         dictationStartedAt = nil
         setState(.idle)
@@ -4069,6 +4092,7 @@ final class MuesliController: NSObject {
         if isMeetingRecording() { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         meetingMonitor.suppressWhileActive()
+        beginDictationAudioDucking()
         beginDictationOutput(mode: outputMode)
 
         // Nemotron streaming: live text at cursor in handsfree mode too
@@ -4079,6 +4103,7 @@ final class MuesliController: NSObject {
                 dictationStartedAt = Date()
                 setState(.recording)
                 indicator.setToggleDictation(true, config: config)
+                ensureDictationAudioDucked()
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
                 startNemotronStreamingAsync()
                 return
@@ -4087,6 +4112,7 @@ final class MuesliController: NSObject {
 
         do {
             try recorder.prepare()
+            ensureDictationAudioDucked()
             try recorder.start()
             dictationStartedAt = Date()
             capturedDictationContext = nil
@@ -4102,6 +4128,7 @@ final class MuesliController: NSObject {
             indicator.setToggleDictation(true, config: config)
         } catch {
             fputs("[muesli-native] toggle start failed: \(error)\n", stderr)
+            restoreDictationAudioDucking()
             resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -4139,6 +4166,7 @@ final class MuesliController: NSObject {
             } else {
                 fputs("[muesli-native] Nemotron streaming stop, controller not ready (short press)\n", stderr)
             }
+            restoreDictationAudioDucking()
             _streamingDictationController = nil
             previousStreamText = ""
 
@@ -4168,7 +4196,9 @@ final class MuesliController: NSObject {
         }
 
         // Standard path: stop recording → transcribe → paste
-        guard let wavURL = recorder.stop() else {
+        let stoppedWavURL = recorder.stop()
+        restoreDictationAudioDucking()
+        guard let wavURL = stoppedWavURL else {
             fputs("[muesli-native] stop without wav\n", stderr)
             resetDictationOutputMode()
             setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -20,6 +20,10 @@ private enum DictationOutputMode {
     }
 }
 
+private enum DictationAudioRouteTiming {
+    static let stabilizationDelay: TimeInterval = 1.0
+}
+
 struct MeetingResummarizationPlan: Equatable {
     let promptTitle: String
     let persistedTitle: String
@@ -209,6 +213,7 @@ final class MuesliController: NSObject {
     private var dictationStartedAt: Date?
     private var dictationLatencyTraceID: UUID?
     private var dictationLatencyTraceStartedAt: Date?
+    private var dictationAudioRouteStabilizingUntil: Date?
     private var currentDictationOutputMode: DictationOutputMode = .paste
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
@@ -285,13 +290,19 @@ final class MuesliController: NSObject {
         dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] preferredInputDeviceID in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                self.dictationAudioRouteStabilizingUntil = Date()
+                    .addingTimeInterval(DictationAudioRouteTiming.stabilizationDelay)
+                self.coolDownDictationRecorder(reason: "route-change")
                 if self.dictationState == .preparing {
                     self.primeDictationRecorderForHotkey(
                         reason: "route-change",
                         preferredInputDeviceID: preferredInputDeviceID
                     )
                 } else {
-                    self.syncDictationRecorderWarmup(reason: "route-change")
+                    self.syncDictationRecorderWarmup(
+                        reason: "route-change",
+                        delay: DictationAudioRouteTiming.stabilizationDelay
+                    )
                 }
             }
         }
@@ -4099,14 +4110,18 @@ final class MuesliController: NSObject {
             && !isStoppingMeetingRecording
     }
 
-    private func syncDictationRecorderWarmup(reason: String) {
+    private func coolDownDictationRecorder(reason: String) {
+        recorder.keepsAudioGraphWarm = false
+        let recorder = self.recorder
+        dictationAudioQueue.async {
+            recorder.coolDown()
+            fputs("[dictation-prime] cooled reason=\(reason)\n", stderr)
+        }
+    }
+
+    private func syncDictationRecorderWarmup(reason: String, delay: TimeInterval = 0) {
         guard canPrimeDictationRecorder, selectedBackend.backend != "nemotron" else {
-            recorder.keepsAudioGraphWarm = false
-            let recorder = self.recorder
-            dictationAudioQueue.async {
-                recorder.coolDown()
-                fputs("[dictation-prime] cooled reason=\(reason)\n", stderr)
-            }
+            coolDownDictationRecorder(reason: reason)
             return
         }
 
@@ -4114,6 +4129,9 @@ final class MuesliController: NSObject {
         let recorder = self.recorder
         let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
         dictationAudioQueue.async { [route = dictationAudioRoutingController.currentRouteDebugDescription()] in
+            if delay > 0 {
+                Thread.sleep(forTimeInterval: delay)
+            }
             do {
                 try recorder.warmUp(preferredInputDeviceID: preferredInputDeviceID)
                 fputs("[dictation-prime] warmed-idle reason=\(reason) \(route)\n", stderr)
@@ -4132,6 +4150,7 @@ final class MuesliController: NSObject {
         guard canPrimeDictationRecorder, selectedBackend.backend != "nemotron" else { return }
         recorder.keepsAudioGraphWarm = true
         let recorder = self.recorder
+        let routeStabilizationDelay = dictationAudioRouteStabilizationDelay()
         markDictationLatency("prime_enqueue:\(reason)")
         let markLatency: @Sendable (String) -> Void = { [weak self] event in
             DispatchQueue.main.async { [weak self] in
@@ -4140,6 +4159,11 @@ final class MuesliController: NSObject {
         }
         dictationAudioQueue.async { [route = dictationAudioRoutingController.currentRouteDebugDescription(), markLatency] in
             do {
+                if routeStabilizationDelay > 0 {
+                    markLatency("route_stabilization_wait_begin:\(reason)")
+                    Thread.sleep(forTimeInterval: routeStabilizationDelay)
+                    markLatency("route_stabilization_wait_end:\(reason)")
+                }
                 markLatency("activation_begin:\(reason)")
                 try recorder.activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
                 markLatency("activation_end:\(reason)")
@@ -4149,6 +4173,16 @@ final class MuesliController: NSObject {
                 fputs("[dictation-prime] activation failed reason=\(reason) \(route) error=\(error)\n", stderr)
             }
         }
+    }
+
+    private func dictationAudioRouteStabilizationDelay() -> TimeInterval {
+        guard let stabilizingUntil = dictationAudioRouteStabilizingUntil else { return 0 }
+        let delay = stabilizingUntil.timeIntervalSinceNow
+        if delay <= 0 {
+            dictationAudioRouteStabilizingUntil = nil
+            return 0
+        }
+        return delay
     }
 
     private func beginDictationLatencyTrace(reason: String) {
@@ -4260,6 +4294,7 @@ final class MuesliController: NSObject {
     ) {
         let recorder = self.recorder
         let tracker = dictationAudioSessionTracker
+        let routeStabilizationDelay = dictationAudioRouteStabilizationDelay()
         let markLatency: @Sendable (String) -> Void = { [weak self] event in
             DispatchQueue.main.async { [weak self] in
                 self?.markDictationLatency(event)
@@ -4269,6 +4304,11 @@ final class MuesliController: NSObject {
             guard tracker.isCurrent(sessionID) else { return }
             recorder.preferredInputDeviceID = preferredInputDeviceID
             do {
+                if routeStabilizationDelay > 0 {
+                    markLatency("route_stabilization_wait_begin:prepare")
+                    Thread.sleep(forTimeInterval: routeStabilizationDelay)
+                    markLatency("route_stabilization_wait_end:prepare")
+                }
                 markLatency("prepare_begin")
                 try recorder.prepare()
                 markLatency("prepare_end")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4015,16 +4015,15 @@ final class MuesliController: NSObject {
             beginDictationLatencyTrace(reason: "prepare")
         }
         markDictationLatency("prepare_requested")
+        guard selectedBackend.backend != "nemotron" else {
+            setState(.idle)
+            meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
+            return
+        }
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
         setState(.preparing)
-        guard selectedBackend.backend != "nemotron" else {
-            return
-        }
-        dictationAudioSessionManager.beginRecording(
-            mode: "hold-prepare",
-            duckingEnabled: config.muteSystemAudioDuringDictation
-        )
     }
 
     private func handleArm() {
@@ -4034,6 +4033,8 @@ final class MuesliController: NSObject {
         }
         setState(.preparing)
         if selectedBackend.backend != "nemotron" {
+            meetingMonitor.suppressWhileActive()
+            meetingMonitor.refreshState()
             dictationAudioSessionManager.arm(
                 source: "hotkey_arm",
                 duckingEnabled: config.muteSystemAudioDuringDictation
@@ -4256,6 +4257,9 @@ final class MuesliController: NSObject {
             dictationAudioSessionManager.cancel(reason: "nemotron-hold-blocked")
             fputs("[muesli-native] hold-to-talk blocked for Nemotron, showing warning\n", stderr)
             indicator.showWarning("Double-tap for Nemotron handsfree mode", icon: "⚡")
+            setState(.idle)
+            meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
             finishDictationLatencyTrace("nemotron_hold_blocked")
             return
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2704,6 +2704,8 @@ final class MuesliController: NSObject {
             return false
         }
         isStartingMeetingRecording = true
+        // Keep this after backend normalization and live-meeting creation so
+        // a failed meeting start does not silently cancel an active dictation.
         cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         syncDictationRecorderWarmup(reason: "meeting-start")
         meetingStartMeetingID = meetingID
@@ -4576,6 +4578,7 @@ final class MuesliController: NSObject {
             _streamingDictationController = nil
             nemotronStreamingSessionID = nil
             previousStreamText = ""
+            indicator.setToggleDictation(false, config: config)
             dictationAudioSessionManager.endExternalSession(reason: "meeting-active")
         } else {
             dictationAudioSessionManager.cancel(reason: "meeting-active")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -214,6 +214,7 @@ final class MuesliController: NSObject {
     private var dictationLatencyTraceID: UUID?
     private var dictationLatencyTraceStartedAt: Date?
     private var dictationAudioRouteStabilizingUntil: Date?
+    private var dictationAwaitingFirstAudioSessionID: UUID?
     private var currentDictationOutputMode: DictationOutputMode = .paste
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
@@ -284,7 +285,7 @@ final class MuesliController: NSObject {
         super.init()
         recorder.onFirstCapturedAudioBuffer = { [weak self] capturedAt in
             Task { @MainActor [weak self] in
-                self?.markDictationLatency("first_audio_buffer", at: capturedAt)
+                self?.handleFirstDictationAudioBuffer(capturedAt: capturedAt)
             }
         }
         dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] preferredInputDeviceID in
@@ -4343,6 +4344,7 @@ final class MuesliController: NSObject {
         restoreDictationAudioDucking()
         restoreDictationInputOverride()
         resetDictationInputRoute()
+        dictationAwaitingFirstAudioSessionID = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
@@ -4384,6 +4386,7 @@ final class MuesliController: NSObject {
             restoreDictationInputOverride()
             resetDictationInputRoute()
             resetDictationOutputMode()
+            dictationAwaitingFirstAudioSessionID = nil
             dictationStartedAt = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -4395,8 +4398,23 @@ final class MuesliController: NSObject {
 
         guard dictationAudioSessionTracker.isCurrent(sessionID) else { return }
         markDictationLatency("start_success")
+        if !isDictationTestMode {
+            indicator.powerProvider = { [weak self] in
+                self?.recorder.currentPower() ?? -160
+            }
+        }
+    }
+
+    private func handleFirstDictationAudioBuffer(capturedAt: Date) {
+        markDictationLatency("first_audio_buffer", at: capturedAt)
+        guard let sessionID = dictationAudioSessionTracker.current(),
+              dictationAwaitingFirstAudioSessionID == sessionID else {
+            return
+        }
+
+        dictationAwaitingFirstAudioSessionID = nil
         if dictationStartedAt == nil {
-            dictationStartedAt = Date()
+            dictationStartedAt = capturedAt
         }
         capturedDictationContext = nil
         if !isDictationTestMode {
@@ -4409,6 +4427,7 @@ final class MuesliController: NSObject {
         } else {
             setState(.recording)
         }
+        markDictationLatency("ui_recording")
         if isDictationTestMode {
             dictationTestRecordingStarted?()
         }
@@ -4471,15 +4490,15 @@ final class MuesliController: NSObject {
             return
         }
         beginDictationOutput()
-        dictationStartedAt = Date()
+        dictationStartedAt = nil
+        dictationAwaitingFirstAudioSessionID = sessionID
         capturedDictationContext = nil
         if !isDictationTestMode {
             indicator.powerProvider = { [weak self] in
                 self?.recorder.currentPower() ?? -160
             }
         }
-        setState(.recording)
-        markDictationLatency("ui_recording")
+        setState(.preparing)
         ensureDictationAudioDucked()
         startDictationRecorderAsync(sessionID: sessionID)
     }
@@ -4535,6 +4554,7 @@ final class MuesliController: NSObject {
         restoreDictationInputOverride()
         resetDictationInputRoute()
         capturedDictationContext = nil
+        dictationAwaitingFirstAudioSessionID = nil
         dictationStartedAt = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
@@ -4553,14 +4573,13 @@ final class MuesliController: NSObject {
         let preferredInputDeviceID = cachedPreferredDictationInputDeviceID()
         beginDictationAudioDucking()
         beginDictationOutput(mode: outputMode)
-        dictationStartedAt = Date()
+        dictationStartedAt = nil
         if !isDictationTestMode {
             indicator.powerProvider = { [weak self] in
                 self?.recorder.currentPower() ?? -160
             }
         }
-        indicator.setToggleDictation(true, config: config)
-        markDictationLatency("ui_recording")
+        setState(.preparing)
 
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
@@ -4578,6 +4597,7 @@ final class MuesliController: NSObject {
         }
 
         let sessionID = dictationAudioSessionTracker.begin()
+        dictationAwaitingFirstAudioSessionID = sessionID
         prepareDictationRecorderAsync(
             sessionID: sessionID,
             preferredInputDeviceID: preferredInputDeviceID
@@ -4593,7 +4613,7 @@ final class MuesliController: NSObject {
     }
 
     func toggleVoiceNoteRecording() {
-        if dictationStartedAt != nil {
+        if dictationStartedAt != nil || dictationAudioSessionTracker.current() != nil || isNemotronStreaming {
             handleToggleStop()
         } else if dictationState == .idle {
             handleToggleStart(outputMode: .voiceNote)
@@ -4621,6 +4641,7 @@ final class MuesliController: NSObject {
             resetDictationInputRoute()
             _streamingDictationController = nil
             previousStreamText = ""
+            dictationAwaitingFirstAudioSessionID = nil
 
             let duration = max(Date().timeIntervalSince(startedAt), 0)
             let cleaned = FillerWordFilter.apply(finalText)
@@ -4653,12 +4674,14 @@ final class MuesliController: NSObject {
             restoreDictationInputOverride()
             resetDictationInputRoute()
             resetDictationOutputMode()
+            dictationAwaitingFirstAudioSessionID = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             finishDictationLatencyTrace("stop_without_session")
             syncDictationRecorderWarmup(reason: "stop-without-session")
             return
         }
+        dictationAwaitingFirstAudioSessionID = nil
         restoreDictationAudioDucking()
         stopDictationRecorderAsync(sessionID: sessionID, startedAt: startedAt)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -231,6 +231,7 @@ final class MuesliController: NSObject {
     private var currentDictationOutputMode: DictationOutputMode = .paste
     private var pendingDictationStopStartedAt: Date?
     private var pendingDictationStopSessionID: UUID?
+    private var pendingReleaseSoundSessionID: UUID?
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
@@ -304,7 +305,7 @@ final class MuesliController: NSObject {
                 self?.handleDictationAudioSessionEvent(event)
             }
         }
-        dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] preferredInputDeviceID in
+        dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.syncDictationRecorderWarmup(
@@ -4225,6 +4226,11 @@ final class MuesliController: NSObject {
             pendingDictationStopSessionID = nil
             pendingDictationStopStartedAt = nil
             finishStandardDictationStop(wavURL: wavURL, startedAt: startedAt)
+        case .audioRestored(let eventSessionID):
+            guard pendingReleaseSoundSessionID == eventSessionID else { break }
+            pendingReleaseSoundSessionID = nil
+            guard dictationAudioSessionManager.currentSessionID == nil else { break }
+            SoundController.playDictationInsert(enabled: true)
         case .cancelled:
             break
         case .failed(_, let error):
@@ -4233,6 +4239,7 @@ final class MuesliController: NSObject {
             dictationStartedAt = nil
             pendingDictationStopSessionID = nil
             pendingDictationStopStartedAt = nil
+            pendingReleaseSoundSessionID = nil
             capturedDictationContext = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -4341,41 +4348,41 @@ final class MuesliController: NSObject {
 
     @available(macOS 15, *)
     private func startNemotronStreamingAsync(
-        preferredInputDeviceID: AudioObjectID?,
         sessionID: UUID
     ) {
         Task {
             let transcriber = await transcriptionCoordinator.getNemotronTranscriber()
             fputs("[muesli-native] got Nemotron transcriber\n", stderr)
 
-            let controller = StreamingDictationController(
-                transcriber: transcriber,
-                preferredInputDeviceID: preferredInputDeviceID
-            )
-            controller.onPartialText = { [weak self] fullText in
-                guard let self else { return }
-                DispatchQueue.main.async {
-                    guard self.isNemotronStreaming, self.nemotronStreamingSessionID == sessionID else { return }
-                    let delta = String(fullText.dropFirst(self.previousStreamText.count))
-                    fputs("[muesli-native] streaming partial: +\"\(delta)\" (total \(fullText.count) chars)\n", stderr)
-                    if !delta.isEmpty {
-                        self.previousStreamText = fullText
-                        if self.currentDictationOutputMode != .voiceNote {
-                            PasteController.typeText(delta)
-                        }
-                    }
-                }
-            }
-            controller.onFailure = { [weak self] error in
-                DispatchQueue.main.async {
-                    self?.handleNemotronStreamingRuntimeFailure(error: error, sessionID: sessionID)
-                }
-            }
-
             await MainActor.run {
                 guard self.isNemotronStreaming, self.nemotronStreamingSessionID == sessionID else {
                     fputs("[muesli-native] Nemotron session cancelled before transcriber ready\n", stderr)
                     return
+                }
+                let currentPreferredInputDeviceID =
+                    self.dictationAudioRoutingController.preferredInputDeviceIDForDictation()
+                let controller = StreamingDictationController(
+                    transcriber: transcriber,
+                    preferredInputDeviceID: currentPreferredInputDeviceID
+                )
+                controller.onPartialText = { [weak self] fullText in
+                    guard let self else { return }
+                    DispatchQueue.main.async {
+                        guard self.isNemotronStreaming, self.nemotronStreamingSessionID == sessionID else { return }
+                        let delta = String(fullText.dropFirst(self.previousStreamText.count))
+                        fputs("[muesli-native] streaming partial: +\"\(delta)\" (total \(fullText.count) chars)\n", stderr)
+                        if !delta.isEmpty {
+                            self.previousStreamText = fullText
+                            if self.currentDictationOutputMode != .voiceNote {
+                                PasteController.typeText(delta)
+                            }
+                        }
+                    }
+                }
+                controller.onFailure = { [weak self] error in
+                    DispatchQueue.main.async {
+                        self?.handleNemotronStreamingRuntimeFailure(error: error, sessionID: sessionID)
+                    }
                 }
                 self._streamingDictationController = controller
                 guard controller.start() else {
@@ -4444,6 +4451,7 @@ final class MuesliController: NSObject {
         dictationStartedAt = nil
         pendingDictationStopSessionID = nil
         pendingDictationStopStartedAt = nil
+        pendingReleaseSoundSessionID = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
@@ -4468,7 +4476,6 @@ final class MuesliController: NSObject {
         // Nemotron streaming: live text at cursor in handsfree mode too
         if selectedBackend.backend == "nemotron" {
             if #available(macOS 15, *) {
-                let preferredInputDeviceID = dictationAudioRoutingController.preferredInputDeviceIDForDictation()
                 let sessionID = UUID()
                 isNemotronStreaming = true
                 nemotronStreamingSessionID = sessionID
@@ -4482,7 +4489,6 @@ final class MuesliController: NSObject {
                 )
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
                 startNemotronStreamingAsync(
-                    preferredInputDeviceID: preferredInputDeviceID,
                     sessionID: sessionID
                 )
                 return
@@ -4542,11 +4548,10 @@ final class MuesliController: NSObject {
         }
 
         markDictationLatency("sound_release_requested:stop")
-        // This cue is intentionally key-up feedback, not a transcription-success
-        // signal. Keeping it off the network/transcription path preserves the
-        // lower perceived release latency of dictation.
-        SoundController.playDictationInsert(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         pendingDictationStopSessionID = dictationAudioSessionManager.currentSessionID
+        pendingReleaseSoundSessionID = shouldPlayDictationLifecycleSounds && !isDictationTestMode
+            ? pendingDictationStopSessionID
+            : nil
         pendingDictationStopStartedAt = startedAt
         dictationAudioSessionManager.stop()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4445,6 +4445,7 @@ final class MuesliController: NSObject {
         pendingDictationStopStartedAt = nil
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
         finishDictationLatencyTrace("cancelled")
         syncDictationRecorderWarmup(reason: "cancel")
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2674,7 +2674,6 @@ final class MuesliController: NSObject {
     @discardableResult
     func startMeetingRecording(title: String = "Meeting", calendarEventID: String? = nil, openDocument: Bool = false, endDate: Date? = nil) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
-        cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
             presentErrorAlert(
                 title: "Meeting failed to start",
@@ -2704,6 +2703,7 @@ final class MuesliController: NSObject {
             presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
             return false
         }
+        cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         isStartingMeetingRecording = true
         syncDictationRecorderWarmup(reason: "meeting-start")
         meetingStartMeetingID = meetingID

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4360,7 +4360,7 @@ final class MuesliController: NSObject {
                     return
                 }
                 let currentPreferredInputDeviceID =
-                    self.dictationAudioRoutingController.preferredInputDeviceIDForDictation()
+                    self.dictationAudioRoutingController.cachedPreferredInputDeviceIDForDictation()
                 let controller = StreamingDictationController(
                     transcriber: transcriber,
                     preferredInputDeviceID: currentPreferredInputDeviceID

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4585,6 +4585,8 @@ final class MuesliController: NSObject {
         pendingReleaseSoundSessionID = nil
         resetDictationOutputMode()
         setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
         finishDictationLatencyTrace("meeting_active_cancel")
         syncDictationRecorderWarmup(reason: "meeting-active")
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4622,6 +4622,9 @@ final class MuesliController: NSObject {
         let outputMode = currentDictationOutputMode
         let transcriptionBackend = isTestMode ? (dictationTestBackend ?? selectedBackend) : selectedBackend
         let transcriptionLanguage = isTestMode ? (dictationTestCohereLanguage ?? config.resolvedCohereLanguage) : config.resolvedCohereLanguage
+        let capturedContext = capturedDictationContext
+        let promptContext = capturedContext.map { DictationContextCapture.formatForPrompt($0) }
+        let storageContext = capturedContext.map { DictationContextCapture.formatForStorage($0) } ?? ""
         let task = Task { [weak self] in
             guard let self else { return }
             defer {
@@ -4635,7 +4638,7 @@ final class MuesliController: NSObject {
                     cohereLanguage: transcriptionLanguage,
                     enablePostProcessor: self.isPostProcessorReady,
                     customWords: self.serializedCustomWords(),
-                    appContext: self.capturedDictationContext.map { DictationContextCapture.formatForPrompt($0) }
+                    appContext: promptContext
                 )
                 // Drop result if test was cancelled (user navigated away)
                 try Task.checkCancellation()
@@ -4663,11 +4666,10 @@ final class MuesliController: NSObject {
                     }
                     return
                 }
-                let appContextString = self.capturedDictationContext.map { DictationContextCapture.formatForStorage($0) } ?? ""
                 _ = try? self.dictationStore.insertDictation(
                     text: text,
                     durationSeconds: duration,
-                    appContext: appContextString,
+                    appContext: storageContext,
                     startedAt: startedAt,
                     endedAt: Date()
                 )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4301,11 +4301,34 @@ final class MuesliController: NSObject {
             }
 
             await MainActor.run {
+                guard self.isNemotronStreaming else {
+                    fputs("[muesli-native] Nemotron session cancelled before transcriber ready\n", stderr)
+                    return
+                }
                 self._streamingDictationController = controller
-                controller.start()
+                guard controller.start() else {
+                    self.handleNemotronStreamingStartFailure()
+                    return
+                }
                 fputs("[muesli-native] Nemotron streaming controller started\n", stderr)
             }
         }
+    }
+
+    @MainActor
+    private func handleNemotronStreamingStartFailure() {
+        fputs("[muesli-native] Nemotron streaming controller failed to start\n", stderr)
+        isNemotronStreaming = false
+        _streamingDictationController = nil
+        previousStreamText = ""
+        dictationStartedAt = nil
+        dictationAudioSessionManager.endExternalSession(reason: "nemotron-start-failed")
+        indicator.setToggleDictation(false, config: config)
+        resetDictationOutputMode()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        finishDictationLatencyTrace("nemotron_start_failed")
+        syncDictationRecorderWarmup(reason: "nemotron-start-failed")
     }
 
     private func handleCancel() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4560,9 +4560,22 @@ final class MuesliController: NSObject {
     }
 
     private func cancelDictationAudioSessionForMeetingRecordingIfNeeded() {
-        guard dictationAudioSessionManager.hasActiveSession else { return }
+        guard dictationAudioSessionManager.hasActiveSession || isNemotronStreaming else { return }
         fputs("[muesli-native] cancelling dictation audio session because meeting is active\n", stderr)
-        dictationAudioSessionManager.cancel(reason: "meeting-active")
+
+        if isNemotronStreaming {
+            isNemotronStreaming = false
+            if #available(macOS 15, *), let controller = _streamingDictationController as? StreamingDictationController {
+                controller.cancel()
+            }
+            _streamingDictationController = nil
+            nemotronStreamingSessionID = nil
+            previousStreamText = ""
+            dictationAudioSessionManager.endExternalSession(reason: "meeting-active")
+        } else {
+            dictationAudioSessionManager.cancel(reason: "meeting-active")
+        }
+
         dictationStartedAt = nil
         capturedDictationContext = nil
         pendingDictationStopSessionID = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4354,13 +4354,12 @@ final class MuesliController: NSObject {
             )
             controller.onPartialText = { [weak self] fullText in
                 guard let self else { return }
-                guard self.nemotronStreamingSessionID == sessionID else { return }
-                let delta = String(fullText.dropFirst(self.previousStreamText.count))
-                fputs("[muesli-native] streaming partial: +\"\(delta)\" (total \(fullText.count) chars)\n", stderr)
-                if !delta.isEmpty {
-                    self.previousStreamText = fullText
-                    DispatchQueue.main.async {
-                        guard self.nemotronStreamingSessionID == sessionID else { return }
+                DispatchQueue.main.async {
+                    guard self.isNemotronStreaming, self.nemotronStreamingSessionID == sessionID else { return }
+                    let delta = String(fullText.dropFirst(self.previousStreamText.count))
+                    fputs("[muesli-native] streaming partial: +\"\(delta)\" (total \(fullText.count) chars)\n", stderr)
+                    if !delta.isEmpty {
+                        self.previousStreamText = fullText
                         if self.currentDictationOutputMode != .voiceNote {
                             PasteController.typeText(delta)
                         }
@@ -4519,7 +4518,6 @@ final class MuesliController: NSObject {
         // Nemotron streaming: text already typed — just finalize and store
         if isNemotronStreaming {
             let sessionID = nemotronStreamingSessionID
-            isNemotronStreaming = false
             if #available(macOS 15, *), let controller = _streamingDictationController as? StreamingDictationController {
                 controller.stop { [weak self] finalText in
                     DispatchQueue.main.async {
@@ -4558,10 +4556,11 @@ final class MuesliController: NSObject {
         startedAt: Date,
         sessionID: UUID?
     ) {
-        guard nemotronStreamingSessionID == sessionID else {
+        guard isNemotronStreaming, nemotronStreamingSessionID == sessionID else {
             fputs("[muesli-native] ignoring stale Nemotron stop completion\n", stderr)
             return
         }
+        isNemotronStreaming = false
         _streamingDictationController = nil
         nemotronStreamingSessionID = nil
         previousStreamText = ""

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4027,9 +4027,6 @@ final class MuesliController: NSObject {
         }
         markDictationLatency("prepare_requested")
         guard selectedBackend.backend != "nemotron" else {
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
             return
         }
         meetingMonitor.suppressWhileActive()
@@ -4072,6 +4069,8 @@ final class MuesliController: NSObject {
             && hasStarted
             && config.resolvedOnboardingUseCase.includesPushToTalk
             && AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+            && dictationState == .idle
+            && computerUseCommandStartedAt == nil
             && !isMeetingRecording()
             && !isStartingMeetingRecording
             && !isStoppingMeetingRecording
@@ -4249,8 +4248,6 @@ final class MuesliController: NSObject {
         if isDictationTestMode {
             dictationTestRecordingStarted?()
         }
-        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
-
         if shouldCaptureDictationContext {
             captureDictationContextAsync()
         }
@@ -4310,6 +4307,8 @@ final class MuesliController: NSObject {
 
         fputs("[muesli-native] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
+        markDictationLatency("sound_start_requested:hold-start")
+        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         beginDictationOutput()
         dictationStartedAt = nil
         capturedDictationContext = nil
@@ -4415,6 +4414,8 @@ final class MuesliController: NSObject {
         }
         markDictationLatency("toggle_start")
         meetingMonitor.suppressWhileActive()
+        markDictationLatency("sound_start_requested:toggle")
+        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         beginDictationOutput(mode: outputMode)
         dictationStartedAt = nil
         setState(.preparing)
@@ -4496,6 +4497,8 @@ final class MuesliController: NSObject {
             return
         }
 
+        markDictationLatency("sound_release_requested:stop")
+        SoundController.playDictationInsert(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         pendingDictationStopSessionID = dictationAudioSessionManager.currentSessionID
         pendingDictationStopStartedAt = startedAt
         dictationAudioSessionManager.stop()
@@ -4626,11 +4629,8 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()
-                    if outputMode == .voiceNote {
-                        SoundController.playDictationInsert(enabled: self.shouldPlayDictationLifecycleSounds)
-                    } else {
+                    if outputMode != .voiceNote {
                         PasteController.paste(text: text)
-                        SoundController.playDictationInsert(enabled: self.shouldPlayDictationLifecycleSounds)
                     }
                     self.resetDictationOutputMode()
                     self.setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4100,7 +4100,8 @@ final class MuesliController: NSObject {
             meetingMonitor.refreshState()
             dictationAudioSessionManager.arm(
                 source: "hotkey_arm",
-                duckingEnabled: config.muteSystemAudioDuringDictation
+                duckingEnabled: config.muteSystemAudioDuringDictation,
+                mediaPauseEnabled: config.pauseMediaDuringDictation
             )
         }
     }
@@ -4246,7 +4247,6 @@ final class MuesliController: NSObject {
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
             finishDictationLatencyTrace("audio_session_failed")
-            syncDictationRecorderWarmup(reason: "audio-session-failed")
         case .latency(let event, let date):
             markDictationLatency(event, at: date)
         }
@@ -4270,6 +4270,8 @@ final class MuesliController: NSObject {
                 self?.dictationAudioSessionManager.currentPower() ?? -160
             }
         }
+        markDictationLatency("sound_start_requested:stream-active")
+        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         markDictationLatency("ui_stream_active")
         logDictationPowerSample(label: "ui_power_sample_350ms", delay: 0.35)
         logDictationPowerSample(label: "ui_power_sample_1000ms", delay: 1.0)
@@ -4335,15 +4337,14 @@ final class MuesliController: NSObject {
 
         fputs("[muesli-native] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
-        markDictationLatency("sound_start_requested:hold-start")
-        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         beginDictationOutput()
         dictationStartedAt = nil
         capturedDictationContext = nil
         setState(.preparing)
         dictationAudioSessionManager.beginRecording(
             mode: "hold-start",
-            duckingEnabled: config.muteSystemAudioDuringDictation
+            duckingEnabled: config.muteSystemAudioDuringDictation,
+            mediaPauseEnabled: config.pauseMediaDuringDictation
         )
     }
 
@@ -4468,8 +4469,6 @@ final class MuesliController: NSObject {
         }
         markDictationLatency("toggle_start")
         meetingMonitor.suppressWhileActive()
-        markDictationLatency("sound_start_requested:toggle")
-        SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         beginDictationOutput(mode: outputMode)
         dictationStartedAt = nil
         setState(.preparing)
@@ -4482,11 +4481,14 @@ final class MuesliController: NSObject {
                 nemotronStreamingSessionID = sessionID
                 previousStreamText = ""
                 dictationStartedAt = Date()
+                markDictationLatency("sound_start_requested:nemotron-toggle")
+                SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
                 setState(.recording)
                 indicator.setToggleDictation(true, config: config)
                 dictationAudioSessionManager.beginExternalSession(
                     source: "nemotron-toggle",
-                    duckingEnabled: config.muteSystemAudioDuringDictation
+                    duckingEnabled: config.muteSystemAudioDuringDictation,
+                    mediaPauseEnabled: config.pauseMediaDuringDictation
                 )
                 meetingMonitor.refreshState()
                 fputs("[muesli-native] Nemotron streaming toggle mode active\n", stderr)
@@ -4499,7 +4501,8 @@ final class MuesliController: NSObject {
 
         dictationAudioSessionManager.beginRecording(
             mode: "toggle",
-            duckingEnabled: config.muteSystemAudioDuringDictation
+            duckingEnabled: config.muteSystemAudioDuringDictation,
+            mediaPauseEnabled: config.pauseMediaDuringDictation
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4588,6 +4588,7 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
         fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
         finishDictationLatencyTrace("nemotron_stop")
+        syncDictationRecorderWarmup(reason: "nemotron-stop")
     }
 
     private func finishStandardDictationStop(wavURL stoppedWavURL: URL?, startedAt: Date) {
@@ -4652,6 +4653,7 @@ final class MuesliController: NSObject {
                         self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
+                        self.syncDictationRecorderWarmup(reason: "transcription-complete")
                     }
                     return
                 }
@@ -4664,6 +4666,7 @@ final class MuesliController: NSObject {
                         self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
+                        self.syncDictationRecorderWarmup(reason: "transcription-complete")
                     }
                     return
                 }
@@ -4685,6 +4688,7 @@ final class MuesliController: NSObject {
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
+                    self.syncDictationRecorderWarmup(reason: "transcription-complete")
                     TelemetryDeck.signal("dictation.completed", parameters: [
                         "backend": self.selectedBackend.backend,
                         "paste_method": outputMode.pasteMethod,
@@ -4696,6 +4700,7 @@ final class MuesliController: NSObject {
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
+                    self.syncDictationRecorderWarmup(reason: "transcription-cancelled")
                 }
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
@@ -4706,6 +4711,7 @@ final class MuesliController: NSObject {
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
+                    self.syncDictationRecorderWarmup(reason: "transcription-failed")
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -408,11 +408,20 @@ struct SettingsView: View {
                             .frame(width: controlWidth, alignment: .trailing)
                     }
                 }
-                Divider().background(MuesliTheme.surfaceBorder)
+            }
+
+            settingsSection("Advanced") {
                 settingsRow("Mute system audio during dictation") {
                     settingsSwitch(isOn: appState.config.muteSystemAudioDuringDictation) { newValue in
                         controller.updateConfig { $0.muteSystemAudioDuringDictation = newValue }
                     }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow(
+                    "Hotkey trigger threshold",
+                    description: "Lower values show the indicator sooner; double-tap keeps a short quick-tap guard."
+                ) {
+                    hotkeyTriggerThresholdControl
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 screenContextRow("App context")
@@ -1353,6 +1362,34 @@ struct SettingsView: View {
         .frame(minHeight: 32)
     }
 
+    @ViewBuilder
+    private func settingsRow(
+        _ label: String,
+        description: String,
+        controlWidth rowControlWidth: CGFloat? = nil,
+        @ViewBuilder control: () -> some View
+    ) -> some View {
+        let width = rowControlWidth ?? controlWidth
+        HStack(alignment: .center, spacing: 20) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(label)
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(description)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 0)
+
+            control()
+                .frame(width: width, alignment: .trailing)
+        }
+        .frame(minHeight: 44)
+    }
+
     private func settingsDescription(_ text: String) -> some View {
         Text(text)
             .font(MuesliTheme.caption())
@@ -1379,6 +1416,62 @@ struct SettingsView: View {
     private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
         FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
             .frame(height: 24)
+    }
+
+    private var hotkeyTriggerThresholdControl: some View {
+        let threshold = HotkeyTriggerTiming.clampedMilliseconds(appState.config.hotkeyTriggerThresholdMS)
+        return HStack(spacing: 6) {
+            thresholdStepButton(
+                systemName: "minus",
+                disabled: threshold <= HotkeyTriggerTiming.minThresholdMilliseconds
+            ) {
+                updateHotkeyTriggerThreshold(threshold - 25)
+            }
+
+            Text("\(threshold) ms")
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .frame(width: 72, alignment: .center)
+
+            thresholdStepButton(
+                systemName: "plus",
+                disabled: threshold >= HotkeyTriggerTiming.maxThresholdMilliseconds
+            ) {
+                updateHotkeyTriggerThreshold(threshold + 25)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func thresholdStepButton(
+        systemName: String,
+        disabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(disabled ? MuesliTheme.textTertiary.opacity(0.45) : MuesliTheme.textSecondary)
+                .frame(width: 24, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .help(systemName == "minus" ? "Decrease threshold" : "Increase threshold")
+    }
+
+    private func updateHotkeyTriggerThreshold(_ value: Int) {
+        controller.updateConfig {
+            $0.hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(value)
+        }
     }
 
     private var mutedMeetingDetectionAppsControl: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -409,6 +409,12 @@ struct SettingsView: View {
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Mute system audio during dictation") {
+                    settingsSwitch(isOn: appState.config.muteSystemAudioDuringDictation) { newValue in
+                        controller.updateConfig { $0.muteSystemAudioDuringDictation = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
                 screenContextRow("App context")
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -411,6 +411,12 @@ struct SettingsView: View {
             }
 
             settingsSection("Advanced") {
+                settingsRow("Pause media during dictation") {
+                    settingsSwitch(isOn: appState.config.pauseMediaDuringDictation) { newValue in
+                        controller.updateConfig { $0.pauseMediaDuringDictation = newValue }
+                    }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Mute system audio during dictation") {
                     settingsSwitch(isOn: appState.config.muteSystemAudioDuringDictation) { newValue in
                         controller.updateConfig { $0.muteSystemAudioDuringDictation = newValue }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -1,22 +1,27 @@
 import AppKit
+import AudioToolbox
 
 /// Plays subtle system sounds for dictation lifecycle events.
 /// Sounds are skipped when `soundEnabled` is false.
 @MainActor
 enum SoundController {
+    static func prewarmLifecycleSounds() {
+        SystemSoundPlayer.prewarm(names: ["Tink", "Purr", "Glass"])
+    }
+
     static func playDictationStart(enabled: Bool) {
         guard enabled else { return }
-        NSSound(named: .init("Tink"))?.play()
+        SystemSoundPlayer.play(named: "Tink")
     }
 
     static func playDictationInsert(enabled: Bool) {
         guard enabled else { return }
-        NSSound(named: .init("Purr"))?.play()
+        SystemSoundPlayer.play(named: "Purr")
     }
 
     static func playModelReady(enabled: Bool) {
         guard enabled else { return }
-        NSSound(named: .init("Glass"))?.play()
+        SystemSoundPlayer.play(named: "Glass")
     }
 
     // MARK: - Marauder's Map
@@ -85,7 +90,7 @@ enum SoundController {
     }
 
     static func playMaraudersMapUnlock() {
-        NSSound(named: .init("Glass"))?.play()
+        SystemSoundPlayer.play(named: "Glass")
     }
 
     /// Copy a user-selected file into the app's support directory and return the destination path.
@@ -110,6 +115,42 @@ enum SoundController {
             }
         }
         return nil
+    }
+}
+
+private enum SystemSoundPlayer {
+    private static let queue = DispatchQueue(label: "com.muesli.system-sound-player", qos: .utility)
+    private static var soundIDs: [String: SystemSoundID] = [:]
+
+    static func prewarm(names: [String]) {
+        queue.async {
+            for name in names {
+                _ = loadSoundID(named: name)
+            }
+        }
+    }
+
+    static func play(named name: String) {
+        queue.async {
+            guard let soundID = loadSoundID(named: name) else { return }
+            AudioServicesPlaySystemSound(soundID)
+        }
+    }
+
+    private static func loadSoundID(named name: String) -> SystemSoundID? {
+        if let soundID = soundIDs[name] {
+            return soundID
+        }
+        let url = URL(fileURLWithPath: "/System/Library/Sounds/\(name).aiff")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        var soundID: SystemSoundID = 0
+        let status = AudioServicesCreateSystemSoundID(url as CFURL, &soundID)
+        guard status == kAudioServicesNoError else {
+            fputs("[muesli-native] failed to load system sound \(name): \(status)\n", stderr)
+            return nil
+        }
+        soundIDs[name] = soundID
+        return soundID
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -149,7 +149,7 @@ private enum SystemSoundPlayer {
     }
 
     private static func disposeCachedSoundsBestEffort() {
-        queue.sync {
+        queue.async {
             for soundID in soundIDs.values {
                 AudioServicesDisposeSystemSoundID(soundID)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -121,9 +121,11 @@ enum SoundController {
 private enum SystemSoundPlayer {
     private static let queue = DispatchQueue(label: "com.muesli.system-sound-player", qos: .userInitiated)
     private static var soundIDs: [String: SystemSoundID] = [:]
+    private static var cleanupRegistered = false
 
     static func prewarm(names: [String]) {
         queue.async {
+            registerCleanupIfNeeded()
             for name in names {
                 _ = loadSoundID(named: name)
             }
@@ -132,8 +134,26 @@ private enum SystemSoundPlayer {
 
     static func play(named name: String) {
         queue.async {
+            registerCleanupIfNeeded()
             guard let soundID = loadSoundID(named: name) else { return }
             AudioServicesPlaySystemSound(soundID)
+        }
+    }
+
+    private static func registerCleanupIfNeeded() {
+        guard !cleanupRegistered else { return }
+        cleanupRegistered = true
+        atexit {
+            SystemSoundPlayer.disposeCachedSounds()
+        }
+    }
+
+    private static func disposeCachedSounds() {
+        queue.sync {
+            for soundID in soundIDs.values {
+                AudioServicesDisposeSystemSoundID(soundID)
+            }
+            soundIDs.removeAll()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -149,7 +149,7 @@ private enum SystemSoundPlayer {
     }
 
     private static func disposeCachedSoundsBestEffort() {
-        queue.async {
+        queue.sync {
             for soundID in soundIDs.values {
                 AudioServicesDisposeSystemSoundID(soundID)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -144,12 +144,12 @@ private enum SystemSoundPlayer {
         guard !cleanupRegistered else { return }
         cleanupRegistered = true
         atexit {
-            SystemSoundPlayer.disposeCachedSounds()
+            SystemSoundPlayer.disposeCachedSoundsBestEffort()
         }
     }
 
-    private static func disposeCachedSounds() {
-        queue.sync {
+    private static func disposeCachedSoundsBestEffort() {
+        queue.async {
             for soundID in soundIDs.values {
                 AudioServicesDisposeSystemSoundID(soundID)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SoundController.swift
@@ -119,7 +119,7 @@ enum SoundController {
 }
 
 private enum SystemSoundPlayer {
-    private static let queue = DispatchQueue(label: "com.muesli.system-sound-player", qos: .utility)
+    private static let queue = DispatchQueue(label: "com.muesli.system-sound-player", qos: .userInitiated)
     private static var soundIDs: [String: SystemSoundID] = [:]
 
     static func prewarm(names: [String]) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -180,6 +180,10 @@ final class StreamingDictationController {
                 sessionID: sessionID,
                 timeout: Self.stopStreamStateTimeout
             )
+            guard self.isCurrentSession(sessionID) else {
+                completion(self.fullTranscript)
+                return
+            }
             self.startDrainIfNeeded(sessionID: sessionID)
             await self.waitForDrain(sessionID: sessionID, timeout: Self.stopDrainTimeout)
             let transcript = self.finishStoppedSession(sessionID: sessionID)

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -10,7 +10,7 @@ import os
 ///   controller.onPartialText = { fullText in /* paste delta */ }
 ///   controller.start()
 ///   // ... user speaks ...
-///   let finalText = controller.stop()
+///   controller.stop { finalText in /* persist final text */ }
 @available(macOS 15, *)
 final class StreamingDictationController {
     /// Called with the full accumulated transcript so far (on a background thread).
@@ -29,6 +29,7 @@ final class StreamingDictationController {
     private var isActive = false
     private var activeSessionID: UUID?
     private let chunkSamples = 8960  // 560ms at 16kHz
+    private static let stopDrainTimeout: TimeInterval = 1.0
 
     init(
         transcriber: NemotronStreamingTranscriber,
@@ -111,12 +112,13 @@ final class StreamingDictationController {
         return true
     }
 
-    /// Stop recording and return text already emitted by real-time chunk drains.
-    /// This intentionally avoids blocking the main thread on trailing chunks.
-    func stop() -> String {
-        guard isActive else { return fullTranscript }
+    /// Stop recording and finish queued audio off the caller's thread.
+    func stop(completion: @escaping (String) -> Void) {
+        guard let sessionID = activeSessionID else {
+            completion(fullTranscript)
+            return
+        }
         isActive = false
-        activeSessionID = nil
 
         let _ = recorder.stop()
 
@@ -127,18 +129,39 @@ final class StreamingDictationController {
             return samples
         }
 
+        if !remaining.isEmpty {
+            var padded = remaining
+            if padded.count < chunkSamples {
+                padded.append(contentsOf: [Float](repeating: 0, count: chunkSamples - padded.count))
+            }
+            let finalChunk = padded
+            queueLock.withLock {
+                chunkQueue.append(finalChunk)
+            }
+        }
+
+        startDrainIfNeeded(sessionID: sessionID)
+        Task {
+            await self.waitForDrain(sessionID: sessionID, timeout: Self.stopDrainTimeout)
+            let transcript = self.finishStoppedSession(sessionID: sessionID)
+            completion(transcript)
+        }
+    }
+
+    func cancel() {
+        isActive = false
+        activeSessionID = nil
+        recorder.cancel()
+        bufferLock.withLock {
+            sampleBuffer.removeAll()
+        }
         queueLock.withLock {
             chunkQueue.removeAll()
         }
         drainLock.withLock {
             isDraining = false
         }
-        if !remaining.isEmpty {
-            fputs("[streaming-dictation] discarded trailing samples on stop: \(remaining.count)\n", stderr)
-        }
-
-        fputs("[streaming-dictation] stopped, transcript (\(fullTranscript.count) chars): \(fullTranscript.prefix(100))...\n", stderr)
-        return fullTranscript
+        streamState = nil
     }
 
     // MARK: - Audio Buffer Handling
@@ -192,7 +215,34 @@ final class StreamingDictationController {
     }
 
     private func isCurrentSession(_ sessionID: UUID) -> Bool {
-        isActive && activeSessionID == sessionID
+        activeSessionID == sessionID
+    }
+
+    private func waitForDrain(sessionID: UUID, timeout: TimeInterval) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            guard isCurrentSession(sessionID) else { return }
+            let queueIsEmpty = queueLock.withLock { chunkQueue.isEmpty }
+            let currentlyDraining = drainLock.withLock { isDraining }
+            if queueIsEmpty && !currentlyDraining { return }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        fputs("[streaming-dictation] stop drain timed out\n", stderr)
+    }
+
+    private func finishStoppedSession(sessionID: UUID) -> String {
+        guard isCurrentSession(sessionID) else { return fullTranscript }
+        activeSessionID = nil
+        queueLock.withLock {
+            chunkQueue.removeAll()
+        }
+        drainLock.withLock {
+            isDraining = false
+        }
+        streamState = nil
+        let transcript = fullTranscript
+        fputs("[streaming-dictation] stopped, transcript (\(transcript.count) chars): \(transcript.prefix(100))...\n", stderr)
+        return transcript
     }
 
     /// Process all queued chunks serially, one at a time.

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -27,6 +27,7 @@ final class StreamingDictationController {
     private let drainLock = OSAllocatedUnfairLock()
     private var fullTranscript = ""
     private var isActive = false
+    private var activeSessionID: UUID?
     private let chunkSamples = 8960  // 560ms at 16kHz
 
     init(
@@ -57,7 +58,9 @@ final class StreamingDictationController {
     @discardableResult
     func start() -> Bool {
         guard !isActive else { return true }
+        let sessionID = UUID()
         isActive = true
+        activeSessionID = sessionID
         fullTranscript = ""
         sampleBuffer.removeAll()
         chunkQueue.removeAll()
@@ -77,6 +80,7 @@ final class StreamingDictationController {
         } catch {
             fputs("[streaming-dictation] mic start failed: \(error)\n", stderr)
             isActive = false
+            activeSessionID = nil
             recorder.cancel()
             bufferLock.withLock {
                 sampleBuffer.removeAll()
@@ -94,21 +98,25 @@ final class StreamingDictationController {
         // Init stream state in background — audio buffers queue while this runs
         Task {
             do {
-                streamState = try await transcriber.makeStreamState()
+                let state = try await transcriber.makeStreamState()
+                guard self.isCurrentSession(sessionID) else { return }
+                streamState = state
                 fputs("[streaming-dictation] stream state ready, draining queued chunks\n", stderr)
-                // Process any chunks that accumulated during init
-                await drainQueue()
+                startDrainIfNeeded(sessionID: sessionID)
             } catch {
+                guard self.isCurrentSession(sessionID) else { return }
                 fputs("[streaming-dictation] failed to create stream state: \(error)\n", stderr)
             }
         }
         return true
     }
 
-    /// Stop recording, process any remaining audio, return final transcript.
+    /// Stop recording and return text already emitted by real-time chunk drains.
+    /// This intentionally avoids blocking the main thread on trailing chunks.
     func stop() -> String {
         guard isActive else { return fullTranscript }
         isActive = false
+        activeSessionID = nil
 
         let _ = recorder.stop()
 
@@ -119,25 +127,15 @@ final class StreamingDictationController {
             return samples
         }
 
-        // Queue final padded chunk if any samples remain
+        queueLock.withLock {
+            chunkQueue.removeAll()
+        }
+        drainLock.withLock {
+            isDraining = false
+        }
         if !remaining.isEmpty {
-            var padded = remaining
-            if padded.count < chunkSamples {
-                padded.append(contentsOf: [Float](repeating: 0, count: chunkSamples - padded.count))
-            }
-            let finalChunk = padded
-            queueLock.withLock {
-                chunkQueue.append(finalChunk)
-            }
+            fputs("[streaming-dictation] discarded trailing samples on stop: \(remaining.count)\n", stderr)
         }
-
-        // Drain all remaining chunks synchronously
-        let sem = DispatchSemaphore(value: 0)
-        Task {
-            await self.drainQueue()
-            sem.signal()
-        }
-        sem.wait()
 
         fputs("[streaming-dictation] stopped, transcript (\(fullTranscript.count) chars): \(fullTranscript.prefix(100))...\n", stderr)
         return fullTranscript
@@ -164,29 +162,43 @@ final class StreamingDictationController {
                 chunkQueue.append(contentsOf: newChunks)
             }
             // Kick off serial processing if not already running
-            let shouldStart = drainLock.withLock {
-                if isDraining { return false }
-                isDraining = true
-                return true
-            }
-            if shouldStart {
-                Task { [weak self] in
-                    await self?.drainQueue()
-                    self?.markDrainFinished()
-                }
-            }
+            guard let sessionID = activeSessionID else { return }
+            startDrainIfNeeded(sessionID: sessionID)
         }
     }
 
-    private func markDrainFinished() {
+    private func startDrainIfNeeded(sessionID: UUID) {
+        guard isCurrentSession(sessionID) else { return }
+        let shouldStart = drainLock.withLock {
+            if isDraining { return false }
+            isDraining = true
+            return true
+        }
+        guard shouldStart else { return }
+        Task { [weak self] in
+            await self?.drainQueue(sessionID: sessionID)
+            self?.markDrainFinished(sessionID: sessionID)
+        }
+    }
+
+    private func markDrainFinished(sessionID: UUID) {
+        let hasQueuedChunks = queueLock.withLock { !chunkQueue.isEmpty }
         drainLock.withLock {
             isDraining = false
         }
+        if hasQueuedChunks {
+            startDrainIfNeeded(sessionID: sessionID)
+        }
+    }
+
+    private func isCurrentSession(_ sessionID: UUID) -> Bool {
+        isActive && activeSessionID == sessionID
     }
 
     /// Process all queued chunks serially, one at a time.
-    private func drainQueue() async {
+    private func drainQueue(sessionID: UUID) async {
         while true {
+            guard isCurrentSession(sessionID) else { return }
             let chunk: [Float]? = queueLock.withLock {
                 chunkQueue.isEmpty ? nil : chunkQueue.removeFirst()
             }
@@ -194,12 +206,16 @@ final class StreamingDictationController {
 
             guard var state = streamState else {
                 fputs("[streaming-dictation] no stream state, skipping chunk\n", stderr)
+                queueLock.withLock {
+                    chunkQueue.insert(chunk, at: 0)
+                }
                 return
             }
 
             let start = CFAbsoluteTimeGetCurrent()
             do {
                 let newText = try await transcriber.transcribeChunk(samples: chunk, state: &state)
+                guard isCurrentSession(sessionID) else { return }
                 streamState = state
                 let elapsed = CFAbsoluteTimeGetCurrent() - start
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreAudio
 import os
 
 /// Merges real-time mic recording with Nemotron chunk-by-chunk transcription.
@@ -28,8 +29,9 @@ final class StreamingDictationController {
     private var isActive = false
     private let chunkSamples = 8960  // 560ms at 16kHz
 
-    init(transcriber: NemotronStreamingTranscriber) {
+    init(transcriber: NemotronStreamingTranscriber, preferredInputDeviceID: AudioObjectID? = nil) {
         self.transcriber = transcriber
+        recorder.preferredInputDeviceID = preferredInputDeviceID
     }
 
     /// Pre-warm the ANE so first real chunk is fast. Call this early (e.g., on backend select).

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -203,7 +203,9 @@ final class StreamingDictationController {
             stoppingSessionID = sessionID
         }
 
-        let _ = recorder.stop()
+        if let wavURL = recorder.stop() {
+            try? FileManager.default.removeItem(at: wavURL)
+        }
 
         // Collect remaining buffered samples
         let remaining: [Float] = bufferLock.withLock {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -192,6 +192,7 @@ final class StreamingDictationController {
 
     private func startDrainIfNeeded(sessionID: UUID) {
         guard isCurrentSession(sessionID) else { return }
+        guard streamState != nil else { return }
         let shouldStart = drainLock.withLock {
             if isDraining { return false }
             isDraining = true
@@ -205,11 +206,11 @@ final class StreamingDictationController {
     }
 
     private func markDrainFinished(sessionID: UUID) {
-        let hasQueuedChunks = queueLock.withLock { !chunkQueue.isEmpty }
+        let shouldContinue = streamState != nil && queueLock.withLock { !chunkQueue.isEmpty }
         drainLock.withLock {
             isDraining = false
         }
-        if hasQueuedChunks {
+        if shouldContinue {
             startDrainIfNeeded(sessionID: sessionID)
         }
     }
@@ -255,7 +256,6 @@ final class StreamingDictationController {
             guard let chunk else { return }
 
             guard var state = streamState else {
-                fputs("[streaming-dictation] no stream state, skipping chunk\n", stderr)
                 queueLock.withLock {
                     chunkQueue.insert(chunk, at: 0)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -60,6 +60,9 @@ final class StreamingDictationController {
     private let queueLock = OSAllocatedUnfairLock()
     private var isDraining = false
     private let drainLock = OSAllocatedUnfairLock()
+    private var isStopping = false
+    private var stopCompletions: [(String) -> Void] = []
+    private let stopLock = OSAllocatedUnfairLock()
     private var fullTranscript = ""
     private var isActive = false
     private var activeSessionID: UUID?
@@ -112,6 +115,10 @@ final class StreamingDictationController {
         fullTranscript = ""
         sampleBuffer.removeAll()
         chunkQueue.removeAll()
+        stopLock.withLock {
+            isStopping = false
+            stopCompletions.removeAll()
+        }
         streamState = nil
         drainLock.withLock {
             isDraining = false
@@ -155,6 +162,13 @@ final class StreamingDictationController {
             completion(fullTranscript)
             return
         }
+        let shouldStartStop = stopLock.withLock {
+            stopCompletions.append(completion)
+            guard !isStopping else { return false }
+            isStopping = true
+            return true
+        }
+        guard shouldStartStop else { return }
         isActive = false
 
         let _ = recorder.stop()
@@ -186,13 +200,13 @@ final class StreamingDictationController {
                 timeout: Self.stopStreamStateTimeout
             )
             guard self.isCurrentSession(sessionID) else {
-                completion(self.fullTranscript)
+                self.completeStop(with: self.fullTranscript)
                 return
             }
             self.startDrainIfNeeded(sessionID: sessionID)
             await self.waitForDrain(sessionID: sessionID, timeout: Self.stopDrainTimeout)
             let transcript = self.finishStoppedSession(sessionID: sessionID)
-            completion(transcript)
+            self.completeStop(with: transcript)
         }
     }
 
@@ -211,6 +225,7 @@ final class StreamingDictationController {
         activeSessionID = nil
         streamStateTask?.cancel()
         streamStateTask = nil
+        completeStop(with: fullTranscript)
         if cancelRecorder {
             recorder.cancel()
         }
@@ -224,6 +239,18 @@ final class StreamingDictationController {
             isDraining = false
         }
         streamState = nil
+    }
+
+    private func completeStop(with transcript: String) {
+        let completions = stopLock.withLock {
+            let completions = stopCompletions
+            stopCompletions.removeAll()
+            isStopping = false
+            return completions
+        }
+        for completion in completions {
+            completion(transcript)
+        }
     }
 
     // MARK: - Audio Buffer Handling

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -12,11 +12,41 @@ import os
 ///   // ... user speaks ...
 ///   controller.stop { finalText in /* persist final text */ }
 @available(macOS 15, *)
+protocol NemotronStreamingTranscribing: AnyObject {
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String
+}
+
+@available(macOS 15, *)
+private final class NemotronStreamingTranscriberAdapter: NemotronStreamingTranscribing {
+    private let transcriber: NemotronStreamingTranscriber
+
+    init(_ transcriber: NemotronStreamingTranscriber) {
+        self.transcriber = transcriber
+    }
+
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        try await transcriber.makeStreamState()
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        try await transcriber.transcribeChunk(samples: samples, state: &state)
+    }
+}
+
+@available(macOS 15, *)
 final class StreamingDictationController {
     /// Called with the full accumulated transcript so far (on a background thread).
     var onPartialText: ((String) -> Void)?
+    var onFailure: ((Error) -> Void)?
 
-    private let transcriber: NemotronStreamingTranscriber
+    private let transcriber: NemotronStreamingTranscribing
     private let recorder: StreamingDictationRecording
     private var streamState: NemotronStreamingTranscriber.StreamState?
     private var sampleBuffer: [Float] = []
@@ -33,6 +63,16 @@ final class StreamingDictationController {
 
     init(
         transcriber: NemotronStreamingTranscriber,
+        preferredInputDeviceID: AudioObjectID? = nil,
+        recorder: StreamingDictationRecording = StreamingMicRecorder()
+    ) {
+        self.transcriber = NemotronStreamingTranscriberAdapter(transcriber)
+        self.recorder = recorder
+        recorder.preferredInputDeviceID = preferredInputDeviceID
+    }
+
+    init(
+        transcriber: NemotronStreamingTranscribing,
         preferredInputDeviceID: AudioObjectID? = nil,
         recorder: StreamingDictationRecording = StreamingMicRecorder()
     ) {
@@ -80,19 +120,7 @@ final class StreamingDictationController {
             fputs("[streaming-dictation] mic started\n", stderr)
         } catch {
             fputs("[streaming-dictation] mic start failed: \(error)\n", stderr)
-            isActive = false
-            activeSessionID = nil
-            recorder.cancel()
-            bufferLock.withLock {
-                sampleBuffer.removeAll()
-            }
-            queueLock.withLock {
-                chunkQueue.removeAll()
-            }
-            drainLock.withLock {
-                isDraining = false
-            }
-            streamState = nil
+            resetActiveSession(cancelRecorder: true)
             return false
         }
 
@@ -107,6 +135,7 @@ final class StreamingDictationController {
             } catch {
                 guard self.isCurrentSession(sessionID) else { return }
                 fputs("[streaming-dictation] failed to create stream state: \(error)\n", stderr)
+                self.failActiveSession(sessionID: sessionID, error: error)
             }
         }
         return true
@@ -149,9 +178,21 @@ final class StreamingDictationController {
     }
 
     func cancel() {
+        resetActiveSession(cancelRecorder: true)
+    }
+
+    private func failActiveSession(sessionID: UUID, error: Error) {
+        guard isCurrentSession(sessionID) else { return }
+        resetActiveSession(cancelRecorder: true)
+        onFailure?(error)
+    }
+
+    private func resetActiveSession(cancelRecorder: Bool) {
         isActive = false
         activeSessionID = nil
-        recorder.cancel()
+        if cancelRecorder {
+            recorder.cancel()
+        }
         bufferLock.withLock {
             sampleBuffer.removeAll()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -41,28 +41,6 @@ private final class NemotronStreamingTranscriberAdapter: NemotronStreamingTransc
 }
 
 @available(macOS 15, *)
-private final class OneShotBoolContinuation: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<Bool, Never>?
-    private var didResume = false
-
-    init(_ continuation: CheckedContinuation<Bool, Never>) {
-        self.continuation = continuation
-    }
-
-    func resume(_ value: Bool) {
-        let continuationToResume = lock.withLock { () -> CheckedContinuation<Bool, Never>? in
-            guard !didResume else { return nil }
-            didResume = true
-            let continuation = self.continuation
-            self.continuation = nil
-            return continuation
-        }
-        continuationToResume?.resume(returning: value)
-    }
-}
-
-@available(macOS 15, *)
 final class StreamingDictationController {
     private enum DrainResult {
         case finished
@@ -431,24 +409,18 @@ final class StreamingDictationController {
         timeout: TimeInterval
     ) async -> Bool {
         guard let task else { return true }
-        let initialized = await withCheckedContinuation { continuation in
-            let gate = OneShotBoolContinuation(continuation)
-
-            Task { [weak self] in
-                await task.value
-                guard self != nil else { return }
-                gate.resume(true)
-            }
-            Task {
-                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                task.cancel()
-                gate.resume(false)
-            }
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            guard isCurrentSession(sessionID) else { return false }
+            if streamState != nil { return true }
+            if streamStateTask == nil { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        if !initialized, isCurrentSession(sessionID), streamState == nil {
+        task.cancel()
+        if isCurrentSession(sessionID), streamState == nil {
             fputs("[streaming-dictation] stream state init timed out during stop\n", stderr)
         }
-        return initialized
+        return false
     }
 
     private func finishStoppedSession(sessionID: UUID) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -69,6 +69,12 @@ final class StreamingDictationController {
         case waitingForStreamState
     }
 
+    private enum StopSetup {
+        case start(UUID)
+        case attached
+        case immediate(String)
+    }
+
     /// Called with the full accumulated transcript so far (on a background thread).
     var onPartialText: ((String) -> Void)?
     var onFailure: ((Error) -> Void)?
@@ -194,42 +200,47 @@ final class StreamingDictationController {
 
     /// Stop recording and finish queued audio off the caller's thread.
     func stop(completion: @escaping (String) -> Void) {
+        let setup = stopLock.withLock { () -> StopSetup in
+            let sessionIDs = bufferLock.withLock {
+                (active: activeSessionID, stopping: stoppingSessionID)
+            }
+            if let activeSessionID = sessionIDs.active {
+                if var stopState {
+                    guard stopState.sessionID == activeSessionID else {
+                        return .immediate(fullTranscript)
+                    }
+                    stopState.completions.append(completion)
+                    self.stopState = stopState
+                    return .attached
+                }
+                stopState = StopState(sessionID: activeSessionID, completions: [completion])
+                bufferLock.withLock {
+                    isActive = false
+                    self.activeSessionID = nil
+                    stoppingSessionID = activeSessionID
+                }
+                return .start(activeSessionID)
+            }
+            if let stoppingSessionID = sessionIDs.stopping {
+                guard var stopState, stopState.sessionID == stoppingSessionID else {
+                    return .immediate(fullTranscript)
+                }
+                stopState.completions.append(completion)
+                self.stopState = stopState
+                return .attached
+            }
+            return .immediate(fullTranscript)
+        }
+
         let sessionID: UUID
-        let sessionIDs = bufferLock.withLock {
-            (active: activeSessionID, stopping: stoppingSessionID)
-        }
-        if let activeSessionID = sessionIDs.active {
-            sessionID = activeSessionID
-        } else if sessionIDs.stopping != nil {
-            let didAttachToStop = stopLock.withLock {
-                guard var stopState else { return false }
-                stopState.completions.append(completion)
-                self.stopState = stopState
-                return true
-            }
-            if !didAttachToStop {
-                completion(fullTranscript)
-            }
+        switch setup {
+        case .start(let id):
+            sessionID = id
+        case .attached:
             return
-        } else {
-            completion(fullTranscript)
+        case .immediate(let transcript):
+            completion(transcript)
             return
-        }
-        let shouldStartStop = stopLock.withLock {
-            if var stopState {
-                guard stopState.sessionID == sessionID else { return false }
-                stopState.completions.append(completion)
-                self.stopState = stopState
-                return false
-            }
-            stopState = StopState(sessionID: sessionID, completions: [completion])
-            return true
-        }
-        guard shouldStartStop else { return }
-        bufferLock.withLock {
-            isActive = false
-            activeSessionID = nil
-            stoppingSessionID = sessionID
         }
 
         if let wavURL = recorder.stop() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -58,6 +58,7 @@ final class StreamingDictationController {
     private var fullTranscript = ""
     private var isActive = false
     private var activeSessionID: UUID?
+    private var streamStateTask: Task<Void, Never>?
     private let chunkSamples = 8960  // 560ms at 16kHz
     private static let stopDrainTimeout: TimeInterval = 1.0
 
@@ -125,7 +126,7 @@ final class StreamingDictationController {
         }
 
         // Init stream state in background — audio buffers queue while this runs
-        Task {
+        let initializationTask = Task {
             do {
                 let state = try await transcriber.makeStreamState()
                 guard self.isCurrentSession(sessionID) else { return }
@@ -138,6 +139,7 @@ final class StreamingDictationController {
                 self.failActiveSession(sessionID: sessionID, error: error)
             }
         }
+        streamStateTask = initializationTask
         return true
     }
 
@@ -170,7 +172,10 @@ final class StreamingDictationController {
         }
 
         startDrainIfNeeded(sessionID: sessionID)
+        let initializationTask = streamStateTask
         Task {
+            await initializationTask?.value
+            self.startDrainIfNeeded(sessionID: sessionID)
             await self.waitForDrain(sessionID: sessionID, timeout: Self.stopDrainTimeout)
             let transcript = self.finishStoppedSession(sessionID: sessionID)
             completion(transcript)
@@ -190,6 +195,8 @@ final class StreamingDictationController {
     private func resetActiveSession(cancelRecorder: Bool) {
         isActive = false
         activeSessionID = nil
+        streamStateTask?.cancel()
+        streamStateTask = nil
         if cancelRecorder {
             recorder.cancel()
         }
@@ -275,6 +282,7 @@ final class StreamingDictationController {
     private func finishStoppedSession(sessionID: UUID) -> String {
         guard isCurrentSession(sessionID) else { return fullTranscript }
         activeSessionID = nil
+        streamStateTask = nil
         queueLock.withLock {
             chunkQueue.removeAll()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -41,6 +41,28 @@ private final class NemotronStreamingTranscriberAdapter: NemotronStreamingTransc
 }
 
 @available(macOS 15, *)
+private final class OneShotBoolContinuation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private var didResume = false
+
+    init(_ continuation: CheckedContinuation<Bool, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ value: Bool) {
+        let continuationToResume = lock.withLock { () -> CheckedContinuation<Bool, Never>? in
+            guard !didResume else { return nil }
+            didResume = true
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        continuationToResume?.resume(returning: value)
+    }
+}
+
+@available(macOS 15, *)
 final class StreamingDictationController {
     private enum DrainResult {
         case finished
@@ -228,13 +250,18 @@ final class StreamingDictationController {
         startDrainIfNeeded(sessionID: sessionID)
         let initializationTask = streamStateTask
         Task {
-            await self.waitForStreamStateInitialization(
+            let streamStateReady = await self.waitForStreamStateInitialization(
                 initializationTask,
                 sessionID: sessionID,
                 timeout: Self.stopStreamStateTimeout
             )
             guard self.isCurrentSession(sessionID) else {
                 self.completeStop(sessionID: sessionID, with: self.fullTranscript)
+                return
+            }
+            guard streamStateReady || self.streamState != nil else {
+                let transcript = self.finishStoppedSession(sessionID: sessionID)
+                self.completeStop(sessionID: sessionID, with: transcript)
                 return
             }
             self.startDrainIfNeeded(sessionID: sessionID)
@@ -380,22 +407,25 @@ final class StreamingDictationController {
         _ task: Task<Void, Never>?,
         sessionID: UUID,
         timeout: TimeInterval
-    ) async {
-        guard let task else { return }
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask {
+    ) async -> Bool {
+        guard let task else { return true }
+        let initialized = await withCheckedContinuation { continuation in
+            let gate = OneShotBoolContinuation(continuation)
+
+            Task {
                 await task.value
+                gate.resume(true)
             }
-            group.addTask {
+            Task {
                 try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
                 task.cancel()
+                gate.resume(false)
             }
-            await group.next()
-            group.cancelAll()
         }
-        if isCurrentSession(sessionID), streamState == nil {
+        if !initialized, isCurrentSession(sessionID), streamState == nil {
             fputs("[streaming-dictation] stream state init timed out during stop\n", stderr)
         }
+        return initialized
     }
 
     private func finishStoppedSession(sessionID: UUID) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -60,8 +60,11 @@ final class StreamingDictationController {
     private let queueLock = OSAllocatedUnfairLock()
     private var isDraining = false
     private let drainLock = OSAllocatedUnfairLock()
-    private var isStopping = false
-    private var stopCompletions: [(String) -> Void] = []
+    private struct StopState {
+        let sessionID: UUID
+        var completions: [(String) -> Void]
+    }
+    private var stopState: StopState?
     private let stopLock = OSAllocatedUnfairLock()
     private var fullTranscript = ""
     private var isActive = false
@@ -109,7 +112,7 @@ final class StreamingDictationController {
 
     @discardableResult
     func start() -> Bool {
-        guard stopLock.withLock({ !isStopping }) else { return false }
+        guard stopLock.withLock({ stopState == nil }) else { return false }
         let sessionID = UUID()
         let didStartSession = bufferLock.withLock { () -> Bool in
             guard !isActive else { return false }
@@ -122,9 +125,6 @@ final class StreamingDictationController {
         fullTranscript = ""
         queueLock.withLock {
             chunkQueue.removeAll()
-        }
-        stopLock.withLock {
-            stopCompletions.removeAll()
         }
         streamState = nil
         drainLock.withLock {
@@ -173,8 +173,9 @@ final class StreamingDictationController {
             sessionID = activeSessionID
         } else if sessionIDs.stopping != nil {
             let didAttachToStop = stopLock.withLock {
-                guard isStopping else { return false }
-                stopCompletions.append(completion)
+                guard var stopState else { return false }
+                stopState.completions.append(completion)
+                self.stopState = stopState
                 return true
             }
             if !didAttachToStop {
@@ -186,9 +187,13 @@ final class StreamingDictationController {
             return
         }
         let shouldStartStop = stopLock.withLock {
-            stopCompletions.append(completion)
-            guard !isStopping else { return false }
-            isStopping = true
+            if var stopState {
+                guard stopState.sessionID == sessionID else { return false }
+                stopState.completions.append(completion)
+                self.stopState = stopState
+                return false
+            }
+            stopState = StopState(sessionID: sessionID, completions: [completion])
             return true
         }
         guard shouldStartStop else { return }
@@ -227,13 +232,13 @@ final class StreamingDictationController {
                 timeout: Self.stopStreamStateTimeout
             )
             guard self.isCurrentSession(sessionID) else {
-                self.completeStop(with: self.fullTranscript)
+                self.completeStop(sessionID: sessionID, with: self.fullTranscript)
                 return
             }
             self.startDrainIfNeeded(sessionID: sessionID)
             await self.waitForDrain(sessionID: sessionID, timeout: Self.stopDrainTimeout)
             let transcript = self.finishStoppedSession(sessionID: sessionID)
-            self.completeStop(with: transcript)
+            self.completeStop(sessionID: sessionID, with: transcript)
         }
     }
 
@@ -256,7 +261,7 @@ final class StreamingDictationController {
         }
         streamStateTask?.cancel()
         streamStateTask = nil
-        completeStop(with: fullTranscript)
+        completeStop(sessionID: nil, with: fullTranscript)
         if cancelRecorder {
             recorder.cancel()
         }
@@ -269,11 +274,14 @@ final class StreamingDictationController {
         streamState = nil
     }
 
-    private func completeStop(with transcript: String) {
-        let completions = stopLock.withLock {
-            let completions = stopCompletions
-            stopCompletions.removeAll()
-            isStopping = false
+    private func completeStop(sessionID: UUID?, with transcript: String) {
+        let completions: [(String) -> Void] = stopLock.withLock {
+            guard let state = stopState else { return [] }
+            if let sessionID, state.sessionID != sessionID {
+                return []
+            }
+            stopState = nil
+            let completions = state.completions
             return completions
         }
         for completion in completions {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -434,8 +434,9 @@ final class StreamingDictationController {
         let initialized = await withCheckedContinuation { continuation in
             let gate = OneShotBoolContinuation(continuation)
 
-            Task {
+            Task { [weak self] in
                 await task.value
+                guard self != nil else { return }
                 gate.resume(true)
             }
             Task {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -17,7 +17,7 @@ final class StreamingDictationController {
     var onPartialText: ((String) -> Void)?
 
     private let transcriber: NemotronStreamingTranscriber
-    private let recorder = StreamingMicRecorder()
+    private let recorder: StreamingDictationRecording
     private var streamState: NemotronStreamingTranscriber.StreamState?
     private var sampleBuffer: [Float] = []
     private let bufferLock = OSAllocatedUnfairLock()
@@ -29,8 +29,13 @@ final class StreamingDictationController {
     private var isActive = false
     private let chunkSamples = 8960  // 560ms at 16kHz
 
-    init(transcriber: NemotronStreamingTranscriber, preferredInputDeviceID: AudioObjectID? = nil) {
+    init(
+        transcriber: NemotronStreamingTranscriber,
+        preferredInputDeviceID: AudioObjectID? = nil,
+        recorder: StreamingDictationRecording = StreamingMicRecorder()
+    ) {
         self.transcriber = transcriber
+        self.recorder = recorder
         recorder.preferredInputDeviceID = preferredInputDeviceID
     }
 
@@ -49,12 +54,17 @@ final class StreamingDictationController {
         }
     }
 
-    func start() {
-        guard !isActive else { return }
+    @discardableResult
+    func start() -> Bool {
+        guard !isActive else { return true }
         isActive = true
         fullTranscript = ""
         sampleBuffer.removeAll()
         chunkQueue.removeAll()
+        streamState = nil
+        drainLock.withLock {
+            isDraining = false
+        }
 
         // Start mic IMMEDIATELY — don't block on state init or warmup
         recorder.onAudioBuffer = { [weak self] samples in
@@ -66,7 +76,19 @@ final class StreamingDictationController {
             fputs("[streaming-dictation] mic started\n", stderr)
         } catch {
             fputs("[streaming-dictation] mic start failed: \(error)\n", stderr)
-            return
+            isActive = false
+            recorder.cancel()
+            bufferLock.withLock {
+                sampleBuffer.removeAll()
+            }
+            queueLock.withLock {
+                chunkQueue.removeAll()
+            }
+            drainLock.withLock {
+                isDraining = false
+            }
+            streamState = nil
+            return false
         }
 
         // Init stream state in background — audio buffers queue while this runs
@@ -80,6 +102,7 @@ final class StreamingDictationController {
                 fputs("[streaming-dictation] failed to create stream state: \(error)\n", stderr)
             }
         }
+        return true
     }
 
     /// Stop recording, process any remaining audio, return final transcript.
@@ -102,8 +125,9 @@ final class StreamingDictationController {
             if padded.count < chunkSamples {
                 padded.append(contentsOf: [Float](repeating: 0, count: chunkSamples - padded.count))
             }
+            let finalChunk = padded
             queueLock.withLock {
-                chunkQueue.append(padded)
+                chunkQueue.append(finalChunk)
             }
         }
 
@@ -125,15 +149,14 @@ final class StreamingDictationController {
     private func handleAudioBuffer(_ samples: [Float]) {
         guard isActive else { return }
 
-        // Accumulate samples and extract full chunks
-        var newChunks: [[Float]] = []
-
-        bufferLock.withLock {
+        let newChunks = bufferLock.withLock { () -> [[Float]] in
+            var chunks: [[Float]] = []
             sampleBuffer.append(contentsOf: samples)
             while sampleBuffer.count >= chunkSamples {
-                newChunks.append(Array(sampleBuffer.prefix(chunkSamples)))
+                chunks.append(Array(sampleBuffer.prefix(chunkSamples)))
                 sampleBuffer.removeFirst(chunkSamples)
             }
+            return chunks
         }
 
         if !newChunks.isEmpty {
@@ -149,9 +172,15 @@ final class StreamingDictationController {
             if shouldStart {
                 Task { [weak self] in
                     await self?.drainQueue()
-                    self?.drainLock.withLock { self?.isDraining = false }
+                    self?.markDrainFinished()
                 }
             }
+        }
+    }
+
+    private func markDrainFinished() {
+        drainLock.withLock {
+            isDraining = false
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -109,14 +109,20 @@ final class StreamingDictationController {
 
     @discardableResult
     func start() -> Bool {
-        guard !isActive else { return true }
         guard stopLock.withLock({ !isStopping }) else { return false }
         let sessionID = UUID()
-        isActive = true
-        activeSessionID = sessionID
+        let didStartSession = bufferLock.withLock { () -> Bool in
+            guard !isActive else { return false }
+            isActive = true
+            activeSessionID = sessionID
+            sampleBuffer.removeAll()
+            return true
+        }
+        guard didStartSession else { return true }
         fullTranscript = ""
-        sampleBuffer.removeAll()
-        chunkQueue.removeAll()
+        queueLock.withLock {
+            chunkQueue.removeAll()
+        }
         stopLock.withLock {
             stopCompletions.removeAll()
         }
@@ -160,9 +166,12 @@ final class StreamingDictationController {
     /// Stop recording and finish queued audio off the caller's thread.
     func stop(completion: @escaping (String) -> Void) {
         let sessionID: UUID
-        if let activeSessionID {
+        let sessionIDs = bufferLock.withLock {
+            (active: activeSessionID, stopping: stoppingSessionID)
+        }
+        if let activeSessionID = sessionIDs.active {
             sessionID = activeSessionID
-        } else if stoppingSessionID != nil {
+        } else if sessionIDs.stopping != nil {
             let didAttachToStop = stopLock.withLock {
                 guard isStopping else { return false }
                 stopCompletions.append(completion)
@@ -183,9 +192,11 @@ final class StreamingDictationController {
             return true
         }
         guard shouldStartStop else { return }
-        isActive = false
-        activeSessionID = nil
-        stoppingSessionID = sessionID
+        bufferLock.withLock {
+            isActive = false
+            activeSessionID = nil
+            stoppingSessionID = sessionID
+        }
 
         let _ = recorder.stop()
 
@@ -237,17 +248,17 @@ final class StreamingDictationController {
     }
 
     private func resetActiveSession(cancelRecorder: Bool) {
-        isActive = false
-        activeSessionID = nil
-        stoppingSessionID = nil
+        bufferLock.withLock {
+            isActive = false
+            activeSessionID = nil
+            stoppingSessionID = nil
+            sampleBuffer.removeAll()
+        }
         streamStateTask?.cancel()
         streamStateTask = nil
         completeStop(with: fullTranscript)
         if cancelRecorder {
             recorder.cancel()
-        }
-        bufferLock.withLock {
-            sampleBuffer.removeAll()
         }
         queueLock.withLock {
             chunkQueue.removeAll()
@@ -274,24 +285,23 @@ final class StreamingDictationController {
 
     /// Called on AVAudioEngine's audio processing thread (4096 samples per call).
     private func handleAudioBuffer(_ samples: [Float]) {
-        guard isActive else { return }
-
-        let newChunks = bufferLock.withLock { () -> [[Float]] in
+        let capture = bufferLock.withLock { () -> (sessionID: UUID?, chunks: [[Float]]) in
+            guard isActive, let sessionID = activeSessionID else { return (nil, []) }
             var chunks: [[Float]] = []
             sampleBuffer.append(contentsOf: samples)
             while sampleBuffer.count >= chunkSamples {
                 chunks.append(Array(sampleBuffer.prefix(chunkSamples)))
                 sampleBuffer.removeFirst(chunkSamples)
             }
-            return chunks
+            return (sessionID, chunks)
         }
 
-        if !newChunks.isEmpty {
+        if !capture.chunks.isEmpty {
             queueLock.withLock {
-                chunkQueue.append(contentsOf: newChunks)
+                chunkQueue.append(contentsOf: capture.chunks)
             }
             // Kick off serial processing if not already running
-            guard let sessionID = activeSessionID else { return }
+            guard let sessionID = capture.sessionID else { return }
             startDrainIfNeeded(sessionID: sessionID)
         }
     }
@@ -339,7 +349,9 @@ final class StreamingDictationController {
     }
 
     private func isCurrentSession(_ sessionID: UUID) -> Bool {
-        activeSessionID == sessionID || stoppingSessionID == sessionID
+        bufferLock.withLock {
+            activeSessionID == sessionID || stoppingSessionID == sessionID
+        }
     }
 
     private func waitForDrain(sessionID: UUID, timeout: TimeInterval) async {
@@ -377,9 +389,13 @@ final class StreamingDictationController {
     }
 
     private func finishStoppedSession(sessionID: UUID) -> String {
-        guard isCurrentSession(sessionID) else { return fullTranscript }
-        activeSessionID = nil
-        stoppingSessionID = nil
+        let didFinishCurrentSession = bufferLock.withLock { () -> Bool in
+            guard activeSessionID == sessionID || stoppingSessionID == sessionID else { return false }
+            activeSessionID = nil
+            stoppingSessionID = nil
+            return true
+        }
+        guard didFinishCurrentSession else { return fullTranscript }
         streamStateTask = nil
         queueLock.withLock {
             chunkQueue.removeAll()

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -401,8 +401,13 @@ final class StreamingDictationController {
     private func finishStoppedSession(sessionID: UUID) -> String {
         let didFinishCurrentSession = bufferLock.withLock { () -> Bool in
             guard activeSessionID == sessionID || stoppingSessionID == sessionID else { return false }
-            activeSessionID = nil
-            stoppingSessionID = nil
+            if activeSessionID == sessionID {
+                activeSessionID = nil
+                isActive = false
+            }
+            if stoppingSessionID == sessionID {
+                stoppingSessionID = nil
+            }
             return true
         }
         guard didFinishCurrentSession else { return fullTranscript }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -297,6 +297,7 @@ final class StreamingDictationController {
             guard let chunk else { return }
 
             guard var state = streamState else {
+                guard isCurrentSession(sessionID) else { return }
                 queueLock.withLock {
                     chunkQueue.insert(chunk, at: 0)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -94,26 +94,30 @@ final class StreamingDictationController {
     private var stoppingSessionID: UUID?
     private var streamStateTask: Task<Void, Never>?
     private let chunkSamples = 8960  // 560ms at 16kHz
-    private static let stopStreamStateTimeout: TimeInterval = 1.0
+    private let stopStreamStateTimeout: TimeInterval
     private static let stopDrainTimeout: TimeInterval = 1.0
 
     init(
         transcriber: NemotronStreamingTranscriber,
         preferredInputDeviceID: AudioObjectID? = nil,
-        recorder: StreamingDictationRecording = StreamingMicRecorder()
+        recorder: StreamingDictationRecording = StreamingMicRecorder(),
+        stopStreamStateTimeout: TimeInterval = 10.0
     ) {
         self.transcriber = NemotronStreamingTranscriberAdapter(transcriber)
         self.recorder = recorder
+        self.stopStreamStateTimeout = stopStreamStateTimeout
         recorder.preferredInputDeviceID = preferredInputDeviceID
     }
 
     init(
         transcriber: NemotronStreamingTranscribing,
         preferredInputDeviceID: AudioObjectID? = nil,
-        recorder: StreamingDictationRecording = StreamingMicRecorder()
+        recorder: StreamingDictationRecording = StreamingMicRecorder(),
+        stopStreamStateTimeout: TimeInterval = 10.0
     ) {
         self.transcriber = transcriber
         self.recorder = recorder
+        self.stopStreamStateTimeout = stopStreamStateTimeout
         recorder.preferredInputDeviceID = preferredInputDeviceID
     }
 
@@ -168,15 +172,16 @@ final class StreamingDictationController {
         }
 
         // Init stream state in background — audio buffers queue while this runs
-        let initializationTask = Task {
+        let transcriber = self.transcriber
+        let initializationTask = Task { [weak self] in
             do {
                 let state = try await transcriber.makeStreamState()
-                guard self.isCurrentSession(sessionID) else { return }
+                guard let self, self.isCurrentSession(sessionID) else { return }
                 streamState = state
                 fputs("[streaming-dictation] stream state ready, draining queued chunks\n", stderr)
                 startDrainIfNeeded(sessionID: sessionID)
             } catch {
-                guard self.isCurrentSession(sessionID) else { return }
+                guard let self, self.isCurrentSession(sessionID) else { return }
                 fputs("[streaming-dictation] failed to create stream state: \(error)\n", stderr)
                 self.failActiveSession(sessionID: sessionID, error: error)
             }
@@ -253,7 +258,7 @@ final class StreamingDictationController {
             let streamStateReady = await self.waitForStreamStateInitialization(
                 initializationTask,
                 sessionID: sessionID,
-                timeout: Self.stopStreamStateTimeout
+                timeout: self.stopStreamStateTimeout
             )
             guard self.isCurrentSession(sessionID) else {
                 self.completeStop(sessionID: sessionID, with: self.fullTranscript)

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -107,7 +107,7 @@ final class StreamingDictationController {
         transcriber: NemotronStreamingTranscriber,
         preferredInputDeviceID: AudioObjectID? = nil,
         recorder: StreamingDictationRecording = StreamingMicRecorder(),
-        stopStreamStateTimeout: TimeInterval = 2.0
+        stopStreamStateTimeout: TimeInterval = 1.0
     ) {
         self.transcriber = NemotronStreamingTranscriberAdapter(transcriber)
         self.recorder = recorder
@@ -119,7 +119,7 @@ final class StreamingDictationController {
         transcriber: NemotronStreamingTranscribing,
         preferredInputDeviceID: AudioObjectID? = nil,
         recorder: StreamingDictationRecording = StreamingMicRecorder(),
-        stopStreamStateTimeout: TimeInterval = 2.0
+        stopStreamStateTimeout: TimeInterval = 1.0
     ) {
         self.transcriber = transcriber
         self.recorder = recorder

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -175,7 +175,7 @@ final class StreamingDictationController {
             fputs("[streaming-dictation] mic started\n", stderr)
         } catch {
             fputs("[streaming-dictation] mic start failed: \(error)\n", stderr)
-            resetActiveSession(cancelRecorder: true)
+            resetActiveSession(cancelRecorder: true, sessionID: sessionID)
             return false
         }
 
@@ -295,20 +295,24 @@ final class StreamingDictationController {
 
     private func failActiveSession(sessionID: UUID, error: Error) {
         guard isCurrentSession(sessionID) else { return }
-        resetActiveSession(cancelRecorder: true)
+        resetActiveSession(cancelRecorder: true, sessionID: sessionID)
         onFailure?(error)
     }
 
-    private func resetActiveSession(cancelRecorder: Bool) {
-        bufferLock.withLock {
+    private func resetActiveSession(cancelRecorder: Bool, sessionID expectedSessionID: UUID? = nil) {
+        let completionSessionID = bufferLock.withLock { () -> UUID? in
+            let sessionID = expectedSessionID ?? activeSessionID ?? stoppingSessionID
             isActive = false
             activeSessionID = nil
             stoppingSessionID = nil
             sampleBuffer.removeAll()
+            return sessionID
         }
         streamStateTask?.cancel()
         streamStateTask = nil
-        completeStop(sessionID: nil, with: fullTranscript)
+        if let completionSessionID {
+            completeStop(sessionID: completionSessionID, with: fullTranscript)
+        }
         if cancelRecorder {
             recorder.cancel()
         }
@@ -321,10 +325,10 @@ final class StreamingDictationController {
         streamState = nil
     }
 
-    private func completeStop(sessionID: UUID?, with transcript: String) {
+    private func completeStop(sessionID: UUID, with transcript: String) {
         let completions: [(String) -> Void] = stopLock.withLock {
             guard let state = stopState else { return [] }
-            if let sessionID, state.sessionID != sessionID {
+            if state.sessionID != sessionID {
                 return []
             }
             stopState = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -101,7 +101,7 @@ final class StreamingDictationController {
         transcriber: NemotronStreamingTranscriber,
         preferredInputDeviceID: AudioObjectID? = nil,
         recorder: StreamingDictationRecording = StreamingMicRecorder(),
-        stopStreamStateTimeout: TimeInterval = 10.0
+        stopStreamStateTimeout: TimeInterval = 2.0
     ) {
         self.transcriber = NemotronStreamingTranscriberAdapter(transcriber)
         self.recorder = recorder
@@ -113,7 +113,7 @@ final class StreamingDictationController {
         transcriber: NemotronStreamingTranscribing,
         preferredInputDeviceID: AudioObjectID? = nil,
         recorder: StreamingDictationRecording = StreamingMicRecorder(),
-        stopStreamStateTimeout: TimeInterval = 10.0
+        stopStreamStateTimeout: TimeInterval = 2.0
     ) {
         self.transcriber = transcriber
         self.recorder = recorder
@@ -138,7 +138,9 @@ final class StreamingDictationController {
 
     @discardableResult
     func start() -> Bool {
-        guard stopLock.withLock({ stopState == nil }) else { return false }
+        guard stopLock.withLock({ stopState == nil }),
+              bufferLock.withLock({ stoppingSessionID == nil })
+        else { return false }
         let sessionID = UUID()
         let didStartSession = bufferLock.withLock { () -> Bool in
             guard !isActive else { return false }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -66,6 +66,7 @@ final class StreamingDictationController {
     private var fullTranscript = ""
     private var isActive = false
     private var activeSessionID: UUID?
+    private var stoppingSessionID: UUID?
     private var streamStateTask: Task<Void, Never>?
     private let chunkSamples = 8960  // 560ms at 16kHz
     private static let stopStreamStateTimeout: TimeInterval = 1.0
@@ -158,7 +159,20 @@ final class StreamingDictationController {
 
     /// Stop recording and finish queued audio off the caller's thread.
     func stop(completion: @escaping (String) -> Void) {
-        guard let sessionID = activeSessionID else {
+        let sessionID: UUID
+        if let activeSessionID {
+            sessionID = activeSessionID
+        } else if stoppingSessionID != nil {
+            let didAttachToStop = stopLock.withLock {
+                guard isStopping else { return false }
+                stopCompletions.append(completion)
+                return true
+            }
+            if !didAttachToStop {
+                completion(fullTranscript)
+            }
+            return
+        } else {
             completion(fullTranscript)
             return
         }
@@ -170,6 +184,8 @@ final class StreamingDictationController {
         }
         guard shouldStartStop else { return }
         isActive = false
+        activeSessionID = nil
+        stoppingSessionID = sessionID
 
         let _ = recorder.stop()
 
@@ -223,6 +239,7 @@ final class StreamingDictationController {
     private func resetActiveSession(cancelRecorder: Bool) {
         isActive = false
         activeSessionID = nil
+        stoppingSessionID = nil
         streamStateTask?.cancel()
         streamStateTask = nil
         completeStop(with: fullTranscript)
@@ -322,7 +339,7 @@ final class StreamingDictationController {
     }
 
     private func isCurrentSession(_ sessionID: UUID) -> Bool {
-        activeSessionID == sessionID
+        activeSessionID == sessionID || stoppingSessionID == sessionID
     }
 
     private func waitForDrain(sessionID: UUID, timeout: TimeInterval) async {
@@ -362,6 +379,7 @@ final class StreamingDictationController {
     private func finishStoppedSession(sessionID: UUID) -> String {
         guard isCurrentSession(sessionID) else { return fullTranscript }
         activeSessionID = nil
+        stoppingSessionID = nil
         streamStateTask = nil
         queueLock.withLock {
             chunkQueue.removeAll()
@@ -408,6 +426,10 @@ final class StreamingDictationController {
                 }
             } catch {
                 fputs("[streaming-dictation] chunk error: \(error)\n", stderr)
+                guard isCurrentSession(sessionID) else { return .finished }
+                streamState = nil
+                failActiveSession(sessionID: sessionID, error: error)
+                return .finished
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -42,6 +42,11 @@ private final class NemotronStreamingTranscriberAdapter: NemotronStreamingTransc
 
 @available(macOS 15, *)
 final class StreamingDictationController {
+    private enum DrainResult {
+        case finished
+        case waitingForStreamState
+    }
+
     /// Called with the full accumulated transcript so far (on a background thread).
     var onPartialText: ((String) -> Void)?
     var onFailure: ((Error) -> Void)?
@@ -257,12 +262,29 @@ final class StreamingDictationController {
         }
         guard shouldStart else { return }
         Task { [weak self] in
-            await self?.drainQueue(sessionID: sessionID)
-            self?.markDrainFinished(sessionID: sessionID)
+            let result = await self?.drainQueue(sessionID: sessionID)
+            switch result {
+            case .finished:
+                self?.markDrainFinished(sessionID: sessionID)
+            case .waitingForStreamState:
+                self?.markDrainPausedForStreamState(sessionID: sessionID)
+            case .none:
+                break
+            }
         }
     }
 
     private func markDrainFinished(sessionID: UUID) {
+        let shouldContinue = streamState != nil && queueLock.withLock { !chunkQueue.isEmpty }
+        drainLock.withLock {
+            isDraining = false
+        }
+        if shouldContinue {
+            startDrainIfNeeded(sessionID: sessionID)
+        }
+    }
+
+    private func markDrainPausedForStreamState(sessionID: UUID) {
         let shouldContinue = streamState != nil && queueLock.withLock { !chunkQueue.isEmpty }
         drainLock.withLock {
             isDraining = false
@@ -327,26 +349,26 @@ final class StreamingDictationController {
     }
 
     /// Process all queued chunks serially, one at a time.
-    private func drainQueue(sessionID: UUID) async {
+    private func drainQueue(sessionID: UUID) async -> DrainResult {
         while true {
-            guard isCurrentSession(sessionID) else { return }
+            guard isCurrentSession(sessionID) else { return .finished }
             let chunk: [Float]? = queueLock.withLock {
                 chunkQueue.isEmpty ? nil : chunkQueue.removeFirst()
             }
-            guard let chunk else { return }
+            guard let chunk else { return .finished }
 
             guard var state = streamState else {
-                guard isCurrentSession(sessionID) else { return }
+                guard isCurrentSession(sessionID) else { return .finished }
                 queueLock.withLock {
                     chunkQueue.insert(chunk, at: 0)
                 }
-                return
+                return .waitingForStreamState
             }
 
             let start = CFAbsoluteTimeGetCurrent()
             do {
                 let newText = try await transcriber.transcribeChunk(samples: chunk, state: &state)
-                guard isCurrentSession(sessionID) else { return }
+                guard isCurrentSession(sessionID) else { return .finished }
                 streamState = state
                 let elapsed = CFAbsoluteTimeGetCurrent() - start
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -109,6 +109,7 @@ final class StreamingDictationController {
     @discardableResult
     func start() -> Bool {
         guard !isActive else { return true }
+        guard stopLock.withLock({ !isStopping }) else { return false }
         let sessionID = UUID()
         isActive = true
         activeSessionID = sessionID
@@ -116,7 +117,6 @@ final class StreamingDictationController {
         sampleBuffer.removeAll()
         chunkQueue.removeAll()
         stopLock.withLock {
-            isStopping = false
             stopCompletions.removeAll()
         }
         streamState = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -60,6 +60,7 @@ final class StreamingDictationController {
     private var activeSessionID: UUID?
     private var streamStateTask: Task<Void, Never>?
     private let chunkSamples = 8960  // 560ms at 16kHz
+    private static let stopStreamStateTimeout: TimeInterval = 1.0
     private static let stopDrainTimeout: TimeInterval = 1.0
 
     init(
@@ -174,7 +175,11 @@ final class StreamingDictationController {
         startDrainIfNeeded(sessionID: sessionID)
         let initializationTask = streamStateTask
         Task {
-            await initializationTask?.value
+            await self.waitForStreamStateInitialization(
+                initializationTask,
+                sessionID: sessionID,
+                timeout: Self.stopStreamStateTimeout
+            )
             self.startDrainIfNeeded(sessionID: sessionID)
             await self.waitForDrain(sessionID: sessionID, timeout: Self.stopDrainTimeout)
             let transcript = self.finishStoppedSession(sessionID: sessionID)
@@ -277,6 +282,28 @@ final class StreamingDictationController {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         fputs("[streaming-dictation] stop drain timed out\n", stderr)
+    }
+
+    private func waitForStreamStateInitialization(
+        _ task: Task<Void, Never>?,
+        sessionID: UUID,
+        timeout: TimeInterval
+    ) async {
+        guard let task else { return }
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await task.value
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                task.cancel()
+            }
+            await group.next()
+            group.cancelAll()
+        }
+        if isCurrentSession(sessionID), streamState == nil {
+            fputs("[streaming-dictation] stream state init timed out during stop\n", stderr)
+        }
     }
 
     private func finishStoppedSession(sessionID: UUID) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -60,6 +60,7 @@ final class StreamingDictationController {
     private let transcriber: NemotronStreamingTranscribing
     private let recorder: StreamingDictationRecording
     private var streamState: NemotronStreamingTranscriber.StreamState?
+    private let streamLock = OSAllocatedUnfairLock()
     private var sampleBuffer: [Float] = []
     private let bufferLock = OSAllocatedUnfairLock()
     private var chunkQueue: [[Float]] = []
@@ -134,11 +135,13 @@ final class StreamingDictationController {
             return true
         }
         guard didStartSession else { return true }
-        fullTranscript = ""
+        streamLock.withLock {
+            fullTranscript = ""
+            streamState = nil
+        }
         queueLock.withLock {
             chunkQueue.removeAll()
         }
-        streamState = nil
         drainLock.withLock {
             isDraining = false
         }
@@ -163,7 +166,9 @@ final class StreamingDictationController {
             do {
                 let state = try await transcriber.makeStreamState()
                 guard let self, self.isCurrentSession(sessionID) else { return }
-                streamState = state
+                self.streamLock.withLock {
+                    self.streamState = state
+                }
                 fputs("[streaming-dictation] stream state ready, draining queued chunks\n", stderr)
                 startDrainIfNeeded(sessionID: sessionID)
             } catch {
@@ -185,7 +190,7 @@ final class StreamingDictationController {
             if let activeSessionID = sessionIDs.active {
                 if var stopState {
                     guard stopState.sessionID == activeSessionID else {
-                        return .immediate(fullTranscript)
+                        return .immediate(currentTranscript())
                     }
                     stopState.completions.append(completion)
                     self.stopState = stopState
@@ -201,13 +206,13 @@ final class StreamingDictationController {
             }
             if let stoppingSessionID = sessionIDs.stopping {
                 guard var stopState, stopState.sessionID == stoppingSessionID else {
-                    return .immediate(fullTranscript)
+                    return .immediate(currentTranscript())
                 }
                 stopState.completions.append(completion)
                 self.stopState = stopState
                 return .attached
             }
-            return .immediate(fullTranscript)
+            return .immediate(currentTranscript())
         }
 
         let sessionID: UUID
@@ -252,10 +257,10 @@ final class StreamingDictationController {
                 timeout: self.stopStreamStateTimeout
             )
             guard self.isCurrentSession(sessionID) else {
-                self.completeStop(sessionID: sessionID, with: self.fullTranscript)
+                self.completeStop(sessionID: sessionID, with: self.currentTranscript())
                 return
             }
-            guard streamStateReady || self.streamState != nil else {
+            guard streamStateReady || self.hasStreamState() else {
                 let transcript = self.finishStoppedSession(sessionID: sessionID)
                 self.completeStop(sessionID: sessionID, with: transcript)
                 return
@@ -289,7 +294,7 @@ final class StreamingDictationController {
         streamStateTask?.cancel()
         streamStateTask = nil
         if let completionSessionID {
-            completeStop(sessionID: completionSessionID, with: fullTranscript)
+            completeStop(sessionID: completionSessionID, with: currentTranscript())
         }
         if cancelRecorder {
             recorder.cancel()
@@ -300,7 +305,9 @@ final class StreamingDictationController {
         drainLock.withLock {
             isDraining = false
         }
-        streamState = nil
+        streamLock.withLock {
+            streamState = nil
+        }
     }
 
     private func completeStop(sessionID: UUID, with transcript: String) {
@@ -345,7 +352,7 @@ final class StreamingDictationController {
 
     private func startDrainIfNeeded(sessionID: UUID) {
         guard isCurrentSession(sessionID) else { return }
-        guard streamState != nil else { return }
+        guard hasStreamState() else { return }
         let shouldStart = drainLock.withLock {
             if isDraining { return false }
             isDraining = true
@@ -366,7 +373,7 @@ final class StreamingDictationController {
     }
 
     private func markDrainFinished(sessionID: UUID) {
-        let shouldContinue = streamState != nil && queueLock.withLock { !chunkQueue.isEmpty }
+        let shouldContinue = hasStreamState() && queueLock.withLock { !chunkQueue.isEmpty }
         drainLock.withLock {
             isDraining = false
         }
@@ -376,7 +383,7 @@ final class StreamingDictationController {
     }
 
     private func markDrainPausedForStreamState(sessionID: UUID) {
-        let shouldContinue = streamState != nil && queueLock.withLock { !chunkQueue.isEmpty }
+        let shouldContinue = hasStreamState() && queueLock.withLock { !chunkQueue.isEmpty }
         drainLock.withLock {
             isDraining = false
         }
@@ -412,12 +419,12 @@ final class StreamingDictationController {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             guard isCurrentSession(sessionID) else { return false }
-            if streamState != nil { return true }
+            if hasStreamState() { return true }
             if streamStateTask == nil { return true }
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         task.cancel()
-        if isCurrentSession(sessionID), streamState == nil {
+        if isCurrentSession(sessionID), !hasStreamState() {
             fputs("[streaming-dictation] stream state init timed out during stop\n", stderr)
         }
         return false
@@ -435,7 +442,7 @@ final class StreamingDictationController {
             }
             return true
         }
-        guard didFinishCurrentSession else { return fullTranscript }
+        guard didFinishCurrentSession else { return currentTranscript() }
         streamStateTask = nil
         queueLock.withLock {
             chunkQueue.removeAll()
@@ -443,10 +450,20 @@ final class StreamingDictationController {
         drainLock.withLock {
             isDraining = false
         }
-        streamState = nil
-        let transcript = fullTranscript
+        let transcript = streamLock.withLock { () -> String in
+            streamState = nil
+            return fullTranscript
+        }
         fputs("[streaming-dictation] stopped, transcript (\(transcript.count) chars): \(transcript.prefix(100))...\n", stderr)
         return transcript
+    }
+
+    private func currentTranscript() -> String {
+        streamLock.withLock { fullTranscript }
+    }
+
+    private func hasStreamState() -> Bool {
+        streamLock.withLock { streamState != nil }
     }
 
     /// Process all queued chunks serially, one at a time.
@@ -458,7 +475,7 @@ final class StreamingDictationController {
             }
             guard let chunk else { return .finished }
 
-            guard var state = streamState else {
+            guard var state = streamLock.withLock({ streamState }) else {
                 guard isCurrentSession(sessionID) else { return .finished }
                 queueLock.withLock {
                     chunkQueue.insert(chunk, at: 0)
@@ -470,20 +487,29 @@ final class StreamingDictationController {
             do {
                 let newText = try await transcriber.transcribeChunk(samples: chunk, state: &state)
                 guard isCurrentSession(sessionID) else { return .finished }
-                streamState = state
                 let elapsed = CFAbsoluteTimeGetCurrent() - start
 
-                if !newText.isEmpty {
+                let updatedState = state
+                let transcript = streamLock.withLock { () -> String? in
+                    streamState = updatedState
+                    guard !newText.isEmpty else { return nil }
                     fullTranscript += newText
+                    return fullTranscript
+                }
+                if !newText.isEmpty {
                     fputs("[streaming-dictation] chunk → \"\(newText)\" (\(String(format: "%.0f", elapsed * 1000))ms)\n", stderr)
-                    onPartialText?(fullTranscript)
+                    if let transcript {
+                        onPartialText?(transcript)
+                    }
                 } else {
                     fputs("[streaming-dictation] chunk → (silence) (\(String(format: "%.0f", elapsed * 1000))ms)\n", stderr)
                 }
             } catch {
                 fputs("[streaming-dictation] chunk error: \(error)\n", stderr)
                 guard isCurrentSession(sessionID) else { return .finished }
-                streamState = nil
+                streamLock.withLock {
+                    streamState = nil
+                }
                 failActiveSession(sessionID: sessionID, error: error)
                 return .finished
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -90,7 +90,13 @@ final class StreamingMicRecorder: StreamingDictationRecording {
                 )
                 guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return }
                 var error: NSError?
+                var didProvideInput = false
                 let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+                    guard !didProvideInput else {
+                        outStatus.pointee = .noDataNow
+                        return nil
+                    }
+                    didProvideInput = true
                     outStatus.pointee = .haveData
                     return buffer
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -57,9 +57,6 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         guard !isRunning else { return }
         try prepare()
 
-        let fileState = try createNewFile()
-        lock.withLock { $0 = fileState }
-
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)
 
@@ -80,6 +77,9 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         let converter: AVAudioConverter? = needsConversion
             ? AVAudioConverter(from: hwFormat, to: targetFormat)
             : nil
+
+        let fileState = try createNewFile()
+        lock.withLock { $0 = fileState }
 
         inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
             guard let self else { return }
@@ -149,8 +149,22 @@ final class StreamingMicRecorder: StreamingDictationRecording {
             self.onAudioBuffer?(floats)
         }
 
-        try engine.start()
-        isRunning = true
+        do {
+            try engine.start()
+            isRunning = true
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            engine.stop()
+            let state = lock.withLock { state -> FileState in
+                let old = state
+                state = FileState()
+                return old
+            }
+            if let url = state.fileURL {
+                try? FileManager.default.removeItem(at: url)
+            }
+            throw error
+        }
     }
 
     /// Rotate to a new file. Returns the completed WAV URL. No audio gap.

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import Foundation
 import os
 
@@ -9,6 +10,7 @@ final class StreamingMicRecorder {
     var onAudioBuffer: (([Float]) -> Void)?
     /// Called with 16-bit PCM mono samples for retained meeting recording.
     var onPCMSamples: (([Int16]) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
 
     private let engine = AVAudioEngine()
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
@@ -26,6 +28,12 @@ final class StreamingMicRecorder {
     private static let bufferSize: AVAudioFrameCount = 4096 // 256ms at 16kHz
 
     func prepare() throws {
+        AudioInputDeviceSelection.applyPreferredInputDeviceID(
+            preferredInputDeviceID,
+            to: engine,
+            logPrefix: "streaming-mic"
+        )
+
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)
         guard hwFormat.sampleRate > 0 else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -25,6 +25,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     private let engine = AVAudioEngine()
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
     private var isRunning = false
+    private var tapInstalled = false
 
     private struct FileState {
         var fileHandle: FileHandle?
@@ -148,12 +149,13 @@ final class StreamingMicRecorder: StreamingDictationRecording {
             let floats = Array(UnsafeBufferPointer(start: floatData, count: frameCount))
             self.onAudioBuffer?(floats)
         }
+        tapInstalled = true
 
         do {
             try engine.start()
             isRunning = true
         } catch {
-            inputNode.removeTap(onBus: 0)
+            removeTapIfNeeded()
             engine.stop()
             let state = lock.withLock { state -> FileState in
                 let old = state
@@ -193,7 +195,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         guard isRunning else { return nil }
         isRunning = false
 
-        engine.inputNode.removeTap(onBus: 0)
+        removeTapIfNeeded()
         engine.stop()
 
         let finalState = lock.withLock { state -> FileState in
@@ -222,7 +224,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     func cancel() {
         isRunning = false
-        engine.inputNode.removeTap(onBus: 0)
+        removeTapIfNeeded()
         engine.stop()
         onAudioBuffer = nil
         onPCMSamples = nil
@@ -240,6 +242,12 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     /// Approximate current power level (dB) from recent samples.
     func currentPower() -> Float {
         lock.withLock { $0.latestPowerDB }
+    }
+
+    private func removeTapIfNeeded() {
+        guard tapInstalled else { return }
+        engine.inputNode.removeTap(onBus: 0)
+        tapInstalled = false
     }
 
     // MARK: - File Management

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -55,6 +55,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     func start() throws {
         guard !isRunning else { return }
+        try prepare()
 
         let fileState = try createNewFile()
         lock.withLock { $0 = fileState }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -5,7 +5,17 @@ import os
 
 /// Mic recorder using AVAudioEngine for real-time buffer access.
 /// Used by MeetingSession for VAD-driven chunk rotation (zero-gap file switching).
-final class StreamingMicRecorder {
+protocol StreamingDictationRecording: AnyObject {
+    var onAudioBuffer: (([Float]) -> Void)? { get set }
+    var preferredInputDeviceID: AudioObjectID? { get set }
+
+    func prepare() throws
+    func start() throws
+    func stop() -> URL?
+    func cancel()
+}
+
+final class StreamingMicRecorder: StreamingDictationRecording {
     /// Called with 4096-sample Float chunks (256ms at 16kHz) for VAD processing.
     var onAudioBuffer: (([Float]) -> Void)?
     /// Called with 16-bit PCM mono samples for retained meeting recording.

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -8,7 +8,7 @@ import os
 /// may be processed against the mutable stream state at a time. Chunks can
 /// arrive faster than VAD inference finishes, so we queue them and drain
 /// serially rather than spawning overlapping Tasks that race the same state.
-final class StreamingVadController {
+final class StreamingVadController: @unchecked Sendable {
     /// Called when VAD detects a natural chunk boundary.
     var onChunkBoundary: (() -> Void)?
 
@@ -205,10 +205,10 @@ final class StreamingVadController {
 
                 if shouldRotate {
                     fputs("[vad] speech end detected, rotating chunk\n", stderr)
+                    onChunkBoundary?()
                     DispatchQueue.main.async { [weak self] in
                         guard let self else { return }
                         self.maxDurationTimer?.fireDate = Date().addingTimeInterval(self.maxChunkDuration)
-                        self.onChunkBoundary?()
                     }
                 }
             } catch {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -10,6 +10,8 @@ import os
 /// serially rather than spawning overlapping Tasks that race the same state.
 final class StreamingVadController: @unchecked Sendable {
     /// Called when VAD detects a natural chunk boundary.
+    /// Delivery is not main-thread guaranteed; handlers must dispatch before
+    /// touching queue- or actor-isolated state.
     var onChunkBoundary: (() -> Void)?
 
     private struct State {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -146,7 +146,9 @@ final class StreamingVadController: @unchecked Sendable {
         }
         guard shouldRotate else { return }
         fputs("[vad] max chunk duration reached, forcing rotation\n", stderr)
-        onChunkBoundary?()
+        DispatchQueue.main.async { [weak self] in
+            self?.onChunkBoundary?()
+        }
     }
 
     private func startDrainIfNeeded() {
@@ -207,9 +209,9 @@ final class StreamingVadController: @unchecked Sendable {
 
                 if shouldRotate {
                     fputs("[vad] speech end detected, rotating chunk\n", stderr)
-                    onChunkBoundary?()
                     DispatchQueue.main.async { [weak self] in
                         guard let self else { return }
+                        self.onChunkBoundary?()
                         self.maxDurationTimer?.fireDate = Date().addingTimeInterval(self.maxChunkDuration)
                     }
                 }

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -281,6 +281,44 @@ struct AudioDuckingControllerTests {
         ])
     }
 
+    @Test("rapid second dictation preserves original volume while restore is pending")
+    func rapidSecondDictationPreservesOriginalVolumeWhileRestoreIsPending() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.volumeElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] = 0.65
+        client.sampleRateValues[1] = [48_000, 24_000, 24_000, 24_000]
+
+        let controller = AudioDuckingController(
+            client: client,
+            queue: DispatchQueue(label: "test.audio-ducking.rapid-volume-turnover"),
+            stabilizationTimeout: 0.05,
+            stabilizationPollInterval: 0.001
+        )
+
+        controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
+        controller.restoreDictationDucking()
+        controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
+        Thread.sleep(forTimeInterval: 0.07)
+        controller.waitForIdle()
+
+        #expect(client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] == 0)
+
+        controller.restoreDictationDucking()
+        Thread.sleep(forTimeInterval: 0.07)
+        controller.waitForIdle()
+
+        #expect(client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] == 0.65)
+        #expect(client.volumeSetCalls == [
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: 0),
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: 0.65),
+        ])
+    }
+
     private func makeController(client: FakeAudioDuckingDeviceClient) -> AudioDuckingController {
         AudioDuckingController(
             client: client,
@@ -307,6 +345,12 @@ private struct MuteSetCall: Equatable {
     let value: Bool
 }
 
+private struct VolumeSetCall: Equatable {
+    let deviceID: AudioObjectID
+    let element: AudioObjectPropertyElement
+    let value: Float32
+}
+
 private final class FakeAudioDuckingDeviceClient: AudioDuckingDeviceClient {
     var activityStatus: AudioOutputActivityStatus = .inactive
     var outputRouteKind: AudioOutputRouteKind = .speakerLike
@@ -319,6 +363,7 @@ private final class FakeAudioDuckingDeviceClient: AudioDuckingDeviceClient {
     var sampleRateValues: [AudioObjectID: [Double]] = [:]
     var sampleRateReadCount: [AudioObjectID: Int] = [:]
     var muteSetCalls: [MuteSetCall] = []
+    var volumeSetCalls: [VolumeSetCall] = []
 
     func outputActivityStatus() -> AudioOutputActivityStatus {
         activityStatus
@@ -369,6 +414,7 @@ private final class FakeAudioDuckingDeviceClient: AudioDuckingDeviceClient {
     func setVolume(_ volume: Float32, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool {
         guard isDeviceAvailable(deviceID) else { return false }
         volumeValues[.init(deviceID, element)] = volume
+        volumeSetCalls.append(VolumeSetCall(deviceID: deviceID, element: element, value: volume))
         return true
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -233,6 +233,7 @@ struct AudioDuckingControllerTests {
         controller.beginDictationDucking(enabled: true)
         controller.waitForIdle()
         controller.restoreDictationDucking()
+        Thread.sleep(forTimeInterval: 0.02)
         controller.waitForIdle()
 
         #expect(client.sampleRateReadCount[1, default: 0] >= 3)
@@ -261,12 +262,22 @@ struct AudioDuckingControllerTests {
         controller.restoreDictationDucking()
         controller.beginDictationDucking(enabled: true)
         controller.waitForIdle()
+        Thread.sleep(forTimeInterval: 0.07)
+        controller.waitForIdle()
 
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
-            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: false),
+        ])
+
+        controller.restoreDictationDucking()
+        Thread.sleep(forTimeInterval: 0.07)
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: false),
         ])
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -239,6 +239,37 @@ struct AudioDuckingControllerTests {
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
     }
 
+    @Test("rapid second dictation re-ducks after restore stabilization")
+    func rapidSecondDictationReducksAfterRestoreStabilization() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+        client.sampleRateValues[1] = [48_000, 24_000, 24_000, 24_000]
+
+        let controller = AudioDuckingController(
+            client: client,
+            queue: DispatchQueue(label: "test.audio-ducking.rapid-turnover"),
+            stabilizationTimeout: 0.05,
+            stabilizationPollInterval: 0.001
+        )
+
+        controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
+        controller.restoreDictationDucking()
+        controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
+        #expect(client.muteSetCalls == [
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: false),
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
+        ])
+    }
+
     private func makeController(client: FakeAudioDuckingDeviceClient) -> AudioDuckingController {
         AudioDuckingController(
             client: client,

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -42,6 +42,26 @@ struct AudioDuckingControllerTests {
         #expect(client.muteSetCalls.isEmpty)
     }
 
+    @Test("headphone output is skipped")
+    func headphoneOutputIsSkipped() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.outputRouteKind = .headphoneLike
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        controller.ensureCurrentDefaultDucked()
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls.isEmpty)
+    }
+
     @Test("active output mutes and restores")
     func activeOutputMutesAndRestores() {
         let client = FakeAudioDuckingDeviceClient()
@@ -53,6 +73,7 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
 
         controller.restoreDictationDucking()
@@ -76,6 +97,7 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
 
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
     }
@@ -91,6 +113,7 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         controller.restoreDictationDucking()
         controller.waitForIdle()
 
@@ -109,6 +132,7 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         #expect(client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] == 0)
 
         controller.restoreDictationDucking()
@@ -128,6 +152,7 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] = 0.3
 
         controller.restoreDictationDucking()
@@ -151,8 +176,10 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         client.defaultDeviceID = 2
         controller.ensureCurrentDefaultDucked()
+        controller.waitForIdle()
         client.defaultDeviceID = 3
 
         controller.restoreDictationDucking()
@@ -175,6 +202,7 @@ struct AudioDuckingControllerTests {
 
         let controller = makeController(client: client)
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         client.availableDevices = []
 
         controller.restoreDictationDucking()
@@ -203,6 +231,7 @@ struct AudioDuckingControllerTests {
             stabilizationPollInterval: 0.001
         )
         controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
         controller.restoreDictationDucking()
         controller.waitForIdle()
 
@@ -238,6 +267,7 @@ private struct MuteSetCall: Equatable {
 
 private final class FakeAudioDuckingDeviceClient: AudioDuckingDeviceClient {
     var activityStatus: AudioOutputActivityStatus = .inactive
+    var outputRouteKind: AudioOutputRouteKind = .speakerLike
     var defaultDeviceID: AudioObjectID?
     var availableDevices = Set<AudioObjectID>()
     var muteElementsByDevice: [AudioObjectID: [AudioObjectPropertyElement]] = [:]
@@ -250,6 +280,10 @@ private final class FakeAudioDuckingDeviceClient: AudioDuckingDeviceClient {
 
     func outputActivityStatus() -> AudioOutputActivityStatus {
         activityStatus
+    }
+
+    func defaultOutputRouteKind() -> AudioOutputRouteKind {
+        outputRouteKind
     }
 
     func defaultOutputDeviceID() -> AudioObjectID? {

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -1,0 +1,298 @@
+import CoreAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("AudioDuckingController")
+struct AudioDuckingControllerTests {
+    @Test("disabled setting is a no-op")
+    func disabledSettingIsNoOp() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: false)
+        controller.ensureCurrentDefaultDucked()
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls.isEmpty)
+    }
+
+    @Test("inactive output is skipped")
+    func inactiveOutputIsSkipped() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .inactive
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls.isEmpty)
+    }
+
+    @Test("active output mutes and restores")
+    func activeOutputMutesAndRestores() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
+
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls == [
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: false),
+        ])
+    }
+
+    @Test("unknown activity fails open and mutes")
+    func unknownActivityFailsOpenAndMutes() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .unknown
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
+    }
+
+    @Test("already-muted output remains muted after restore")
+    func alreadyMutedOutputRemainsMutedAfterRestore() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = true
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
+        #expect(client.muteSetCalls.isEmpty)
+    }
+
+    @Test("unsupported mute falls back to volume restore")
+    func unsupportedMuteFallsBackToVolumeRestore() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.volumeElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] = 0.75
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        #expect(client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] == 0)
+
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] == 0.75)
+    }
+
+    @Test("user volume changes during dictation are not overwritten")
+    func userVolumeChangeIsNotOverwritten() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.volumeElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] = 0.75
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] = 0.3
+
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.volumeValues[.init(1, kAudioObjectPropertyElementMain)] == 0.3)
+    }
+
+    @Test("default output changes restore only touched devices")
+    func defaultOutputChangesRestoreTouchedDevices() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1, 2, 3]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteElementsByDevice[2] = [kAudioObjectPropertyElementMain]
+        client.muteElementsByDevice[3] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+        client.muteValues[.init(2, kAudioObjectPropertyElementMain)] = false
+        client.muteValues[.init(3, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        client.defaultDeviceID = 2
+        controller.ensureCurrentDefaultDucked()
+        client.defaultDeviceID = 3
+
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteValues[.init(2, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteValues[.init(3, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls.map(\.deviceID).sorted() == [1, 1, 2, 2])
+    }
+
+    @Test("disconnected devices are skipped on restore")
+    func disconnectedDevicesAreSkippedOnRestore() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+
+        let controller = makeController(client: client)
+        controller.beginDictationDucking(enabled: true)
+        client.availableDevices = []
+
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
+        #expect(client.muteSetCalls == [
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
+        ])
+    }
+
+    @Test("restore waits briefly for codec sample rate to stabilize")
+    func restoreWaitsForCodecStabilization() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+        client.sampleRateValues[1] = [48_000, 24_000, 48_000]
+
+        let controller = AudioDuckingController(
+            client: client,
+            queue: DispatchQueue(label: "test.audio-ducking.codec"),
+            stabilizationTimeout: 0.1,
+            stabilizationPollInterval: 0.001
+        )
+        controller.beginDictationDucking(enabled: true)
+        controller.restoreDictationDucking()
+        controller.waitForIdle()
+
+        #expect(client.sampleRateReadCount[1, default: 0] >= 3)
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+    }
+
+    private func makeController(client: FakeAudioDuckingDeviceClient) -> AudioDuckingController {
+        AudioDuckingController(
+            client: client,
+            queue: DispatchQueue(label: "test.audio-ducking.\(UUID().uuidString)"),
+            stabilizationTimeout: 0,
+            stabilizationPollInterval: 0
+        )
+    }
+}
+
+private struct DeviceElement: Hashable {
+    let deviceID: AudioObjectID
+    let element: AudioObjectPropertyElement
+
+    init(_ deviceID: AudioObjectID, _ element: AudioObjectPropertyElement) {
+        self.deviceID = deviceID
+        self.element = element
+    }
+}
+
+private struct MuteSetCall: Equatable {
+    let deviceID: AudioObjectID
+    let element: AudioObjectPropertyElement
+    let value: Bool
+}
+
+private final class FakeAudioDuckingDeviceClient: AudioDuckingDeviceClient {
+    var activityStatus: AudioOutputActivityStatus = .inactive
+    var defaultDeviceID: AudioObjectID?
+    var availableDevices = Set<AudioObjectID>()
+    var muteElementsByDevice: [AudioObjectID: [AudioObjectPropertyElement]] = [:]
+    var muteValues: [DeviceElement: Bool] = [:]
+    var volumeElementsByDevice: [AudioObjectID: [AudioObjectPropertyElement]] = [:]
+    var volumeValues: [DeviceElement: Float32] = [:]
+    var sampleRateValues: [AudioObjectID: [Double]] = [:]
+    var sampleRateReadCount: [AudioObjectID: Int] = [:]
+    var muteSetCalls: [MuteSetCall] = []
+
+    func outputActivityStatus() -> AudioOutputActivityStatus {
+        activityStatus
+    }
+
+    func defaultOutputDeviceID() -> AudioObjectID? {
+        defaultDeviceID
+    }
+
+    func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {
+        availableDevices.contains(deviceID)
+    }
+
+    func nominalSampleRate(for deviceID: AudioObjectID) -> Double? {
+        sampleRateReadCount[deviceID, default: 0] += 1
+        guard let values = sampleRateValues[deviceID], !values.isEmpty else { return nil }
+        let index = min(sampleRateReadCount[deviceID, default: 1] - 1, values.count - 1)
+        return values[index]
+    }
+
+    func muteElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement] {
+        muteElementsByDevice[deviceID] ?? []
+    }
+
+    func isMuted(deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool? {
+        muteValues[.init(deviceID, element)]
+    }
+
+    func setMuted(_ muted: Bool, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool {
+        guard isDeviceAvailable(deviceID) else { return false }
+        muteValues[.init(deviceID, element)] = muted
+        muteSetCalls.append(MuteSetCall(deviceID: deviceID, element: element, value: muted))
+        return true
+    }
+
+    func volumeElements(for deviceID: AudioObjectID) -> [AudioObjectPropertyElement] {
+        volumeElementsByDevice[deviceID] ?? []
+    }
+
+    func volume(deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Float32? {
+        volumeValues[.init(deviceID, element)]
+    }
+
+    func setVolume(_ volume: Float32, deviceID: AudioObjectID, element: AudioObjectPropertyElement) -> Bool {
+        guard isDeviceAvailable(deviceID) else { return false }
+        volumeValues[.init(deviceID, element)] = volume
+        return true
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -240,8 +240,8 @@ struct AudioDuckingControllerTests {
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
     }
 
-    @Test("rapid second dictation re-ducks after restore stabilization")
-    func rapidSecondDictationReducksAfterRestoreStabilization() {
+    @Test("rapid second dictation drains cancelled restore completions")
+    func rapidSecondDictationDrainsCancelledRestoreCompletions() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -268,7 +268,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 0)
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -268,7 +268,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 1)
+        #expect(restoreCompletionCount == 0)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
@@ -278,6 +278,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -286,6 +286,41 @@ struct AudioDuckingControllerTests {
         ])
     }
 
+    @Test("disabling ducking during pending restore cancels stale completions")
+    func disablingDuckingDuringPendingRestoreCancelsStaleCompletions() {
+        let client = FakeAudioDuckingDeviceClient()
+        client.activityStatus = .active
+        client.defaultDeviceID = 1
+        client.availableDevices = [1]
+        client.muteElementsByDevice[1] = [kAudioObjectPropertyElementMain]
+        client.muteValues[.init(1, kAudioObjectPropertyElementMain)] = false
+        client.sampleRateValues[1] = [48_000, 24_000, 24_000, 24_000]
+
+        let controller = AudioDuckingController(
+            client: client,
+            queue: DispatchQueue(label: "test.audio-ducking.disable-pending"),
+            stabilizationTimeout: 0.05,
+            stabilizationPollInterval: 0.001
+        )
+
+        controller.beginDictationDucking(enabled: true)
+        controller.waitForIdle()
+        var restoreCompletionCount = 0
+        controller.restoreDictationDucking {
+            restoreCompletionCount += 1
+        }
+        controller.beginDictationDucking(enabled: false)
+        Thread.sleep(forTimeInterval: 0.07)
+        controller.waitForIdle()
+
+        #expect(restoreCompletionCount == 0)
+        #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
+        #expect(client.muteSetCalls == [
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
+            .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: false),
+        ])
+    }
+
     @Test("rapid second dictation preserves original volume while restore is pending")
     func rapidSecondDictationPreservesOriginalVolumeWhileRestoreIsPending() {
         let client = FakeAudioDuckingDeviceClient()

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -240,8 +240,8 @@ struct AudioDuckingControllerTests {
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
     }
 
-    @Test("rapid second dictation completes cancelled restore callbacks")
-    func rapidSecondDictationCompletesCancelledRestoreCallbacks() {
+    @Test("rapid second dictation drops cancelled restore completions")
+    func rapidSecondDictationDropsCancelledRestoreCompletions() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -268,7 +268,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 1)
+        #expect(restoreCompletionCount == 0)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
@@ -278,7 +278,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 1)
+        #expect(restoreCompletionCount == 0)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
@@ -286,8 +286,8 @@ struct AudioDuckingControllerTests {
         ])
     }
 
-    @Test("disabling ducking during pending restore completes stale callbacks")
-    func disablingDuckingDuringPendingRestoreCompletesStaleCallbacks() {
+    @Test("disabling ducking during pending restore cancels stale completions")
+    func disablingDuckingDuringPendingRestoreCancelsStaleCompletions() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -313,7 +313,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 1)
+        #expect(restoreCompletionCount == 0)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -240,8 +240,8 @@ struct AudioDuckingControllerTests {
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
     }
 
-    @Test("rapid second dictation drains cancelled restore completions")
-    func rapidSecondDictationDrainsCancelledRestoreCompletions() {
+    @Test("rapid second dictation drops cancelled restore completions")
+    func rapidSecondDictationDropsCancelledRestoreCompletions() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -268,7 +268,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 1)
+        #expect(restoreCompletionCount == 0)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
@@ -278,7 +278,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 1)
+        #expect(restoreCompletionCount == 0)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -240,8 +240,8 @@ struct AudioDuckingControllerTests {
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
     }
 
-    @Test("rapid second dictation drops cancelled restore completions")
-    func rapidSecondDictationDropsCancelledRestoreCompletions() {
+    @Test("rapid second dictation completes cancelled restore callbacks")
+    func rapidSecondDictationCompletesCancelledRestoreCallbacks() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -268,7 +268,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 0)
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
@@ -278,7 +278,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 0)
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),
@@ -286,8 +286,8 @@ struct AudioDuckingControllerTests {
         ])
     }
 
-    @Test("disabling ducking during pending restore cancels stale completions")
-    func disablingDuckingDuringPendingRestoreCancelsStaleCompletions() {
+    @Test("disabling ducking during pending restore completes stale callbacks")
+    func disablingDuckingDuringPendingRestoreCompletesStaleCallbacks() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -313,7 +313,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 0)
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -286,8 +286,8 @@ struct AudioDuckingControllerTests {
         ])
     }
 
-    @Test("disabling ducking during pending restore cancels stale completions")
-    func disablingDuckingDuringPendingRestoreCancelsStaleCompletions() {
+    @Test("disabling ducking during pending restore preserves restore completions")
+    func disablingDuckingDuringPendingRestorePreservesRestoreCompletions() {
         let client = FakeAudioDuckingDeviceClient()
         client.activityStatus = .active
         client.defaultDeviceID = 1
@@ -313,7 +313,7 @@ struct AudioDuckingControllerTests {
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
-        #expect(restoreCompletionCount == 0)
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == false)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioDuckingControllerTests.swift
@@ -259,12 +259,16 @@ struct AudioDuckingControllerTests {
 
         controller.beginDictationDucking(enabled: true)
         controller.waitForIdle()
-        controller.restoreDictationDucking()
+        var restoreCompletionCount = 0
+        controller.restoreDictationDucking {
+            restoreCompletionCount += 1
+        }
         controller.beginDictationDucking(enabled: true)
         controller.waitForIdle()
         Thread.sleep(forTimeInterval: 0.07)
         controller.waitForIdle()
 
+        #expect(restoreCompletionCount == 1)
         #expect(client.muteValues[.init(1, kAudioObjectPropertyElementMain)] == true)
         #expect(client.muteSetCalls == [
             .init(deviceID: 1, element: kAudioObjectPropertyElementMain, value: true),

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -19,19 +19,33 @@ struct AudioRouteClassifierTests {
         #expect(route == .headphoneLike)
     }
 
-    @Test("Bluetooth low-rate generic input profile is unknown")
-    func bluetoothLowRateGenericInputProfileIsUnknown() {
+    @Test("Bluetooth input without terminal metadata is unknown")
+    func bluetoothInputWithoutTerminalMetadataIsUnknown() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: nil,
                 transportType: kAudioDeviceTransportTypeBluetooth,
                 hasOutputStreams: true,
-                hasInputStreams: true,
-                nominalSampleRate: 16_000
+                hasInputStreams: true
             )
         )
 
         #expect(route == .unknown)
+    }
+
+    @Test("Bluetooth input without terminal metadata is marked ambiguous")
+    func bluetoothInputWithoutTerminalMetadataIsMarkedAmbiguous() {
+        let classification = AudioRouteClassifier.outputRouteClassification(
+            for: AudioOutputDeviceDescription(
+                name: nil,
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true,
+                hasInputStreams: true
+            )
+        )
+
+        #expect(classification.kind == .unknown)
+        #expect(classification.isAmbiguousBluetooth)
     }
 
     @Test("generic Bluetooth output with input is unknown")

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -120,6 +120,52 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
+    @Test("mixed headphone and speaker terminals are speaker-like")
+    func mixedHeadphoneAndSpeakerTerminalsAreSpeakerLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Mixed Output",
+                transportType: kAudioDeviceTransportTypeUSB,
+                hasOutputStreams: true,
+                hasInputStreams: true,
+                outputTerminalTypes: [
+                    kAudioStreamTerminalTypeHeadphones,
+                    kAudioStreamTerminalTypeSpeaker,
+                ]
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("USB headset without terminal metadata is headphone-like when input capable")
+    func usbHeadsetWithoutTerminalMetadataIsHeadphoneLikeWhenInputCapable() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "USB Audio Device",
+                transportType: kAudioDeviceTransportTypeUSB,
+                hasOutputStreams: true,
+                hasInputStreams: true
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("Thunderbolt headset without terminal metadata is headphone-like when input capable")
+    func thunderboltHeadsetWithoutTerminalMetadataIsHeadphoneLikeWhenInputCapable() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Thunderbolt Audio Device",
+                transportType: kAudioDeviceTransportTypeThunderbolt,
+                hasOutputStreams: true,
+                hasInputStreams: true
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
     @Test("device names do not override transport classification")
     func deviceNamesDoNotOverrideTransportClassification() {
         let route = AudioRouteClassifier.outputRouteKind(

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -1,0 +1,84 @@
+import CoreAudio
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("AudioRouteClassifier")
+struct AudioRouteClassifierTests {
+    @Test("AirPods output is headphone-like")
+    func airPodsOutputIsHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Pranav's AirPods Pro",
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("generic Bluetooth output defaults to headphone-like")
+    func genericBluetoothOutputDefaultsToHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Wireless Audio",
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("Bluetooth speakers remain speaker-like")
+    func bluetoothSpeakersRemainSpeakerLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "JBL Flip",
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("built-in speakers are speaker-like")
+    func builtInSpeakersAreSpeakerLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "MacBook Pro Speakers",
+                transportType: kAudioDeviceTransportTypeBuiltIn,
+                hasOutputStreams: true
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("wired headphone outputs are headphone-like")
+    func wiredHeadphonesAreHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "External Headphones",
+                transportType: kAudioDeviceTransportTypeBuiltIn,
+                hasOutputStreams: true
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("devices without output streams are unknown")
+    func devicesWithoutOutputStreamsAreUnknown() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "MacBook Pro Microphone",
+                transportType: kAudioDeviceTransportTypeBuiltIn,
+                hasOutputStreams: false
+            )
+        )
+
+        #expect(route == .unknown)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -67,7 +67,53 @@ struct AudioRouteClassifierTests {
                 name: "MacBook Pro Speakers",
                 transportType: kAudioDeviceTransportTypeBuiltIn,
                 hasOutputStreams: true,
-                hasInputStreams: false
+                hasInputStreams: false,
+                outputTerminalTypes: [kAudioStreamTerminalTypeSpeaker]
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("wired headphones are headphone-like by terminal type")
+    func wiredHeadphonesAreHeadphoneLikeByTerminalType() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "External Output",
+                transportType: kAudioDeviceTransportTypeBuiltIn,
+                hasOutputStreams: true,
+                hasInputStreams: false,
+                outputTerminalTypes: [kAudioStreamTerminalTypeHeadphones]
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("USB headphones are headphone-like by terminal type")
+    func usbHeadphonesAreHeadphoneLikeByTerminalType() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "USB Output",
+                transportType: kAudioDeviceTransportTypeUSB,
+                hasOutputStreams: true,
+                hasInputStreams: false,
+                outputTerminalTypes: [kAudioStreamTerminalTypeHeadphones]
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("USB speakers are speaker-like by terminal type")
+    func usbSpeakersAreSpeakerLikeByTerminalType() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "USB Output",
+                transportType: kAudioDeviceTransportTypeUSB,
+                hasOutputStreams: true,
+                hasInputStreams: false,
+                outputTerminalTypes: [kAudioStreamTerminalTypeSpeaker]
             )
         )
 
@@ -81,7 +127,8 @@ struct AudioRouteClassifierTests {
                 name: "External Headphones",
                 transportType: kAudioDeviceTransportTypeBuiltIn,
                 hasOutputStreams: true,
-                hasInputStreams: false
+                hasInputStreams: false,
+                outputTerminalTypes: [kAudioStreamTerminalTypeSpeaker]
             )
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -8,7 +8,7 @@ struct AudioRouteClassifierTests {
     func airPodsOutputIsHeadphoneLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
-                name: "Pranav's AirPods Pro",
+                name: nil,
                 transportType: kAudioDeviceTransportTypeBluetooth,
                 hasOutputStreams: true
             )
@@ -30,17 +30,17 @@ struct AudioRouteClassifierTests {
         #expect(route == .headphoneLike)
     }
 
-    @Test("Bluetooth speakers remain speaker-like")
-    func bluetoothSpeakersRemainSpeakerLike() {
+    @Test("Bluetooth route does not depend on brand or product words")
+    func bluetoothRouteDoesNotDependOnBrandOrProductWords() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
-                name: "JBL Flip",
+                name: "Generic Output",
                 transportType: kAudioDeviceTransportTypeBluetooth,
                 hasOutputStreams: true
             )
         )
 
-        #expect(route == .speakerLike)
+        #expect(route == .headphoneLike)
     }
 
     @Test("built-in speakers are speaker-like")
@@ -56,8 +56,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("wired headphone outputs are headphone-like")
-    func wiredHeadphonesAreHeadphoneLike() {
+    @Test("device names do not override transport classification")
+    func deviceNamesDoNotOverrideTransportClassification() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "External Headphones",
@@ -66,7 +66,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .speakerLike)
     }
 
     @Test("devices without output streams are unknown")

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -213,8 +213,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .headphoneLike)
     }
 
-    @Test("USB output without input or terminal metadata is headphone-like")
-    func usbOutputWithoutInputOrTerminalMetadataIsHeadphoneLike() {
+    @Test("USB output without input or terminal metadata is speaker-like")
+    func usbOutputWithoutInputOrTerminalMetadataIsSpeakerLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "USB Output",
@@ -224,7 +224,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .speakerLike)
     }
 
     @Test("Thunderbolt device without terminal metadata is headphone-like")
@@ -241,8 +241,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .headphoneLike)
     }
 
-    @Test("built-in output without route metadata is headphone-like")
-    func builtInOutputWithoutRouteMetadataIsHeadphoneLike() {
+    @Test("built-in output without route metadata is speaker-like")
+    func builtInOutputWithoutRouteMetadataIsSpeakerLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "External Output",
@@ -252,7 +252,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .speakerLike)
     }
 
     @Test("selected headphone data source is headphone-like")

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -138,8 +138,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("USB headset without terminal metadata is headphone-like when input capable")
-    func usbHeadsetWithoutTerminalMetadataIsHeadphoneLikeWhenInputCapable() {
+    @Test("USB headset without terminal metadata is speaker-like even when input capable")
+    func usbHeadsetWithoutTerminalMetadataIsSpeakerLikeEvenWhenInputCapable() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "USB Audio Device",
@@ -149,17 +149,47 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .speakerLike)
     }
 
-    @Test("Thunderbolt headset without terminal metadata is headphone-like when input capable")
-    func thunderboltHeadsetWithoutTerminalMetadataIsHeadphoneLikeWhenInputCapable() {
+    @Test("Thunderbolt device without terminal metadata is speaker-like even when input capable")
+    func thunderboltDeviceWithoutTerminalMetadataIsSpeakerLikeEvenWhenInputCapable() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Thunderbolt Audio Device",
                 transportType: kAudioDeviceTransportTypeThunderbolt,
                 hasOutputStreams: true,
                 hasInputStreams: true
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("selected headphone data source is headphone-like")
+    func selectedHeadphoneDataSourceIsHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Output",
+                transportType: kAudioDeviceTransportTypeBuiltIn,
+                hasOutputStreams: true,
+                hasInputStreams: false,
+                outputDataSourceKinds: [kAudioStreamTerminalTypeHeadphones]
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("Bluetooth A2DP headphone data source is headphone-like without input stream")
+    func bluetoothA2DPHeadphoneDataSourceIsHeadphoneLikeWithoutInputStream() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Wireless Output",
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true,
+                hasInputStreams: false,
+                outputDataSourceKinds: [kAudioStreamTerminalTypeHeadphones]
             )
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -33,8 +33,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .unknown)
     }
 
-    @Test("Bluetooth input without terminal metadata is unknown but not ambiguous")
-    func bluetoothInputWithoutTerminalMetadataIsUnknownButNotAmbiguous() {
+    @Test("classic Bluetooth input without terminal metadata is marked ambiguous")
+    func classicBluetoothInputWithoutTerminalMetadataIsMarkedAmbiguous() {
         let classification = AudioRouteClassifier.outputRouteClassification(
             for: AudioOutputDeviceDescription(
                 name: nil,
@@ -45,7 +45,7 @@ struct AudioRouteClassifierTests {
         )
 
         #expect(classification.kind == .unknown)
-        #expect(!classification.isAmbiguousBluetooth)
+        #expect(classification.isAmbiguousBluetooth)
     }
 
     @Test("Bluetooth LE input without terminal metadata is marked ambiguous")

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -199,8 +199,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("USB headset without terminal metadata is speaker-like even when input capable")
-    func usbHeadsetWithoutTerminalMetadataIsSpeakerLikeEvenWhenInputCapable() {
+    @Test("USB headset without terminal metadata is headphone-like")
+    func usbHeadsetWithoutTerminalMetadataIsHeadphoneLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "USB Audio Device",
@@ -210,11 +210,25 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .speakerLike)
+        #expect(route == .headphoneLike)
     }
 
-    @Test("Thunderbolt device without terminal metadata is speaker-like even when input capable")
-    func thunderboltDeviceWithoutTerminalMetadataIsSpeakerLikeEvenWhenInputCapable() {
+    @Test("USB output without input or terminal metadata is headphone-like")
+    func usbOutputWithoutInputOrTerminalMetadataIsHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "USB Output",
+                transportType: kAudioDeviceTransportTypeUSB,
+                hasOutputStreams: true,
+                hasInputStreams: false
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("Thunderbolt device without terminal metadata is headphone-like")
+    func thunderboltDeviceWithoutTerminalMetadataIsHeadphoneLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Thunderbolt Audio Device",
@@ -224,7 +238,21 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .speakerLike)
+        #expect(route == .headphoneLike)
+    }
+
+    @Test("built-in output without route metadata is headphone-like")
+    func builtInOutputWithoutRouteMetadataIsHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "External Output",
+                transportType: kAudioDeviceTransportTypeBuiltIn,
+                hasOutputStreams: true,
+                hasInputStreams: false
+            )
+        )
+
+        #expect(route == .headphoneLike)
     }
 
     @Test("selected headphone data source is headphone-like")

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -11,15 +11,16 @@ struct AudioRouteClassifierTests {
                 name: nil,
                 transportType: kAudioDeviceTransportTypeBluetooth,
                 hasOutputStreams: true,
-                hasInputStreams: true
+                hasInputStreams: true,
+                outputDataSourceKinds: [kAudioStreamTerminalTypeHeadphones]
             )
         )
 
         #expect(route == .headphoneLike)
     }
 
-    @Test("Bluetooth headset low-rate input profile is headphone-like")
-    func bluetoothHeadsetLowRateInputProfileIsHeadphoneLike() {
+    @Test("Bluetooth low-rate generic input profile is unknown")
+    func bluetoothLowRateGenericInputProfileIsUnknown() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: nil,
@@ -30,11 +31,11 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .unknown)
     }
 
-    @Test("generic Bluetooth output defaults to headphone-like")
-    func genericBluetoothOutputDefaultsToHeadphoneLike() {
+    @Test("generic Bluetooth output with input is unknown")
+    func genericBluetoothOutputWithInputIsUnknown() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Wireless Audio",
@@ -44,7 +45,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .unknown)
     }
 
     @Test("Bluetooth speaker output is speaker-like when no input stream is exposed")
@@ -61,8 +62,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("Bluetooth high-rate generic route with input is headphone-like")
-    func bluetoothHighRateGenericRouteWithInputIsHeadphoneLike() {
+    @Test("Bluetooth high-rate generic route with input is unknown")
+    func bluetoothHighRateGenericRouteWithInputIsUnknown() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Wireless Output",
@@ -73,17 +74,18 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .unknown)
     }
 
-    @Test("Bluetooth headset route does not depend on brand or product words")
-    func bluetoothHeadsetRouteDoesNotDependOnBrandOrProductWords() {
+    @Test("Bluetooth headset terminal route does not depend on brand or product words")
+    func bluetoothHeadsetTerminalRouteDoesNotDependOnBrandOrProductWords() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Generic Output",
                 transportType: kAudioDeviceTransportTypeBluetooth,
                 hasOutputStreams: true,
-                hasInputStreams: true
+                hasInputStreams: true,
+                outputTerminalTypes: [kAudioStreamTerminalTypeHeadphones]
             )
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -18,6 +18,21 @@ struct AudioRouteClassifierTests {
         #expect(route == .headphoneLike)
     }
 
+    @Test("Bluetooth headset low-rate input profile is headphone-like")
+    func bluetoothHeadsetLowRateInputProfileIsHeadphoneLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: nil,
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true,
+                hasInputStreams: true,
+                nominalSampleRate: 16_000
+            )
+        )
+
+        #expect(route == .headphoneLike)
+    }
+
     @Test("generic Bluetooth output defaults to headphone-like")
     func genericBluetoothOutputDefaultsToHeadphoneLike() {
         let route = AudioRouteClassifier.outputRouteKind(
@@ -40,6 +55,21 @@ struct AudioRouteClassifierTests {
                 transportType: kAudioDeviceTransportTypeBluetooth,
                 hasOutputStreams: true,
                 hasInputStreams: false
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("Bluetooth speakerphone high-rate generic route is speaker-like")
+    func bluetoothSpeakerphoneHighRateGenericRouteIsSpeakerLike() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Wireless Output",
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true,
+                hasInputStreams: true,
+                nominalSampleRate: 48_000
             )
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -33,12 +33,27 @@ struct AudioRouteClassifierTests {
         #expect(route == .unknown)
     }
 
-    @Test("Bluetooth input without terminal metadata is marked ambiguous")
-    func bluetoothInputWithoutTerminalMetadataIsMarkedAmbiguous() {
+    @Test("Bluetooth input without terminal metadata is unknown but not ambiguous")
+    func bluetoothInputWithoutTerminalMetadataIsUnknownButNotAmbiguous() {
         let classification = AudioRouteClassifier.outputRouteClassification(
             for: AudioOutputDeviceDescription(
                 name: nil,
                 transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true,
+                hasInputStreams: true
+            )
+        )
+
+        #expect(classification.kind == .unknown)
+        #expect(!classification.isAmbiguousBluetooth)
+    }
+
+    @Test("Bluetooth LE input without terminal metadata is marked ambiguous")
+    func bluetoothLEInputWithoutTerminalMetadataIsMarkedAmbiguous() {
+        let classification = AudioRouteClassifier.outputRouteClassification(
+            for: AudioOutputDeviceDescription(
+                name: nil,
+                transportType: kAudioDeviceTransportTypeBluetoothLE,
                 hasOutputStreams: true,
                 hasInputStreams: true
             )

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -61,8 +61,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("Bluetooth speakerphone high-rate generic route is speaker-like")
-    func bluetoothSpeakerphoneHighRateGenericRouteIsSpeakerLike() {
+    @Test("Bluetooth high-rate generic route with input is headphone-like")
+    func bluetoothHighRateGenericRouteWithInputIsHeadphoneLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Wireless Output",
@@ -73,7 +73,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .speakerLike)
+        #expect(route == .headphoneLike)
     }
 
     @Test("Bluetooth headset route does not depend on brand or product words")

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -10,7 +10,8 @@ struct AudioRouteClassifierTests {
             for: AudioOutputDeviceDescription(
                 name: nil,
                 transportType: kAudioDeviceTransportTypeBluetooth,
-                hasOutputStreams: true
+                hasOutputStreams: true,
+                hasInputStreams: true
             )
         )
 
@@ -23,20 +24,36 @@ struct AudioRouteClassifierTests {
             for: AudioOutputDeviceDescription(
                 name: "Wireless Audio",
                 transportType: kAudioDeviceTransportTypeBluetooth,
-                hasOutputStreams: true
+                hasOutputStreams: true,
+                hasInputStreams: true
             )
         )
 
         #expect(route == .headphoneLike)
     }
 
-    @Test("Bluetooth route does not depend on brand or product words")
-    func bluetoothRouteDoesNotDependOnBrandOrProductWords() {
+    @Test("Bluetooth speaker output is speaker-like when no input stream is exposed")
+    func bluetoothSpeakerOutputIsSpeakerLikeWithoutInputStream() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Generic Output",
                 transportType: kAudioDeviceTransportTypeBluetooth,
-                hasOutputStreams: true
+                hasOutputStreams: true,
+                hasInputStreams: false
+            )
+        )
+
+        #expect(route == .speakerLike)
+    }
+
+    @Test("Bluetooth headset route does not depend on brand or product words")
+    func bluetoothHeadsetRouteDoesNotDependOnBrandOrProductWords() {
+        let route = AudioRouteClassifier.outputRouteKind(
+            for: AudioOutputDeviceDescription(
+                name: "Generic Output",
+                transportType: kAudioDeviceTransportTypeBluetooth,
+                hasOutputStreams: true,
+                hasInputStreams: true
             )
         )
 
@@ -49,7 +66,8 @@ struct AudioRouteClassifierTests {
             for: AudioOutputDeviceDescription(
                 name: "MacBook Pro Speakers",
                 transportType: kAudioDeviceTransportTypeBuiltIn,
-                hasOutputStreams: true
+                hasOutputStreams: true,
+                hasInputStreams: false
             )
         )
 
@@ -62,7 +80,8 @@ struct AudioRouteClassifierTests {
             for: AudioOutputDeviceDescription(
                 name: "External Headphones",
                 transportType: kAudioDeviceTransportTypeBuiltIn,
-                hasOutputStreams: true
+                hasOutputStreams: true,
+                hasInputStreams: false
             )
         )
 
@@ -75,7 +94,8 @@ struct AudioRouteClassifierTests {
             for: AudioOutputDeviceDescription(
                 name: "MacBook Pro Microphone",
                 transportType: kAudioDeviceTransportTypeBuiltIn,
-                hasOutputStreams: false
+                hasOutputStreams: false,
+                hasInputStreams: true
             )
         )
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioRouteClassifierTests.swift
@@ -199,8 +199,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("USB headset without terminal metadata is headphone-like")
-    func usbHeadsetWithoutTerminalMetadataIsHeadphoneLike() {
+    @Test("USB headset without terminal metadata is speaker-like")
+    func usbHeadsetWithoutTerminalMetadataIsSpeakerLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "USB Audio Device",
@@ -210,7 +210,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .speakerLike)
     }
 
     @Test("USB output without input or terminal metadata is speaker-like")
@@ -227,8 +227,8 @@ struct AudioRouteClassifierTests {
         #expect(route == .speakerLike)
     }
 
-    @Test("Thunderbolt device without terminal metadata is headphone-like")
-    func thunderboltDeviceWithoutTerminalMetadataIsHeadphoneLike() {
+    @Test("Thunderbolt device without terminal metadata is speaker-like")
+    func thunderboltDeviceWithoutTerminalMetadataIsSpeakerLike() {
         let route = AudioRouteClassifier.outputRouteKind(
             for: AudioOutputDeviceDescription(
                 name: "Thunderbolt Audio Device",
@@ -238,7 +238,7 @@ struct AudioRouteClassifierTests {
             )
         )
 
-        #expect(route == .headphoneLike)
+        #expect(route == .speakerLike)
     }
 
     @Test("built-in output without route metadata is speaker-like")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -38,11 +38,12 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
     }
 
-    @Test("dictation prefers built-in mic for unknown output")
-    func dictationPrefersBuiltInMicForUnknownOutput() {
+    @Test("dictation prefers built-in mic for ambiguous Bluetooth unknown output")
+    func dictationPrefersBuiltInMicForAmbiguousBluetoothUnknownOutput() {
         let inspector = FakeCoreAudioDeviceInspector(
             defaultOutputDeviceID: 10,
             outputRouteKind: .unknown,
+            outputIsAmbiguousBluetooth: true,
             builtInInputDeviceID: 82
         )
         let controller = DictationAudioRouteController(
@@ -53,6 +54,24 @@ struct DictationAudioRouteControllerTests {
 
         #expect(controller.preferredInputDeviceIDForDictation() == 82)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
+    }
+
+    @Test("dictation preserves default input for non-Bluetooth unknown output")
+    func dictationPreservesDefaultInputForNonBluetoothUnknownOutput() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .unknown,
+            outputIsAmbiguousBluetooth: false,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.unknown-non-bluetooth"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForDictation() == nil)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
     }
 
     @Test("dictation falls back to default input when built-in mic is unavailable")
@@ -76,15 +95,18 @@ struct DictationAudioRouteControllerTests {
 private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     var defaultOutputDeviceIDValue: AudioObjectID?
     var outputRouteKindValue: AudioOutputRouteKind
+    var outputIsAmbiguousBluetoothValue: Bool
     var builtInInputDeviceIDValue: AudioObjectID?
 
     init(
         defaultOutputDeviceID: AudioObjectID?,
         outputRouteKind: AudioOutputRouteKind,
+        outputIsAmbiguousBluetooth: Bool = false,
         builtInInputDeviceID: AudioObjectID?
     ) {
         self.defaultOutputDeviceIDValue = defaultOutputDeviceID
         self.outputRouteKindValue = outputRouteKind
+        self.outputIsAmbiguousBluetoothValue = outputIsAmbiguousBluetooth
         self.builtInInputDeviceIDValue = builtInInputDeviceID
     }
 
@@ -108,8 +130,11 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
         nil
     }
 
-    func outputRouteKind(for deviceID: AudioObjectID) -> AudioOutputRouteKind {
-        outputRouteKindValue
+    func outputRouteClassification(for deviceID: AudioObjectID) -> AudioRouteClassifier.Classification {
+        AudioRouteClassifier.Classification(
+            kind: outputRouteKindValue,
+            isAmbiguousBluetooth: outputIsAmbiguousBluetoothValue
+        )
     }
 
     func builtInInputDeviceID() -> AudioObjectID? {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -4,9 +4,26 @@ import Testing
 
 @Suite("DictationAudioRouteController")
 struct DictationAudioRouteControllerTests {
-    @Test("dictation prefers built-in mic for every output route")
-    func dictationPrefersBuiltInMicForEveryOutputRoute() {
-        for routeKind in [AudioOutputRouteKind.speakerLike, .headphoneLike, .unknown] {
+    @Test("dictation prefers built-in mic for headphone output")
+    func dictationPrefersBuiltInMicForHeadphoneOutput() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.headphone-like"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForDictation() == 82)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
+    }
+
+    @Test("dictation preserves default input for speaker and unknown output")
+    func dictationPreservesDefaultInputForSpeakerAndUnknownOutput() {
+        for routeKind in [AudioOutputRouteKind.speakerLike, .unknown] {
             let inspector = FakeCoreAudioDeviceInspector(
                 defaultOutputDeviceID: 10,
                 outputRouteKind: routeKind,
@@ -18,8 +35,8 @@ struct DictationAudioRouteControllerTests {
                 observesDefaultOutputChanges: false
             )
 
-            #expect(controller.preferredInputDeviceIDForDictation() == 82)
-            #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
+            #expect(controller.preferredInputDeviceIDForDictation() == nil)
+            #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -1,0 +1,86 @@
+import CoreAudio
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("DictationAudioRouteController")
+struct DictationAudioRouteControllerTests {
+    @Test("dictation prefers built-in mic for every output route")
+    func dictationPrefersBuiltInMicForEveryOutputRoute() {
+        for routeKind in [AudioOutputRouteKind.speakerLike, .headphoneLike, .unknown] {
+            let inspector = FakeCoreAudioDeviceInspector(
+                defaultOutputDeviceID: 10,
+                outputRouteKind: routeKind,
+                builtInInputDeviceID: 82
+            )
+            let controller = DictationAudioRouteController(
+                inspector: inspector,
+                queue: DispatchQueue(label: "test.dictation-audio-route.\(routeKind.description)"),
+                observesDefaultOutputChanges: false
+            )
+
+            #expect(controller.preferredInputDeviceIDForDictation() == 82)
+            #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
+        }
+    }
+
+    @Test("dictation falls back to default input when built-in mic is unavailable")
+    func dictationFallsBackWhenBuiltInMicUnavailable() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            builtInInputDeviceID: nil
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.no-built-in"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForDictation() == nil)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
+    }
+}
+
+private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
+    var defaultOutputDeviceIDValue: AudioObjectID?
+    var outputRouteKindValue: AudioOutputRouteKind
+    var builtInInputDeviceIDValue: AudioObjectID?
+
+    init(
+        defaultOutputDeviceID: AudioObjectID?,
+        outputRouteKind: AudioOutputRouteKind,
+        builtInInputDeviceID: AudioObjectID?
+    ) {
+        self.defaultOutputDeviceIDValue = defaultOutputDeviceID
+        self.outputRouteKindValue = outputRouteKind
+        self.builtInInputDeviceIDValue = builtInInputDeviceID
+    }
+
+    func defaultOutputDeviceID() -> AudioObjectID? {
+        defaultOutputDeviceIDValue
+    }
+
+    func defaultInputDeviceID() -> AudioObjectID? {
+        nil
+    }
+
+    func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {
+        false
+    }
+
+    func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {
+        true
+    }
+
+    func nominalSampleRate(for deviceID: AudioObjectID) -> Double? {
+        nil
+    }
+
+    func outputRouteKind(for deviceID: AudioObjectID) -> AudioOutputRouteKind {
+        outputRouteKindValue
+    }
+
+    func builtInInputDeviceID() -> AudioObjectID? {
+        builtInInputDeviceIDValue
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -90,6 +90,28 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.preferredInputDeviceIDForDictation() == nil)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
     }
+
+    @Test("default input refresh can notify even when preferred route is unchanged")
+    func defaultInputRefreshCanNotifyEvenWhenPreferredRouteIsUnchanged() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.default-input-refresh"),
+            observesDefaultOutputChanges: false
+        )
+        _ = controller.preferredInputDeviceIDForDictation()
+        var preferredInputChanges: [AudioObjectID?] = []
+        controller.onPreferredInputDeviceChanged = { preferredInputChanges.append($0) }
+
+        controller.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+        _ = controller.preferredInputDeviceIDForDictation()
+
+        #expect(preferredInputChanges == [nil])
+    }
 }
 
 private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -21,23 +21,38 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
     }
 
-    @Test("dictation preserves default input for speaker and unknown output")
-    func dictationPreservesDefaultInputForSpeakerAndUnknownOutput() {
-        for routeKind in [AudioOutputRouteKind.speakerLike, .unknown] {
-            let inspector = FakeCoreAudioDeviceInspector(
-                defaultOutputDeviceID: 10,
-                outputRouteKind: routeKind,
-                builtInInputDeviceID: 82
-            )
-            let controller = DictationAudioRouteController(
-                inspector: inspector,
-                queue: DispatchQueue(label: "test.dictation-audio-route.\(routeKind.description)"),
-                observesDefaultOutputChanges: false
-            )
+    @Test("dictation preserves default input for speaker output")
+    func dictationPreservesDefaultInputForSpeakerOutput() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.speaker-like"),
+            observesDefaultOutputChanges: false
+        )
 
-            #expect(controller.preferredInputDeviceIDForDictation() == nil)
-            #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
-        }
+        #expect(controller.preferredInputDeviceIDForDictation() == nil)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
+    }
+
+    @Test("dictation prefers built-in mic for unknown output")
+    func dictationPrefersBuiltInMicForUnknownOutput() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .unknown,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.unknown"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForDictation() == 82)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
     }
 
     @Test("dictation falls back to default input when built-in mic is unavailable")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -1,0 +1,252 @@
+import CoreAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("DictationAudioSessionManager")
+struct DictationAudioSessionManagerTests {
+    @Test("arm activates warm engine without starting capture")
+    func armActivatesWarmEngineWithoutStartingCapture() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.wait()
+
+        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.prepareCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.ducking.beginCalls == [true])
+    }
+
+    @Test("begin recording starts capture and reuses duplicate activation")
+    func beginRecordingReusesDuplicateActivation() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.manager.beginRecording(mode: "start", duckingEnabled: true)
+        harness.wait()
+
+        #expect(harness.recorder.prepareCalls == 1)
+        #expect(harness.recorder.startCalls == 1)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "activation_reused:start"
+            }
+            return false
+        })
+    }
+
+    @Test("headphone route skips ducking and selects built-in mic")
+    func headphoneRouteSkipsDucking() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.wait()
+
+        #expect(harness.ducking.beginCalls.allSatisfy { $0 == false })
+        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.preferredInputDeviceID == 82)
+    }
+
+    @Test("stop restores ducking and emits wav URL")
+    func stopRestoresDuckingAndEmitsWavURL() {
+        let harness = Harness(routeKind: .speakerLike)
+        let wavURL = URL(fileURLWithPath: "/tmp/dictation.wav")
+        harness.recorder.stopURL = wavURL
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true)
+        harness.wait()
+        harness.manager.stop()
+        harness.wait()
+
+        #expect(harness.recorder.stopCalls == 1)
+        #expect(harness.ducking.restoreCalls == 1)
+        #expect(harness.route.restoreCalls == 1)
+        #expect(harness.events.contains { event in
+            if case .stopped(_, let url) = event {
+                return url == wavURL
+            }
+            return false
+        })
+    }
+
+    @Test("route refresh warms graph without opening mic")
+    func routeRefreshWarmsGraphWithoutOpeningMic() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.refreshRoute(reason: "route-change", canWarmUp: true)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.warmUpCalls == 1)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.activateCalls == 0)
+    }
+
+    @Test("recorder callbacks emit stream active, speech detected, and no audio timeout")
+    func recorderCallbacksEmitAudioStateEvents() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false)
+        harness.wait()
+        let firstBufferAt = Date()
+        harness.recorder.onFirstCapturedAudioBuffer?(firstBufferAt)
+        harness.recorder.onFirstSpeechDetected?(firstBufferAt.addingTimeInterval(0.1))
+        harness.recorder.onNoAudioTimeout?(firstBufferAt.addingTimeInterval(1.5))
+        harness.wait()
+
+        #expect(harness.events.contains { if case .streamActive = $0 { return true }; return false })
+        #expect(harness.events.contains { if case .speechDetected = $0 { return true }; return false })
+        #expect(harness.events.contains { if case .noAudioTimeout = $0 { return true }; return false })
+    }
+}
+
+private final class Harness {
+    let recorder = FakeDictationRecorder()
+    let ducking = FakeDuckingManager()
+    let route: FakeDictationRoute
+    let managerQueue = DispatchQueue(label: "test.dictation-session.manager")
+    let eventQueue = DispatchQueue(label: "test.dictation-session.events")
+    var events: [DictationAudioSessionEvent] = []
+    lazy var manager: DictationAudioSessionManager = {
+        let manager = DictationAudioSessionManager(
+            recorder: recorder,
+            duckingController: ducking,
+            routingController: route,
+            queue: managerQueue,
+            eventQueue: eventQueue
+        )
+        manager.onEvent = { [weak self] event in
+            self?.events.append(event)
+        }
+        return manager
+    }()
+
+    init(routeKind: AudioOutputRouteKind, preferredInputDeviceID: AudioObjectID? = nil) {
+        self.route = FakeDictationRoute(
+            routeKind: routeKind,
+            preferredInputDeviceID: preferredInputDeviceID
+        )
+    }
+
+    func wait() {
+        managerQueue.sync {}
+        eventQueue.sync {}
+    }
+}
+
+private final class FakeDictationRecorder: DictationAudioRecording {
+    var preferredInputDeviceID: AudioObjectID?
+    var keepsAudioGraphWarm = false
+    var onFirstCapturedAudioBuffer: ((Date) -> Void)?
+    var onFirstSpeechDetected: ((Date) -> Void)?
+    var onNoAudioTimeout: ((Date) -> Void)?
+
+    var prepareCalls = 0
+    var warmUpCalls = 0
+    var activateCalls = 0
+    var coolDownCalls = 0
+    var startCalls = 0
+    var stopCalls = 0
+    var cancelCalls = 0
+    var stopURL: URL?
+    var lastWarmInputDeviceID: AudioObjectID?
+
+    func prepare() throws {
+        prepareCalls += 1
+    }
+
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
+        warmUpCalls += 1
+        lastWarmInputDeviceID = preferredInputDeviceID
+    }
+
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
+        activateCalls += 1
+        lastWarmInputDeviceID = preferredInputDeviceID
+    }
+
+    func coolDown() {
+        coolDownCalls += 1
+    }
+
+    func start() throws {
+        startCalls += 1
+    }
+
+    func stop() -> URL? {
+        stopCalls += 1
+        return stopURL
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -24
+    }
+}
+
+private final class FakeDuckingManager: AudioDuckingManaging {
+    var beginCalls: [Bool] = []
+    var ensureCalls = 0
+    var restoreCalls = 0
+
+    func beginDictationDucking(enabled: Bool) {
+        beginCalls.append(enabled)
+    }
+
+    func ensureCurrentDefaultDucked() {
+        ensureCalls += 1
+    }
+
+    func restoreDictationDucking() {
+        restoreCalls += 1
+    }
+}
+
+private final class FakeDictationRoute: DictationAudioRouting {
+    var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
+    var routeKind: AudioOutputRouteKind
+    var preferredInputDeviceID: AudioObjectID?
+    var refreshCalls = 0
+    var restoreCalls = 0
+
+    init(routeKind: AudioOutputRouteKind, preferredInputDeviceID: AudioObjectID?) {
+        self.routeKind = routeKind
+        self.preferredInputDeviceID = preferredInputDeviceID
+    }
+
+    func refreshRouteCache() {
+        refreshCalls += 1
+    }
+
+    func preferredInputDeviceIDForDictation() -> AudioObjectID? {
+        preferredInputDeviceID
+    }
+
+    func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID? {
+        preferredInputDeviceID
+    }
+
+    func isDefaultOutputHeadphoneLike() -> Bool {
+        routeKind == .headphoneLike
+    }
+
+    func currentOutputRouteKindForDebug() -> AudioOutputRouteKind {
+        routeKind
+    }
+
+    func currentRouteDebugDescription() -> String {
+        "output=\(routeKind.description) preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")"
+    }
+
+    func beginDictationInputOverride() {}
+
+    func restoreDictationInputOverride() {
+        restoreCalls += 1
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -153,6 +153,21 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
+    @Test("stop without active session does not emit stale stopped event")
+    func stopWithoutActiveSessionDoesNotEmitStoppedEvent() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.stop()
+        harness.wait()
+
+        #expect(!harness.events.contains { event in
+            if case .stopped = event {
+                return true
+            }
+            return false
+        })
+    }
+
     @Test("route refresh warms graph without opening mic")
     func routeRefreshWarmsGraphWithoutOpeningMic() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -75,6 +75,24 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
     }
 
+    @Test("begin recording refreshes route changed after arm")
+    func beginRecordingRefreshesRouteChangedAfterArm() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.wait()
+        harness.route.routeKind = .speakerLike
+        harness.route.preferredInputDeviceID = nil
+
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.wait()
+
+        #expect(harness.route.preferredInputCalls == 2)
+        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.preferredInputDeviceID == nil)
+        #expect(harness.ducking.beginCalls == [false, true])
+    }
+
     @Test("stop restores ducking and emits wav URL")
     func stopRestoresDuckingAndEmitsWavURL() {
         let harness = Harness(routeKind: .speakerLike)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -50,6 +50,31 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.preferredInputDeviceID == 82)
     }
 
+    @Test("arm refreshes preferred input instead of using stale route cache")
+    func armRefreshesPreferredInput() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+        harness.route.cachedPreferredInputDeviceID = nil
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: false)
+        harness.wait()
+
+        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+    }
+
+    @Test("begin recording refreshes preferred input when there was no arm")
+    func beginRecordingRefreshesPreferredInput() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+        harness.route.cachedPreferredInputDeviceID = nil
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false)
+        harness.wait()
+
+        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.recorder.preferredInputDeviceID == 82)
+        #expect(harness.recorder.startCalls == 1)
+    }
+
     @Test("stop restores ducking and emits wav URL")
     func stopRestoresDuckingAndEmitsWavURL() {
         let harness = Harness(routeKind: .speakerLike)
@@ -236,12 +261,15 @@ private final class FakeDictationRoute: DictationAudioRouting {
     var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
     var routeKind: AudioOutputRouteKind
     var preferredInputDeviceID: AudioObjectID?
+    var cachedPreferredInputDeviceID: AudioObjectID?
     var refreshCalls = 0
     var restoreCalls = 0
+    var preferredInputCalls = 0
 
     init(routeKind: AudioOutputRouteKind, preferredInputDeviceID: AudioObjectID?) {
         self.routeKind = routeKind
         self.preferredInputDeviceID = preferredInputDeviceID
+        self.cachedPreferredInputDeviceID = preferredInputDeviceID
     }
 
     func refreshRouteCache() {
@@ -249,11 +277,13 @@ private final class FakeDictationRoute: DictationAudioRouting {
     }
 
     func preferredInputDeviceIDForDictation() -> AudioObjectID? {
-        preferredInputDeviceID
+        preferredInputCalls += 1
+        cachedPreferredInputDeviceID = preferredInputDeviceID
+        return preferredInputDeviceID
     }
 
     func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID? {
-        preferredInputDeviceID
+        cachedPreferredInputDeviceID
     }
 
     func isDefaultOutputHeadphoneLike() -> Bool {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -268,9 +268,7 @@ private final class FakeDictationRoute: DictationAudioRouting {
         "output=\(routeKind.description) preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")"
     }
 
-    func beginDictationInputOverride() {}
-
-    func restoreDictationInputOverride() {
+    func refreshRouteAfterDictationSession() {
         restoreCalls += 1
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -210,6 +210,39 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
+    @Test("media resume waits until ducking restore completes")
+    func mediaResumeWaitsUntilDuckingRestoreCompletes() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.ducking.completeRestoreImmediately = false
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        harness.manager.stop()
+        harness.wait()
+
+        #expect(harness.ducking.restoreCalls == 1)
+        #expect(harness.media.restoreCalls == 0)
+        #expect(harness.route.restoreCalls == 0)
+        #expect(!harness.events.contains { event in
+            if case .audioRestored = event {
+                return true
+            }
+            return false
+        })
+
+        harness.ducking.finishPendingRestore()
+        harness.wait()
+
+        #expect(harness.media.restoreCalls == 1)
+        #expect(harness.route.restoreCalls == 1)
+        #expect(harness.events.contains { event in
+            if case .audioRestored = event {
+                return true
+            }
+            return false
+        })
+    }
+
     @Test("stop without active session does not emit stale stopped event")
     func stopWithoutActiveSessionDoesNotEmitStoppedEvent() {
         let harness = Harness(routeKind: .speakerLike)
@@ -406,6 +439,8 @@ private final class FakeDuckingManager: AudioDuckingManaging {
     var beginCalls: [Bool] = []
     var ensureCalls = 0
     var restoreCalls = 0
+    var completeRestoreImmediately = true
+    private var pendingRestoreCompletion: (() -> Void)?
 
     func beginDictationDucking(enabled: Bool) {
         beginCalls.append(enabled)
@@ -417,6 +452,16 @@ private final class FakeDuckingManager: AudioDuckingManaging {
 
     func restoreDictationDucking(completion: (() -> Void)?) {
         restoreCalls += 1
+        guard completeRestoreImmediately else {
+            pendingRestoreCompletion = completion
+            return
+        }
+        completion?()
+    }
+
+    func finishPendingRestore() {
+        let completion = pendingRestoreCompletion
+        pendingRestoreCompletion = nil
         completion?()
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -9,7 +9,7 @@ struct DictationAudioSessionManagerTests {
     func armActivatesWarmEngineWithoutStartingCapture() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
 
         #expect(harness.recorder.activateCalls == 1)
@@ -26,7 +26,7 @@ struct DictationAudioSessionManagerTests {
 
         harness.manager.refreshRoute(reason: "route-change", canWarmUp: true)
         let startedAt = Date()
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         let elapsed = Date().timeIntervalSince(startedAt)
         harness.wait()
 
@@ -39,7 +39,7 @@ struct DictationAudioSessionManagerTests {
     func beginRecordingReusesDuplicateActivation() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.manager.beginRecording(mode: "start", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
@@ -60,7 +60,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .speakerLike)
         harness.recorder.activateError = NSError(domain: "DictationAudioSessionManagerTests", code: 1)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.manager.beginRecording(mode: "hold-start", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
@@ -85,7 +85,7 @@ struct DictationAudioSessionManagerTests {
     func headphoneRouteSkipsDucking() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
@@ -98,7 +98,7 @@ struct DictationAudioSessionManagerTests {
     func unknownRouteDucksDuringOutputTransitions() {
         let harness = Harness(routeKind: .unknown)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
@@ -112,7 +112,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
@@ -149,7 +149,7 @@ struct DictationAudioSessionManagerTests {
     func beginRecordingRefreshesRouteChangedAfterArm() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
         harness.route.routeKind = .speakerLike
         harness.route.preferredInputDeviceID = nil
@@ -169,7 +169,7 @@ struct DictationAudioSessionManagerTests {
     func holdStartUsesCachedRouteSnapshot() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
         harness.manager.beginRecording(mode: "hold-start", duckingEnabled: false, mediaPauseEnabled: false)
         harness.wait()
@@ -278,7 +278,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
         harness.manager.refreshRoute(reason: "route-change", delay: 0.2, canWarmUp: true)
-        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
@@ -318,7 +318,7 @@ struct DictationAudioSessionManagerTests {
     func mediaPauseRequestedWithCurrentRoute() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: true)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
         #expect(harness.media.beginCalls.isEmpty)
 
@@ -334,7 +334,7 @@ struct DictationAudioSessionManagerTests {
     func beginRecordingAfterArmStartsAudioControlsOnce() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
         #expect(harness.media.beginCalls.isEmpty)
         #expect(harness.ducking.beginCalls.isEmpty)
@@ -351,7 +351,7 @@ struct DictationAudioSessionManagerTests {
     func shortArmedTapDoesNotPauseOrDuckAudio() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
         harness.manager.cancel(reason: "short-tap")
         harness.wait()
@@ -378,7 +378,7 @@ struct DictationAudioSessionManagerTests {
     func cancelTearsDownWarmRecorderGraph() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.manager.arm(source: "hotkey")
         harness.wait()
         #expect(harness.recorder.keepsAudioGraphWarm)
 

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -325,6 +325,20 @@ struct DictationAudioSessionManagerTests {
         ])
     }
 
+    @Test("begin recording after arm does not restart audio controls")
+    func beginRecordingAfterArmDoesNotRestartAudioControls() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        harness.manager.beginRecording(mode: "hold-start", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+
+        #expect(harness.media.beginCalls.count == 1)
+        #expect(harness.ducking.beginCalls == [true])
+        #expect(harness.ducking.ensureCalls == 1)
+    }
+
     @Test("stop restores media pause state")
     func stopRestoresMediaPauseState() {
         let harness = Harness(routeKind: .speakerLike)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -222,7 +222,7 @@ struct DictationAudioSessionManagerTests {
 
         #expect(harness.ducking.restoreCalls == 1)
         #expect(harness.media.restoreCalls == 0)
-        #expect(harness.route.restoreCalls == 0)
+        #expect(harness.route.restoreCalls == 1)
         #expect(!harness.events.contains { event in
             if case .audioRestored = event {
                 return true

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -85,6 +85,30 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.activateCalls == 0)
     }
 
+    @Test("delayed route refresh does not block hotkey arm")
+    func delayedRouteRefreshDoesNotBlockHotkeyArm() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.refreshRoute(reason: "route-change", delay: 0.2, canWarmUp: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: false)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.warmUpCalls == 0)
+
+        Thread.sleep(forTimeInterval: 0.25)
+        harness.wait()
+
+        #expect(harness.recorder.warmUpCalls == 0)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "route_refresh_cancelled:route-change"
+            }
+            return false
+        })
+    }
+
     @Test("recorder callbacks emit stream active, speech detected, and no audio timeout")
     func recorderCallbacksEmitAudioStateEvents() {
         let harness = Harness(routeKind: .speakerLike)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -18,6 +18,22 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.ducking.beginCalls == [true])
     }
 
+    @Test("arm does not block caller while route warmup is in flight")
+    func armDoesNotBlockCallerWhileRouteWarmupIsInFlight() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.recorder.warmUpDelay = 0.2
+
+        harness.manager.refreshRoute(reason: "route-change", canWarmUp: true)
+        let startedAt = Date()
+        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        let elapsed = Date().timeIntervalSince(startedAt)
+        harness.wait()
+
+        #expect(elapsed < 0.05)
+        #expect(harness.recorder.warmUpCalls == 1)
+        #expect(harness.recorder.activateCalls == 1)
+    }
+
     @Test("begin recording starts capture and reuses duplicate activation")
     func beginRecordingReusesDuplicateActivation() {
         let harness = Harness(routeKind: .speakerLike)
@@ -220,6 +236,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
     var cancelCalls = 0
     var stopURL: URL?
     var lastWarmInputDeviceID: AudioObjectID?
+    var warmUpDelay: TimeInterval = 0
 
     func prepare() throws {
         prepareCalls += 1
@@ -227,6 +244,9 @@ private final class FakeDictationRecorder: DictationAudioRecording {
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
         warmUpCalls += 1
+        if warmUpDelay > 0 {
+            Thread.sleep(forTimeInterval: warmUpDelay)
+        }
         lastWarmInputDeviceID = preferredInputDeviceID
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -67,15 +67,15 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.preferredInputDeviceID == 82)
     }
 
-    @Test("unknown route skips ducking during output transitions")
-    func unknownRouteSkipsDuckingDuringOutputTransitions() {
+    @Test("unknown route ducks to avoid speaker bleed during output transitions")
+    func unknownRouteDucksDuringOutputTransitions() {
         let harness = Harness(routeKind: .unknown)
 
         harness.manager.arm(source: "hotkey", duckingEnabled: true)
         harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
         harness.wait()
 
-        #expect(harness.ducking.beginCalls.allSatisfy { $0 == false })
+        #expect(harness.ducking.beginCalls.allSatisfy { $0 == true })
         #expect(harness.ducking.ensureCalls == 1)
         #expect(harness.recorder.startCalls == 1)
     }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -15,7 +15,8 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.prepareCalls == 0)
         #expect(harness.recorder.startCalls == 0)
-        #expect(harness.ducking.beginCalls == [true])
+        #expect(harness.ducking.beginCalls.isEmpty)
+        #expect(harness.media.beginCalls.isEmpty)
     }
 
     @Test("arm does not block caller while route warmup is in flight")
@@ -161,7 +162,7 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.activateCalls == 2)
         #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
-        #expect(harness.ducking.beginCalls == [false, true])
+        #expect(harness.ducking.beginCalls == [true])
     }
 
     @Test("hold start uses cached route snapshot from arm path")
@@ -313,11 +314,15 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.events.contains { if case .noAudioTimeout = $0 { return true }; return false })
     }
 
-    @Test("media pause is requested with current route when enabled")
+    @Test("media pause is requested with current route after threshold")
     func mediaPauseRequestedWithCurrentRoute() {
         let harness = Harness(routeKind: .speakerLike)
 
         harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: true)
+        harness.wait()
+        #expect(harness.media.beginCalls.isEmpty)
+
+        harness.manager.beginRecording(mode: "hold-start", duckingEnabled: false, mediaPauseEnabled: true)
         harness.wait()
 
         #expect(harness.media.beginCalls == [
@@ -325,18 +330,36 @@ struct DictationAudioSessionManagerTests {
         ])
     }
 
-    @Test("begin recording after arm does not restart audio controls")
-    func beginRecordingAfterArmDoesNotRestartAudioControls() {
+    @Test("begin recording after arm starts audio controls once")
+    func beginRecordingAfterArmStartsAudioControlsOnce() {
         let harness = Harness(routeKind: .speakerLike)
 
         harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: true)
         harness.wait()
+        #expect(harness.media.beginCalls.isEmpty)
+        #expect(harness.ducking.beginCalls.isEmpty)
+
         harness.manager.beginRecording(mode: "hold-start", duckingEnabled: true, mediaPauseEnabled: true)
         harness.wait()
 
         #expect(harness.media.beginCalls.count == 1)
         #expect(harness.ducking.beginCalls == [true])
         #expect(harness.ducking.ensureCalls == 1)
+    }
+
+    @Test("short armed tap does not pause or duck audio")
+    func shortArmedTapDoesNotPauseOrDuckAudio() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        harness.manager.cancel(reason: "short-tap")
+        harness.wait()
+
+        #expect(harness.media.beginCalls.isEmpty)
+        #expect(harness.ducking.beginCalls.isEmpty)
+        #expect(harness.media.restoreCalls == 1)
+        #expect(harness.ducking.restoreCalls == 1)
     }
 
     @Test("stop restores media pause state")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -106,6 +106,18 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
     }
 
+    @Test("external session refreshes preferred input instead of using stale route cache")
+    func externalSessionRefreshesPreferredInput() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+        harness.route.cachedPreferredInputDeviceID = nil
+
+        harness.manager.beginExternalSession(source: "nemotron-toggle", duckingEnabled: true)
+        harness.wait()
+
+        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.ducking.beginCalls == [false])
+    }
+
     @Test("begin recording refreshes route changed after arm")
     func beginRecordingRefreshesRouteChangedAfterArm() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -336,6 +336,21 @@ struct DictationAudioSessionManagerTests {
 
         #expect(harness.media.restoreCalls == 1)
     }
+
+    @Test("cancel tears down warm recorder graph")
+    func cancelTearsDownWarmRecorderGraph() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.wait()
+        #expect(harness.recorder.keepsAudioGraphWarm)
+
+        harness.manager.cancel(reason: "test")
+        harness.wait()
+
+        #expect(harness.recorder.cancelCalls == 1)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+    }
 }
 
 private final class Harness {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -43,6 +43,7 @@ struct DictationAudioSessionManagerTests {
         harness.manager.beginRecording(mode: "start", duckingEnabled: true)
         harness.wait()
 
+        #expect(harness.recorder.activateCalls == 2)
         #expect(harness.recorder.prepareCalls == 1)
         #expect(harness.recorder.startCalls == 1)
         #expect(harness.events.contains { event in
@@ -87,6 +88,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.preferredInputDeviceID == 82)
         #expect(harness.recorder.startCalls == 1)
     }
@@ -104,7 +106,8 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 2)
-        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.activateCalls == 2)
+        #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.ducking.beginCalls == [false, true])
     }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -67,6 +67,19 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.preferredInputDeviceID == 82)
     }
 
+    @Test("unknown route skips ducking during output transitions")
+    func unknownRouteSkipsDuckingDuringOutputTransitions() {
+        let harness = Harness(routeKind: .unknown)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.wait()
+
+        #expect(harness.ducking.beginCalls.allSatisfy { $0 == false })
+        #expect(harness.ducking.ensureCalls == 1)
+        #expect(harness.recorder.startCalls == 1)
+    }
+
     @Test("arm refreshes preferred input instead of using stale route cache")
     func armRefreshesPreferredInput() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -145,6 +145,12 @@ struct DictationAudioSessionManagerTests {
             }
             return false
         })
+        #expect(harness.events.contains { event in
+            if case .audioRestored = event {
+                return true
+            }
+            return false
+        })
     }
 
     @Test("route refresh warms graph without opening mic")
@@ -155,6 +161,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 1)
         #expect(harness.recorder.warmUpCalls == 1)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)
@@ -306,8 +313,9 @@ private final class FakeDuckingManager: AudioDuckingManaging {
         ensureCalls += 1
     }
 
-    func restoreDictationDucking() {
+    func restoreDictationDucking(completion: (() -> Void)?) {
         restoreCalls += 1
+        completion?()
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -9,7 +9,7 @@ struct DictationAudioSessionManagerTests {
     func armActivatesWarmEngineWithoutStartingCapture() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.recorder.activateCalls == 1)
@@ -25,7 +25,7 @@ struct DictationAudioSessionManagerTests {
 
         harness.manager.refreshRoute(reason: "route-change", canWarmUp: true)
         let startedAt = Date()
-        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
         let elapsed = Date().timeIntervalSince(startedAt)
         harness.wait()
 
@@ -38,9 +38,9 @@ struct DictationAudioSessionManagerTests {
     func beginRecordingReusesDuplicateActivation() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true)
-        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
-        harness.manager.beginRecording(mode: "start", duckingEnabled: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.beginRecording(mode: "start", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.recorder.activateCalls == 2)
@@ -54,12 +54,38 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
+    @Test("begin recording queued behind a failed arm does not restart failed session")
+    func queuedBeginAfterFailedArmIsIgnored() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.recorder.activateError = NSError(domain: "DictationAudioSessionManagerTests", code: 1)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.beginRecording(mode: "hold-start", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.wait()
+
+        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.prepareCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.events.contains { event in
+            if case .failed = event {
+                return true
+            }
+            return false
+        })
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "stale_session_ignored:hold-start"
+            }
+            return false
+        })
+    }
+
     @Test("headphone route skips ducking and selects built-in mic")
     func headphoneRouteSkipsDucking() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true)
-        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.ducking.beginCalls.allSatisfy { $0 == false })
@@ -71,8 +97,8 @@ struct DictationAudioSessionManagerTests {
     func unknownRouteDucksDuringOutputTransitions() {
         let harness = Harness(routeKind: .unknown)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true)
-        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.ducking.beginCalls.allSatisfy { $0 == true })
@@ -85,7 +111,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: false)
+        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
@@ -97,7 +123,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
 
-        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false)
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
@@ -111,7 +137,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
 
-        harness.manager.beginExternalSession(source: "nemotron-toggle", duckingEnabled: true)
+        harness.manager.beginExternalSession(source: "nemotron-toggle", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
@@ -122,19 +148,38 @@ struct DictationAudioSessionManagerTests {
     func beginRecordingRefreshesRouteChangedAfterArm() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.arm(source: "hotkey", duckingEnabled: true)
+        harness.manager.arm(source: "hotkey", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
         harness.route.routeKind = .speakerLike
         harness.route.preferredInputDeviceID = nil
+        harness.route.cachedPreferredInputDeviceID = nil
 
-        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true)
+        harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
-        #expect(harness.route.preferredInputCalls == 2)
+        #expect(harness.route.preferredInputCalls == 1)
         #expect(harness.recorder.activateCalls == 2)
         #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.ducking.beginCalls == [false, true])
+    }
+
+    @Test("hold start uses cached route snapshot from arm path")
+    func holdStartUsesCachedRouteSnapshot() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.wait()
+        harness.manager.beginRecording(mode: "hold-start", duckingEnabled: false, mediaPauseEnabled: false)
+        harness.wait()
+
+        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name.hasPrefix("route_snapshot_cached:hold-start")
+            }
+            return false
+        })
     }
 
     @Test("stop restores ducking and emits wav URL")
@@ -143,7 +188,7 @@ struct DictationAudioSessionManagerTests {
         let wavURL = URL(fileURLWithPath: "/tmp/dictation.wav")
         harness.recorder.stopURL = wavURL
 
-        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true)
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
         harness.manager.stop()
         harness.wait()
@@ -199,7 +244,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
         harness.manager.refreshRoute(reason: "route-change", delay: 0.2, canWarmUp: true)
-        harness.manager.arm(source: "hotkey", duckingEnabled: false)
+        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: false)
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
@@ -222,7 +267,7 @@ struct DictationAudioSessionManagerTests {
     func recorderCallbacksEmitAudioStateEvents() {
         let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false)
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false, mediaPauseEnabled: false)
         harness.wait()
         let firstBufferAt = Date()
         harness.recorder.onFirstCapturedAudioBuffer?(firstBufferAt)
@@ -234,11 +279,36 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.events.contains { if case .speechDetected = $0 { return true }; return false })
         #expect(harness.events.contains { if case .noAudioTimeout = $0 { return true }; return false })
     }
+
+    @Test("media pause is requested with current route when enabled")
+    func mediaPauseRequestedWithCurrentRoute() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.arm(source: "hotkey", duckingEnabled: false, mediaPauseEnabled: true)
+        harness.wait()
+
+        #expect(harness.media.beginCalls == [
+            .init(enabled: true, routeKind: .speakerLike),
+        ])
+    }
+
+    @Test("stop restores media pause state")
+    func stopRestoresMediaPauseState() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: false, mediaPauseEnabled: true)
+        harness.wait()
+        harness.manager.stop()
+        harness.wait()
+
+        #expect(harness.media.restoreCalls == 1)
+    }
 }
 
 private final class Harness {
     let recorder = FakeDictationRecorder()
     let ducking = FakeDuckingManager()
+    let media = FakeMediaPlaybackManager()
     let route: FakeDictationRoute
     let managerQueue = DispatchQueue(label: "test.dictation-session.manager")
     let eventQueue = DispatchQueue(label: "test.dictation-session.events")
@@ -247,6 +317,7 @@ private final class Harness {
         let manager = DictationAudioSessionManager(
             recorder: recorder,
             duckingController: ducking,
+            mediaPlaybackController: media,
             routingController: route,
             queue: managerQueue,
             eventQueue: eventQueue
@@ -287,6 +358,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
     var stopURL: URL?
     var lastWarmInputDeviceID: AudioObjectID?
     var warmUpDelay: TimeInterval = 0
+    var activateError: Error?
 
     func prepare() throws {
         prepareCalls += 1
@@ -302,6 +374,9 @@ private final class FakeDictationRecorder: DictationAudioRecording {
 
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
         activateCalls += 1
+        if let activateError {
+            throw activateError
+        }
         lastWarmInputDeviceID = preferredInputDeviceID
     }
 
@@ -343,6 +418,24 @@ private final class FakeDuckingManager: AudioDuckingManaging {
     func restoreDictationDucking(completion: (() -> Void)?) {
         restoreCalls += 1
         completion?()
+    }
+}
+
+private struct MediaPauseBeginCall: Equatable {
+    let enabled: Bool
+    let routeKind: AudioOutputRouteKind
+}
+
+private final class FakeMediaPlaybackManager: MediaPlaybackManaging {
+    var beginCalls: [MediaPauseBeginCall] = []
+    var restoreCalls = 0
+
+    func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind) {
+        beginCalls.append(.init(enabled: enabled, routeKind: routeKind))
+    }
+
+    func restoreDictationMediaPause() {
+        restoreCalls += 1
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -67,6 +67,20 @@ struct MediaPlaybackControllerTests {
         #expect(client.toggleCalls == 1)
     }
 
+    @Test("restore resumes when output activity is unknown")
+    func restoreResumesWhenActivityIsUnknown() {
+        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        client.activityStatus = .unknown
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 2)
+    }
+
     @Test("duplicate begin only pauses once")
     func duplicateBeginOnlyPausesOnce() {
         let client = FakeMediaPlaybackClient(activityStatus: .active)

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MediaPlaybackController")
+struct MediaPlaybackControllerTests {
+    @Test("disabled setting is a no-op")
+    func disabledSettingIsNoOp() {
+        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: false, routeKind: .speakerLike)
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 0)
+    }
+
+    @Test("inactive output is skipped")
+    func inactiveOutputIsSkipped() {
+        let client = FakeMediaPlaybackClient(activityStatus: .inactive)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 0)
+    }
+
+    @Test("headphone output is skipped")
+    func headphoneOutputIsSkipped() {
+        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .headphoneLike)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 0)
+    }
+
+    @Test("speaker active output pauses and restores")
+    func speakerActiveOutputPausesAndRestores() {
+        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.toggleCalls == 1)
+
+        client.activityStatus = .inactive
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 2)
+    }
+
+    @Test("restore does not toggle if user already started playback")
+    func restoreDoesNotToggleActivePlayback() {
+        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 1)
+    }
+
+    @Test("duplicate begin only pauses once")
+    func duplicateBeginOnlyPausesOnce() {
+        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 1)
+    }
+
+    private func makeController(client: FakeMediaPlaybackClient) -> MediaPlaybackController {
+        MediaPlaybackController(
+            client: client,
+            queue: DispatchQueue(label: "test.media-playback")
+        )
+    }
+}
+
+private final class FakeMediaPlaybackClient: MediaPlaybackClient {
+    var activityStatus: AudioOutputActivityStatus
+    var toggleCalls = 0
+
+    init(activityStatus: AudioOutputActivityStatus) {
+        self.activityStatus = activityStatus
+    }
+
+    func outputActivityStatus() -> AudioOutputActivityStatus {
+        activityStatus
+    }
+
+    func sendMediaPlayPauseToggle() {
+        toggleCalls += 1
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1055,6 +1055,26 @@ struct HotkeyMonitorTests {
 
         #expect(startCount == 1)
     }
+
+    @Test("reconfiguring hotkey during active recording stops cleanly")
+    func configureKeyCodeDuringActiveRecordingStopsCleanly() {
+        let monitor = HotkeyMonitor()
+        var stopCount = 0
+        var cancelCount = 0
+        monitor.onStop = {
+            stopCount += 1
+        }
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        monitor.setHoldRecordingActiveForTests()
+        monitor.configure(keyCode: 56)
+
+        #expect(stopCount == 1)
+        #expect(cancelCount == 0)
+        #expect(monitor.targetKeyCode == 56)
+    }
 }
 
 @Suite("MeetingResummarizationPolicy")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1095,6 +1095,25 @@ struct HotkeyMonitorTests {
         #expect(cancelCount == 1)
         #expect(monitor.targetKeyCode == 56)
     }
+
+    @Test("changing trigger threshold during pending double tap cancel preserves cleanup")
+    @MainActor
+    func configureTriggerThresholdDuringPendingDoubleTapCancelPreservesCleanup() async throws {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.05)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        var cancelCount = 0
+        monitor.onArm = {}
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        monitor.configureTriggerThreshold(milliseconds: 125)
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(cancelCount == 1)
+    }
 }
 
 @Suite("MeetingResummarizationPolicy")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -420,6 +420,7 @@ struct AppConfigTests {
         #expect(config.enableComputerUsePlanner == true)
         #expect(config.computerUsePlannerModel.isEmpty)
         #expect(config.computerUseTimeoutSeconds == 120)
+        #expect(config.hotkeyTriggerThresholdMS == HotkeyTriggerTiming.defaultThresholdMilliseconds)
         #expect(config.showFloatingIndicator == true)
         #expect(config.indicatorAnchor == .midTrailing)
         #expect(config.hasCompletedOnboarding == false)
@@ -460,6 +461,7 @@ struct AppConfigTests {
         config.enableComputerUsePlanner = false
         config.computerUsePlannerModel = "gpt-5.4"
         config.computerUseTimeoutSeconds = 180
+        config.hotkeyTriggerThresholdMS = 125
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -487,6 +489,7 @@ struct AppConfigTests {
         #expect(decoded.enableComputerUsePlanner == false)
         #expect(decoded.computerUsePlannerModel == "gpt-5.4")
         #expect(decoded.computerUseTimeoutSeconds == 180)
+        #expect(decoded.hotkeyTriggerThresholdMS == 125)
     }
 
     @Test("JSON coding keys use snake_case")
@@ -503,6 +506,7 @@ struct AppConfigTests {
         #expect(json["enable_computer_use_planner"] != nil)
         #expect(json["computer_use_planner_model"] != nil)
         #expect(json["computer_use_timeout_seconds"] != nil)
+        #expect(json["hotkey_trigger_threshold_ms"] != nil)
         #expect(json["cohere_language"] != nil)
         #expect(json["meeting_transcription_backend"] != nil)
         #expect(json["meeting_transcription_model"] != nil)
@@ -544,6 +548,7 @@ struct AppConfigTests {
         #expect(config.enableComputerUsePlanner == true)
         #expect(config.computerUsePlannerModel.isEmpty)
         #expect(config.computerUseTimeoutSeconds == 120)
+        #expect(config.hotkeyTriggerThresholdMS == HotkeyTriggerTiming.defaultThresholdMilliseconds)
         #expect(config.meetingHookEnabled == false)
         #expect(config.meetingHookPath.isEmpty)
         #expect(config.meetingHookTimeoutSeconds == 30)
@@ -954,6 +959,101 @@ struct HotkeyMonitorTests {
                 firstResponder: textView
             ) == true
         )
+    }
+
+    @Test("trigger threshold derives prepare and start delays")
+    func triggerThresholdTiming() {
+        #expect(HotkeyTriggerTiming.clampedMilliseconds(10) == HotkeyTriggerTiming.minThresholdMilliseconds)
+        #expect(HotkeyTriggerTiming.clampedMilliseconds(2_000) == HotkeyTriggerTiming.maxThresholdMilliseconds)
+        #expect(HotkeyTriggerTiming.startDelay(forThresholdMilliseconds: 250) == 0.25)
+        #expect(HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: 250) == 0.15)
+        #expect(HotkeyTriggerTiming.prepareDelay(forThresholdMilliseconds: 100) == 0)
+    }
+
+    @Test("low trigger threshold still allows double-tap toggle")
+    @MainActor
+    func lowTriggerThresholdStillAllowsDoubleTapToggle() async throws {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        var prepareCount = 0
+        var toggleStartCount = 0
+        monitor.onPrepare = {
+            prepareCount += 1
+        }
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        try await Task.sleep(for: .milliseconds(100))
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+
+        #expect(prepareCount == 0)
+        #expect(toggleStartCount == 1)
+    }
+
+    @Test("low trigger threshold arms immediately but defers audio while double-tap is possible")
+    @MainActor
+    func lowTriggerThresholdArmsImmediatelyButDefersAudio() async throws {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        var armCount = 0
+        var prepareCount = 0
+        var startCount = 0
+        monitor.onArm = {
+            armCount += 1
+        }
+        monitor.onPrepare = {
+            prepareCount += 1
+        }
+        monitor.onStart = {
+            startCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        #expect(armCount == 1)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(prepareCount == 0)
+        #expect(startCount == 0)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+    }
+
+    @Test("quick armed tap cancels after double-tap window")
+    @MainActor
+    func quickArmedTapCancelsAfterDoubleTapWindow() async throws {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.05)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        var cancelCount = 0
+        monitor.onArm = {}
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        #expect(cancelCount == 0)
+
+        try await Task.sleep(for: .milliseconds(80))
+        #expect(cancelCount == 1)
+    }
+
+    @Test("low trigger threshold starts quickly when double-tap is disabled")
+    @MainActor
+    func lowTriggerThresholdStartsQuicklyWhenDoubleTapDisabled() async throws {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        monitor.doubleTapEnabled = false
+        var startCount = 0
+        monitor.onStart = {
+            startCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        try await Task.sleep(for: .milliseconds(100))
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+
+        #expect(startCount == 1)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1201,6 +1201,12 @@ struct AppConfigAppearanceTests {
         #expect(config.soundEnabled == true)
     }
 
+    @Test("muteSystemAudioDuringDictation defaults to false")
+    func muteSystemAudioDuringDictationDefault() {
+        let config = AppConfig()
+        #expect(config.muteSystemAudioDuringDictation == false)
+    }
+
     @Test("recordingColorHex defaults to Catppuccin Mocha base")
     func recordingColorHexDefault() {
         let config = AppConfig()
@@ -1214,6 +1220,15 @@ struct AppConfigAppearanceTests {
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.soundEnabled == false)
+    }
+
+    @Test("muteSystemAudioDuringDictation round-trips through JSON")
+    func muteSystemAudioDuringDictationRoundTrip() throws {
+        var config = AppConfig()
+        config.muteSystemAudioDuringDictation = true
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.muteSystemAudioDuringDictation == true)
     }
 
     @Test("recordingColorHex round-trips through JSON")
@@ -1232,6 +1247,13 @@ struct AppConfigAppearanceTests {
         #expect(decoded.soundEnabled == true)
     }
 
+    @Test("unknown JSON keys are ignored — muteSystemAudioDuringDictation falls back to default")
+    func muteSystemAudioDuringDictationFallsBackOnMissingKey() throws {
+        let json = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(decoded.muteSystemAudioDuringDictation == false)
+    }
+
     @Test("unknown JSON keys are ignored — recordingColorHex falls back to default")
     func recordingColorHexFallsBackOnMissingKey() throws {
         let json = Data("{}".utf8)
@@ -1246,6 +1268,15 @@ struct AppConfigAppearanceTests {
         let data = try JSONEncoder().encode(config)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(json?["sound_enabled"] as? Bool == false)
+    }
+
+    @Test("muteSystemAudioDuringDictation CodingKey is mute_system_audio_during_dictation")
+    func muteSystemAudioDuringDictationCodingKey() throws {
+        var config = AppConfig()
+        config.muteSystemAudioDuringDictation = true
+        let data = try JSONEncoder().encode(config)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["mute_system_audio_during_dictation"] as? Bool == true)
     }
 
     @Test("recordingColorHex CodingKey is recording_color_hex")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1075,6 +1075,26 @@ struct HotkeyMonitorTests {
         #expect(cancelCount == 0)
         #expect(monitor.targetKeyCode == 56)
     }
+
+    @Test("reconfiguring hotkey during pending double tap cancel cancels cleanly")
+    @MainActor
+    func configureKeyCodeDuringPendingDoubleTapCancelCancelsCleanly() async throws {
+        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        var cancelCount = 0
+        monitor.onArm = {}
+        monitor.onCancel = {
+            cancelCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        monitor.configure(keyCode: 56)
+        try await Task.sleep(for: .milliseconds(380))
+
+        #expect(cancelCount == 1)
+        #expect(monitor.targetKeyCode == 56)
+    }
 }
 
 @Suite("MeetingResummarizationPolicy")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -1366,6 +1366,12 @@ struct AppConfigAppearanceTests {
         #expect(config.muteSystemAudioDuringDictation == false)
     }
 
+    @Test("pauseMediaDuringDictation defaults to false")
+    func pauseMediaDuringDictationDefault() {
+        let config = AppConfig()
+        #expect(config.pauseMediaDuringDictation == false)
+    }
+
     @Test("recordingColorHex defaults to Catppuccin Mocha base")
     func recordingColorHexDefault() {
         let config = AppConfig()
@@ -1388,6 +1394,15 @@ struct AppConfigAppearanceTests {
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.muteSystemAudioDuringDictation == true)
+    }
+
+    @Test("pauseMediaDuringDictation round-trips through JSON")
+    func pauseMediaDuringDictationRoundTrip() throws {
+        var config = AppConfig()
+        config.pauseMediaDuringDictation = true
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.pauseMediaDuringDictation == true)
     }
 
     @Test("recordingColorHex round-trips through JSON")
@@ -1413,6 +1428,13 @@ struct AppConfigAppearanceTests {
         #expect(decoded.muteSystemAudioDuringDictation == false)
     }
 
+    @Test("unknown JSON keys are ignored — pauseMediaDuringDictation falls back to default")
+    func pauseMediaDuringDictationFallsBackOnMissingKey() throws {
+        let json = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(decoded.pauseMediaDuringDictation == false)
+    }
+
     @Test("unknown JSON keys are ignored — recordingColorHex falls back to default")
     func recordingColorHexFallsBackOnMissingKey() throws {
         let json = Data("{}".utf8)
@@ -1436,6 +1458,15 @@ struct AppConfigAppearanceTests {
         let data = try JSONEncoder().encode(config)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(json?["mute_system_audio_during_dictation"] as? Bool == true)
+    }
+
+    @Test("pauseMediaDuringDictation CodingKey is pause_media_during_dictation")
+    func pauseMediaDuringDictationCodingKey() throws {
+        var config = AppConfig()
+        config.pauseMediaDuringDictation = true
+        let data = try JSONEncoder().encode(config)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["pause_media_during_dictation"] as? Bool == true)
     }
 
     @Test("recordingColorHex CodingKey is recording_color_hex")

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -68,10 +68,10 @@ struct StreamingDictationControllerTests {
 
     @available(macOS 15, *)
     @Test("stop returns empty string when not started")
-    func stopWithoutStart() {
+    func stopWithoutStart() async {
         let transcriber = NemotronStreamingTranscriber()
         let controller = StreamingDictationController(transcriber: transcriber)
-        let result = controller.stop()
+        let result = await stop(controller)
         #expect(result.isEmpty)
     }
 
@@ -228,11 +228,11 @@ struct StreamingDictationControllerLifecycleTests {
 
     @available(macOS 15, *)
     @Test("double stop is safe")
-    func doubleStop() {
+    func doubleStop() async {
         let transcriber = NemotronStreamingTranscriber()
         let controller = StreamingDictationController(transcriber: transcriber)
-        let result1 = controller.stop()
-        let result2 = controller.stop()
+        let result1 = await stop(controller)
+        let result2 = await stop(controller)
         #expect(result1.isEmpty)
         #expect(result2.isEmpty)
     }
@@ -244,6 +244,15 @@ struct StreamingDictationControllerLifecycleTests {
         let controller = StreamingDictationController(transcriber: transcriber)
         // warmup should handle errors gracefully
         controller.warmup()
+    }
+}
+
+@available(macOS 15, *)
+private func stop(_ controller: StreamingDictationController) async -> String {
+    await withCheckedContinuation { continuation in
+        controller.stop { text in
+            continuation.resume(returning: text)
+        }
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -165,6 +165,31 @@ struct StreamingDictationControllerTests {
     }
 
     @available(macOS 15, *)
+    @Test("concurrent stops share one drain and transcript")
+    func concurrentStopsShareOneDrainAndTranscript() async {
+        let transcriber = DelayedNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+
+        async let firstStop = stop(controller)
+        async let secondStop = stop(controller)
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(recorder.stopCalls == 1)
+        #expect(await transcriber.transcribeCalls == 0)
+
+        await transcriber.releaseState()
+        let results = await [firstStop, secondStop]
+        #expect(results == [" hello", " hello"])
+        #expect(await transcriber.transcribeCalls == 1)
+    }
+
+    @available(macOS 15, *)
     @Test("stop completes when stream state initialization stalls")
     func stopCompletesWhenStreamStateInitializationStalls() async {
         let transcriber = HangingNemotronStreamingTranscriber()

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -90,6 +90,37 @@ struct StreamingDictationControllerTests {
         #expect(recorder.prepareCalls == 2)
         #expect(recorder.cancelCalls == 2)
     }
+
+    @available(macOS 15, *)
+    @Test("stream state failure cancels mic session and permits retry")
+    func streamStateFailureCancelsMicSessionAndPermitsRetry() async {
+        let transcriber = FailingNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let failures = FailureCounter()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+        controller.onFailure = { _ in
+            failures.increment()
+        }
+
+        #expect(controller.start() == true)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(transcriber.makeStateCalls == 1)
+        #expect(recorder.prepareCalls == 1)
+        #expect(recorder.startCalls == 1)
+        #expect(recorder.cancelCalls == 1)
+        #expect(failures.value == 1)
+
+        #expect(controller.start() == true)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(transcriber.makeStateCalls == 2)
+        #expect(recorder.prepareCalls == 2)
+        #expect(recorder.startCalls == 2)
+        #expect(recorder.cancelCalls == 2)
+        #expect(failures.value == 2)
+    }
 }
 
 private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
@@ -114,6 +145,64 @@ private final class FailingStreamingDictationRecorder: StreamingDictationRecordi
 
     func cancel() {
         cancelCalls += 1
+    }
+}
+
+@available(macOS 15, *)
+private final class FailingNemotronStreamingTranscriber: NemotronStreamingTranscribing {
+    var makeStateCalls = 0
+
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        makeStateCalls += 1
+        throw NSError(domain: "FailingNemotronStreamingTranscriber", code: 1)
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        ""
+    }
+}
+
+private final class InspectableStreamingDictationRecorder: StreamingDictationRecording {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
+    var prepareCalls = 0
+    var startCalls = 0
+    var stopCalls = 0
+    var cancelCalls = 0
+
+    func prepare() throws {
+        prepareCalls += 1
+    }
+
+    func start() throws {
+        startCalls += 1
+    }
+
+    func stop() -> URL? {
+        stopCalls += 1
+        return nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+}
+
+private final class FailureCounter {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var value: Int {
+        lock.withLock { storage }
+    }
+
+    func increment() {
+        lock.withLock {
+            storage += 1
+        }
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -216,6 +216,29 @@ struct StreamingDictationControllerTests {
     }
 
     @available(macOS 15, *)
+    @Test("stop removes unused recorder WAV output")
+    func stopRemovesUnusedRecorderWavOutput() async throws {
+        let transcriber = DelayedNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+        let wavURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("wav")
+        try Data([1, 2, 3]).write(to: wavURL)
+        recorder.stopURL = wavURL
+
+        #expect(controller.start() == true)
+        async let stoppedText = stop(controller)
+        await transcriber.releaseState()
+        _ = await stoppedText
+
+        #expect(!FileManager.default.fileExists(atPath: wavURL.path))
+    }
+
+    @available(macOS 15, *)
     @Test("chunk transcription failure cancels mic session and permits retry")
     func chunkTranscriptionFailureCancelsMicSessionAndPermitsRetry() async {
         let transcriber = ThrowingChunkNemotronStreamingTranscriber()
@@ -313,6 +336,7 @@ private final class InspectableStreamingDictationRecorder: StreamingDictationRec
     var cancelCalls = 0
     var preparedPreferredInputDeviceID: AudioObjectID?
     var startedPreferredInputDeviceID: AudioObjectID?
+    var stopURL: URL?
 
     func prepare() throws {
         prepareCalls += 1
@@ -330,7 +354,7 @@ private final class InspectableStreamingDictationRecorder: StreamingDictationRec
 
     func stop() -> URL? {
         stopCalls += 1
-        return nil
+        return stopURL
     }
 
     func cancel() {

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -140,6 +140,29 @@ struct StreamingDictationControllerTests {
         #expect(recorder.startCalls == 1)
         controller.cancel()
     }
+
+    @available(macOS 15, *)
+    @Test("stop waits for pending stream state before draining queued audio")
+    func stopWaitsForPendingStreamStateBeforeDrainingQueuedAudio() async {
+        let transcriber = DelayedNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+
+        async let stoppedText = stop(controller)
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(await transcriber.transcribeCalls == 0)
+
+        await transcriber.releaseState()
+        let text = await stoppedText
+        #expect(text == " hello")
+        #expect(await transcriber.transcribeCalls == 1)
+    }
 }
 
 private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
@@ -204,6 +227,10 @@ private final class InspectableStreamingDictationRecorder: StreamingDictationRec
         startedPreferredInputDeviceID = preferredInputDeviceID
     }
 
+    func emit(samples: [Float]) {
+        onAudioBuffer?(samples)
+    }
+
     func stop() -> URL? {
         stopCalls += 1
         return nil
@@ -211,6 +238,38 @@ private final class InspectableStreamingDictationRecorder: StreamingDictationRec
 
     func cancel() {
         cancelCalls += 1
+    }
+}
+
+@available(macOS 15, *)
+private actor DelayedNemotronStreamingTranscriber: NemotronStreamingTranscribing {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+    private(set) var transcribeCalls = 0
+
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        if !released {
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+        return try await NemotronStreamingTranscriber().makeStreamState()
+    }
+
+    func releaseState() {
+        released = true
+        if let continuation {
+            self.continuation = nil
+            continuation.resume()
+        }
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        transcribeCalls += 1
+        return " hello"
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -283,6 +283,28 @@ struct StreamingDictationControllerTests {
         #expect(text.isEmpty)
         #expect(elapsed < 2.5)
     }
+
+    @available(macOS 15, *)
+    @Test("stop completes when stream state initialization ignores cancellation")
+    func stopCompletesWhenStreamStateInitializationIgnoresCancellation() async {
+        let transcriber = CancellationIgnoringNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+
+        let startedAt = Date()
+        let text = await stop(controller)
+        let elapsed = Date().timeIntervalSince(startedAt)
+        await transcriber.releaseState()
+
+        #expect(text.isEmpty)
+        #expect(elapsed < 2.5)
+    }
 }
 
 private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
@@ -417,6 +439,36 @@ private final class HangingNemotronStreamingTranscriber: NemotronStreamingTransc
         while true {
             try Task.checkCancellation()
             try await Task.sleep(for: .milliseconds(100))
+        }
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        "should not be reached"
+    }
+}
+
+@available(macOS 15, *)
+private actor CancellationIgnoringNemotronStreamingTranscriber: NemotronStreamingTranscribing {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        if !released {
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+        return try await NemotronStreamingTranscriber().makeStreamState()
+    }
+
+    func releaseState() {
+        released = true
+        if let continuation {
+            self.continuation = nil
+            continuation.resume()
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -270,7 +270,8 @@ struct StreamingDictationControllerTests {
         let recorder = InspectableStreamingDictationRecorder()
         let controller = StreamingDictationController(
             transcriber: transcriber,
-            recorder: recorder
+            recorder: recorder,
+            stopStreamStateTimeout: 1.0
         )
 
         #expect(controller.start() == true)
@@ -291,7 +292,8 @@ struct StreamingDictationControllerTests {
         let recorder = InspectableStreamingDictationRecorder()
         let controller = StreamingDictationController(
             transcriber: transcriber,
-            recorder: recorder
+            recorder: recorder,
+            stopStreamStateTimeout: 1.0
         )
 
         #expect(controller.start() == true)
@@ -304,6 +306,29 @@ struct StreamingDictationControllerTests {
 
         #expect(text.isEmpty)
         #expect(elapsed < 2.5)
+    }
+
+    @available(macOS 15, *)
+    @Test("stop waits for cold stream state and drains final queued chunk")
+    func stopWaitsForColdStreamStateAndDrainsFinalQueuedChunk() async {
+        let transcriber = DelayedNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder,
+            stopStreamStateTimeout: 2.0
+        )
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+
+        async let stoppedText = stop(controller)
+        try? await Task.sleep(for: .milliseconds(1_100))
+        await transcriber.releaseState()
+
+        let text = await stoppedText
+        #expect(text == " hello")
+        #expect(await transcriber.transcribeCalls == 1)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -121,6 +121,25 @@ struct StreamingDictationControllerTests {
         #expect(recorder.cancelCalls == 2)
         #expect(failures.value == 2)
     }
+
+    @available(macOS 15, *)
+    @Test("start prepares routed input before mic capture")
+    func startPreparesRoutedInputBeforeMicCapture() {
+        let transcriber = FailingNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            preferredInputDeviceID: 82,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == true)
+        #expect(recorder.preparedPreferredInputDeviceID == 82)
+        #expect(recorder.startedPreferredInputDeviceID == 82)
+        #expect(recorder.prepareCalls == 1)
+        #expect(recorder.startCalls == 1)
+        controller.cancel()
+    }
 }
 
 private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
@@ -172,13 +191,17 @@ private final class InspectableStreamingDictationRecorder: StreamingDictationRec
     var startCalls = 0
     var stopCalls = 0
     var cancelCalls = 0
+    var preparedPreferredInputDeviceID: AudioObjectID?
+    var startedPreferredInputDeviceID: AudioObjectID?
 
     func prepare() throws {
         prepareCalls += 1
+        preparedPreferredInputDeviceID = preferredInputDeviceID
     }
 
     func start() throws {
         startCalls += 1
+        startedPreferredInputDeviceID = preferredInputDeviceID
     }
 
     func stop() -> URL? {

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import CoreAudio
 @testable import MuesliNativeApp
 
 @Suite("NemotronStreamState")
@@ -72,6 +73,47 @@ struct StreamingDictationControllerTests {
         let controller = StreamingDictationController(transcriber: transcriber)
         let result = controller.stop()
         #expect(result.isEmpty)
+    }
+
+    @available(macOS 15, *)
+    @Test("failed mic start resets active state")
+    func failedMicStartResetsActiveState() {
+        let transcriber = NemotronStreamingTranscriber()
+        let recorder = FailingStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == false)
+        #expect(controller.start() == false)
+        #expect(recorder.prepareCalls == 2)
+        #expect(recorder.cancelCalls == 2)
+    }
+}
+
+private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
+    var prepareCalls = 0
+    var startCalls = 0
+    var cancelCalls = 0
+
+    func prepare() throws {
+        prepareCalls += 1
+        throw NSError(domain: "FailingStreamingDictationRecorder", code: 1)
+    }
+
+    func start() throws {
+        startCalls += 1
+    }
+
+    func stop() -> URL? {
+        nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -190,6 +190,32 @@ struct StreamingDictationControllerTests {
     }
 
     @available(macOS 15, *)
+    @Test("start during stop does not drop pending stop completion")
+    func startDuringStopDoesNotDropPendingStopCompletion() async {
+        let transcriber = DelayedNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+
+        async let stoppedText = stop(controller)
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(controller.start() == false)
+        #expect(recorder.stopCalls == 1)
+        #expect(recorder.startCalls == 1)
+
+        await transcriber.releaseState()
+        let text = await stoppedText
+        #expect(text == " hello")
+        #expect(controller.start() == true)
+        controller.cancel()
+    }
+
+    @available(macOS 15, *)
     @Test("stop completes when stream state initialization stalls")
     func stopCompletesWhenStreamStateInitializationStalls() async {
         let transcriber = HangingNemotronStreamingTranscriber()

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -163,6 +163,27 @@ struct StreamingDictationControllerTests {
         #expect(text == " hello")
         #expect(await transcriber.transcribeCalls == 1)
     }
+
+    @available(macOS 15, *)
+    @Test("stop completes when stream state initialization stalls")
+    func stopCompletesWhenStreamStateInitializationStalls() async {
+        let transcriber = HangingNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+
+        let startedAt = Date()
+        let text = await stop(controller)
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        #expect(text.isEmpty)
+        #expect(elapsed < 2.5)
+    }
 }
 
 private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
@@ -270,6 +291,23 @@ private actor DelayedNemotronStreamingTranscriber: NemotronStreamingTranscribing
     ) async throws -> String {
         transcribeCalls += 1
         return " hello"
+    }
+}
+
+@available(macOS 15, *)
+private final class HangingNemotronStreamingTranscriber: NemotronStreamingTranscribing {
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        while true {
+            try Task.checkCancellation()
+            try await Task.sleep(for: .milliseconds(100))
+        }
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        "should not be reached"
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -216,6 +216,31 @@ struct StreamingDictationControllerTests {
     }
 
     @available(macOS 15, *)
+    @Test("chunk transcription failure cancels mic session and permits retry")
+    func chunkTranscriptionFailureCancelsMicSessionAndPermitsRetry() async {
+        let transcriber = ThrowingChunkNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let failures = FailureCounter()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+        controller.onFailure = { _ in
+            failures.increment()
+        }
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(await transcriber.transcribeCalls == 1)
+        #expect(recorder.cancelCalls == 1)
+        #expect(failures.value == 1)
+        #expect(controller.start() == true)
+        controller.cancel()
+    }
+
+    @available(macOS 15, *)
     @Test("stop completes when stream state initialization stalls")
     func stopCompletesWhenStreamStateInitializationStalls() async {
         let transcriber = HangingNemotronStreamingTranscriber()
@@ -342,6 +367,23 @@ private actor DelayedNemotronStreamingTranscriber: NemotronStreamingTranscribing
     ) async throws -> String {
         transcribeCalls += 1
         return " hello"
+    }
+}
+
+@available(macOS 15, *)
+private actor ThrowingChunkNemotronStreamingTranscriber: NemotronStreamingTranscribing {
+    private(set) var transcribeCalls = 0
+
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        try await NemotronStreamingTranscriber().makeStreamState()
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        transcribeCalls += 1
+        throw NSError(domain: "ThrowingChunkNemotronStreamingTranscriber", code: 1)
     }
 }
 


### PR DESCRIPTION
## Summary
- adds opt-in CoreAudio-based system audio ducking for hotkey dictation
- routes headphone/AirPods dictation toward the built-in mic while leaving headphone output playing
- moves dictation recorder startup onto an AVAudioEngine warm-graph path with cached route lookup and latency logging
- adds hotkey threshold settings and focused tests for ducking, route classification, and config defaults

## Why
Issue #119 requested audio ducking during dictation. During local AirPods testing, direct CoreAudio route/activity work on the hotkey path also exposed latency problems, so this PR keeps the hotkey/UI path cheap and avoids speaker-style ducking for headphone-class outputs.

## Local profiling notes
Recent AirPods traces show the hotkey/UI path at 0 ms, cached route enqueue at 2-4 ms, and first audio buffer around 336-857 ms depending on route warmth. A cold Bluetooth/HAL activation outlier was still observed around 4s, but the normal recent AirPods path is now under about 1s.

## Validation
- `git diff --check`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"`
- `MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" ./scripts/dev-test.sh`

Fixes #119