### PR TITLE
Harden dictation recorder failure handling

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -37,12 +37,13 @@ protocol DictationAudioRecording: AnyObject {
     var onFirstCapturedAudioBuffer: ((Date) -> Void)? { get set }
     var onFirstSpeechDetected: ((Date) -> Void)? { get set }
     var onNoAudioTimeout: ((Date) -> Void)? { get set }
+    var onRecordingFailed: ((Error, UUID) -> Void)? { get set }
 
     func prepare() throws
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws
     func coolDown()
-    func start() throws
+    func start() throws -> UUID
     func stop() -> URL?
     func cancel()
     func currentPower() -> Float
@@ -86,6 +87,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private var duckingEnabledForSession = false
     private var externalSessionActive = false
     private var routeRefreshGeneration = 0
+    private var activeRecorderRunID: UUID?
     private let sessionHintLock = NSLock()
     private var sessionHint: UUID?
     private var externalSessionHint = false
@@ -120,6 +122,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
         recorder.onNoAudioTimeout = { [weak self] at in
             self?.handleNoAudioTimeout(at: at)
+        }
+        recorder.onRecordingFailed = { [weak self] error, recorderRunID in
+            self?.handleRecordingFailure(error: error, recorderRunID: recorderRunID)
         }
     }
 
@@ -211,7 +216,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
                 self.emitLatency("engine_prepare_begin")
                 try self.recorder.prepare()
                 self.emitLatency("engine_prepare_end")
-                try self.recorder.start()
+                self.activeRecorderRunID = try self.recorder.start()
                 self.emitLatency("activation_end:\(mode)")
                 fputs("[dictation-session] recording mode=\(mode) \(self.routeSnapshot.debugDescription)\n", stderr)
             } catch {
@@ -253,6 +258,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             }
             self.emitLatency("stop")
             let wavURL = self.recorder.stop()
+            self.activeRecorderRunID = nil
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
             self.clearSessionHint(sessionID)
@@ -268,6 +274,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             let sessionID = self.stateStorage.sessionID
             self.recorder.keepsAudioGraphWarm = false
             self.recorder.cancel()
+            self.activeRecorderRunID = nil
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
             self.externalSessionActive = false
