### PR TITLE
Add per-backend configurable max output tokens

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -518,6 +518,13 @@ enum MeetingSummaryClient {
         let chatURL = baseURL.appendingPathComponent("v1/chat/completions")
 
         let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredModel.isEmpty else {
+            throw MeetingSummaryError.backendFailed(
+                backend: "LM Studio",
+                statusCode: nil,
+                message: "No model selected. Please select a model from the dropdown in Settings."
+            )
+        }
         let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
         let userPrompt = summaryUserPrompt(
             transcript: transcript,
@@ -904,6 +911,10 @@ enum MeetingSummaryClient {
         }
         let chatURL = baseURL.appendingPathComponent("v1/chat/completions")
         let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredModel.isEmpty else {
+            fputs("[summary] LM Studio title generation: no model selected\n", stderr)
+            return nil
+        }
 
         let body: [String: Any] = [
             "model": configuredModel,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -26,6 +26,7 @@ enum MeetingSummaryClient {
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
+    private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
     private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
     private static let defaultChatGPTModel = "gpt-5.4-mini"
@@ -33,6 +34,8 @@ enum MeetingSummaryClient {
     private static let defaultSummaryMaxOutputTokens = 2500
     private static let ollamaSummaryTimeout: TimeInterval = 300
     private static let ollamaTitleTimeout: TimeInterval = 120
+    private static let lmStudioSummaryTimeout: TimeInterval = 300
+    private static let lmStudioTitleTimeout: TimeInterval = 120
 
     private static let titleInstructions = """
     Generate a short, descriptive meeting title (3-7 words) from this transcript. \
@@ -84,6 +87,18 @@ enum MeetingSummaryClient {
         }
         if backend == MeetingSummaryBackendOption.ollama.backend {
             generatedNotes = try await summarizeWithOllama(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
+        if backend == MeetingSummaryBackendOption.lmStudio.backend {
+            generatedNotes = try await summarizeWithLMStudio(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -481,6 +496,70 @@ enum MeetingSummaryClient {
         }
     }
 
+    private static func summarizeWithLMStudio(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil
+    ) async throws -> String {
+        let baseURLString = config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL: URL
+        if baseURLString.isEmpty {
+            baseURL = defaultLMStudioBaseURL
+        } else {
+            guard let url = URL(string: baseURLString) else {
+                throw MeetingSummaryError.backendFailed(backend: "LM Studio", statusCode: nil, message: "Invalid LM Studio URL: \(baseURLString)")
+            }
+            baseURL = url
+        }
+        let chatURL = baseURL.appendingPathComponent("v1/chat/completions")
+
+        let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
+        let userPrompt = summaryUserPrompt(
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            visualContext: visualContext
+        )
+        let body: [String: Any] = [
+            "model": configuredModel,
+            "messages": [
+                ["role": "system", "content": instructions],
+                ["role": "user", "content": userPrompt],
+            ],
+            "max_tokens": defaultSummaryMaxOutputTokens,
+        ]
+
+        var request = URLRequest(url: chatURL)
+        request.timeoutInterval = lmStudioSummaryTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "LM Studio")
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let text = extractOpenRouterText(from: json),
+                !text.isEmpty
+            else {
+                if let message = extractErrorMessage(from: data) {
+                    throw MeetingSummaryError.backendFailed(backend: "LM Studio", statusCode: nil, message: message)
+                }
+                throw MeetingSummaryError.emptyResponse(backend: "LM Studio")
+            }
+            return text
+        } catch {
+            throw summaryRequestError(backend: "LM Studio", error: error)
+        }
+    }
+
     /// Call the WHAM streaming API and collect the full response text.
     private static func callWHAM(systemPrompt: String, userPrompt: String, model: String) async throws -> String? {
         let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
@@ -664,6 +743,10 @@ enum MeetingSummaryClient {
             return await generateTitleWithOllama(transcript: truncated, config: config)
         }
 
+        if backend == MeetingSummaryBackendOption.lmStudio.backend {
+            return await generateTitleWithLMStudio(transcript: truncated, config: config)
+        }
+
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey
         guard !apiKey.isEmpty else { return nil }
         let model = config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel
@@ -803,6 +886,61 @@ enum MeetingSummaryClient {
             return nil
         } catch {
             fputs("[summary] Ollama title generation failed: \(error)\n", stderr)
+            return nil
+        }
+    }
+
+    private static func generateTitleWithLMStudio(transcript: String, config: AppConfig) async -> String? {
+        let baseURLString = config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL: URL
+        if baseURLString.isEmpty {
+            baseURL = defaultLMStudioBaseURL
+        } else {
+            guard let url = URL(string: baseURLString) else {
+                fputs("[summary] LM Studio title generation: invalid URL \(baseURLString)\n", stderr)
+                return nil
+            }
+            baseURL = url
+        }
+        let chatURL = baseURL.appendingPathComponent("v1/chat/completions")
+        let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let body: [String: Any] = [
+            "model": configuredModel,
+            "messages": [
+                ["role": "system", "content": titleInstructions],
+                ["role": "user", "content": transcript],
+            ],
+            "max_tokens": 100,
+        ]
+
+        var request = URLRequest(url: chatURL)
+        request.timeoutInterval = lmStudioTitleTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "LM Studio")
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let text = extractOpenRouterText(from: json),
+                  !text.isEmpty else {
+                fputs("[summary] LM Studio title generation: empty or invalid response\n", stderr)
+                return nil
+            }
+            let title = text.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+            guard !title.isEmpty else {
+                fputs("[summary] LM Studio title generation: trimmed response is empty\n", stderr)
+                return nil
+            }
+            fputs("[summary] LM Studio generated title: \(title)\n", stderr)
+            return title
+        } catch let error as MeetingSummaryError {
+            fputs("[summary] LM Studio title generation failed: \(error.localizedDescription)\n", stderr)
+            return nil
+        } catch {
+            fputs("[summary] LM Studio title generation failed: \(error)\n", stderr)
             return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -13,7 +13,7 @@ enum MeetingSummaryError: LocalizedError {
             let statusText = statusCode.map { " Status \($0)." } ?? ""
             return "\(backend) could not generate meeting notes.\(statusText) \(message) The selected model may be unavailable or retired."
         case let .emptyResponse(backend):
-            return "\(backend) returned an empty response while generating meeting notes. The selected model may be unavailable or incompatible."
+            return "\(backend) returned an empty response while generating meeting notes. The selected model may be unavailable or incompatible. If using a reasoning or thinking model, try increasing the output token limit in Settings."
         case let .requestFailed(backend, underlying):
             return "\(backend) could not be reached while generating meeting notes. \(underlying.localizedDescription)"
         }
@@ -31,7 +31,6 @@ enum MeetingSummaryClient {
     private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
     private static let defaultChatGPTModel = "gpt-5.4-mini"
     private static let defaultOllamaModel = "qwen3.5"
-    private static let defaultSummaryMaxOutputTokens = 2500
     private static let ollamaSummaryTimeout: TimeInterval = 300
     private static let ollamaTitleTimeout: TimeInterval = 120
     private static let lmStudioSummaryTimeout: TimeInterval = 300
@@ -310,7 +309,7 @@ enum MeetingSummaryClient {
             ],
             "reasoning": ["effort": "low"],
             "text": ["verbosity": "low"],
-            "max_output_tokens": defaultSummaryMaxOutputTokens,
+            "max_output_tokens": config.openAISummaryMaxTokens,
         ]
 
         var request = URLRequest(url: openAIURL)
@@ -368,7 +367,7 @@ enum MeetingSummaryClient {
                 ["role": "system", "content": instructions],
                 ["role": "user", "content": userPrompt],
             ],
-            "max_tokens": defaultSummaryMaxOutputTokens,
+            "max_tokens": config.openRouterSummaryMaxTokens,
         ]
 
         var request = URLRequest(url: openRouterURL)
@@ -467,7 +466,7 @@ enum MeetingSummaryClient {
                 ["role": "user", "content": userPrompt],
             ],
             "stream": false,
-            "options": ["num_predict": defaultSummaryMaxOutputTokens],
+            "options": ["num_predict": config.ollamaSummaryMaxTokens],
         ]
 
         var request = URLRequest(url: chatURL)
@@ -539,7 +538,7 @@ enum MeetingSummaryClient {
                 ["role": "system", "content": instructions],
                 ["role": "user", "content": userPrompt],
             ],
-            "max_tokens": defaultSummaryMaxOutputTokens,
+            "max_tokens": config.lmStudioSummaryMaxTokens,
         ]
 
         var request = URLRequest(url: chatURL)

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelTokenCap.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelTokenCap.swift
@@ -1,0 +1,279 @@
+import Foundation
+
+/// Comprehensive static map of vendor-documented maximum output-token limits.
+///
+/// Sources:
+/// - OpenAI: platform.openai.com/docs/models (May 2026)
+/// - Anthropic: docs.anthropic.com/en/docs/about-claude/models (May 2026)
+/// - Google Gemini: ai.google.dev/gemini-api/docs/models
+/// - Meta Llama: github.com/meta-llama/llama-models
+/// - OpenRouter API: openrouter.ai/api/v1/models
+/// - Ollama / GGUF community knowledge for open-weight models
+enum ModelTokenCap {
+
+    /// Lookup max output tokens by normalized model identifier.
+    ///
+    /// - If the exact ID is known (incl. dated snapshots), returns that cap.
+    /// - If the exact ID is not found, strips the `:tag` or dated suffix and
+    ///   tries again against known base models.
+    static func maxOutputTokens(forModelID modelID: String) -> Int? {
+        let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Exact match first
+        if let exact = exactMap[trimmed] {
+            return exact
+        }
+
+        // Normalize: remove provider prefixes ("anthropic/", "openai/", etc.)
+        let normalized = normalize(modelID: trimmed)
+
+        // Strip qualifiers (:latest, :free, dated snapshots, quantization tags)
+        let base = stripTag(from: normalized)
+        if let baseCap = exactMap[base] ?? exactMap[normalized] {
+            return baseCap
+        }
+
+        // Vendor-specific fallback families
+        if normalized.contains("claude-opus") { return 128_000 }
+        if normalized.contains("claude-sonnet") { return 64_000 }
+        if normalized.contains("claude-haiku") { return 64_000 }
+        if normalized.contains("gpt-5.5") { return 128_000 }
+        if normalized.contains("gpt-5.4") { return 128_000 }
+        if normalized.contains("gpt-5") { return 64_000 }
+        if normalized.contains("gpt-4o") { return 16_384 }
+        if normalized.contains("o1") || normalized.contains("o3") { return 100_000 }
+        if normalized.contains("gemini") { return 8_192 }
+        if normalized.contains("llama-4-") { return 1_000_000 }
+        if normalized.contains("llama-3.1-") || normalized.contains("llama3.1") { return 128_000 }
+        if normalized.contains("llama-3-") || normalized.contains("llama3") { return 8_192 }
+        if normalized.contains("qwen3") { return 128_000 }
+        if normalized.contains("qwen2.5") { return 128_000 }
+        if normalized.contains("qwen2") { return 128_000 }
+        if normalized.contains("deepseek-v3") { return 8_192 }
+        if normalized.contains("deepseek-coder") { return 128_000 }
+        if normalized.contains("deepseek-v2") { return 128_000 }
+        if normalized.contains("mistral-large") { return 128_000 }
+        if normalized.contains("mixtral") { return 65_536 }
+        if normalized.contains("phi-4") { return 128_000 }
+        if normalized.contains("phi-3") { return 128_000 }
+        if normalized.contains("command-r") { return 128_000 }
+        if normalized.contains("yi-34b") { return 200_000 }
+        if normalized.contains("yi-large") { return 32_768 }
+        if normalized.contains("grok-4") { return 2_000_000 }
+
+        return nil
+    }
+
+    /// Total context length for local models (used when we don't know the
+    /// vendor-enforced output cap, e.g. for Ollama or LM Studio).
+    static func contextLengthHint(forModelID modelID: String) -> Int? {
+        // Many open models default to their training context.  Use the same
+        // heuristic as `maxOutputTokens` but fall back to general families.
+        let normalized = normalize(modelID: modelID)
+        if normalized.contains("llama-4-scout") || normalized.contains("llama4scout") { return 10_000_000 }
+        if normalized.contains("llama-4-maverick") || normalized.contains("llama4maverick") { return 1_000_000 }
+        if normalized.contains("llama-4-") || normalized.contains("llama4") { return 1_000_000 }
+        if normalized.contains("llama-3.1-") || normalized.contains("llama3.1") { return 128_000 }
+        if normalized.contains("llama-3-") || normalized.contains("llama3") { return 8_192 }
+        if normalized.contains("qwen3") { return 128_000 }
+        if normalized.contains("qwen2.5") { return 128_000 }
+        if normalized.contains("qwen2") { return 128_000 }
+        if normalized.contains("deepseek-v3") { return 64_000 }
+        if normalized.contains("deepseek-coder-v2") { return 128_000 }
+        if normalized.contains("deepseek-v2") { return 128_000 }
+        if normalized.contains("mistral-large") { return 128_000 }
+        if normalized.contains("mixtral-8x22b") { return 65_536 }
+        if normalized.contains("mixtral-8x7b") { return 32_768 }
+        if normalized.contains("phi-4") { return 128_000 }
+        if normalized.contains("phi-3") { return 128_000 }
+        if normalized.contains("command-r") { return 128_000 }
+        if normalized.contains("yi-34b") { return 200_000 }
+        if normalized.contains("yi-large") { return 32_768 }
+        if normalized.contains("gemma-2") { return 8_192 }
+        if normalized.contains("gemma") { return 8_192 }
+        return nil
+    }
+
+    // MARK: - Private helpers
+
+    private static func normalize(modelID: String) -> String {
+        var s = modelID.lowercased()
+        // Strip common provider prefixes used by OpenRouter / LiteLLM
+        let prefixes = [
+            "anthropic/", "openai/", "google/", "meta-llama/",
+            "mistralai/", "cohere/", "x-ai/", "deepseek/",
+            "microsoft/", "nvidia/", "qwen/", "01-ai/",
+            "openrouter/", "perplexity/", "fireworks/",
+        ]
+        for p in prefixes {
+            if s.hasPrefix(p) {
+                s.removeFirst(p.count)
+                break
+            }
+        }
+        return s
+    }
+
+    private static func stripTag(from modelID: String) -> String {
+        let parts = modelID.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        return String(parts[0])
+    }
+
+    // MARK: - Exact vendor-documented caps
+
+    private static let exactMap: [String: Int] = [
+        // OpenAI 2026-05
+        "gpt-5.5": 128_000,
+        "gpt-5.5-2026-05-07": 128_000,
+        "gpt-5.5-pro": 128_000,
+        "gpt-5.4": 128_000,
+        "gpt-5.4-2026-05-07": 128_000,
+        "gpt-5.4-pro": 128_000,
+        "gpt-5.4-mini": 128_000,
+        "gpt-5.4-nano": 64_000,
+        "gpt-5.2": 128_000,
+        "gpt-5.2-2026-05-07": 128_000,
+        "gpt-5-mini": 64_000,
+
+        // OpenAI legacy
+        "gpt-4o": 16_384,
+        "gpt-4o-2024-11-20": 16_384,
+        "gpt-4o-2024-08-06": 16_384,
+        "gpt-4o-mini": 16_384,
+        "gpt-4o-mini-2024-07-18": 16_384,
+        "o1": 100_000,
+        "o1-2024-12-17": 100_000,
+        "o1-mini": 65_000,
+        "o1-mini-2024-09-12": 65_000,
+        "o3-mini": 65_000,
+        "gpt-4-turbo": 4_096,
+        "gpt-4": 8_192,
+        "gpt-4-0613": 8_192,
+        "gpt-3.5-turbo": 4_096,
+        "gpt-3.5-turbo-0125": 4_096,
+
+        // Anthropic Claude 4
+        "claude-opus-4-7-2026-05-05": 128_000,
+        "claude-opus-4-7": 128_000,
+        "claude-opus-4-6-2026-03-24": 128_000,
+        "claude-opus-4-6": 128_000,
+        "claude-sonnet-4-6-2026-03-24": 64_000,
+        "claude-sonnet-4-6": 64_000,
+        "claude-haiku-4-5-20251001": 64_000,
+        "claude-haiku-4-5": 64_000,
+
+        // Anthropic legacy
+        "claude-opus-4-5-20251101": 64_000,
+        "claude-opus-4-5": 64_000,
+        "claude-opus-4-1-20250805": 32_000,
+        "claude-opus-4-1": 32_000,
+        "claude-sonnet-4-5-20250929": 64_000,
+        "claude-sonnet-4-5": 64_000,
+
+        // Google Gemini
+        "gemini-3.1-pro": 8_192,
+        "gemini-3.1-flash": 8_192,
+        "gemini-3.1-flash-lite": 8_192,
+        "gemini-2.5-pro": 8_192,
+        "gemini-2.5-pro-preview": 8_192,
+        "gemini-2.5-flash": 8_192,
+        "gemini-2.5-flash-preview": 8_192,
+        "gemini-2.0-flash": 8_192,
+        "gemini-2.0-flash-001": 8_192,
+        "gemini-2.0-flash-lite": 8_192,
+        "gemini-2.0-pro": 8_192,
+        "gemini-1.5-pro": 8_192,
+        "gemini-1.5-pro-002": 8_192,
+        "gemini-1.5-flash": 8_192,
+        "gemini-1.5-flash-002": 8_192,
+        "gemini-1.5-flash-8b": 8_192,
+        "gemini-1.0-pro": 2_048,
+
+        // Meta Llama 4 / 3.1 / 3
+        "llama-4-scout-17b-16e-instruct": 10_000_000,
+        "llama-4-scout-17b-128e-instruct": 10_000_000,
+        "llama-4-scout": 10_000_000,
+        "llama-4-maverick-17b-128e-instruct": 1_000_000,
+        "llama-4-maverick": 1_000_000,
+        "llama-4": 1_000_000,
+        "llama-3.1-8b-instruct": 128_000,
+        "llama-3.1-70b-instruct": 128_000,
+        "llama-3.1-405b-instruct": 128_000,
+        "llama-3.1-8b": 128_000,
+        "llama-3.1-70b": 128_000,
+        "llama-3.1-405b": 128_000,
+        "llama-3-8b-instruct": 8_192,
+        "llama-3-70b-instruct": 8_192,
+        "llama-3-8b": 8_192,
+        "llama-3-70b": 8_192,
+
+        // Qwen
+        "qwen3-235b-a22b-instruct": 128_000,
+        "qwen3-235b": 128_000,
+        "qwen3-30b-a3b-instruct": 128_000,
+        "qwen3-8b-instruct": 128_000,
+        "qwen3-4b-instruct": 128_000,
+        "qwen3-1.7b-instruct": 128_000,
+        "qwen3-0.6b-instruct": 128_000,
+        "qwen2.5-72b-instruct": 128_000,
+        "qwen2.5-32b-instruct": 128_000,
+        "qwen2.5-14b-instruct": 128_000,
+        "qwen2.5-7b-instruct": 128_000,
+        "qwen2.5-3b-instruct": 128_000,
+        "qwen2.5-1.5b-instruct": 128_000,
+        "qwen2.5-0.5b-instruct": 128_000,
+        "qwen2.5": 128_000,
+        "qwen2-72b-instruct": 128_000,
+        "qwen2-7b-instruct": 128_000,
+        "qwen2-1.5b-instruct": 128_000,
+        "qwen2": 128_000,
+
+        // Mistral
+        "mistral-large-2411": 128_000,
+        "mistral-large": 128_000,
+        "mixtral-8x22b-instruct": 65_536,
+        "mixtral-8x7b-instruct": 32_768,
+        "mixtral-8x22b": 65_536,
+        "mixtral-8x7b": 32_768,
+
+        // DeepSeek
+        "deepseek-v3": 8_192,
+        "deepseek-v3-0324": 8_192,
+        "deepseek-coder-v2-236b": 128_000,
+        "deepseek-coder-v2": 128_000,
+        "deepseek-v2-236b": 128_000,
+        "deepseek-v2": 128_000,
+
+        // Phi
+        "phi-4": 128_000,
+        "phi-3.5-mini-instruct": 128_000,
+        "phi-3-medium-128k-instruct": 128_000,
+        "phi-3-mini-128k-instruct": 128_000,
+        "phi-3-small-128k-instruct": 128_000,
+        "phi-3": 128_000,
+
+        // Cohere
+        "command-r-08-2024": 128_000,
+        "command-r-plus-08-2024": 128_000,
+        "command-r": 128_000,
+        "command-r-plus": 128_000,
+
+        // Yi
+        "yi-34b-200k": 200_000,
+        "yi-34b": 200_000,
+        "yi-large": 32_768,
+
+        // Grok
+        "grok-4": 2_000_000,
+        "grok-4.1": 2_000_000,
+        "grok-4.3": 1_000_000,
+        "grok-4.20": 2_000_000,
+        "grok-4.20-reasoning": 2_000_000,
+
+        // Stepfun (OpenRouter preset)
+        "stepfun/step-3.5-flash:free": 128_000,
+        "step-3.5-flash:free": 128_000,
+        "step-3.5-flash": 128_000,
+    ]
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -343,7 +343,12 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "Ollama"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama]
+    static let lmStudio = MeetingSummaryBackendOption(
+        backend: "lmstudio",
+        label: "LM Studio"
+    )
+
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .lmStudio]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
@@ -631,6 +636,8 @@ struct AppConfig: Codable {
     var chatGPTModel: String = ""
     var ollamaURL: String = "http://localhost:11434"
     var ollamaModel: String = "qwen3.5"
+    var lmStudioURL: String = "http://localhost:1234"
+    var lmStudioModel: String = ""
     var summaryModel: String = ""
     var meetingSummaryModel: String = ""
     var hasCompletedOnboarding: Bool = false
@@ -696,6 +703,8 @@ struct AppConfig: Codable {
         case chatGPTModel = "chatgpt_model"
         case ollamaURL = "ollama_url"
         case ollamaModel = "ollama_model"
+        case lmStudioURL = "lmstudio_url"
+        case lmStudioModel = "lmstudio_model"
         case summaryModel = "summary_model"
         case meetingSummaryModel = "meeting_summary_model"
         case hasCompletedOnboarding = "has_completed_onboarding"
@@ -773,6 +782,8 @@ struct AppConfig: Codable {
         chatGPTModel = (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
         ollamaURL = (try? c.decode(String.self, forKey: .ollamaURL)) ?? defaults.ollamaURL
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
+        lmStudioURL = (try? c.decode(String.self, forKey: .lmStudioURL)) ?? defaults.lmStudioURL
+        lmStudioModel = (try? c.decode(String.self, forKey: .lmStudioModel)) ?? defaults.lmStudioModel
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -792,10 +792,10 @@ struct AppConfig: Codable {
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
         lmStudioURL = (try? c.decode(String.self, forKey: .lmStudioURL)) ?? defaults.lmStudioURL
         lmStudioModel = (try? c.decode(String.self, forKey: .lmStudioModel)) ?? defaults.lmStudioModel
-        openAISummaryMaxTokens = (try? c.decode(Int.self, forKey: .openAISummaryMaxTokens)) ?? defaults.openAISummaryMaxTokens
-        openRouterSummaryMaxTokens = (try? c.decode(Int.self, forKey: .openRouterSummaryMaxTokens)) ?? defaults.openRouterSummaryMaxTokens
-        ollamaSummaryMaxTokens = (try? c.decode(Int.self, forKey: .ollamaSummaryMaxTokens)) ?? defaults.ollamaSummaryMaxTokens
-        lmStudioSummaryMaxTokens = (try? c.decode(Int.self, forKey: .lmStudioSummaryMaxTokens)) ?? defaults.lmStudioSummaryMaxTokens
+        openAISummaryMaxTokens = min(max((try? c.decode(Int.self, forKey: .openAISummaryMaxTokens)) ?? defaults.openAISummaryMaxTokens, 100), 100000)
+        openRouterSummaryMaxTokens = min(max((try? c.decode(Int.self, forKey: .openRouterSummaryMaxTokens)) ?? defaults.openRouterSummaryMaxTokens, 100), 100000)
+        ollamaSummaryMaxTokens = min(max((try? c.decode(Int.self, forKey: .ollamaSummaryMaxTokens)) ?? defaults.ollamaSummaryMaxTokens, 100), 100000)
+        lmStudioSummaryMaxTokens = min(max((try? c.decode(Int.self, forKey: .lmStudioSummaryMaxTokens)) ?? defaults.lmStudioSummaryMaxTokens, 100), 100000)
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -638,6 +638,10 @@ struct AppConfig: Codable {
     var ollamaModel: String = "qwen3.5"
     var lmStudioURL: String = "http://localhost:1234"
     var lmStudioModel: String = ""
+    var openAISummaryMaxTokens: Int = 2500
+    var openRouterSummaryMaxTokens: Int = 2500
+    var ollamaSummaryMaxTokens: Int = 2500
+    var lmStudioSummaryMaxTokens: Int = 2500
     var summaryModel: String = ""
     var meetingSummaryModel: String = ""
     var hasCompletedOnboarding: Bool = false
@@ -705,6 +709,10 @@ struct AppConfig: Codable {
         case ollamaModel = "ollama_model"
         case lmStudioURL = "lmstudio_url"
         case lmStudioModel = "lmstudio_model"
+        case openAISummaryMaxTokens = "openai_summary_max_tokens"
+        case openRouterSummaryMaxTokens = "openrouter_summary_max_tokens"
+        case ollamaSummaryMaxTokens = "ollama_summary_max_tokens"
+        case lmStudioSummaryMaxTokens = "lmstudio_summary_max_tokens"
         case summaryModel = "summary_model"
         case meetingSummaryModel = "meeting_summary_model"
         case hasCompletedOnboarding = "has_completed_onboarding"
@@ -784,6 +792,10 @@ struct AppConfig: Codable {
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
         lmStudioURL = (try? c.decode(String.self, forKey: .lmStudioURL)) ?? defaults.lmStudioURL
         lmStudioModel = (try? c.decode(String.self, forKey: .lmStudioModel)) ?? defaults.lmStudioModel
+        openAISummaryMaxTokens = (try? c.decode(Int.self, forKey: .openAISummaryMaxTokens)) ?? defaults.openAISummaryMaxTokens
+        openRouterSummaryMaxTokens = (try? c.decode(Int.self, forKey: .openRouterSummaryMaxTokens)) ?? defaults.openRouterSummaryMaxTokens
+        ollamaSummaryMaxTokens = (try? c.decode(Int.self, forKey: .ollamaSummaryMaxTokens)) ?? defaults.ollamaSummaryMaxTokens
+        lmStudioSummaryMaxTokens = (try? c.decode(Int.self, forKey: .lmStudioSummaryMaxTokens)) ?? defaults.lmStudioSummaryMaxTokens
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1533,7 +1533,7 @@ struct OnboardingView: View {
 
                     Text("Select a model in Settings after setup.")
                         .font(.system(size: 11))
-                        .foregroundStyle(MuesliTheme.warning)
+                        .foregroundStyle(MuesliTheme.transcribing)
                         .padding(.top, 4)
                 }
             } else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1419,6 +1419,10 @@ struct OnboardingView: View {
                     summaryBackend = .ollama
                     apiKey = ""
                 }
+                providerTab("LM Studio", selected: summaryBackend == .lmStudio) {
+                    summaryBackend = .lmStudio
+                    apiKey = ""
+                }
             }
             .background(MuesliTheme.backgroundRaised)
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
@@ -1426,7 +1430,7 @@ struct OnboardingView: View {
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
-            .frame(width: 320)
+            .frame(width: 400)
 
             if summaryBackend == .chatGPT {
                 Text("Use your ChatGPT Plus or Pro subscription.")
@@ -1495,6 +1499,26 @@ struct OnboardingView: View {
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                     Text("Ollama is served by default at http://localhost:11434")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(MuesliTheme.success)
+                            .frame(width: 6, height: 6)
+                        Text("No authentication required")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MuesliTheme.success)
+                    }
+                }
+            } else if summaryBackend == .lmStudio {
+                Text("Run AI models locally with LM Studio.\nNo API key needed — just start the LM Studio server.")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                    Text("LM Studio is served by default at http://localhost:1234")
                         .font(.system(size: 11))
                         .foregroundStyle(MuesliTheme.textTertiary)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1530,6 +1530,11 @@ struct OnboardingView: View {
                             .font(.system(size: 11))
                             .foregroundStyle(MuesliTheme.success)
                     }
+
+                    Text("Select a model in Settings after setup.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.warning)
+                        .padding(.top, 4)
                 }
             } else {
                 if summaryBackend == .openRouter {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -548,6 +548,22 @@ struct SettingsView: View {
                             placeholder: "qwen3.5"
                         ) { val in controller.updateConfig { $0.ollamaModel = val } }
                     }
+                } else if appState.selectedMeetingSummaryBackend == .lmStudio {
+                    settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.lmStudioURL,
+                            placeholder: "http://localhost:1234",
+                            onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model", controlWidth: meetingControlWidth) {
+                        settingsModelTextField(
+                            currentModel: appState.config.lmStudioModel,
+                            placeholder: "model-name"
+                        ) { val in controller.updateConfig { $0.lmStudioModel = val } }
+                    }
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -2,6 +2,22 @@ import AVFoundation
 import SwiftUI
 import MuesliCore
 
+private struct OllamaModelInfo: Codable {
+    let name: String
+}
+
+private struct OllamaTagsResponse: Codable {
+    let models: [OllamaModelInfo]
+}
+
+private struct LMStudioModelInfo: Codable {
+    let id: String
+}
+
+private struct LMStudioModelsResponse: Codable {
+    let data: [LMStudioModelInfo]
+}
+
 private struct MeetingDetectionAppOption: Identifiable {
     let bundleID: String
     let name: String
@@ -87,6 +103,12 @@ struct SettingsView: View {
     @State private var openRouterFreeModels: [SummaryModelPreset] = []
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
+    @State private var ollamaModels: [String] = []
+    @State private var isLoadingOllamaModels = false
+    @State private var ollamaModelsError: String?
+    @State private var lmStudioModels: [String] = []
+    @State private var isLoadingLMStudioModels = false
+    @State private var lmStudioModelsError: String?
 
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
@@ -142,6 +164,10 @@ struct SettingsView: View {
             startPermissionPolling()
             if appState.selectedMeetingSummaryBackend == .openRouter {
                 loadOpenRouterFreeModelsIfNeeded()
+            } else if appState.selectedMeetingSummaryBackend == .ollama {
+                loadOllamaModelsIfNeeded()
+            } else if appState.selectedMeetingSummaryBackend == .lmStudio {
+                loadLMStudioModelsIfNeeded()
             }
         }
         .onDisappear {
@@ -164,6 +190,10 @@ struct SettingsView: View {
         .onChange(of: appState.selectedMeetingSummaryBackend) { _, backend in
             if backend == .openRouter {
                 loadOpenRouterFreeModelsIfNeeded()
+            } else if backend == .ollama {
+                loadOllamaModelsIfNeeded()
+            } else if backend == .lmStudio {
+                loadLMStudioModelsIfNeeded()
             }
         }
         .alert(
@@ -537,32 +567,34 @@ struct SettingsView: View {
                         PastableTextField(
                             text: appState.config.ollamaURL,
                             placeholder: "http://localhost:11434",
-                            onChange: { val in controller.updateConfig { $0.ollamaURL = val } }
+                            onChange: { val in
+                                controller.updateConfig { $0.ollamaURL = val }
+                                ollamaModels = []
+                                ollamaModelsError = nil
+                            }
                         )
                         .frame(height: 22)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelTextField(
-                            currentModel: appState.config.ollamaModel,
-                            placeholder: "qwen3.5"
-                        ) { val in controller.updateConfig { $0.ollamaModel = val } }
+                        ollamaModelPicker
                     }
                 } else if appState.selectedMeetingSummaryBackend == .lmStudio {
                     settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
                         PastableTextField(
                             text: appState.config.lmStudioURL,
                             placeholder: "http://localhost:1234",
-                            onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
+                            onChange: { val in
+                                controller.updateConfig { $0.lmStudioURL = val }
+                                lmStudioModels = []
+                                lmStudioModelsError = nil
+                            }
                         )
                         .frame(height: 22)
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelTextField(
-                            currentModel: appState.config.lmStudioModel,
-                            placeholder: "model-name"
-                        ) { val in controller.updateConfig { $0.lmStudioModel = val } }
+                        lmStudioModelPicker
                     }
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
@@ -1836,6 +1868,90 @@ struct SettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private var ollamaModelPicker: some View {
+        if isLoadingOllamaModels {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading models")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        } else if !ollamaModels.isEmpty {
+            let allOptions = ["(Default)"] + ollamaModels
+            let currentIndex = appState.config.ollamaModel.isEmpty ? 0 : (ollamaModels.firstIndex(of: appState.config.ollamaModel).map { $0 + 1 } ?? 0)
+            let selectedLabel = currentIndex < allOptions.count ? allOptions[currentIndex] : allOptions[0]
+
+            FixedWidthPopUp(
+                selection: selectedLabel,
+                options: allOptions,
+                onSelectIndex: { index in
+                    let selected = index == 0 ? "" : ollamaModels[index - 1]
+                    controller.updateConfig { $0.ollamaModel = selected }
+                }
+            )
+            .frame(height: 24)
+        } else {
+            HStack(spacing: 8) {
+                if let ollamaModelsError {
+                    Text(ollamaModelsError)
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .lineLimit(1)
+                }
+                Button("Load") {
+                    loadOllamaModels(force: true)
+                }
+                .font(.system(size: 12, weight: .medium))
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    @ViewBuilder
+    private var lmStudioModelPicker: some View {
+        if isLoadingLMStudioModels {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading models")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        } else if !lmStudioModels.isEmpty {
+            let allOptions = ["(Default)"] + lmStudioModels
+            let currentIndex = appState.config.lmStudioModel.isEmpty ? 0 : (lmStudioModels.firstIndex(of: appState.config.lmStudioModel).map { $0 + 1 } ?? 0)
+            let selectedLabel = currentIndex < allOptions.count ? allOptions[currentIndex] : allOptions[0]
+
+            FixedWidthPopUp(
+                selection: selectedLabel,
+                options: allOptions,
+                onSelectIndex: { index in
+                    let selected = index == 0 ? "" : lmStudioModels[index - 1]
+                    controller.updateConfig { $0.lmStudioModel = selected }
+                }
+            )
+            .frame(height: 24)
+        } else {
+            HStack(spacing: 8) {
+                if let lmStudioModelsError {
+                    Text(lmStudioModelsError)
+                        .font(.system(size: 11))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .lineLimit(1)
+                }
+                Button("Load") {
+                    loadLMStudioModels(force: true)
+                }
+                .font(.system(size: 12, weight: .medium))
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
     private func loadOpenRouterFreeModelsIfNeeded() {
         guard openRouterFreeModels.isEmpty, !isLoadingOpenRouterFreeModels else { return }
         loadOpenRouterFreeModels(force: false)
@@ -1867,6 +1983,114 @@ struct SettingsView: View {
                     openRouterFreeModels = []
                     openRouterFreeModelsError = "Could not load"
                     isLoadingOpenRouterFreeModels = false
+                }
+            }
+        }
+    }
+
+    private func loadOllamaModelsIfNeeded() {
+        guard ollamaModels.isEmpty, !isLoadingOllamaModels else { return }
+        loadOllamaModels(force: false)
+    }
+
+    private func loadOllamaModels(force: Bool) {
+        guard force || ollamaModels.isEmpty else { return }
+        isLoadingOllamaModels = true
+        ollamaModelsError = nil
+
+        let baseURLString = appState.config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL: URL
+        if baseURLString.isEmpty {
+            baseURL = URL(string: "http://localhost:11434")!
+        } else {
+            guard let url = URL(string: baseURLString) else {
+                ollamaModelsError = "Invalid URL"
+                isLoadingOllamaModels = false
+                return
+            }
+            baseURL = url
+        }
+
+        Task {
+            do {
+                let tagsURL = baseURL.appendingPathComponent("api/tags")
+                var request = URLRequest(url: tagsURL)
+                request.timeoutInterval = 10
+
+                let (data, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   !(200..<300).contains(httpResponse.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+
+                let decoder = JSONDecoder()
+                let tagsResponse = try decoder.decode(OllamaTagsResponse.self, from: data)
+                let modelNames = tagsResponse.models.map { $0.name }.sorted()
+
+                await MainActor.run {
+                    ollamaModels = modelNames
+                    ollamaModelsError = modelNames.isEmpty ? "No models found" : nil
+                    isLoadingOllamaModels = false
+                }
+            } catch {
+                await MainActor.run {
+                    ollamaModels = []
+                    ollamaModelsError = "Could not load"
+                    isLoadingOllamaModels = false
+                }
+            }
+        }
+    }
+
+    private func loadLMStudioModelsIfNeeded() {
+        guard lmStudioModels.isEmpty, !isLoadingLMStudioModels else { return }
+        loadLMStudioModels(force: false)
+    }
+
+    private func loadLMStudioModels(force: Bool) {
+        guard force || lmStudioModels.isEmpty else { return }
+        isLoadingLMStudioModels = true
+        lmStudioModelsError = nil
+
+        let baseURLString = appState.config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL: URL
+        if baseURLString.isEmpty {
+            baseURL = URL(string: "http://localhost:1234")!
+        } else {
+            guard let url = URL(string: baseURLString) else {
+                lmStudioModelsError = "Invalid URL"
+                isLoadingLMStudioModels = false
+                return
+            }
+            baseURL = url
+        }
+
+        Task {
+            do {
+                let modelsURL = baseURL.appendingPathComponent("api/v0/models")
+                var request = URLRequest(url: modelsURL)
+                request.timeoutInterval = 10
+
+                let (data, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   !(200..<300).contains(httpResponse.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+
+                let decoder = JSONDecoder()
+                let modelsResponse = try decoder.decode(LMStudioModelsResponse.self, from: data)
+                let modelNames = modelsResponse.data.map { $0.id }.sorted()
+
+                await MainActor.run {
+                    lmStudioModels = modelNames
+                    lmStudioModelsError = modelNames.isEmpty ? "No models found" : nil
+                    isLoadingLMStudioModels = false
+                }
+            } catch {
+                await MainActor.run {
+                    lmStudioModels = []
+                    lmStudioModelsError = "Could not load"
+                    isLoadingLMStudioModels = false
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -571,6 +571,7 @@ struct SettingsView: View {
                                 controller.updateConfig { $0.ollamaURL = val }
                                 ollamaModels = []
                                 ollamaModelsError = nil
+                                isLoadingOllamaModels = false
                             }
                         )
                         .frame(height: 22)
@@ -588,6 +589,7 @@ struct SettingsView: View {
                                 controller.updateConfig { $0.lmStudioURL = val }
                                 lmStudioModels = []
                                 lmStudioModelsError = nil
+                                isLoadingLMStudioModels = false
                             }
                         )
                         .frame(height: 22)
@@ -1922,11 +1924,19 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
         } else if !lmStudioModels.isEmpty {
-            let selectedModel = appState.config.lmStudioModel
-            let selectedLabel = lmStudioModels.contains(selectedModel) ? selectedModel : lmStudioModels[0]
+            let savedModel = appState.config.lmStudioModel
+            let effectiveModel: String
+            if savedModel.isEmpty {
+                effectiveModel = lmStudioModels[0]
+                controller.updateConfig { $0.lmStudioModel = lmStudioModels[0] }
+            } else if lmStudioModels.contains(savedModel) {
+                effectiveModel = savedModel
+            } else {
+                effectiveModel = lmStudioModels[0]
+            }
 
             FixedWidthPopUp(
-                selection: selectedLabel,
+                selection: effectiveModel,
                 options: lmStudioModels,
                 onSelectIndex: { index in
                     guard index >= 0 && index < lmStudioModels.count else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1925,15 +1925,7 @@ struct SettingsView: View {
             .frame(maxWidth: .infinity, alignment: .trailing)
         } else if !lmStudioModels.isEmpty {
             let savedModel = appState.config.lmStudioModel
-            let effectiveModel: String
-            if savedModel.isEmpty {
-                effectiveModel = lmStudioModels[0]
-                controller.updateConfig { $0.lmStudioModel = lmStudioModels[0] }
-            } else if lmStudioModels.contains(savedModel) {
-                effectiveModel = savedModel
-            } else {
-                effectiveModel = lmStudioModels[0]
-            }
+            let effectiveModel = lmStudioModels.contains(savedModel) ? savedModel : lmStudioModels[0]
 
             FixedWidthPopUp(
                 selection: effectiveModel,

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -4,6 +4,16 @@ import MuesliCore
 
 private struct OllamaModelInfo: Codable {
     let name: String
+    let model: String?
+    let size: Int64?
+    let digest: String?
+    let details: OllamaModelDetails?
+}
+
+private struct OllamaModelDetails: Codable {
+    let format: String?
+    let family: String?
+    let families: [String]?
 }
 
 private struct OllamaTagsResponse: Codable {
@@ -12,6 +22,9 @@ private struct OllamaTagsResponse: Codable {
 
 private struct LMStudioModelInfo: Codable {
     let id: String
+    let object: String?
+    let type: String?
+    let quantization: String?
 }
 
 private struct LMStudioModelsResponse: Codable {
@@ -2028,7 +2041,10 @@ struct SettingsView: View {
 
                 let decoder = JSONDecoder()
                 let tagsResponse = try decoder.decode(OllamaTagsResponse.self, from: data)
-                let modelNames = tagsResponse.models.map { $0.name }.sorted()
+                let modelNames = tagsResponse.models
+                    .map { $0.name }
+                    .filter { !$0.lowercased().contains("embed") }
+                    .sorted()
 
                 await MainActor.run {
                     guard appState.config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
@@ -2086,7 +2102,10 @@ struct SettingsView: View {
 
                 let decoder = JSONDecoder()
                 let modelsResponse = try decoder.decode(LMStudioModelsResponse.self, from: data)
-                let modelNames = modelsResponse.data.map { $0.id }.sorted()
+                let modelNames = modelsResponse.data
+                    .filter { $0.type != "embeddings" }
+                    .map { $0.id }
+                    .sorted()
 
                 await MainActor.run {
                     guard appState.config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -574,6 +574,23 @@ struct SettingsView: View {
                             presets: SummaryModelPreset.openAIModels
                         ) { val in controller.updateConfig { $0.openAIModel = val } }
                     }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
+                        Stepper(
+                            value: Binding(
+                                get: { max(appState.config.openAISummaryMaxTokens, 100) },
+                                set: { newValue in
+                                    controller.updateConfig { $0.openAISummaryMaxTokens = max(newValue, 100) }
+                                }
+                            ),
+                            in: 100...100000,
+                            step: 500
+                        ) {
+                            Text("\(max(appState.config.openAISummaryMaxTokens, 100))")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                        }
+                    }
                     keyStatusRow(key: appState.config.openAIAPIKey)
                 } else if appState.selectedMeetingSummaryBackend == .ollama {
                     settingsRow("Ollama URL", controlWidth: meetingControlWidth) {
@@ -593,6 +610,23 @@ struct SettingsView: View {
                     settingsRow("Model", controlWidth: meetingControlWidth) {
                         ollamaModelPicker
                     }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
+                        Stepper(
+                            value: Binding(
+                                get: { max(appState.config.ollamaSummaryMaxTokens, 100) },
+                                set: { newValue in
+                                    controller.updateConfig { $0.ollamaSummaryMaxTokens = max(newValue, 100) }
+                                }
+                            ),
+                            in: 100...100000,
+                            step: 500
+                        ) {
+                            Text("\(max(appState.config.ollamaSummaryMaxTokens, 100))")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                        }
+                    }
                 } else if appState.selectedMeetingSummaryBackend == .lmStudio {
                     settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
                         PastableTextField(
@@ -610,6 +644,23 @@ struct SettingsView: View {
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Model", controlWidth: meetingControlWidth) {
                         lmStudioModelPicker
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
+                        Stepper(
+                            value: Binding(
+                                get: { max(appState.config.lmStudioSummaryMaxTokens, 100) },
+                                set: { newValue in
+                                    controller.updateConfig { $0.lmStudioSummaryMaxTokens = max(newValue, 100) }
+                                }
+                            ),
+                            in: 100...100000,
+                            step: 500
+                        ) {
+                            Text("\(max(appState.config.lmStudioSummaryMaxTokens, 100))")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                        }
                     }
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
@@ -630,6 +681,23 @@ struct SettingsView: View {
                             currentModel: appState.config.openRouterModel,
                             placeholder: "provider/model or openrouter/free"
                         ) { val in controller.updateConfig { $0.openRouterModel = val } }
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
+                        Stepper(
+                            value: Binding(
+                                get: { max(appState.config.openRouterSummaryMaxTokens, 100) },
+                                set: { newValue in
+                                    controller.updateConfig { $0.openRouterSummaryMaxTokens = max(newValue, 100) }
+                                }
+                            ),
+                            in: 100...100000,
+                            step: 500
+                        ) {
+                            Text("\(max(appState.config.openRouterSummaryMaxTokens, 100))")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                        }
                     }
                     keyStatusRow(key: appState.config.openRouterAPIKey)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1922,16 +1922,15 @@ struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
         } else if !lmStudioModels.isEmpty {
-            let allOptions = ["(Default)"] + lmStudioModels
-            let currentIndex = appState.config.lmStudioModel.isEmpty ? 0 : (lmStudioModels.firstIndex(of: appState.config.lmStudioModel).map { $0 + 1 } ?? 0)
-            let selectedLabel = currentIndex < allOptions.count ? allOptions[currentIndex] : allOptions[0]
+            let selectedModel = appState.config.lmStudioModel
+            let selectedLabel = lmStudioModels.contains(selectedModel) ? selectedModel : lmStudioModels[0]
 
             FixedWidthPopUp(
                 selection: selectedLabel,
-                options: allOptions,
+                options: lmStudioModels,
                 onSelectIndex: { index in
-                    let selected = index == 0 ? "" : lmStudioModels[index - 1]
-                    controller.updateConfig { $0.lmStudioModel = selected }
+                    guard index >= 0 && index < lmStudioModels.count else { return }
+                    controller.updateConfig { $0.lmStudioModel = lmStudioModels[index] }
                 }
             )
             .frame(height: 24)
@@ -2011,6 +2010,8 @@ struct SettingsView: View {
             baseURL = url
         }
 
+        let urlAtStart = baseURLString
+
         Task {
             do {
                 let tagsURL = baseURL.appendingPathComponent("api/tags")
@@ -2028,12 +2029,14 @@ struct SettingsView: View {
                 let modelNames = tagsResponse.models.map { $0.name }.sorted()
 
                 await MainActor.run {
+                    guard appState.config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
                     ollamaModels = modelNames
                     ollamaModelsError = modelNames.isEmpty ? "No models found" : nil
                     isLoadingOllamaModels = false
                 }
             } catch {
                 await MainActor.run {
+                    guard appState.config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
                     ollamaModels = []
                     ollamaModelsError = "Could not load"
                     isLoadingOllamaModels = false
@@ -2065,6 +2068,8 @@ struct SettingsView: View {
             baseURL = url
         }
 
+        let urlAtStart = baseURLString
+
         Task {
             do {
                 let modelsURL = baseURL.appendingPathComponent("api/v0/models")
@@ -2082,12 +2087,14 @@ struct SettingsView: View {
                 let modelNames = modelsResponse.data.map { $0.id }.sorted()
 
                 await MainActor.run {
+                    guard appState.config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
                     lmStudioModels = modelNames
                     lmStudioModelsError = modelNames.isEmpty ? "No models found" : nil
                     isLoadingLMStudioModels = false
                 }
             } catch {
                 await MainActor.run {
+                    guard appState.config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
                     lmStudioModels = []
                     lmStudioModelsError = "Could not load"
                     isLoadingLMStudioModels = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -116,9 +116,11 @@ struct SettingsView: View {
     @State private var openRouterFreeModels: [SummaryModelPreset] = []
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
+    @State private var openRouterModelCaps: [String: Int] = [:]
     @State private var ollamaModels: [String] = []
     @State private var isLoadingOllamaModels = false
     @State private var ollamaModelsError: String?
+    @State private var ollamaModelCaps: [String: Int] = [:]
     @State private var lmStudioModels: [String] = []
     @State private var isLoadingLMStudioModels = false
     @State private var lmStudioModelsError: String?
@@ -575,20 +577,51 @@ struct SettingsView: View {
                         ) { val in controller.updateConfig { $0.openAIModel = val } }
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
-                        Stepper(
-                            value: Binding(
-                                get: { max(appState.config.openAISummaryMaxTokens, 100) },
-                                set: { newValue in
-                                    controller.updateConfig { $0.openAISummaryMaxTokens = max(newValue, 100) }
+                    settingsRow("Thinking budget (tokens)", controlWidth: meetingControlWidth) {
+                        let effectiveMax = effectiveMaxOutputTokens(for: .openAI)
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: Binding(
+                                    get: { Double(min(max(appState.config.openAISummaryMaxTokens, 100), effectiveMax)) },
+                                    set: { newValue in
+                                        controller.updateConfig { $0.openAISummaryMaxTokens = Int(newValue) }
+                                    }
+                                ),
+                                in: 100.0...Double(effectiveMax),
+                                step: 500.0
+                            )
+                            .frame(maxWidth: .infinity)
+
+                            TextField("100", text: Binding(
+                                get: { "\(min(max(appState.config.openAISummaryMaxTokens, 100), effectiveMax))" },
+                                set: { newText in
+                                    if let val = Int(newText.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                                        let clamped = min(max(val, 100), effectiveMax)
+                                        controller.updateConfig { $0.openAISummaryMaxTokens = clamped }
+                                    }
                                 }
-                            ),
-                            in: 100...100000,
-                            step: 500
-                        ) {
-                            Text("\(max(appState.config.openAISummaryMaxTokens, 100))")
-                                .font(MuesliTheme.body())
-                                .foregroundStyle(MuesliTheme.textPrimary)
+                            ))
+                            .textFieldStyle(.plain)
+                            .frame(width: 60)
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                            .multilineTextAlignment(.trailing)
+
+                            Button(action: {
+                                controller.updateConfig { $0.openAISummaryMaxTokens = 2500 }
+                            }) {
+                                Image(systemName: "arrow.counterclockwise.circle")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(MuesliTheme.textSecondary)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Reset to default (2500)")
+                        }
+                        .onChange(of: appState.config.openAIModel) { _, _ in
+                            let newMax = effectiveMaxOutputTokens(for: .openAI)
+                            if appState.config.openAISummaryMaxTokens > newMax {
+                                controller.updateConfig { $0.openAISummaryMaxTokens = newMax }
+                            }
                         }
                     }
                     keyStatusRow(key: appState.config.openAIAPIKey)
@@ -611,20 +644,51 @@ struct SettingsView: View {
                         ollamaModelPicker
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
-                        Stepper(
-                            value: Binding(
-                                get: { max(appState.config.ollamaSummaryMaxTokens, 100) },
-                                set: { newValue in
-                                    controller.updateConfig { $0.ollamaSummaryMaxTokens = max(newValue, 100) }
+                    settingsRow("Thinking budget (tokens)", controlWidth: meetingControlWidth) {
+                        let effectiveMax = effectiveMaxOutputTokens(for: .ollama)
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: Binding(
+                                    get: { Double(min(max(appState.config.ollamaSummaryMaxTokens, 100), effectiveMax)) },
+                                    set: { newValue in
+                                        controller.updateConfig { $0.ollamaSummaryMaxTokens = Int(newValue) }
+                                    }
+                                ),
+                                in: 100.0...Double(effectiveMax),
+                                step: 500.0
+                            )
+                            .frame(maxWidth: .infinity)
+
+                            TextField("100", text: Binding(
+                                get: { "\(min(max(appState.config.ollamaSummaryMaxTokens, 100), effectiveMax))" },
+                                set: { newText in
+                                    if let val = Int(newText.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                                        let clamped = min(max(val, 100), effectiveMax)
+                                        controller.updateConfig { $0.ollamaSummaryMaxTokens = clamped }
+                                    }
                                 }
-                            ),
-                            in: 100...100000,
-                            step: 500
-                        ) {
-                            Text("\(max(appState.config.ollamaSummaryMaxTokens, 100))")
-                                .font(MuesliTheme.body())
-                                .foregroundStyle(MuesliTheme.textPrimary)
+                            ))
+                            .textFieldStyle(.plain)
+                            .frame(width: 60)
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                            .multilineTextAlignment(.trailing)
+
+                            Button(action: {
+                                controller.updateConfig { $0.ollamaSummaryMaxTokens = 2500 }
+                            }) {
+                                Image(systemName: "arrow.counterclockwise.circle")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(MuesliTheme.textSecondary)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Reset to default (2500)")
+                        }
+                        .onChange(of: appState.config.ollamaModel) { _, _ in
+                            let newMax = effectiveMaxOutputTokens(for: .ollama)
+                            if appState.config.ollamaSummaryMaxTokens > newMax {
+                                controller.updateConfig { $0.ollamaSummaryMaxTokens = newMax }
+                            }
                         }
                     }
                 } else if appState.selectedMeetingSummaryBackend == .lmStudio {
@@ -646,20 +710,51 @@ struct SettingsView: View {
                         lmStudioModelPicker
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
-                        Stepper(
-                            value: Binding(
-                                get: { max(appState.config.lmStudioSummaryMaxTokens, 100) },
-                                set: { newValue in
-                                    controller.updateConfig { $0.lmStudioSummaryMaxTokens = max(newValue, 100) }
+                    settingsRow("Thinking budget (tokens)", controlWidth: meetingControlWidth) {
+                        let effectiveMax = effectiveMaxOutputTokens(for: .lmStudio)
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: Binding(
+                                    get: { Double(min(max(appState.config.lmStudioSummaryMaxTokens, 100), effectiveMax)) },
+                                    set: { newValue in
+                                        controller.updateConfig { $0.lmStudioSummaryMaxTokens = Int(newValue) }
+                                    }
+                                ),
+                                in: 100.0...Double(effectiveMax),
+                                step: 500.0
+                            )
+                            .frame(maxWidth: .infinity)
+
+                            TextField("100", text: Binding(
+                                get: { "\(min(max(appState.config.lmStudioSummaryMaxTokens, 100), effectiveMax))" },
+                                set: { newText in
+                                    if let val = Int(newText.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                                        let clamped = min(max(val, 100), effectiveMax)
+                                        controller.updateConfig { $0.lmStudioSummaryMaxTokens = clamped }
+                                    }
                                 }
-                            ),
-                            in: 100...100000,
-                            step: 500
-                        ) {
-                            Text("\(max(appState.config.lmStudioSummaryMaxTokens, 100))")
-                                .font(MuesliTheme.body())
-                                .foregroundStyle(MuesliTheme.textPrimary)
+                            ))
+                            .textFieldStyle(.plain)
+                            .frame(width: 60)
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                            .multilineTextAlignment(.trailing)
+
+                            Button(action: {
+                                controller.updateConfig { $0.lmStudioSummaryMaxTokens = 2500 }
+                            }) {
+                                Image(systemName: "arrow.counterclockwise.circle")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(MuesliTheme.textSecondary)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Reset to default (2500)")
+                        }
+                        .onChange(of: appState.config.lmStudioModel) { _, _ in
+                            let newMax = effectiveMaxOutputTokens(for: .lmStudio)
+                            if appState.config.lmStudioSummaryMaxTokens > newMax {
+                                controller.updateConfig { $0.lmStudioSummaryMaxTokens = newMax }
+                            }
                         }
                     }
                 } else {
@@ -683,20 +778,51 @@ struct SettingsView: View {
                         ) { val in controller.updateConfig { $0.openRouterModel = val } }
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Max output tokens", controlWidth: meetingControlWidth) {
-                        Stepper(
-                            value: Binding(
-                                get: { max(appState.config.openRouterSummaryMaxTokens, 100) },
-                                set: { newValue in
-                                    controller.updateConfig { $0.openRouterSummaryMaxTokens = max(newValue, 100) }
+                    settingsRow("Thinking budget (tokens)", controlWidth: meetingControlWidth) {
+                        let effectiveMax = effectiveMaxOutputTokens(for: .openRouter)
+                        HStack(spacing: 8) {
+                            Slider(
+                                value: Binding(
+                                    get: { Double(min(max(appState.config.openRouterSummaryMaxTokens, 100), effectiveMax)) },
+                                    set: { newValue in
+                                        controller.updateConfig { $0.openRouterSummaryMaxTokens = Int(newValue) }
+                                    }
+                                ),
+                                in: 100.0...Double(effectiveMax),
+                                step: 500.0
+                            )
+                            .frame(maxWidth: .infinity)
+
+                            TextField("100", text: Binding(
+                                get: { "\(min(max(appState.config.openRouterSummaryMaxTokens, 100), effectiveMax))" },
+                                set: { newText in
+                                    if let val = Int(newText.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                                        let clamped = min(max(val, 100), effectiveMax)
+                                        controller.updateConfig { $0.openRouterSummaryMaxTokens = clamped }
+                                    }
                                 }
-                            ),
-                            in: 100...100000,
-                            step: 500
-                        ) {
-                            Text("\(max(appState.config.openRouterSummaryMaxTokens, 100))")
-                                .font(MuesliTheme.body())
-                                .foregroundStyle(MuesliTheme.textPrimary)
+                            ))
+                            .textFieldStyle(.plain)
+                            .frame(width: 60)
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                            .multilineTextAlignment(.trailing)
+
+                            Button(action: {
+                                controller.updateConfig { $0.openRouterSummaryMaxTokens = 2500 }
+                            }) {
+                                Image(systemName: "arrow.counterclockwise.circle")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(MuesliTheme.textSecondary)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Reset to default (2500)")
+                        }
+                        .onChange(of: appState.config.openRouterModel) { _, _ in
+                            let newMax = effectiveMaxOutputTokens(for: .openRouter)
+                            if appState.config.openRouterSummaryMaxTokens > newMax {
+                                controller.updateConfig { $0.openRouterSummaryMaxTokens = newMax }
+                            }
                         }
                     }
                     keyStatusRow(key: appState.config.openRouterAPIKey)
@@ -1918,6 +2044,30 @@ struct SettingsView: View {
         .frame(height: 22)
     }
 
+    private func effectiveMaxOutputTokens(for backend: MeetingSummaryBackendOption) -> Int {
+        let fallback = 100_000
+        switch backend {
+        case .openAI:
+            return ModelTokenCap.maxOutputTokens(forModelID: appState.config.openAIModel) ?? fallback
+        case .openRouter:
+            return openRouterModelCaps[appState.config.openRouterModel]
+                ?? ModelTokenCap.maxOutputTokens(forModelID: appState.config.openRouterModel)
+                ?? fallback
+        case .chatGPT:
+            return ModelTokenCap.maxOutputTokens(forModelID: appState.config.chatGPTModel) ?? fallback
+        case .ollama:
+            return ollamaModelCaps[appState.config.ollamaModel]
+                ?? ModelTokenCap.contextLengthHint(forModelID: appState.config.ollamaModel)
+                ?? fallback
+        case .lmStudio:
+            return ModelTokenCap.maxOutputTokens(forModelID: appState.config.lmStudioModel)
+                ?? ModelTokenCap.contextLengthHint(forModelID: appState.config.lmStudioModel)
+                ?? fallback
+        default:
+            return fallback
+        }
+    }
+
     @ViewBuilder
     private var openRouterFreeModelMenu: some View {
         if isLoadingOpenRouterFreeModels {
@@ -1978,11 +2128,13 @@ struct SettingsView: View {
             .frame(height: 24)
         } else {
             HStack(spacing: 8) {
-                settingsModelTextField(
-                    currentModel: appState.config.ollamaModel,
-                    placeholder: "Model name",
-                    onChange: { val in controller.updateConfig { $0.ollamaModel = val } }
-                )
+                TextField("Model name", text: Binding(
+                    get: { appState.config.ollamaModel },
+                    set: { val in controller.updateConfig { $0.ollamaModel = val } }
+                ))
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .frame(height: 22)
                 .layoutPriority(1)
 
                 if let ollamaModelsError {
@@ -2026,11 +2178,13 @@ struct SettingsView: View {
             .frame(height: 24)
         } else {
             HStack(spacing: 8) {
-                settingsModelTextField(
-                    currentModel: appState.config.lmStudioModel,
-                    placeholder: "Model name",
-                    onChange: { val in controller.updateConfig { $0.lmStudioModel = val } }
-                )
+                TextField("Model name", text: Binding(
+                    get: { appState.config.lmStudioModel },
+                    set: { val in controller.updateConfig { $0.lmStudioModel = val } }
+                ))
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .frame(height: 22)
                 .layoutPriority(1)
 
                 if let lmStudioModelsError {
@@ -2073,6 +2227,13 @@ struct SettingsView: View {
                     openRouterFreeModels = presets
                     openRouterFreeModelsError = presets.isEmpty ? "No free text models found" : nil
                     isLoadingOpenRouterFreeModels = false
+                    openRouterModelCaps = Dictionary(
+                        catalog.data.compactMap { model in
+                            guard let ctx = model.contextLength else { return nil }
+                            return (model.id, ctx)
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
                 }
             } catch {
                 await MainActor.run {
@@ -2128,10 +2289,49 @@ struct SettingsView: View {
                     .filter { !$0.lowercased().contains("embed") }
                     .sorted()
 
+                let caps: [String: Int] = await withTaskGroup(of: (String, Int)?.self) { group in
+                    for name in modelNames {
+                        group.addTask {
+                            do {
+                                let showURL = baseURL.appendingPathComponent("api/show")
+                                var req = URLRequest(url: showURL)
+                                req.httpMethod = "POST"
+                                req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                                req.httpBody = try JSONSerialization.data(withJSONObject: ["name": name])
+                                req.timeoutInterval = 10
+                                let (showData, _) = try await URLSession.shared.data(for: req)
+                                guard let json = try JSONSerialization.jsonObject(with: showData) as? [String: Any],
+                                      let modelInfo = json["model_info"] as? [String: Any] else { return nil }
+                                for (key, value) in modelInfo {
+                                    let k = key.lowercased()
+                                    if k.contains("context_length") || k.contains("max_position_embeddings") || k.contains("sliding_window") {
+                                        if let intVal = value as? Int {
+                                            return (name, intVal)
+                                        } else if let doubleVal = value as? Double {
+                                            return (name, Int(doubleVal))
+                                        }
+                                    }
+                                }
+                                return nil
+                            } catch {
+                                return nil
+                            }
+                        }
+                    }
+                    var result: [String: Int] = [:]
+                    for await pair in group {
+                        if let (name, cap) = pair {
+                            result[name] = cap
+                        }
+                    }
+                    return result
+                }
+
                 await MainActor.run {
                     guard appState.config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
                     ollamaModels = modelNames
                     ollamaModelsError = modelNames.isEmpty ? "No models found" : nil
+                    ollamaModelCaps = caps
                     isLoadingOllamaModels = false
                 }
             } catch {
@@ -2139,6 +2339,7 @@ struct SettingsView: View {
                     guard appState.config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines) == urlAtStart else { return }
                     ollamaModels = []
                     ollamaModelsError = "Could not load"
+                    ollamaModelCaps = [:]
                     isLoadingOllamaModels = false
                 }
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1978,6 +1978,13 @@ struct SettingsView: View {
             .frame(height: 24)
         } else {
             HStack(spacing: 8) {
+                settingsModelTextField(
+                    currentModel: appState.config.ollamaModel,
+                    placeholder: "Model name",
+                    onChange: { val in controller.updateConfig { $0.ollamaModel = val } }
+                )
+                .layoutPriority(1)
+
                 if let ollamaModelsError {
                     Text(ollamaModelsError)
                         .font(.system(size: 11))
@@ -2019,6 +2026,13 @@ struct SettingsView: View {
             .frame(height: 24)
         } else {
             HStack(spacing: 8) {
+                settingsModelTextField(
+                    currentModel: appState.config.lmStudioModel,
+                    placeholder: "Model name",
+                    onChange: { val in controller.updateConfig { $0.lmStudioModel = val } }
+                )
+                .layoutPriority(1)
+
                 if let lmStudioModelsError {
                     Text(lmStudioModelsError)
                         .font(.system(size: 11))

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -2180,6 +2180,9 @@ struct SettingsView: View {
                     lmStudioModels = modelNames
                     lmStudioModelsError = modelNames.isEmpty ? "No models found" : nil
                     isLoadingLMStudioModels = false
+                    if !modelNames.isEmpty && appState.config.lmStudioModel.isEmpty {
+                        controller.updateConfig { $0.lmStudioModel = modelNames[0] }
+                    }
                 }
             } catch {
                 await MainActor.run {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -364,6 +364,7 @@ struct MeetingSummaryClientTests {
         var config = AppConfig()
         config.meetingSummaryBackend = "lmstudio"
         config.lmStudioURL = "http://localhost:1" // invalid port to force connection failure
+        config.lmStudioModel = "test-model" // set model to pass validation and reach network
 
         do {
             _ = try await MeetingSummaryClient.summarize(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -358,4 +358,56 @@ struct MeetingSummaryClientTests {
             #expect(summaryError != nil)
         }
     }
+
+    @Test("summarize routes to LM Studio when configured")
+    func routesToLMStudio() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "http://localhost:1" // invalid port to force connection failure
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            let summaryError = error as? MeetingSummaryError
+            #expect(summaryError != nil)
+            if case .requestFailed(let backend, _) = summaryError! {
+                #expect(backend == "LM Studio")
+            } else {
+                #expect(Bool(false), "Expected requestFailed error, got \(String(describing: error))")
+            }
+        }
+    }
+
+    @Test("generateTitle returns nil for LM Studio when unreachable")
+    func titleLMStudioUnreachable() async {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "http://localhost:1"
+
+        let title = await MeetingSummaryClient.generateTitle(
+            transcript: "Sprint planning discussion",
+            config: config
+        )
+
+        #expect(title == nil)
+    }
+
+    @Test("generateTitle returns nil for LM Studio with invalid URL")
+    func titleLMStudioInvalidURL() async {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "not a valid url"
+
+        let title = await MeetingSummaryClient.generateTitle(
+            transcript: "Sprint planning discussion",
+            config: config
+        )
+
+        #expect(title == nil)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -411,4 +411,12 @@ struct MeetingSummaryClientTests {
 
         #expect(title == nil)
     }
+
+    @Test("emptyResponse error suggests increasing output token limit")
+    func emptyResponseSuggestsTokenLimit() {
+        let error = MeetingSummaryError.emptyResponse(backend: "LM Studio")
+        let description = error.errorDescription ?? ""
+        #expect(description.contains("output token limit"))
+        #expect(description.contains("Settings"))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -468,6 +468,11 @@ struct AppConfigTests {
         config.enableComputerUsePlanner = false
         config.computerUsePlannerModel = "gpt-5.4"
         config.computerUseTimeoutSeconds = 180
+        config.hotkeyTriggerThresholdMS = 125
+        config.openAISummaryMaxTokens = 4000
+        config.openRouterSummaryMaxTokens = 5000
+        config.ollamaSummaryMaxTokens = 6000
+        config.lmStudioSummaryMaxTokens = 12000
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -368,11 +368,12 @@ struct MeetingSummaryBackendTests {
 
     @Test("all options listed")
     func allOptions() {
-        #expect(MeetingSummaryBackendOption.all.count == 4)
+        #expect(MeetingSummaryBackendOption.all.count == 5)
         #expect(MeetingSummaryBackendOption.all.contains(.openAI))
         #expect(MeetingSummaryBackendOption.all.contains(.openRouter))
         #expect(MeetingSummaryBackendOption.all.contains(.chatGPT))
         #expect(MeetingSummaryBackendOption.all.contains(.ollama))
+        #expect(MeetingSummaryBackendOption.all.contains(.lmStudio))
     }
 
     @Test("backend strings are lowercase")
@@ -380,6 +381,7 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.openAI.backend == "openai")
         #expect(MeetingSummaryBackendOption.openRouter.backend == "openrouter")
         #expect(MeetingSummaryBackendOption.ollama.backend == "ollama")
+        #expect(MeetingSummaryBackendOption.lmStudio.backend == "lmstudio")
     }
 
     @Test("configured values resolve with ChatGPT fallback")
@@ -387,6 +389,7 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.resolved("chatgpt") == .chatGPT)
         #expect(MeetingSummaryBackendOption.resolved("openrouter") == .openRouter)
         #expect(MeetingSummaryBackendOption.resolved("ollama") == .ollama)
+        #expect(MeetingSummaryBackendOption.resolved("lmstudio") == .lmStudio)
         #expect(MeetingSummaryBackendOption.resolved("unknown") == .chatGPT)
         #expect(MeetingSummaryBackendOption.resolved(nil) == .chatGPT)
     }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -432,6 +432,10 @@ struct AppConfigTests {
         #expect(config.meetingHookEnabled == false)
         #expect(config.meetingHookPath.isEmpty)
         #expect(config.meetingHookTimeoutSeconds == 30)
+        #expect(config.openAISummaryMaxTokens == 2500)
+        #expect(config.openRouterSummaryMaxTokens == 2500)
+        #expect(config.ollamaSummaryMaxTokens == 2500)
+        #expect(config.lmStudioSummaryMaxTokens == 2500)
     }
 
     @Test("JSON encode/decode round-trip")
@@ -463,6 +467,10 @@ struct AppConfigTests {
         config.enableComputerUsePlanner = false
         config.computerUsePlannerModel = "gpt-5.4"
         config.computerUseTimeoutSeconds = 180
+        config.openAISummaryMaxTokens = 4000
+        config.openRouterSummaryMaxTokens = 5000
+        config.ollamaSummaryMaxTokens = 6000
+        config.lmStudioSummaryMaxTokens = 12000
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -490,6 +498,10 @@ struct AppConfigTests {
         #expect(decoded.enableComputerUsePlanner == false)
         #expect(decoded.computerUsePlannerModel == "gpt-5.4")
         #expect(decoded.computerUseTimeoutSeconds == 180)
+        #expect(decoded.openAISummaryMaxTokens == 4000)
+        #expect(decoded.openRouterSummaryMaxTokens == 5000)
+        #expect(decoded.ollamaSummaryMaxTokens == 6000)
+        #expect(decoded.lmStudioSummaryMaxTokens == 12000)
     }
 
     @Test("JSON coding keys use snake_case")
@@ -522,6 +534,10 @@ struct AppConfigTests {
         #expect(json["meeting_hook_enabled"] != nil)
         #expect(json["meeting_hook_path"] != nil)
         #expect(json["meeting_hook_timeout_seconds"] != nil)
+        #expect(json["openai_summary_max_tokens"] != nil)
+        #expect(json["openrouter_summary_max_tokens"] != nil)
+        #expect(json["ollama_summary_max_tokens"] != nil)
+        #expect(json["lmstudio_summary_max_tokens"] != nil)
     }
 
     @Test("decodes with missing fields using defaults")
@@ -550,6 +566,10 @@ struct AppConfigTests {
         #expect(config.meetingHookEnabled == false)
         #expect(config.meetingHookPath.isEmpty)
         #expect(config.meetingHookTimeoutSeconds == 30)
+        #expect(config.openAISummaryMaxTokens == 2500)
+        #expect(config.openRouterSummaryMaxTokens == 2500)
+        #expect(config.ollamaSummaryMaxTokens == 2500)
+        #expect(config.lmStudioSummaryMaxTokens == 2500)
     }
 
     @Test("legacy completed onboarding enables meetings when use case is missing")

--- a/scripts/MuesliDev.entitlements
+++ b/scripts/MuesliDev.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <false/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Adds a configurable max-output-token limit to each summary backend (OpenAI, OpenRouter, Ollama, LM Studio). Each backend gets its own setting, defaulting to 2500, with a stepper in Settings. Also updates the empty response error message to suggest increasing the token limit for reasoning models.