### PR TITLE
Add Dust API as a meeting summary backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Local-first macOS app for **dictation** and **meeting transcription** on Apple S
 - **Meeting export:** Export notes or transcript as PDF (paginated US Letter) or Markdown via `MeetingExporter.swift`
 - **Screen context:** Accessibility API captures app name + text around cursor for dictation context-awareness (opt-in, off by default)
 - **7 ASR models:** Parakeet v3/v2, Whisper Small/Medium/Large Turbo, Qwen3 ASR, Nemotron Streaming
-- **3 summarization backends:** OpenAI API key, OpenRouter API key, ChatGPT OAuth (subscription-based)
+- **5 summarization backends:** OpenAI API key, OpenRouter API key, ChatGPT OAuth (subscription-based), local Ollama, Dust API (enterprise agent)
 - **Camera-based meeting detection:** Requires mic + camera + recognized meeting app (camera alone won't trigger)
 - **Join & Record:** Extract meeting URLs from calendar events (Zoom, Meet, Teams, Webex, Chime, FaceTime), split button with "Join & Record" / "Join Only" / "Record Only", platform icons in notifications
 - **Google Calendar integration:** Coming Up section, status bar, pre-meeting countdowns, event-driven notifications via `EKEventStoreChangedNotification`
@@ -101,7 +101,7 @@ native/MuesliNative/Sources/
 │   ├── OnboardingView.swift      # 7-step onboarding with real permission polling + dictation test
 │   ├── OnboardingProgress.swift  # Crash-safe onboarding state persistence
 │   ├── MeetingSession.swift      # Meeting lifecycle + diarization + screen context
-│   ├── MeetingSummaryClient.swift # OpenAI / OpenRouter / ChatGPT summarization
+│   ├── MeetingSummaryClient.swift # OpenAI / OpenRouter / ChatGPT / Ollama / Dust summarization
 │   ├── SystemAudioRecorder.swift # ScreenCaptureKit SCStream for system audio
 │   ├── ChatGPTAuthManager.swift  # OAuth PKCE + WHAM API
 │   ├── HotkeyMonitor.swift       # Global hotkey detection (modifier keys)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -1153,7 +1153,7 @@ enum MeetingSummaryClient {
             fputs("[summary] Dust generated title successfully\n", stderr)
             return title
         } catch {
-            fputs("[summary] Dust title generation failed: \(error.localizedDescription)\n", stderr)
+            fputs("[summary] Dust title generation failed\n", stderr)
             return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -1150,7 +1150,7 @@ enum MeetingSummaryClient {
                 fputs("[summary] Dust title generation: trimmed response is empty\n", stderr)
                 return nil
             }
-            fputs("[summary] Dust generated title: \(title)\n", stderr)
+            fputs("[summary] Dust generated title successfully\n", stderr)
             return title
         } catch {
             fputs("[summary] Dust title generation failed: \(error.localizedDescription)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -34,6 +34,23 @@ enum MeetingSummaryClient {
     private static let ollamaSummaryTimeout: TimeInterval = 300
     private static let ollamaTitleTimeout: TimeInterval = 120
 
+    // Dust backend. The base URL is region-selectable (EU vs Worldwide) and overridable
+    // via the DUST_BASE_URL environment variable for QA and tests.
+    private static let dustDefaultBaseURL = URL(string: "https://eu.dust.tt")!
+    private static func dustBaseURL(for config: AppConfig) -> URL {
+        if let override = ProcessInfo.processInfo.environment["DUST_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !override.isEmpty,
+           let url = URL(string: override) {
+            return url
+        }
+        return URL(string: DustRegionOption.resolved(config.dustRegion).host) ?? dustDefaultBaseURL
+    }
+    private static let dustSummaryTimeout: TimeInterval = 300
+    private static let dustTitleTimeout: TimeInterval = 120
+    private static let dustPollInterval: TimeInterval = 2
+    private static let dustPollBudget: TimeInterval = 60
+    private static let dustRegionHint = "Verify the selected Dust region (EU uses eu.dust.tt, Worldwide uses dust.tt) matches your workspace."
+
     private static let titleInstructions = """
     Generate a short, descriptive meeting title (3-7 words) from these transcript excerpts. \
     Prefer the main topic and outcome across the whole meeting over opening small talk or setup. \
@@ -85,6 +102,18 @@ enum MeetingSummaryClient {
         }
         if backend == MeetingSummaryBackendOption.ollama.backend {
             generatedNotes = try await summarizeWithOllama(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
+        if backend == MeetingSummaryBackendOption.dust.backend {
+            generatedNotes = try await summarizeWithDust(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -664,6 +693,10 @@ enum MeetingSummaryClient {
             return await generateTitleWithOllama(transcript: excerpt, config: config)
         }
 
+        if backend == MeetingSummaryBackendOption.dust.backend {
+            return await generateTitleWithDust(transcript: excerpt, config: config)
+        }
+
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey
         guard !apiKey.isEmpty else { return nil }
         let model = config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel
@@ -835,5 +868,293 @@ enum MeetingSummaryClient {
 
     private static func rawTranscriptFallback(transcript: String, meetingTitle: String) -> String {
         "## Raw Transcript\n\n\(transcript)"
+    }
+
+    // MARK: - Dust backend
+
+    /// Dust agent credentials. Resolved from env-var overrides over config.json.
+    private struct DustCredentials {
+        let apiKey: String
+        let workspaceID: String
+        let agentID: String
+        let baseURL: URL
+
+        /// Returns resolved credentials, or nil if any of the three values is empty.
+        static func resolve(from config: AppConfig) -> DustCredentials? {
+            let env = ProcessInfo.processInfo.environment
+            let apiKey = (env["DUST_API_KEY"] ?? config.dustAPIKey)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let workspaceID = (env["DUST_WORKSPACE_ID"] ?? config.dustWorkspaceID)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let agentID = (env["DUST_AGENT_ID"] ?? config.dustAgentID)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !apiKey.isEmpty, !workspaceID.isEmpty, !agentID.isEmpty else { return nil }
+            return DustCredentials(
+                apiKey: apiKey,
+                workspaceID: workspaceID,
+                agentID: agentID,
+                baseURL: dustBaseURL(for: config)
+            )
+        }
+    }
+
+    /// State of the most recent agent message in a Dust conversation.
+    enum DustAgentOutcome: Equatable {
+        case answer(String)   // a finished agent message with non-empty text
+        case running          // an agent message exists but is still generating
+        case failed(String)   // the agent reported a terminal failure
+        case missing          // no agent message present yet
+    }
+
+    /// Pure parsing of Dust conversation JSON. No network — unit-testable with fixtures.
+    ///
+    /// Dust's conversation `content` is an array of ranks; each rank is an array of message
+    /// versions (newest last). The agent's answer is the latest `agent_message`.
+    enum DustResponseParser {
+        /// Extracts the conversation's string ID from a create- or get-conversation response.
+        static func conversationID(in json: [String: Any]) -> String? {
+            let conversation = (json["conversation"] as? [String: Any]) ?? json
+            if let sId = conversation["sId"] as? String, !sId.isEmpty { return sId }
+            if let id = conversation["id"] as? String, !id.isEmpty { return id }
+            if let id = conversation["id"] as? Int { return String(id) }
+            return nil
+        }
+
+        /// Reports the state of the most recent agent message in the conversation.
+        static func agentOutcome(in json: [String: Any]) -> DustAgentOutcome {
+            let conversation = (json["conversation"] as? [String: Any]) ?? json
+            guard let content = conversation["content"] as? [[Any]] else { return .missing }
+            for rank in content.reversed() {
+                guard let latest = rank.last as? [String: Any] else { continue }
+                guard (latest["type"] as? String) == "agent_message" else { continue }
+                return outcome(for: latest)
+            }
+            return .missing
+        }
+
+        private static func outcome(for message: [String: Any]) -> DustAgentOutcome {
+            let status = (message["status"] as? String)?.lowercased()
+            let text = answerText(from: message)
+            switch status {
+            case "succeeded", "completed":
+                if let text { return .answer(text) }
+                return .failed("The Dust agent finished without returning any text.")
+            case "failed", "errored", "error":
+                return .failed(errorMessage(from: message) ?? "The Dust agent failed to generate a response.")
+            case "cancelled", "canceled":
+                return .failed("The Dust agent run was cancelled.")
+            case nil:
+                // No status field — treat non-empty content as a finished answer.
+                if let text { return .answer(text) }
+                return .running
+            default:
+                // Any other (in-progress) status, e.g. "created" / "running" / "pending".
+                return .running
+            }
+        }
+
+        private static func answerText(from message: [String: Any]) -> String? {
+            guard let content = message["content"] as? String else { return nil }
+            let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        private static func errorMessage(from message: [String: Any]) -> String? {
+            if let error = message["error"] as? [String: Any],
+               let msg = error["message"] as? String, !msg.isEmpty {
+                return msg
+            }
+            if let error = message["error"] as? String, !error.isEmpty {
+                return error
+            }
+            return nil
+        }
+    }
+
+    /// Like `validateHTTPResponse` but surfaces the EU-region limitation on the status
+    /// codes a region/credential mismatch most likely produces.
+    private static func validateDustHTTPResponse(_ response: URLResponse, data: Data) throws {
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let serverMessage = extractErrorMessage(from: data)
+                ?? String(data: data, encoding: .utf8)
+                ?? HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode)
+            var message = String(serverMessage.prefix(800))
+            if [401, 403, 404].contains(httpResponse.statusCode) {
+                message += " \(dustRegionHint) Also verify the workspace ID, agent ID, and API key."
+            }
+            throw MeetingSummaryError.backendFailed(
+                backend: "Dust",
+                statusCode: httpResponse.statusCode,
+                message: message
+            )
+        }
+    }
+
+    /// Posts `prompt` to the configured Dust agent and returns the agent's answer text.
+    /// Throws `MeetingSummaryError` on any failure (network, region, timeout, empty).
+    private static func runDustAgent(
+        prompt: String,
+        credentials: DustCredentials,
+        timeout: TimeInterval
+    ) async throws -> String {
+        let createURL = credentials.baseURL
+            .appendingPathComponent("api/v1/w")
+            .appendingPathComponent(credentials.workspaceID)
+            .appendingPathComponent("assistant/conversations")
+
+        // One user message that @-mentions the configured agent. `blocking: true` waits
+        // for the agent's initial reply so the response usually already carries the answer.
+        let body: [String: Any] = [
+            "blocking": true,
+            "title": "Muesli meeting summary",
+            "visibility": "unlisted",
+            "message": [
+                "content": prompt,
+                "mentions": [["configurationId": credentials.agentID]],
+                "context": [
+                    "username": "muesli",
+                    "timezone": TimeZone.current.identifier,
+                    "origin": "api",
+                ],
+            ] as [String: Any],
+        ]
+
+        var request = URLRequest(url: createURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(credentials.apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateDustHTTPResponse(response, data: data)
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw MeetingSummaryError.emptyResponse(backend: "Dust")
+            }
+
+            switch DustResponseParser.agentOutcome(in: json) {
+            case let .answer(text):
+                return text
+            case let .failed(message):
+                throw MeetingSummaryError.backendFailed(backend: "Dust", statusCode: nil, message: message)
+            case .running, .missing:
+                // Blocking response carried no finished answer — poll the conversation.
+                fputs("[summary] Dust blocking response without answer; keys=\(Array(json.keys)). Polling conversation.\n", stderr)
+                guard let conversationID = DustResponseParser.conversationID(in: json) else {
+                    throw MeetingSummaryError.emptyResponse(backend: "Dust")
+                }
+                return try await pollDustConversation(conversationID: conversationID, credentials: credentials)
+            }
+        } catch {
+            throw summaryRequestError(backend: "Dust", error: error)
+        }
+    }
+
+    /// Polls a Dust conversation until the agent message completes or the budget expires.
+    private static func pollDustConversation(
+        conversationID: String,
+        credentials: DustCredentials
+    ) async throws -> String {
+        let getURL = credentials.baseURL
+            .appendingPathComponent("api/v1/w")
+            .appendingPathComponent(credentials.workspaceID)
+            .appendingPathComponent("assistant/conversations")
+            .appendingPathComponent(conversationID)
+
+        let deadline = Date().addingTimeInterval(dustPollBudget)
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: UInt64(dustPollInterval * 1_000_000_000))
+
+            var request = URLRequest(url: getURL)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 30
+            request.setValue("Bearer \(credentials.apiKey)", forHTTPHeaderField: "Authorization")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateDustHTTPResponse(response, data: data)
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+            switch DustResponseParser.agentOutcome(in: json) {
+            case let .answer(text):
+                return text
+            case let .failed(message):
+                throw MeetingSummaryError.backendFailed(backend: "Dust", statusCode: nil, message: message)
+            case .running, .missing:
+                continue
+            }
+        }
+        throw MeetingSummaryError.backendFailed(
+            backend: "Dust",
+            statusCode: nil,
+            message: "The Dust agent did not return an answer within \(Int(dustPollBudget))s. The agent may be running long tool calls or may be misconfigured."
+        )
+    }
+
+    private static func summarizeWithDust(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil
+    ) async throws -> String {
+        // FR8: incomplete credentials -> raw-transcript fallback, never crash or throw.
+        guard let credentials = DustCredentials.resolve(from: config) else {
+            return rawTranscriptFallback(transcript: transcript, meetingTitle: meetingTitle)
+        }
+
+        // A Dust agent has no separate system-prompt channel, so Muesli's instructions
+        // and the transcript are delivered together in one user message.
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
+        let userPrompt = summaryUserPrompt(
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            visualContext: visualContext
+        )
+        let prompt = instructions + "\n\n---\n\n" + userPrompt
+
+        let answer = try await runDustAgent(
+            prompt: prompt,
+            credentials: credentials,
+            timeout: dustSummaryTimeout
+        )
+        guard !answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MeetingSummaryError.emptyResponse(backend: "Dust")
+        }
+        return answer
+    }
+
+    /// Routes title generation through the configured Dust agent. Note: this is a second
+    /// agent invocation per meeting, in addition to the summary call.
+    private static func generateTitleWithDust(transcript: String, config: AppConfig) async -> String? {
+        guard let credentials = DustCredentials.resolve(from: config) else {
+            fputs("[summary] Dust title generation skipped: incomplete credentials\n", stderr)
+            return nil
+        }
+        let prompt = titleInstructions + "\n\n---\n\n" + transcript
+        do {
+            let answer = try await runDustAgent(
+                prompt: prompt,
+                credentials: credentials,
+                timeout: dustTitleTimeout
+            )
+            let title = answer.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+            guard !title.isEmpty else {
+                fputs("[summary] Dust title generation: trimmed response is empty\n", stderr)
+                return nil
+            }
+            fputs("[summary] Dust generated title: \(title)\n", stderr)
+            return title
+        } catch {
+            fputs("[summary] Dust title generation failed: \(error.localizedDescription)\n", stderr)
+            return nil
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -343,11 +343,44 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "Ollama"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama]
+    static let dust = MeetingSummaryBackendOption(
+        backend: "dust",
+        label: "Dust"
+    )
+
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .dust]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
             return .chatGPT
+        }
+        return option
+    }
+}
+
+/// Dust API region. EU customers use eu.dust.tt; Worldwide customers use dust.tt.
+struct DustRegionOption: Equatable {
+    let region: String   // persisted in config.json
+    let label: String    // shown in Settings
+    let host: String      // API base URL for this region
+
+    static let europe = DustRegionOption(
+        region: "eu",
+        label: "EU (eu.dust.tt)",
+        host: "https://eu.dust.tt"
+    )
+
+    static let worldwide = DustRegionOption(
+        region: "worldwide",
+        label: "Worldwide (dust.tt)",
+        host: "https://dust.tt"
+    )
+
+    static let all: [DustRegionOption] = [.europe, .worldwide]
+
+    static func resolved(_ region: String?) -> DustRegionOption {
+        guard let region, let option = all.first(where: { $0.region == region }) else {
+            return .europe
         }
         return option
     }
@@ -632,6 +665,10 @@ struct AppConfig: Codable {
     var chatGPTModel: String = ""
     var ollamaURL: String = "http://localhost:11434"
     var ollamaModel: String = "qwen3.5"
+    var dustAPIKey: String = ""
+    var dustWorkspaceID: String = ""
+    var dustAgentID: String = ""
+    var dustRegion: String = DustRegionOption.europe.region
     var summaryModel: String = ""
     var meetingSummaryModel: String = ""
     var hasCompletedOnboarding: Bool = false
@@ -700,6 +737,10 @@ struct AppConfig: Codable {
         case chatGPTModel = "chatgpt_model"
         case ollamaURL = "ollama_url"
         case ollamaModel = "ollama_model"
+        case dustAPIKey = "dust_api_key"
+        case dustWorkspaceID = "dust_workspace_id"
+        case dustAgentID = "dust_agent_id"
+        case dustRegion = "dust_region"
         case summaryModel = "summary_model"
         case meetingSummaryModel = "meeting_summary_model"
         case hasCompletedOnboarding = "has_completed_onboarding"
@@ -782,6 +823,10 @@ struct AppConfig: Codable {
         chatGPTModel = (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
         ollamaURL = (try? c.decode(String.self, forKey: .ollamaURL)) ?? defaults.ollamaURL
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
+        dustAPIKey = (try? c.decode(String.self, forKey: .dustAPIKey)) ?? defaults.dustAPIKey
+        dustWorkspaceID = (try? c.decode(String.self, forKey: .dustWorkspaceID)) ?? defaults.dustWorkspaceID
+        dustAgentID = (try? c.decode(String.self, forKey: .dustAgentID)) ?? defaults.dustAgentID
+        dustRegion = (try? c.decode(String.self, forKey: .dustRegion)) ?? defaults.dustRegion
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -569,6 +569,49 @@ struct SettingsView: View {
                             placeholder: "qwen3.5"
                         ) { val in controller.updateConfig { $0.ollamaModel = val } }
                     }
+                } else if appState.selectedMeetingSummaryBackend == .dust {
+                    settingsRow("Region", controlWidth: meetingControlWidth) {
+                        settingsMenu(
+                            selection: DustRegionOption.resolved(appState.config.dustRegion).label,
+                            options: DustRegionOption.all.map(\.label)
+                        ) { label in
+                            if let option = DustRegionOption.all.first(where: { $0.label == label }) {
+                                controller.updateConfig { $0.dustRegion = option.region }
+                            }
+                        }
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("API Key", controlWidth: meetingControlWidth) {
+                        PastableSecureField(
+                            text: appState.config.dustAPIKey,
+                            placeholder: "sk-...",
+                            onChange: { val in controller.updateConfig { $0.dustAPIKey = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Workspace ID", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.dustWorkspaceID,
+                            placeholder: "Dust workspace ID",
+                            onChange: { val in controller.updateConfig { $0.dustWorkspaceID = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Agent ID", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.dustAgentID,
+                            placeholder: "Dust agent configurationId",
+                            onChange: { val in controller.updateConfig { $0.dustAgentID = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    dustStatusRow(
+                        apiKey: appState.config.dustAPIKey,
+                        workspaceID: appState.config.dustWorkspaceID,
+                        agentID: appState.config.dustAgentID
+                    )
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(
@@ -1971,6 +2014,26 @@ struct SettingsView: View {
             Text(key.isEmpty ? "No API key configured" : "Key configured")
                 .font(.system(size: 11))
                 .foregroundStyle(key.isEmpty ? MuesliTheme.textTertiary : MuesliTheme.success)
+        }
+        .frame(minHeight: 20)
+    }
+
+    @ViewBuilder
+    private func dustStatusRow(apiKey: String, workspaceID: String, agentID: String) -> some View {
+        let missing: [String] = [
+            apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "API key" : nil,
+            workspaceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "workspace ID" : nil,
+            agentID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "agent ID" : nil,
+        ].compactMap { $0 }
+        let configured = missing.isEmpty
+        HStack(spacing: 6) {
+            Spacer()
+            Circle()
+                .fill(configured ? MuesliTheme.success : MuesliTheme.textTertiary)
+                .frame(width: 6, height: 6)
+            Text(configured ? "Dust agent configured" : "Missing: \(missing.joined(separator: ", "))")
+                .font(.system(size: 11))
+                .foregroundStyle(configured ? MuesliTheme.success : MuesliTheme.textTertiary)
         }
         .frame(minHeight: 20)
     }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -385,4 +385,166 @@ struct MeetingSummaryClientTests {
             #expect(summaryError != nil)
         }
     }
+
+    // MARK: - Dust backend
+
+    private func dustJSON(_ string: String) throws -> [String: Any] {
+        try #require(try JSONSerialization.jsonObject(with: Data(string.utf8)) as? [String: Any])
+    }
+
+    @Test("summarize falls back to raw transcript when Dust credentials are missing")
+    func dustFallbackWithoutCredentials() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "dust"
+
+        let result = try await MeetingSummaryClient.summarize(
+            transcript: "Hello world",
+            meetingTitle: "Test",
+            config: config
+        )
+
+        #expect(result.contains("## Raw Transcript"))
+        #expect(result.contains("Hello world"))
+    }
+
+    @Test("summarize falls back to raw transcript when Dust credentials are incomplete")
+    func dustFallbackWithPartialCredentials() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "dust"
+        config.dustAPIKey = "sk-test"
+        // workspace ID and agent ID intentionally left empty
+
+        let result = try await MeetingSummaryClient.summarize(
+            transcript: "Hello world",
+            meetingTitle: "Test",
+            config: config
+        )
+
+        #expect(result.contains("## Raw Transcript"))
+    }
+
+    @Test("generateTitle returns nil for Dust without credentials")
+    func dustTitleNilWithoutCredentials() async {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "dust"
+
+        let title = await MeetingSummaryClient.generateTitle(
+            transcript: "Sprint planning discussion",
+            config: config
+        )
+
+        #expect(title == nil)
+    }
+
+    @Test("summarize surfaces a Dust error when the host is unreachable")
+    func dustSummarizeThrowsOnUnreachableHost() async throws {
+        setenv("DUST_BASE_URL", "http://localhost:1", 1)
+        defer { unsetenv("DUST_BASE_URL") }
+
+        var config = AppConfig()
+        config.meetingSummaryBackend = "dust"
+        config.dustAPIKey = "sk-test"
+        config.dustWorkspaceID = "ws-test"
+        config.dustAgentID = "agent-test"
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            let summaryError = error as? MeetingSummaryError
+            #expect(summaryError != nil)
+            if case .requestFailed(let backend, _) = summaryError! {
+                #expect(backend == "Dust")
+            } else {
+                #expect(Bool(false), "Expected requestFailed error, got \(String(describing: error))")
+            }
+        }
+    }
+
+    @Test("DustResponseParser extracts a completed agent answer")
+    func dustParserExtractsAnswer() throws {
+        let json = try dustJSON("""
+        {
+          "conversation": {
+            "sId": "conv_abc",
+            "content": [
+              [{"type": "user_message", "content": "raw transcript"}],
+              [{"type": "agent_message", "status": "succeeded", "content": "# Notes\\n- shipped"}]
+            ]
+          }
+        }
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.agentOutcome(in: json) == .answer("# Notes\n- shipped"))
+    }
+
+    @Test("DustResponseParser reports a still-running agent message")
+    func dustParserReportsRunning() throws {
+        let json = try dustJSON("""
+        {"conversation": {"content": [
+          [{"type": "user_message", "content": "x"}],
+          [{"type": "agent_message", "status": "created"}]
+        ]}}
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.agentOutcome(in: json) == .running)
+    }
+
+    @Test("DustResponseParser reports missing when no agent message exists")
+    func dustParserReportsMissing() throws {
+        let json = try dustJSON("""
+        {"conversation": {"content": [[{"type": "user_message", "content": "x"}]]}}
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.agentOutcome(in: json) == .missing)
+    }
+
+    @Test("DustResponseParser surfaces a failed agent run")
+    func dustParserReportsFailure() throws {
+        let json = try dustJSON("""
+        {"conversation": {"content": [
+          [{"type": "agent_message", "status": "failed", "error": {"message": "tool timeout"}}]
+        ]}}
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.agentOutcome(in: json) == .failed("tool timeout"))
+    }
+
+    @Test("DustResponseParser picks the latest version within a rank")
+    func dustParserPicksLatestVersion() throws {
+        let json = try dustJSON("""
+        {"conversation": {"content": [
+          [{"type": "user_message", "content": "x"}],
+          [
+            {"type": "agent_message", "status": "created"},
+            {"type": "agent_message", "status": "succeeded", "content": "final answer"}
+          ]
+        ]}}
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.agentOutcome(in: json) == .answer("final answer"))
+    }
+
+    @Test("DustResponseParser extracts the conversation ID from sId")
+    func dustParserExtractsConversationID() throws {
+        let json = try dustJSON("""
+        {"conversation": {"sId": "conv_xyz", "content": []}}
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.conversationID(in: json) == "conv_xyz")
+    }
+
+    @Test("DustResponseParser handles a numeric id and an unwrapped conversation")
+    func dustParserHandlesUnwrappedConversation() throws {
+        let json = try dustJSON("""
+        {"id": 4321, "content": [[{"type": "agent_message", "status": "succeeded", "content": "notes"}]]}
+        """)
+
+        #expect(MeetingSummaryClient.DustResponseParser.conversationID(in: json) == "4321")
+        #expect(MeetingSummaryClient.DustResponseParser.agentOutcome(in: json) == .answer("notes"))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -368,11 +368,12 @@ struct MeetingSummaryBackendTests {
 
     @Test("all options listed")
     func allOptions() {
-        #expect(MeetingSummaryBackendOption.all.count == 4)
+        #expect(MeetingSummaryBackendOption.all.count == 5)
         #expect(MeetingSummaryBackendOption.all.contains(.openAI))
         #expect(MeetingSummaryBackendOption.all.contains(.openRouter))
         #expect(MeetingSummaryBackendOption.all.contains(.chatGPT))
         #expect(MeetingSummaryBackendOption.all.contains(.ollama))
+        #expect(MeetingSummaryBackendOption.all.contains(.dust))
     }
 
     @Test("backend strings are lowercase")
@@ -380,6 +381,7 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.openAI.backend == "openai")
         #expect(MeetingSummaryBackendOption.openRouter.backend == "openrouter")
         #expect(MeetingSummaryBackendOption.ollama.backend == "ollama")
+        #expect(MeetingSummaryBackendOption.dust.backend == "dust")
     }
 
     @Test("configured values resolve with ChatGPT fallback")
@@ -389,6 +391,38 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.resolved("ollama") == .ollama)
         #expect(MeetingSummaryBackendOption.resolved("unknown") == .chatGPT)
         #expect(MeetingSummaryBackendOption.resolved(nil) == .chatGPT)
+    }
+}
+
+@Suite("DustRegionOption")
+struct DustRegionTests {
+
+    @Test("both regions listed")
+    func allRegions() {
+        #expect(DustRegionOption.all.count == 2)
+        #expect(DustRegionOption.all.contains(.europe))
+        #expect(DustRegionOption.all.contains(.worldwide))
+    }
+
+    @Test("region hosts map to the correct Dust endpoints")
+    func regionHosts() {
+        #expect(DustRegionOption.europe.region == "eu")
+        #expect(DustRegionOption.europe.host == "https://eu.dust.tt")
+        #expect(DustRegionOption.worldwide.region == "worldwide")
+        #expect(DustRegionOption.worldwide.host == "https://dust.tt")
+    }
+
+    @Test("configured region resolves with EU fallback")
+    func resolvedRegions() {
+        #expect(DustRegionOption.resolved("eu") == .europe)
+        #expect(DustRegionOption.resolved("worldwide") == .worldwide)
+        #expect(DustRegionOption.resolved("unknown") == .europe)
+        #expect(DustRegionOption.resolved(nil) == .europe)
+    }
+
+    @Test("AppConfig defaults the Dust region to EU")
+    func configDefault() {
+        #expect(AppConfig().dustRegion == "eu")
     }
 }
 

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -66,6 +66,7 @@ case "${shard}" in
       MeetingBrowserLogicTests
       TranscriptFormatterTests
       MeetingSummaryBackendTests
+      DustRegionTests
       MeetingResummarizationPolicyTests
       MeetingTemplateResolutionTests
       DisabledCalendarFilterTests


### PR DESCRIPTION
## Summary

Adds **Dust** as a fifth meeting-summary backend alongside ChatGPT, OpenAI, OpenRouter, and Ollama. Instead of calling a raw LLM, Muesli posts the meeting transcript to a customer-configured **Dust agent** (API key + workspace ID + agent ID), so professional users can route summarization through their organization's enterprise AI platform.

## What's included

- **Settings** — new "Dust" option under Meetings → Meeting Summaries, with Region, API Key, Workspace ID, and Agent ID fields plus a configured-status row that turns green only when all three credentials are set.
- **Region selector** — EU (`eu.dust.tt`) vs Worldwide (`dust.tt`), defaults to EU.
- **Summarization** — posts a blocking conversation that @-mentions the configured agent; polls the conversation for up to 60s when the blocking response has no answer yet.
- **Title generation** also routes through the Dust agent.
- **Credentials** stored in `config.json`, consistent with the existing OpenAI/OpenRouter API keys. `DUST_API_KEY` / `DUST_WORKSPACE_ID` / `DUST_AGENT_ID` env vars override stored values for testing.

## Testing

All three CI shards pass locally:

```
bash ./scripts/run_ci_test_shard.sh core                     # 136 tests
bash ./scripts/run_ci_test_shard.sh dictation-transcription   # 147 tests
bash ./scripts/run_ci_test_shard.sh meetings                  # 186 tests (incl. new Dust suites)
swift test --package-path native/MuesliNative                 # full suite
```

New tests: Dust routing & credential fallback, `DustResponseParser` parsing (completed/running/failed/missing outcomes, conversation-ID extraction), and `DustRegionOption` resolution. `DustRegionTests` is wired into the `meetings` shard so CI picks it up.

Note: a few `HotkeyMonitor` timing tests flake under full-suite parallel load but pass in every CI shard and in isolation — pre-existing, unrelated to this change.

Verified end-to-end against a live EU Dust workspace using a release-config local build (`MUESLI_SKIP_SIGN=1`).

## Notes

- Region defaults to **EU**; switchable in Settings.
- The Dust API key is stored plaintext in `config.json`, consistent with how the OpenAI/OpenRouter keys are stored today. Migrating all API keys to the Keychain would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
