### PR TITLE
[codex] Fix dictation audio route capture

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -51,6 +51,17 @@ protocol DictationAudioRecording: AnyObject {
 extension MicrophoneRecorder: DictationAudioRecording {}
 
 final class DictationAudioSessionManager: @unchecked Sendable {
+    private enum StartupError: LocalizedError {
+        case noAudioBuffer
+
+        var errorDescription: String? {
+            switch self {
+            case .noAudioBuffer:
+                return "Microphone capture did not deliver audio."
+            }
+        }
+    }
+
     private struct RouteSnapshot {
         let routeKind: AudioOutputRouteKind
         let preferredInputDeviceID: AudioObjectID?
@@ -144,6 +155,11 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
             self.recorder.keepsAudioGraphWarm = true
+            guard self.routeSnapshot.routeKind != .headphoneLike else {
+                self.emitLatency("activation_deferred:\(source)")
+                fputs("[dictation-session] armed without warm activation source=\(source) \(self.routeSnapshot.debugDescription)\n", stderr)
+                return
+            }
             do {
                 self.emitLatency("activation_begin:\(source)")
                 try self.recorder.activateWarmEngine(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
@@ -429,6 +445,15 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         queue.async { [self] in
             guard let sessionID = self.stateStorage.sessionID else { return }
             self.emitLatency("no_audio_timeout", at: at)
+            switch self.stateStorage {
+            case .armed(sessionID), .acquiringAudio(sessionID):
+                self.recorder.keepsAudioGraphWarm = false
+                self.recorder.cancel()
+                self.failCurrentSession(error: StartupError.noAudioBuffer)
+                return
+            default:
+                break
+            }
             self.emit(.noAudioTimeout(sessionID, at: at))
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -26,7 +26,7 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     }
 
     func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind) {
-        queue.async { [self] in
+        queue.sync { [self] in
             guard enabled else { return }
             guard !pausedForSession else { return }
             guard routeKind == .speakerLike else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -1,461 +1,328 @@
 @preconcurrency import AVFoundation
 import CoreAudio
 import Foundation
-import os
 
-final class MicrophoneRecorder: @unchecked Sendable {
+final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Sendable {
     var preferredInputDeviceID: AudioObjectID?
     var keepsAudioGraphWarm = false
     var onFirstCapturedAudioBuffer: ((Date) -> Void)?
     var onFirstSpeechDetected: ((Date) -> Void)?
     var onNoAudioTimeout: ((Date) -> Void)?
 
-    private struct FileState {
-        var fileHandle: FileHandle?
-        var fileURL: URL?
-        var bytesWritten: Int = 0
-        var latestPowerDB: Float = -160
-        var isPaused = false
-        var isCapturing = false
-        var hasReceivedFirstAudioBuffer = false
-        var hasDetectedSpeech = false
-        var hasReportedNoAudioTimeout = false
-    }
-
     private static let sampleRate: Double = 16_000
-    private static let bufferSize: AVAudioFrameCount = 640
     private static let speechThresholdDB: Float = -58
     private static let noAudioTimeout: TimeInterval = 1.5
+    private static let firstBufferDelay: TimeInterval = 0.05
+    private static let meterInterval: TimeInterval = 0.08
 
-    private let engine = AVAudioEngine()
-    private let lock = OSAllocatedUnfairLock(initialState: FileState())
-    private let lifecycleLock = NSRecursiveLock()
-    private let writerQueue = DispatchQueue(label: "com.muesli.microphone-recorder-writer")
-    private let timeoutQueue = DispatchQueue(label: "com.muesli.microphone-recorder-timeout")
-    private let tapCallbackGroup = DispatchGroup()
-    private var isPrepared = false
-    private var isRunning = false
-    private var isGraphPrepared = false
-    private var tapInstalled = false
-    private var preparedInputDeviceID: AudioObjectID?
+    private let lock = NSRecursiveLock()
+    private let callbackQueue = DispatchQueue(label: "com.muesli.microphone-recorder-callbacks")
+    private var recorder: AVAudioRecorder?
+    private var preparedURL: URL?
+    private var activeInputOverride: DefaultInputOverride?
+    private var firstBufferWorkItem: DispatchWorkItem?
     private var noAudioTimeoutWorkItem: DispatchWorkItem?
+    private var meterWorkItem: DispatchWorkItem?
+    private var isRecording = false
+    private var hasReceivedFirstAudioBuffer = false
+    private var hasDetectedSpeech = false
+    private var hasReportedNoAudioTimeout = false
 
     func prepare() throws {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
 
-        guard !isPrepared else { return }
-        try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
+        guard recorder == nil else { return }
+        try applyPreferredInputIfNeeded()
 
-        let fileState = try createNewFile()
-        lock.withLock { $0 = fileState }
-        isPrepared = true
-    }
-
-    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        self.preferredInputDeviceID = preferredInputDeviceID
-        guard !isPrepared && !isRunning else {
-            fputs("[mic-recorder] warmup deferred while capture is active\n", stderr)
-            return
-        }
-        try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
-    }
-
-    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        self.preferredInputDeviceID = preferredInputDeviceID
-        guard !isPrepared && !isRunning else {
-            fputs("[mic-recorder] activation deferred while capture is active\n", stderr)
-            return
-        }
-        if engine.isRunning, preparedInputDeviceID != preferredInputDeviceID {
-            fputs(
-                "[mic-recorder] rebuilding warm engine for preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n",
-                stderr
-            )
-            stopWarmGraphLocked()
-        }
-        try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
-        guard !engine.isRunning else { return }
-        lock.withLock { state in
-            state.isCapturing = false
-            state.isPaused = false
-            state.latestPowerDB = -160
-            state.hasReceivedFirstAudioBuffer = false
-        }
-        do {
-            try engine.start()
-        } catch {
-            stopWarmGraphLocked()
-            throw error
-        }
-        fputs(
-            "[mic-recorder] warm engine activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n",
-            stderr
-        )
-    }
-
-    func coolDown() {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        guard !isPrepared && !isRunning else { return }
-        stopWarmGraphLocked()
-    }
-
-    private func ensurePreparedGraphLocked(preferredInputDeviceID: AudioObjectID?) throws {
-        if isGraphPrepared, preparedInputDeviceID == preferredInputDeviceID {
-            return
-        }
-        if isRunning {
-            return
-        }
-
-        stopWarmGraphLocked()
-
-        AudioInputDeviceSelection.applyPreferredInputDeviceID(
-            preferredInputDeviceID,
-            to: engine,
-            logPrefix: "mic-recorder"
-        )
-
-        let inputNode = engine.inputNode
-        let hwFormat = inputNode.outputFormat(forBus: 0)
-        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
-            throw NSError(domain: "MicrophoneRecorder", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "No audio input available",
-            ])
-        }
-
-        guard let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Self.sampleRate,
-            channels: 1,
-            interleaved: false
-        ) else {
-            throw NSError(domain: "MicrophoneRecorder", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "Could not create target audio format",
-            ])
-        }
-
-        let needsConversion = hwFormat.sampleRate != Self.sampleRate || hwFormat.channelCount != 1
-        let converter = needsConversion ? AVAudioConverter(from: hwFormat, to: targetFormat) : nil
-
-        fputs(
-            "[mic-recorder] preparing graph preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default") hwRate=\(Int(hwFormat.sampleRate)) channels=\(hwFormat.channelCount)\n",
-            stderr
-        )
-        inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
-            self?.handleAudioBuffer(buffer, converter: converter, targetFormat: targetFormat)
-        }
-        tapInstalled = true
-        engine.prepare()
-        isGraphPrepared = true
-        preparedInputDeviceID = preferredInputDeviceID
-    }
-
-    func start() throws {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        guard !isRunning else { return }
-        try prepare()
-
-        do {
-            // The preferred input can refresh between prepare/warmup and start
-            // after a route change, so keep this re-check on the start path.
-            try ensurePreparedGraphLocked(preferredInputDeviceID: preferredInputDeviceID)
-            if !engine.isRunning {
-                lock.withLock { state in
-                    state.isCapturing = true
-                    state.isPaused = false
-                    state.latestPowerDB = -160
-                    state.hasReceivedFirstAudioBuffer = false
-                    state.hasDetectedSpeech = false
-                    state.hasReportedNoAudioTimeout = false
-                }
-                try engine.start()
-            } else {
-                lock.withLock { state in
-                    state.isCapturing = true
-                    state.isPaused = false
-                    state.latestPowerDB = -160
-                    state.hasReceivedFirstAudioBuffer = false
-                    state.hasDetectedSpeech = false
-                    state.hasReportedNoAudioTimeout = false
-                }
-            }
-            isRunning = true
-            scheduleNoAudioTimeout()
-        } catch {
-            isRunning = false
-            lock.withLock { state in
-                state.isCapturing = false
-                state.latestPowerDB = -160
-            }
-            cancelNoAudioTimeout()
-            stopWarmGraphLocked()
-            throw error
-        }
-    }
-
-    func stop() -> URL? {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        guard isPrepared else { return nil }
-        isRunning = false
-        cancelNoAudioTimeout()
-
-        let finalState = lock.withLock { state -> FileState in
-            let old = state
-            state = FileState()
-            return old
-        }
-        isPrepared = false
-        engine.stop()
-        // AVAudioEngine.stop() must happen before waiting here: after it returns,
-        // CoreAudio will not enter new tap callbacks, so this wait only drains
-        // callbacks that already reached the dispatch group.
-        if tapCallbackGroup.wait(timeout: .now() + 2.0) == .timedOut {
-            fputs("[audio-recorder] timed out waiting for tap callbacks during stop\n", stderr)
-        }
-        waitForPendingWrites()
-        if keepsAudioGraphWarm {
-            lock.withLock { $0.latestPowerDB = -160 }
-        } else {
-            stopWarmGraphLocked()
-        }
-
-        return finalizeFile(finalState)
-    }
-
-    func pause() {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        guard isPrepared else { return }
-        lock.withLock { state in
-            state.isPaused = true
-            state.latestPowerDB = -160
-        }
-    }
-
-    func resume() {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        guard isPrepared else { return }
-        lock.withLock { state in
-            state.isPaused = false
-        }
-    }
-
-    func currentPower() -> Float {
-        lock.withLock { $0.latestPowerDB }
-    }
-
-    func cancel() {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
-        isRunning = false
-        isPrepared = false
-        cancelNoAudioTimeout()
-
-        let state = lock.withLock { state -> FileState in
-            let old = state
-            state = FileState()
-            return old
-        }
-        engine.stop()
-        // See stop(): engine.stop() closes the door on new tap callbacks before
-        // we wait for callbacks that were already in flight.
-        if tapCallbackGroup.wait(timeout: .now() + 2.0) == .timedOut {
-            fputs("[audio-recorder] timed out waiting for tap callbacks during cancel\n", stderr)
-        }
-        waitForPendingWrites()
-        state.fileHandle?.closeFile()
-        if let url = state.fileURL {
-            try? FileManager.default.removeItem(at: url)
-        }
-        if keepsAudioGraphWarm {
-            lock.withLock { $0.latestPowerDB = -160 }
-        } else {
-            stopWarmGraphLocked()
-        }
-    }
-
-    private func handleAudioBuffer(
-        _ buffer: AVAudioPCMBuffer,
-        converter: AVAudioConverter?,
-        targetFormat: AVAudioFormat
-    ) {
-        let capturedAt = Date()
-        tapCallbackGroup.enter()
-        defer { tapCallbackGroup.leave() }
-
-        let shouldCapture = lock.withLock { state -> Bool in
-            guard state.isCapturing, !state.isPaused else {
-                state.latestPowerDB = -160
-                return false
-            }
-            return true
-        }
-        guard shouldCapture else { return }
-
-        let monoBuffer: AVAudioPCMBuffer
-        if let converter {
-            let frameCapacity = max(
-                1,
-                AVAudioFrameCount(Double(buffer.frameLength) * Self.sampleRate / buffer.format.sampleRate)
-            )
-            guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else {
-                return
-            }
-            var error: NSError?
-            var didProvideInput = false
-            let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
-                guard !didProvideInput else {
-                    outStatus.pointee = .noDataNow
-                    return nil
-                }
-                didProvideInput = true
-                outStatus.pointee = .haveData
-                return buffer
-            }
-            converter.convert(to: converted, error: &error, withInputFrom: inputBlock)
-            guard error == nil else { return }
-            monoBuffer = converted
-        } else {
-            monoBuffer = buffer
-        }
-
-        guard let floatData = monoBuffer.floatChannelData?[0] else { return }
-        let frameCount = Int(monoBuffer.frameLength)
-        guard frameCount > 0 else { return }
-
-        var sumSquares: Float = 0
-        var pcmData = Data(count: frameCount * MemoryLayout<Int16>.size)
-        pcmData.withUnsafeMutableBytes { rawBuffer in
-            guard let output = rawBuffer.bindMemory(to: Int16.self).baseAddress else { return }
-            for i in 0..<frameCount {
-                let sample = floatData[i]
-                let clamped = max(-1.0, min(1.0, sample))
-                output[i] = Int16(clamped * 32767)
-                sumSquares += sample * sample
-            }
-        }
-
-        let rms = sqrt(sumSquares / Float(frameCount))
-        let rawDB = rms > 0.000_001 ? 20 * log10(rms) : -160
-        let powerDB = max(-160, min(0, rawDB))
-        let pcmByteCount = pcmData.count
-        let dataToWrite = pcmData
-
-        let writeTarget = lock.withLock { state -> (FileHandle?, Bool, Bool) in
-            guard state.isCapturing, !state.isPaused else {
-                state.latestPowerDB = -160
-                return (nil, false, false)
-            }
-            let shouldNotifyFirstBuffer = !state.hasReceivedFirstAudioBuffer
-            if !state.hasReceivedFirstAudioBuffer {
-                state.hasReceivedFirstAudioBuffer = true
-            }
-            let shouldNotifySpeech = !state.hasDetectedSpeech && powerDB >= Self.speechThresholdDB
-            if shouldNotifySpeech {
-                state.hasDetectedSpeech = true
-            }
-            state.bytesWritten += pcmByteCount
-            state.latestPowerDB = powerDB
-            return (state.fileHandle, shouldNotifyFirstBuffer, shouldNotifySpeech)
-        }
-        if let handle = writeTarget.0 {
-            writerQueue.async { [dataToWrite] in
-                handle.write(dataToWrite)
-            }
-        }
-        if writeTarget.1 {
-            onFirstCapturedAudioBuffer?(capturedAt)
-        }
-        if writeTarget.2 {
-            onFirstSpeechDetected?(capturedAt)
-        }
-    }
-
-    private func createNewFile() throws -> FileState {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-native", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let url = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
-        FileManager.default.createFile(atPath: url.path, contents: nil)
-        guard let handle = FileHandle(forWritingAtPath: url.path) else {
-            throw NSError(domain: "MicrophoneRecorder", code: 3, userInfo: [
-                NSLocalizedDescriptionKey: "Could not open file for writing",
-            ])
-        }
-        handle.write(WavWriter.header(dataSize: 0))
-        return FileState(fileHandle: handle, fileURL: url)
+        let fileURL = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: Self.sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+        let nextRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
+        nextRecorder.delegate = self
+        nextRecorder.isMeteringEnabled = true
+        nextRecorder.prepareToRecord()
+        preparedURL = fileURL
+        recorder = nextRecorder
     }
 
