### PR TITLE
Simplify preprod update action UI

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -37,12 +37,14 @@ struct AboutView: View {
                             .foregroundStyle(MuesliTheme.textPrimary)
                     }
 
-                    Divider().background(MuesliTheme.surfaceBorder)
+                    if showsManualUpdateCheckRow {
+                        Divider().background(MuesliTheme.surfaceBorder)
 
-                    aboutRow("Check for Updates") {
-                        let action = updatePrimaryAction
-                        actionButton(action.title, icon: action.icon) {
-                            performUpdateAction(action)
+                        aboutRow("Check for Updates") {
+                            let action = updatePrimaryAction
+                            actionButton(action.title, icon: action.icon) {
+                                performUpdateAction(action)
+                            }
                         }
                     }
                 }
@@ -198,6 +200,15 @@ struct AboutView: View {
             return .retry
         case .idle, .checking, .busy, .installing, .upToDate, .disabled:
             return .check
+        }
+    }
+
+    private var showsManualUpdateCheckRow: Bool {
+        switch appState.sparkleUpdateStatus {
+        case .idle, .upToDate:
+            return true
+        case .checking, .busy, .available, .downloaded, .installing, .disabled, .failed:
+            return false
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2007,11 +2007,22 @@ final class MuesliController: NSObject {
     }
 
     @objc func checkForUpdates() {
-        presentStandardUpdateCheck()
+        switch appState.sparkleUpdateStatus {
+        case .available, .downloaded:
+            installAvailableUpdate()
+        case .checking, .busy, .installing:
+            showBusyStatus(
+                UpdateInteractionPolicy.busyMessage,
+                restoring: appState.sparkleUpdateStatus
+            )
+        case .idle, .upToDate, .disabled, .failed:
+            openHistoryWindow(tab: .about)
+            probeForUpdateInformation()
+        }
     }
 
     func retryUpdateCheck() {
-        presentStandardUpdateCheck()
+        probeForUpdateInformation()
     }
 
     func installAvailableUpdate() {
@@ -2039,6 +2050,22 @@ final class MuesliController: NSObject {
             return
         }
         updaterController.checkForUpdates(nil)
+    }
+
+    private func probeForUpdateInformation() {
+        guard let updaterController else {
+            appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
+            return
+        }
+        guard !updaterController.updater.sessionInProgress else {
+            showBusyStatus(
+                UpdateInteractionPolicy.busyMessage,
+                restoring: appState.sparkleUpdateStatus
+            )
+            return
+        }
+        appState.sparkleUpdateStatus = .checking
+        updaterController.updater.checkForUpdateInformation()
     }
 
     private func showBusyStatus(_ message: String, restoring previousStatus: SparkleUpdateStatus) {


### PR DESCRIPTION
## Summary\n- Hide the redundant About-page manual update row when an update banner is already active\n- Keep the neutral manual check row for idle/up-to-date states\n- Use Sparkle's non-presenting update-information probe for status-bar/About rechecks so an up-to-date check cannot leave the app blocked by standard Sparkle UI\n- Open the About tab before status-bar rechecks so silent probe results are visible\n- Keep Sparkle's standard UI for available/downloaded update installation\n\n## Verification\n- swift test --package-path native/MuesliNative --scratch-path "/Users/pranavhari/Library/Caches/muesli-spm/test-about-update" --filter Update\n- swift test --package-path native/MuesliNative --scratch-path "/Users/pranavhari/Library/Caches/muesli-spm/test-about-update" --filter HotkeyMonitor\n\nNote: full-suite reruns can still hit the existing HotkeyMonitor timing flake seen during the preprod pipeline; focused HotkeyMonitor passes.