### PR TITLE
Fix issue #154: Feature Request: Import audio file for offline transcription (m4a, mp4, wav, etc.)

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -22,7 +22,7 @@ public final class DictationStore {
     t.id, t.final_status, t.final_message, t.trace_json, t.created_at
     """
     private static let meetingColumns = """
-    id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt
+    id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source
     """
 
     public init() {
@@ -131,6 +131,9 @@ public final class DictationStore {
             // Column may already exist.
         }
         if sqlite3_exec(db, "ALTER TABLE meetings ADD COLUMN manual_notes TEXT NOT NULL DEFAULT ''", nil, nil, nil) != SQLITE_OK {
+            // Column may already exist.
+        }
+        if sqlite3_exec(db, "ALTER TABLE meetings ADD COLUMN source TEXT NOT NULL DEFAULT 'meeting'", nil, nil, nil) != SQLITE_OK {
             // Column may already exist.
         }
         if sqlite3_exec(db, "ALTER TABLE dictations ADD COLUMN source TEXT NOT NULL DEFAULT 'dictation'", nil, nil, nil) != SQLITE_OK {
@@ -462,7 +465,8 @@ public final class DictationStore {
         selectedTemplateID: String? = nil,
         selectedTemplateName: String? = nil,
         selectedTemplateKind: MeetingTemplateKind? = nil,
-        selectedTemplatePrompt: String? = nil
+        selectedTemplatePrompt: String? = nil,
+        source: MeetingSource = .meeting
     ) throws -> Int64 {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
@@ -470,7 +474,7 @@ public final class DictationStore {
         let sql = """
         INSERT INTO meetings
         (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes, mic_audio_path, system_audio_path, saved_recording_path, word_count, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'meeting')
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
@@ -499,6 +503,7 @@ public final class DictationStore {
         bindOptionalText(selectedTemplateName, at: 13, statement: statement)
         bindOptionalText(selectedTemplateKind?.rawValue, at: 14, statement: statement)
         bindOptionalText(selectedTemplatePrompt, at: 15, statement: statement)
+        sqlite3_bind_text(statement, 16, (source.rawValue as NSString).utf8String, -1, nil)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
@@ -1148,6 +1153,7 @@ public final class DictationStore {
             ? nil
             : MeetingTemplateKind(rawValue: stringColumn(statement, index: 16))
         let selectedTemplatePrompt: String? = sqlite3_column_type(statement, 17) == SQLITE_NULL ? nil : stringColumn(statement, index: 17)
+        let source = MeetingSource(rawValue: stringColumn(statement, index: 18)) ?? .meeting
         return MeetingRecord(
             id: sqlite3_column_int64(statement, 0),
             title: stringColumn(statement, index: 1),
@@ -1166,7 +1172,8 @@ public final class DictationStore {
             selectedTemplateID: selectedTemplateID,
             selectedTemplateName: selectedTemplateName,
             selectedTemplateKind: selectedTemplateKind,
-            selectedTemplatePrompt: selectedTemplatePrompt
+            selectedTemplatePrompt: selectedTemplatePrompt,
+            source: source
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -26,6 +26,11 @@ public enum MeetingRecordingSavePolicy: String, Codable, CaseIterable, Sendable 
     case always
 }
 
+public enum MeetingSource: String, Codable, Sendable {
+    case meeting
+    case audioImport = "audio_import"
+}
+
 public struct DictationRecord: Identifiable, Codable, Sendable {
     public let id: Int64
     public let timestamp: String
@@ -129,6 +134,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
     public let selectedTemplateName: String?
     public let selectedTemplateKind: MeetingTemplateKind?
     public let selectedTemplatePrompt: String?
+    public let source: MeetingSource
 
     public init(
         id: Int64,
@@ -148,7 +154,8 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         selectedTemplateID: String? = nil,
         selectedTemplateName: String? = nil,
         selectedTemplateKind: MeetingTemplateKind? = nil,
-        selectedTemplatePrompt: String? = nil
+        selectedTemplatePrompt: String? = nil,
+        source: MeetingSource = .meeting
     ) {
         self.id = id
         self.title = title
@@ -168,6 +175,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         self.selectedTemplateName = selectedTemplateName
         self.selectedTemplateKind = selectedTemplateKind
         self.selectedTemplatePrompt = selectedTemplatePrompt
+        self.source = source
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -189,6 +197,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         case selectedTemplateName
         case selectedTemplateKind
         case selectedTemplatePrompt
+        case source
     }
 
     public init(from decoder: Decoder) throws {
@@ -211,7 +220,8 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
             selectedTemplateID: try c.decodeIfPresent(String.self, forKey: .selectedTemplateID),
             selectedTemplateName: try c.decodeIfPresent(String.self, forKey: .selectedTemplateName),
             selectedTemplateKind: try c.decodeIfPresent(MeetingTemplateKind.self, forKey: .selectedTemplateKind),
-            selectedTemplatePrompt: try c.decodeIfPresent(String.self, forKey: .selectedTemplatePrompt)
+            selectedTemplatePrompt: try c.decodeIfPresent(String.self, forKey: .selectedTemplatePrompt),
+            source: (try? c.decode(MeetingSource.self, forKey: .source)) ?? .meeting
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -9,6 +9,8 @@ import UniformTypeIdentifiers
 /// Converts the source file to 16kHz mono WAV, transcribes it, optionally runs
 /// speaker diarization, and creates a meeting record with the result.
 enum AudioFileImportController {
+    static let supportedExtensions: Set<String> = ["m4a", "mp4", "wav", "mp3"]
+
     private static let allowedTypes: [UTType] = {
         var types: [UTType] = [
             .wav,
@@ -20,6 +22,10 @@ enum AudioFileImportController {
         if let mp4 = UTType(filenameExtension: "mp4") { types.append(mp4) }
         return types
     }()
+
+    static func isSupportedFileURL(_ url: URL) -> Bool {
+        supportedExtensions.contains(url.pathExtension.lowercased())
+    }
 
     // MARK: - File Selection
 
@@ -55,7 +61,7 @@ enum AudioFileImportController {
 
     // MARK: - Audio Conversion
 
-    enum ImportError: Error, LocalizedError {
+    enum ImportError: Error, Equatable, LocalizedError {
         case unsupportedFormat
         case conversionFailed(String)
         case noAudioTracks
@@ -78,71 +84,39 @@ enum AudioFileImportController {
     /// Converts the source audio file to 16kHz mono WAV for transcription.
     /// Returns the temporary WAV URL and the audio duration in seconds.
     static func convertToWAV(sourceURL: URL) async throws -> (wavURL: URL, duration: TimeInterval) {
-        let asset = AVAsset(url: sourceURL)
-        guard let audioTrack = asset.tracks(withMediaType: .audio).first else {
+        guard isSupportedFileURL(sourceURL) else {
+            throw ImportError.unsupportedFormat
+        }
+        try Task.checkCancellation()
+
+        if let compatibleWAV = try compatibleWAVInfo(sourceURL: sourceURL) {
+            let outputURL = try temporaryWAVURL()
+            try FileManager.default.copyItem(at: sourceURL, to: outputURL)
+            return (outputURL, compatibleWAV.duration)
+        }
+
+        let duration = try await audioDuration(sourceURL: sourceURL)
+        try Task.checkCancellation()
+
+        let samples: [Float]
+        do {
+            samples = try AudioConverter().resampleAudioFile(sourceURL)
+        } catch {
+            samples = try await decodeSamplesWithAssetReader(sourceURL: sourceURL)
+        }
+        try Task.checkCancellation()
+
+        guard !samples.isEmpty else {
             throw ImportError.noAudioTracks
         }
 
-        let duration = CMTimeGetSeconds(asset.duration)
-        guard duration > 0, duration.isFinite else {
+        let wavURL = try WavWriter.writeTemporaryWAV(samples: samples, directoryName: "muesli-import")
+        let resolvedDuration = duration ?? Double(samples.count) / Double(WavWriter.sampleRate)
+        guard resolvedDuration > 0, resolvedDuration.isFinite else {
+            try? FileManager.default.removeItem(at: wavURL)
             throw ImportError.readError("Invalid audio duration.")
         }
-
-        let outputURL = try temporaryWAVURL()
-        let reader = try AVAssetReader(asset: asset)
-        let outputSettings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
-            AVSampleRateKey: 16000,
-            AVNumberOfChannelsKey: 1,
-            AVLinearPCMBitDepthKey: 16,
-            AVLinearPCMIsFloatKey: false,
-            AVLinearPCMIsBigEndianKey: false,
-        ]
-        let readerOutput = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: outputSettings)
-        readerOutput.alwaysCopiesSampleData = false
-        reader.add(readerOutput)
-
-        let writer = try AVAssetWriter(url: outputURL, fileType: .wav)
-        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: outputSettings)
-        writerInput.expectsMediaDataInRealTime = false
-        writer.add(writerInput)
-
-        guard reader.startReading() else {
-            throw ImportError.readError(reader.error?.localizedDescription ?? "Unknown read error")
-        }
-        guard writer.startWriting() else {
-            throw ImportError.conversionFailed(writer.error?.localizedDescription ?? "Unknown write error")
-        }
-        writer.startSession(atSourceTime: .zero)
-
-        // Use async dispatch group to avoid blocking cooperative thread pool
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            let queue = DispatchQueue(label: "com.muesli.import.convert")
-            writerInput.requestMediaDataWhenReady(on: queue) {
-                while writerInput.isReadyForMoreMediaData {
-                    if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
-                        writerInput.append(sampleBuffer)
-                    } else {
-                        writerInput.markAsFinished()
-                        writer.finishWriting {
-                            continuation.resume()
-                        }
-                        return
-                    }
-                }
-            }
-        }
-
-        if let error = writer.error {
-            try? FileManager.default.removeItem(at: outputURL)
-            throw ImportError.conversionFailed(error.localizedDescription)
-        }
-        guard reader.status == .completed else {
-            try? FileManager.default.removeItem(at: outputURL)
-            throw ImportError.readError(reader.error?.localizedDescription ?? "Read did not complete")
-        }
-
-        return (outputURL, duration)
+        return (wavURL, resolvedDuration)
     }
 
     // MARK: - Import Pipeline
@@ -154,6 +128,13 @@ enum AudioFileImportController {
         let formattedNotes: String
         let durationSeconds: Double
         let wordCount: Int
+    }
+
+    struct ImportContext {
+        let config: AppConfig
+        let backend: BackendOption
+        let transcriptionCoordinator: TranscriptionCoordinator
+        let templateSnapshot: MeetingTemplateSnapshot
     }
 
     /// Runs the full import pipeline: convert, transcribe, diarize, format, persist, summarize.
@@ -169,9 +150,10 @@ enum AudioFileImportController {
 
         try Task.checkCancellation()
 
-        let config = controller.config
-        let backend = controller.selectedMeetingTranscriptionBackend
-        let transcriptionCoordinator = controller.transcriptionCoordinator
+        let context = await controller.audioFileImportContext()
+        let config = context.config
+        let backend = context.backend
+        let transcriptionCoordinator = context.transcriptionCoordinator
 
         progress("Loading transcription model...")
         try await transcriptionCoordinator.preloadRequired(
@@ -183,7 +165,7 @@ enum AudioFileImportController {
         try Task.checkCancellation()
 
         // Run VAD to skip silent files (prevents Cohere hallucinations on silence)
-        if let vadManager = transcriptionCoordinator.vadManager {
+        if let vadManager = await transcriptionCoordinator.getVadManager() {
             do {
                 let vadResults = try await vadManager.process(wavURL)
                 let hasSpeech = vadResults.contains { $0.probability > 0.5 }
@@ -214,7 +196,7 @@ enum AudioFileImportController {
 
         // Run speaker diarization if available
         var diarizedTranscript = rawTranscript
-        if let diarizerManager = transcriptionCoordinator.getDiarizerManager(),
+        if let diarizerManager = await transcriptionCoordinator.getDiarizerManager(),
            diarizerManager.isAvailable {
             progress("Identifying speakers...")
             do {
@@ -227,13 +209,13 @@ enum AudioFileImportController {
                 )
                 if !diarizationResult.segments.isEmpty {
                     diarizedTranscript = formatTranscriptWithSpeakers(
-                        rawText: rawTranscript,
+                        transcription: transcription,
                         diarizationSegments: diarizationResult.segments,
-                        duration: duration
+                        meetingStart: importedTranscriptTimelineStart()
                     )
                 }
             } catch is CancellationError {
-                throw ImportError.readError("Import was cancelled.")
+                throw CancellationError()
             } catch {
                 fputs("[import] diarization failed, using raw transcript: \(error)\n", stderr)
             }
@@ -242,14 +224,24 @@ enum AudioFileImportController {
         try Task.checkCancellation()
 
         let wordCount = DictationStore.countWords(in: diarizedTranscript)
+        let generatedTitle: String
+        progress("Generating title...")
+        if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: diarizedTranscript, config: config),
+           !autoTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            generatedTitle = autoTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            generatedTitle = title
+        }
+
+        try Task.checkCancellation()
 
         progress("Generating summary...")
-        let templateSnapshot = controller.defaultMeetingTemplate()
+        let templateSnapshot = context.templateSnapshot
         let formattedNotes: String
         do {
             formattedNotes = try await MeetingSummaryClient.summarize(
                 transcript: diarizedTranscript,
-                meetingTitle: title,
+                meetingTitle: generatedTitle,
                 config: config,
                 template: templateSnapshot,
                 existingNotes: nil,
@@ -259,7 +251,7 @@ enum AudioFileImportController {
             fputs("[import] summary generation failed: \(error)\n", stderr)
             formattedNotes = MeetingSummaryClient.summaryFailureNotes(
                 transcript: diarizedTranscript,
-                meetingTitle: title,
+                meetingTitle: generatedTitle,
                 error: error,
                 manualNotes: ""
             )
@@ -268,13 +260,13 @@ enum AudioFileImportController {
         try Task.checkCancellation()
 
         // Persist the converted WAV as a saved recording so retranscription works
-        let savedRecordingPath = try persistRecording(wavURL: wavURL, title: title)
+        let savedRecordingPath = try persistRecording(wavURL: wavURL, title: generatedTitle)
 
         progress("Saving...")
         let now = Date()
         let startTime = now.addingTimeInterval(-duration)
-        let meetingID = try controller.dictationStore.insertMeeting(
-            title: title,
+        let meetingID = try await controller.persistImportedAudioMeeting(
+            title: generatedTitle,
             calendarEventID: nil,
             startTime: startTime,
             endTime: now,
@@ -291,7 +283,7 @@ enum AudioFileImportController {
 
         return ImportResult(
             meetingID: meetingID,
-            title: title,
+            title: generatedTitle,
             rawTranscript: diarizedTranscript,
             formattedNotes: formattedNotes,
             durationSeconds: duration,
@@ -308,6 +300,78 @@ enum AudioFileImportController {
         return directory.appendingPathComponent("import_\(UUID().uuidString).wav")
     }
 
+    private struct CompatibleWAVInfo {
+        let duration: TimeInterval
+    }
+
+    private static func compatibleWAVInfo(sourceURL: URL) throws -> CompatibleWAVInfo? {
+        guard sourceURL.pathExtension.lowercased() == "wav" else { return nil }
+        let file = try AVAudioFile(forReading: sourceURL)
+        let fileFormat = file.fileFormat
+        guard fileFormat.sampleRate == Double(WavWriter.sampleRate),
+              fileFormat.channelCount == UInt32(WavWriter.channels),
+              fileFormat.commonFormat == .pcmFormatInt16 else {
+            return nil
+        }
+        let duration = Double(file.length) / fileFormat.sampleRate
+        guard duration > 0, duration.isFinite else {
+            throw ImportError.readError("Invalid audio duration.")
+        }
+        return CompatibleWAVInfo(duration: duration)
+    }
+
+    private static func audioDuration(sourceURL: URL) async throws -> TimeInterval? {
+        let asset = AVURLAsset(url: sourceURL)
+        let tracks = try await asset.load(.tracks)
+        guard tracks.contains(where: { $0.mediaType == .audio }) else {
+            throw ImportError.noAudioTracks
+        }
+        let duration = CMTimeGetSeconds(try await asset.load(.duration))
+        return duration > 0 && duration.isFinite ? duration : nil
+    }
+
+    private static func decodeSamplesWithAssetReader(sourceURL: URL) async throws -> [Float] {
+        let asset = AVURLAsset(url: sourceURL)
+        let tracks = try await asset.load(.tracks)
+        guard let audioTrack = tracks.first(where: { $0.mediaType == .audio }) else {
+            throw ImportError.noAudioTracks
+        }
+
+        let reader = try AVAssetReader(asset: asset)
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        let output = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: outputSettings)
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else {
+            throw ImportError.conversionFailed("Could not read audio samples from the selected file.")
+        }
+        reader.add(output)
+
+        guard reader.startReading() else {
+            throw ImportError.readError(reader.error?.localizedDescription ?? "Unknown read error")
+        }
+
+        let converter = AudioConverter()
+        var samples: [Float] = []
+        while reader.status == .reading {
+            try Task.checkCancellation()
+            guard let sampleBuffer = output.copyNextSampleBuffer() else {
+                break
+            }
+            samples.append(contentsOf: try converter.resampleSampleBuffer(sampleBuffer))
+        }
+
+        guard reader.status == .completed else {
+            throw ImportError.readError(reader.error?.localizedDescription ?? "Read did not complete")
+        }
+        return samples
+    }
+
     /// Copies the converted WAV to the meeting-recordings directory so the imported
     /// meeting can be retranscribed later.
     private static func persistRecording(wavURL: URL, title: String) throws -> String {
@@ -321,76 +385,77 @@ enum AudioFileImportController {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
         let datePrefix = dateFormatter.string(from: Date())
-        let safeTitle = title.replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ":", with: "-")
-        let filename = "\(datePrefix)_\(safeTitle).wav"
+        let safeTitle = safeFilenameComponent(title)
+        let filename = "\(datePrefix)_\(safeTitle)_\(UUID().uuidString.prefix(8)).wav"
         let destinationURL = recordingsDirectory.appendingPathComponent(filename)
 
-        if FileManager.default.fileExists(atPath: destinationURL.path) {
-            try FileManager.default.removeItem(at: destinationURL)
-        }
         try FileManager.default.copyItem(at: wavURL, to: destinationURL)
         return destinationURL.path
     }
 
+    private static func safeFilenameComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(.whitespaces).union(CharacterSet(charactersIn: "-_"))
+        let scalars = value.unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        let collapsed = String(scalars)
+            .split(whereSeparator: { $0.isWhitespace || $0 == "-" })
+            .joined(separator: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-_ "))
+        return collapsed.isEmpty ? "Imported-Recording" : String(collapsed.prefix(80))
+    }
+
+    private static func importedTranscriptTimelineStart() -> Date {
+        Calendar.current.startOfDay(for: Date())
+    }
+
     /// Formats transcript text with speaker labels based on diarization segments.
     /// When diarization identifies multiple speakers, the transcript is annotated with
-    /// speaker labels at segment boundaries so both the user and summarizer can
-    /// attribute spoken text to individual speakers.
+    /// speaker labels using ASR segment timestamps so both the user and summarizer can
+    /// attribute spoken text to individual speakers without inventing text boundaries.
+    static func formatTranscriptWithSpeakers(
+        transcription: SpeechTranscriptionResult,
+        diarizationSegments: [TimedSpeakerSegment],
+        meetingStart: Date
+    ) -> String {
+        let rawText = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawText.isEmpty, !diarizationSegments.isEmpty else { return rawText }
+
+        let speakerCount = Set(diarizationSegments.map(\.speakerId)).count
+        guard speakerCount > 1 else { return rawText }
+
+        if rawText.range(of: #"(?m)^\[[0-9]{2}:[0-9]{2}(?::[0-9]{2})?\]\s+(You|Others|Speaker\s+\d+):"#, options: .regularExpression) != nil {
+            return rawText
+        }
+
+        let transcribedSegments = transcription.segments.filter {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !transcribedSegments.isEmpty else { return rawText }
+
+        let formatted = TranscriptFormatter.merge(
+            micSegments: [],
+            systemSegments: transcribedSegments,
+            diarizationSegments: diarizationSegments,
+            meetingStart: meetingStart
+        )
+        return formatted.isEmpty ? rawText : formatted
+    }
+
+    /// Backward-compatible helper for tests and any callers that only have raw text.
     static func formatTranscriptWithSpeakers(
         rawText: String,
         diarizationSegments: [TimedSpeakerSegment],
         duration: TimeInterval
     ) -> String {
-        guard !diarizationSegments.isEmpty else { return rawText }
-
-        let speakerCount = Set(diarizationSegments.map(\.speakerId)).count
-        guard speakerCount > 1 else { return rawText }
-
-        // If the raw text already has timestamped speaker lines, use those instead.
-        if rawText.range(of: #"(?m)^\[[0-9]{2}:[0-9]{2}(?::[0-9]{2})?\]\s+(You|Others|Speaker\s+\d+):"#, options: .regularExpression) != nil {
-            return rawText
-        }
-
-        // Build a speaker-labeled transcript using diarization segments
-        var result = "## Speaker Segments\n"
-        for segment in diarizationSegments {
-            let startStr = formatTimeInterval(segment.startTime)
-            let endStr = formatTimeInterval(segment.endTime)
-            let speaker = segment.speakerId.replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
-            result += "[\(startStr) - \(endStr)] \(speaker)\n"
-        }
-
-        result += "\n## Transcript\n"
-
-        // Annotate the transcript with speaker labels at segment boundaries
-        let lines = rawText.components(separatedBy: .newlines)
-        let segmentCount = diarizationSegments.count
-        let lineCount = lines.count
-
-        if lineCount > 0, segmentCount > 0 {
-            let linesPerSegment = max(1, lineCount / segmentCount)
-            for (i, line) in lines.enumerated() {
-                let segmentIndex = min(i / linesPerSegment, segmentCount - 1)
-                let speaker = diarizationSegments[segmentIndex].speakerId
-                    .replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
-                let startStr = formatTimeInterval(diarizationSegments[segmentIndex].startTime)
-                result += "[\(startStr)] \(speaker): \(line)\n"
-            }
-        } else {
-            result += rawText
-        }
-
-        return result
-    }
-
-    private static func formatTimeInterval(_ interval: TimeInterval) -> String {
-        let hours = Int(interval) / 3600
-        let minutes = (Int(interval) % 3600) / 60
-        let seconds = Int(interval) % 60
-        if hours > 0 {
-            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-        }
-        return String(format: "%02d:%02d", minutes, seconds)
+        let transcription = SpeechTranscriptionResult(
+            text: rawText,
+            segments: [SpeechSegment(start: 0, end: max(duration, 0.1), text: rawText)]
+        )
+        return formatTranscriptWithSpeakers(
+            transcription: transcription,
+            diarizationSegments: diarizationSegments,
+            meetingStart: importedTranscriptTimelineStart()
+        )
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -1,0 +1,332 @@
+import AppKit
+import AVFoundation
+import FluidAudio
+import Foundation
+import MuesliCore
+import UniformTypeIdentifiers
+
+/// Handles importing audio files (m4a, mp4, wav, mp3) for offline transcription.
+/// Converts the source file to 16kHz mono WAV, transcribes it, optionally runs
+/// speaker diarization, and creates a meeting record with the result.
+enum AudioFileImportController {
+    private static let allowedTypes: [UTType] = [
+        .wav,
+        .mp3,
+        .mpeg4Audio,
+        .appleProtectedMPEG4Audio,
+        UTType(filenameExtension: "m4a") ?? .audio,
+        UTType(filenameExtension: "mp4") ?? .audio,
+    ].filter { $0 != .audio }  // drop fallback if real types are present
+
+    // MARK: - File Selection
+
+    /// Presents an NSOpenPanel for selecting an audio file and returns the chosen URL.
+    static func selectFile() async -> URL? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                let panel = NSOpenPanel()
+                panel.title = "Import Audio File for Transcription"
+                panel.message = "Choose an audio file (m4a, mp4, wav, mp3)"
+                panel.allowedContentTypes = allowedTypes
+                panel.allowsMultipleSelection = false
+                panel.canChooseDirectories = false
+                panel.canCreateDirectories = false
+
+                NSApp.activate()
+                if let window = NSApp.keyWindow {
+                    panel.beginSheetModal(for: window) { response in
+                        continuation.resume(
+                            returning: response == .OK ? panel.url : nil
+                        )
+                    }
+                } else {
+                    panel.begin { response in
+                        continuation.resume(
+                            returning: response == .OK ? panel.url : nil
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Audio Conversion
+
+    enum ImportError: Error, LocalizedError {
+        case unsupportedFormat
+        case conversionFailed(String)
+        case noAudioTracks
+        case readError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedFormat:
+                return "This audio file format is not supported."
+            case .conversionFailed(let detail):
+                return "Could not convert the audio file. \(detail)"
+            case .noAudioTracks:
+                return "The selected file does not contain any audio tracks."
+            case .readError(let detail):
+                return "Could not read the audio file. \(detail)"
+            }
+        }
+    }
+
+    /// Converts the source audio file to 16kHz mono WAV for transcription.
+    /// Returns the temporary WAV URL and the audio duration in seconds.
+    static func convertToWAV(sourceURL: URL) throws -> (wavURL: URL, duration: TimeInterval) {
+        let asset = AVAsset(url: sourceURL)
+        guard let audioTrack = asset.tracks(withMediaType: .audio).first else {
+            throw ImportError.noAudioTracks
+        }
+
+        let duration = CMTimeGetSeconds(asset.duration)
+        guard duration > 0, duration.isFinite else {
+            throw ImportError.readError("Invalid audio duration.")
+        }
+
+        let outputURL = try temporaryWAVURL()
+        let reader = try AVAssetReader(asset: asset)
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: 16000,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+        let readerOutput = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: outputSettings)
+        readerOutput.alwaysCopiesSampleData = false
+        reader.add(readerOutput)
+
+        let writer = try AVAssetWriter(url: outputURL, fileType: .wav)
+        let sourceFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false
+        )!
+        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: sourceFormat.settings)
+        writerInput.expectsMediaDataInRealTime = false
+        writer.add(writerInput)
+
+        guard reader.startReading() else {
+            throw ImportError.readError(reader.error?.localizedDescription ?? "Unknown read error")
+        }
+        guard writer.startWriting() else {
+            throw ImportError.conversionFailed(writer.error?.localizedDescription ?? "Unknown write error")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        writerInput.requestMediaDataWhenReady(on: DispatchQueue(label: "com.muesli.import.convert")) {
+            while writerInput.isReadyForMoreMediaData {
+                if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+                    writerInput.append(sampleBuffer)
+                } else {
+                    writerInput.markAsFinished()
+                    dispatchGroup.leave()
+                    return
+                }
+            }
+        }
+        dispatchGroup.wait()
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            writer.finishWriting {
+                continuation.resume()
+            }
+        }
+
+        if let error = writer.error {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw ImportError.conversionFailed(error.localizedDescription)
+        }
+        guard reader.status == .completed else {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw ImportError.readError(reader.error?.localizedDescription ?? "Read did not complete")
+        }
+
+        return (outputURL, duration)
+    }
+
+    // MARK: - Import Pipeline
+
+    struct ImportResult {
+        let meetingID: Int64
+        let title: String
+        let rawTranscript: String
+        let formattedNotes: String
+        let durationSeconds: Double
+        let wordCount: Int
+    }
+
+    /// Runs the full import pipeline: convert, transcribe, diarize, format, persist, summarize.
+    static func importAudioFile(
+        sourceURL: URL,
+        title: String,
+        controller: MuesliController,
+        progress: @escaping (String) -> Void
+    ) async throws -> ImportResult {
+        progress("Converting audio file...")
+        let (wavURL, duration) = try convertToWAV(sourceURL: sourceURL)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        let config = controller.config
+        let backend = controller.selectedMeetingTranscriptionBackend
+        let transcriptionCoordinator = controller.transcriptionCoordinator
+
+        progress("Loading transcription model...")
+        try await transcriptionCoordinator.preloadRequired(
+            backend: backend,
+            enablePostProcessor: false,
+            includeMeetingHelpers: true
+        )
+
+        progress("Transcribing audio...")
+        let transcription = try await transcriptionCoordinator.transcribeMeeting(
+            at: wavURL,
+            backend: backend,
+            cohereLanguage: config.resolvedCohereLanguage
+        )
+        let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Run speaker diarization if available
+        var diarizedTranscript = rawTranscript
+        if let diarizerManager = transcriptionCoordinator.getDiarizerManager(),
+           diarizerManager.isAvailable,
+           !rawTranscript.isEmpty {
+            progress("Identifying speakers...")
+            do {
+                let converter = AudioConverter()
+                let samples = try converter.resampleAudioFile(wavURL)
+                let diarizationResult = try diarizerManager.performCompleteDiarization(
+                    samples,
+                    sampleRate: 16000
+                )
+                if !diarizationResult.segments.isEmpty {
+                    diarizedTranscript = formatTranscriptWithSpeakers(
+                        rawText: rawTranscript,
+                        diarizationSegments: diarizationResult.segments,
+                        duration: duration
+                    )
+                }
+            } catch {
+                fputs("[import] diarization failed, using raw transcript: \(error)\n", stderr)
+            }
+        }
+
+        let wordCount = DictationStore.countWords(in: diarizedTranscript)
+
+        progress("Generating summary...")
+        let templateSnapshot = controller.defaultMeetingTemplate()
+        let formattedNotes: String
+        do {
+            formattedNotes = try await MeetingSummaryClient.summarize(
+                transcript: diarizedTranscript,
+                meetingTitle: title,
+                config: config,
+                template: templateSnapshot,
+                existingNotes: nil,
+                manualNotesToRetain: ""
+            )
+        } catch {
+            fputs("[import] summary generation failed: \(error)\n", stderr)
+            formattedNotes = MeetingSummaryClient.summaryFailureNotes(
+                transcript: diarizedTranscript,
+                meetingTitle: title,
+                error: error,
+                manualNotes: ""
+            )
+        }
+
+        progress("Saving...")
+        let now = Date()
+        let startTime = now.addingTimeInterval(-duration)
+        let meetingID = try controller.dictationStore.insertMeeting(
+            title: title,
+            calendarEventID: nil,
+            startTime: startTime,
+            endTime: now,
+            rawTranscript: diarizedTranscript,
+            formattedNotes: formattedNotes,
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: nil,
+            selectedTemplateID: templateSnapshot.id,
+            selectedTemplateName: templateSnapshot.name,
+            selectedTemplateKind: templateSnapshot.kind,
+            selectedTemplatePrompt: templateSnapshot.prompt
+        )
+
+        return ImportResult(
+            meetingID: meetingID,
+            title: title,
+            rawTranscript: diarizedTranscript,
+            formattedNotes: formattedNotes,
+            durationSeconds: duration,
+            wordCount: wordCount
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func temporaryWAVURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-import", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("import_\(UUID().uuidString).wav")
+    }
+
+    /// Formats transcript text with speaker labels based on diarization segments.
+    /// Uses a simple approach: if diarization identifies distinct speakers, prefix
+    /// transcript lines with speaker labels.
+    static func formatTranscriptWithSpeakers(
+        rawText: String,
+        diarizationSegments: [TimedSpeakerSegment],
+        duration: TimeInterval
+    ) -> String {
+        guard !diarizationSegments.isEmpty else { return rawText }
+
+        let speakerCount = Set(diarizationSegments.map(\.speakerId)).count
+        guard speakerCount > 1 else { return rawText }
+
+        // Build a speaker-labeled transcript using diarization segments
+        var lines: [String] = []
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.zeroFormattingBehavior = [.pad]
+
+        for segment in diarizationSegments {
+            let startStr = formatTimeInterval(segment.startTime)
+            let speaker = segment.speakerId.replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
+            lines.append("[\(startStr)] \(speaker):")
+        }
+
+        // If the raw text has timestamp markers, use those instead
+        if rawText.contains("[") && rawText.contains("]") {
+            return rawText
+        }
+
+        // Fallback: prepend a header and return the raw text
+        let header = diarizationSegments.map { segment in
+            let startStr = formatTimeInterval(segment.startTime)
+            let endStr = formatTimeInterval(segment.endTime)
+            let speaker = segment.speakerId.replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
+            return "[\(startStr) - \(endStr)] \(speaker)"
+        }.joined(separator: "\n")
+
+        return "## Speaker Segments\n\(header)\n\n## Transcript\n\(rawText)"
+    }
+
+    private static func formatTimeInterval(_ interval: TimeInterval) -> String {
+        let hours = Int(interval) / 3600
+        let minutes = (Int(interval) % 3600) / 60
+        let seconds = Int(interval) % 60
+        if hours > 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -9,14 +9,17 @@ import UniformTypeIdentifiers
 /// Converts the source file to 16kHz mono WAV, transcribes it, optionally runs
 /// speaker diarization, and creates a meeting record with the result.
 enum AudioFileImportController {
-    private static let allowedTypes: [UTType] = [
-        .wav,
-        .mp3,
-        .mpeg4Audio,
-        .appleProtectedMPEG4Audio,
-        UTType(filenameExtension: "m4a") ?? .audio,
-        UTType(filenameExtension: "mp4") ?? .audio,
-    ].filter { $0 != .audio }  // drop fallback if real types are present
+    private static let allowedTypes: [UTType] = {
+        var types: [UTType] = [
+            .wav,
+            .mp3,
+            .mpeg4Audio,
+            .appleProtectedMPEG4Audio,
+        ]
+        if let m4a = UTType(filenameExtension: "m4a") { types.append(m4a) }
+        if let mp4 = UTType(filenameExtension: "mp4") { types.append(mp4) }
+        return types
+    }()
 
     // MARK: - File Selection
 
@@ -100,13 +103,7 @@ enum AudioFileImportController {
         reader.add(readerOutput)
 
         let writer = try AVAssetWriter(url: outputURL, fileType: .wav)
-        let sourceFormat = AVAudioFormat(
-            commonFormat: .pcmFormatInt16,
-            sampleRate: 16000,
-            channels: 1,
-            interleaved: false
-        )!
-        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: sourceFormat.settings)
+        let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: outputSettings)
         writerInput.expectsMediaDataInRealTime = false
         writer.add(writerInput)
 
@@ -118,24 +115,21 @@ enum AudioFileImportController {
         }
         writer.startSession(atSourceTime: .zero)
 
-        let dispatchGroup = DispatchGroup()
-        dispatchGroup.enter()
-        writerInput.requestMediaDataWhenReady(on: DispatchQueue(label: "com.muesli.import.convert")) {
-            while writerInput.isReadyForMoreMediaData {
-                if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
-                    writerInput.append(sampleBuffer)
-                } else {
-                    writerInput.markAsFinished()
-                    dispatchGroup.leave()
-                    return
+        // Use async dispatch group to avoid blocking cooperative thread pool
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let queue = DispatchQueue(label: "com.muesli.import.convert")
+            writerInput.requestMediaDataWhenReady(on: queue) {
+                while writerInput.isReadyForMoreMediaData {
+                    if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+                        writerInput.append(sampleBuffer)
+                    } else {
+                        writerInput.markAsFinished()
+                        writer.finishWriting {
+                            continuation.resume()
+                        }
+                        return
+                    }
                 }
-            }
-        }
-        dispatchGroup.wait()
-
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            writer.finishWriting {
-                continuation.resume()
             }
         }
 
@@ -173,6 +167,8 @@ enum AudioFileImportController {
         let (wavURL, duration) = try await convertToWAV(sourceURL: sourceURL)
         defer { try? FileManager.default.removeItem(at: wavURL) }
 
+        try Task.checkCancellation()
+
         let config = controller.config
         let backend = controller.selectedMeetingTranscriptionBackend
         let transcriptionCoordinator = controller.transcriptionCoordinator
@@ -183,6 +179,8 @@ enum AudioFileImportController {
             enablePostProcessor: false,
             includeMeetingHelpers: true
         )
+
+        try Task.checkCancellation()
 
         // Run VAD to skip silent files (prevents Cohere hallucinations on silence)
         if let vadManager = transcriptionCoordinator.vadManager {
@@ -199,6 +197,8 @@ enum AudioFileImportController {
             }
         }
 
+        try Task.checkCancellation()
+
         progress("Transcribing audio...")
         let transcription = try await transcriptionCoordinator.transcribeMeeting(
             at: wavURL,
@@ -210,6 +210,8 @@ enum AudioFileImportController {
             throw ImportError.readError("No speech was transcribed from the selected audio file.")
         }
 
+        try Task.checkCancellation()
+
         // Run speaker diarization if available
         var diarizedTranscript = rawTranscript
         if let diarizerManager = transcriptionCoordinator.getDiarizerManager(),
@@ -218,6 +220,7 @@ enum AudioFileImportController {
             do {
                 let converter = AudioConverter()
                 let samples = try converter.resampleAudioFile(wavURL)
+                try Task.checkCancellation()
                 let diarizationResult = try diarizerManager.performCompleteDiarization(
                     samples,
                     sampleRate: 16000
@@ -229,10 +232,14 @@ enum AudioFileImportController {
                         duration: duration
                     )
                 }
+            } catch is CancellationError {
+                throw ImportError.readError("Import was cancelled.")
             } catch {
                 fputs("[import] diarization failed, using raw transcript: \(error)\n", stderr)
             }
         }
+
+        try Task.checkCancellation()
 
         let wordCount = DictationStore.countWords(in: diarizedTranscript)
 
@@ -257,6 +264,8 @@ enum AudioFileImportController {
                 manualNotes: ""
             )
         }
+
+        try Task.checkCancellation()
 
         // Persist the converted WAV as a saved recording so retranscription works
         let savedRecordingPath = try persistRecording(wavURL: wavURL, title: title)

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -74,7 +74,7 @@ enum AudioFileImportController {
 
     /// Converts the source audio file to 16kHz mono WAV for transcription.
     /// Returns the temporary WAV URL and the audio duration in seconds.
-    static func convertToWAV(sourceURL: URL) throws -> (wavURL: URL, duration: TimeInterval) {
+    static func convertToWAV(sourceURL: URL) async throws -> (wavURL: URL, duration: TimeInterval) {
         let asset = AVAsset(url: sourceURL)
         guard let audioTrack = asset.tracks(withMediaType: .audio).first else {
             throw ImportError.noAudioTracks
@@ -170,7 +170,7 @@ enum AudioFileImportController {
         progress: @escaping (String) -> Void
     ) async throws -> ImportResult {
         progress("Converting audio file...")
-        let (wavURL, duration) = try convertToWAV(sourceURL: sourceURL)
+        let (wavURL, duration) = try await convertToWAV(sourceURL: sourceURL)
         defer { try? FileManager.default.removeItem(at: wavURL) }
 
         let config = controller.config
@@ -184,6 +184,21 @@ enum AudioFileImportController {
             includeMeetingHelpers: true
         )
 
+        // Run VAD to skip silent files (prevents Cohere hallucinations on silence)
+        if let vadManager = transcriptionCoordinator.vadManager {
+            do {
+                let vadResults = try await vadManager.process(wavURL)
+                let hasSpeech = vadResults.contains { $0.probability > 0.5 }
+                if !hasSpeech {
+                    throw ImportError.readError("No speech detected in the selected audio file.")
+                }
+            } catch let error as ImportError {
+                throw error
+            } catch {
+                fputs("[import] VAD check failed, transcribing anyway: \(error)\n", stderr)
+            }
+        }
+
         progress("Transcribing audio...")
         let transcription = try await transcriptionCoordinator.transcribeMeeting(
             at: wavURL,
@@ -191,12 +206,14 @@ enum AudioFileImportController {
             cohereLanguage: config.resolvedCohereLanguage
         )
         let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawTranscript.isEmpty else {
+            throw ImportError.readError("No speech was transcribed from the selected audio file.")
+        }
 
         // Run speaker diarization if available
         var diarizedTranscript = rawTranscript
         if let diarizerManager = transcriptionCoordinator.getDiarizerManager(),
-           diarizerManager.isAvailable,
-           !rawTranscript.isEmpty {
+           diarizerManager.isAvailable {
             progress("Identifying speakers...")
             do {
                 let converter = AudioConverter()
@@ -241,6 +258,9 @@ enum AudioFileImportController {
             )
         }
 
+        // Persist the converted WAV as a saved recording so retranscription works
+        let savedRecordingPath = try persistRecording(wavURL: wavURL, title: title)
+
         progress("Saving...")
         let now = Date()
         let startTime = now.addingTimeInterval(-duration)
@@ -253,7 +273,7 @@ enum AudioFileImportController {
             formattedNotes: formattedNotes,
             micAudioPath: nil,
             systemAudioPath: nil,
-            savedRecordingPath: nil,
+            savedRecordingPath: savedRecordingPath,
             selectedTemplateID: templateSnapshot.id,
             selectedTemplateName: templateSnapshot.name,
             selectedTemplateKind: templateSnapshot.kind,
@@ -279,9 +299,35 @@ enum AudioFileImportController {
         return directory.appendingPathComponent("import_\(UUID().uuidString).wav")
     }
 
+    /// Copies the converted WAV to the meeting-recordings directory so the imported
+    /// meeting can be retranscribed later.
+    private static func persistRecording(wavURL: URL, title: String) throws -> String {
+        let recordingsDirectory = AppIdentity.supportDirectoryURL
+            .appendingPathComponent("meeting-recordings", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: recordingsDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
+        let datePrefix = dateFormatter.string(from: Date())
+        let safeTitle = title.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+        let filename = "\(datePrefix)_\(safeTitle).wav"
+        let destinationURL = recordingsDirectory.appendingPathComponent(filename)
+
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            try FileManager.default.removeItem(at: destinationURL)
+        }
+        try FileManager.default.copyItem(at: wavURL, to: destinationURL)
+        return destinationURL.path
+    }
+
     /// Formats transcript text with speaker labels based on diarization segments.
-    /// Uses a simple approach: if diarization identifies distinct speakers, prefix
-    /// transcript lines with speaker labels.
+    /// When diarization identifies multiple speakers, the transcript is annotated with
+    /// speaker labels at segment boundaries so both the user and summarizer can
+    /// attribute spoken text to individual speakers.
     static func formatTranscriptWithSpeakers(
         rawText: String,
         diarizationSegments: [TimedSpeakerSegment],
@@ -292,32 +338,41 @@ enum AudioFileImportController {
         let speakerCount = Set(diarizationSegments.map(\.speakerId)).count
         guard speakerCount > 1 else { return rawText }
 
-        // Build a speaker-labeled transcript using diarization segments
-        var lines: [String] = []
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.hour, .minute, .second]
-        formatter.zeroFormattingBehavior = [.pad]
-
-        for segment in diarizationSegments {
-            let startStr = formatTimeInterval(segment.startTime)
-            let speaker = segment.speakerId.replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
-            lines.append("[\(startStr)] \(speaker):")
-        }
-
-        // If the raw text has timestamp markers, use those instead
-        if rawText.contains("[") && rawText.contains("]") {
+        // If the raw text already has timestamped speaker lines, use those instead.
+        if rawText.range(of: #"(?m)^\[[0-9]{2}:[0-9]{2}(?::[0-9]{2})?\]\s+(You|Others|Speaker\s+\d+):"#, options: .regularExpression) != nil {
             return rawText
         }
 
-        // Fallback: prepend a header and return the raw text
-        let header = diarizationSegments.map { segment in
+        // Build a speaker-labeled transcript using diarization segments
+        var result = "## Speaker Segments\n"
+        for segment in diarizationSegments {
             let startStr = formatTimeInterval(segment.startTime)
             let endStr = formatTimeInterval(segment.endTime)
             let speaker = segment.speakerId.replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
-            return "[\(startStr) - \(endStr)] \(speaker)"
-        }.joined(separator: "\n")
+            result += "[\(startStr) - \(endStr)] \(speaker)\n"
+        }
 
-        return "## Speaker Segments\n\(header)\n\n## Transcript\n\(rawText)"
+        result += "\n## Transcript\n"
+
+        // Annotate the transcript with speaker labels at segment boundaries
+        let lines = rawText.components(separatedBy: .newlines)
+        let segmentCount = diarizationSegments.count
+        let lineCount = lines.count
+
+        if lineCount > 0, segmentCount > 0 {
+            let linesPerSegment = max(1, lineCount / segmentCount)
+            for (i, line) in lines.enumerated() {
+                let segmentIndex = min(i / linesPerSegment, segmentCount - 1)
+                let speaker = diarizationSegments[segmentIndex].speakerId
+                    .replacingOccurrences(of: "SPEAKER_", with: "Speaker ")
+                let startStr = formatTimeInterval(diarizationSegments[segmentIndex].startTime)
+                result += "[\(startStr)] \(speaker): \(line)\n"
+            }
+        } else {
+            result += rawText
+        }
+
+        return result
     }
 
     private static func formatTimeInterval(_ interval: TimeInterval) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -156,7 +156,12 @@ final class FloatingIndicatorController: NSObject {
     func collapseForDrag() {
         isDragging = true
         hoverExitWorkItem?.cancel()
-        guard state == .idle, let panel, let contentView, let iconLabel, let textLabel else { return }
+        guard state == .idle,
+              !isShowingLoading,
+              let panel,
+              let contentView,
+              let iconLabel,
+              let textLabel else { return }
         isHovered = false
 
         let config = configStore.load()
@@ -552,11 +557,11 @@ final class FloatingIndicatorController: NSObject {
         let config = configStore.load()
         if panel == nil { createPanel(config: config) }
         guard let panel, let contentView, let textLabel else { return }
+        guard let screen = NSScreen.main?.visibleFrame else { return }
 
         isShowingLoading = true
-        let loadingSize = NSSize(width: 180, height: 36)
+        let loadingSize = loadingPillSize(message: message, screen: screen)
         let center = CGPoint(x: panel.frame.midX, y: panel.frame.midY)
-        guard let screen = NSScreen.main?.visibleFrame else { return }
         let x = min(max(center.x - loadingSize.width / 2, screen.minX), screen.maxX - loadingSize.width)
         let y = min(max(center.y - loadingSize.height / 2, screen.minY), screen.maxY - loadingSize.height)
         let targetFrame = NSRect(x: x, y: y, width: loadingSize.width, height: loadingSize.height)
@@ -574,10 +579,13 @@ final class FloatingIndicatorController: NSObject {
 
         let spinnerSize: CGFloat = 16
         let gap: CGFloat = 8
+        let horizontalPadding: CGFloat = 16
         let attrs: [NSAttributedString.Key: Any] = [.font: NSFont.systemFont(ofSize: 11, weight: .medium)]
-        let textW = ceil((message as NSString).size(withAttributes: attrs).width) + 2
+        let measuredTextW = ceil((message as NSString).size(withAttributes: attrs).width) + 2
+        let availableTextW = max(40, loadingSize.width - (horizontalPadding * 2) - spinnerSize - gap)
+        let textW = min(measuredTextW, availableTextW)
         let totalW = spinnerSize + gap + textW
-        let startX = (loadingSize.width - totalW) / 2
+        let startX = max(horizontalPadding, (loadingSize.width - totalW) / 2)
 
         micIconView?.isHidden = true
         wandIconView?.isHidden = true
@@ -609,6 +617,11 @@ final class FloatingIndicatorController: NSObject {
 
             textLabel.stringValue = message
             textLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+            textLabel.lineBreakMode = .byTruncatingTail
+            textLabel.maximumNumberOfLines = 1
+            textLabel.usesSingleLineMode = true
+            textLabel.cell?.wraps = false
+            textLabel.cell?.isScrollable = false
             textLabel.textColor = NSColor.colorWith(hex: 0xFFFFFF, alpha: 0.82)
             textLabel.frame = NSRect(
                 x: startX + spinnerSize + gap,
@@ -619,6 +632,18 @@ final class FloatingIndicatorController: NSObject {
             textLabel.animator().alphaValue = 1
         }
         panel.orderFrontRegardless()
+    }
+
+    private func loadingPillSize(message: String, screen: NSRect) -> NSSize {
+        let font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        let spinnerSize: CGFloat = 16
+        let gap: CGFloat = 8
+        let horizontalPadding: CGFloat = 16
+        let textWidth = ceil((message as NSString).size(withAttributes: [.font: font]).width) + 2
+        let preferredWidth = horizontalPadding + spinnerSize + gap + textWidth + horizontalPadding
+        let minWidth = min(CGFloat(180), max(120, screen.width - 32))
+        let maxWidth = max(minWidth, min(360, screen.width - 32))
+        return NSSize(width: min(max(preferredWidth, minWidth), maxWidth), height: 36)
     }
 
     func hideLoading() {
@@ -633,7 +658,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func setHovered(_ hovered: Bool) {
-        guard state == .idle, !isDragging, isHovered != hovered else { return }
+        guard state == .idle, !isShowingLoading, !isDragging, isHovered != hovered else { return }
         hoverExitWorkItem?.cancel()
         isHovered = hovered
         let config = configStore.load()
@@ -641,7 +666,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func scheduleHoverExit() {
-        guard state == .idle, isHovered else { return }
+        guard state == .idle, !isShowingLoading, isHovered else { return }
         hoverExitWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
@@ -653,7 +678,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func closeIfIdle() {
-        if state == .idle { close() }
+        if state == .idle, !isShowingLoading { close() }
     }
 
     func close() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -193,6 +193,11 @@ struct MeetingDetailView: View {
                 }
             }
 
+            if let savedRecordingPath = meeting.savedRecordingPath,
+               FileManager.default.fileExists(atPath: savedRecordingPath) {
+                MeetingRecordingPlayerView(recordingPath: savedRecordingPath)
+            }
+
             if !showsManualNotesEditor(for: meeting), isRawTranscript(meeting), documentMode == .notes {
                 transcriptCTA
             }
@@ -323,25 +328,21 @@ struct MeetingDetailView: View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: MuesliTheme.spacing8) {
                 templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                recordingAction(for: meeting)
+                exportMenu(for: meeting)
                 summaryAction(for: meeting)
                 editButton(for: meeting)
-                if controller.canDeleteMeeting(meeting) {
-                    deleteButton
-                }
+                moreActionsMenu(for: meeting)
             }
 
             VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
                 HStack(spacing: MuesliTheme.spacing8) {
                     templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                    recordingAction(for: meeting)
+                    exportMenu(for: meeting)
                     summaryAction(for: meeting)
                 }
                 HStack(spacing: MuesliTheme.spacing8) {
                     editButton(for: meeting)
-                    if controller.canDeleteMeeting(meeting) {
-                        deleteButton
-                    }
+                    moreActionsMenu(for: meeting)
                 }
             }
         }
@@ -423,15 +424,6 @@ struct MeetingDetailView: View {
             }
         }
         .disabled(isRetranscribing && !isEditingNotes && !isEditingTranscript)
-    }
-
-    @ViewBuilder
-    private func recordingAction(for meeting: MeetingRecord) -> some View {
-        if let savedRecordingPath = meeting.savedRecordingPath {
-            iconButton("folder", label: "Show Recording") {
-                controller.revealMeetingRecordingInFinder(path: savedRecordingPath)
-            }
-        }
     }
 
     @ViewBuilder
@@ -544,7 +536,6 @@ struct MeetingDetailView: View {
             Spacer()
 
             retranscribeAction(for: meeting)
-            exportMenu(for: meeting)
 
             Button(action: {
                 controller.copyToClipboard(activeCopyText(for: meeting))
@@ -709,6 +700,48 @@ struct MeetingDetailView: View {
         .menuStyle(.borderlessButton)
         .fixedSize()
         .disabled(isEditingNotes || isEditingTranscript)
+    }
+
+    @ViewBuilder
+    private func moreActionsMenu(for meeting: MeetingRecord) -> some View {
+        if meeting.savedRecordingPath != nil || controller.canDeleteMeeting(meeting) {
+            Menu {
+                if let savedRecordingPath = meeting.savedRecordingPath {
+                    Button {
+                        controller.revealMeetingRecordingInFinder(path: savedRecordingPath)
+                    } label: {
+                        Label("Show Recording", systemImage: "folder")
+                    }
+                }
+
+                if controller.canDeleteMeeting(meeting) {
+                    if meeting.savedRecordingPath != nil {
+                        Divider()
+                    }
+                    Button(role: .destructive) {
+                        showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete Meeting", systemImage: "trash")
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 30, height: 28)
+                .background(MuesliTheme.surfacePrimary)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("More actions")
+        }
     }
 
     private func templateMenuItem(title: String, systemImage: String, isSelected: Bool) -> some View {
@@ -1215,7 +1248,11 @@ private struct MarqueeTitleTextField: View {
                         Color.clear.preference(key: TitleContentWidthPreferenceKey.self, value: proxy.size.width)
                     }
                 )
+                .allowsHitTesting(false)
         )
+        .onTapGesture {
+            isTitleFocused = true
+        }
         .onPreferenceChange(TitleContainerWidthPreferenceKey.self) { width in
             containerWidth = width
             restartMarqueeIfNeeded()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingListItemView.swift
@@ -51,6 +51,10 @@ struct MeetingListItemView: View {
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textSecondary)
 
+                if let sourceIndicator = sourceIndicator {
+                    sourceIndicator
+                }
+
                 // Current folder badge
                 if let name = currentFolderName {
                     Text("\u{2022}")
@@ -203,6 +207,48 @@ struct MeetingListItemView: View {
             .padding(.vertical, 2)
             .background(record.status.displayColor.opacity(0.12))
             .clipShape(Capsule())
+    }
+
+    private var sourceIndicator: AnyView? {
+        if isImportedAudio {
+            return AnyView(sourceBadge(icon: "square.and.arrow.down", label: "Imported", help: "Imported audio"))
+        }
+        if hasSavedRecording {
+            return AnyView(sourceBadge(icon: "waveform", label: "Recording", help: "Saved recording available"))
+        }
+        return nil
+    }
+
+    private var isImportedAudio: Bool {
+        record.source == .audioImport || hasLegacyImportedRecordingPath
+    }
+
+    private var hasLegacyImportedRecordingPath: Bool {
+        guard let savedRecordingPath = record.savedRecordingPath else { return false }
+        let filename = URL(fileURLWithPath: savedRecordingPath).lastPathComponent
+        let pattern = #"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}_.+_[0-9A-Fa-f]{8}\.wav$"#
+        return filename.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private var hasSavedRecording: Bool {
+        guard let savedRecordingPath = record.savedRecordingPath else { return false }
+        return !savedRecordingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func sourceBadge(icon: String, label: String, help: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .foregroundStyle(isImportedAudio ? MuesliTheme.accent : MuesliTheme.textSecondary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background((isImportedAudio ? MuesliTheme.accent : MuesliTheme.textSecondary).opacity(0.12))
+        .clipShape(Capsule())
+        .help(help)
+        .accessibilityLabel(help)
     }
 
     private func formatMeta() -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingPlayerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingPlayerView.swift
@@ -1,0 +1,373 @@
+import AVFoundation
+import CryptoKit
+import SwiftUI
+
+private struct RecordingWaveformData: Equatable {
+    static let defaultBucketCount = 512
+    private static let cacheMagic = Data("MWF1".utf8)
+    private static let cacheVersion: UInt16 = 1
+
+    let peaks: [UInt8]
+    let duration: TimeInterval
+
+    static func load(from url: URL, bucketCount: Int = defaultBucketCount) throws -> RecordingWaveformData {
+        let file = try AVAudioFile(forReading: url)
+        let frameTotal = max(Int(file.length), 1)
+        let format = file.processingFormat
+        let channelCount = max(Int(format.channelCount), 1)
+        let capacity: AVAudioFrameCount = 8_192
+        var peaks = Array(repeating: Double(0), count: bucketCount)
+        var globalFrame = 0
+
+        while file.framePosition < file.length {
+            let remaining = Int(file.length - file.framePosition)
+            let framesToRead = AVAudioFrameCount(min(Int(capacity), remaining))
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: framesToRead) else {
+                break
+            }
+            try file.read(into: buffer, frameCount: framesToRead)
+            guard buffer.frameLength > 0 else { break }
+
+            if let channelData = buffer.floatChannelData {
+                for frame in 0..<Int(buffer.frameLength) {
+                    var samplePeak = Float(0)
+                    for channel in 0..<channelCount {
+                        samplePeak = max(samplePeak, abs(channelData[channel][frame]))
+                    }
+                    let bucket = min(
+                        Int((Double(globalFrame + frame) / Double(frameTotal)) * Double(bucketCount)),
+                        bucketCount - 1
+                    )
+                    peaks[bucket] = max(peaks[bucket], Double(samplePeak))
+                }
+            } else if let channelData = buffer.int16ChannelData {
+                for frame in 0..<Int(buffer.frameLength) {
+                    var samplePeak = Float(0)
+                    for channel in 0..<channelCount {
+                        samplePeak = max(samplePeak, Float(abs(Int(channelData[channel][frame]))) / Float(Int16.max))
+                    }
+                    let bucket = min(
+                        Int((Double(globalFrame + frame) / Double(frameTotal)) * Double(bucketCount)),
+                        bucketCount - 1
+                    )
+                    peaks[bucket] = max(peaks[bucket], Double(samplePeak))
+                }
+            }
+            globalFrame += Int(buffer.frameLength)
+        }
+
+        let maxPeak = max(peaks.max() ?? 0, 0.01)
+        let normalized = peaks.map { peak in
+            UInt8(min(max(Int((peak / maxPeak * 255).rounded()), 10), 255))
+        }
+        let duration = Double(file.length) / max(format.sampleRate, 1)
+        return RecordingWaveformData(peaks: normalized, duration: duration)
+    }
+
+    func encodedCacheData() -> Data {
+        var data = Self.cacheMagic
+        data.appendLittleEndian(Self.cacheVersion)
+        data.appendLittleEndian(UInt16(min(peaks.count, Int(UInt16.max))))
+        data.appendLittleEndian(duration.bitPattern)
+        data.append(contentsOf: peaks)
+        return data
+    }
+
+    static func decodeCacheData(_ data: Data) -> RecordingWaveformData? {
+        var cursor = data.startIndex
+        guard data.count >= cacheMagic.count + 2 + 2 + 8 else { return nil }
+        guard data[cursor..<data.index(cursor, offsetBy: cacheMagic.count)] == cacheMagic else { return nil }
+        cursor = data.index(cursor, offsetBy: cacheMagic.count)
+        guard let version = data.readLittleEndian(UInt16.self, cursor: &cursor),
+              version == cacheVersion,
+              let count = data.readLittleEndian(UInt16.self, cursor: &cursor),
+              let durationBits = data.readLittleEndian(UInt64.self, cursor: &cursor) else {
+            return nil
+        }
+        let peakCount = Int(count)
+        guard peakCount > 0, data.distance(from: cursor, to: data.endIndex) >= peakCount else { return nil }
+        let peaks = Array(data[cursor..<data.index(cursor, offsetBy: peakCount)])
+        return RecordingWaveformData(peaks: peaks, duration: Double(bitPattern: durationBits))
+    }
+}
+
+private actor RecordingWaveformCache {
+    static let shared = RecordingWaveformCache()
+
+    private var memory: [String: RecordingWaveformData] = [:]
+    private let fileManager = FileManager.default
+
+    func waveform(for url: URL) throws -> RecordingWaveformData {
+        let cacheKey = try cacheKey(for: url)
+        if let cached = memory[cacheKey] {
+            return cached
+        }
+
+        let cacheURL = try cacheURL(for: cacheKey)
+        if let data = try? Data(contentsOf: cacheURL),
+           let cached = RecordingWaveformData.decodeCacheData(data) {
+            memory[cacheKey] = cached
+            return cached
+        }
+
+        let waveform = try RecordingWaveformData.load(from: url)
+        memory[cacheKey] = waveform
+        persist(waveform, to: cacheURL)
+        return waveform
+    }
+
+    private func cacheKey(for url: URL) throws -> String {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        return "\(url.path)|\(size)|\(modified)"
+    }
+
+    private func cacheURL(for cacheKey: String) throws -> URL {
+        let directory = AppIdentity.supportDirectoryURL
+            .appendingPathComponent("waveform-cache", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let digest = SHA256.hash(data: Data(cacheKey.utf8))
+        let filename = digest.map { String(format: "%02x", $0) }.joined() + ".mwf"
+        return directory.appendingPathComponent(filename)
+    }
+
+    private func persist(_ waveform: RecordingWaveformData, to cacheURL: URL) {
+        do {
+            try waveform.encodedCacheData().write(to: cacheURL, options: .atomic)
+        } catch {
+            fputs("[meeting-recording-player] failed to persist waveform cache: \(error)\n", stderr)
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { bytes in
+            append(contentsOf: bytes)
+        }
+    }
+
+    func readLittleEndian<T: FixedWidthInteger>(_ type: T.Type, cursor: inout Index) -> T? {
+        let byteCount = MemoryLayout<T>.size
+        guard distance(from: cursor, to: endIndex) >= byteCount else { return nil }
+        let next = index(cursor, offsetBy: byteCount)
+        let value = self[cursor..<next].withUnsafeBytes { bytes in
+            bytes.loadUnaligned(as: T.self)
+        }
+        cursor = next
+        return T(littleEndian: value)
+    }
+}
+
+struct MeetingRecordingPlayerView: View {
+    let recordingPath: String
+
+    @State private var waveform: RecordingWaveformData?
+    @State private var player: AVAudioPlayer?
+    @State private var isPlaying = false
+    @State private var currentTime: TimeInterval = 0
+    @State private var loadFailed = false
+
+    private let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            Button {
+                togglePlayback()
+            } label: {
+                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .frame(width: 34, height: 34)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(player == nil)
+            .help(isPlaying ? "Pause recording" : "Play recording")
+
+            Group {
+                if let waveform {
+                    RecordingWaveformView(
+                        peaks: waveform.peaks,
+                        progress: progress,
+                        onSeek: seek(to:)
+                    )
+                } else if loadFailed {
+                    Text("Recording unavailable")
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Loading recording")
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(height: 44)
+
+            Text("\(formatTime(currentTime)) / \(formatTime(duration))")
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(minWidth: 88, alignment: .trailing)
+        }
+        .padding(.horizontal, MuesliTheme.spacing12)
+        .padding(.vertical, MuesliTheme.spacing8)
+        .background(MuesliTheme.backgroundRaised.opacity(0.74))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+        .task(id: recordingPath) {
+            await loadRecording()
+        }
+        .onReceive(timer) { _ in
+            guard let player else { return }
+            currentTime = player.currentTime
+            if !player.isPlaying, isPlaying {
+                isPlaying = false
+                if player.currentTime >= max(player.duration - 0.1, 0) {
+                    currentTime = 0
+                    player.currentTime = 0
+                }
+            }
+        }
+        .onDisappear {
+            player?.stop()
+            player = nil
+            isPlaying = false
+        }
+    }
+
+    private var duration: TimeInterval {
+        waveform?.duration ?? player?.duration ?? 0
+    }
+
+    private var progress: CGFloat {
+        guard duration > 0 else { return 0 }
+        return min(max(currentTime / duration, 0), 1)
+    }
+
+    @MainActor
+    private func loadRecording() async {
+        player?.stop()
+        player = nil
+        waveform = nil
+        loadFailed = false
+        currentTime = 0
+        isPlaying = false
+
+        let url = URL(fileURLWithPath: recordingPath)
+        do {
+            let loadedWaveform = try await Task.detached(priority: .utility) {
+                try await RecordingWaveformCache.shared.waveform(for: url)
+            }.value
+            let loadedPlayer = try AVAudioPlayer(contentsOf: url)
+            loadedPlayer.prepareToPlay()
+            waveform = loadedWaveform
+            player = loadedPlayer
+        } catch {
+            loadFailed = true
+        }
+    }
+
+    private func togglePlayback() {
+        guard let player else { return }
+        if player.isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            if player.currentTime >= max(player.duration - 0.1, 0) {
+                player.currentTime = 0
+            }
+            player.play()
+            isPlaying = true
+        }
+        currentTime = player.currentTime
+    }
+
+    private func seek(to progress: CGFloat) {
+        guard let player else { return }
+        let clamped = min(max(progress, 0), 1)
+        player.currentTime = player.duration * Double(clamped)
+        currentTime = player.currentTime
+    }
+
+    private func formatTime(_ seconds: TimeInterval) -> String {
+        let rounded = max(Int(seconds.rounded()), 0)
+        let hours = rounded / 3600
+        let minutes = (rounded % 3600) / 60
+        let secs = rounded % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}
+
+private struct RecordingWaveformView: View {
+    let peaks: [UInt8]
+    let progress: CGFloat
+    let onSeek: (CGFloat) -> Void
+
+    var body: some View {
+        GeometryReader { proxy in
+            Canvas { context, size in
+                let sourceCount = peaks.count
+                guard sourceCount > 0, size.width > 0, size.height > 0 else { return }
+                let spacing: CGFloat = 2
+                let barCount = min(sourceCount, max(48, Int(size.width / 4)))
+                let barWidth = max(1, (size.width - spacing * CGFloat(barCount - 1)) / CGFloat(barCount))
+                let playedX = size.width * progress
+
+                for index in 0..<barCount {
+                    let x = CGFloat(index) * (barWidth + spacing)
+                    let peak = peakForVisibleBar(index, visibleCount: barCount, sourceCount: sourceCount)
+                    let height = max(4, size.height * peak)
+                    let y = (size.height - height) / 2
+                    let rect = CGRect(x: x, y: y, width: barWidth, height: height)
+                    let color = x <= playedX ? MuesliTheme.accent : MuesliTheme.textTertiary.opacity(0.24)
+                    context.fill(
+                        Path(roundedRect: rect, cornerRadius: barWidth / 2),
+                        with: .color(color)
+                    )
+                }
+
+                let playhead = CGRect(x: max(0, min(playedX - 1, size.width - 2)), y: 0, width: 2, height: size.height)
+                context.fill(
+                    Path(roundedRect: playhead, cornerRadius: 1),
+                    with: .color(MuesliTheme.accent)
+                )
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        guard proxy.size.width > 0 else { return }
+                        onSeek(value.location.x / proxy.size.width)
+                    }
+            )
+        }
+        .frame(minHeight: 36)
+        .accessibilityLabel("Recording waveform")
+    }
+
+    private func peakForVisibleBar(_ index: Int, visibleCount: Int, sourceCount: Int) -> CGFloat {
+        let start = index * sourceCount / visibleCount
+        let end = max(start + 1, (index + 1) * sourceCount / visibleCount)
+        let maxPeak = peaks[start..<min(end, sourceCount)].max() ?? 10
+        return CGFloat(maxPeak) / 255
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -251,8 +251,7 @@ struct MeetingsView: View {
                 guard let data = item as? Data,
                       let urlString = String(data: data, encoding: .utf8),
                       let url = URL(string: urlString) else { return }
-                let supportedExtensions = ["m4a", "mp4", "wav", "mp3"]
-                guard supportedExtensions.contains(url.pathExtension.lowercased()) else { return }
+                guard AudioFileImportController.isSupportedFileURL(url) else { return }
                 DispatchQueue.main.async {
                     controller.importAudioFileFromURL(url)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -245,6 +245,18 @@ struct MeetingsView: View {
             .padding(.vertical, 32)
             .frame(maxWidth: .infinity, alignment: .center)
         }
+        .onDrop(of: ["public.file-url"], isTargeted: nil) { providers in
+            guard let provider = providers.first else { return false }
+            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { item, _ in
+                guard let data = item as? Data,
+                      let urlString = String(data: data, encoding: .utf8),
+                      let url = URL(string: urlString) else { return }
+                DispatchQueue.main.async {
+                    controller.importAudioFileFromURL(url)
+                }
+            }
+            return true
+        }
     }
 
     // MARK: - Coming Up
@@ -547,6 +559,31 @@ struct MeetingsView: View {
             .buttonStyle(.plain)
             .disabled(appState.isMeetingRecording || appState.isMeetingStarting)
             .help("Start a quick meeting note")
+            .fixedSize()
+
+            Button {
+                controller.importAudioFile()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "square.and.arrow.down")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Import Audio")
+                        .font(.system(size: 12, weight: .semibold))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .padding(.horizontal, MuesliTheme.spacing12)
+                .padding(.vertical, 8)
+                .background(MuesliTheme.surfacePrimary)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(appState.isMeetingRecording || appState.isMeetingStarting)
+            .help("Import an audio file for offline transcription")
             .fixedSize()
 
             sortButton

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -251,6 +251,8 @@ struct MeetingsView: View {
                 guard let data = item as? Data,
                       let urlString = String(data: data, encoding: .utf8),
                       let url = URL(string: urlString) else { return }
+                let supportedExtensions = ["m4a", "mp4", "wav", "mp3"]
+                guard supportedExtensions.contains(url.pathExtension.lowercased()) else { return }
                 DispatchQueue.main.async {
                     controller.importAudioFileFromURL(url)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2776,6 +2776,94 @@ final class MuesliController: NSObject {
         startForegroundMeetingRecording(title: "Meeting")
     }
 
+    // MARK: - Audio File Import
+
+    /// Presents a file picker and imports an audio file for offline transcription.
+    func importAudioFile() {
+        guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        guard normalizeMeetingTranscriptionSelectionForAvailability() != nil else {
+            presentErrorAlert(
+                title: "Import Failed",
+                message: "Download a transcription model before importing audio files."
+            )
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let sourceURL = await AudioFileImportController.selectFile() else { return }
+            await self.importAudioFile(from: sourceURL)
+        }
+    }
+
+    /// Imports an audio file from a URL (drag-and-drop or file picker).
+    func importAudioFileFromURL(_ url: URL) {
+        guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        guard normalizeMeetingTranscriptionSelectionForAvailability() != nil else {
+            presentErrorAlert(
+                title: "Import Failed",
+                message: "Download a transcription model before importing audio files."
+            )
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.importAudioFile(from: url)
+        }
+    }
+
+    private func importAudioFile(from sourceURL: URL) async {
+        let filename = sourceURL.deletingPathExtension().lastPathComponent
+        let title = filename.isEmpty ? "Imported Recording" : filename
+
+        self.isStartingMeetingRecording = true
+        self.updateMeetingStartStatus("Importing audio file...")
+        self.beginMeetingActivity(reason: "Importing audio file for transcription")
+        self.statusBarController?.setStatus("Importing audio...")
+        self.statusBarController?.refresh()
+
+        do {
+            let result = try await AudioFileImportController.importAudioFile(
+                sourceURL: sourceURL,
+                title: title,
+                controller: self,
+                progress: { [weak self] status in
+                    Task { @MainActor in
+                        self?.updateMeetingStartStatus(status)
+                        self?.statusBarController?.setStatus(status)
+                        self?.statusBarController?.refresh()
+                    }
+                }
+            )
+
+            await MainActor.run {
+                self.isStartingMeetingRecording = false
+                self.updateMeetingStartStatus(nil)
+                self.endMeetingActivity()
+                self.statusBarController?.setStatus("Idle")
+                self.statusBarController?.refresh()
+                self.syncAppState()
+                self.historyWindowController?.reload()
+                self.showMeetingDocument(id: result.meetingID)
+                TelemetryDeck.signal("meeting.imported")
+            }
+        } catch {
+            await MainActor.run {
+                self.isStartingMeetingRecording = false
+                self.updateMeetingStartStatus(nil)
+                self.endMeetingActivity()
+                self.statusBarController?.setStatus("Idle")
+                self.statusBarController?.refresh()
+                self.syncAppState()
+                self.presentErrorAlert(
+                    title: "Import Failed",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
     func cancelMeetingPreparation() {
         guard isStartingMeetingRecording,
               activeMeetingSession == nil,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2797,6 +2797,7 @@ final class MuesliController: NSObject {
             guard let sourceURL = await AudioFileImportController.selectFile() else {
                 self.isStartingMeetingRecording = false
                 self.importTask = nil
+                self.syncAppState()
                 return
             }
             await self.importAudioFile(from: sourceURL)
@@ -2806,6 +2807,13 @@ final class MuesliController: NSObject {
     /// Imports an audio file from a URL (drag-and-drop or file picker).
     func importAudioFileFromURL(_ url: URL) {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return }
+        guard AudioFileImportController.isSupportedFileURL(url) else {
+            presentErrorAlert(
+                title: "Import Failed",
+                message: "This audio file format is not supported."
+            )
+            return
+        }
         guard normalizeMeetingTranscriptionSelectionForAvailability() != nil else {
             presentErrorAlert(
                 title: "Import Failed",
@@ -2826,10 +2834,8 @@ final class MuesliController: NSObject {
         let filename = sourceURL.deletingPathExtension().lastPathComponent
         let title = filename.isEmpty ? "Imported Recording" : filename
 
-        self.updateMeetingStartStatus("Importing audio file...")
+        self.updateImportProgressStatus("Importing audio file...")
         self.beginMeetingActivity(reason: "Importing audio file for transcription")
-        self.statusBarController?.setStatus("Importing audio...")
-        self.statusBarController?.refresh()
 
         do {
             let result = try await AudioFileImportController.importAudioFile(
@@ -2838,9 +2844,7 @@ final class MuesliController: NSObject {
                 controller: self,
                 progress: { [weak self] status in
                     Task { @MainActor in
-                        self?.updateMeetingStartStatus(status)
-                        self?.statusBarController?.setStatus(status)
-                        self?.statusBarController?.refresh()
+                        self?.updateImportProgressStatus(status)
                     }
                 }
             )
@@ -2849,6 +2853,7 @@ final class MuesliController: NSObject {
                 self.importTask = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
+                self.indicator.hideLoading()
                 self.endMeetingActivity()
                 self.statusBarController?.setStatus("Idle")
                 self.statusBarController?.refresh()
@@ -2857,24 +2862,75 @@ final class MuesliController: NSObject {
                 self.showMeetingDocument(id: result.meetingID)
                 TelemetryDeck.signal("meeting.imported")
             }
+        } catch is CancellationError {
+            await MainActor.run {
+                self.importTask = nil
+                self.isStartingMeetingRecording = false
+                self.updateMeetingStartStatus(nil)
+                self.indicator.hideLoading()
+                self.endMeetingActivity()
+                self.statusBarController?.setStatus("Idle")
+                self.statusBarController?.refresh()
+                self.syncAppState()
+            }
         } catch {
             await MainActor.run {
                 self.importTask = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
+                self.indicator.hideLoading()
                 self.endMeetingActivity()
                 self.statusBarController?.setStatus("Idle")
                 self.statusBarController?.refresh()
                 self.syncAppState()
-                // Only show error if import was not cancelled by the user
-                if !Task.isCancelled {
-                    self.presentErrorAlert(
-                        title: "Import Failed",
-                        message: error.localizedDescription
-                    )
-                }
+                self.presentErrorAlert(
+                    title: "Import Failed",
+                    message: error.localizedDescription
+                )
             }
         }
+    }
+
+    func audioFileImportContext() -> AudioFileImportController.ImportContext {
+        AudioFileImportController.ImportContext(
+            config: config,
+            backend: selectedMeetingTranscriptionBackend,
+            transcriptionCoordinator: transcriptionCoordinator,
+            templateSnapshot: defaultMeetingTemplate()
+        )
+    }
+
+    func persistImportedAudioMeeting(
+        title: String,
+        calendarEventID: String?,
+        startTime: Date,
+        endTime: Date,
+        rawTranscript: String,
+        formattedNotes: String,
+        micAudioPath: String?,
+        systemAudioPath: String?,
+        savedRecordingPath: String?,
+        selectedTemplateID: String?,
+        selectedTemplateName: String?,
+        selectedTemplateKind: MeetingTemplateKind?,
+        selectedTemplatePrompt: String?
+    ) throws -> Int64 {
+        try dictationStore.insertMeeting(
+            title: title,
+            calendarEventID: calendarEventID,
+            startTime: startTime,
+            endTime: endTime,
+            rawTranscript: rawTranscript,
+            formattedNotes: formattedNotes,
+            micAudioPath: micAudioPath,
+            systemAudioPath: systemAudioPath,
+            savedRecordingPath: savedRecordingPath,
+            selectedTemplateID: selectedTemplateID,
+            selectedTemplateName: selectedTemplateName,
+            selectedTemplateKind: selectedTemplateKind,
+            selectedTemplatePrompt: selectedTemplatePrompt,
+            source: .audioImport
+        )
     }
 
     func cancelMeetingPreparation() {
@@ -3693,6 +3749,22 @@ final class MuesliController: NSObject {
         appState.meetingStartStatus = status
     }
 
+    private func updateImportProgressStatus(_ status: String) {
+        updateMeetingStartStatus(status)
+        statusBarController?.setStatus(status)
+        statusBarController?.refresh()
+        indicator.showLoading(status)
+    }
+
+    private func blockDictationForMeetingActivityIfNeeded() -> Bool {
+        guard isStartingMeetingRecording else { return false }
+        let status = meetingStartStatus ?? "Preparing meeting..."
+        indicator.showLoading(status)
+        statusBarController?.setStatus(status)
+        statusBarController?.refresh()
+        return true
+    }
+
     private func endMeetingActivity() {
         guard let activity = meetingActivity else { return }
         ProcessInfo.processInfo.endActivity(activity)
@@ -4182,6 +4254,7 @@ final class MuesliController: NSObject {
 
     private func handlePrepare() {
         if isMeetingRecording() { return }
+        if blockDictationForMeetingActivityIfNeeded() { return }
         fputs("[muesli-native] prepare\n", stderr)
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "prepare")
@@ -4199,6 +4272,7 @@ final class MuesliController: NSObject {
 
     private func handleArm() {
         if isMeetingRecording() { return }
+        if blockDictationForMeetingActivityIfNeeded() { return }
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "hotkey")
         }
@@ -4426,6 +4500,7 @@ final class MuesliController: NSObject {
 
     private func handleStart() {
         if isMeetingRecording() { return }
+        if blockDictationForMeetingActivityIfNeeded() { return }
 
         // Nemotron is handsfree-only — block hold-to-talk and show a hint
         if selectedBackend.backend == "nemotron" {
@@ -4567,6 +4642,7 @@ final class MuesliController: NSObject {
 
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
         if isMeetingRecording() { return }
+        if blockDictationForMeetingActivityIfNeeded() { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "toggle")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -259,6 +259,7 @@ final class MuesliController: NSObject {
     private var meetingStartTask: Task<Void, Never>?
     private var meetingStartMeetingID: Int64?
     private var importTask: Task<Void, Never>?
+    private var importSessionID: UUID?
     private var canceledMeetingStartIDs = Set<Int64>()
     private var hasStarted = false
 
@@ -2791,16 +2792,19 @@ final class MuesliController: NSObject {
         }
 
         isStartingMeetingRecording = true
+        let sessionID = UUID()
+        importSessionID = sessionID
 
         importTask = Task { @MainActor [weak self] in
             guard let self else { return }
             guard let sourceURL = await AudioFileImportController.selectFile() else {
                 self.isStartingMeetingRecording = false
                 self.importTask = nil
+                self.importSessionID = nil
                 self.syncAppState()
                 return
             }
-            await self.importAudioFile(from: sourceURL)
+            await self.importAudioFile(from: sourceURL, sessionID: sessionID)
         }
     }
 
@@ -2823,18 +2827,20 @@ final class MuesliController: NSObject {
         }
 
         isStartingMeetingRecording = true
+        let sessionID = UUID()
+        importSessionID = sessionID
 
         importTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.importAudioFile(from: url)
+            await self.importAudioFile(from: url, sessionID: sessionID)
         }
     }
 
-    private func importAudioFile(from sourceURL: URL) async {
+    private func importAudioFile(from sourceURL: URL, sessionID: UUID) async {
         let filename = sourceURL.deletingPathExtension().lastPathComponent
         let title = filename.isEmpty ? "Imported Recording" : filename
 
-        self.updateImportProgressStatus("Importing audio file...")
+        self.updateImportProgressStatus("Importing audio file...", sessionID: sessionID)
         self.beginMeetingActivity(reason: "Importing audio file for transcription")
 
         do {
@@ -2844,13 +2850,16 @@ final class MuesliController: NSObject {
                 controller: self,
                 progress: { [weak self] status in
                     Task { @MainActor in
-                        self?.updateImportProgressStatus(status)
+                        guard let self,
+                              self.importSessionID == sessionID else { return }
+                        self.updateImportProgressStatus(status, sessionID: sessionID)
                     }
                 }
             )
 
             await MainActor.run {
                 self.importTask = nil
+                self.importSessionID = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
                 self.indicator.hideLoading()
@@ -2865,6 +2874,7 @@ final class MuesliController: NSObject {
         } catch is CancellationError {
             await MainActor.run {
                 self.importTask = nil
+                self.importSessionID = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
                 self.indicator.hideLoading()
@@ -2876,6 +2886,7 @@ final class MuesliController: NSObject {
         } catch {
             await MainActor.run {
                 self.importTask = nil
+                self.importSessionID = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
                 self.indicator.hideLoading()
@@ -2950,6 +2961,7 @@ final class MuesliController: NSObject {
             // Audio import cancellation
             importTask?.cancel()
             importTask = nil
+            importSessionID = nil
             indicator.hideLoading()
         }
 
@@ -3750,7 +3762,10 @@ final class MuesliController: NSObject {
         appState.meetingStartStatus = status
     }
 
-    private func updateImportProgressStatus(_ status: String) {
+    private func updateImportProgressStatus(_ status: String, sessionID: UUID) {
+        guard importTask != nil,
+              importSessionID == sessionID,
+              isStartingMeetingRecording else { return }
         updateMeetingStartStatus(status)
         statusBarController?.setStatus(status)
         statusBarController?.refresh()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2950,6 +2950,7 @@ final class MuesliController: NSObject {
             // Audio import cancellation
             importTask?.cancel()
             importTask = nil
+            indicator.hideLoading()
         }
 
         statusBarController?.setStatus("Idle")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -258,6 +258,7 @@ final class MuesliController: NSObject {
     private var isStoppingMeetingRecording = false
     private var meetingStartTask: Task<Void, Never>?
     private var meetingStartMeetingID: Int64?
+    private var importTask: Task<Void, Never>?
     private var canceledMeetingStartIDs = Set<Int64>()
     private var hasStarted = false
 
@@ -2791,10 +2792,11 @@ final class MuesliController: NSObject {
 
         isStartingMeetingRecording = true
 
-        Task { @MainActor [weak self] in
+        importTask = Task { @MainActor [weak self] in
             guard let self else { return }
             guard let sourceURL = await AudioFileImportController.selectFile() else {
                 self.isStartingMeetingRecording = false
+                self.importTask = nil
                 return
             }
             await self.importAudioFile(from: sourceURL)
@@ -2814,7 +2816,7 @@ final class MuesliController: NSObject {
 
         isStartingMeetingRecording = true
 
-        Task { @MainActor [weak self] in
+        importTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.importAudioFile(from: url)
         }
@@ -2844,6 +2846,7 @@ final class MuesliController: NSObject {
             )
 
             await MainActor.run {
+                self.importTask = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
                 self.endMeetingActivity()
@@ -2856,42 +2859,51 @@ final class MuesliController: NSObject {
             }
         } catch {
             await MainActor.run {
+                self.importTask = nil
                 self.isStartingMeetingRecording = false
                 self.updateMeetingStartStatus(nil)
                 self.endMeetingActivity()
                 self.statusBarController?.setStatus("Idle")
                 self.statusBarController?.refresh()
                 self.syncAppState()
-                self.presentErrorAlert(
-                    title: "Import Failed",
-                    message: error.localizedDescription
-                )
+                // Only show error if import was not cancelled by the user
+                if !Task.isCancelled {
+                    self.presentErrorAlert(
+                        title: "Import Failed",
+                        message: error.localizedDescription
+                    )
+                }
             }
         }
     }
 
     func cancelMeetingPreparation() {
-        guard isStartingMeetingRecording,
-              activeMeetingSession == nil,
-              let meetingID = meetingStartMeetingID else {
-            return
+        guard isStartingMeetingRecording, activeMeetingSession == nil else { return }
+
+        if let meetingID = meetingStartMeetingID {
+            // Live meeting start cancellation
+            canceledMeetingStartIDs.insert(meetingID)
+            meetingStartTask?.cancel()
+            resolveLiveMeetingAfterStartFailure(id: meetingID)
+            meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
+            meetingStartTask = nil
+            meetingStartMeetingID = nil
+            syncDictationRecorderWarmup(reason: "meeting-start-cancelled")
+        } else {
+            // Audio import cancellation
+            importTask?.cancel()
+            importTask = nil
         }
-        canceledMeetingStartIDs.insert(meetingID)
-        meetingStartTask?.cancel()
-        resolveLiveMeetingAfterStartFailure(id: meetingID)
-        meetingMonitor.resumeAfterCooldown()
-        meetingMonitor.refreshState()
+
         statusBarController?.setStatus("Idle")
         statusBarController?.refresh()
         setState(.idle)
         endMeetingActivity()
-        meetingStartTask = nil
-        meetingStartMeetingID = nil
         isStartingMeetingRecording = false
         updateMeetingStartStatus(nil)
         updateMeetingNotificationVisibility()
         syncAppState()
-        syncDictationRecorderWarmup(reason: "meeting-start-cancelled")
     }
 
     private func finishMeetingStartAttempt(meetingID: Int64) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2789,9 +2789,14 @@ final class MuesliController: NSObject {
             return
         }
 
+        isStartingMeetingRecording = true
+
         Task { @MainActor [weak self] in
             guard let self else { return }
-            guard let sourceURL = await AudioFileImportController.selectFile() else { return }
+            guard let sourceURL = await AudioFileImportController.selectFile() else {
+                self.isStartingMeetingRecording = false
+                return
+            }
             await self.importAudioFile(from: sourceURL)
         }
     }
@@ -2807,6 +2812,8 @@ final class MuesliController: NSObject {
             return
         }
 
+        isStartingMeetingRecording = true
+
         Task { @MainActor [weak self] in
             guard let self else { return }
             await self.importAudioFile(from: url)
@@ -2817,7 +2824,6 @@ final class MuesliController: NSObject {
         let filename = sourceURL.deletingPathExtension().lastPathComponent
         let title = filename.isEmpty ? "Imported Recording" : filename
 
-        self.isStartingMeetingRecording = true
         self.updateMeetingStartStatus("Importing audio file...")
         self.beginMeetingActivity(reason: "Importing audio file for transcription")
         self.statusBarController?.setStatus("Importing audio...")

--- a/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
@@ -23,7 +23,7 @@ struct AudioFileImportControllerTests {
 
         // Verify the output is a valid WAV with expected format
         let file = try AVAudioFile(forReading: wavURL)
-        let format = file.processingFormat
+        let format = file.fileFormat
         #expect(format.sampleRate == 16000)
         #expect(format.channelCount == 1)
         #expect(format.commonFormat == .pcmFormatInt16)
@@ -58,8 +58,23 @@ struct AudioFileImportControllerTests {
 
         #expect(duration > 0)
         let file = try AVAudioFile(forReading: wavURL)
-        #expect(file.processingFormat.channelCount == 1)
-        #expect(file.processingFormat.sampleRate == 16000)
+        #expect(file.fileFormat.channelCount == 1)
+        #expect(file.fileFormat.sampleRate == 16000)
+    }
+
+    @Test("convertToWAV handles already normalized Muesli WAV")
+    func convertToWAVHandlesAlreadyNormalizedWAV() async throws {
+        let sourceURL = try createTestAudioFile(duration: 1.0, sampleRate: 16000, channels: 1)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let (wavURL, duration) = try await AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        #expect(duration > 0.9)
+        let file = try AVAudioFile(forReading: wavURL)
+        #expect(file.fileFormat.channelCount == 1)
+        #expect(file.fileFormat.sampleRate == 16000)
+        #expect(file.fileFormat.commonFormat == .pcmFormatInt16)
     }
 
     @Test("convertToWAV handles short audio clips")
@@ -72,6 +87,13 @@ struct AudioFileImportControllerTests {
 
         #expect(duration > 0)
         #expect(duration < 1.0)
+    }
+
+    @Test("supported file URL validation accepts only importable audio extensions")
+    func supportedFileURLValidation() {
+        #expect(AudioFileImportController.isSupportedFileURL(URL(fileURLWithPath: "/tmp/test.wav")))
+        #expect(AudioFileImportController.isSupportedFileURL(URL(fileURLWithPath: "/tmp/test.MP3")))
+        #expect(!AudioFileImportController.isSupportedFileURL(URL(fileURLWithPath: "/tmp/test.txt")))
     }
 
     // MARK: - Speaker Formatting Tests
@@ -89,8 +111,8 @@ struct AudioFileImportControllerTests {
     @Test("formatTranscriptWithSpeakers returns raw text for single speaker")
     func formatTranscriptWithSpeakersSingleSpeaker() {
         let segments = [
-            TimedSpeakerSegment(startTime: 0, endTime: 5, speakerId: "SPEAKER_0"),
-            TimedSpeakerSegment(startTime: 5, endTime: 10, speakerId: "SPEAKER_0"),
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 0, end: 5),
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 5, end: 10),
         ]
         let result = AudioFileImportController.formatTranscriptWithSpeakers(
             rawText: "Hello world",
@@ -103,26 +125,45 @@ struct AudioFileImportControllerTests {
     @Test("formatTranscriptWithSpeakers adds speaker labels for multiple speakers")
     func formatTranscriptWithSpeakersMultipleSpeakers() {
         let segments = [
-            TimedSpeakerSegment(startTime: 0, endTime: 5, speakerId: "SPEAKER_0"),
-            TimedSpeakerSegment(startTime: 5, endTime: 10, speakerId: "SPEAKER_1"),
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 0, end: 5),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 5, end: 10),
+        ]
+        let transcription = SpeechTranscriptionResult(
+            text: "Hello world\nHi there",
+            segments: [
+                SpeechSegment(start: 0, end: 4, text: "Hello world"),
+                SpeechSegment(start: 6, end: 9, text: "Hi there"),
+            ]
+        )
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            transcription: transcription,
+            diarizationSegments: segments,
+            meetingStart: localMidnight()
+        )
+        #expect(result.contains("Speaker 1: Hello world"))
+        #expect(result.contains("Speaker 2: Hi there"))
+        #expect(!result.contains("## Speaker Segments"))
+    }
+
+    @Test("formatTranscriptWithSpeakers falls back to raw text without ASR segments")
+    func formatTranscriptWithSpeakersFallsBackWithoutASRSegments() {
+        let segments = [
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 0, end: 5),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 5, end: 10),
         ]
         let result = AudioFileImportController.formatTranscriptWithSpeakers(
-            rawText: "Hello world",
+            transcription: SpeechTranscriptionResult(text: "Hello world", segments: []),
             diarizationSegments: segments,
-            duration: 10.0
+            meetingStart: Date(timeIntervalSince1970: 0)
         )
-        #expect(result.contains("## Speaker Segments"))
-        #expect(result.contains("Speaker 0"))
-        #expect(result.contains("Speaker 1"))
-        #expect(result.contains("## Transcript"))
-        #expect(result.contains("Hello world"))
+        #expect(result == "Hello world")
     }
 
     @Test("formatTranscriptWithSpeakers preserves timestamped text")
     func formatTranscriptWithSpeakersPreservesTimestampedText() {
         let segments = [
-            TimedSpeakerSegment(startTime: 0, endTime: 5, speakerId: "SPEAKER_0"),
-            TimedSpeakerSegment(startTime: 5, endTime: 10, speakerId: "SPEAKER_1"),
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 0, end: 5),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 5, end: 10),
         ]
         let timestampedText = "[00:00] Speaker 1: Hello\n[00:05] Speaker 2: Hi there"
         let result = AudioFileImportController.formatTranscriptWithSpeakers(
@@ -140,31 +181,59 @@ struct AudioFileImportControllerTests {
     func formatTimeIntervalUnderHour() {
         // Test via formatTranscriptWithSpeakers which uses internal formatting
         let segments = [
-            TimedSpeakerSegment(startTime: 65.0, endTime: 125.0, speakerId: "SPEAKER_0"),
-            TimedSpeakerSegment(startTime: 125.0, endTime: 185.0, speakerId: "SPEAKER_1"),
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 65.0, end: 125.0),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 125.0, end: 185.0),
         ]
-        let result = AudioFileImportController.formatTranscriptWithSpeakers(
-            rawText: "Test transcript",
-            diarizationSegments: segments,
-            duration: 200.0
+        let transcription = SpeechTranscriptionResult(
+            text: "First\nSecond",
+            segments: [
+                SpeechSegment(start: 65, end: 66, text: "First"),
+                SpeechSegment(start: 125, end: 126, text: "Second"),
+            ]
         )
-        #expect(result.contains("01:05"))
-        #expect(result.contains("02:05"))
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            transcription: transcription,
+            diarizationSegments: segments,
+            meetingStart: localMidnight()
+        )
+        #expect(result.contains("00:01:05"))
+        #expect(result.contains("00:02:05"))
     }
 
     @Test("format time interval over one hour")
     func formatTimeIntervalOverHour() {
         let segments = [
-            TimedSpeakerSegment(startTime: 3661.0, endTime: 3720.0, speakerId: "SPEAKER_0"),
-            TimedSpeakerSegment(startTime: 7200.0, endTime: 7260.0, speakerId: "SPEAKER_1"),
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 3661.0, end: 3720.0),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 7200.0, end: 7260.0),
+        ]
+        let transcription = SpeechTranscriptionResult(
+            text: "First\nSecond",
+            segments: [
+                SpeechSegment(start: 3661, end: 3662, text: "First"),
+                SpeechSegment(start: 7200, end: 7201, text: "Second"),
+            ]
+        )
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            transcription: transcription,
+            diarizationSegments: segments,
+            meetingStart: localMidnight()
+        )
+        #expect(result.contains("01:01:01"))
+        #expect(result.contains("02:00:00"))
+    }
+
+    @Test("raw-text compatibility formatter preserves text without timestamped ASR segments")
+    func rawTextCompatibilityFormatterPreservesText() {
+        let segments = [
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 0, end: 5),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 5, end: 10),
         ]
         let result = AudioFileImportController.formatTranscriptWithSpeakers(
             rawText: "Test transcript",
             diarizationSegments: segments,
-            duration: 8000.0
+            duration: 10.0
         )
-        #expect(result.contains("01:01:01"))
-        #expect(result.contains("02:00:00"))
+        #expect(result.contains("Test transcript"))
     }
 
     // MARK: - Helpers
@@ -206,5 +275,19 @@ struct AudioFileImportControllerTests {
         try file.write(from: buffer)
 
         return url
+    }
+
+    private func makeDiarSeg(speakerId: String, start: Float, end: Float) -> TimedSpeakerSegment {
+        TimedSpeakerSegment(
+            speakerId: speakerId,
+            embedding: [],
+            startTimeSeconds: start,
+            endTimeSeconds: end,
+            qualityScore: 1.0
+        )
+    }
+
+    private func localMidnight() -> Date {
+        Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 0))
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
@@ -1,0 +1,210 @@
+import Testing
+import Foundation
+import AVFoundation
+import FluidAudio
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("AudioFileImportController")
+struct AudioFileImportControllerTests {
+
+    // MARK: - WAV Conversion Tests
+
+    @Test("convertToWAV produces valid 16kHz mono WAV from valid audio")
+    func convertToWAVProducesValidOutput() throws {
+        let sourceURL = try createTestAudioFile(duration: 2.0, sampleRate: 44100, channels: 2)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let (wavURL, duration) = try AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        #expect(duration > 0)
+        #expect(duration <= 2.5)  // allow small tolerance
+
+        // Verify the output is a valid WAV with expected format
+        let file = try AVAudioFile(forReading: wavURL)
+        let format = file.processingFormat
+        #expect(format.sampleRate == 16000)
+        #expect(format.channelCount == 1)
+        #expect(format.commonFormat == .pcmFormatInt16)
+        #expect(file.length > 0)
+    }
+
+    @Test("convertToWAV throws noAudioTracks for file without audio")
+    func convertToWAVThrowsForNoAudio() throws {
+        // Create a minimal file that has no audio tracks (just a temp empty file)
+        let tempDir = FileManager.default.temporaryDirectory
+        let emptyURL = tempDir.appendingPathComponent("empty_test_\(UUID().uuidString).txt")
+        try "not audio".write(to: emptyURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: emptyURL) }
+
+        do {
+            _ = try AudioFileImportController.convertToWAV(sourceURL: emptyURL)
+            Issue.record("Expected convertToWAV to throw for non-audio file")
+        } catch let error as AudioFileImportController.ImportError {
+            #expect(error == .noAudioTracks || error.localizedDescription.contains("audio"))
+        } catch {
+            // AVAsset may throw other errors for non-media files, which is acceptable
+        }
+    }
+
+    @Test("convertToWAV handles mono source audio")
+    func convertToWAVHandlesMonoSource() throws {
+        let sourceURL = try createTestAudioFile(duration: 1.0, sampleRate: 48000, channels: 1)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let (wavURL, duration) = try AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        #expect(duration > 0)
+        let file = try AVAudioFile(forReading: wavURL)
+        #expect(file.processingFormat.channelCount == 1)
+        #expect(file.processingFormat.sampleRate == 16000)
+    }
+
+    @Test("convertToWAV handles short audio clips")
+    func convertToWAVHandlesShortAudio() throws {
+        let sourceURL = try createTestAudioFile(duration: 0.5, sampleRate: 44100, channels: 1)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        let (wavURL, duration) = try AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+
+        #expect(duration > 0)
+        #expect(duration < 1.0)
+    }
+
+    // MARK: - Speaker Formatting Tests
+
+    @Test("formatTranscriptWithSpeakers returns raw text when no segments")
+    func formatTranscriptWithSpeakersNoSegments() {
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            rawText: "Hello world",
+            diarizationSegments: [],
+            duration: 10.0
+        )
+        #expect(result == "Hello world")
+    }
+
+    @Test("formatTranscriptWithSpeakers returns raw text for single speaker")
+    func formatTranscriptWithSpeakersSingleSpeaker() {
+        let segments = [
+            TimedSpeakerSegment(startTime: 0, endTime: 5, speakerId: "SPEAKER_0"),
+            TimedSpeakerSegment(startTime: 5, endTime: 10, speakerId: "SPEAKER_0"),
+        ]
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            rawText: "Hello world",
+            diarizationSegments: segments,
+            duration: 10.0
+        )
+        #expect(result == "Hello world")
+    }
+
+    @Test("formatTranscriptWithSpeakers adds speaker labels for multiple speakers")
+    func formatTranscriptWithSpeakersMultipleSpeakers() {
+        let segments = [
+            TimedSpeakerSegment(startTime: 0, endTime: 5, speakerId: "SPEAKER_0"),
+            TimedSpeakerSegment(startTime: 5, endTime: 10, speakerId: "SPEAKER_1"),
+        ]
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            rawText: "Hello world",
+            diarizationSegments: segments,
+            duration: 10.0
+        )
+        #expect(result.contains("## Speaker Segments"))
+        #expect(result.contains("Speaker 0"))
+        #expect(result.contains("Speaker 1"))
+        #expect(result.contains("## Transcript"))
+        #expect(result.contains("Hello world"))
+    }
+
+    @Test("formatTranscriptWithSpeakers preserves timestamped text")
+    func formatTranscriptWithSpeakersPreservesTimestampedText() {
+        let segments = [
+            TimedSpeakerSegment(startTime: 0, endTime: 5, speakerId: "SPEAKER_0"),
+            TimedSpeakerSegment(startTime: 5, endTime: 10, speakerId: "SPEAKER_1"),
+        ]
+        let timestampedText = "[00:00] Speaker 1: Hello\n[00:05] Speaker 2: Hi there"
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            rawText: timestampedText,
+            diarizationSegments: segments,
+            duration: 10.0
+        )
+        // Should preserve the original timestamped text
+        #expect(result == timestampedText)
+    }
+
+    // MARK: - Time Formatting Tests
+
+    @Test("format time interval under one hour")
+    func formatTimeIntervalUnderHour() {
+        // Test via formatTranscriptWithSpeakers which uses internal formatting
+        let segments = [
+            TimedSpeakerSegment(startTime: 65.0, endTime: 125.0, speakerId: "SPEAKER_0"),
+            TimedSpeakerSegment(startTime: 125.0, endTime: 185.0, speakerId: "SPEAKER_1"),
+        ]
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            rawText: "Test transcript",
+            diarizationSegments: segments,
+            duration: 200.0
+        )
+        #expect(result.contains("01:05"))
+        #expect(result.contains("02:05"))
+    }
+
+    @Test("format time interval over one hour")
+    func formatTimeIntervalOverHour() {
+        let segments = [
+            TimedSpeakerSegment(startTime: 3661.0, endTime: 3720.0, speakerId: "SPEAKER_0"),
+            TimedSpeakerSegment(startTime: 7200.0, endTime: 7260.0, speakerId: "SPEAKER_1"),
+        ]
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            rawText: "Test transcript",
+            diarizationSegments: segments,
+            duration: 8000.0
+        )
+        #expect(result.contains("01:01:01"))
+        #expect(result.contains("02:00:00"))
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a test audio file with a sine wave tone.
+    private func createTestAudioFile(
+        duration: TimeInterval,
+        sampleRate: Double,
+        channels: Int
+    ) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_audio_\(UUID().uuidString).wav")
+
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: sampleRate,
+            channels: AVAudioChannelCount(channels),
+            interleaved: false
+        )!
+
+        let frameCount = AVAudioFrameCount(duration * sampleRate)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create buffer"])
+        }
+        buffer.frameLength = frameCount
+
+        // Fill with a 440Hz sine wave
+        let frequency: Float = 440.0
+        if let channelData = buffer.int16ChannelData {
+            for frame in 0..<Int(frameCount) {
+                let sample = Int16(sin(2.0 * .pi * frequency * Float(frame) / Float(sampleRate)) * 16000)
+                for ch in 0..<channels {
+                    channelData[ch][frame] = sample
+                }
+            }
+        }
+
+        let file = try AVAudioFile(forWriting: url, settings: format.settings, commonFormat: .pcmFormatInt16, interleaved: false)
+        try file.write(from: buffer)
+
+        return url
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
@@ -11,11 +11,11 @@ struct AudioFileImportControllerTests {
     // MARK: - WAV Conversion Tests
 
     @Test("convertToWAV produces valid 16kHz mono WAV from valid audio")
-    func convertToWAVProducesValidOutput() throws {
+    func convertToWAVProducesValidOutput() async throws {
         let sourceURL = try createTestAudioFile(duration: 2.0, sampleRate: 44100, channels: 2)
         defer { try? FileManager.default.removeItem(at: sourceURL) }
 
-        let (wavURL, duration) = try AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        let (wavURL, duration) = try await AudioFileImportController.convertToWAV(sourceURL: sourceURL)
         defer { try? FileManager.default.removeItem(at: wavURL) }
 
         #expect(duration > 0)
@@ -31,7 +31,7 @@ struct AudioFileImportControllerTests {
     }
 
     @Test("convertToWAV throws noAudioTracks for file without audio")
-    func convertToWAVThrowsForNoAudio() throws {
+    func convertToWAVThrowsForNoAudio() async throws {
         // Create a minimal file that has no audio tracks (just a temp empty file)
         let tempDir = FileManager.default.temporaryDirectory
         let emptyURL = tempDir.appendingPathComponent("empty_test_\(UUID().uuidString).txt")
@@ -39,7 +39,7 @@ struct AudioFileImportControllerTests {
         defer { try? FileManager.default.removeItem(at: emptyURL) }
 
         do {
-            _ = try AudioFileImportController.convertToWAV(sourceURL: emptyURL)
+            _ = try await AudioFileImportController.convertToWAV(sourceURL: emptyURL)
             Issue.record("Expected convertToWAV to throw for non-audio file")
         } catch let error as AudioFileImportController.ImportError {
             #expect(error == .noAudioTracks || error.localizedDescription.contains("audio"))
@@ -49,11 +49,11 @@ struct AudioFileImportControllerTests {
     }
 
     @Test("convertToWAV handles mono source audio")
-    func convertToWAVHandlesMonoSource() throws {
+    func convertToWAVHandlesMonoSource() async throws {
         let sourceURL = try createTestAudioFile(duration: 1.0, sampleRate: 48000, channels: 1)
         defer { try? FileManager.default.removeItem(at: sourceURL) }
 
-        let (wavURL, duration) = try AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        let (wavURL, duration) = try await AudioFileImportController.convertToWAV(sourceURL: sourceURL)
         defer { try? FileManager.default.removeItem(at: wavURL) }
 
         #expect(duration > 0)
@@ -63,11 +63,11 @@ struct AudioFileImportControllerTests {
     }
 
     @Test("convertToWAV handles short audio clips")
-    func convertToWAVHandlesShortAudio() throws {
+    func convertToWAVHandlesShortAudio() async throws {
         let sourceURL = try createTestAudioFile(duration: 0.5, sampleRate: 44100, channels: 1)
         defer { try? FileManager.default.removeItem(at: sourceURL) }
 
-        let (wavURL, duration) = try AudioFileImportController.convertToWAV(sourceURL: sourceURL)
+        let (wavURL, duration) = try await AudioFileImportController.convertToWAV(sourceURL: sourceURL)
         defer { try? FileManager.default.removeItem(at: wavURL) }
 
         #expect(duration > 0)

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -78,6 +78,7 @@ struct DictationStoreTests {
         #expect(inserted?.savedRecordingPath == nil)
         #expect(inserted?.status == .completed)
         #expect(inserted?.manualNotes == "")
+        #expect(inserted?.source == .meeting)
     }
 
     @Test("migration adds saved recording path column to legacy meeting schema")
@@ -103,6 +104,28 @@ struct DictationStoreTests {
         #expect(inserted?.savedRecordingPath == "/tmp/meeting.wav")
     }
 
+    @Test("meeting source is persisted")
+    func meetingSourcePersists() throws {
+        let store = try makeStore()
+        let start = Date()
+
+        try store.insertMeeting(
+            title: "Imported Audio",
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(60),
+            rawTranscript: "Transcript",
+            formattedNotes: "Notes",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: "/tmp/import.wav",
+            source: .audioImport
+        )
+
+        let inserted = try #require(try store.recentMeetings(limit: 1).first)
+        #expect(inserted.source == .audioImport)
+    }
+
     @Test("live meeting starts as recording with empty manual notes")
     func createLiveMeeting() throws {
         let store = try makeStore()
@@ -125,6 +148,7 @@ struct DictationStoreTests {
         #expect(meeting.rawTranscript == "")
         #expect(meeting.formattedNotes == "")
         #expect(meeting.selectedTemplateID == "auto")
+        #expect(meeting.source == .meeting)
     }
 
     @Test("manual notes update independently from final notes")


### PR DESCRIPTION
This pull request fixes #154.

The PR introduces a complete audio file import feature. A new `AudioFileImportController` handles file selection via `NSOpenPanel`, converts the chosen file (m4a, mp4, wav, mp3) to 16kHz mono WAV, transcribes it using the existing transcription pipeline, optionally runs speaker diarization and formats speaker labels, generates a summary, and saves the result as a meeting record. The `MeetingsView` now includes an "Import Audio" button and supports drag-and-drop of audio files. The `MuesliController` orchestrates the import flow, showing progress and opening the resulting transcript view. Unit tests validate audio conversion, speaker formatting, and time formatting. This directly addresses the issue by providing a file picker and drag-and-drop entry point that produces the same transcript and summary output as a live meeting, including speaker labels when diarization is available.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