-    private func finalizeFile(_ state: FileState) -> URL? {
-        guard let handle = state.fileHandle, let url = state.fileURL else { return nil }
-        handle.seek(toFileOffset: 0)
-        handle.write(WavWriter.header(dataSize: UInt32(state.bytesWritten)))
-        handle.closeFile()
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
+        lock.lock()
+        defer { lock.unlock() }
 
-        if state.bytesWritten == 0 {
-            try? FileManager.default.removeItem(at: url)
+        self.preferredInputDeviceID = preferredInputDeviceID
+        guard recorder == nil, !isRecording else { return }
+        try prepare()
+        fputs("[mic-recorder] avrecorder warmed preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
+    }
+
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        self.preferredInputDeviceID = preferredInputDeviceID
+        guard recorder == nil, !isRecording else { return }
+        try prepare()
+        fputs("[mic-recorder] avrecorder activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
+    }
+
+    func coolDown() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !isRecording else { return }
+        cleanupPreparedRecording(removeFile: true)
+        restorePreferredInputIfNeeded()
+    }
+
+    func start() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !isRecording else { return }
+        try prepare()
+        guard let recorder else {
+            throw NSError(domain: "MicrophoneRecorder", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "No audio recorder available",
+            ])
+        }
+        resetCaptureState()
+        guard recorder.record() else {
+            throw NSError(domain: "MicrophoneRecorder", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Microphone recorder failed to start",
+            ])
+        }
+        isRecording = true
+        scheduleFirstBufferNotification()
+        scheduleMeterPoll()
+        scheduleNoAudioTimeout()
+    }
+
+    func stop() -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let recorder else {
+            restorePreferredInputIfNeeded()
             return nil
         }