@@ -411,6 +418,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private func failCurrentSession(error: Error) {
         let sessionID = stateStorage.sessionID
         stateStorage = .idle
+        activeRecorderRunID = nil
         recorder.preferredInputDeviceID = nil
         clearSessionHint(sessionID)
         restoreSessionAudioState()
@@ -446,7 +454,8 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             guard let sessionID = self.stateStorage.sessionID else { return }
             self.emitLatency("no_audio_timeout", at: at)
             switch self.stateStorage {
-            case .armed(sessionID), .acquiringAudio(sessionID):
+            case .armed(let id) where id == sessionID,
+                 .acquiringAudio(let id) where id == sessionID:
                 self.recorder.keepsAudioGraphWarm = false
                 self.recorder.cancel()
                 self.failCurrentSession(error: StartupError.noAudioBuffer)
@@ -455,6 +464,17 @@ final class DictationAudioSessionManager: @unchecked Sendable {
                 break
             }
             self.emit(.noAudioTimeout(sessionID, at: at))
+        }
+    }
+
+    private func handleRecordingFailure(error: Error, recorderRunID: UUID) {
+        queue.async { [self] in
+            guard self.stateStorage.sessionID != nil,
+                  self.activeRecorderRunID == recorderRunID else { return }
+            self.emitLatency("recorder_failed")
+            self.recorder.keepsAudioGraphWarm = false
+            self.recorder.cancel()
+            self.failCurrentSession(error: error)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -8,51 +8,81 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
     var onFirstCapturedAudioBuffer: ((Date) -> Void)?
     var onFirstSpeechDetected: ((Date) -> Void)?
     var onNoAudioTimeout: ((Date) -> Void)?
+    var onRecordingFailed: ((Error, UUID) -> Void)?
 
     private static let sampleRate: Double = 16_000
     private static let speechThresholdDB: Float = -58
     private static let noAudioTimeout: TimeInterval = 1.5
-    private static let firstBufferDelay: TimeInterval = 0.05
+    private static let captureProgressInterval: TimeInterval = 0.05
     private static let meterInterval: TimeInterval = 0.08
+    private static let requiredFileGrowthObservations = 2
 
     private let lock = NSRecursiveLock()
     private let callbackQueue = DispatchQueue(label: "com.muesli.microphone-recorder-callbacks")
     private var recorder: AVAudioRecorder?
     private var preparedURL: URL?
+    private var preparedInputDeviceID: AudioObjectID?
     private var activeInputOverride: DefaultInputOverride?
-    private var firstBufferWorkItem: DispatchWorkItem?
+    private var captureProgressWorkItem: DispatchWorkItem?
     private var noAudioTimeoutWorkItem: DispatchWorkItem?
     private var meterWorkItem: DispatchWorkItem?
     private var isRecording = false
+    private var activeRecordingID: UUID?
     private var hasReceivedFirstAudioBuffer = false
     private var hasDetectedSpeech = false
     private var hasReportedNoAudioTimeout = false
+    private var lastObservedFileByteCount = 0
+    private var captureFileGrowthObservations = 0
+
+    deinit {
+        cancel()
+    }
 
     func prepare() throws {
         lock.lock()
         defer { lock.unlock() }
 
-        guard recorder == nil else { return }
+        if recorder != nil {
+            guard preparedInputDeviceID != preferredInputDeviceID else { return }
+            guard !isRecording else {
+                throw NSError(domain: "MicrophoneRecorder", code: 4, userInfo: [
+                    NSLocalizedDescriptionKey: "Cannot change microphone input while recording",
+                ])
+            }
+            cleanupPreparedRecording(removeFile: true)
+            restorePreferredInputIfNeeded()
+        }
         try applyPreferredInputIfNeeded()
 
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("muesli-native", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let fileURL = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
-        let settings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
-            AVSampleRateKey: Self.sampleRate,
-            AVNumberOfChannelsKey: 1,
-            AVLinearPCMBitDepthKey: 16,
-            AVLinearPCMIsFloatKey: false,
-            AVLinearPCMIsBigEndianKey: false,
-        ]
-        let nextRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
-        nextRecorder.delegate = self
-        nextRecorder.isMeteringEnabled = true
-        nextRecorder.prepareToRecord()
-        preparedURL = fileURL
-        recorder = nextRecorder
+        do {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("muesli-native", isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let fileURL = directory.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+            let settings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: Self.sampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false,
+            ]
+            let nextRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
+            nextRecorder.delegate = self
+            nextRecorder.isMeteringEnabled = true
+            guard nextRecorder.prepareToRecord() else {
+                throw NSError(domain: "MicrophoneRecorder", code: 6, userInfo: [
+                    NSLocalizedDescriptionKey: "Microphone recorder failed to prepare",
+                ])
+            }
+            preparedURL = fileURL
+            recorder = nextRecorder
+            preparedInputDeviceID = preferredInputDeviceID
+        } catch {
+            cleanupPreparedRecording(removeFile: true)
+            restorePreferredInputIfNeeded()
+            throw error
+        }
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
@@ -60,7 +90,7 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         defer { lock.unlock() }
 
         self.preferredInputDeviceID = preferredInputDeviceID
-        guard recorder == nil, !isRecording else { return }
+        guard !isRecording else { return }
         try prepare()
         fputs("[mic-recorder] avrecorder warmed preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
     }
@@ -70,7 +100,7 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         defer { lock.unlock() }
 
         self.preferredInputDeviceID = preferredInputDeviceID
-        guard recorder == nil, !isRecording else { return }
+        guard !isRecording else { return }
         try prepare()
         fputs("[mic-recorder] avrecorder activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
     }
@@ -84,11 +114,12 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         restorePreferredInputIfNeeded()
     }
 
-    func start() throws {
+    @discardableResult
+    func start() throws -> UUID {
         lock.lock()
         defer { lock.unlock() }
 
-        guard !isRecording else { return }
+        if isRecording, let activeRecordingID { return activeRecordingID }
         try prepare()
         guard let recorder else {
             throw NSError(domain: "MicrophoneRecorder", code: 1, userInfo: [
@@ -102,9 +133,13 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
             ])
         }
         isRecording = true
-        scheduleFirstBufferNotification()
-        scheduleMeterPoll()
-        scheduleNoAudioTimeout()
+        let recordingID = UUID()
+        activeRecordingID = recordingID
+        lastObservedFileByteCount = recordedFileByteCountLocked()
+        scheduleCaptureProgressPollLocked()
+        scheduleMeterPollLocked()
+        scheduleNoAudioTimeoutLocked()
+        return recordingID
     }
 
     func stop() -> URL? {
@@ -117,10 +152,12 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         }
         cancelTimers()
         isRecording = false
+        activeRecordingID = nil
         recorder.stop()
         let url = preparedURL
         self.recorder = nil
         preparedURL = nil
+        preparedInputDeviceID = nil
         restorePreferredInputIfNeeded()
         return url
     }
@@ -151,6 +188,7 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
 
         cancelTimers()
         isRecording = false
+        activeRecordingID = nil
         cleanupPreparedRecording(removeFile: true)
         restorePreferredInputIfNeeded()
     }
@@ -174,26 +212,40 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
             try? FileManager.default.removeItem(at: preparedURL)
         }
         preparedURL = nil
