### PR TITLE
[codex] Fix silent system audio capture diagnostics

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -114,7 +114,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         guard let file = FileHandle(forWritingAtPath: url.path) else {
             throw RecorderError.fileCreationFailed
         }
-        file.write(WAVHeader.create(dataSize: 0))
+        file.write(WavWriter.header(dataSize: 0))
         outputFile = file
         outputURL = url
         totalBytesWritten = 0
@@ -145,7 +145,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         }
 
         if let file = outputFile {
-            let header = WAVHeader.create(dataSize: totalBytesWritten)
+            let header = WavWriter.header(dataSize: totalBytesWritten)
             file.seek(toFileOffset: 0)
             file.write(header)
             file.closeFile()
@@ -354,7 +354,6 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         else {
             return nil
         }
-        converter.reset()
 
         let inputFrameCount = AVAudioFrameCount(samples.count)
         guard let inputBuffer = AVAudioPCMBuffer(
@@ -831,30 +830,4 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         totalBytesWritten = 0
     }
 
-    // MARK: - WAV Header
-
-    private enum WAVHeader {
-        static func create(dataSize: Int) -> Data {
-            let sampleRate = Int(CoreAudioSystemRecorder.targetSampleRate)
-            let channels = 1
-            let byteRate = sampleRate * channels * 16 / 8
-            let blockAlign = channels * 16 / 8
-
-            var header = Data()
-            header.append(contentsOf: "RIFF".utf8)
-            header.append(contentsOf: withUnsafeBytes(of: UInt32(36 + dataSize).littleEndian) { Array($0) })
-            header.append(contentsOf: "WAVE".utf8)
-            header.append(contentsOf: "fmt ".utf8)
-            header.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) })
-            header.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) })
-            header.append(contentsOf: withUnsafeBytes(of: UInt16(channels).littleEndian) { Array($0) })
-            header.append(contentsOf: withUnsafeBytes(of: UInt32(sampleRate).littleEndian) { Array($0) })
-            header.append(contentsOf: withUnsafeBytes(of: UInt32(byteRate).littleEndian) { Array($0) })
-            header.append(contentsOf: withUnsafeBytes(of: UInt16(blockAlign).littleEndian) { Array($0) })
-            header.append(contentsOf: withUnsafeBytes(of: UInt16(16).littleEndian) { Array($0) })
-            header.append(contentsOf: "data".utf8)
-            header.append(contentsOf: withUnsafeBytes(of: UInt32(dataSize).littleEndian) { Array($0) })
-            return header
-        }
-    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -57,6 +57,9 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
     private var sourceSampleRate: Double = 48_000
     private var sourceChannels: UInt32 = 2
     private var sourceFormat = AudioStreamBasicDescription()
+    private var resampler: AVAudioConverter?
+    private var resamplerInputFormat: AVAudioFormat?
+    private var resamplerOutputFormat: AVAudioFormat?
     private let diagnosticsLock = OSAllocatedUnfairLock(initialState: DiagnosticsState())
 
     private struct DiagnosticsState {
@@ -243,6 +246,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
 
     private func setupAndStartAudioDevice() throws {
         let format = sourceFormat
+        configureResampler(for: format)
         activeCaptureGeneration &+= 1
         let generation = activeCaptureGeneration
         let block: AudioDeviceIOBlock = { [weak self] _, inputData, _, _, _ in
@@ -343,19 +347,14 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
             return samples.map { Int16(max(-1.0, min(1.0, $0)) * 32767.0) }
         }
 
-        guard let inputFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: sourceSampleRate,
-            channels: 1,
-            interleaved: false
-        ), let outputFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Self.targetSampleRate,
-            channels: 1,
-            interleaved: false
-        ), let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+        guard let converter = resampler,
+              let inputFormat = resamplerInputFormat,
+              let outputFormat = resamplerOutputFormat,
+              abs(inputFormat.sampleRate - sourceSampleRate) < 1.0
+        else {
             return nil
         }