+        cancelTimers()
+        isRecording = false
+        recorder.stop()
+        let url = preparedURL
+        self.recorder = nil
+        preparedURL = nil
+        restorePreferredInputIfNeeded()
         return url
     }
 
-    private func waitForPendingWrites() {
-        writerQueue.sync {}
+    func pause() {
+        lock.lock()
+        defer { lock.unlock() }
+        recorder?.pause()
+    }
+
+    func resume() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard isRecording else { return }
+        recorder?.record()
+    }
+
+    func currentPower() -> Float {
+        lock.lock()
+        defer { lock.unlock() }
+        recorder?.updateMeters()
+        return recorder?.averagePower(forChannel: 0) ?? -160
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        cancelTimers()
+        isRecording = false
+        cleanupPreparedRecording(removeFile: true)
+        restorePreferredInputIfNeeded()
+    }
+
+    private func applyPreferredInputIfNeeded() throws {
+        guard let preferredInputDeviceID else { return }
+        if activeInputOverride?.preferredDeviceID == preferredInputDeviceID { return }
+        restorePreferredInputIfNeeded()
+        activeInputOverride = try DefaultInputOverride(preferredDeviceID: preferredInputDeviceID)
+    }
+
+    private func restorePreferredInputIfNeeded() {
+        activeInputOverride?.restore()
+        activeInputOverride = nil
+    }
+
+    private func cleanupPreparedRecording(removeFile: Bool) {
+        recorder?.stop()
+        recorder = nil
+        if removeFile, let preparedURL {
+            try? FileManager.default.removeItem(at: preparedURL)
+        }
+        preparedURL = nil
+    }
+
+    private func resetCaptureState() {
+        hasReceivedFirstAudioBuffer = false
+        hasDetectedSpeech = false
+        hasReportedNoAudioTimeout = false
+    }
+
+    private func scheduleFirstBufferNotification() {
+        firstBufferWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.notifyFirstBufferIfNeeded()
+        }
+        firstBufferWorkItem = workItem
+        callbackQueue.asyncAfter(deadline: .now() + Self.firstBufferDelay, execute: workItem)
+    }
+
+    private func notifyFirstBufferIfNeeded() {
+        lock.lock()
+        guard isRecording, !hasReceivedFirstAudioBuffer else {
+            lock.unlock()
+            return
+        }
+        hasReceivedFirstAudioBuffer = true
+        lock.unlock()
+        onFirstCapturedAudioBuffer?(Date())
+    }
+
+    private func scheduleMeterPoll() {
+        meterWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pollMeter()
+        }
+        meterWorkItem = workItem
+        callbackQueue.asyncAfter(deadline: .now() + Self.meterInterval, execute: workItem)
+    }
+
+    private func pollMeter() {
+        lock.lock()
+        guard isRecording, let recorder else {
+            lock.unlock()
+            return
+        }
+        recorder.updateMeters()
+        let power = recorder.averagePower(forChannel: 0)
+        let shouldNotifySpeech = !hasDetectedSpeech && power >= Self.speechThresholdDB
+        if shouldNotifySpeech {
+            hasDetectedSpeech = true
+        }
+        lock.unlock()
+
+        if shouldNotifySpeech {
+            onFirstSpeechDetected?(Date())
+        }
+        scheduleMeterPoll()
     }
 
     private func scheduleNoAudioTimeout() {
-        cancelNoAudioTimeout()
+        noAudioTimeoutWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            let shouldNotify = self.lock.withLock { state -> Bool in
-                guard state.isCapturing,
-                      !state.hasDetectedSpeech,
-                      !state.hasReportedNoAudioTimeout else {
-                    return false
-                }
-                state.hasReportedNoAudioTimeout = true
-                return true
-            }
-            if shouldNotify {
-                self.onNoAudioTimeout?(Date())
-            }
+            self?.notifyNoAudioTimeoutIfNeeded()
         }
         noAudioTimeoutWorkItem = workItem
