### PR TITLE
[codex] Fix meeting finalizing recording prompt

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2717,6 +2717,9 @@ final class MuesliController: NSObject {
         }
         if !didPresent {
             isPresentingMeetingTerminationConfirmation = false
+            discardMeetingStateForTermination()
+            isTerminatingAfterMeetingConfirmation = true
+            NSApp.terminate(nil)
         }
 
         return false
@@ -3567,7 +3570,7 @@ final class MuesliController: NSObject {
                 await MainActor.run {
                     self.setMeetingProcessingStatus("Finalizing")
                 }
-                let recordingSaveDecision = await self.recordingSaveDecision(for: result.title)
+                let recordingSaveDecision = await self.recordingSaveDecision(for: result)
                 let persistenceResult = try await MainActor.run {
                     try self.persistCompletedMeetingResultAndDispatchHook(
                         result,
@@ -3754,13 +3757,15 @@ final class MuesliController: NSObject {
         saveDecision: Bool? = nil
     ) throws -> String? {
         let shouldSave: Bool
-        switch config.meetingRecordingSavePolicy {
-        case .never:
-            shouldSave = false
-        case .always:
-            shouldSave = true
-        case .prompt:
-            shouldSave = saveDecision ?? true
+        if let saveDecision {
+            shouldSave = saveDecision
+        } else {
+            switch config.meetingRecordingSavePolicy {
+            case .never:
+                shouldSave = false
+            case .always, .prompt:
+                shouldSave = true
+            }
         }
 
         guard shouldSave else {
@@ -3837,9 +3842,10 @@ final class MuesliController: NSObject {
     }
 
     @MainActor
-    private func recordingSaveDecision(for title: String) async -> Bool? {
+    private func recordingSaveDecision(for result: MeetingSessionResult) async -> Bool? {
         guard config.meetingRecordingSavePolicy == .prompt else { return nil }
-        return await promptToSaveMeetingRecording(for: title)
+        guard result.retainedRecordingURL != nil, result.retainedRecordingError == nil else { return nil }
+        return await promptToSaveMeetingRecording(for: result.title)
     }
 
     @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3765,7 +3765,7 @@ final class MuesliController: NSObject {
             case .always:
                 shouldSave = true
             case .prompt:
-                shouldSave = false
+                shouldSave = result.retainedRecordingError != nil
             }
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3384,15 +3384,17 @@ final class MuesliController: NSObject {
 
     private func confirmationAnchorWindow() -> NSWindow? {
         NSApp.windows.first { window in
-            window.isVisible &&
-                !window.isMiniaturized &&
-                !(window is NSPanel) &&
-                window.canBecomeKey
+            isUsableSheetHost(window, allowPanel: false)
         } ?? NSApp.windows.first { window in
-            window.isVisible &&
-                !window.isMiniaturized &&
-                window.canBecomeKey
+            isUsableSheetHost(window, allowPanel: true)
         }
+    }
+
+    private func isUsableSheetHost(_ window: NSWindow, allowPanel: Bool) -> Bool {
+        window.isVisible &&
+            !window.isMiniaturized &&
+            window.canBecomeKey &&
+            (allowPanel || !(window is NSPanel))
     }
 
     private func discardMeetingRecording(resolution: MeetingDiscardResolution = .discardRecording) {
@@ -3760,8 +3762,10 @@ final class MuesliController: NSObject {
             switch config.meetingRecordingSavePolicy {
             case .never:
                 shouldSave = false
-            case .always, .prompt:
+            case .always:
                 shouldSave = true
+            case .prompt:
+                shouldSave = false
             }
         }
 
@@ -3868,7 +3872,8 @@ final class MuesliController: NSObject {
 
     @MainActor
     private func alertPresentationWindow(showHistoryIfNeeded: Bool = true) -> NSWindow? {
-        if let window = historyWindowController?.presentationWindow, window.isVisible {
+        if let window = historyWindowController?.presentationWindow,
+           isUsableSheetHost(window, allowPanel: false) {
             return window
         }
 
@@ -3876,14 +3881,15 @@ final class MuesliController: NSObject {
             historyWindowController?.show()
         }
 
-        if let window = historyWindowController?.presentationWindow, window.isVisible {
+        if let window = historyWindowController?.presentationWindow,
+           isUsableSheetHost(window, allowPanel: false) {
             return window
         }
 
         return NSApp.windows.first { window in
-            window.isVisible && window.canBecomeKey && !(window is NSPanel)
+            isUsableSheetHost(window, allowPanel: false)
         } ?? NSApp.windows.first { window in
-            window.isVisible && window.canBecomeKey
+            isUsableSheetHost(window, allowPanel: true)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2717,9 +2717,6 @@ final class MuesliController: NSObject {
         }
         if !didPresent {
             isPresentingMeetingTerminationConfirmation = false
-            discardMeetingStateForTermination()
-            isTerminatingAfterMeetingConfirmation = true
-            NSApp.terminate(nil)
         }
 
         return false
@@ -3879,8 +3876,7 @@ final class MuesliController: NSObject {
             historyWindowController?.show()
         }
 
-        if let window = historyWindowController?.presentationWindow,
-           window.isVisible || showHistoryIfNeeded {
+        if let window = historyWindowController?.presentationWindow, window.isVisible {
             return window
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3560,8 +3560,13 @@ final class MuesliController: NSObject {
                 await MainActor.run {
                     self.setMeetingProcessingStatus("Finalizing")
                 }
+                let recordingSaveDecision = await self.recordingSaveDecision(for: result.title)
                 let persistenceResult = try await MainActor.run {
-                    try self.persistCompletedMeetingResultAndDispatchHook(result, existingMeetingID: liveMeetingID)
+                    try self.persistCompletedMeetingResultAndDispatchHook(
+                        result,
+                        existingMeetingID: liveMeetingID,
+                        recordingSaveDecision: recordingSaveDecision
+                    )
                 }
                 completedMeetingID = persistenceResult.meetingID
                 if let recordingSaveError = persistenceResult.recordingSaveError {
@@ -3634,12 +3639,19 @@ final class MuesliController: NSObject {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
-    func persistCompletedMeetingResult(_ result: MeetingSessionResult, existingMeetingID: Int64? = nil) throws -> CompletedMeetingPersistenceResult {
+    func persistCompletedMeetingResult(
+        _ result: MeetingSessionResult,
+        existingMeetingID: Int64? = nil,
+        recordingSaveDecision: Bool? = nil
+    ) throws -> CompletedMeetingPersistenceResult {
         let meetingID: Int64
         var savedRecordingPath: String?
         var recordingSaveError: MeetingLifecycleError?
         do {
-            savedRecordingPath = try persistMeetingRecordingIfNeeded(for: result)
+            savedRecordingPath = try persistMeetingRecordingIfNeeded(
+                for: result,
+                saveDecision: recordingSaveDecision
+            )
         } catch let error as MeetingLifecycleError {
             recordingSaveError = error
         } catch {
@@ -3712,8 +3724,16 @@ final class MuesliController: NSObject {
         return liveTitle
     }
 
-    func persistCompletedMeetingResultAndDispatchHook(_ result: MeetingSessionResult, existingMeetingID: Int64? = nil) throws -> CompletedMeetingPersistenceResult {
-        let persistenceResult = try persistCompletedMeetingResult(result, existingMeetingID: existingMeetingID)
+    func persistCompletedMeetingResultAndDispatchHook(
+        _ result: MeetingSessionResult,
+        existingMeetingID: Int64? = nil,
+        recordingSaveDecision: Bool? = nil
+    ) throws -> CompletedMeetingPersistenceResult {
+        let persistenceResult = try persistCompletedMeetingResult(
+            result,
+            existingMeetingID: existingMeetingID,
+            recordingSaveDecision: recordingSaveDecision
+        )
         meetingHookDispatcher.dispatchCompletedMeetingHook(
             meetingID: persistenceResult.meetingID,
             completedAt: result.endTime,
@@ -3722,7 +3742,10 @@ final class MuesliController: NSObject {
         return persistenceResult
     }
 
-    private func persistMeetingRecordingIfNeeded(for result: MeetingSessionResult) throws -> String? {
+    private func persistMeetingRecordingIfNeeded(
+        for result: MeetingSessionResult,
+        saveDecision: Bool? = nil
+    ) throws -> String? {
         let shouldSave: Bool
         switch config.meetingRecordingSavePolicy {
         case .never:
@@ -3730,7 +3753,7 @@ final class MuesliController: NSObject {
         case .always:
             shouldSave = true
         case .prompt:
-            shouldSave = promptToSaveMeetingRecording(for: result.title)
+            shouldSave = saveDecision ?? true
         }
 
         guard shouldSave else {
@@ -3806,7 +3829,14 @@ final class MuesliController: NSObject {
         }
     }
 
-    private func promptToSaveMeetingRecording(for title: String) -> Bool {
+    @MainActor
+    private func recordingSaveDecision(for title: String) async -> Bool? {
+        guard config.meetingRecordingSavePolicy == .prompt else { return nil }
+        return await promptToSaveMeetingRecording(for: title)
+    }
+
+    @MainActor
+    private func promptToSaveMeetingRecording(for title: String) async -> Bool {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.messageText = "Save meeting recording?"
@@ -3814,7 +3844,30 @@ final class MuesliController: NSObject {
         alert.alertStyle = .informational
         alert.addButton(withTitle: "Save Recording")
         alert.addButton(withTitle: "Don't Save")
-        return alert.runModal() == .alertFirstButtonReturn
+        guard let window = recordingSavePromptWindow() else {
+            fputs("[muesli-native] no window available for recording save prompt; saving recording by default\n", stderr)
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            alert.beginSheetModal(for: window) { response in
+                continuation.resume(returning: response == .alertFirstButtonReturn)
+            }
+        }
+    }
+
+    @MainActor
+    private func recordingSavePromptWindow() -> NSWindow? {
+        if let window = historyWindowController?.presentationWindow, window.isVisible {
+            return window
+        }
+        historyWindowController?.show()
+        if let window = historyWindowController?.presentationWindow {
+            return window
+        }
+        return NSApp.windows.first { window in
+            window.isVisible && window.canBecomeKey && !(window is NSPanel)
+        }
     }
 
     private func presentErrorAlert(title: String, message: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -261,6 +261,8 @@ final class MuesliController: NSObject {
     private let meetingAutoStopGracePeriod: TimeInterval = 20
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
+    private var isPresentingMeetingTerminationConfirmation = false
+    private var isTerminatingAfterMeetingConfirmation = false
     private var meetingStartTask: Task<Void, Never>?
     private var meetingStartMeetingID: Int64?
     private var importTask: Task<Void, Never>?
@@ -2672,6 +2674,11 @@ final class MuesliController: NSObject {
         let messageText: String
         let informativeText: String
 
+        if isTerminatingAfterMeetingConfirmation {
+            isTerminatingAfterMeetingConfirmation = false
+            return true
+        }
+
         switch state {
         case .none:
             return true
@@ -2686,7 +2693,9 @@ final class MuesliController: NSObject {
             informativeText = "Quitting now will interrupt transcription and the meeting notes may not be saved."
         }
 
-        NSApp.activate(ignoringOtherApps: true)
+        guard !isPresentingMeetingTerminationConfirmation else {
+            return false
+        }
 
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -2695,11 +2704,25 @@ final class MuesliController: NSObject {
         alert.addButton(withTitle: "Keep Muesli Running")
         alert.addButton(withTitle: "Quit Anyway")
 
-        let response = alert.runModal()
-        guard response == .alertSecondButtonReturn else {
-            return false
+        isPresentingMeetingTerminationConfirmation = true
+        let didPresent = presentAlert(alert, fallbackLogContext: "meeting termination confirmation") { [weak self] response in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isPresentingMeetingTerminationConfirmation = false
+                guard response == .alertSecondButtonReturn else { return }
+                self.discardMeetingStateForTermination()
+                self.isTerminatingAfterMeetingConfirmation = true
+                NSApp.terminate(nil)
+            }
+        }
+        if !didPresent {
+            isPresentingMeetingTerminationConfirmation = false
         }
 
+        return false
+    }
+
+    private func discardMeetingStateForTermination() {
         activeMeetingSession?.discard()
         activeMeetingSession = nil
         disarmMeetingAutoStop()
@@ -2716,7 +2739,6 @@ final class MuesliController: NSObject {
         updateMeetingNotificationVisibility()
         endMeetingActivity()
         syncAppState()
-        return true
     }
 
     @objc func toggleMeetingRecording() {
@@ -2883,22 +2905,7 @@ final class MuesliController: NSObject {
                     self.endMeetingActivity()
                     self.syncDictationRecorderWarmup(reason: "meeting-start-failed")
 
-                    let isSystemAudioError = error is CoreAudioSystemRecorder.RecorderError
-                    let alert = NSAlert()
-                    alert.alertStyle = .warning
-                    if isSystemAudioError {
-                        alert.messageText = "System audio capture failed"
-                        alert.informativeText = "Could not start system audio recording. Open System Settings > Privacy & Security > Screen & System Audio Recording and enable \(AppIdentity.displayName) under \"System Audio Recording Only\".\n\nError: \(error.localizedDescription)"
-                        alert.addButton(withTitle: "Open System Settings")
-                        alert.addButton(withTitle: "OK")
-                        if alert.runModal() == .alertFirstButtonReturn {
-                            CoreAudioSystemRecorder.openSystemAudioSettings()
-                        }
-                    } else {
-                        alert.messageText = "Meeting failed to start"
-                        alert.informativeText = error.localizedDescription
-                        alert.runModal()
-                    }
+                    self.presentMeetingStartFailureAlert(error: error)
                 }
             }
             self.finishMeetingStartAttempt(meetingID: meetingID)
@@ -3844,7 +3851,7 @@ final class MuesliController: NSObject {
         alert.alertStyle = .informational
         alert.addButton(withTitle: "Save Recording")
         alert.addButton(withTitle: "Don't Save")
-        guard let window = recordingSavePromptWindow() else {
+        guard let window = alertPresentationWindow(showHistoryIfNeeded: true) else {
             fputs("[muesli-native] no window available for recording save prompt; saving recording by default\n", stderr)
             return true
         }
@@ -3857,27 +3864,79 @@ final class MuesliController: NSObject {
     }
 
     @MainActor
-    private func recordingSavePromptWindow() -> NSWindow? {
+    private func alertPresentationWindow(showHistoryIfNeeded: Bool = true) -> NSWindow? {
         if let window = historyWindowController?.presentationWindow, window.isVisible {
             return window
         }
-        historyWindowController?.show()
-        if let window = historyWindowController?.presentationWindow {
+
+        if showHistoryIfNeeded {
+            historyWindowController?.show()
+        }
+
+        if let window = historyWindowController?.presentationWindow,
+           window.isVisible || showHistoryIfNeeded {
             return window
         }
+
         return NSApp.windows.first { window in
             window.isVisible && window.canBecomeKey && !(window is NSPanel)
+        } ?? NSApp.windows.first { window in
+            window.isVisible && window.canBecomeKey
+        }
+    }
+
+    @discardableResult
+    private func presentAlert(
+        _ alert: NSAlert,
+        fallbackLogContext: String,
+        completion: ((NSApplication.ModalResponse) -> Void)? = nil
+    ) -> Bool {
+        NSApp.activate(ignoringOtherApps: true)
+        guard let window = alertPresentationWindow(showHistoryIfNeeded: true) else {
+            fputs(
+                "[muesli-native] unable to present \(fallbackLogContext) alert: \(alert.messageText) - \(alert.informativeText)\n",
+                stderr
+            )
+            statusBarController?.setStatus(alert.messageText)
+            statusBarController?.refresh()
+            NSSound.beep()
+            return false
+        }
+
+        alert.beginSheetModal(for: window) { response in
+            completion?(response)
+        }
+        return true
+    }
+
+    private func presentMeetingStartFailureAlert(error: Error) {
+        let isSystemAudioError = error is CoreAudioSystemRecorder.RecorderError
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        if isSystemAudioError {
+            alert.messageText = "System audio capture failed"
+            alert.informativeText = "Could not start system audio recording. Open System Settings > Privacy & Security > Screen & System Audio Recording and enable \(AppIdentity.displayName) under \"System Audio Recording Only\".\n\nError: \(error.localizedDescription)"
+            alert.addButton(withTitle: "Open System Settings")
+            alert.addButton(withTitle: "OK")
+        } else {
+            alert.messageText = "Meeting failed to start"
+            alert.informativeText = error.localizedDescription
+            alert.addButton(withTitle: "OK")
+        }
+
+        presentAlert(alert, fallbackLogContext: "meeting start failure") { response in
+            guard isSystemAudioError, response == .alertFirstButtonReturn else { return }
+            CoreAudioSystemRecorder.openSystemAudioSettings()
         }
     }
 
     private func presentErrorAlert(title: String, message: String) {
-        NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
         alert.addButton(withTitle: "OK")
-        alert.runModal()
+        presentAlert(alert, fallbackLogContext: title)
     }
 
     func copyToClipboard(_ text: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -10,6 +10,10 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private var keyMonitor: Any?
 
+    var presentationWindow: NSWindow? {
+        window
+    }
+
     init(store: DictationStore, controller: MuesliController) {
         self.store = store
         self.controller = controller

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -460,6 +460,87 @@ struct MeetingsNavigationTests {
         #expect(FileManager.default.fileExists(atPath: retainedRecordingURL.path) == false)
     }
 
+    @Test("persistCompletedMeetingResult honors explicit recording save decision after policy drift")
+    func persistCompletedMeetingResultHonorsExplicitRecordingSaveDecisionAfterPolicyDrift() async throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        controller.updateConfig { $0.meetingRecordingSavePolicy = .never }
+
+        let retainedRecordingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retained-policy-drift-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        try Data("recording".utf8).write(to: retainedRecordingURL)
+
+        let result = MeetingSessionResult(
+            title: "Policy Drift",
+            originalTitle: "Meeting",
+            calendarEventID: nil,
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(30),
+            durationSeconds: 30,
+            rawTranscript: "Policy drift transcript.",
+            formattedNotes: "## Summary\nPolicy drift notes.",
+            retainedRecordingURL: retainedRecordingURL,
+            retainedRecordingError: nil,
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+
+        let persistenceResult = try controller.persistCompletedMeetingResult(
+            result,
+            recordingSaveDecision: true
+        )
+
+        let storedMeeting = try #require(try store.meeting(id: persistenceResult.meetingID))
+        let savedRecordingPath = try #require(storedMeeting.savedRecordingPath)
+        #expect(FileManager.default.fileExists(atPath: savedRecordingPath))
+        #expect(FileManager.default.fileExists(atPath: retainedRecordingURL.path) == false)
+    }
+
+    @Test("persistCompletedMeetingResult surfaces prompt policy retained recording failures")
+    func persistCompletedMeetingResultSurfacesPromptPolicyRetainedRecordingFailures() async throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        controller.updateConfig { $0.meetingRecordingSavePolicy = .prompt }
+
+        let result = MeetingSessionResult(
+            title: "Failed Retention",
+            originalTitle: "Meeting",
+            calendarEventID: nil,
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(30),
+            durationSeconds: 30,
+            rawTranscript: "Retention failure transcript.",
+            formattedNotes: "## Summary\nRetention failure notes.",
+            retainedRecordingURL: nil,
+            retainedRecordingError: CocoaError(.fileWriteUnknown),
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+
+        let persistenceResult = try controller.persistCompletedMeetingResult(result)
+
+        let storedMeeting = try #require(try store.meeting(id: persistenceResult.meetingID))
+        #expect(storedMeeting.savedRecordingPath == nil)
+        #expect(persistenceResult.recordingSaveError != nil)
+    }
+
     @Test("persistCompletedMeetingResult preserves user-edited live meeting title")
     func persistCompletedMeetingResultPreservesEditedLiveTitle() async throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -505,8 +505,8 @@ struct MeetingsNavigationTests {
         #expect(FileManager.default.fileExists(atPath: retainedRecordingURL.path) == false)
     }
 
-    @Test("persistCompletedMeetingResult skips prompt policy retained recording failures without decision")
-    func persistCompletedMeetingResultSkipsPromptPolicyRetainedRecordingFailuresWithoutDecision() async throws {
+    @Test("persistCompletedMeetingResult surfaces prompt policy retained recording failures without decision")
+    func persistCompletedMeetingResultSurfacesPromptPolicyRetainedRecordingFailuresWithoutDecision() async throws {
         let store = try makeStore()
         let controller = MuesliController(
             runtime: RuntimePaths(
@@ -538,7 +538,7 @@ struct MeetingsNavigationTests {
 
         let storedMeeting = try #require(try store.meeting(id: persistenceResult.meetingID))
         #expect(storedMeeting.savedRecordingPath == nil)
-        #expect(persistenceResult.recordingSaveError == nil)
+        #expect(persistenceResult.recordingSaveError != nil)
     }
 
     @Test("persistCompletedMeetingResult surfaces retained recording failures after explicit save decision")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -505,8 +505,8 @@ struct MeetingsNavigationTests {
         #expect(FileManager.default.fileExists(atPath: retainedRecordingURL.path) == false)
     }
 
-    @Test("persistCompletedMeetingResult surfaces prompt policy retained recording failures")
-    func persistCompletedMeetingResultSurfacesPromptPolicyRetainedRecordingFailures() async throws {
+    @Test("persistCompletedMeetingResult skips prompt policy retained recording failures without decision")
+    func persistCompletedMeetingResultSkipsPromptPolicyRetainedRecordingFailuresWithoutDecision() async throws {
         let store = try makeStore()
         let controller = MuesliController(
             runtime: RuntimePaths(
@@ -535,6 +535,45 @@ struct MeetingsNavigationTests {
         )
 
         let persistenceResult = try controller.persistCompletedMeetingResult(result)
+
+        let storedMeeting = try #require(try store.meeting(id: persistenceResult.meetingID))
+        #expect(storedMeeting.savedRecordingPath == nil)
+        #expect(persistenceResult.recordingSaveError == nil)
+    }
+
+    @Test("persistCompletedMeetingResult surfaces retained recording failures after explicit save decision")
+    func persistCompletedMeetingResultSurfacesRetainedRecordingFailuresAfterExplicitSaveDecision() async throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        controller.updateConfig { $0.meetingRecordingSavePolicy = .prompt }
+
+        let result = MeetingSessionResult(
+            title: "Explicit Save Failed Retention",
+            originalTitle: "Meeting",
+            calendarEventID: nil,
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(30),
+            durationSeconds: 30,
+            rawTranscript: "Explicit save retention failure transcript.",
+            formattedNotes: "## Summary\nExplicit save retention failure notes.",
+            retainedRecordingURL: nil,
+            retainedRecordingError: CocoaError(.fileWriteUnknown),
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+
+        let persistenceResult = try controller.persistCompletedMeetingResult(
+            result,
+            recordingSaveDecision: true
+        )
 
         let storedMeeting = try #require(try store.meeting(id: persistenceResult.meetingID))
         #expect(storedMeeting.savedRecordingPath == nil)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -415,6 +415,51 @@ struct MeetingsNavigationTests {
         #expect(storedMeeting?.savedRecordingPath == nil)
     }
 
+    @Test("persistCompletedMeetingResult honors prompt recording save decision")
+    func persistCompletedMeetingResultHonorsPromptRecordingSaveDecision() async throws {
+        let store = try makeStore()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        controller.updateConfig { $0.meetingRecordingSavePolicy = .prompt }
+
+        let retainedRecordingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retained-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        try Data("recording".utf8).write(to: retainedRecordingURL)
+
+        let result = MeetingSessionResult(
+            title: "Prompt Decision",
+            originalTitle: "Meeting",
+            calendarEventID: nil,
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(30),
+            durationSeconds: 30,
+            rawTranscript: "Prompt decision transcript.",
+            formattedNotes: "## Summary\nPrompt decision notes.",
+            retainedRecordingURL: retainedRecordingURL,
+            retainedRecordingError: nil,
+            systemRecordingURL: nil,
+            templateSnapshot: MeetingTemplates.auto.snapshot
+        )
+
+        let persistenceResult = try controller.persistCompletedMeetingResult(
+            result,
+            recordingSaveDecision: false
+        )
+
+        let storedMeeting = try store.meeting(id: persistenceResult.meetingID)
+        #expect(storedMeeting?.rawTranscript == "Prompt decision transcript.")
+        #expect(storedMeeting?.savedRecordingPath == nil)
+        #expect(FileManager.default.fileExists(atPath: retainedRecordingURL.path) == false)
+    }
+
     @Test("persistCompletedMeetingResult preserves user-edited live meeting title")
     func persistCompletedMeetingResultPreservesEditedLiveTitle() async throws {
         let store = try makeStore()

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+PACKAGE_DIR="$ROOT/native/MuesliNative"
+SWIFTPM_SCRATCH_PATH="${MUESLI_SWIFTPM_SCRATCH_PATH:-$HOME/Library/Caches/muesli-spm/alpha}"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 APP_DIR="/Applications/MuesliCanary.app"
@@ -115,12 +117,15 @@ mkdir -p "$OUTPUT_DIR"
 
 # --- Step 1: Run tests ---
 echo "[1/10] Running tests..."
-swift test --package-path "$ROOT/native/MuesliNative"
+mkdir -p "$SWIFTPM_SCRATCH_PATH"
+echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
+swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/10] Building and signing (version: ${VERSION})..."
 echo "y" | MUESLI_BUILD_VERSION="$VERSION" \
+  MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
   MUESLI_APP_NAME=MuesliCanary \
   MUESLI_BUNDLE_ID=com.muesli.canary \
   MUESLI_DISPLAY_NAME=MuesliCanary \

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -132,10 +132,6 @@ echo "[1/11] Running tests..."
 mkdir -p "$SWIFTPM_SCRATCH_PATH"
 echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
 swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
-if [[ ! -x "$GENERATE_APPCAST" ]]; then
-  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
-  exit 1
-fi
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
@@ -154,6 +150,10 @@ MUESLI_INSTALL_DIR="$INSTALL_DIR" \
   MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY" \
   "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
+if [[ ! -x "$GENERATE_APPCAST" ]]; then
+  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
+  exit 1
+fi
 
 FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')
 echo "  Signature: $FLAGS"

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+PACKAGE_DIR="$ROOT/native/MuesliNative"
+SWIFTPM_SCRATCH_PATH="${MUESLI_SWIFTPM_SCRATCH_PATH:-$HOME/Library/Caches/muesli-spm/preprod}"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 APP_NAME="MuesliPreprod"
@@ -30,7 +32,7 @@ OUTPUT_DIR="$ROOT/dist-preprod"
 INSTALL_DIR="$OUTPUT_DIR/install-root"
 APP_DIR="$INSTALL_DIR/${APP_NAME}.app"
 APPCAST_PATH="$ROOT/docs/appcast-preprod.xml"
-GENERATE_APPCAST="$ROOT/native/MuesliNative/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+GENERATE_APPCAST="$SWIFTPM_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 VERIFY_DIR=""
 HOSTED_MOUNT_POINT=""
@@ -85,11 +87,6 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-if [[ ! -x "$GENERATE_APPCAST" ]]; then
-  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
-  exit 1
-fi
-
 if [[ ! -f "$UPDATE_APPCAST_RELEASE_NOTES" ]]; then
   echo "ERROR: update_appcast_release_notes.py not found at $UPDATE_APPCAST_RELEASE_NOTES" >&2
   exit 1
@@ -132,12 +129,19 @@ mkdir -p "$INSTALL_DIR"
 
 # --- Step 1: Run tests ---
 echo "[1/11] Running tests..."
-swift test --package-path "$ROOT/native/MuesliNative"
+mkdir -p "$SWIFTPM_SCRATCH_PATH"
+echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
+swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
+if [[ ! -x "$GENERATE_APPCAST" ]]; then
+  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
+  exit 1
+fi
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/11] Building and signing..."
 MUESLI_INSTALL_DIR="$INSTALL_DIR" \
+  MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
   MUESLI_BUILD_VERSION="$VERSION" \
   MUESLI_BUNDLE_VERSION="$SPARKLE_BUILD_VERSION" \
   MUESLI_SHORT_VERSION="$VERSION" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -151,10 +151,6 @@ echo "[1/13] Running tests..."
 mkdir -p "$SWIFTPM_SCRATCH_PATH"
 echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
 swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
-if [[ ! -x "$GENERATE_APPCAST" ]]; then
-  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
-  exit 1
-fi
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
@@ -165,6 +161,10 @@ echo "y" | MUESLI_INSTALL_DIR="$INSTALL_DIR" \
   MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
   "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
 echo "  Installed to $APP_DIR"
+if [[ ! -x "$GENERATE_APPCAST" ]]; then
+  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
+  exit 1
+fi
 
 # Verify signature
 FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,12 +30,14 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+PACKAGE_DIR="$ROOT/native/MuesliNative"
+SWIFTPM_SCRATCH_PATH="${MUESLI_SWIFTPM_SCRATCH_PATH:-$HOME/Library/Caches/muesli-spm/release}"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 OUTPUT_DIR="$ROOT/dist-release"
 INSTALL_DIR="${MUESLI_RELEASE_INSTALL_DIR:-$OUTPUT_DIR/install-root}"
 APP_DIR="${MUESLI_RELEASE_APP_DIR:-$INSTALL_DIR/Muesli.app}"
-GENERATE_APPCAST="$ROOT/native/MuesliNative/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+GENERATE_APPCAST="$SWIFTPM_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 TAP_REPO="${MUESLI_TAP_REPO:-pHequals7/homebrew-muesli}"
 TAP_CASK_REL_PATH="${MUESLI_TAP_CASK_REL_PATH:-Casks/m/muesli.rb}"
@@ -83,11 +85,6 @@ fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "ERROR: Working tree must be clean before running the release pipeline." >&2
-  exit 1
-fi
-
-if [[ ! -x "$GENERATE_APPCAST" ]]; then
-  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
   exit 1
 fi
 
@@ -151,14 +148,22 @@ sed -i '' "s/^DEFAULT_APP_VERSION=.*/DEFAULT_APP_VERSION=\"${VERSION}\"/" "$ROOT
 
 # --- Step 1: Run tests ---
 echo "[1/13] Running tests..."
-swift test --package-path "$ROOT/native/MuesliNative"
+mkdir -p "$SWIFTPM_SCRATCH_PATH"
+echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
+swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
+if [[ ! -x "$GENERATE_APPCAST" ]]; then
+  echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2
+  exit 1
+fi
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/13] Building and signing..."
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
-echo "y" | MUESLI_INSTALL_DIR="$INSTALL_DIR" "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
+echo "y" | MUESLI_INSTALL_DIR="$INSTALL_DIR" \
+  MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
+  "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
 echo "  Installed to $APP_DIR"
 
 # Verify signature


### PR DESCRIPTION
## Summary

- Replaces the blocking meeting recording save prompt during finalization with an async sheet attached to a visible app window.
- Converts the high-risk meeting lifecycle alerts in `MuesliController` to visible sheets with safe fallback behavior: quit while meeting active, meeting start system-audio failure, generic meeting start failure, and shared meeting error alerts.
- Passes the recording save decision into meeting persistence so finalization does not call a hidden `NSAlert.runModal()`.
- Hardens review edge cases: explicit prompt decisions survive settings drift, retention failures surface instead of being hidden by the prompt, quit does not silently block if no sheet host exists, and appcast checks run after release builds materialize the Sparkle artifact.
- Adds coverage for declining a prompt-based retained recording save, preserving explicit save decisions after policy drift, and surfacing retained-recording failures under prompt policy.
- Updates release scripts to use the shared SwiftPM scratch path convention for release builds.

## Root Cause

When meeting recording save policy was set to prompt, finalization called `NSAlert.runModal()` from the meeting persistence path. In some flows the modal was hidden or inaccessible while still blocking the main thread, leaving Muesli stuck at `Finalizing`. The same hidden-modal class of bug was still possible in other meeting lifecycle alerts, so this PR moves those paths to non-blocking sheets as well.

## Validation

- `git diff --check origin/main`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/dev-c403-zoom-audio" --filter MeetingsNavigationTests`
- Rebuilt and launched `/Applications/MuesliDev.app` with `MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev-c403-zoom-audio" ./scripts/dev-test.sh`

## Notes

Zoom/CoreAudio and dictation latency experiments were intentionally removed from this PR scope and preserved separately in local backup state.