+        converter.reset()
 
         let inputFrameCount = AVAudioFrameCount(samples.count)
         guard let inputBuffer = AVAudioPCMBuffer(
@@ -401,6 +400,33 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         return (0..<frameLength).map { index in
             Int16(max(-1.0, min(1.0, outputChannel[index])) * 32767.0)
         }
+    }
+
+    private func configureResampler(for format: AudioStreamBasicDescription) {
+        resampler = nil
+        resamplerInputFormat = nil
+        resamplerOutputFormat = nil
+
+        guard abs(format.mSampleRate - Self.targetSampleRate) >= 1.0 else { return }
+        guard let inputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: format.mSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.targetSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            diagnosticsLock.withLock { $0.unsupportedFormatCount += 1 }
+            fputs("[system-audio] failed to configure AVAudioConverter for \(format.mSampleRate)Hz\n", stderr)
+            return
+        }
+
+        resampler = converter
+        resamplerInputFormat = inputFormat
+        resamplerOutputFormat = outputFormat
     }
 
     private func mixToMonoFloat(
@@ -763,6 +789,9 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
 
     private func teardownTapAndAudioDevice() {
         activeCaptureGeneration &+= 1
+        resampler = nil
+        resamplerInputFormat = nil
+        resamplerOutputFormat = nil
 
         if let procID = deviceIOProcID, aggregateDeviceID != kAudioObjectUnknown {
             AudioDeviceStop(aggregateDeviceID, procID)

--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -1,9 +1,11 @@
 import AppKit
 import Atomics
 import AudioToolbox
+import AVFoundation
 import CoreAudio
 import Foundation
 import MuesliCore
+import os
 
 /// Protocol for system audio capture backends (ScreenCaptureKit vs CoreAudio tap).
 protocol SystemAudioCapturing: AnyObject {
@@ -23,16 +25,16 @@ protocol SystemAudioCapturing: AnyObject {
 /// - No conflict with `CGWindowListCreateImage` (screenshot OCR works during meetings)
 /// - Doesn't require "Screen & System Audio Recording" permission for audio capture
 /// - Hardware-synchronized with mic input when used in an aggregate device
-final class CoreAudioSystemRecorder: SystemAudioCapturing {
+final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnosticsProviding {
     var onPCMSamples: (([Int16]) -> Void)?
 
     private var tapID: AudioObjectID = kAudioObjectUnknown
     private var aggregateDeviceID: AudioDeviceID = kAudioObjectUnknown
-    private var audioUnit: AudioUnit?
+    private var deviceIOProcID: AudioDeviceIOProcID?
+    private var deviceIOBlock: AudioDeviceIOBlock?
+    private let deviceIOQueue = DispatchQueue(label: "com.muesli.system-audio-tap.io", qos: .userInitiated)
     private let processingQueue = DispatchQueue(label: "com.muesli.system-audio-tap")
     private var defaultOutputDeviceListenerBlock: AudioObjectPropertyListenerBlock?
-    private var renderBuffer: UnsafeMutableRawPointer?
-    private var renderBufferCapacity = 0
 
     private var outputFile: FileHandle?
     private var outputURL: URL?
@@ -49,11 +51,43 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     }
 
     private static let targetSampleRate: Double = 16_000
-    private static let maxRenderFrames: UInt32 = 4096
 
     /// Source format from the tap (queried at setup time).
     private var sourceSampleRate: Double = 48_000
     private var sourceChannels: UInt32 = 2
+    private var sourceFormat = AudioStreamBasicDescription()
+    private let diagnosticsLock = OSAllocatedUnfairLock(initialState: DiagnosticsState())
+
+    private struct DiagnosticsState {
+        var callbackCount = 0
+        var bufferCount = 0
+        var emptyBufferCount = 0
+        var unsupportedFormatCount = 0
+        var inputByteCount = 0
+        var bytesWritten = 0
+        var sourceSampleRate: Double = 0
+        var sourceChannels: UInt32 = 0
+        var preConversion = AudioSampleStats()
+        var postConversion = AudioSampleStats()
+    }
+
+    var diagnosticsSnapshot: SystemAudioCaptureDiagnosticsSnapshot {
+        diagnosticsLock.withLock { state in
+            SystemAudioCaptureDiagnosticsSnapshot(
+                backend: "CoreAudioTapIOProc",
+                callbackCount: state.callbackCount,
+                bufferCount: state.bufferCount,
+                emptyBufferCount: state.emptyBufferCount,
+                unsupportedFormatCount: state.unsupportedFormatCount,
+                inputByteCount: state.inputByteCount,
+                bytesWritten: state.bytesWritten,
+                sourceSampleRate: state.sourceSampleRate,
+                sourceChannels: state.sourceChannels,
+                preConversion: state.preConversion.snapshot(),
+                postConversion: state.postConversion.snapshot()
+            )
+        }
+    }
 
     deinit {
         if isRecording
@@ -85,7 +119,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
 
         do {
             try createTapAndAggregateDevice()
-            try setupAndStartAudioUnit()
+            try setupAndStartAudioDevice()
             installDefaultOutputDeviceListener()
             fputs("[system-audio] CoreAudio tap capture started\n", stderr)
         } catch {
@@ -102,7 +136,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
 
         removeDefaultOutputDeviceListener()
         processingQueue.sync {
-            teardownTapAndAudioUnit()
+            teardownTapAndAudioDevice()
             onPCMSamples = nil
         }
 
@@ -136,16 +170,11 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     // MARK: - Tap + Aggregate Device Setup
 
     private func createTapAndAggregateDevice() throws {
-        // Tap the default output device directly rather than the stereo global mix.
-        // Native call clients (Zoom, Teams) route audio through private pipelines
-        // (virtual devices, custom AudioUnits for AEC/noise suppression) that bypass
-        // the system's stereo mix. A device-level tap captures all audio flowing
-        // through the output device regardless of which app or pipeline produces it.
-        guard let outputDevice = Self.defaultOutputDeviceTapTarget() else {
-            throw RecorderError.noDefaultOutputDevice
-        }
-        let tapDesc = Self.makeOutputDeviceTapDescription(
-            deviceUID: outputDevice.uid,
+        // Use the global stereo process mix. This is the closest CoreAudio tap
+        // equivalent to ScreenCaptureKit's "system audio" stream: all process
+        // output mixed to stereo, excluding Muesli itself. The previous
+        // device-stream tap could be valid but zero-filled on some routes.
+        let tapDesc = Self.makeGlobalTapDescription(
             excludingProcessID: Self.currentProcessAudioObjectID(),
             name: "Muesli System Audio Tap"
         )
@@ -164,15 +193,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         // CATapDescription objects (passing objects crashes CoreAudio).
         let tapUIDString = tapDesc.uuid.uuidString
         let aggUID = "com.muesli.system-audio-tap-\(UUID().uuidString)"
-        let aggDesc: NSDictionary = [
-            kAudioAggregateDeviceNameKey: "Muesli System Audio",
-            kAudioAggregateDeviceUIDKey: aggUID,
-            kAudioAggregateDeviceIsPrivateKey: true,
-            kAudioAggregateDeviceTapListKey: [
-                [kAudioSubTapUIDKey: tapUIDString],
-            ],
-            kAudioAggregateDeviceTapAutoStartKey: true,
-        ]
+        let aggDesc = Self.makeAggregateDeviceDescription(tapUID: tapUIDString, aggregateUID: aggUID)
 
         status = AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggregateDeviceID)
         guard status == noErr, aggregateDeviceID != kAudioObjectUnknown else {
@@ -181,6 +202,15 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
             throw RecorderError.aggregateDeviceCreationFailed(status)
         }
         fputs("[system-audio] aggregate device \(aggregateDeviceID) created (uid: \(aggUID))\n", stderr)
+
+        sourceFormat = try Self.audioTapStreamFormat(for: tapID)
+        sourceSampleRate = sourceFormat.mSampleRate
+        sourceChannels = sourceFormat.mChannelsPerFrame
+        diagnosticsLock.withLock { state in
+            state.sourceSampleRate = sourceSampleRate
+            state.sourceChannels = sourceChannels
+        }
+        fputs("[system-audio] tap format: \(sourceSampleRate)Hz, \(sourceChannels)ch, flags=\(sourceFormat.mFormatFlags), bytesPerFrame=\(sourceFormat.mBytesPerFrame)\n", stderr)
     }
 
     static func makeOutputDeviceTapDescription(
@@ -195,199 +225,235 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         return tapDesc
     }
 
-    private func setupAndStartAudioUnit() throws {
-        // Find AUHAL component
-        var componentDesc = AudioComponentDescription(
-            componentType: kAudioUnitType_Output,
-            componentSubType: kAudioUnitSubType_HALOutput,
-            componentManufacturer: kAudioUnitManufacturer_Apple,
-            componentFlags: 0,
-            componentFlagsMask: 0
-        )
-        guard let component = AudioComponentFindNext(nil, &componentDesc) else {
-            throw RecorderError.auhalNotFound
-        }
-
-        var au: AudioUnit?
-        try osCheck(AudioComponentInstanceNew(component, &au), "create AUHAL")
-        guard let au else { throw RecorderError.auhalNotFound }
-
-        do {
-            // Enable input (bus 1), disable output (bus 0) — input-only capture
-            var one: UInt32 = 1
-            var zero: UInt32 = 0
-            try osCheck(AudioUnitSetProperty(
-                au, kAudioOutputUnitProperty_EnableIO,
-                kAudioUnitScope_Input, 1, &one, Self.u32Size
-            ), "enable input")
-            try osCheck(AudioUnitSetProperty(
-                au, kAudioOutputUnitProperty_EnableIO,
-                kAudioUnitScope_Output, 0, &zero, Self.u32Size
-            ), "disable output")
-
-            // Point at the aggregate device
-            var devID = aggregateDeviceID
-            try osCheck(AudioUnitSetProperty(
-                au, kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global, 0, &devID,
-                UInt32(MemoryLayout<AudioDeviceID>.size)
-            ), "set device")
-
-            // Query the native input format from the tap
-            var nativeFormat = AudioStreamBasicDescription()
-            var fmtSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-            try osCheck(AudioUnitGetProperty(
-                au, kAudioUnitProperty_StreamFormat,
-                kAudioUnitScope_Input, 1, &nativeFormat, &fmtSize
-            ), "get input format")
-
-            sourceSampleRate = nativeFormat.mSampleRate
-            sourceChannels = nativeFormat.mChannelsPerFrame
-            fputs("[system-audio] tap format: \(sourceSampleRate)Hz, \(sourceChannels)ch\n", stderr)
-            allocateRenderBuffer(for: sourceChannels)
-
-            // Request float32 interleaved on the output scope of bus 1
-            var outFormat = AudioStreamBasicDescription(
-                mSampleRate: sourceSampleRate,
-                mFormatID: kAudioFormatLinearPCM,
-                mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
-                mBytesPerPacket: sourceChannels * 4,
-                mFramesPerPacket: 1,
-                mBytesPerFrame: sourceChannels * 4,
-                mChannelsPerFrame: sourceChannels,
-                mBitsPerChannel: 32,
-                mReserved: 0
-            )
-            try osCheck(AudioUnitSetProperty(
-                au, kAudioUnitProperty_StreamFormat,
-                kAudioUnitScope_Output, 1, &outFormat, fmtSize
-            ), "set output format")
-
-            // Register input callback
-            var cb = AURenderCallbackStruct(
-                inputProc: Self.renderCallback,
-                inputProcRefCon: Unmanaged.passUnretained(self).toOpaque()
-            )
-            try osCheck(AudioUnitSetProperty(
-                au, kAudioOutputUnitProperty_SetInputCallback,
-                kAudioUnitScope_Global, 0, &cb,
-                UInt32(MemoryLayout<AURenderCallbackStruct>.size)
-            ), "set input callback")
-
-            try osCheck(AudioUnitInitialize(au), "initialize AUHAL")
-            try osCheck(AudioOutputUnitStart(au), "start AUHAL")
-        } catch {
-            AudioComponentInstanceDispose(au)
-            throw error
-        }
-
-        audioUnit = au
+    static func makeGlobalTapDescription(
+        excludingProcessID: AudioObjectID?,
+        name: String
+    ) -> CATapDescription {
+        let excludeList = excludingProcessID.map { [$0] } ?? []
+        let tapDesc = CATapDescription(stereoGlobalTapButExcludeProcesses: excludeList)
+        tapDesc.name = name
+        tapDesc.isPrivate = true
+        tapDesc.muteBehavior = .unmuted
+        return tapDesc
     }
 
-    // MARK: - Render Callback (real-time audio thread)
+    static func makeAggregateDeviceDescription(tapUID: String, aggregateUID: String) -> NSDictionary {
+        [
+            kAudioAggregateDeviceNameKey: "Muesli System Audio",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapUIDKey: tapUID,
+                    kAudioSubTapDriftCompensationKey: true,
+                ],
+            ],
+            kAudioAggregateDeviceTapAutoStartKey: true,
+        ]
+    }
 
-    private static let renderCallback: AURenderCallback = { (
-        inRefCon, ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, _
-    ) -> OSStatus in
-        let recorder = Unmanaged<CoreAudioSystemRecorder>.fromOpaque(inRefCon).takeUnretainedValue()
-        guard recorder.isRecording, let au = recorder.audioUnit else { return noErr }
+    private func setupAndStartAudioDevice() throws {
+        let format = sourceFormat
+        let block: AudioDeviceIOBlock = { [weak self] _, inputData, _, _, _ in
+            guard let self, self.isRecording, !self.isPaused else { return }
+            self.diagnosticsLock.withLock { $0.callbackCount += 1 }
 
-        let channels = Int(recorder.sourceChannels)
-        let byteSize = Int(inNumberFrames) * channels * MemoryLayout<Float>.size
-        guard let rawBuf = recorder.renderBuffer, byteSize <= recorder.renderBufferCapacity else {
-            return kAudio_ParamError
+            let buffers = Self.copyAudioBuffers(from: inputData)
+            guard !buffers.isEmpty else {
+                self.diagnosticsLock.withLock { $0.emptyBufferCount += 1 }
+                return
+            }
+            self.diagnosticsLock.withLock { state in
+                state.bufferCount += buffers.count
+                state.inputByteCount += buffers.reduce(0) { $0 + $1.data.count }
+            }
+
+            self.processingQueue.async { [weak self] in
+                guard let self, self.isRecording, !self.isPaused else { return }
+                self.processAudioBuffers(buffers, format: format)
+            }
         }
 
-        var bufferList = AudioBufferList(
-            mNumberBuffers: 1,
-            mBuffers: AudioBuffer(
-                mNumberChannels: UInt32(channels),
-                mDataByteSize: UInt32(byteSize),
-                mData: rawBuf
-            )
-        )
-
-        let status = AudioUnitRender(
-            au, ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, &bufferList
-        )
-        guard status == noErr else { return status }
-        guard !recorder.isPaused else { return noErr }
-
-        // Copy rendered data and dispatch off the audio thread for conversion + I/O
-        let data = Data(bytes: rawBuf, count: byteSize)
-
-        let frameCount = Int(inNumberFrames)
-        let srcRate = recorder.sourceSampleRate
-
-        recorder.processingQueue.async { [weak recorder] in
-            guard let recorder, recorder.isRecording, !recorder.isPaused else { return }
-            recorder.processAudioData(data, frameCount: frameCount, channels: channels, sourceRate: srcRate)
+        var procID: AudioDeviceIOProcID?
+        try osCheck(AudioDeviceCreateIOProcIDWithBlock(
+            &procID,
+            aggregateDeviceID,
+            deviceIOQueue,
+            block
+        ), "create aggregate IOProc")
+        guard let procID else {
+            throw RecorderError.deviceIOProcCreationFailed
         }
 
-        return noErr
+        deviceIOProcID = procID
+        deviceIOBlock = block
+
+        do {
+            try osCheck(AudioDeviceStart(aggregateDeviceID, procID), "start aggregate device")
+        } catch {
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
+            deviceIOProcID = nil
+            deviceIOBlock = nil
+            throw error
+        }
     }
 
     // MARK: - Audio Processing (processing queue)
 
-    private func processAudioData(_ data: Data, frameCount: Int, channels: Int, sourceRate: Double) {
-        guard isRecording, !isPaused else { return }
-        data.withUnsafeBytes { rawBuffer in
-            let floatPtr = rawBuffer.bindMemory(to: Float.self)
+    private struct CapturedAudioBuffer {
+        let numberChannels: UInt32
+        let data: Data
+    }
 
-            // 1. Mix to mono
-            var mono = [Float](repeating: 0, count: frameCount)
-            if channels > 1 {
-                let scale = 1.0 / Float(channels)
-                for i in 0..<frameCount {
-                    var sum: Float = 0
-                    for ch in 0..<channels {
-                        sum += floatPtr[i * channels + ch]
-                    }
-                    mono[i] = sum * scale
-                }
-            } else {
-                for i in 0..<frameCount {
-                    mono[i] = floatPtr[i]
-                }
-            }
+    private static func copyAudioBuffers(from inputData: UnsafePointer<AudioBufferList>) -> [CapturedAudioBuffer] {
+        let bufferList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inputData))
+        var buffers: [CapturedAudioBuffer] = []
+        buffers.reserveCapacity(bufferList.count)
 
-            // 2. Resample to 16 kHz and convert to Int16
-            let targetRate = Self.targetSampleRate
-            let int16Samples: [Int16]
-
-            if abs(sourceRate - targetRate) < 1.0 {
-                int16Samples = mono.map { Int16(max(-1.0, min(1.0, $0)) * 32767.0) }
-            } else {
-                let ratio = sourceRate / targetRate
-                let outputCount = Int(Double(frameCount) / ratio)
-                guard outputCount > 0 else { return }
-                var resampled = [Int16](repeating: 0, count: outputCount)
-                for i in 0..<outputCount {
-                    let srcPos = Double(i) * ratio
-                    let idx = Int(srcPos)
-                    let frac = Float(srcPos - Double(idx))
-                    let sample: Float
-                    if idx + 1 < frameCount {
-                        sample = mono[idx] * (1.0 - frac) + mono[idx + 1] * frac
-                    } else if idx < frameCount {
-                        sample = mono[idx]
-                    } else {
-                        sample = 0
-                    }
-                    resampled[i] = Int16(max(-1.0, min(1.0, sample)) * 32767.0)
-                }
-                int16Samples = resampled
-            }
-
-            // 3. Write WAV data + deliver callback
-            guard !int16Samples.isEmpty else { return }
-            let rawData = int16Samples.withUnsafeBufferPointer { buf in
-                Data(bytes: buf.baseAddress!, count: buf.count * MemoryLayout<Int16>.size)
-            }
-            outputFile?.write(rawData)
-            totalBytesWritten += rawData.count
-            onPCMSamples?(int16Samples)
+        for buffer in bufferList {
+            guard let data = buffer.mData, buffer.mDataByteSize > 0 else { continue }
+            buffers.append(CapturedAudioBuffer(
+                numberChannels: buffer.mNumberChannels,
+                data: Data(bytes: data, count: Int(buffer.mDataByteSize))
+            ))
         }
+
+        return buffers
+    }
+
+    private func processAudioBuffers(_ buffers: [CapturedAudioBuffer], format: AudioStreamBasicDescription) {
+        guard isRecording, !isPaused else { return }
+        guard let mono = mixToMonoFloat(buffers: buffers, format: format), !mono.isEmpty else { return }
+        diagnosticsLock.withLock { $0.preConversion.addFloats(mono) }
+
+        // Resample to 16 kHz and convert to Int16.
+        let targetRate = Self.targetSampleRate
+        let int16Samples: [Int16]
+
+        if abs(format.mSampleRate - targetRate) < 1.0 {
+            int16Samples = mono.map { Int16(max(-1.0, min(1.0, $0)) * 32767.0) }
+        } else {
+            let ratio = format.mSampleRate / targetRate
+            let outputCount = Int(Double(mono.count) / ratio)
+            guard outputCount > 0 else { return }
+            var resampled = [Int16](repeating: 0, count: outputCount)
+            for i in 0..<outputCount {
+                let srcPos = Double(i) * ratio
+                let idx = Int(srcPos)
+                let frac = Float(srcPos - Double(idx))
+                let sample: Float
+                if idx + 1 < mono.count {
+                    sample = mono[idx] * (1.0 - frac) + mono[idx + 1] * frac
+                } else if idx < mono.count {
+                    sample = mono[idx]
+                } else {
+                    sample = 0
+                }
+                resampled[i] = Int16(max(-1.0, min(1.0, sample)) * 32767.0)
+            }
+            int16Samples = resampled
+        }
+
+        guard !int16Samples.isEmpty else { return }
+        let rawData = int16Samples.withUnsafeBufferPointer { buf in
+            Data(bytes: buf.baseAddress!, count: buf.count * MemoryLayout<Int16>.size)
+        }
+        outputFile?.write(rawData)
+        totalBytesWritten += rawData.count
+        diagnosticsLock.withLock { state in
+            state.bytesWritten += rawData.count
+            state.postConversion.addInt16(int16Samples)
+        }
+        onPCMSamples?(int16Samples)
+    }
+
+    private func mixToMonoFloat(
+        buffers: [CapturedAudioBuffer],
+        format: AudioStreamBasicDescription
+    ) -> [Float]? {
+        guard format.mFormatID == kAudioFormatLinearPCM else { return nil }
+
+        let flags = format.mFormatFlags
+        let isFloat = (flags & kAudioFormatFlagIsFloat) != 0
+        let bitsPerChannel = Int(format.mBitsPerChannel)
+
+        if isFloat, bitsPerChannel == 32 {
+            return mixFloatingPointBuffers(buffers)
+        }
+
+        if !isFloat, bitsPerChannel == 16 {
+            return mixInt16Buffers(buffers)
+        }
+
+        fputs("[system-audio] unsupported tap PCM format flags=\(flags) bits=\(bitsPerChannel)\n", stderr)
+        diagnosticsLock.withLock { $0.unsupportedFormatCount += 1 }
+        return nil
+    }
+
+    private func mixFloatingPointBuffers(_ buffers: [CapturedAudioBuffer]) -> [Float]? {
+        var mono: [Float] = []
+        var channelsMixed = 0
+
+        for buffer in buffers {
+            let channels = max(Int(buffer.numberChannels), 1)
+            let samples = buffer.data.withUnsafeBytes { rawBuffer in
+                Array(rawBuffer.bindMemory(to: Float.self))
+            }
+            guard !samples.isEmpty else { continue }
+
+            let frames = samples.count / channels
+            if mono.isEmpty {
+                mono = [Float](repeating: 0, count: frames)
+            }
+
+            let framesToMix = min(mono.count, frames)
+            for frame in 0..<framesToMix {
+                for channel in 0..<channels {
+                    mono[frame] += samples[frame * channels + channel]
+                }
+            }
+            channelsMixed += channels
+        }
+
+        guard channelsMixed > 0, !mono.isEmpty else { return nil }
+        let scale = 1.0 / Float(channelsMixed)
+        for index in mono.indices {
+            mono[index] *= scale
+        }
+        return mono
+    }
+
+    private func mixInt16Buffers(_ buffers: [CapturedAudioBuffer]) -> [Float]? {
+        var mono: [Float] = []
+        var channelsMixed = 0
+
+        for buffer in buffers {
+            let channels = max(Int(buffer.numberChannels), 1)
+            let samples = buffer.data.withUnsafeBytes { rawBuffer in
+                Array(rawBuffer.bindMemory(to: Int16.self))
+            }
+            guard !samples.isEmpty else { continue }
+
+            let frames = samples.count / channels
+            if mono.isEmpty {
+                mono = [Float](repeating: 0, count: frames)
+            }
+
+            let framesToMix = min(mono.count, frames)
+            for frame in 0..<framesToMix {
+                for channel in 0..<channels {
+                    mono[frame] += Float(samples[frame * channels + channel]) / 32768.0
+                }
+            }
+            channelsMixed += channels
+        }
+
+        guard channelsMixed > 0, !mono.isEmpty else { return nil }
+        let scale = 1.0 / Float(channelsMixed)
+        for index in mono.indices {
+            mono[index] *= scale
+        }
+        return mono
     }
 
     // MARK: - Permission
@@ -395,11 +461,8 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
     /// Check whether system audio capture permission (`kTCCServiceAudioCapture`)
     /// is granted by attempting to create a device tap on the default output device.
     static func checkSystemAudioPermission() -> Bool {
-        guard let outputDevice = defaultOutputDeviceTapTarget(),
-              let selfObjectID = currentProcessAudioObjectID()
-        else { return false }
-        let tapDesc = makeOutputDeviceTapDescription(
-            deviceUID: outputDevice.uid,
+        guard let selfObjectID = currentProcessAudioObjectID() else { return false }
+        let tapDesc = makeGlobalTapDescription(
             excludingProcessID: selfObjectID,
             name: "Muesli Permission Check"
         )
@@ -493,6 +556,21 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
             }
         }
         return nil
+    }
+
+    private static func audioTapStreamFormat(for tapID: AudioObjectID) throws -> AudioStreamBasicDescription {
+        var format = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(tapID, &address, 0, nil, &size, &format)
+        guard status == noErr else {
+            throw RecorderError.tapFormatUnavailable(status)
+        }
+        return format
     }
 
     /// Trigger the macOS "System Audio Recording" permission dialog by briefly
@@ -620,15 +698,15 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         guard isRecording else { return }
 
         fputs("[system-audio] default output device changed; rebuilding tap\n", stderr)
-        teardownTapAndAudioUnit()
+        teardownTapAndAudioDevice()
         guard isRecording else { return }
 
         do {
             try createTapAndAggregateDevice()
-            try setupAndStartAudioUnit()
+            try setupAndStartAudioDevice()
             fputs("[system-audio] CoreAudio tap capture restarted for default output device\n", stderr)
         } catch {
-            teardownTapAndAudioUnit()
+            teardownTapAndAudioDevice()
             isRecording = false
             isPaused = false
             onPCMSamples = nil
@@ -643,8 +721,9 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         case noDefaultOutputDevice
         case tapCreationFailed(OSStatus)
         case aggregateDeviceCreationFailed(OSStatus)
-        case auhalNotFound
-        case auhalSetupFailed(String, OSStatus)
+        case coreAudioSetupFailed(String, OSStatus)
+        case deviceIOProcCreationFailed
+        case tapFormatUnavailable(OSStatus)
 
         var errorDescription: String? {
             switch self {
@@ -656,45 +735,29 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
                 return "Process tap creation failed (status: \(s))"
             case .aggregateDeviceCreationFailed(let s):
                 return "Aggregate device creation failed (status: \(s))"
-            case .auhalNotFound:
-                return "AUHAL audio component not found"
-            case .auhalSetupFailed(let step, let s):
-                return "AUHAL setup failed at '\(step)' (status: \(s))"
+            case .coreAudioSetupFailed(let step, let s):
+                return "CoreAudio setup failed at '\(step)' (status: \(s))"
+            case .deviceIOProcCreationFailed:
+                return "Could not create aggregate device IOProc"
+            case .tapFormatUnavailable(let s):
+                return "Could not read tap stream format (status: \(s))"
             }
         }
     }
 
-    private static let u32Size = UInt32(MemoryLayout<UInt32>.size)
-
     private func osCheck(_ status: OSStatus, _ label: String) throws {
         guard status == noErr else {
-            throw RecorderError.auhalSetupFailed(label, status)
+            throw RecorderError.coreAudioSetupFailed(label, status)
         }
     }
 
-    private func allocateRenderBuffer(for channels: UInt32) {
-        releaseRenderBuffer()
-        renderBufferCapacity = Int(Self.maxRenderFrames) * Int(channels) * MemoryLayout<Float>.size
-        renderBuffer = UnsafeMutableRawPointer.allocate(
-            byteCount: renderBufferCapacity,
-            alignment: MemoryLayout<Float>.alignment
-        )
-    }
-
-    private func releaseRenderBuffer() {
-        renderBuffer?.deallocate()
-        renderBuffer = nil
-        renderBufferCapacity = 0
-    }
-
-    private func teardownTapAndAudioUnit() {
-        if let au = audioUnit {
-            AudioOutputUnitStop(au)
-            AudioUnitUninitialize(au)
-            AudioComponentInstanceDispose(au)
+    private func teardownTapAndAudioDevice() {
+        if let procID = deviceIOProcID, aggregateDeviceID != kAudioObjectUnknown {
+            AudioDeviceStop(aggregateDeviceID, procID)
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
         }
-        audioUnit = nil
-        releaseRenderBuffer()
+        deviceIOProcID = nil
+        deviceIOBlock = nil
 
         if aggregateDeviceID != kAudioObjectUnknown {
             AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
@@ -713,7 +776,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing {
         onPCMSamples = nil
 
         removeDefaultOutputDeviceListener()
-        teardownTapAndAudioUnit()
+        teardownTapAndAudioDevice()
 
         if let file = outputFile {
             file.closeFile()

--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -39,6 +39,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
     private var outputFile: FileHandle?
     private var outputURL: URL?
     private var totalBytesWritten = 0
+    private var activeCaptureGeneration: UInt64 = 0
     private let recordingFlag = ManagedAtomic(false)
     private let pausedFlag = ManagedAtomic(false)
     private(set) var isRecording: Bool {
@@ -213,18 +214,6 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         fputs("[system-audio] tap format: \(sourceSampleRate)Hz, \(sourceChannels)ch, flags=\(sourceFormat.mFormatFlags), bytesPerFrame=\(sourceFormat.mBytesPerFrame)\n", stderr)
     }
 
-    static func makeOutputDeviceTapDescription(
-        deviceUID: String,
-        excludingProcessID: AudioObjectID?,
-        name: String
-    ) -> CATapDescription {
-        let excludeList = excludingProcessID.map { [$0] } ?? []
-        // Default output devices expose the render stream we need at index 0 on supported macOS hardware.
-        let tapDesc = CATapDescription(excludingProcesses: excludeList, deviceUID: deviceUID, stream: 0)
-        tapDesc.name = name
-        return tapDesc
-    }
-
     static func makeGlobalTapDescription(
         excludingProcessID: AudioObjectID?,
         name: String
@@ -254,6 +243,8 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
 
     private func setupAndStartAudioDevice() throws {
         let format = sourceFormat
+        activeCaptureGeneration &+= 1
+        let generation = activeCaptureGeneration
         let block: AudioDeviceIOBlock = { [weak self] _, inputData, _, _, _ in
             guard let self, self.isRecording, !self.isPaused else { return }
             self.diagnosticsLock.withLock { $0.callbackCount += 1 }
@@ -270,6 +261,7 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
 
             self.processingQueue.async { [weak self] in
                 guard let self, self.isRecording, !self.isPaused else { return }
+                guard self.activeCaptureGeneration == generation else { return }
                 self.processAudioBuffers(buffers, format: format)
             }
         }
@@ -326,32 +318,9 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         guard let mono = mixToMonoFloat(buffers: buffers, format: format), !mono.isEmpty else { return }
         diagnosticsLock.withLock { $0.preConversion.addFloats(mono) }
 
-        // Resample to 16 kHz and convert to Int16.
-        let targetRate = Self.targetSampleRate
-        let int16Samples: [Int16]
-
-        if abs(format.mSampleRate - targetRate) < 1.0 {
-            int16Samples = mono.map { Int16(max(-1.0, min(1.0, $0)) * 32767.0) }
-        } else {
-            let ratio = format.mSampleRate / targetRate
-            let outputCount = Int(Double(mono.count) / ratio)
-            guard outputCount > 0 else { return }
-            var resampled = [Int16](repeating: 0, count: outputCount)
-            for i in 0..<outputCount {
-                let srcPos = Double(i) * ratio
-                let idx = Int(srcPos)
-                let frac = Float(srcPos - Double(idx))
-                let sample: Float
-                if idx + 1 < mono.count {
-                    sample = mono[idx] * (1.0 - frac) + mono[idx + 1] * frac
-                } else if idx < mono.count {
-                    sample = mono[idx]
-                } else {
-                    sample = 0
-                }
-                resampled[i] = Int16(max(-1.0, min(1.0, sample)) * 32767.0)
-            }
-            int16Samples = resampled
+        guard let int16Samples = resampleMonoFloatToInt16(mono, sourceSampleRate: format.mSampleRate) else {
+            diagnosticsLock.withLock { $0.unsupportedFormatCount += 1 }
+            return
         }
 
         guard !int16Samples.isEmpty else { return }
@@ -367,6 +336,73 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         onPCMSamples?(int16Samples)
     }
 
+    private func resampleMonoFloatToInt16(_ samples: [Float], sourceSampleRate: Double) -> [Int16]? {
+        guard !samples.isEmpty, sourceSampleRate > 0 else { return nil }
+
+        if abs(sourceSampleRate - Self.targetSampleRate) < 1.0 {
+            return samples.map { Int16(max(-1.0, min(1.0, $0)) * 32767.0) }
+        }
+
+        guard let inputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sourceSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.targetSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            return nil
+        }
+
+        let inputFrameCount = AVAudioFrameCount(samples.count)
+        guard let inputBuffer = AVAudioPCMBuffer(
+            pcmFormat: inputFormat,
+            frameCapacity: inputFrameCount
+        ), let inputChannel = inputBuffer.floatChannelData?[0] else {
+            return nil
+        }
+        inputBuffer.frameLength = inputFrameCount
+        inputChannel.update(from: samples, count: samples.count)
+
+        let ratio = Self.targetSampleRate / sourceSampleRate
+        let outputFrameCapacity = AVAudioFrameCount(max(1, Int(ceil(Double(samples.count) * ratio)) + 32))
+        guard let outputBuffer = AVAudioPCMBuffer(
+            pcmFormat: outputFormat,
+            frameCapacity: outputFrameCapacity
+        ) else {
+            return nil
+        }
+
+        var didProvideInput = false
+        let inputBlock: AVAudioConverterInputBlock = { _, status in
+            if didProvideInput {
+                status.pointee = .noDataNow
+                return nil
+            }
+            didProvideInput = true
+            status.pointee = .haveData
+            return inputBuffer
+        }
+
+        var conversionError: NSError?
+        let status = converter.convert(to: outputBuffer, error: &conversionError, withInputFrom: inputBlock)
+        guard status != .error, conversionError == nil, let outputChannel = outputBuffer.floatChannelData?[0] else {
+            if let conversionError {
+                fputs("[system-audio] AVAudioConverter failed: \(conversionError)\n", stderr)
+            }
+            return nil
+        }
+
+        let frameLength = Int(outputBuffer.frameLength)
+        guard frameLength > 0 else { return nil }
+        return (0..<frameLength).map { index in
+            Int16(max(-1.0, min(1.0, outputChannel[index])) * 32767.0)
+        }
+    }
+
     private func mixToMonoFloat(
         buffers: [CapturedAudioBuffer],
         format: AudioStreamBasicDescription
@@ -375,14 +411,24 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
 
         let flags = format.mFormatFlags
         let isFloat = (flags & kAudioFormatFlagIsFloat) != 0
+        let isNonInterleaved = (flags & kAudioFormatFlagIsNonInterleaved) != 0
         let bitsPerChannel = Int(format.mBitsPerChannel)
+        let channelCount = max(Int(format.mChannelsPerFrame), 1)
 
         if isFloat, bitsPerChannel == 32 {
-            return mixFloatingPointBuffers(buffers)
+            return mixFloatingPointBuffers(
+                buffers,
+                channelCount: channelCount,
+                isNonInterleaved: isNonInterleaved
+            )
         }
 
         if !isFloat, bitsPerChannel == 16 {
-            return mixInt16Buffers(buffers)
+            return mixInt16Buffers(
+                buffers,
+                channelCount: channelCount,
+                isNonInterleaved: isNonInterleaved
+            )
         }
 
         fputs("[system-audio] unsupported tap PCM format flags=\(flags) bits=\(bitsPerChannel)\n", stderr)
@@ -390,12 +436,16 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         return nil
     }
 
-    private func mixFloatingPointBuffers(_ buffers: [CapturedAudioBuffer]) -> [Float]? {
+    private func mixFloatingPointBuffers(
+        _ buffers: [CapturedAudioBuffer],
+        channelCount: Int,
+        isNonInterleaved: Bool
+    ) -> [Float]? {
         var mono: [Float] = []
         var channelsMixed = 0
 
         for buffer in buffers {
-            let channels = max(Int(buffer.numberChannels), 1)
+            let channels = isNonInterleaved ? max(Int(buffer.numberChannels), 1) : max(Int(buffer.numberChannels), channelCount)
             let samples = buffer.data.withUnsafeBytes { rawBuffer in
                 Array(rawBuffer.bindMemory(to: Float.self))
             }
@@ -423,12 +473,16 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         return mono
     }
 
-    private func mixInt16Buffers(_ buffers: [CapturedAudioBuffer]) -> [Float]? {
+    private func mixInt16Buffers(
+        _ buffers: [CapturedAudioBuffer],
+        channelCount: Int,
+        isNonInterleaved: Bool
+    ) -> [Float]? {
         var mono: [Float] = []
         var channelsMixed = 0
 
         for buffer in buffers {
-            let channels = max(Int(buffer.numberChannels), 1)
+            let channels = isNonInterleaved ? max(Int(buffer.numberChannels), 1) : max(Int(buffer.numberChannels), channelCount)
             let samples = buffer.data.withUnsafeBytes { rawBuffer in
                 Array(rawBuffer.bindMemory(to: Int16.self))
             }
@@ -474,50 +528,6 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
             return true
         }
         return false
-    }
-
-    private struct OutputDeviceTapTarget {
-        let uid: String
-    }
-
-    private static func defaultOutputDeviceTapTarget() -> OutputDeviceTapTarget? {
-        guard let deviceID = defaultOutputDeviceID(),
-              let uid = deviceUID(for: deviceID)
-        else { return nil }
-        return OutputDeviceTapTarget(uid: uid)
-    }
-
-    /// Look up the default audio output device ID.
-    private static func defaultOutputDeviceID() -> AudioDeviceID? {
-        var deviceID: AudioDeviceID = 0
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        guard AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
-        ) == noErr, deviceID != 0 else {
-            return nil
-        }
-        return deviceID
-    }
-
-    private static func deviceUID(for deviceID: AudioDeviceID) -> String? {
-        var uid: Unmanaged<CFString>?
-        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceUID,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        guard AudioObjectGetPropertyData(
-            deviceID, &address, 0, nil, &size, &uid
-        ) == noErr, let uid else {
-            return nil
-        }
-        return uid.takeRetainedValue() as String
     }
 
     /// Look up our process's AudioObjectID from the HAL process object list.
@@ -752,6 +762,8 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
     }
 
     private func teardownTapAndAudioDevice() {
+        activeCaptureGeneration &+= 1
+
         if let procID = deviceIOProcID, aggregateDeviceID != kAudioObjectUnknown {
             AudioDeviceStop(aggregateDeviceID, procID)
             AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -900,7 +900,10 @@ final class FloatingIndicatorController: NSObject {
                 let attrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.systemFont(ofSize: 11, weight: .regular)
                 ]
-                let measuredTextW = ceil((transcribingTitle as NSString).size(withAttributes: attrs).width) + 2
+                let measuredTextW = max(
+                    ceil((transcribingTitle as NSString).size(withAttributes: attrs).width),
+                    ceil(textLabel?.intrinsicContentSize.width ?? 0)
+                ) + 8
                 let availableTextW = max(0, frameSize.width - iconSize.width - gap - (horizontalPadding * 2))
                 let textW = min(measuredTextW, availableTextW)
                 let totalW = iconSize.width + gap + textW
@@ -1379,7 +1382,7 @@ final class FloatingIndicatorController: NSObject {
         let iconWidth: CGFloat = 18
         let gap: CGFloat = 6
         let horizontalPadding: CGFloat = 14
-        let textWidth = ceil((title as NSString).size(withAttributes: [.font: font]).width) + 2
+        let textWidth = ceil((title as NSString).size(withAttributes: [.font: font]).width) + 8
         let preferredWidth = horizontalPadding + iconWidth + gap + textWidth + horizontalPadding
         let minWidth = min(CGFloat(190), max(120, screenWidth - 32))
         let maxWidth = max(minWidth, min(420, screenWidth - 32))

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -761,7 +761,10 @@ struct MeetingDetailView: View {
                     .font(.system(size: 10))
                 Text(label)
                     .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
             }
+            .fixedSize(horizontal: true, vertical: false)
             .foregroundStyle(MuesliTheme.textSecondary)
             .padding(.horizontal, MuesliTheme.spacing8)
             .padding(.vertical, 5)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -257,8 +257,8 @@ final class MeetingNeuralAec {
         let decision = delayDecision(for: result)
         if decision.shouldApply {
             currentDelaySamples = decision.reason == "acceptedRepeatedSupport"
-                ? result.delaySamples
-                : MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: recentDelayResults)
+                ? MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: recentDelayResults)
+                : result.delaySamples
         }
 
         recordDelayObservation(result, decision: decision.reason)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -47,14 +47,32 @@ final class MeetingNeuralAec {
     private var isLoaded = false
 
     private let frameSize = 512
+    private let sampleRate = 16_000
 
-    // Position-indexed streaming state — both streams track absolute sample position
-    // so mic frame at position P is always paired with system frame at position P.
     // Accessed only from MeetingSession's chunkRotationQueue.
-    private var systemSampleBuffer: [Float] = []
+    //
+    // Mic and CoreAudio tap callbacks are delivered on independent queues. Keep
+    // mic frames pending and system audio in a history buffer so the AEC model
+    // can receive the far-end frame that matches the mic frame's sample position.
+    private var pendingMicSamples: [Float] = []
+    private var pendingMicStartSample: Int = 0
+    private var systemHistory: [Float] = []
+    private var systemHistoryStartSample: Int = 0
+    private var micHistory: [Float] = []
+    private var micHistoryStartSample: Int = 0
     private var systemSamplesReceived: Int = 0
     private var micSamplesReceived: Int = 0
-    private var micFrameBuffer: [Float] = []
+    private var processedFrames = 0
+    private var fullReferenceFrames = 0
+    private var partialReferenceFrames = 0
+    private var missingReferenceFrames = 0
+    private let maxReferenceWaitSamples = 16_000
+    private let delayEstimator = MeetingAecDelayEstimator()
+    private var currentDelaySamples = 0
+    private var nextDelayEstimateSample = 16_000
+    private var recentDelayResults: [MeetingAecDelayEstimator.Result] = []
+    private var delayHistory: [MeetingAecDelayObservation] = []
+    private var delaySkipHistory: [MeetingAecDelaySkip] = []
 
     /// Pre-load the DTLN-aec model so it's ready for processing.
     func preload() async {
@@ -73,98 +91,597 @@ final class MeetingNeuralAec {
     /// Reset processor state and streaming buffers for a new meeting.
     func resetForStreaming() {
         processor?.resetStates()
-        systemSampleBuffer.removeAll(keepingCapacity: true)
+        pendingMicSamples.removeAll(keepingCapacity: true)
+        pendingMicStartSample = 0
+        systemHistory.removeAll(keepingCapacity: true)
+        systemHistoryStartSample = 0
+        micHistory.removeAll(keepingCapacity: true)
+        micHistoryStartSample = 0
         systemSamplesReceived = 0
         micSamplesReceived = 0
-        micFrameBuffer.removeAll(keepingCapacity: true)
+        processedFrames = 0
+        fullReferenceFrames = 0
+        partialReferenceFrames = 0
+        missingReferenceFrames = 0
+        currentDelaySamples = 0
+        nextDelayEstimateSample = sampleRate
+        recentDelayResults.removeAll(keepingCapacity: true)
+        delayHistory.removeAll(keepingCapacity: true)
+        delaySkipHistory.removeAll(keepingCapacity: true)
     }
 
     /// Buffer system audio samples indexed by absolute position.
-    func feedSystemSamples(_ samples: [Float]) {
-        systemSampleBuffer.append(contentsOf: samples)
+    func feedSystemSamples(_ samples: [Float]) -> [Float] {
+        guard let processor else { return [] }
+        systemHistory.append(contentsOf: samples)
         systemSamplesReceived += samples.count
+        updateDelayEstimateIfNeeded()
+        return processQueuedFrames(processor: processor, flush: false)
     }
 
-    /// Process mic samples through DTLN-aec, using position-aligned system reference.
-    /// Mic position P is always paired with system position P — no drift.
+    /// Process mic samples through DTLN-aec using the currently estimated far-end delay.
     func processStreamingMic(_ micSamples: [Float]) -> [Float] {
         guard let processor else {
             fputs("[meeting-aec] processor not loaded, passing through raw mic audio\n", stderr)
             return micSamples
         }
 
-        micFrameBuffer.append(contentsOf: micSamples)
-        var cleaned: [Float] = []
-        cleaned.reserveCapacity(micSamples.count)
-
-        while micFrameBuffer.count >= frameSize {
-            let micFrame = Array(micFrameBuffer.prefix(frameSize))
-            micFrameBuffer.removeFirst(frameSize)
-
-            // The system buffer stores samples starting from position 0.
-            // micSamplesReceived tracks how many mic samples we've consumed so far.
-            // We need system samples at the same absolute position.
-            let systemPos = micSamplesReceived
-            let systemFrame: [Float]
-            if systemPos + frameSize <= systemSamplesReceived {
-                // System samples available at this position
-                systemFrame = Array(systemSampleBuffer[systemPos..<(systemPos + frameSize)])
-            } else if systemPos < systemSamplesReceived {
-                // Partial system samples available — pad remainder with silence
-                let available = systemSamplesReceived - systemPos
-                systemFrame = Array(systemSampleBuffer[systemPos..<systemSamplesReceived])
-                    + [Float](repeating: 0, count: frameSize - available)
-            } else {
-                // System audio hasn't arrived yet for this position — use silence
-                systemFrame = [Float](repeating: 0, count: frameSize)
-            }
-
-            autoreleasepool {
-                processor.feedFarEnd(systemFrame)
-                let cleanedFrame = processor.processNearEnd(micFrame)
-                cleaned.append(contentsOf: cleanedFrame)
-            }
-
-            micSamplesReceived += frameSize
-        }
-
-        // Trim consumed system samples to prevent unbounded memory growth.
-        // Keep only samples from micSamplesReceived onward (not yet consumed).
-        let consumed = min(micSamplesReceived, systemSampleBuffer.count)
-        if consumed > 16_000 { // trim every ~1s worth
-            systemSampleBuffer.removeFirst(consumed)
-            systemSamplesReceived -= consumed
-            micSamplesReceived -= consumed
-        }
-
-        return cleaned
+        pendingMicSamples.append(contentsOf: micSamples)
+        micHistory.append(contentsOf: micSamples)
+        micSamplesReceived += micSamples.count
+        updateDelayEstimateIfNeeded()
+        return processQueuedFrames(processor: processor, flush: false)
     }
 
     /// Flush remaining buffered mic samples (zero-padded to frame boundary).
     func flushStreamingMic() -> [Float] {
-        guard let processor, !micFrameBuffer.isEmpty else { return [] }
+        guard let processor, !pendingMicSamples.isEmpty else { return [] }
+        return processQueuedFrames(processor: processor, flush: true)
+    }
 
-        let actualCount = micFrameBuffer.count
-        let padded = micFrameBuffer + [Float](repeating: 0, count: frameSize - actualCount)
-        micFrameBuffer.removeAll(keepingCapacity: true)
+    private func processQueuedFrames(processor: DTLNAecEchoProcessor, flush: Bool) -> [Float] {
+        var cleaned: [Float] = []
+        cleaned.reserveCapacity(pendingMicSamples.count)
 
-        let systemPos = micSamplesReceived
-        let systemFrame: [Float]
-        if systemPos + frameSize <= systemSamplesReceived {
-            systemFrame = Array(systemSampleBuffer[systemPos..<(systemPos + frameSize)])
-        } else {
-            systemFrame = [Float](repeating: 0, count: frameSize)
+        while pendingMicSamples.count >= frameSize {
+            let referenceState = referenceAvailability(forMicFrameStartingAt: pendingMicStartSample)
+            guard referenceState.isReady || flush else { break }
+
+            let micFrame = Array(pendingMicSamples.prefix(frameSize))
+            pendingMicSamples.removeFirst(frameSize)
+
+            let systemFrame = systemFrame(forMicFrameStartingAt: pendingMicStartSample, force: flush)
+            autoreleasepool {
+                processor.feedFarEnd(systemFrame)
+                cleaned.append(contentsOf: processor.processNearEnd(micFrame))
+            }
+
+            pendingMicStartSample += frameSize
+            processedFrames += 1
         }
 
-        var result: [Float] = []
-        autoreleasepool {
-            processor.feedFarEnd(systemFrame)
-            result = processor.processNearEnd(padded)
+        if flush, !pendingMicSamples.isEmpty {
+            let actualCount = pendingMicSamples.count
+            let micFrame = pendingMicSamples + [Float](repeating: 0, count: frameSize - actualCount)
+            pendingMicSamples.removeAll(keepingCapacity: true)
+
+            let systemFrame = systemFrame(forMicFrameStartingAt: pendingMicStartSample, force: true)
+            var cleanedFrame: [Float] = []
+            autoreleasepool {
+                processor.feedFarEnd(systemFrame)
+                cleanedFrame = processor.processNearEnd(micFrame)
+            }
+            cleaned.append(contentsOf: cleanedFrame.prefix(actualCount))
+            pendingMicStartSample += actualCount
+            processedFrames += 1
         }
 
-        return Array(result.prefix(actualCount))
+        trimHistoryBuffersIfNeeded()
+        return cleaned
+    }
+
+    private enum ReferenceAvailability {
+        case full
+        case partial
+        case missing
+        case waiting
+
+        var isReady: Bool {
+            switch self {
+            case .full, .partial, .missing:
+                true
+            case .waiting:
+                false
+            }
+        }
+    }
+
+    private func referenceAvailability(forMicFrameStartingAt micStart: Int) -> ReferenceAvailability {
+        let referenceStart = micStart - currentDelaySamples
+        let referenceEnd = referenceStart + frameSize
+
+        if referenceEnd > systemSamplesReceived {
+            return .waiting
+        }
+
+        if referenceEnd <= systemHistoryStartSample || referenceStart >= systemSamplesReceived {
+            return .missing
+        }
+
+        if referenceStart >= systemHistoryStartSample && referenceEnd <= systemSamplesReceived {
+            return .full
+        }
+
+        return .partial
+    }
+
+    private func systemFrame(forMicFrameStartingAt micStart: Int, force: Bool) -> [Float] {
+        let referenceStart = micStart - currentDelaySamples
+        let referenceEnd = referenceStart + frameSize
+
+        if referenceStart >= systemHistoryStartSample, referenceEnd <= systemSamplesReceived {
+            let startIndex = referenceStart - systemHistoryStartSample
+            let frame = Array(systemHistory[startIndex..<(startIndex + frameSize)])
+            fullReferenceFrames += 1
+            return frame
+        }
+
+        let overlapStart = max(referenceStart, systemHistoryStartSample)
+        let overlapEnd = min(referenceEnd, systemSamplesReceived)
+        guard overlapStart < overlapEnd else {
+            missingReferenceFrames += 1
+            return [Float](repeating: 0, count: frameSize)
+        }
+
+        if !force, referenceEnd > systemSamplesReceived {
+            missingReferenceFrames += 1
+            return [Float](repeating: 0, count: frameSize)
+        }
+
+        var frame = [Float](repeating: 0, count: frameSize)
+        let sourceStartIndex = overlapStart - systemHistoryStartSample
+        let destinationStartIndex = overlapStart - referenceStart
+        let overlapCount = overlapEnd - overlapStart
+        frame.replaceSubrange(
+            destinationStartIndex..<(destinationStartIndex + overlapCount),
+            with: systemHistory[sourceStartIndex..<(sourceStartIndex + overlapCount)]
+        )
+        partialReferenceFrames += 1
+        return frame
+    }
+
+    private func updateDelayEstimateIfNeeded() {
+        guard micSamplesReceived >= nextDelayEstimateSample else { return }
+
+        let maxCandidateDelaySamples = delayEstimator.maxCandidateDelaySamples
+        let latestComparableSystemSample = min(systemSamplesReceived, micSamplesReceived - maxCandidateDelaySamples)
+        guard latestComparableSystemSample > 0 else {
+            recordDelaySkip(
+                reason: "waitingForComparableSystemAudio",
+                comparableEndSample: nil,
+                failure: nil
+            )
+            nextDelayEstimateSample = micSamplesReceived + delayEstimator.estimateIntervalSamples
+            return
+        }
+
+        defer {
+            nextDelayEstimateSample = micSamplesReceived + delayEstimator.estimateIntervalSamples
+        }
+
+        let attempt = delayEstimator.estimateAttempt(
+            micHistory: micHistory,
+            micHistoryStartSample: micHistoryStartSample,
+            systemHistory: systemHistory,
+            systemHistoryStartSample: systemHistoryStartSample,
+            comparableEndSample: latestComparableSystemSample
+        )
+
+        guard case let .result(result) = attempt else {
+            if case let .failure(failure) = attempt {
+                recordDelaySkip(
+                    reason: failure.reason,
+                    comparableEndSample: latestComparableSystemSample,
+                    failure: failure
+                )
+            }
+            return
+        }
+
+        if result.score >= 0.55 {
+            recentDelayResults.append(result)
+            if recentDelayResults.count > 7 {
+                recentDelayResults.removeFirst(recentDelayResults.count - 7)
+            }
+        }
+
+        let decision = delayDecision(for: result)
+        if decision.shouldApply {
+            currentDelaySamples = MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: recentDelayResults)
+        }
+
+        recordDelayObservation(result, decision: decision.reason)
+    }
+
+    private func trimHistoryBuffersIfNeeded() {
+        let maxCandidateDelaySamples = delayEstimator.maxCandidateDelaySamples
+        let retentionSamples = delayEstimator.windowSamples + maxCandidateDelaySamples + maxReferenceWaitSamples
+        let latestComparableSystemSample = min(systemSamplesReceived, micSamplesReceived - maxCandidateDelaySamples)
+        let oldestNeededForEstimator = latestComparableSystemSample > 0
+            ? max(0, latestComparableSystemSample - delayEstimator.windowSamples)
+            : 0
+        let oldestNeededForAec = max(0, pendingMicStartSample - maxCandidateDelaySamples - frameSize)
+        trimSystemHistory(before: min(oldestNeededForEstimator, oldestNeededForAec))
+        trimMicHistory(before: min(oldestNeededForEstimator, max(0, micSamplesReceived - retentionSamples)))
+    }
+
+    private func delayDecision(for result: MeetingAecDelayEstimator.Result) -> (shouldApply: Bool, reason: String) {
+        if result.score >= 0.55, result.confidence >= 0.003 {
+            return (true, "acceptedConfidence")
+        }
+
+        if result.score >= 0.85, result.delayMs >= 160 {
+            let baselineScore = result.candidateScores
+                .first { $0.delayMs == 0 }?
+                .score ?? result.candidateScores.min(by: { $0.delayMs < $1.delayMs })?.score
+            if let baselineScore, result.score - baselineScore >= 0.015 {
+                return (true, "acceptedBaselineSeparation")
+            }
+        }
+
+        if hasConsistentRecentDelaySupport() {
+            return (true, "acceptedRepeatedSupport")
+        }
+
+        return (false, "rejectedLowConfidence")
+    }
+
+    private func hasConsistentRecentDelaySupport() -> Bool {
+        let candidates = Array(recentDelayResults.suffix(5))
+        guard candidates.count >= 3 else { return false }
+
+        for candidate in candidates {
+            let nearby = candidates.filter { abs($0.delayMs - candidate.delayMs) <= 80 }
+            if nearby.count >= 3 {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func recordDelayObservation(_ result: MeetingAecDelayEstimator.Result, decision: String) {
+        let observation = MeetingAecDelayObservation(
+            delayMs: result.delayMs,
+            appliedDelayMs: Int(round(Double(currentDelaySamples) * 1000.0 / Double(sampleRate))),
+            score: result.score,
+            confidence: result.confidence,
+            comparedFrames: result.comparedFrames,
+            decision: decision,
+            candidateScores: result.candidateScores
+        )
+        delayHistory.append(observation)
+        if delayHistory.count > 24 {
+            delayHistory.removeFirst(delayHistory.count - 24)
+        }
+    }
+
+    private func recordDelaySkip(
+        reason: String,
+        comparableEndSample: Int?,
+        failure: MeetingAecDelayEstimator.Failure?
+    ) {
+        let skip = MeetingAecDelaySkip(
+            reason: reason,
+            micSamplesReceived: micSamplesReceived,
+            systemSamplesReceived: systemSamplesReceived,
+            micHistoryStartSample: micHistoryStartSample,
+            systemHistoryStartSample: systemHistoryStartSample,
+            comparableEndSample: comparableEndSample,
+            validCandidateCount: failure?.validCandidateCount ?? 0,
+            missingCandidateCount: failure?.missingCandidateCount ?? 0,
+            lowActiveCandidateCount: failure?.lowActiveCandidateCount ?? 0,
+            systemWindowSamples: failure?.systemWindowSamples ?? 0,
+            systemPeak: failure?.systemPeak
+        )
+        delaySkipHistory.append(skip)
+        if delaySkipHistory.count > 24 {
+            delaySkipHistory.removeFirst(delaySkipHistory.count - 24)
+        }
+    }
+
+    private func trimSystemHistory(before samplePosition: Int) {
+        let cappedSamplePosition = min(samplePosition, systemSamplesReceived)
+        guard cappedSamplePosition > systemHistoryStartSample else { return }
+        let removeCount = min(cappedSamplePosition - systemHistoryStartSample, systemHistory.count)
+        guard removeCount > 0 else { return }
+        systemHistory.removeFirst(removeCount)
+        systemHistoryStartSample += removeCount
+    }
+
+    private func trimMicHistory(before samplePosition: Int) {
+        guard samplePosition > micHistoryStartSample else { return }
+        let removeCount = min(samplePosition - micHistoryStartSample, micHistory.count)
+        guard removeCount > 0 else { return }
+        micHistory.removeFirst(removeCount)
+        micHistoryStartSample += removeCount
     }
 
     /// Whether the model is loaded and ready.
     var isReady: Bool { isLoaded && processor != nil }
+
+    var diagnosticsSnapshot: MeetingAecDiagnosticsSnapshot {
+        MeetingAecDiagnosticsSnapshot(
+            ready: isReady,
+            processedFrames: processedFrames,
+            fullReferenceFrames: fullReferenceFrames,
+            partialReferenceFrames: partialReferenceFrames,
+            missingReferenceFrames: missingReferenceFrames,
+            systemSamplesReceived: systemSamplesReceived,
+            micSamplesReceived: micSamplesReceived,
+            bufferedSystemSamples: systemHistory.count,
+            bufferedMicSamples: pendingMicSamples.count,
+            currentDelayMs: Int(round(Double(currentDelaySamples) * 1000.0 / Double(sampleRate))),
+            delayHistory: delayHistory,
+            delaySkipHistory: delaySkipHistory
+        )
+    }
+}
+
+struct MeetingAecDelayEstimator {
+    enum Attempt {
+        case result(Result)
+        case failure(Failure)
+    }
+
+    struct Result {
+        let delaySamples: Int
+        let delayMs: Int
+        let score: Double
+        let confidence: Double
+        let comparedFrames: Int
+        let candidateScores: [MeetingAecDelayCandidateScore]
+    }
+
+    struct Failure {
+        let reason: String
+        let validCandidateCount: Int
+        let missingCandidateCount: Int
+        let lowActiveCandidateCount: Int
+        let systemWindowSamples: Int
+        let systemPeak: Double?
+    }
+
+    static let defaultCandidateDelaysMs = [
+        0, 40, 80, 120, 160, 200, 240, 280,
+        320, 360, 400, 440, 480, 520, 560, 600, 640,
+        720, 800,
+    ]
+
+    let sampleRate = 16_000
+    let envelopeFrameSize = 320
+    let windowSamples = 8 * 16_000
+    let estimateIntervalSamples = 2 * 16_000
+    let candidateDelaysMs: [Int]
+
+    init(candidateDelaysMs: [Int] = Self.defaultCandidateDelaysMs) {
+        self.candidateDelaysMs = candidateDelaysMs
+    }
+
+    var maxCandidateDelaySamples: Int {
+        candidateDelaysMs.map(delaySamples(for:)).max() ?? 0
+    }
+
+    func estimate(
+        micHistory: [Float],
+        micHistoryStartSample: Int,
+        systemHistory: [Float],
+        systemHistoryStartSample: Int,
+        comparableEndSample: Int
+    ) -> Result? {
+        guard case let .result(result) = estimateAttempt(
+            micHistory: micHistory,
+            micHistoryStartSample: micHistoryStartSample,
+            systemHistory: systemHistory,
+            systemHistoryStartSample: systemHistoryStartSample,
+            comparableEndSample: comparableEndSample
+        ) else {
+            return nil
+        }
+        return result
+    }
+
+    func estimateAttempt(
+        micHistory: [Float],
+        micHistoryStartSample: Int,
+        systemHistory: [Float],
+        systemHistoryStartSample: Int,
+        comparableEndSample: Int
+    ) -> Attempt {
+        let windowEnd = comparableEndSample
+        let windowStart = max(0, windowEnd - windowSamples)
+        let systemWindow = samples(
+            from: systemHistory,
+            historyStartSample: systemHistoryStartSample,
+            startSample: windowStart,
+            endSample: windowEnd
+        )
+        guard systemWindow.count >= envelopeFrameSize * 25 else {
+            return .failure(Failure(
+                reason: "insufficientSystemHistory",
+                validCandidateCount: 0,
+                missingCandidateCount: 0,
+                lowActiveCandidateCount: 0,
+                systemWindowSamples: systemWindow.count,
+                systemPeak: nil
+            ))
+        }
+
+        let systemEnvelope = rmsEnvelope(systemWindow)
+        guard let systemPeak = systemEnvelope.max(), systemPeak > 0.0005 else {
+            return .failure(Failure(
+                reason: "quietSystemAudio",
+                validCandidateCount: 0,
+                missingCandidateCount: 0,
+                lowActiveCandidateCount: 0,
+                systemWindowSamples: systemWindow.count,
+                systemPeak: systemEnvelope.max()
+            ))
+        }
+
+        let activeThreshold = max(systemPeak * 0.18, 0.001)
+        var scoredCandidates: [(
+            delayMs: Int,
+            delaySamples: Int,
+            score: Double,
+            compared: Int
+        )] = []
+        var missingCandidateCount = 0
+        var lowActiveCandidateCount = 0
+
+        for delayMs in candidateDelaysMs {
+            let delaySamples = delaySamples(for: delayMs)
+            let micWindow = samples(
+                from: micHistory,
+                historyStartSample: micHistoryStartSample,
+                startSample: windowStart + delaySamples,
+                endSample: windowEnd + delaySamples
+            )
+            guard micWindow.count == systemWindow.count else {
+                missingCandidateCount += 1
+                continue
+            }
+
+            let micEnvelope = rmsEnvelope(micWindow)
+            let scored = activeSystemCosineSimilarity(
+                micEnvelope: micEnvelope,
+                systemEnvelope: systemEnvelope,
+                activeThreshold: activeThreshold
+            )
+            guard scored.comparedFrames >= 25 else {
+                lowActiveCandidateCount += 1
+                continue
+            }
+            scoredCandidates.append((delayMs, delaySamples, scored.score, scored.comparedFrames))
+        }
+
+        guard let best = scoredCandidates.max(by: { lhs, rhs in
+            if lhs.score == rhs.score {
+                return lhs.compared < rhs.compared
+            }
+            return lhs.score < rhs.score
+        }) else {
+            let reason = missingCandidateCount == candidateDelaysMs.count
+                ? "missingMicCandidateWindows"
+                : "noValidCandidates"
+            return .failure(Failure(
+                reason: reason,
+                validCandidateCount: scoredCandidates.count,
+                missingCandidateCount: missingCandidateCount,
+                lowActiveCandidateCount: lowActiveCandidateCount,
+                systemWindowSamples: systemWindow.count,
+                systemPeak: systemPeak
+            ))
+        }
+
+        let runnerUpScore = scoredCandidates
+            .filter { $0.delayMs != best.delayMs }
+            .map(\.score)
+            .max() ?? 0
+
+        return .result(Result(
+            delaySamples: best.delaySamples,
+            delayMs: best.delayMs,
+            score: best.score,
+            confidence: best.score - runnerUpScore,
+            comparedFrames: best.compared,
+            candidateScores: scoredCandidates.map {
+                MeetingAecDelayCandidateScore(
+                    delayMs: $0.delayMs,
+                    score: $0.score,
+                    comparedFrames: $0.compared
+                )
+            }
+        ))
+    }
+
+    private func delaySamples(for delayMs: Int) -> Int {
+        Int(round(Double(delayMs) * Double(sampleRate) / 1000.0))
+    }
+
+    private func samples(
+        from history: [Float],
+        historyStartSample: Int,
+        startSample: Int,
+        endSample: Int
+    ) -> [Float] {
+        guard startSample >= historyStartSample, endSample > startSample else { return [] }
+        let startIndex = startSample - historyStartSample
+        let endIndex = endSample - historyStartSample
+        guard startIndex >= 0, endIndex <= history.count else { return [] }
+        return Array(history[startIndex..<endIndex])
+    }
+
+    private func rmsEnvelope(_ samples: [Float]) -> [Double] {
+        guard envelopeFrameSize > 0 else { return [] }
+        var envelope: [Double] = []
+        envelope.reserveCapacity(samples.count / envelopeFrameSize)
+
+        var index = 0
+        while index + envelopeFrameSize <= samples.count {
+            var sumSquares = 0.0
+            for sample in samples[index..<(index + envelopeFrameSize)] {
+                let value = Double(sample)
+                sumSquares += value * value
+            }
+            envelope.append(sqrt(sumSquares / Double(envelopeFrameSize)))
+            index += envelopeFrameSize
+        }
+        return envelope
+    }
+
+    private func activeSystemCosineSimilarity(
+        micEnvelope: [Double],
+        systemEnvelope: [Double],
+        activeThreshold: Double
+    ) -> (score: Double, comparedFrames: Int) {
+        let comparedFrames = min(micEnvelope.count, systemEnvelope.count)
+        guard comparedFrames > 0 else { return (0, 0) }
+
+        var dot = 0.0
+        var micNorm = 0.0
+        var systemNorm = 0.0
+        var activeFrames = 0
+
+        for index in 0..<comparedFrames where systemEnvelope[index] >= activeThreshold {
+            let mic = micEnvelope[index]
+            let system = systemEnvelope[index]
+            dot += mic * system
+            micNorm += mic * mic
+            systemNorm += system * system
+            activeFrames += 1
+        }
+
+        guard activeFrames > 0, micNorm > 0, systemNorm > 0 else {
+            return (0, activeFrames)
+        }
+        return (dot / sqrt(micNorm * systemNorm), activeFrames)
+    }
+
+    static func recencyWeightedMedianDelay(from results: [Result]) -> Int {
+        guard !results.isEmpty else { return 0 }
+        let weighted = results.enumerated().map { index, result in
+            (delaySamples: result.delaySamples, weight: Double(index + 1))
+        }
+        let totalWeight = weighted.reduce(0) { $0 + $1.weight }
+        let midpoint = totalWeight / 2.0
+        var cumulative = 0.0
+        for item in weighted.sorted(by: { $0.delaySamples < $1.delaySamples }) {
+            cumulative += item.weight
+            if cumulative > midpoint {
+                return item.delaySamples
+            }
+        }
+        return weighted.last?.delaySamples ?? 0
+    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -256,7 +256,9 @@ final class MeetingNeuralAec {
 
         let decision = delayDecision(for: result)
         if decision.shouldApply {
-            currentDelaySamples = MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: recentDelayResults)
+            currentDelaySamples = decision.reason == "acceptedRepeatedSupport"
+                ? result.delaySamples
+                : MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: recentDelayResults)
         }
 
         recordDelayObservation(result, decision: decision.reason)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -66,10 +66,9 @@ final class MeetingNeuralAec {
     private var fullReferenceFrames = 0
     private var partialReferenceFrames = 0
     private var missingReferenceFrames = 0
-    private let maxReferenceWaitSamples = 16_000
     private let delayEstimator = MeetingAecDelayEstimator()
     private var currentDelaySamples = 0
-    private var nextDelayEstimateSample = 16_000
+    private var nextDelayEstimateSample = 8_000
     private var recentDelayResults: [MeetingAecDelayEstimator.Result] = []
     private var delayHistory: [MeetingAecDelayObservation] = []
     private var delaySkipHistory: [MeetingAecDelaySkip] = []
@@ -104,19 +103,18 @@ final class MeetingNeuralAec {
         partialReferenceFrames = 0
         missingReferenceFrames = 0
         currentDelaySamples = 0
-        nextDelayEstimateSample = sampleRate
+        nextDelayEstimateSample = sampleRate / 2
         recentDelayResults.removeAll(keepingCapacity: true)
         delayHistory.removeAll(keepingCapacity: true)
         delaySkipHistory.removeAll(keepingCapacity: true)
     }
 
     /// Buffer system audio samples indexed by absolute position.
-    func feedSystemSamples(_ samples: [Float]) -> [Float] {
-        guard let processor else { return [] }
+    func feedSystemSamples(_ samples: [Float]) {
         systemHistory.append(contentsOf: samples)
         systemSamplesReceived += samples.count
         updateDelayEstimateIfNeeded()
-        return processQueuedFrames(processor: processor, flush: false)
+        trimHistoryBuffersIfNeeded()
     }
 
     /// Process mic samples through DTLN-aec using the currently estimated far-end delay.
@@ -144,9 +142,6 @@ final class MeetingNeuralAec {
         cleaned.reserveCapacity(pendingMicSamples.count)
 
         while pendingMicSamples.count >= frameSize {
-            let referenceState = referenceAvailability(forMicFrameStartingAt: pendingMicStartSample)
-            guard referenceState.isReady || flush else { break }
-
             let micFrame = Array(pendingMicSamples.prefix(frameSize))
             pendingMicSamples.removeFirst(frameSize)
 
@@ -180,41 +175,6 @@ final class MeetingNeuralAec {
         return cleaned
     }
 
-    private enum ReferenceAvailability {
-        case full
-        case partial
-        case missing
-        case waiting
-
-        var isReady: Bool {
-            switch self {
-            case .full, .partial, .missing:
-                true
-            case .waiting:
-                false
-            }
-        }
-    }
-
-    private func referenceAvailability(forMicFrameStartingAt micStart: Int) -> ReferenceAvailability {
-        let referenceStart = micStart - currentDelaySamples
-        let referenceEnd = referenceStart + frameSize
-
-        if referenceEnd > systemSamplesReceived {
-            return .waiting
-        }
-
-        if referenceEnd <= systemHistoryStartSample || referenceStart >= systemSamplesReceived {
-            return .missing
-        }
-
-        if referenceStart >= systemHistoryStartSample && referenceEnd <= systemSamplesReceived {
-            return .full
-        }
-
-        return .partial
-    }
-
     private func systemFrame(forMicFrameStartingAt micStart: Int, force: Bool) -> [Float] {
         let referenceStart = micStart - currentDelaySamples
         let referenceEnd = referenceStart + frameSize
@@ -233,11 +193,6 @@ final class MeetingNeuralAec {
             return [Float](repeating: 0, count: frameSize)
         }
 
-        if !force, referenceEnd > systemSamplesReceived {
-            missingReferenceFrames += 1
-            return [Float](repeating: 0, count: frameSize)
-        }
-
         var frame = [Float](repeating: 0, count: frameSize)
         let sourceStartIndex = overlapStart - systemHistoryStartSample
         let destinationStartIndex = overlapStart - referenceStart
@@ -251,6 +206,10 @@ final class MeetingNeuralAec {
     }
 
     private func updateDelayEstimateIfNeeded() {
+        // The live estimator is gated by mic sample position because each
+        // candidate compares a mic window against the already captured system
+        // history. System callbacks may call this too, but cannot advance the
+        // gate without new mic samples to compare.
         guard micSamplesReceived >= nextDelayEstimateSample else { return }
 
         let maxCandidateDelaySamples = delayEstimator.maxCandidateDelaySamples
@@ -305,7 +264,7 @@ final class MeetingNeuralAec {
 
     private func trimHistoryBuffersIfNeeded() {
         let maxCandidateDelaySamples = delayEstimator.maxCandidateDelaySamples
-        let retentionSamples = delayEstimator.windowSamples + maxCandidateDelaySamples + maxReferenceWaitSamples
+        let retentionSamples = delayEstimator.windowSamples + maxCandidateDelaySamples
         let latestComparableSystemSample = min(systemSamplesReceived, micSamplesReceived - maxCandidateDelaySamples)
         let oldestNeededForEstimator = latestComparableSystemSample > 0
             ? max(0, latestComparableSystemSample - delayEstimator.windowSamples)
@@ -329,25 +288,19 @@ final class MeetingNeuralAec {
             }
         }
 
-        if hasConsistentRecentDelaySupport() {
+        if result.score >= 0.55, hasConsistentRecentDelaySupport(around: result.delayMs) {
             return (true, "acceptedRepeatedSupport")
         }
 
         return (false, "rejectedLowConfidence")
     }
 
-    private func hasConsistentRecentDelaySupport() -> Bool {
+    private func hasConsistentRecentDelaySupport(around delayMs: Int) -> Bool {
         let candidates = Array(recentDelayResults.suffix(5))
         guard candidates.count >= 3 else { return false }
 
-        for candidate in candidates {
-            let nearby = candidates.filter { abs($0.delayMs - candidate.delayMs) <= 80 }
-            if nearby.count >= 3 {
-                return true
-            }
-        }
-
-        return false
+        let nearby = candidates.filter { abs($0.delayMs - delayMs) <= 80 }
+        return nearby.count >= 3
     }
 
     private func recordDelayObservation(_ result: MeetingAecDelayEstimator.Result, decision: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -799,8 +799,7 @@ final class MeetingSession {
             self.systemChunkTimingTracker.append(sampleCount: samples.count)
 
             let floatSamples = samples.map { Float($0) / 32767.0 }
-            let cleanedFloat = self.neuralAec.feedSystemSamples(floatSamples)
-            self.appendCleanedMicSamplesOnQueue(cleanedFloat)
+            self.neuralAec.feedSystemSamples(floatSamples)
 
             if let systemVadController = self.systemVadController {
                 systemVadController.processAudio(floatSamples)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -618,6 +618,7 @@ final class MeetingSession {
 
     private func rotateChunkOnQueue() {
         guard isRecording, !isPaused else { return }
+        appendFlushedStreamingMicOnQueue()
         guard let chunkTiming = chunkTimingTracker.rotate() else {
             return
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -115,6 +115,7 @@ final class MeetingSession {
     var manualNotesProvider: (() async -> String?)?
     var liveTitleProvider: (() async -> String?)?
     private let screenContextCollector = MeetingScreenContextCollector()
+    private var diagnostics: MeetingSessionDiagnostics?
 
     /// Current mic power level for waveform visualization.
     func currentPower() -> Float {
@@ -165,6 +166,7 @@ final class MeetingSession {
     func start() async throws {
         let vadManager = await transcriptionCoordinator.getVadManager()
         let now = Date()
+        diagnostics = MeetingSessionDiagnostics(title: title, startedAt: now)
 
         // AEC must be loaded before audio pipeline starts (streaming mode)
         await neuralAec.preload()
@@ -555,6 +557,21 @@ final class MeetingSession {
             )
         }
 
+        diagnostics?.writeFinalReport(
+            title: generatedTitle,
+            startedAt: meetingStart,
+            endedAt: endTime,
+            rawTranscript: rawTranscript,
+            rawMicURL: fullSessionMicURL,
+            systemAudioURL: systemAudioURL,
+            systemCapture: (systemAudioRecorder as? SystemAudioDiagnosticsProviding)?.diagnosticsSnapshot,
+            aec: neuralAec.diagnosticsSnapshot,
+            micChunks: micChunkHealthTracker.snapshot(),
+            systemChunks: systemChunkHealthTracker.snapshot(),
+            diarizationSegments: protectedTranscriptInputs.diarizationSegments,
+            protectedSystemSegmentCount: protectedTranscriptInputs.systemSegments.count
+        )
+
         return MeetingSessionResult(
             title: generatedTitle,
             originalTitle: title,
@@ -588,11 +605,7 @@ final class MeetingSession {
 
     private func appendFlushedStreamingMicOnQueue() {
         let flushed = neuralAec.flushStreamingMic()
-        guard !flushed.isEmpty else { return }
-        let flushedInt16 = flushed.map { sample -> Int16 in
-            Int16(max(-1.0, min(1.0, sample)) * 32767)
-        }
-        rawMicChunkRecorder?.append(flushedInt16)
+        appendCleanedMicSamplesOnQueue(flushed)
     }
 
     /// Called by VAD on speech boundaries or max-duration fallback.
@@ -765,12 +778,7 @@ final class MeetingSession {
 
             // AEC: clean mic using position-aligned system reference
             let cleanedFloat = self.neuralAec.processStreamingMic(floatSamples)
-            if !cleanedFloat.isEmpty {
-                let cleanedInt16 = cleanedFloat.map { sample -> Int16 in
-                    Int16(max(-1.0, min(1.0, sample)) * 32767)
-                }
-                self.rawMicChunkRecorder?.append(cleanedInt16)
-            }
+            self.appendCleanedMicSamplesOnQueue(cleanedFloat)
 
             // VAD sees raw audio, but only after the cleaned samples for this
             // buffer have been appended so boundary rotation stays ordered.
@@ -791,12 +799,22 @@ final class MeetingSession {
             self.systemChunkTimingTracker.append(sampleCount: samples.count)
 
             let floatSamples = samples.map { Float($0) / 32767.0 }
-            self.neuralAec.feedSystemSamples(floatSamples)
+            let cleanedFloat = self.neuralAec.feedSystemSamples(floatSamples)
+            self.appendCleanedMicSamplesOnQueue(cleanedFloat)
 
             if let systemVadController = self.systemVadController {
                 systemVadController.processAudio(floatSamples)
             }
         }
+    }
+
+    private func appendCleanedMicSamplesOnQueue(_ cleanedFloat: [Float]) {
+        guard !cleanedFloat.isEmpty else { return }
+        let cleanedInt16 = cleanedFloat.map { sample -> Int16 in
+            Int16(max(-1.0, min(1.0, sample)) * 32767)
+        }
+        rawMicChunkRecorder?.append(cleanedInt16)
+        diagnostics?.appendCleanedMicSamples(cleanedInt16)
     }
 
     private func transcribeMicChunk(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
@@ -1,0 +1,467 @@
+import FluidAudio
+import Foundation
+import os
+
+struct AudioSampleStatsSnapshot: Codable {
+    let sampleCount: Int
+    let zeroSampleCount: Int
+    let rms: Double
+    let peak: Double
+}
+
+struct AudioSampleStats: Codable {
+    private(set) var sampleCount = 0
+    private(set) var zeroSampleCount = 0
+    private(set) var sumSquares: Double = 0
+    private(set) var peak: Double = 0
+
+    mutating func addInt16(_ samples: [Int16]) {
+        for sample in samples {
+            addInt16Sample(sample)
+        }
+    }
+
+    mutating func addInt16Sample(_ sample: Int16) {
+        let value = Double(sample) / 32768.0
+        addNormalizedSample(value)
+    }
+
+    mutating func addFloats(_ samples: [Float]) {
+        for sample in samples {
+            addNormalizedSample(Double(sample))
+        }
+    }
+
+    private mutating func addNormalizedSample(_ sample: Double) {
+        sampleCount += 1
+        if sample == 0 {
+            zeroSampleCount += 1
+        }
+        sumSquares += sample * sample
+        peak = max(peak, abs(sample))
+    }
+
+    func snapshot() -> AudioSampleStatsSnapshot {
+        AudioSampleStatsSnapshot(
+            sampleCount: sampleCount,
+            zeroSampleCount: zeroSampleCount,
+            rms: sampleCount > 0 ? sqrt(sumSquares / Double(sampleCount)) : 0,
+            peak: peak
+        )
+    }
+}
+
+struct SystemAudioCaptureDiagnosticsSnapshot: Codable {
+    let backend: String
+    let callbackCount: Int
+    let bufferCount: Int
+    let emptyBufferCount: Int
+    let unsupportedFormatCount: Int
+    let inputByteCount: Int
+    let bytesWritten: Int
+    let sourceSampleRate: Double
+    let sourceChannels: UInt32
+    let preConversion: AudioSampleStatsSnapshot
+    let postConversion: AudioSampleStatsSnapshot
+}
+
+protocol SystemAudioDiagnosticsProviding {
+    var diagnosticsSnapshot: SystemAudioCaptureDiagnosticsSnapshot { get }
+}
+
+struct MeetingAecDiagnosticsSnapshot: Codable {
+    let ready: Bool
+    let processedFrames: Int
+    let fullReferenceFrames: Int
+    let partialReferenceFrames: Int
+    let missingReferenceFrames: Int
+    let systemSamplesReceived: Int
+    let micSamplesReceived: Int
+    let bufferedSystemSamples: Int
+    let bufferedMicSamples: Int
+    let currentDelayMs: Int
+    let delayHistory: [MeetingAecDelayObservation]
+    let delaySkipHistory: [MeetingAecDelaySkip]
+}
+
+struct MeetingAecDelayObservation: Codable {
+    let delayMs: Int
+    let appliedDelayMs: Int
+    let score: Double
+    let confidence: Double
+    let comparedFrames: Int
+    let decision: String
+    let candidateScores: [MeetingAecDelayCandidateScore]
+}
+
+struct MeetingAecDelayCandidateScore: Codable {
+    let delayMs: Int
+    let score: Double
+    let comparedFrames: Int
+}
+
+struct MeetingAecDelaySkip: Codable {
+    let reason: String
+    let micSamplesReceived: Int
+    let systemSamplesReceived: Int
+    let micHistoryStartSample: Int
+    let systemHistoryStartSample: Int
+    let comparableEndSample: Int?
+    let validCandidateCount: Int
+    let missingCandidateCount: Int
+    let lowActiveCandidateCount: Int
+    let systemWindowSamples: Int
+    let systemPeak: Double?
+}
+
+final class MeetingSessionDiagnostics {
+    struct ChunkStats: Codable {
+        let successful: Int
+        let empty: Int
+        let failed: Int
+    }
+
+    struct Summary: Codable {
+        let meetingTitle: String
+        let startedAt: String
+        let endedAt: String
+        let durationSeconds: Double
+        let systemCapture: SystemAudioCaptureDiagnosticsSnapshot?
+        let aec: MeetingAecDiagnosticsSnapshot
+        let micChunks: ChunkStats
+        let systemChunks: ChunkStats
+        let diarizationSegments: Int
+        let diarizationSpeakers: Int
+        let protectedSystemSegments: Int
+        let rawMic: AudioSampleStatsSnapshot?
+        let cleanedMicAec: AudioSampleStatsSnapshot?
+        let systemAudio: AudioSampleStatsSnapshot?
+        let aecDelayEstimate: AecDelayEstimate?
+    }
+
+    struct AecDelayEstimate: Codable {
+        let bestDelayMs: Int?
+        let confidence: Double
+        let scores: [DelayScore]
+    }
+
+    struct DelayScore: Codable {
+        let delayMs: Int
+        let score: Double
+        let comparedFrames: Int
+    }
+
+    private let outputDirectory: URL?
+    private let cleanedMicURL: URL?
+    private let cleanedMicFile: FileHandle?
+    private let lock = OSAllocatedUnfairLock(initialState: CleanedMicState())
+    private let enabled: Bool
+
+    private struct CleanedMicState {
+        var bytesWritten = 0
+        var stats = AudioSampleStats()
+        var isClosed = false
+    }
+
+    static var isEnabled: Bool {
+        FileManager.default.fileExists(atPath: enabledFlagURL.path)
+    }
+
+    private static var enabledFlagURL: URL {
+        AppIdentity.supportDirectoryURL.appendingPathComponent("MeetingDiagnostics.enabled")
+    }
+
+    init(title: String, startedAt: Date) {
+        enabled = Self.isEnabled
+        guard enabled else {
+            outputDirectory = nil
+            cleanedMicURL = nil
+            cleanedMicFile = nil
+            return
+        }
+
+        let timestamp = Self.fileTimestamp.string(from: startedAt)
+        let safeTitle = Self.safePathComponent(title)
+        let runDirectory = AppIdentity.supportDirectoryURL
+            .appendingPathComponent("MeetingDiagnostics", isDirectory: true)
+            .appendingPathComponent("\(timestamp)-\(safeTitle)-\(UUID().uuidString.prefix(8))", isDirectory: true)
+
+        do {
+            try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+            let cleanedURL = runDirectory.appendingPathComponent("cleaned-mic-aec.wav")
+            FileManager.default.createFile(atPath: cleanedURL.path, contents: nil)
+            let file = FileHandle(forWritingAtPath: cleanedURL.path)
+            file?.write(WavWriter.header(dataSize: 0))
+            outputDirectory = runDirectory
+            cleanedMicURL = cleanedURL
+            cleanedMicFile = file
+            fputs("[meeting-diagnostics] enabled: \(runDirectory.path)\n", stderr)
+        } catch {
+            outputDirectory = nil
+            cleanedMicURL = nil
+            cleanedMicFile = nil
+            fputs("[meeting-diagnostics] failed to create diagnostics directory: \(error)\n", stderr)
+        }
+    }
+
+    func appendCleanedMicSamples(_ samples: [Int16]) {
+        guard enabled, !samples.isEmpty else { return }
+        let data = samples.withUnsafeBufferPointer { Data(buffer: $0) }
+        lock.withLock { state in
+            guard !state.isClosed else { return }
+            cleanedMicFile?.write(data)
+            state.bytesWritten += data.count
+            state.stats.addInt16(samples)
+        }
+    }
+
+    func writeFinalReport(
+        title: String,
+        startedAt: Date,
+        endedAt: Date,
+        rawTranscript: String,
+        rawMicURL: URL?,
+        systemAudioURL: URL?,
+        systemCapture: SystemAudioCaptureDiagnosticsSnapshot?,
+        aec: MeetingAecDiagnosticsSnapshot,
+        micChunks: MeetingTranscriptChunkHealthSnapshot,
+        systemChunks: MeetingTranscriptChunkHealthSnapshot,
+        diarizationSegments: [TimedSpeakerSegment]?,
+        protectedSystemSegmentCount: Int
+    ) {
+        guard enabled, let outputDirectory else { return }
+
+        let cleanedMicStats = finalizeCleanedMic()
+        let rawMicDiagnosticsURL = outputDirectory.appendingPathComponent("raw-mic-full-session.wav")
+        let systemDiagnosticsURL = outputDirectory.appendingPathComponent("system-audio.wav")
+        let rawMicStats = copyAudioFileAndMeasure(from: rawMicURL, to: rawMicDiagnosticsURL)
+        let systemStats = copyAudioFileAndMeasure(from: systemAudioURL, to: systemDiagnosticsURL)
+        let delayEstimate = Self.estimateAecDelay(
+            rawMicURL: rawMicDiagnosticsURL,
+            systemAudioURL: systemDiagnosticsURL
+        )
+
+        writeText(rawTranscript, to: outputDirectory.appendingPathComponent("raw-transcript.txt"))
+
+        let speakerCount = Set((diarizationSegments ?? []).map(\.speakerId)).count
+        let summary = Summary(
+            meetingTitle: title,
+            startedAt: Self.iso8601.string(from: startedAt),
+            endedAt: Self.iso8601.string(from: endedAt),
+            durationSeconds: max(endedAt.timeIntervalSince(startedAt), 0),
+            systemCapture: systemCapture,
+            aec: aec,
+            micChunks: ChunkStats(
+                successful: micChunks.successfulChunkCount,
+                empty: micChunks.emptyChunkCount,
+                failed: micChunks.failedChunkCount
+            ),
+            systemChunks: ChunkStats(
+                successful: systemChunks.successfulChunkCount,
+                empty: systemChunks.emptyChunkCount,
+                failed: systemChunks.failedChunkCount
+            ),
+            diarizationSegments: diarizationSegments?.count ?? 0,
+            diarizationSpeakers: speakerCount,
+            protectedSystemSegments: protectedSystemSegmentCount,
+            rawMic: rawMicStats,
+            cleanedMicAec: cleanedMicStats,
+            systemAudio: systemStats,
+            aecDelayEstimate: delayEstimate
+        )
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(summary)
+            try data.write(
+                to: outputDirectory.appendingPathComponent("diagnostics.json"),
+                options: Data.WritingOptions.atomic
+            )
+        } catch {
+            fputs("[meeting-diagnostics] failed to write diagnostics.json: \(error)\n", stderr)
+        }
+    }
+
+    private func finalizeCleanedMic() -> AudioSampleStatsSnapshot? {
+        guard let cleanedMicFile else { return nil }
+        let finalState = lock.withLock { state -> CleanedMicState in
+            state.isClosed = true
+            return state
+        }
+        cleanedMicFile.seek(toFileOffset: 0)
+        cleanedMicFile.write(WavWriter.header(dataSize: UInt32(finalState.bytesWritten)))
+        cleanedMicFile.closeFile()
+        return finalState.stats.snapshot()
+    }
+
+    private func copyAudioFileAndMeasure(from sourceURL: URL?, to destinationURL: URL) -> AudioSampleStatsSnapshot? {
+        guard let sourceURL, FileManager.default.fileExists(atPath: sourceURL.path) else { return nil }
+        do {
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+            return Self.measureInt16Wav(at: destinationURL)
+        } catch {
+            fputs("[meeting-diagnostics] failed to copy \(sourceURL.path): \(error)\n", stderr)
+            return nil
+        }
+    }
+
+    private func writeText(_ text: String, to url: URL) {
+        do {
+            try text.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            fputs("[meeting-diagnostics] failed to write \(url.lastPathComponent): \(error)\n", stderr)
+        }
+    }
+
+    static func measureInt16Wav(at url: URL) -> AudioSampleStatsSnapshot? {
+        guard let data = try? Data(contentsOf: url), data.count > 44 else { return nil }
+        var stats = AudioSampleStats()
+        data.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            var offset = 44
+            while offset + 1 < bytes.count {
+                let low = UInt16(bytes[offset])
+                let high = UInt16(bytes[offset + 1]) << 8
+                let sample = Int16(bitPattern: high | low)
+                stats.addInt16Sample(sample)
+                offset += 2
+            }
+        }
+        return stats.snapshot()
+    }
+
+    static func estimateAecDelay(
+        rawMicURL: URL,
+        systemAudioURL: URL,
+        candidateDelaysMs: [Int] = MeetingAecDelayEstimator.defaultCandidateDelaysMs
+    ) -> AecDelayEstimate? {
+        guard let rawMicSamples = loadInt16WavSamples(at: rawMicURL),
+              let systemSamples = loadInt16WavSamples(at: systemAudioURL),
+              !rawMicSamples.isEmpty,
+              !systemSamples.isEmpty
+        else { return nil }
+
+        let frameSize = 320 // 20ms at 16kHz
+        let micEnvelope = rmsEnvelope(samples: rawMicSamples, frameSize: frameSize)
+        let systemEnvelope = rmsEnvelope(samples: systemSamples, frameSize: frameSize)
+        guard !micEnvelope.isEmpty, !systemEnvelope.isEmpty else { return nil }
+
+        let scores = candidateDelaysMs.map { delayMs in
+            let delayFrames = max(0, Int(round(Double(delayMs) / 20.0)))
+            let result = envelopeCosineSimilarity(
+                micEnvelope: micEnvelope,
+                systemEnvelope: systemEnvelope,
+                delayFrames: delayFrames
+            )
+            return DelayScore(
+                delayMs: delayMs,
+                score: result.score,
+                comparedFrames: result.comparedFrames
+            )
+        }
+
+        let best = scores.max { lhs, rhs in
+            if lhs.score == rhs.score {
+                return lhs.comparedFrames < rhs.comparedFrames
+            }
+            return lhs.score < rhs.score
+        }
+        let runnerUpScore = scores
+            .filter { $0.delayMs != best?.delayMs }
+            .map(\.score)
+            .max() ?? 0
+
+        return AecDelayEstimate(
+            bestDelayMs: (best?.comparedFrames ?? 0) > 0 ? best?.delayMs : nil,
+            confidence: max(0, (best?.score ?? 0) - runnerUpScore),
+            scores: scores
+        )
+    }
+
+    private static func loadInt16WavSamples(at url: URL) -> [Int16]? {
+        guard let data = try? Data(contentsOf: url), data.count > 44 else { return nil }
+        return data.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            var samples: [Int16] = []
+            samples.reserveCapacity((bytes.count - 44) / 2)
+
+            var offset = 44
+            while offset + 1 < bytes.count {
+                let low = UInt16(bytes[offset])
+                let high = UInt16(bytes[offset + 1]) << 8
+                samples.append(Int16(bitPattern: high | low))
+                offset += 2
+            }
+            return samples
+        }
+    }
+
+    private static func rmsEnvelope(samples: [Int16], frameSize: Int) -> [Double] {
+        guard frameSize > 0 else { return [] }
+        var envelope: [Double] = []
+        envelope.reserveCapacity(samples.count / frameSize)
+
+        var index = 0
+        while index + frameSize <= samples.count {
+            var sumSquares = 0.0
+            for sample in samples[index..<(index + frameSize)] {
+                let value = Double(sample) / 32768.0
+                sumSquares += value * value
+            }
+            envelope.append(sqrt(sumSquares / Double(frameSize)))
+            index += frameSize
+        }
+        return envelope
+    }
+
+    private static func envelopeCosineSimilarity(
+        micEnvelope: [Double],
+        systemEnvelope: [Double],
+        delayFrames: Int
+    ) -> (score: Double, comparedFrames: Int) {
+        guard delayFrames < micEnvelope.count else { return (0, 0) }
+
+        let comparedFrames = min(systemEnvelope.count, micEnvelope.count - delayFrames)
+        guard comparedFrames > 0 else { return (0, 0) }
+
+        var dot = 0.0
+        var micNorm = 0.0
+        var systemNorm = 0.0
+        for index in 0..<comparedFrames {
+            let mic = micEnvelope[index + delayFrames]
+            let system = systemEnvelope[index]
+            dot += mic * system
+            micNorm += mic * mic
+            systemNorm += system * system
+        }
+
+        guard micNorm > 0, systemNorm > 0 else { return (0, comparedFrames) }
+        return (dot / sqrt(micNorm * systemNorm), comparedFrames)
+    }
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let fileTimestamp: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static func safePathComponent(_ input: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_ "))
+        let scalars = input.unicodeScalars.map { scalar -> Character in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        let collapsed = String(scalars).trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = collapsed.isEmpty ? "Meeting" : String(collapsed.prefix(48))
+        return prefix.replacingOccurrences(of: " ", with: "-")
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
@@ -156,6 +156,8 @@ final class MeetingSessionDiagnostics {
     private let cleanedMicFile: FileHandle?
     private let lock = OSAllocatedUnfairLock(initialState: CleanedMicState())
     private let enabled: Bool
+    private static let maxDiagnosticRuns = 10
+    private static let maxDiagnosticBytes = 2 * 1_024 * 1_024 * 1_024
 
     private struct CleanedMicState {
         var bytesWritten = 0
@@ -182,12 +184,14 @@ final class MeetingSessionDiagnostics {
 
         let timestamp = Self.fileTimestamp.string(from: startedAt)
         let safeTitle = Self.safePathComponent(title)
-        let runDirectory = AppIdentity.supportDirectoryURL
+        let diagnosticsRoot = AppIdentity.supportDirectoryURL
             .appendingPathComponent("MeetingDiagnostics", isDirectory: true)
+        let runDirectory = diagnosticsRoot
             .appendingPathComponent("\(timestamp)-\(safeTitle)-\(UUID().uuidString.prefix(8))", isDirectory: true)
 
         do {
             try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+            Self.pruneOldRuns(in: diagnosticsRoot, preserving: runDirectory)
             let cleanedURL = runDirectory.appendingPathComponent("cleaned-mic-aec.wav")
             FileManager.default.createFile(atPath: cleanedURL.path, contents: nil)
             let file = FileHandle(forWritingAtPath: cleanedURL.path)
@@ -317,20 +321,67 @@ final class MeetingSessionDiagnostics {
         }
     }
 
-    static func measureInt16Wav(at url: URL) -> AudioSampleStatsSnapshot? {
-        guard let data = try? Data(contentsOf: url), data.count > 44 else { return nil }
-        var stats = AudioSampleStats()
-        data.withUnsafeBytes { rawBuffer in
-            let bytes = rawBuffer.bindMemory(to: UInt8.self)
-            var offset = 44
-            while offset + 1 < bytes.count {
-                let low = UInt16(bytes[offset])
-                let high = UInt16(bytes[offset + 1]) << 8
-                let sample = Int16(bitPattern: high | low)
-                stats.addInt16Sample(sample)
-                offset += 2
+    private static func pruneOldRuns(in diagnosticsRoot: URL, preserving preservedRun: URL) {
+        let fileManager = FileManager.default
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: diagnosticsRoot,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        var runs = contents.compactMap { url -> DiagnosticRun? in
+            guard url.standardizedFileURL != preservedRun.standardizedFileURL else { return nil }
+            let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .contentModificationDateKey])
+            guard values?.isDirectory == true else { return nil }
+            return DiagnosticRun(
+                url: url,
+                modifiedAt: values?.contentModificationDate ?? .distantPast,
+                byteSize: directoryByteSize(url)
+            )
+        }
+        runs.sort { $0.modifiedAt > $1.modifiedAt }
+
+        var retainedCount = 1
+        var retainedBytes = directoryByteSize(preservedRun)
+        for run in runs {
+            let shouldKeep = retainedCount < maxDiagnosticRuns
+                && retainedBytes + run.byteSize <= maxDiagnosticBytes
+            if shouldKeep {
+                retainedCount += 1
+                retainedBytes += run.byteSize
+            } else {
+                try? fileManager.removeItem(at: run.url)
             }
         }
+    }
+
+    private struct DiagnosticRun {
+        let url: URL
+        let modifiedAt: Date
+        let byteSize: Int
+    }
+
+    private static func directoryByteSize(_ url: URL) -> Int {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+
+        var total = 0
+        for case let fileURL as URL in enumerator {
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard values?.isRegularFile == true else { continue }
+            total += values?.fileSize ?? 0
+        }
+        return total
+    }
+
+    static func measureInt16Wav(at url: URL) -> AudioSampleStatsSnapshot? {
+        guard let wav = loadInt16Wav(at: url) else { return nil }
+        var stats = AudioSampleStats()
+        stats.addInt16(wav.samples)
         return stats.snapshot()
     }
 
@@ -339,15 +390,17 @@ final class MeetingSessionDiagnostics {
         systemAudioURL: URL,
         candidateDelaysMs: [Int] = MeetingAecDelayEstimator.defaultCandidateDelaysMs
     ) -> AecDelayEstimate? {
-        guard let rawMicSamples = loadInt16WavSamples(at: rawMicURL),
-              let systemSamples = loadInt16WavSamples(at: systemAudioURL),
-              !rawMicSamples.isEmpty,
-              !systemSamples.isEmpty
+        guard let rawMic = loadInt16Wav(at: rawMicURL),
+              let system = loadInt16Wav(at: systemAudioURL),
+              rawMic.sampleRate == 16_000,
+              system.sampleRate == 16_000,
+              !rawMic.samples.isEmpty,
+              !system.samples.isEmpty
         else { return nil }
 
         let frameSize = 320 // 20ms at 16kHz
-        let micEnvelope = rmsEnvelope(samples: rawMicSamples, frameSize: frameSize)
-        let systemEnvelope = rmsEnvelope(samples: systemSamples, frameSize: frameSize)
+        let micEnvelope = rmsEnvelope(samples: rawMic.samples, frameSize: frameSize)
+        let systemEnvelope = rmsEnvelope(samples: system.samples, frameSize: frameSize)
         guard !micEnvelope.isEmpty, !systemEnvelope.isEmpty else { return nil }
 
         let scores = candidateDelaysMs.map { delayMs in
@@ -382,22 +435,100 @@ final class MeetingSessionDiagnostics {
         )
     }
 
-    private static func loadInt16WavSamples(at url: URL) -> [Int16]? {
-        guard let data = try? Data(contentsOf: url), data.count > 44 else { return nil }
-        return data.withUnsafeBytes { rawBuffer in
-            let bytes = rawBuffer.bindMemory(to: UInt8.self)
-            var samples: [Int16] = []
-            samples.reserveCapacity((bytes.count - 44) / 2)
+    private struct Int16WavData {
+        let sampleRate: Int
+        let samples: [Int16]
+    }
 
-            var offset = 44
-            while offset + 1 < bytes.count {
-                let low = UInt16(bytes[offset])
-                let high = UInt16(bytes[offset + 1]) << 8
-                samples.append(Int16(bitPattern: high | low))
-                offset += 2
+    private static func loadInt16Wav(at url: URL) -> Int16WavData? {
+        guard let data = try? Data(contentsOf: url), data.count >= 12 else { return nil }
+        guard String(bytes: data[0..<4], encoding: .ascii) == "RIFF",
+              String(bytes: data[8..<12], encoding: .ascii) == "WAVE"
+        else { return nil }
+
+        var sampleRate: Int?
+        var channels: Int?
+        var bitsPerSample: Int?
+        var audioFormat: Int?
+        var dataRange: Range<Int>?
+        var offset = 12
+
+        while offset + 8 <= data.count {
+            guard let chunkID = String(bytes: data[offset..<(offset + 4)], encoding: .ascii),
+                  let chunkSize = readUInt32LE(data, at: offset + 4)
+            else { return nil }
+
+            let payloadStart = offset + 8
+            let payloadEnd = payloadStart + Int(chunkSize)
+            guard payloadEnd <= data.count else { return nil }
+
+            if chunkID == "fmt " {
+                guard Int(chunkSize) >= 16,
+                      let parsedFormat = readUInt16LE(data, at: payloadStart),
+                      let parsedChannels = readUInt16LE(data, at: payloadStart + 2),
+                      let parsedSampleRate = readUInt32LE(data, at: payloadStart + 4),
+                      let parsedBits = readUInt16LE(data, at: payloadStart + 14)
+                else { return nil }
+                audioFormat = Int(parsedFormat)
+                channels = Int(parsedChannels)
+                sampleRate = Int(parsedSampleRate)
+                bitsPerSample = Int(parsedBits)
+            } else if chunkID == "data" {
+                dataRange = payloadStart..<payloadEnd
             }
-            return samples
+
+            offset = payloadEnd + (Int(chunkSize) % 2)
         }
+
+        guard audioFormat == 1,
+              bitsPerSample == 16,
+              let sampleRate,
+              let channelCount = channels,
+              channelCount > 0,
+              let dataRange
+        else { return nil }
+
+        let byteCount = dataRange.count - (dataRange.count % 2)
+        var interleaved: [Int16] = []
+        interleaved.reserveCapacity(byteCount / 2)
+
+        var sampleOffset = dataRange.lowerBound
+        let sampleEnd = dataRange.lowerBound + byteCount
+        while sampleOffset + 1 < sampleEnd {
+            let low = UInt16(data[sampleOffset])
+            let high = UInt16(data[sampleOffset + 1]) << 8
+            interleaved.append(Int16(bitPattern: high | low))
+            sampleOffset += 2
+        }
+
+        let monoSamples: [Int16]
+        if channelCount == 1 {
+            monoSamples = interleaved
+        } else {
+            let frameCount = interleaved.count / channelCount
+            monoSamples = (0..<frameCount).map { frame in
+                var sum = 0
+                for channel in 0..<channelCount {
+                    sum += Int(interleaved[frame * channelCount + channel])
+                }
+                return Int16(clamping: sum / channelCount)
+            }
+        }
+
+        return Int16WavData(sampleRate: sampleRate, samples: monoSamples)
+    }
+
+    private static func readUInt16LE(_ data: Data, at offset: Int) -> UInt16? {
+        guard offset + 2 <= data.count else { return nil }
+        return UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private static func readUInt32LE(_ data: Data, at offset: Int) -> UInt32? {
+        guard offset + 4 <= data.count else { return nil }
+        return UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
     }
 
     private static func rmsEnvelope(samples: [Int16], frameSize: Int) -> [Double] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
@@ -67,7 +67,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing,
                 NSLocalizedDescriptionKey: "Could not open output file",
             ])
         }
-        file.write(Self.createWAVHeader(dataSize: 0))
+        file.write(WavWriter.header(dataSize: 0))
         outputFile = file
         outputURL = url
         totalBytesWritten = 0
@@ -120,7 +120,7 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing,
 
         // Finalize WAV
         if let outputFile {
-            let header = Self.createWAVHeader(dataSize: totalBytesWritten)
+            let header = WavWriter.header(dataSize: totalBytesWritten)
             outputFile.seek(toFileOffset: 0)
             outputFile.write(header)
             outputFile.closeFile()
@@ -301,29 +301,6 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing,
             }
             onPCMSamples?(int16Samples)
         }
-    }
-
-    // MARK: - WAV Header
-
-    private static func createWAVHeader(dataSize: Int) -> Data {
-        var header = Data()
-        let byteRate = Int(sampleRate) * channels * 16 / 8
-        let blockAlign = channels * 16 / 8
-
-        header.append(contentsOf: "RIFF".utf8)
-        header.append(contentsOf: withUnsafeBytes(of: UInt32(36 + dataSize).littleEndian) { Array($0) })
-        header.append(contentsOf: "WAVE".utf8)
-        header.append(contentsOf: "fmt ".utf8)
-        header.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) })
-        header.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) })
-        header.append(contentsOf: withUnsafeBytes(of: UInt16(channels).littleEndian) { Array($0) })
-        header.append(contentsOf: withUnsafeBytes(of: UInt32(sampleRate).littleEndian) { Array($0) })
-        header.append(contentsOf: withUnsafeBytes(of: UInt32(byteRate).littleEndian) { Array($0) })
-        header.append(contentsOf: withUnsafeBytes(of: UInt16(blockAlign).littleEndian) { Array($0) })
-        header.append(contentsOf: withUnsafeBytes(of: UInt16(16).littleEndian) { Array($0) })
-        header.append(contentsOf: "data".utf8)
-        header.append(contentsOf: withUnsafeBytes(of: UInt32(dataSize).littleEndian) { Array($0) })
-        return header
     }
 
     private func cleanupFailedStart() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
@@ -2,8 +2,9 @@ import AVFoundation
 import Foundation
 import ScreenCaptureKit
 import MuesliCore
+import os
 
-final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing {
+final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing, SystemAudioDiagnosticsProviding {
     var onPCMSamples: (([Int16]) -> Void)?
 
     private var stream: SCStream?
@@ -15,6 +16,38 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
 
     private static let sampleRate: Double = 16_000
     private static let channels: Int = 1
+    private let diagnosticsLock = OSAllocatedUnfairLock(initialState: DiagnosticsState())
+
+    private struct DiagnosticsState {
+        var callbackCount = 0
+        var bufferCount = 0
+        var emptyBufferCount = 0
+        var unsupportedFormatCount = 0
+        var inputByteCount = 0
+        var bytesWritten = 0
+        var sourceSampleRate: Double = 0
+        var sourceChannels: UInt32 = 0
+        var preConversion = AudioSampleStats()
+        var postConversion = AudioSampleStats()
+    }
+
+    var diagnosticsSnapshot: SystemAudioCaptureDiagnosticsSnapshot {
+        diagnosticsLock.withLock { state in
+            SystemAudioCaptureDiagnosticsSnapshot(
+                backend: "ScreenCaptureKit",
+                callbackCount: state.callbackCount,
+                bufferCount: state.bufferCount,
+                emptyBufferCount: state.emptyBufferCount,
+                unsupportedFormatCount: state.unsupportedFormatCount,
+                inputByteCount: state.inputByteCount,
+                bytesWritten: state.bytesWritten,
+                sourceSampleRate: state.sourceSampleRate,
+                sourceChannels: state.sourceChannels,
+                preConversion: state.preConversion.snapshot(),
+                postConversion: state.postConversion.snapshot()
+            )
+        }
+    }
 
     override init() {
         super.init()
@@ -150,14 +183,27 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
 
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .audio, isRecording, !isPaused else { return }
+        diagnosticsLock.withLock { $0.callbackCount += 1 }
 
-        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return }
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else {
+            diagnosticsLock.withLock { $0.emptyBufferCount += 1 }
+            return
+        }
         let length = CMBlockBufferGetDataLength(blockBuffer)
-        guard length > 0 else { return }
+        guard length > 0 else {
+            diagnosticsLock.withLock { $0.emptyBufferCount += 1 }
+            return
+        }
 
         // Get the audio format
         guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer) else { return }
         guard let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc)?.pointee else { return }
+        diagnosticsLock.withLock { state in
+            state.bufferCount += 1
+            state.inputByteCount += length
+            state.sourceSampleRate = asbd.mSampleRate
+            state.sourceChannels = asbd.mChannelsPerFrame
+        }
 
         // Extract raw audio bytes
         var dataPointer: UnsafeMutablePointer<Int8>?
@@ -179,6 +225,8 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
             }
 
             var int16Data = Data(count: outputSamples * 2)
+            var preConversion = [Float]()
+            preConversion.reserveCapacity(outputSamples)
             int16Data.withUnsafeMutableBytes { rawBuffer in
                 let int16Buffer = rawBuffer.bindMemory(to: Int16.self)
                 let channels = Int(asbd.mChannelsPerFrame)
@@ -194,25 +242,40 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing 
                     } else {
                         sample = floatPointer[i]
                     }
+                    preConversion.append(sample)
                     // Clamp and convert to int16
                     let clamped = max(-1.0, min(1.0, sample))
                     int16Buffer[i] = Int16(clamped * 32767.0)
                 }
             }
+            let int16Samples = int16Data.withUnsafeBytes { rawBuffer in
+                Array(rawBuffer.bindMemory(to: Int16.self))
+            }
+            let bytesToWrite = int16Data.count
+            let preConversionSamples = preConversion
 
             outputFile?.write(int16Data)
-            totalBytesWritten += int16Data.count
-            onPCMSamples?(int16Data.withUnsafeBytes { rawBuffer in
-                Array(rawBuffer.bindMemory(to: Int16.self))
-            })
+            totalBytesWritten += bytesToWrite
+            diagnosticsLock.withLock { state in
+                state.bytesWritten += bytesToWrite
+                state.preConversion.addFloats(preConversionSamples)
+                state.postConversion.addInt16(int16Samples)
+            }
+            onPCMSamples?(int16Samples)
         } else {
             // Already PCM int16, write directly
             let rawData = Data(bytes: dataPointer, count: length)
+            let int16Samples = rawData.withUnsafeBytes { rawBuffer in
+                Array(rawBuffer.bindMemory(to: Int16.self))
+            }
             outputFile?.write(rawData)
             totalBytesWritten += length
-            onPCMSamples?(rawData.withUnsafeBytes { rawBuffer in
-                Array(rawBuffer.bindMemory(to: Int16.self))
-            })
+            diagnosticsLock.withLock { state in
+                state.bytesWritten += length
+                state.preConversion.addInt16(int16Samples)
+                state.postConversion.addInt16(int16Samples)
+            }
+            onPCMSamples?(int16Samples)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SystemAudioRecorder.swift
@@ -263,16 +263,40 @@ final class SystemAudioRecorder: NSObject, SCStreamOutput, SystemAudioCapturing,
             }
             onPCMSamples?(int16Samples)
         } else {
-            // Already PCM int16, write directly
+            guard asbd.mFormatID == kAudioFormatLinearPCM,
+                  asbd.mBitsPerChannel == 16,
+                  abs(asbd.mSampleRate - Self.sampleRate) < 1.0,
+                  (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved) == 0
+            else {
+                diagnosticsLock.withLock { $0.unsupportedFormatCount += 1 }
+                fputs("[system-audio] unsupported SCStream integer PCM format rate=\(asbd.mSampleRate) channels=\(asbd.mChannelsPerFrame) bits=\(asbd.mBitsPerChannel) flags=\(asbd.mFormatFlags)\n", stderr)
+                return
+            }
+
             let rawData = Data(bytes: dataPointer, count: length)
-            let int16Samples = rawData.withUnsafeBytes { rawBuffer in
+            let interleavedSamples = rawData.withUnsafeBytes { rawBuffer in
                 Array(rawBuffer.bindMemory(to: Int16.self))
             }
-            outputFile?.write(rawData)
-            totalBytesWritten += length
+            let channels = max(Int(asbd.mChannelsPerFrame), 1)
+            let int16Samples: [Int16]
+            if channels == 1 {
+                int16Samples = interleavedSamples
+            } else {
+                let frameCount = interleavedSamples.count / channels
+                int16Samples = (0..<frameCount).map { frame in
+                    var sum = 0
+                    for channel in 0..<channels {
+                        sum += Int(interleavedSamples[frame * channels + channel])
+                    }
+                    return Int16(clamping: sum / channels)
+                }
+            }
+            let int16Data = int16Samples.withUnsafeBufferPointer { Data(buffer: $0) }
+            outputFile?.write(int16Data)
+            totalBytesWritten += int16Data.count
             diagnosticsLock.withLock { state in
-                state.bytesWritten += length
-                state.preConversion.addInt16(int16Samples)
+                state.bytesWritten += int16Data.count
+                state.preConversion.addInt16(interleavedSamples)
                 state.postConversion.addInt16(int16Samples)
             }
             onPCMSamples?(int16Samples)

--- a/native/MuesliNative/Sources/MuesliNativeApp/WavWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WavWriter.swift
@@ -5,14 +5,18 @@ enum WavWriter {
     static let channels: UInt16 = 1
     static let bitsPerSample: UInt16 = 16
 
+    static func header(dataSize: Int) -> Data {
+        header(dataSize: UInt32(clamping: dataSize))
+    }
+
     static func header(dataSize: UInt32) -> Data {
         let byteRate = sampleRate * UInt32(channels) * UInt32(bitsPerSample / 8)
         let blockAlign = channels * (bitsPerSample / 8)
-        let chunkSize = 36 + dataSize
+        let (chunkSize, overflow) = dataSize.addingReportingOverflow(36)
 
         var header = Data()
         header.append(contentsOf: "RIFF".utf8)
-        header.append(contentsOf: withUnsafeBytes(of: chunkSize.littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: (overflow ? UInt32.max : chunkSize).littleEndian) { Array($0) })
         header.append(contentsOf: "WAVE".utf8)
         header.append(contentsOf: "fmt ".utf8)
         header.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) })

--- a/native/MuesliNative/Tests/MuesliTests/CoreAudioSystemRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CoreAudioSystemRecorderTests.swift
@@ -5,20 +5,6 @@ import Testing
 @Suite("CoreAudioSystemRecorder")
 struct CoreAudioSystemRecorderTests {
 
-    @Test("device tap description excludes Muesli process audio")
-    func deviceTapDescriptionExcludesSelfAudio() {
-        let tapDescription = CoreAudioSystemRecorder.makeOutputDeviceTapDescription(
-            deviceUID: "test-output-device",
-            excludingProcessID: 123,
-            name: "Muesli Test Tap"
-        )
-
-        #expect(tapDescription.name == "Muesli Test Tap")
-        #expect(tapDescription.deviceUID == "test-output-device")
-        #expect(tapDescription.stream == 0)
-        #expect(tapDescription.processes == [123])
-    }
-
     @Test("global tap description captures process mix except Muesli")
     func globalTapDescriptionExcludesSelfAudio() {
         let tapDescription = CoreAudioSystemRecorder.makeGlobalTapDescription(
@@ -30,9 +16,6 @@ struct CoreAudioSystemRecorderTests {
         #expect(tapDescription.deviceUID == nil)
         #expect(tapDescription.stream == nil)
         #expect(tapDescription.processes == [123])
-        #expect(tapDescription.isExclusive)
-        #expect(tapDescription.isMixdown)
-        #expect(!tapDescription.isMono)
         #expect(tapDescription.isPrivate)
         #expect(tapDescription.muteBehavior == .unmuted)
     }

--- a/native/MuesliNative/Tests/MuesliTests/CoreAudioSystemRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CoreAudioSystemRecorderTests.swift
@@ -18,4 +18,40 @@ struct CoreAudioSystemRecorderTests {
         #expect(tapDescription.stream == 0)
         #expect(tapDescription.processes == [123])
     }
+
+    @Test("global tap description captures process mix except Muesli")
+    func globalTapDescriptionExcludesSelfAudio() {
+        let tapDescription = CoreAudioSystemRecorder.makeGlobalTapDescription(
+            excludingProcessID: 123,
+            name: "Muesli Global Test Tap"
+        )
+
+        #expect(tapDescription.name == "Muesli Global Test Tap")
+        #expect(tapDescription.deviceUID == nil)
+        #expect(tapDescription.stream == nil)
+        #expect(tapDescription.processes == [123])
+        #expect(tapDescription.isExclusive)
+        #expect(tapDescription.isMixdown)
+        #expect(!tapDescription.isMono)
+        #expect(tapDescription.isPrivate)
+        #expect(tapDescription.muteBehavior == .unmuted)
+    }
+
+    @Test("aggregate device description includes tap with drift compensation")
+    func aggregateDeviceDescriptionIncludesTap() throws {
+        let description = CoreAudioSystemRecorder.makeAggregateDeviceDescription(
+            tapUID: "tap-uid",
+            aggregateUID: "aggregate-uid"
+        )
+
+        #expect(description[kAudioAggregateDeviceNameKey] as? String == "Muesli System Audio")
+        #expect(description[kAudioAggregateDeviceUIDKey] as? String == "aggregate-uid")
+        #expect(description[kAudioAggregateDeviceIsPrivateKey] as? Bool == true)
+        #expect(description[kAudioAggregateDeviceTapAutoStartKey] as? Bool == true)
+
+        let taps = try #require(description[kAudioAggregateDeviceTapListKey] as? [[String: Any]])
+        let tap = try #require(taps.first)
+        #expect(tap[kAudioSubTapUIDKey] as? String == "tap-uid")
+        #expect(tap[kAudioSubTapDriftCompensationKey] as? Bool == true)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
@@ -47,6 +47,87 @@ struct MeetingNeuralAecTests {
         #expect(resolved.bundleURL.standardizedFileURL == rootBundleURL.standardizedFileURL)
     }
 
+    @Test("delay estimator finds delayed mic echo")
+    func delayEstimatorFindsDelayedMicEcho() throws {
+        let estimator = MeetingAecDelayEstimator()
+        let delaySamples = 3_840 // 240ms at 16kHz
+        let sampleCount = estimator.windowSamples + estimator.maxCandidateDelaySamples + 4_000
+        var system = [Float](repeating: 0, count: sampleCount)
+        var mic = [Float](repeating: 0, count: sampleCount)
+
+        for start in stride(from: 4_000, to: estimator.windowSamples - 8_000, by: 12_000) {
+            for offset in 0..<3_200 {
+                let value = Float(sin(Double(offset) * 0.04)) * 0.25
+                system[start + offset] = value
+                mic[start + delaySamples + offset] += value * 0.55
+            }
+        }
+
+        let result = try #require(estimator.estimate(
+            micHistory: mic,
+            micHistoryStartSample: 0,
+            systemHistory: system,
+            systemHistoryStartSample: 0,
+            comparableEndSample: estimator.windowSamples
+        ))
+
+        #expect(result.delayMs == 240)
+        #expect(result.score > 0.9)
+    }
+
+    @Test("delay estimator median smooths recent estimates")
+    func delayEstimatorMedianSmoothsRecentEstimates() {
+        #expect(MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: [
+            makeDelayResult(delayMs: 0),
+            makeDelayResult(delayMs: 240),
+            makeDelayResult(delayMs: 240),
+        ]) == 3_840)
+        #expect(MeetingAecDelayEstimator.recencyWeightedMedianDelay(from: [
+            makeDelayResult(delayMs: 80),
+            makeDelayResult(delayMs: 80),
+            makeDelayResult(delayMs: 400),
+        ]) == 6_400)
+    }
+
+    @Test("delay estimator exposes finer shared candidate grid")
+    func delayEstimatorCandidateGridIncludesFineRange() {
+        let candidates = MeetingAecDelayEstimator.defaultCandidateDelaysMs
+        #expect(candidates.contains(360))
+        #expect(candidates.contains(400))
+        #expect(candidates.contains(440))
+        #expect(candidates.contains(480))
+        #expect(candidates.contains(520))
+        #expect(candidates.contains(560))
+        #expect(candidates.contains(600))
+    }
+
+    @Test("delay estimator reports missing mic candidate windows")
+    func delayEstimatorReportsMissingMicCandidateWindows() throws {
+        let estimator = MeetingAecDelayEstimator()
+        let sampleCount = estimator.windowSamples + estimator.maxCandidateDelaySamples + 4_000
+        var system = [Float](repeating: 0, count: sampleCount)
+        let mic = [Float](repeating: 0, count: sampleCount)
+
+        for offset in 0..<3_200 {
+            system[4_000 + offset] = 0.25
+        }
+
+        let attempt = estimator.estimateAttempt(
+            micHistory: Array(mic.suffix(1_000)),
+            micHistoryStartSample: sampleCount - 1_000,
+            systemHistory: system,
+            systemHistoryStartSample: 0,
+            comparableEndSample: estimator.windowSamples
+        )
+
+        guard case let .failure(failure) = attempt else {
+            Issue.record("Expected missing mic candidate windows failure")
+            return
+        }
+        #expect(failure.reason == "missingMicCandidateWindows")
+        #expect(failure.missingCandidateCount == estimator.candidateDelaysMs.count)
+    }
+
     private func makeTemporaryAppBundle() throws -> TemporaryAppBundle {
         let appURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("meeting-aec-\(UUID().uuidString)", isDirectory: true)
@@ -85,6 +166,20 @@ struct MeetingNeuralAecTests {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         try "{}".write(to: url.appendingPathComponent("Manifest.json"), atomically: true, encoding: .utf8)
         return url
+    }
+
+    private func makeDelayResult(delayMs: Int) -> MeetingAecDelayEstimator.Result {
+        let delaySamples = Int(round(Double(delayMs) * 16_000.0 / 1_000.0))
+        return MeetingAecDelayEstimator.Result(
+            delaySamples: delaySamples,
+            delayMs: delayMs,
+            score: 0.8,
+            confidence: 0.01,
+            comparedFrames: 100,
+            candidateScores: [
+                MeetingAecDelayCandidateScore(delayMs: delayMs, score: 0.8, comparedFrames: 100)
+            ]
+        )
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSessionDiagnosticsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSessionDiagnosticsTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingSessionDiagnostics")
+struct MeetingSessionDiagnosticsTests {
+
+    @Test("WAV measurement reads data chunk after metadata chunks")
+    func wavMeasurementReadsDataChunkAfterMetadataChunks() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-diagnostics-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let samples: [Int16] = [0, 16_384, -16_384, 0]
+        var data = Data()
+        let dataByteCount = UInt32(samples.count * MemoryLayout<Int16>.size)
+        let listPayload = Data("test".utf8)
+        let riffSize = UInt32(4 + 8 + 16 + 8 + listPayload.count + 8 + Int(dataByteCount))
+
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: riffSize.littleEndian) { Array($0) })
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(16_000).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(32_000).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(2).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(16).littleEndian) { Array($0) })
+        data.append(contentsOf: "LIST".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(listPayload.count).littleEndian) { Array($0) })
+        data.append(listPayload)
+        data.append(contentsOf: "data".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: dataByteCount.littleEndian) { Array($0) })
+        samples.withUnsafeBufferPointer { data.append(Data(buffer: $0)) }
+        try data.write(to: url)
+
+        let stats = try #require(MeetingSessionDiagnostics.measureInt16Wav(at: url))
+
+        #expect(stats.sampleCount == samples.count)
+        #expect(stats.zeroSampleCount == 2)
+        #expect(abs(stats.peak - 0.5) < 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the silent system-audio capture path and adds focused meeting diagnostics for the CoreAudio/AEC pipeline.

This PR keeps the scope to the current CoreAudio + DTLN path:

- switches the CoreAudio system recorder toward the process-mix tap/aggregate-device path that produced non-silent system audio in meeting tests
- adds opt-in meeting diagnostics behind `MeetingDiagnostics.enabled`
- captures raw mic, cleaned mic, system audio, transcript, chunk counters, diarization counters, and AEC delay history for each diagnostic run
- improves AEC reference buffering and live delay observability so we can distinguish silent capture, missing reference frames, and noisy delay estimates
- adds tests for CoreAudio tap descriptions and AEC delay-estimator behavior
- fixes premature truncation in the meeting/floating indicator labels while validating the test builds

## Root Cause / Findings

The original failure was not primarily diarization. The system recorder was creating a WAV of the right duration but with `rms=0` and `peak=0`, so system transcription, system diarization, and AEC reference input were all starved.

After the CoreAudio capture fix, system audio is no longer silent in diagnostics. The remaining issue is far-end bleed appearing as `You`, which is now an AEC/reference-alignment quality problem rather than a capture failure.

## Follow-up Outside This PR

Do not add WebRTC back into the consideration set for now. Integrating WebRTC APM/AEC3 would require owning a custom native extraction/build path, which is too much surface area for this thread.

The next separate PR/spike should compare:

- improving the existing DTLN delay-estimation path
- replacing the AEC backend with LocalVQE

LocalVQE is intentionally not integrated here. It should be evaluated offline first against the diagnostic WAVs (`raw-mic-full-session.wav`, `system-audio.wav`, and current `cleaned-mic-aec.wav`). If it materially reduces far-end bleed while preserving near-end speech and ASR quality, it can become a feature-flagged backend. Core ML conversion can be explored after that, since it depends on whether the PyTorch checkpoint and streaming state convert cleanly.

## Validation

- `git diff --check`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/agent-silent-system-audio" --filter MeetingNeuralAecTests`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/agent-silent-system-audio" --filter CoreAudioSystemRecorderTests`
- rebuilt and relaunched `MuesliDev.app` locally for meeting transcription verification before opening this PR