-        timeoutQueue.asyncAfter(deadline: .now() + Self.noAudioTimeout, execute: workItem)
+        callbackQueue.asyncAfter(deadline: .now() + Self.noAudioTimeout, execute: workItem)
     }
 
-    private func cancelNoAudioTimeout() {
+    private func notifyNoAudioTimeoutIfNeeded() {
+        lock.lock()
+        guard isRecording, !hasDetectedSpeech, !hasReportedNoAudioTimeout else {
+            lock.unlock()
+            return
+        }
+        hasReportedNoAudioTimeout = true
+        lock.unlock()
+        onNoAudioTimeout?(Date())
+    }
+
+    private func cancelTimers() {
+        firstBufferWorkItem?.cancel()
+        firstBufferWorkItem = nil
         noAudioTimeoutWorkItem?.cancel()
         noAudioTimeoutWorkItem = nil
+        meterWorkItem?.cancel()
+        meterWorkItem = nil
+    }
+}
+
+private final class DefaultInputOverride {
+    let preferredDeviceID: AudioObjectID
+    private let previousDeviceID: AudioObjectID?
+    private var didApply = false
+
+    init(preferredDeviceID: AudioObjectID) throws {
+        self.preferredDeviceID = preferredDeviceID
+        self.previousDeviceID = Self.defaultInputDeviceID()
+        guard previousDeviceID != preferredDeviceID else { return }
+        guard Self.setDefaultInputDeviceID(preferredDeviceID) else {
+            throw NSError(domain: "MicrophoneRecorder", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Could not select preferred microphone",
+            ])
+        }
+        didApply = true
+        fputs("[mic-recorder] selected default input \(preferredDeviceID) previous=\(previousDeviceID.map(String.init) ?? "unknown")\n", stderr)
     }
 