+        preparedInputDeviceID = nil
     }
 
     private func resetCaptureState() {
         hasReceivedFirstAudioBuffer = false
         hasDetectedSpeech = false
         hasReportedNoAudioTimeout = false
+        lastObservedFileByteCount = 0
+        captureFileGrowthObservations = 0
     }
 
-    private func scheduleFirstBufferNotification() {
-        firstBufferWorkItem?.cancel()
+    private func scheduleCaptureProgressPollLocked() {
+        captureProgressWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
-            self?.notifyFirstBufferIfNeeded()
+            self?.pollCaptureProgress()
         }
-        firstBufferWorkItem = workItem
-        callbackQueue.asyncAfter(deadline: .now() + Self.firstBufferDelay, execute: workItem)
+        captureProgressWorkItem = workItem
+        callbackQueue.asyncAfter(deadline: .now() + Self.captureProgressInterval, execute: workItem)
     }
 
-    private func notifyFirstBufferIfNeeded() {
+    private func pollCaptureProgress() {
         lock.lock()
         guard isRecording, !hasReceivedFirstAudioBuffer else {
+            lock.unlock()
+            return
+        }
+        let byteCount = recordedFileByteCountLocked()
+        if byteCount > lastObservedFileByteCount {
+            captureFileGrowthObservations += 1
+            lastObservedFileByteCount = byteCount
+        }
+        let hasCaptureProgress = captureFileGrowthObservations >= Self.requiredFileGrowthObservations
+        guard hasCaptureProgress else {
+            scheduleCaptureProgressPollLocked()
             lock.unlock()
             return
         }
@@ -202,7 +254,7 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         onFirstCapturedAudioBuffer?(Date())
     }
 
-    private func scheduleMeterPoll() {
+    private func scheduleMeterPollLocked() {
         meterWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             self?.pollMeter()
@@ -223,15 +275,15 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         if shouldNotifySpeech {
             hasDetectedSpeech = true
         }
+        scheduleMeterPollLocked()
         lock.unlock()
 
         if shouldNotifySpeech {
             onFirstSpeechDetected?(Date())
         }
-        scheduleMeterPoll()
     }
 
-    private func scheduleNoAudioTimeout() {
+    private func scheduleNoAudioTimeoutLocked() {
         noAudioTimeoutWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             self?.notifyNoAudioTimeoutIfNeeded()
@@ -252,12 +304,45 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
     }
 
     private func cancelTimers() {
-        firstBufferWorkItem?.cancel()
-        firstBufferWorkItem = nil
+        captureProgressWorkItem?.cancel()
+        captureProgressWorkItem = nil
         noAudioTimeoutWorkItem?.cancel()
         noAudioTimeoutWorkItem = nil
         meterWorkItem?.cancel()
         meterWorkItem = nil
+    }
+
+    private func recordedFileByteCountLocked() -> Int {
+        guard let preparedURL,
+              let attributes = try? FileManager.default.attributesOfItem(atPath: preparedURL.path),
+              let size = attributes[.size] as? NSNumber else {
+            return 0
+        }
+        return size.intValue
+    }
+
+    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        notifyRecordingFailed(from: recorder, error: error)
+    }
+
+    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        guard !flag else { return }
+        notifyRecordingFailed(from: recorder, error: nil)
+    }
+
+    private func notifyRecordingFailed(from failedRecorder: AVAudioRecorder, error: Error?) {
+        lock.lock()
+        guard isRecording,
+              recorder === failedRecorder,
+              let activeRecordingID else {
+            lock.unlock()
+            return
+        }
+        let resolvedError = error ?? NSError(domain: "MicrophoneRecorder", code: 5, userInfo: [
+            NSLocalizedDescriptionKey: "Microphone recording stopped unexpectedly",
+        ])
+        lock.unlock()
+        onRecordingFailed?(resolvedError, activeRecordingID)
     }
 }
 