-    private func removeTapIfNeeded() {
-        guard tapInstalled else { return }
-        engine.inputNode.removeTap(onBus: 0)
-        tapInstalled = false
+    func restore() {
+        guard didApply, let previousDeviceID else { return }
+        if Self.setDefaultInputDeviceID(previousDeviceID) {
+            fputs("[mic-recorder] restored default input \(previousDeviceID)\n", stderr)
+        }
+        didApply = false
     }
 
-    private func stopWarmGraphLocked() {
-        removeTapIfNeeded()
-        engine.stop()
-        isGraphPrepared = false
-        preparedInputDeviceID = nil
+    private static func defaultInputDeviceID() -> AudioObjectID? {
+        var address = defaultInputAddress()
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &deviceID
+        ) == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
+            return nil
+        }
+        return deviceID
+    }
+
+    private static func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {
+        var address = defaultInputAddress()
+        var mutableDeviceID = deviceID
+        let dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        return AudioObjectSetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            dataSize,
+            &mutableDeviceID
+        ) == noErr
+    }
+
+    private static func defaultInputAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -107,7 +107,7 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
     }
 
-    @Test("arm refreshes preferred input instead of using stale route cache")
+    @Test("headphone arm refreshes preferred input without opening mic")
     func armRefreshesPreferredInput() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
@@ -116,7 +116,14 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.lastWarmInputDeviceID == nil)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "activation_deferred:hotkey"
+            }
+            return false
+        })
     }
 
     @Test("begin recording refreshes preferred input when there was no arm")
@@ -159,7 +166,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.activateCalls == 2)
+        #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.ducking.beginCalls == [true])
@@ -282,7 +289,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.activateCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
 
         Thread.sleep(forTimeInterval: 0.25)
@@ -312,6 +319,49 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.events.contains { if case .streamActive = $0 { return true }; return false })
         #expect(harness.events.contains { if case .speechDetected = $0 { return true }; return false })
         #expect(harness.events.contains { if case .noAudioTimeout = $0 { return true }; return false })
+    }
+
+    @Test("no audio timeout before first buffer fails startup")
+    func noAudioTimeoutBeforeFirstBufferFailsStartup() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        harness.recorder.onNoAudioTimeout?(Date().addingTimeInterval(1.5))
+        harness.wait()
+
+        #expect(harness.recorder.cancelCalls == 1)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+        #expect(harness.manager.currentState == .idle)
+        #expect(harness.manager.currentSessionID == nil)
+        #expect(harness.ducking.restoreCalls == 1)
+        #expect(harness.media.restoreCalls == 1)
+        #expect(harness.events.contains { if case .failed = $0 { return true }; return false })
+        #expect(!harness.events.contains { if case .noAudioTimeout = $0 { return true }; return false })
+    }
+
+    @Test("no audio timeout on headphone preferred input does not retry default input")
+    func noAudioTimeoutOnHeadphonePreferredInputDoesNotRetryDefaultInput() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.wait()
+        harness.recorder.onNoAudioTimeout?(Date().addingTimeInterval(1.5))
+        harness.wait()
+
+        #expect(harness.recorder.cancelCalls == 1)
+        #expect(harness.recorder.startCalls == 1)
+        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.preferredInputDeviceID == nil)
+        #expect(harness.manager.currentSessionID == nil)
+        #expect(harness.events.contains { if case .failed = $0 { return true }; return false })
+        #expect(!harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name.hasPrefix("input_fallback_begin:default")
+            }
+            return false
+        })
     }
 
     @Test("media pause is requested with current route after threshold")


### PR DESCRIPTION
## Summary
- restore standard dictation capture to the stable AVAudioRecorder path after the AVAudioEngine graph produced silent/no-buffer sessions on main
- keep headphone/AirPods policy intact by deferring hotkey-arm activation and avoiding fallback to default/AirPods input
- make speaker-route media pause run before duck/mute so pause wins when both settings are enabled
- add dictation session coverage for headphone activation deferral and startup no-audio failure handling

## Root cause
The main-branch dictation route treated AVAudioEngine startup as equivalent to usable mic capture. In practice the graph could start but deliver no first buffer or only silence (`-160 dB`), leaving the UI stuck in Preparing or recording unusable audio. The previous local fallback to default input was also wrong for AirPods because default input could be the AirPods mic, which is the route we wanted to avoid.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter DictationAudioSessionManager`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter MediaPlaybackController`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"`
- rebuilt and tested `/Applications/MuesliDev.app` locally with AirPods and speaker playback routes