@@ -277,6 +362,10 @@ private final class DefaultInputOverride {
         }
         didApply = true
         fputs("[mic-recorder] selected default input \(preferredDeviceID) previous=\(previousDeviceID.map(String.init) ?? "unknown")\n", stderr)
+    }
+
+    deinit {
+        restore()
     }
 
     func restore() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingDictationController.swift
@@ -150,6 +150,9 @@ final class StreamingDictationController {
         recorder.onAudioBuffer = { [weak self] samples in
             self?.handleAudioBuffer(samples)
         }
+        recorder.onRecordingFailed = { [weak self] error in
+            self?.failActiveSession(sessionID: sessionID, error: error)
+        }
         do {
             try recorder.prepare()
             try recorder.start()
@@ -229,6 +232,8 @@ final class StreamingDictationController {
         if let wavURL = recorder.stop() {
             try? FileManager.default.removeItem(at: wavURL)
         }
+        recorder.onAudioBuffer = nil
+        recorder.onRecordingFailed = nil
 
         // Collect remaining buffered samples
         let remaining: [Float] = bufferLock.withLock {
@@ -277,7 +282,7 @@ final class StreamingDictationController {
     }
 
     private func failActiveSession(sessionID: UUID, error: Error) {
-        guard isCurrentSession(sessionID) else { return }
+        guard isActiveSession(sessionID) else { return }
         resetActiveSession(cancelRecorder: true, sessionID: sessionID)
         onFailure?(error)
     }
@@ -299,6 +304,8 @@ final class StreamingDictationController {
         if cancelRecorder {
             recorder.cancel()
         }
+        recorder.onAudioBuffer = nil
+        recorder.onRecordingFailed = nil
         queueLock.withLock {
             chunkQueue.removeAll()
         }
@@ -395,6 +402,12 @@ final class StreamingDictationController {
     private func isCurrentSession(_ sessionID: UUID) -> Bool {
         bufferLock.withLock {
             activeSessionID == sessionID || stoppingSessionID == sessionID
+        }
+    }
+
+    private func isActiveSession(_ sessionID: UUID) -> Bool {
+        bufferLock.withLock {
+            activeSessionID == sessionID
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -7,6 +7,7 @@ import os
 /// Used by MeetingSession for VAD-driven chunk rotation (zero-gap file switching).
 protocol StreamingDictationRecording: AnyObject {
     var onAudioBuffer: (([Float]) -> Void)? { get set }
+    var onRecordingFailed: ((Error) -> Void)? { get set }
     var preferredInputDeviceID: AudioObjectID? { get set }
 
     func prepare() throws
@@ -18,14 +19,22 @@ protocol StreamingDictationRecording: AnyObject {
 final class StreamingMicRecorder: StreamingDictationRecording {
     /// Called with 4096-sample Float chunks (256ms at 16kHz) for VAD processing.
     var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
     /// Called with 16-bit PCM mono samples for retained meeting recording.
     var onPCMSamples: (([Int16]) -> Void)?
     var preferredInputDeviceID: AudioObjectID?
 
     private let engine = AVAudioEngine()
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
+    private let failureLock = OSAllocatedUnfairLock(initialState: FailureState())
+    private let failureCallbackQueue = DispatchQueue(label: "com.muesli.streaming-mic-recorder-failures")
     private var isRunning = false
     private var tapInstalled = false
+
+    private struct FailureState {
+        var activeRecordingID: UUID?
+        var hasReportedFailure = false
+    }
 
     private struct FileState {
         var fileHandle: FileHandle?
@@ -57,6 +66,11 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     func start() throws {
         guard !isRunning else { return }
         try prepare()
+        let recordingID = UUID()
+        failureLock.withLock {
+            $0.activeRecordingID = recordingID
+            $0.hasReportedFailure = false
+        }
 
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)
@@ -84,13 +98,20 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
         inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
             guard let self else { return }
+            guard self.isCurrentRecording(recordingID) else { return }
 
             let monoBuffer: AVAudioPCMBuffer
             if let converter {
                 let frameCapacity = AVAudioFrameCount(
                     Double(buffer.frameLength) * Self.sampleRate / buffer.format.sampleRate
                 )
-                guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return }
+                guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else {
+                    self.reportRecordingFailure(
+                        Self.runtimeError(code: 4, message: "Could not allocate converted microphone buffer"),
+                        recordingID: recordingID
+                    )
+                    return
+                }
                 var error: NSError?
                 var didProvideInput = false
                 let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
@@ -103,13 +124,22 @@ final class StreamingMicRecorder: StreamingDictationRecording {
                     return buffer
                 }
                 converter.convert(to: converted, error: &error, withInputFrom: inputBlock)
-                if error != nil { return }
+                if let error {
+                    self.reportRecordingFailure(error, recordingID: recordingID)
+                    return
+                }
                 monoBuffer = converted
             } else {
                 monoBuffer = buffer
             }
 
-            guard let floatData = monoBuffer.floatChannelData?[0] else { return }
+            guard let floatData = monoBuffer.floatChannelData?[0] else {
+                self.reportRecordingFailure(
+                    Self.runtimeError(code: 5, message: "Microphone buffer did not contain float channel data"),
+                    recordingID: recordingID
+                )
+                return
+            }
             let frameCount = Int(monoBuffer.frameLength)
 
             // Write Int16 PCM to file
@@ -157,6 +187,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         } catch {
             removeTapIfNeeded()
             engine.stop()
+            clearFailureState()
             let state = lock.withLock { state -> FileState in
                 let old = state
                 state = FileState()
@@ -194,6 +225,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     func stop() -> URL? {
         guard isRunning else { return nil }
         isRunning = false
+        clearFailureState()
 
         removeTapIfNeeded()
         engine.stop()
@@ -224,10 +256,12 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     func cancel() {
         isRunning = false
+        clearFailureState()
         removeTapIfNeeded()
         engine.stop()
         onAudioBuffer = nil
         onPCMSamples = nil
+        onRecordingFailed = nil
 
         let state = lock.withLock { state -> FileState in
             let old = state
@@ -248,6 +282,36 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         guard tapInstalled else { return }
         engine.inputNode.removeTap(onBus: 0)
         tapInstalled = false
+    }
+
+    private func isCurrentRecording(_ recordingID: UUID) -> Bool {
+        failureLock.withLock { $0.activeRecordingID == recordingID }
+    }
+
+    private func clearFailureState() {
+        failureLock.withLock {
+            $0.activeRecordingID = nil
+            $0.hasReportedFailure = true
+        }
+    }
+
+    private func reportRecordingFailure(_ error: Error, recordingID: UUID) {
+        let callback = failureLock.withLock { state -> ((Error) -> Void)? in
+            guard state.activeRecordingID == recordingID,
+                  !state.hasReportedFailure else { return nil }
+            state.hasReportedFailure = true
+            return onRecordingFailed
+        }
+        guard let callback else { return }
+        failureCallbackQueue.async {
+            callback(error)
+        }
+    }
+
+    private static func runtimeError(code: Int, message: String) -> NSError {
+        NSError(domain: "StreamingMicRecorder", code: code, userInfo: [
+            NSLocalizedDescriptionKey: message,
+        ])
     }
 
     // MARK: - File Management

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -364,6 +364,53 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
+    @Test("recorder failure fails active session")
+    func recorderFailureFailsActiveSession() {
+        let harness = Harness(routeKind: .speakerLike)
+        let error = NSError(domain: "DictationAudioSessionManagerTests", code: 42)
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        harness.recorder.onFirstCapturedAudioBuffer?(Date())
+        harness.wait()
+        harness.recorder.onRecordingFailed?(error, harness.recorder.activeRecordingID!)
+        harness.wait()
+
+        #expect(harness.recorder.cancelCalls == 1)
+        #expect(harness.manager.currentState == .idle)
+        #expect(harness.manager.currentSessionID == nil)
+        #expect(harness.ducking.restoreCalls == 1)
+        #expect(harness.media.restoreCalls == 1)
+        #expect(harness.events.contains { if case .failed = $0 { return true }; return false })
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "recorder_failed"
+            }
+            return false
+        })
+    }
+
+    @Test("stale recorder failure does not fail newer session")
+    func staleRecorderFailureDoesNotFailNewerSession() {
+        let harness = Harness(routeKind: .speakerLike)
+        let error = NSError(domain: "DictationAudioSessionManagerTests", code: 43)
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        let staleRunID = harness.recorder.activeRecordingID!
+        harness.manager.stop()
+        harness.wait()
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: true)
+        harness.wait()
+        harness.recorder.onRecordingFailed?(error, staleRunID)
+        harness.wait()
+
+        #expect(harness.manager.currentState == .acquiringAudio(harness.manager.currentSessionID!))
+        #expect(harness.recorder.cancelCalls == 0)
+        #expect(!harness.events.contains { if case .failed = $0 { return true }; return false })
+    }
+
     @Test("media pause is requested with current route after threshold")
     func mediaPauseRequestedWithCurrentRoute() {
         let harness = Harness(routeKind: .speakerLike)
@@ -482,6 +529,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
     var onFirstCapturedAudioBuffer: ((Date) -> Void)?
     var onFirstSpeechDetected: ((Date) -> Void)?
     var onNoAudioTimeout: ((Date) -> Void)?
+    var onRecordingFailed: ((Error, UUID) -> Void)?
 
     var prepareCalls = 0
     var warmUpCalls = 0
@@ -492,6 +540,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
     var cancelCalls = 0
     var stopURL: URL?
     var lastWarmInputDeviceID: AudioObjectID?
+    var activeRecordingID: UUID?
     var warmUpDelay: TimeInterval = 0
     var activateError: Error?
 
@@ -519,17 +568,22 @@ private final class FakeDictationRecorder: DictationAudioRecording {
         coolDownCalls += 1
     }
 
-    func start() throws {
+    func start() throws -> UUID {
         startCalls += 1
+        let id = UUID()
+        activeRecordingID = id
+        return id
     }
 
     func stop() -> URL? {
         stopCalls += 1
+        activeRecordingID = nil
         return stopURL
     }
 
     func cancel() {
         cancelCalls += 1
+        activeRecordingID = nil
     }
 
     func currentPower() -> Float {

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import CoreAudio
+import CoreML
 @testable import MuesliNativeApp
 
 @Suite("NemotronStreamState")
@@ -264,6 +265,61 @@ struct StreamingDictationControllerTests {
     }
 
     @available(macOS 15, *)
+    @Test("recorder failure cancels streaming session and permits retry")
+    func recorderFailureCancelsStreamingSessionAndPermitsRetry() async {
+        let transcriber = ImmediateNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let failures = FailureCounter()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+        controller.onFailure = { _ in
+            failures.increment()
+        }
+
+        #expect(controller.start() == true)
+        recorder.onRecordingFailed?(NSError(domain: "StreamingDictationControllerTests", code: 1))
+        try? await Task.sleep(for: .milliseconds(25))
+
+        #expect(recorder.cancelCalls == 1)
+        #expect(failures.value == 1)
+        #expect(recorder.onAudioBuffer == nil)
+        #expect(recorder.onRecordingFailed == nil)
+        #expect(controller.start() == true)
+        controller.cancel()
+    }
+
+    @available(macOS 15, *)
+    @Test("recorder failure after stop begins does not fail stopping session")
+    func recorderFailureAfterStopBeginsDoesNotFailStoppingSession() async {
+        let transcriber = DelayedNemotronStreamingTranscriber()
+        let recorder = InspectableStreamingDictationRecorder()
+        let failures = FailureCounter()
+        let controller = StreamingDictationController(
+            transcriber: transcriber,
+            recorder: recorder
+        )
+        controller.onFailure = { _ in
+            failures.increment()
+        }
+
+        #expect(controller.start() == true)
+        recorder.emit(samples: [Float](repeating: 0.2, count: 8960))
+        let capturedFailure = recorder.onRecordingFailed
+
+        async let stoppedText = stop(controller)
+        try? await Task.sleep(for: .milliseconds(25))
+        capturedFailure?(NSError(domain: "StreamingDictationControllerTests", code: 2))
+
+        await transcriber.releaseState()
+        let text = await stoppedText
+        #expect(text == " hello")
+        #expect(recorder.cancelCalls == 0)
+        #expect(failures.value == 0)
+    }
+
+    @available(macOS 15, *)
     @Test("stop completes when stream state initialization stalls")
     func stopCompletesWhenStreamStateInitializationStalls() async {
         let transcriber = HangingNemotronStreamingTranscriber()
@@ -334,6 +390,7 @@ struct StreamingDictationControllerTests {
 
 private final class FailingStreamingDictationRecorder: StreamingDictationRecording {
     var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
     var preferredInputDeviceID: AudioObjectID?
     var prepareCalls = 0
     var startCalls = 0
@@ -376,6 +433,7 @@ private final class FailingNemotronStreamingTranscriber: NemotronStreamingTransc
 
 private final class InspectableStreamingDictationRecorder: StreamingDictationRecording {
     var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
     var preferredInputDeviceID: AudioObjectID?
     var prepareCalls = 0
     var startCalls = 0
@@ -438,6 +496,33 @@ private actor DelayedNemotronStreamingTranscriber: NemotronStreamingTranscribing
     ) async throws -> String {
         transcribeCalls += 1
         return " hello"
+    }
+}
+
+@available(macOS 15, *)
+private actor ImmediateNemotronStreamingTranscriber: NemotronStreamingTranscribing {
+    func makeStreamState() async throws -> NemotronStreamingTranscriber.StreamState {
+        let cacheChannel = try MLMultiArray(shape: [1, 24, 70, 1024], dataType: .float32)
+        let cacheTime = try MLMultiArray(shape: [1, 24, 1024, 8], dataType: .float32)
+        let cacheLen = try MLMultiArray(shape: [1], dataType: .int32)
+        let hState = try MLMultiArray(shape: [2, 1, 640], dataType: .float32)
+        let cState = try MLMultiArray(shape: [2, 1, 640], dataType: .float32)
+        return NemotronStreamingTranscriber.StreamState(
+            cacheChannel: cacheChannel,
+            cacheTime: cacheTime,
+            cacheLen: cacheLen,
+            hState: hState,
+            cState: cState,
+            lastToken: 0,
+            allTokens: []
+        )
+    }
+
+    func transcribeChunk(
+        samples: [Float],
+        state: inout NemotronStreamingTranscriber.StreamState
+    ) async throws -> String {
+        ""
     }
 }
 


### PR DESCRIPTION
## Summary
- fail active dictation sessions when AVAudioRecorder reports encode or unexpected finish failures, scoped by per-recording run IDs so stale delegate callbacks cannot cancel newer sessions
- report first captured audio only after the recorder WAV grows beyond its header instead of using elapsed recording time
- rebuild prepared recorders when preferred input changes and restore default-input overrides on cleanup/deinit
- wire direct streaming dictation recorder failures through the streaming controller cleanup path

## Verification
- swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter HotkeyMonitor
- swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter DictationAudioSessionManager
- swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test" --filter StreamingDictationController
- MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" ./scripts/dev-test.sh

## Notes
- Normal parallel `swift test` still exposes the existing HotkeyMonitor timing interference seen before this PR: the two combination-shortcut threshold tests can fire early under full-suite parallel load, while the HotkeyMonitor suite passes in isolation.
- A serial full-suite run passed before the second review patch; after the second patch I re-verified the focused affected suites and dev build. I am not treating the PR as mergeable until CI and both bot reviews are read directly.
- This is a follow-up to #174 specifically because Greptile rated that merged PR 2/5 and flagged recorder progress, silent/no-buffer startup, stale warmed input, and default-input cleanup risks.