### PR TITLE
Use standard Sparkle flow for update actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If Muesli saves you time, consider supporting development:
 ## Acknowledgements
 
 - [FluidAudio](https://github.com/FluidInference/FluidAudio) — CoreML speech models for Apple devices (Parakeet TDT, Qwen3 ASR, Silero VAD, speaker diarization)
-- [LocalVQE](https://github.com/localai-org/LocalVQE) — on-device acoustic echo cancellation for meeting transcription
+- [localai-org/LocalVQE](https://github.com/localai-org/LocalVQE) — on-device acoustic echo cancellation for meeting transcription
 - [WhisperKit](https://github.com/argmaxinc/WhisperKit) — Swift Whisper inference on CoreML/ANE
 - [Core Audio](https://developer.apple.com/documentation/coreaudio) by Apple — system audio process taps
 - [ScreenCaptureKit](https://developer.apple.com/documentation/screencapturekit) by Apple — system audio fallback capture

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -3,7 +3,6 @@ import MuesliCore
 
 struct AboutView: View {
     let appState: AppState
-    let controller: MuesliController
 
     private let githubURL = "https://github.com/pHequals7/muesli"
     private let donateURL = "https://buymeacoffee.com/phequals7"
@@ -40,15 +39,10 @@ struct AboutView: View {
                     Divider().background(MuesliTheme.surfaceBorder)
 
                     aboutRow("Updates") {
-                        if canStartUpdateCheck {
-                            actionButton(updateRowActionTitle, icon: "arrow.triangle.2.circlepath") {
-                                controller.checkForUpdates()
-                            }
-                        } else {
-                            Text(updateRowActionTitle)
-                                .font(MuesliTheme.callout())
-                                .foregroundStyle(MuesliTheme.textSecondary)
-                        }
+                        Text(updateRowGuidance)
+                            .font(MuesliTheme.callout())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .multilineTextAlignment(.trailing)
                     }
                 }
 
@@ -161,31 +155,21 @@ struct AboutView: View {
         let icon: String
         let title: String
         let message: String
-        let actionTitle: String?
         let tint: Color
     }
 
-    private var updateRowActionTitle: String {
+    private var updateRowGuidance: String {
         switch appState.sparkleUpdateStatus {
         case .available:
-            return "Install Update"
+            return "Use the menu bar icon > Check for Updates..."
         case .downloaded:
-            return "Finish Update"
+            return "Use the menu bar updater to finish installation."
         case .checking, .busy, .installing:
             return "Checking..."
         case .failed:
-            return "Try Again"
+            return "Use the menu bar icon > Check for Updates..."
         case .idle, .upToDate, .disabled:
-            return "Check Now"
-        }
-    }
-
-    private var canStartUpdateCheck: Bool {
-        switch appState.sparkleUpdateStatus {
-        case .checking, .busy, .installing, .disabled:
-            return false
-        case .idle, .available, .downloaded, .upToDate, .failed:
-            return true
+            return "Use the menu bar icon > Check for Updates..."
         }
     }
 
@@ -198,7 +182,6 @@ struct AboutView: View {
                 icon: "arrow.triangle.2.circlepath",
                 title: "Checking for updates",
                 message: "Muesli is checking the appcast for the latest version.",
-                actionTitle: nil,
                 tint: MuesliTheme.transcribing
             )
         case .busy(let message):
@@ -206,23 +189,20 @@ struct AboutView: View {
                 icon: "clock.arrow.circlepath",
                 title: "Updater is busy",
                 message: message,
-                actionTitle: nil,
                 tint: MuesliTheme.transcribing
             )
         case .available(let version):
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is available",
-                message: "An update is available. Install it now or continue working and update later.",
-                actionTitle: "Install Update",
+                message: "An update is available. Use the menu bar icon > Check for Updates... to open the updater.",
                 tint: MuesliTheme.transcribing
             )
         case .downloaded(let version):
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is ready to install",
-                message: "The update is downloaded and ready to finish installing.",
-                actionTitle: "Finish Update",
+                message: "The update is downloaded. Use the menu bar updater to finish installation.",
                 tint: MuesliTheme.transcribing
             )
         case .installing(let version):
@@ -230,7 +210,6 @@ struct AboutView: View {
                 icon: "arrow.down.circle.fill",
                 title: "Installing Muesli \(version)",
                 message: "Sparkle is preparing the update. Muesli may relaunch when installation finishes.",
-                actionTitle: nil,
                 tint: MuesliTheme.transcribing
             )
         case .upToDate:
@@ -238,7 +217,6 @@ struct AboutView: View {
                 icon: "checkmark.circle.fill",
                 title: "Muesli is up to date",
                 message: "No newer version was found in the appcast.",
-                actionTitle: "Check Again",
                 tint: MuesliTheme.success
             )
         case .disabled(let message):
@@ -246,15 +224,13 @@ struct AboutView: View {
                 icon: "minus.circle.fill",
                 title: "Updates are disabled",
                 message: message,
-                actionTitle: nil,
                 tint: MuesliTheme.textTertiary
             )
         case .failed(let message):
             return UpdateBanner(
                 icon: "xmark.octagon.fill",
                 title: "Update check failed",
-                message: message,
-                actionTitle: "Try Again",
+                message: "\(message) Use the menu bar icon > Check for Updates... to try again.",
                 tint: MuesliTheme.recording
             )
         }
@@ -279,12 +255,6 @@ struct AboutView: View {
             }
 
             Spacer(minLength: MuesliTheme.spacing16)
-
-            if let actionTitle = banner.actionTitle {
-                actionButton(actionTitle, icon: "arrow.down.circle") {
-                    controller.checkForUpdates()
-                }
-            }
         }
         .padding(MuesliTheme.spacing16)
         .background(banner.tint.opacity(0.14))

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -3,6 +3,7 @@ import MuesliCore
 
 struct AboutView: View {
     let appState: AppState
+    let controller: MuesliController
 
     private let githubURL = "https://github.com/pHequals7/muesli"
     private let donateURL = "https://buymeacoffee.com/phequals7"
@@ -39,10 +40,15 @@ struct AboutView: View {
                     Divider().background(MuesliTheme.surfaceBorder)
 
                     aboutRow("Updates") {
-                        Text("Use the Muesli menu bar icon > Check for Updates...")
-                            .font(MuesliTheme.callout())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                            .multilineTextAlignment(.trailing)
+                        if canStartUpdateCheck {
+                            actionButton(updateRowActionTitle, icon: "arrow.triangle.2.circlepath") {
+                                controller.checkForUpdates()
+                            }
+                        } else {
+                            Text(updateRowActionTitle)
+                                .font(MuesliTheme.callout())
+                                .foregroundStyle(MuesliTheme.textSecondary)
+                        }
                     }
                 }
 
@@ -155,7 +161,32 @@ struct AboutView: View {
         let icon: String
         let title: String
         let message: String
+        let actionTitle: String?
         let tint: Color
+    }
+
+    private var updateRowActionTitle: String {
+        switch appState.sparkleUpdateStatus {
+        case .available:
+            return "Install Update"
+        case .downloaded:
+            return "Finish Update"
+        case .checking, .busy, .installing:
+            return "Checking..."
+        case .failed:
+            return "Try Again"
+        case .idle, .upToDate, .disabled:
+            return "Check Now"
+        }
+    }
+
+    private var canStartUpdateCheck: Bool {
+        switch appState.sparkleUpdateStatus {
+        case .checking, .busy, .installing, .disabled:
+            return false
+        case .idle, .available, .downloaded, .upToDate, .failed:
+            return true
+        }
     }
 
     private var updateBanner: UpdateBanner? {
@@ -167,6 +198,7 @@ struct AboutView: View {
                 icon: "arrow.triangle.2.circlepath",
                 title: "Checking for updates",
                 message: "Muesli is checking the appcast for the latest version.",
+                actionTitle: nil,
                 tint: MuesliTheme.transcribing
             )
         case .busy(let message):
@@ -174,20 +206,23 @@ struct AboutView: View {
                 icon: "clock.arrow.circlepath",
                 title: "Updater is busy",
                 message: message,
+                actionTitle: nil,
                 tint: MuesliTheme.transcribing
             )
         case .available(let version):
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is available",
-                message: "An update is available. Use the Muesli menu bar icon > Check for Updates... to download and install it.",
+                message: "An update is available. Install it now or continue working and update later.",
+                actionTitle: "Install Update",
                 tint: MuesliTheme.transcribing
             )
         case .downloaded(let version):
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is ready to install",
-                message: "The update is downloaded. Use the menu bar updater to finish installation.",
+                message: "The update is downloaded and ready to finish installing.",
+                actionTitle: "Finish Update",
                 tint: MuesliTheme.transcribing
             )
         case .installing(let version):
@@ -195,6 +230,7 @@ struct AboutView: View {
                 icon: "arrow.down.circle.fill",
                 title: "Installing Muesli \(version)",
                 message: "Sparkle is preparing the update. Muesli may relaunch when installation finishes.",
+                actionTitle: nil,
                 tint: MuesliTheme.transcribing
             )
         case .upToDate:
@@ -202,6 +238,7 @@ struct AboutView: View {
                 icon: "checkmark.circle.fill",
                 title: "Muesli is up to date",
                 message: "No newer version was found in the appcast.",
+                actionTitle: "Check Again",
                 tint: MuesliTheme.success
             )
         case .disabled(let message):
@@ -209,13 +246,15 @@ struct AboutView: View {
                 icon: "minus.circle.fill",
                 title: "Updates are disabled",
                 message: message,
+                actionTitle: nil,
                 tint: MuesliTheme.textTertiary
             )
         case .failed(let message):
             return UpdateBanner(
                 icon: "xmark.octagon.fill",
                 title: "Update check failed",
-                message: "\(message) Use the Muesli menu bar icon > Check for Updates... to try again.",
+                message: message,
+                actionTitle: "Try Again",
                 tint: MuesliTheme.recording
             )
         }
@@ -240,6 +279,12 @@ struct AboutView: View {
             }
 
             Spacer(minLength: MuesliTheme.spacing16)
+
+            if let actionTitle = banner.actionTitle {
+                actionButton(actionTitle, icon: "arrow.down.circle") {
+                    controller.checkForUpdates()
+                }
+            }
         }
         .padding(MuesliTheme.spacing16)
         .background(banner.tint.opacity(0.14))

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -3,7 +3,6 @@ import MuesliCore
 
 struct AboutView: View {
     let appState: AppState
-    let controller: MuesliController
 
     private let githubURL = "https://github.com/pHequals7/muesli"
     private let donateURL = "https://buymeacoffee.com/phequals7"
@@ -37,15 +36,13 @@ struct AboutView: View {
                             .foregroundStyle(MuesliTheme.textPrimary)
                     }
 
-                    if showsManualUpdateCheckRow {
-                        Divider().background(MuesliTheme.surfaceBorder)
+                    Divider().background(MuesliTheme.surfaceBorder)
 
-                        aboutRow("Check for Updates") {
-                            let action = updatePrimaryAction
-                            actionButton(action.title, icon: action.icon) {
-                                performUpdateAction(action)
-                            }
-                        }
+                    aboutRow("Updates") {
+                        Text("Use the Muesli menu bar icon > Check for Updates...")
+                            .font(MuesliTheme.callout())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .multilineTextAlignment(.trailing)
                     }
                 }
 
@@ -159,71 +156,6 @@ struct AboutView: View {
         let title: String
         let message: String
         let tint: Color
-        let action: UpdateBannerAction?
-    }
-
-    private enum UpdateBannerAction {
-        case check
-        case install
-        case restartInstall
-        case retry
-
-        var title: String {
-            switch self {
-            case .check:
-                return "Check Now"
-            case .install:
-                return "Install Update"
-            case .restartInstall:
-                return "Restart & Install"
-            case .retry:
-                return "Try Again"
-            }
-        }
-
-        var icon: String {
-            switch self {
-            case .check:
-                return "arrow.triangle.2.circlepath"
-            case .install:
-                return "arrow.down.circle"
-            case .restartInstall:
-                return "arrow.clockwise.circle"
-            case .retry:
-                return "arrow.triangle.2.circlepath"
-            }
-        }
-    }
-
-    private var updatePrimaryAction: UpdateBannerAction {
-        switch appState.sparkleUpdateStatus {
-        case .available:
-            return .install
-        case .downloaded:
-            return .restartInstall
-        case .failed:
-            return .retry
-        case .idle, .checking, .busy, .installing, .upToDate, .disabled:
-            return .check
-        }
-    }
-
-    private var showsManualUpdateCheckRow: Bool {
-        switch appState.sparkleUpdateStatus {
-        case .idle, .upToDate:
-            return true
-        case .checking, .busy, .available, .downloaded, .installing, .disabled, .failed:
-            return false
-        }
-    }
-
-    private func performUpdateAction(_ action: UpdateBannerAction) {
-        switch action {
-        case .check, .retry:
-            controller.retryUpdateCheck()
-        case .install, .restartInstall:
-            controller.installAvailableUpdate()
-        }
     }
 
     private var updateBanner: UpdateBanner? {
@@ -235,64 +167,56 @@ struct AboutView: View {
                 icon: "arrow.triangle.2.circlepath",
                 title: "Checking for updates",
                 message: "Muesli is checking the appcast for the latest version.",
-                tint: MuesliTheme.transcribing,
-                action: nil
+                tint: MuesliTheme.transcribing
             )
         case .busy(let message):
             return UpdateBanner(
                 icon: "clock.arrow.circlepath",
                 title: "Updater is busy",
                 message: message,
-                tint: MuesliTheme.transcribing,
-                action: nil
+                tint: MuesliTheme.transcribing
             )
         case .available(let version):
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is available",
-                message: "An update is available. Start the updater to download and install it.",
-                tint: MuesliTheme.transcribing,
-                action: .install
+                message: "An update is available. Use the Muesli menu bar icon > Check for Updates... to download and install it.",
+                tint: MuesliTheme.transcribing
             )
         case .downloaded(let version):
             return UpdateBanner(
                 icon: "exclamationmark.triangle.fill",
                 title: "Muesli \(version) is ready to install",
-                message: "Restart Muesli from here and Sparkle will finish installing the update automatically.",
-                tint: MuesliTheme.transcribing,
-                action: .restartInstall
+                message: "The update is downloaded. Use the menu bar updater to finish installation.",
+                tint: MuesliTheme.transcribing
             )
         case .installing(let version):
             return UpdateBanner(
                 icon: "arrow.down.circle.fill",
                 title: "Installing Muesli \(version)",
                 message: "Sparkle is preparing the update. Muesli may relaunch when installation finishes.",
-                tint: MuesliTheme.transcribing,
-                action: nil
+                tint: MuesliTheme.transcribing
             )
         case .upToDate:
             return UpdateBanner(
                 icon: "checkmark.circle.fill",
                 title: "Muesli is up to date",
                 message: "No newer version was found in the appcast.",
-                tint: MuesliTheme.success,
-                action: nil
+                tint: MuesliTheme.success
             )
         case .disabled(let message):
             return UpdateBanner(
                 icon: "minus.circle.fill",
                 title: "Updates are disabled",
                 message: message,
-                tint: MuesliTheme.textTertiary,
-                action: nil
+                tint: MuesliTheme.textTertiary
             )
         case .failed(let message):
             return UpdateBanner(
                 icon: "xmark.octagon.fill",
                 title: "Update check failed",
-                message: message,
-                tint: MuesliTheme.recording,
-                action: .retry
+                message: "\(message) Use the Muesli menu bar icon > Check for Updates... to try again.",
+                tint: MuesliTheme.recording
             )
         }
     }
@@ -316,12 +240,6 @@ struct AboutView: View {
             }
 
             Spacer(minLength: MuesliTheme.spacing16)
-
-            if let action = banner.action {
-                actionButton(action.title, icon: action.icon) {
-                    performUpdateAction(action)
-                }
-            }
         }
         .padding(MuesliTheme.spacing16)
         .background(banner.tint.opacity(0.14))

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -112,6 +112,11 @@ struct AboutView: View {
                     )
                     Divider().background(MuesliTheme.surfaceBorder)
                     acknowledgement(
+                        name: "LocalVQE by localai-org",
+                        description: "On-device acoustic echo cancellation powering cleaner meeting transcription."
+                    )
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    acknowledgement(
                         name: "WhisperKit by Argmax",
                         description: "Swift Whisper inference on CoreML/ANE powering the app's Whisper Small, Medium, and Large Turbo backends."
                     )

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -138,55 +138,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUserDriverDelegate {
     weak var appState: AppState?
     private var lastPresentedAt: Date?
+    private var updateCycleGeneration = 0
 
     func updater(_ updater: SPUUpdater, mayPerform updateCheck: SPUUpdateCheck) throws {
+        updateCycleGeneration += 1
+        let generation = updateCycleGeneration
+        let restoreStatus = recoverableUpdateStatus(appState?.sparkleUpdateStatus ?? .idle)
         appState?.sparkleUpdateStatus = .checking
+        restoreStaleUpdateCheck(generation: generation, to: restoreStatus)
     }
 
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
-        appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
+        finishUpdateCheck(with: .available(version: item.displayVersionString))
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
         let nsError = error as NSError
         if UpdateFailureGuidance.isNoUpdateError(nsError) {
-            appState?.sparkleUpdateStatus = .upToDate
+            finishUpdateCheck(with: .upToDate)
         } else {
-            appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
+            finishUpdateCheck(with: .failed(message: nsError.localizedDescription))
         }
     }
 
     func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
-        appState?.sparkleUpdateStatus = .downloaded(version: item.displayVersionString)
+        finishUpdateCheck(with: .downloaded(version: item.displayVersionString))
     }
 
     func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
-        appState?.sparkleUpdateStatus = .installing(version: item.displayVersionString)
+        finishUpdateCheck(with: .installing(version: item.displayVersionString))
     }
 
     func updater(_ updater: SPUUpdater, userDidMake choice: SPUUserUpdateChoice, forUpdate item: SUAppcastItem, state: SPUUserUpdateState) {
         switch choice {
         case .install:
-            appState?.sparkleUpdateStatus = .installing(version: item.displayVersionString)
+            finishUpdateCheck(with: .installing(version: item.displayVersionString))
         case .dismiss where state.stage == .downloaded:
-            appState?.sparkleUpdateStatus = .downloaded(version: item.displayVersionString)
+            finishUpdateCheck(with: .downloaded(version: item.displayVersionString))
         case .dismiss:
-            appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
+            finishUpdateCheck(with: .available(version: item.displayVersionString))
         case .skip:
-            appState?.sparkleUpdateStatus = .idle
+            finishUpdateCheck(with: .idle)
         @unknown default:
-            appState?.sparkleUpdateStatus = .available(version: item.displayVersionString)
+            finishUpdateCheck(with: .available(version: item.displayVersionString))
         }
     }
 
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
         let nsError = error as NSError
         if UpdateFailureGuidance.isNoUpdateError(nsError) {
-            appState?.sparkleUpdateStatus = .upToDate
+            finishUpdateCheck(with: .upToDate)
             return
         }
 
-        appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
+        finishUpdateCheck(with: .failed(message: nsError.localizedDescription))
         guard UpdateFailureGuidance.shouldShowFallback(for: nsError) else { return }
 
         // Sparkle shows its own error alert first. Delay briefly so this
@@ -204,9 +209,32 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
         // didAbortWithError is the primary error callback; this keeps the
         // final-cycle handler self-contained for any Sparkle path that ends here.
         if UpdateFailureGuidance.isNoUpdateError(nsError) {
-            appState?.sparkleUpdateStatus = .upToDate
+            finishUpdateCheck(with: .upToDate)
         } else {
-            appState?.sparkleUpdateStatus = .failed(message: nsError.localizedDescription)
+            finishUpdateCheck(with: .failed(message: nsError.localizedDescription))
+        }
+    }
+
+    private func finishUpdateCheck(with status: SparkleUpdateStatus) {
+        updateCycleGeneration += 1
+        appState?.sparkleUpdateStatus = status
+    }
+
+    private func restoreStaleUpdateCheck(generation: Int, to restoreStatus: SparkleUpdateStatus) {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 30_000_000_000)
+            guard let self, self.updateCycleGeneration == generation else { return }
+            guard case .checking = self.appState?.sparkleUpdateStatus else { return }
+            self.finishUpdateCheck(with: restoreStatus)
+        }
+    }
+
+    private func recoverableUpdateStatus(_ status: SparkleUpdateStatus) -> SparkleUpdateStatus {
+        switch status {
+        case .checking, .busy:
+            return .idle
+        default:
+            return status
         }
     }
 
@@ -216,15 +244,11 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
         state: SPUUserUpdateState
     ) {
         guard handleShowingUpdate else { return }
-        Task { @MainActor [weak self] in
-            self?.activateBeforeSparklePresentsUI()
-        }
+        activateSynchronouslyBeforeSparklePresentsUI()
     }
 
     nonisolated func standardUserDriverWillShowModalAlert() {
-        Task { @MainActor [weak self] in
-            self?.activateBeforeSparklePresentsUI()
-        }
+        activateSynchronouslyBeforeSparklePresentsUI()
     }
 
     private func showManualInstallGuidance() {
@@ -246,8 +270,27 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
         }
     }
 
-    private func activateBeforeSparklePresentsUI() {
-        NSApplication.shared.activate(ignoringOtherApps: true)
+    private nonisolated func activateSynchronouslyBeforeSparklePresentsUI() {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                Self.activateApplicationForSparkle()
+            }
+        } else {
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated {
+                    Self.activateApplicationForSparkle()
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private static func activateApplicationForSparkle() {
+        if #available(macOS 14, *) {
+            NSApplication.shared.activate()
+        } else {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -217,13 +217,13 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
     ) {
         guard handleShowingUpdate else { return }
         Task { @MainActor [weak self] in
-            self?.focusUpdaterUI()
+            self?.activateBeforeSparklePresentsUI()
         }
     }
 
     nonisolated func standardUserDriverWillShowModalAlert() {
         Task { @MainActor [weak self] in
-            self?.focusUpdaterUI()
+            self?.activateBeforeSparklePresentsUI()
         }
     }
 
@@ -246,11 +246,8 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
         }
     }
 
-    private func focusUpdaterUI() {
+    private func activateBeforeSparklePresentsUI() {
         NSApplication.shared.activate(ignoringOtherApps: true)
-        for window in NSApplication.shared.windows where window.isVisible {
-            window.orderFrontRegardless()
-        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -276,16 +276,15 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
                 Self.activateApplicationForSparkle()
             }
         } else {
-            let activationCompleted = DispatchSemaphore(value: 0)
-            DispatchQueue.main.async {
+            // Sparkle calls this immediately before presenting update UI.
+            // Complete activation before returning so LSUIElement update
+            // prompts are ordered in front of the current app. This block only
+            // performs AppKit activation and does not wait on Sparkle work.
+            DispatchQueue.main.sync {
                 MainActor.assumeIsolated {
                     Self.activateApplicationForSparkle()
                 }
-                activationCompleted.signal()
             }
-            // Sparkle calls this immediately before presenting update UI. Wait
-            // briefly so the app is active first, but never block permanently.
-            _ = activationCompleted.wait(timeout: .now() + .milliseconds(250))
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -286,11 +286,10 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
 
     @MainActor
     private static func activateApplicationForSparkle() {
-        if #available(macOS 14, *) {
-            NSApplication.shared.activate()
-        } else {
-            NSApplication.shared.activate(ignoringOtherApps: true)
-        }
+        // Sparkle UI is opened from an LSUIElement menu-bar app. This is a
+        // user-initiated update action, so use strong activation even though
+        // AppKit deprecated the argumented API on macOS 14.
+        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -29,7 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let updaterController = SPUStandardUpdaterController(
                     startingUpdater: true,
                     updaterDelegate: sparkleUpdateDelegate,
-                    userDriverDelegate: nil
+                    userDriverDelegate: sparkleUpdateDelegate
                 )
                 controller.updaterController = updaterController
                 self.updaterController = updaterController
@@ -135,7 +135,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 @MainActor
-final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
+final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUserDriverDelegate {
     weak var appState: AppState?
     private var lastPresentedAt: Date?
 
@@ -210,6 +210,23 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
         }
     }
 
+    nonisolated func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        guard handleShowingUpdate else { return }
+        Task { @MainActor [weak self] in
+            self?.focusUpdaterUI()
+        }
+    }
+
+    nonisolated func standardUserDriverWillShowModalAlert() {
+        Task { @MainActor [weak self] in
+            self?.focusUpdaterUI()
+        }
+    }
+
     private func showManualInstallGuidance() {
         if let lastPresentedAt, Date().timeIntervalSince(lastPresentedAt) < 60 {
             return
@@ -226,6 +243,13 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate {
         if alert.runModal() == .alertFirstButtonReturn,
            let url = URL(string: UpdateFailureGuidance.downloadPageURLString) {
             NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func focusUpdaterUI() {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        for window in NSApplication.shared.windows where window.isVisible {
+            window.orderFrontRegardless()
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -244,11 +244,11 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
         state: SPUUserUpdateState
     ) {
         guard handleShowingUpdate else { return }
-        activateSynchronouslyBeforeSparklePresentsUI()
+        activateBeforeSparklePresentsUI()
     }
 
     nonisolated func standardUserDriverWillShowModalAlert() {
-        activateSynchronouslyBeforeSparklePresentsUI()
+        activateBeforeSparklePresentsUI()
     }
 
     private func showManualInstallGuidance() {
@@ -270,13 +270,13 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
         }
     }
 
-    private nonisolated func activateSynchronouslyBeforeSparklePresentsUI() {
+    private nonisolated func activateBeforeSparklePresentsUI() {
         if Thread.isMainThread {
             MainActor.assumeIsolated {
                 Self.activateApplicationForSparkle()
             }
         } else {
-            DispatchQueue.main.sync {
+            DispatchQueue.main.async {
                 MainActor.assumeIsolated {
                     Self.activateApplicationForSparkle()
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -276,11 +276,16 @@ final class SparkleUpdateDelegate: NSObject, SPUUpdaterDelegate, SPUStandardUser
                 Self.activateApplicationForSparkle()
             }
         } else {
+            let activationCompleted = DispatchSemaphore(value: 0)
             DispatchQueue.main.async {
                 MainActor.assumeIsolated {
                     Self.activateApplicationForSparkle()
                 }
+                activationCompleted.signal()
             }
+            // Sparkle calls this immediately before presenting update UI. Wait
+            // briefly so the app is active first, but never block permanently.
+            _ = activationCompleted.wait(timeout: .now() + .milliseconds(250))
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -29,29 +29,11 @@ enum SparkleUpdateStatus: Equatable {
     case failed(message: String)
 }
 
-enum UserInitiatedUpdateAction: Equatable {
-    case presentStandardUpdater
-    case showBusy(message: String)
-}
-
 enum GoogleCalendarListLoadState: Equatable {
     case idle
     case loading
     case loaded
     case failed(String)
-}
-
-enum UpdateInteractionPolicy {
-    static let busyMessage = "Sparkle is still finishing the previous update check. Try again in a moment."
-
-    static func installAction(for status: SparkleUpdateStatus) -> UserInitiatedUpdateAction {
-        switch status {
-        case .checking, .busy, .installing:
-            return .showBusy(message: busyMessage)
-        case .idle, .available, .downloaded, .upToDate, .disabled, .failed:
-            return .presentStandardUpdater
-        }
-    }
 }
 
 @MainActor

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -52,7 +52,7 @@ struct DashboardRootView: View {
             case .settings:
                 SettingsView(appState: appState, controller: controller)
             case .about:
-                AboutView(appState: appState, controller: controller)
+                AboutView(appState: appState)
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -52,7 +52,7 @@ struct DashboardRootView: View {
             case .settings:
                 SettingsView(appState: appState, controller: controller)
             case .about:
-                AboutView(appState: appState)
+                AboutView(appState: appState, controller: controller)
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2031,6 +2031,7 @@ final class MuesliController: NSObject {
             )
             return
         }
+        // Defer one run loop so app activation takes effect before Sparkle presents its UI.
         DispatchQueue.main.async {
             updaterController.checkForUpdates(nil)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2054,6 +2054,17 @@ final class MuesliController: NSObject {
             className.localizedCaseInsensitiveContains("Sparkle") {
             return true
         }
+
+        // Sparkle's standard UI can present through AppKit alert/window
+        // classes. Keep this semantic fallback narrow and only apply it to
+        // windows created after the update action.
+        let title = window.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return false }
+        if title.localizedCaseInsensitiveContains("update") ||
+            title.localizedCaseInsensitiveContains("updater") ||
+            title.localizedCaseInsensitiveContains("new version") {
+            return true
+        }
         return false
     }
 
@@ -2080,11 +2091,10 @@ final class MuesliController: NSObject {
 
     @MainActor
     private func activateApplicationForSparkle() {
-        if #available(macOS 14, *) {
-            NSApplication.shared.activate()
-        } else {
-            NSApplication.shared.activate(ignoringOtherApps: true)
-        }
+        // Sparkle UI is opened from an LSUIElement menu-bar app. This is a
+        // user-initiated update action, so use strong activation even though
+        // AppKit deprecated the argumented API on macOS 14.
+        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     @objc func quitApp() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2007,34 +2007,15 @@ final class MuesliController: NSObject {
     }
 
     @objc func checkForUpdates() {
-        switch appState.sparkleUpdateStatus {
-        case .available, .downloaded:
-            installAvailableUpdate()
-        case .checking, .busy, .installing:
-            showBusyStatus(
-                UpdateInteractionPolicy.busyMessage,
-                restoring: appState.sparkleUpdateStatus
-            )
-        case .idle, .upToDate, .disabled, .failed:
-            openHistoryWindow(tab: .about)
-            probeForUpdateInformation()
-        }
+        presentStandardUpdateCheck()
     }
 
     func retryUpdateCheck() {
-        probeForUpdateInformation()
+        presentStandardUpdateCheck()
     }
 
     func installAvailableUpdate() {
-        switch UpdateInteractionPolicy.installAction(for: appState.sparkleUpdateStatus) {
-        case .presentStandardUpdater:
-            presentStandardUpdateCheck()
-        case .showBusy(let message):
-            showBusyStatus(
-                message,
-                restoring: appState.sparkleUpdateStatus
-            )
-        }
+        presentStandardUpdateCheck()
     }
 
     private func presentStandardUpdateCheck() {
@@ -2042,6 +2023,7 @@ final class MuesliController: NSObject {
             appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
             return
         }
+        NSApplication.shared.activate(ignoringOtherApps: true)
         guard updaterController.updater.canCheckForUpdates else {
             showBusyStatus(
                 "Sparkle cannot start a new update check yet. Try again in a moment.",
@@ -2049,23 +2031,9 @@ final class MuesliController: NSObject {
             )
             return
         }
-        updaterController.checkForUpdates(nil)
-    }
-
-    private func probeForUpdateInformation() {
-        guard let updaterController else {
-            appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
-            return
+        DispatchQueue.main.async {
+            updaterController.checkForUpdates(nil)
         }
-        guard !updaterController.updater.sessionInProgress else {
-            showBusyStatus(
-                UpdateInteractionPolicy.busyMessage,
-                restoring: appState.sparkleUpdateStatus
-            )
-            return
-        }
-        appState.sparkleUpdateStatus = .checking
-        updaterController.updater.checkForUpdateInformation()
     }
 
     private func showBusyStatus(_ message: String, restoring previousStatus: SparkleUpdateStatus) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -209,6 +209,7 @@ final class MuesliController: NSObject {
     private var onboardingWindowController: OnboardingWindowController?
     var updaterController: SPUStandardUpdaterController?
     private var busyStatusGeneration = 0
+    private var updateCheckGeneration = 0
 
     let appState = AppState()
 
@@ -2010,31 +2011,72 @@ final class MuesliController: NSObject {
         presentStandardUpdateCheck()
     }
 
-    func retryUpdateCheck() {
-        presentStandardUpdateCheck()
-    }
-
-    func installAvailableUpdate() {
-        presentStandardUpdateCheck()
-    }
-
     private func presentStandardUpdateCheck() {
         guard let updaterController else {
             appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
             return
         }
+        updateCheckGeneration += 1
+        let generation = updateCheckGeneration
+        let restoreStatus = recoverableUpdateStatus(appState.sparkleUpdateStatus)
+        let existingWindows = Set(NSApplication.shared.windows.map(ObjectIdentifier.init))
         NSApplication.shared.activate(ignoringOtherApps: true)
-        guard updaterController.updater.canCheckForUpdates else {
-            showBusyStatus(
-                "Sparkle cannot start a new update check yet. Try again in a moment.",
-                restoring: appState.sparkleUpdateStatus
-            )
-            return
-        }
-        // Defer one run loop so app activation takes effect before Sparkle presents its UI.
-        DispatchQueue.main.async {
+        // Always enter Sparkle's standard path. Sparkle uses this same call to
+        // refocus existing updater UI, so local availability gates would make
+        // in-app buttons less reliable than the status-bar action.
+        DispatchQueue.main.async { [weak self] in
             updaterController.checkForUpdates(nil)
+            self?.focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)
+            self?.restoreStaleUpdateCheck(generation: generation, to: restoreStatus)
         }
+    }
+
+    private func restoreStaleUpdateCheck(generation: Int, to restoreStatus: SparkleUpdateStatus) {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 30_000_000_000)
+            guard let self, self.updateCheckGeneration == generation else { return }
+            switch self.appState.sparkleUpdateStatus {
+            case .checking, .busy:
+                self.appState.sparkleUpdateStatus = restoreStatus
+            default:
+                break
+            }
+        }
+    }
+
+    private func focusUpdaterWindowsCreatedAfterUpdateAction(excluding existingWindows: Set<ObjectIdentifier>) {
+        for delay in [80_000_000, 240_000_000, 600_000_000, 1_200_000_000, 2_500_000_000] {
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay))
+                self?.focusUpdaterWindows(excluding: existingWindows)
+            }
+        }
+    }
+
+    private func focusUpdaterWindows(excluding existingWindows: Set<ObjectIdentifier>) {
+        let updaterWindows = NSApplication.shared.windows.filter { window in
+            guard window.isVisible else { return false }
+            if !existingWindows.contains(ObjectIdentifier(window)) {
+                return true
+            }
+            return isLikelyUpdaterWindow(window)
+        }
+        guard !updaterWindows.isEmpty else { return }
+
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        for window in updaterWindows {
+            window.makeKeyAndOrderFront(nil)
+            window.orderFrontRegardless()
+        }
+    }
+
+    private func isLikelyUpdaterWindow(_ window: NSWindow) -> Bool {
+        let className = String(describing: type(of: window))
+        if className.localizedCaseInsensitiveContains("SU") ||
+            className.localizedCaseInsensitiveContains("Sparkle") {
+            return true
+        }
+        return window.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func showBusyStatus(_ message: String, restoring previousStatus: SparkleUpdateStatus) {
@@ -2056,6 +2098,15 @@ final class MuesliController: NSObject {
             return .idle
         }
         return status
+    }
+
+    private func recoverableUpdateStatus(_ status: SparkleUpdateStatus) -> SparkleUpdateStatus {
+        switch status {
+        case .checking, .busy:
+            return .idle
+        default:
+            return status
+        }
     }
 
     @objc func quitApp() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2038,10 +2038,7 @@ final class MuesliController: NSObject {
     private func focusUpdaterWindows(excluding existingWindows: Set<ObjectIdentifier>) {
         let updaterWindows = NSApplication.shared.windows.filter { window in
             guard window.isVisible else { return false }
-            if !existingWindows.contains(ObjectIdentifier(window)) {
-                return true
-            }
-            return isLikelyUpdaterWindow(window)
+            return !existingWindows.contains(ObjectIdentifier(window)) && isLikelyUpdaterWindow(window)
         }
         guard !updaterWindows.isEmpty else { return }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -209,7 +209,6 @@ final class MuesliController: NSObject {
     private var onboardingWindowController: OnboardingWindowController?
     var updaterController: SPUStandardUpdaterController?
     private var busyStatusGeneration = 0
-    private var updateCheckGeneration = 0
 
     let appState = AppState()
 
@@ -2016,31 +2015,14 @@ final class MuesliController: NSObject {
             appState.sparkleUpdateStatus = .disabled(message: "Update checks are disabled for this build.")
             return
         }
-        updateCheckGeneration += 1
-        let generation = updateCheckGeneration
-        let restoreStatus = recoverableUpdateStatus(appState.sparkleUpdateStatus)
         let existingWindows = Set(NSApplication.shared.windows.map(ObjectIdentifier.init))
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        activateApplicationForSparkle()
         // Always enter Sparkle's standard path. Sparkle uses this same call to
         // refocus existing updater UI, so local availability gates would make
         // in-app buttons less reliable than the status-bar action.
         DispatchQueue.main.async { [weak self] in
             updaterController.checkForUpdates(nil)
             self?.focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)
-            self?.restoreStaleUpdateCheck(generation: generation, to: restoreStatus)
-        }
-    }
-
-    private func restoreStaleUpdateCheck(generation: Int, to restoreStatus: SparkleUpdateStatus) {
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 30_000_000_000)
-            guard let self, self.updateCheckGeneration == generation else { return }
-            switch self.appState.sparkleUpdateStatus {
-            case .checking, .busy:
-                self.appState.sparkleUpdateStatus = restoreStatus
-            default:
-                break
-            }
         }
     }
 
@@ -2063,10 +2045,9 @@ final class MuesliController: NSObject {
         }
         guard !updaterWindows.isEmpty else { return }
 
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        activateApplicationForSparkle()
         for window in updaterWindows {
             window.makeKeyAndOrderFront(nil)
-            window.orderFrontRegardless()
         }
     }
 
@@ -2076,7 +2057,7 @@ final class MuesliController: NSObject {
             className.localizedCaseInsensitiveContains("Sparkle") {
             return true
         }
-        return window.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return false
     }
 
     private func showBusyStatus(_ message: String, restoring previousStatus: SparkleUpdateStatus) {
@@ -2100,12 +2081,12 @@ final class MuesliController: NSObject {
         return status
     }
 
-    private func recoverableUpdateStatus(_ status: SparkleUpdateStatus) -> SparkleUpdateStatus {
-        switch status {
-        case .checking, .busy:
-            return .idle
-        default:
-            return status
+    @MainActor
+    private func activateApplicationForSparkle() {
+        if #available(macOS 14, *) {
+            NSApplication.shared.activate()
+        } else {
+            NSApplication.shared.activate(ignoringOtherApps: true)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2020,10 +2020,8 @@ final class MuesliController: NSObject {
         // Always enter Sparkle's standard path. Sparkle uses this same call to
         // refocus existing updater UI, so local availability gates would make
         // in-app buttons less reliable than the status-bar action.
-        DispatchQueue.main.async { [weak self] in
-            updaterController.checkForUpdates(nil)
-            self?.focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)
-        }
+        updaterController.checkForUpdates(nil)
+        focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)
     }
 
     private func focusUpdaterWindowsCreatedAfterUpdateAction(excluding existingWindows: Set<ObjectIdentifier>) {
@@ -2050,7 +2048,8 @@ final class MuesliController: NSObject {
 
     private func isLikelyUpdaterWindow(_ window: NSWindow) -> Bool {
         let className = String(describing: type(of: window))
-        if className.localizedCaseInsensitiveContains("SU") ||
+        if className.localizedCaseInsensitiveContains("SPU") ||
+            className.localizedCaseInsensitiveContains("SU") ||
             className.localizedCaseInsensitiveContains("Sparkle") {
             return true
         }
@@ -2062,7 +2061,8 @@ final class MuesliController: NSObject {
         guard !title.isEmpty else { return false }
         if title.localizedCaseInsensitiveContains("update") ||
             title.localizedCaseInsensitiveContains("updater") ||
-            title.localizedCaseInsensitiveContains("new version") {
+            title.localizedCaseInsensitiveContains("new version") ||
+            title.localizedCaseInsensitiveContains("available") {
             return true
         }
         return false

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -39,7 +39,26 @@ struct SidebarView: View {
     }
 
     private var pendingUpdateCTA: UpdateCTA? {
-        nil
+        switch appState.sparkleUpdateStatus {
+        case .available:
+            return UpdateCTA(
+                label: "Update",
+                icon: "arrow.down",
+                foreground: updateCTAForeground,
+                accessibilityLabel: "Update available",
+                tooltip: "Open About for update instructions"
+            )
+        case .downloaded:
+            return UpdateCTA(
+                label: "Ready",
+                icon: "arrow.clockwise",
+                foreground: updateCTAForeground,
+                accessibilityLabel: "Update ready to install",
+                tooltip: "Open About for update instructions"
+            )
+        case .idle, .checking, .busy, .installing, .upToDate, .disabled, .failed:
+            return nil
+        }
     }
 
     private var updateCTAForeground: Color {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -39,26 +39,7 @@ struct SidebarView: View {
     }
 
     private var pendingUpdateCTA: UpdateCTA? {
-        switch appState.sparkleUpdateStatus {
-        case .available:
-            return UpdateCTA(
-                label: "Update Now",
-                icon: "arrow.down",
-                foreground: updateCTAForeground,
-                accessibilityLabel: "Update available",
-                tooltip: "Install update"
-            )
-        case .downloaded:
-            return UpdateCTA(
-                label: "Restart",
-                icon: "arrow.clockwise",
-                foreground: updateCTAForeground,
-                accessibilityLabel: "Update ready to install",
-                tooltip: "Finish update"
-            )
-        case .idle, .checking, .busy, .installing, .upToDate, .disabled, .failed:
-            return nil
-        }
+        nil
     }
 
     private var updateCTAForeground: Color {
@@ -394,9 +375,6 @@ struct SidebarView: View {
         Button {
             withAnimation(.easeInOut(duration: 0.15)) {
                 appState.selectedTab = tab
-            }
-            if updateCTA != nil {
-                controller.checkForUpdates()
             }
         } label: {
             HStack(spacing: MuesliTheme.spacing12) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -46,7 +46,7 @@ struct SidebarView: View {
                 icon: "arrow.down",
                 foreground: updateCTAForeground,
                 accessibilityLabel: "Update available",
-                tooltip: "Open About to install the update"
+                tooltip: "Install update"
             )
         case .downloaded:
             return UpdateCTA(
@@ -54,7 +54,7 @@ struct SidebarView: View {
                 icon: "arrow.clockwise",
                 foreground: updateCTAForeground,
                 accessibilityLabel: "Update ready to install",
-                tooltip: "Open About to finish installing the update"
+                tooltip: "Finish update"
             )
         case .idle, .checking, .busy, .installing, .upToDate, .disabled, .failed:
             return nil
@@ -394,6 +394,9 @@ struct SidebarView: View {
         Button {
             withAnimation(.easeInOut(duration: 0.15)) {
                 appState.selectedTab = tab
+            }
+            if updateCTA != nil {
+                controller.checkForUpdates()
             }
         } label: {
             HStack(spacing: MuesliTheme.spacing12) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -247,6 +247,7 @@ struct SidebarView: View {
                         Spacer(minLength: 0)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
 
@@ -273,10 +274,12 @@ struct SidebarView: View {
             }
             .padding(.horizontal, sidebarRowHorizontalPadding)
             .padding(.vertical, MuesliTheme.spacing8)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
             )
+            .contentShape(Rectangle())
             .padding(.horizontal, sidebarRowOuterPadding)
 
             if meetingsExpanded {
@@ -424,10 +427,12 @@ struct SidebarView: View {
             }
             .padding(.horizontal, sidebarRowHorizontalPadding)
             .padding(.vertical, MuesliTheme.spacing8)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .fill(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
             )
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .padding(.horizontal, sidebarRowOuterPadding)
@@ -505,6 +510,7 @@ struct SidebarView: View {
         }
         .padding(.horizontal, sidebarRowHorizontalPadding)
         .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                 .fill(isSelected ? MuesliTheme.surfaceSelected.opacity(0.6) : Color.clear)

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import Sparkle
 import MuesliCore
 
 @MainActor
@@ -278,10 +277,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private func checkForUpdatesItem() -> NSMenuItem {
         let item = NSMenuItem(
             title: "Check for Updates…",
-            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            action: #selector(MuesliController.checkForUpdates),
             keyEquivalent: ""
         )
-        item.target = controller.updaterController
+        item.target = controller
         item.isEnabled = controller.updaterController != nil
         return item
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Sparkle
 import MuesliCore
 
 @MainActor
@@ -157,7 +158,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Settings…", action: #selector(MuesliController.openSettingsTab)))
-        menu.addItem(actionItem(title: "Check for Updates…", action: #selector(MuesliController.checkForUpdates)))
+        menu.addItem(checkForUpdatesItem())
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Quit", action: #selector(MuesliController.quitApp)))
     }
@@ -271,6 +272,17 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private func actionItem(title: String, action: Selector) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = controller
+        return item
+    }
+
+    private func checkForUpdatesItem() -> NSMenuItem {
+        let item = NSMenuItem(
+            title: "Check for Updates…",
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        item.target = controller.updaterController
+        item.isEnabled = controller.updaterController != nil
         return item
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -176,7 +176,9 @@ struct UpdateActionRoutingTests {
     func sparkleFocusHandlingDoesNotOrderApplicationWindows() throws {
         let source = try appDelegateSource()
 
-        #expect(source.contains("activateSynchronouslyBeforeSparklePresentsUI()"))
+        #expect(source.contains("activateBeforeSparklePresentsUI()"))
+        #expect(source.contains("DispatchQueue.main.async"))
+        #expect(!source.contains("DispatchQueue.main.sync"))
         #expect(source.contains("NSApplication.shared.activate(ignoringOtherApps: true)"))
         #expect(!source.contains("orderFrontRegardless()"))
     }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -73,35 +73,48 @@ struct UpdateFailureGuidanceTests {
     }
 }
 
-@Suite("Update interaction policy")
-struct UpdateInteractionPolicyTests {
-    @Test(
-        "user install action opens standard Sparkle UI for actionable states",
-        arguments: [
-            SparkleUpdateStatus.idle,
-            .available(version: "0.6.7"),
-            .downloaded(version: "0.6.7"),
-            .upToDate,
-            .disabled(message: "disabled"),
-            .failed(message: "network"),
-        ]
-    )
-    func installActionUsesStandardUpdater(status: SparkleUpdateStatus) {
-        #expect(UpdateInteractionPolicy.installAction(for: status) == .presentStandardUpdater)
+@Suite("Update action routing")
+struct UpdateActionRoutingTests {
+    @Test("all user-initiated update actions enter the standard Sparkle UI")
+    func userUpdateActionsUseStandardSparkleFlow() throws {
+        let source = try muesliControllerSource()
+
+        for method in ["checkForUpdates", "retryUpdateCheck", "installAvailableUpdate"] {
+            let body = try methodBody(named: method, in: source)
+            #expect(body.contains("presentStandardUpdateCheck()"))
+            #expect(!body.contains("checkForUpdateInformation()"))
+        }
     }
 
-    @Test(
-        "user install action stays busy while Sparkle is already in a session",
-        arguments: [
-            SparkleUpdateStatus.checking,
-            .busy(message: "busy"),
-            .installing(version: "0.6.7"),
-        ]
-    )
-    func installActionStaysBusy(status: SparkleUpdateStatus) {
-        #expect(
-            UpdateInteractionPolicy.installAction(for: status)
-                == .showBusy(message: UpdateInteractionPolicy.busyMessage)
-        )
+    private func muesliControllerSource() throws -> String {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let controllerURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent("MuesliController.swift")
+        return try String(contentsOf: controllerURL, encoding: .utf8)
+    }
+
+    private func methodBody(named name: String, in source: String) throws -> String {
+        let pattern = #"(?s)func \#(name)\([^)]*\) \{\s*(.*?)\n    \}"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        guard let match = regex.firstMatch(in: source, range: range),
+              let bodyRange = Range(match.range(at: 1), in: source) else {
+            throw TestFailure("Could not find \(name) body")
+        }
+        return String(source[bodyRange])
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -93,10 +93,17 @@ struct UpdateActionRoutingTests {
         let source = try muesliControllerSource()
 
         #expect(source.contains("updaterController.checkForUpdates(nil)"))
+        #expect(source.contains("focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)"))
+        #expect(try index(of: "updaterController.checkForUpdates(nil)", in: source) <
+            index(of: "focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)", in: source))
         #expect(source.contains("activateApplicationForSparkle()"))
         #expect(!source.contains("canCheckForUpdates"))
         #expect(!source.contains("func installAvailableUpdate()"))
         #expect(!source.contains("restoreStaleUpdateCheck(generation: generation, to: restoreStatus)"))
+        #expect(!source.contains("""
+        DispatchQueue.main.async { [weak self] in
+            updaterController.checkForUpdates(nil)
+        """))
     }
 
     @Test("About page does not launch Sparkle directly")
@@ -117,8 +124,10 @@ struct UpdateActionRoutingTests {
         #expect(source.contains("focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)"))
         #expect(source.contains("return !existingWindows.contains(ObjectIdentifier(window)) && isLikelyUpdaterWindow(window)"))
         #expect(source.contains("isLikelyUpdaterWindow(window)"))
+        #expect(source.contains("className.localizedCaseInsensitiveContains(\"SPU\")"))
         #expect(source.contains("title.localizedCaseInsensitiveContains(\"update\")"))
         #expect(source.contains("title.localizedCaseInsensitiveContains(\"new version\")"))
+        #expect(source.contains("title.localizedCaseInsensitiveContains(\"available\")"))
         #expect(source.contains("return false"))
         #expect(!source.contains("window.collectionBehavior ="))
         #expect(!source.contains("return window.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty"))
@@ -187,6 +196,13 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("AboutView.swift")
         return try String(contentsOf: aboutViewURL, encoding: .utf8)
+    }
+
+    private func index(of needle: String, in haystack: String) throws -> String.Index {
+        guard let range = haystack.range(of: needle) else {
+            throw TestFailure("Could not find \(needle)")
+        }
+        return range.lowerBound
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -78,12 +78,15 @@ struct UpdateActionRoutingTests {
     @Test("status-bar update action enters the standard Sparkle UI")
     func statusBarUpdateActionUsesStandardSparkleFlow() throws {
         let source = try muesliControllerSource()
+        let statusBarSource = try statusBarControllerSource()
 
         #expect(source.contains("""
             @objc func checkForUpdates() {
                 presentStandardUpdateCheck()
             }
         """))
+        #expect(statusBarSource.contains("#selector(SPUStandardUpdaterController.checkForUpdates(_:))"))
+        #expect(statusBarSource.contains("item.target = controller.updaterController"))
         #expect(!source.contains("func retryUpdateCheck()"))
         #expect(!source.contains("checkForUpdateInformation()"))
     }
@@ -106,25 +109,28 @@ struct UpdateActionRoutingTests {
         """))
     }
 
-    @Test("About page update controls route to the standard updater action")
-    func aboutPageUpdateControlsUseStandardUpdaterAction() throws {
+    @Test("About page does not expose unreliable in-app install controls")
+    func aboutPageUsesMenuBarGuidanceOnly() throws {
         let source = try aboutViewSource()
 
-        #expect(source.contains("let controller: MuesliController"))
-        #expect(source.contains("controller.checkForUpdates()"))
-        #expect(source.contains("Install Update"))
-        #expect(source.contains("Finish Update"))
+        #expect(source.contains("Use the menu bar icon > Check for Updates..."))
+        #expect(!source.contains("let controller: MuesliController"))
+        #expect(!source.contains("controller.checkForUpdates()"))
+        #expect(!source.contains("Install Update"))
+        #expect(!source.contains("Finish Update"))
         #expect(!source.contains("retryUpdateCheck()"))
         #expect(!source.contains("installAvailableUpdate()"))
         #expect(!source.contains("performUpdateAction"))
     }
 
-    @Test("Sidebar update call-to-action routes to the standard updater action")
-    func sidebarUpdateCTAUsesStandardUpdaterAction() throws {
+    @Test("Sidebar does not expose an unreliable update call-to-action")
+    func sidebarDoesNotExposeUpdateCTA() throws {
         let source = try sidebarViewSource()
 
-        #expect(source.contains("if updateCTA != nil"))
-        #expect(source.contains("controller.checkForUpdates()"))
+        #expect(source.contains("private var pendingUpdateCTA: UpdateCTA?"))
+        #expect(source.contains("nil"))
+        #expect(!source.contains("if updateCTA != nil"))
+        #expect(!source.contains("Update Now"))
         #expect(!source.contains("Open About to install the update"))
         #expect(!source.contains("Open About to finish installing the update"))
     }
@@ -208,6 +214,19 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("AboutView.swift")
         return try String(contentsOf: aboutViewURL, encoding: .utf8)
+    }
+
+    private func statusBarControllerSource() throws -> String {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let statusBarControllerURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent("StatusBarController.swift")
+        return try String(contentsOf: statusBarControllerURL, encoding: .utf8)
     }
 
     private func sidebarViewSource() throws -> String {

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -75,22 +75,71 @@ struct UpdateFailureGuidanceTests {
 
 @Suite("Update action routing")
 struct UpdateActionRoutingTests {
-    @Test("all user-initiated update actions enter the standard Sparkle UI")
-    func userUpdateActionsUseStandardSparkleFlow() throws {
+    @Test("status-bar update action enters the standard Sparkle UI")
+    func statusBarUpdateActionUsesStandardSparkleFlow() throws {
         let source = try muesliControllerSource()
 
-        for method in ["checkForUpdates", "retryUpdateCheck", "installAvailableUpdate"] {
-            let body = try methodBody(named: method, in: source)
-            #expect(body.contains("presentStandardUpdateCheck()"))
-            #expect(!body.contains("checkForUpdateInformation()"))
-        }
+        let body = try methodBody(named: "checkForUpdates", in: source)
+        #expect(body.contains("presentStandardUpdateCheck()"))
+        #expect(!body.contains("checkForUpdateInformation()"))
+        #expect(!source.contains("func retryUpdateCheck()"))
+    }
+
+    @Test("standard update presentation does not preflight canCheckForUpdates")
+    func standardUpdatePresentationLetsSparkleRefocusExistingUI() throws {
+        let source = try muesliControllerSource()
+        let body = try methodBody(named: "presentStandardUpdateCheck", in: source)
+
+        #expect(body.contains("checkForUpdates(nil)"))
+        #expect(body.contains("restoreStaleUpdateCheck(generation: generation, to: restoreStatus)"))
+        #expect(!body.contains("canCheckForUpdates"))
+        #expect(!source.contains("func installAvailableUpdate()"))
+    }
+
+    @Test("About page does not launch Sparkle directly")
+    func aboutPageIsPassiveUpdateGuidance() throws {
+        let source = try aboutViewSource()
+
+        #expect(source.contains("Use the Muesli menu bar icon > Check for Updates..."))
+        #expect(!source.contains("retryUpdateCheck()"))
+        #expect(!source.contains("Install Update"))
+        #expect(!source.contains("Finish Update"))
+        #expect(!source.contains("performUpdateAction"))
+    }
+
+    @Test("updater focus only targets windows created by the update action")
+    func updaterFocusTargetsNewUpdaterWindowsOnly() throws {
+        let source = try muesliControllerSource()
+
+        #expect(source.contains("focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)"))
+        #expect(source.contains("!existingWindows.contains(ObjectIdentifier(window))"))
+        #expect(source.contains("isLikelyUpdaterWindow(window)"))
+        #expect(!source.contains("window.collectionBehavior ="))
+        #expect(!source.contains(".moveToActiveSpace"))
+        #expect(!source.contains(".fullScreenAuxiliary"))
+        #expect(!source.contains(".canJoinAllSpaces"))
+    }
+
+    @Test("Sparkle delegate cannot leave the About UI checking forever")
+    func sparkleDelegateRestoresStaleCheckingState() throws {
+        let source = try appDelegateSource()
+        let body = try methodBody(named: "restoreStaleUpdateCheck", in: source)
+
+        #expect(source.contains("private var updateCycleGeneration = 0"))
+        #expect(source.contains("let restoreStatus = recoverableUpdateStatus(appState?.sparkleUpdateStatus ?? .idle)"))
+        #expect(source.contains("finishUpdateCheck(with:"))
+        #expect(body.contains("30_000_000_000"))
+        #expect(body.contains("self.updateCycleGeneration == generation"))
+        #expect(body.contains("guard case .checking = self.appState?.sparkleUpdateStatus else { return }"))
+        #expect(body.contains("self.finishUpdateCheck(with: restoreStatus)"))
     }
 
     @Test("Sparkle focus handling activates without manually ordering app windows")
     func sparkleFocusHandlingDoesNotOrderApplicationWindows() throws {
         let source = try appDelegateSource()
 
-        #expect(source.contains("activateBeforeSparklePresentsUI()"))
+        #expect(source.contains("activateSynchronouslyBeforeSparklePresentsUI()"))
+        #expect(source.contains("NSApplication.shared.activate()"))
         #expect(!source.contains("orderFrontRegardless()"))
     }
 
@@ -118,6 +167,19 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("AppDelegate.swift")
         return try String(contentsOf: appDelegateURL, encoding: .utf8)
+    }
+
+    private func aboutViewSource() throws -> String {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let aboutViewURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent("AboutView.swift")
+        return try String(contentsOf: aboutViewURL, encoding: .utf8)
     }
 
     private func methodBody(named name: String, in source: String) throws -> String {

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -106,15 +106,27 @@ struct UpdateActionRoutingTests {
         """))
     }
 
-    @Test("About page does not launch Sparkle directly")
-    func aboutPageIsPassiveUpdateGuidance() throws {
+    @Test("About page update controls route to the standard updater action")
+    func aboutPageUpdateControlsUseStandardUpdaterAction() throws {
         let source = try aboutViewSource()
 
-        #expect(source.contains("Use the Muesli menu bar icon > Check for Updates..."))
+        #expect(source.contains("let controller: MuesliController"))
+        #expect(source.contains("controller.checkForUpdates()"))
+        #expect(source.contains("Install Update"))
+        #expect(source.contains("Finish Update"))
         #expect(!source.contains("retryUpdateCheck()"))
-        #expect(!source.contains("Install Update"))
-        #expect(!source.contains("Finish Update"))
+        #expect(!source.contains("installAvailableUpdate()"))
         #expect(!source.contains("performUpdateAction"))
+    }
+
+    @Test("Sidebar update call-to-action routes to the standard updater action")
+    func sidebarUpdateCTAUsesStandardUpdaterAction() throws {
+        let source = try sidebarViewSource()
+
+        #expect(source.contains("if updateCTA != nil"))
+        #expect(source.contains("controller.checkForUpdates()"))
+        #expect(!source.contains("Open About to install the update"))
+        #expect(!source.contains("Open About to finish installing the update"))
     }
 
     @Test("updater focus only targets windows created by the update action")
@@ -196,6 +208,19 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("AboutView.swift")
         return try String(contentsOf: aboutViewURL, encoding: .utf8)
+    }
+
+    private func sidebarViewSource() throws -> String {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sidebarViewURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent("SidebarView.swift")
+        return try String(contentsOf: sidebarViewURL, encoding: .utf8)
     }
 
     private func index(of needle: String, in haystack: String) throws -> String.Index {

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -86,6 +86,14 @@ struct UpdateActionRoutingTests {
         }
     }
 
+    @Test("Sparkle focus handling activates without manually ordering app windows")
+    func sparkleFocusHandlingDoesNotOrderApplicationWindows() throws {
+        let source = try appDelegateSource()
+
+        #expect(source.contains("activateBeforeSparklePresentsUI()"))
+        #expect(!source.contains("orderFrontRegardless()"))
+    }
+
     private func muesliControllerSource() throws -> String {
         let testFileURL = URL(fileURLWithPath: #filePath)
         let packageRoot = testFileURL
@@ -97,6 +105,19 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("MuesliController.swift")
         return try String(contentsOf: controllerURL, encoding: .utf8)
+    }
+
+    private func appDelegateSource() throws -> String {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let appDelegateURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent("AppDelegate.swift")
+        return try String(contentsOf: appDelegateURL, encoding: .utf8)
     }
 
     private func methodBody(named name: String, in source: String) throws -> String {

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -178,6 +178,8 @@ struct UpdateActionRoutingTests {
 
         #expect(source.contains("activateBeforeSparklePresentsUI()"))
         #expect(source.contains("DispatchQueue.main.async"))
+        #expect(source.contains("DispatchSemaphore(value: 0)"))
+        #expect(source.contains("activationCompleted.wait(timeout: .now() + .milliseconds(250))"))
         #expect(!source.contains("DispatchQueue.main.sync"))
         #expect(source.contains("NSApplication.shared.activate(ignoringOtherApps: true)"))
         #expect(!source.contains("orderFrontRegardless()"))

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -123,14 +123,16 @@ struct UpdateActionRoutingTests {
         #expect(!source.contains("performUpdateAction"))
     }
 
-    @Test("Sidebar does not expose an unreliable update call-to-action")
-    func sidebarDoesNotExposeUpdateCTA() throws {
+    @Test("Sidebar update badge is status-only and does not start updates")
+    func sidebarUpdateBadgeIsStatusOnly() throws {
         let source = try sidebarViewSource()
 
         #expect(source.contains("private var pendingUpdateCTA: UpdateCTA?"))
-        #expect(source.contains("nil"))
+        #expect(source.contains("label: \"Update\""))
+        #expect(source.contains("Open About for update instructions"))
         #expect(!source.contains("if updateCTA != nil"))
         #expect(!source.contains("Update Now"))
+        #expect(!source.contains("controller.checkForUpdates()"))
         #expect(!source.contains("Open About to install the update"))
         #expect(!source.contains("Open About to finish installing the update"))
     }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -85,8 +85,10 @@ struct UpdateActionRoutingTests {
                 presentStandardUpdateCheck()
             }
         """))
-        #expect(statusBarSource.contains("#selector(SPUStandardUpdaterController.checkForUpdates(_:))"))
-        #expect(statusBarSource.contains("item.target = controller.updaterController"))
+        #expect(statusBarSource.contains("#selector(MuesliController.checkForUpdates)"))
+        #expect(statusBarSource.contains("item.target = controller"))
+        #expect(statusBarSource.contains("item.isEnabled = controller.updaterController != nil"))
+        #expect(!statusBarSource.contains("#selector(SPUStandardUpdaterController.checkForUpdates(_:))"))
         #expect(!source.contains("func retryUpdateCheck()"))
         #expect(!source.contains("checkForUpdateInformation()"))
     }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -115,7 +115,7 @@ struct UpdateActionRoutingTests {
         let source = try muesliControllerSource()
 
         #expect(source.contains("focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)"))
-        #expect(source.contains("!existingWindows.contains(ObjectIdentifier(window))"))
+        #expect(source.contains("return !existingWindows.contains(ObjectIdentifier(window)) && isLikelyUpdaterWindow(window)"))
         #expect(source.contains("isLikelyUpdaterWindow(window)"))
         #expect(source.contains("return false"))
         #expect(!source.contains("window.collectionBehavior ="))
@@ -185,6 +185,69 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("AboutView.swift")
         return try String(contentsOf: aboutViewURL, encoding: .utf8)
+    }
+}
+
+@Suite("Sidebar hit areas")
+struct SidebarHitAreaTests {
+    @Test("primary sidebar rows use their full highlighted surface as the hit target")
+    func primarySidebarRowsExpandBeforeApplyingHitShape() throws {
+        let source = try sidebarViewSource()
+        let sidebarItem = try sourceSection(
+            in: source,
+            from: "private func sidebarItem",
+            to: "private var darkModeToggle"
+        )
+
+        #expect(sidebarItem.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
+        #expect(sidebarItem.contains(".background("))
+        #expect(sidebarItem.contains(".contentShape(Rectangle())"))
+        #expect(try index(of: ".frame(maxWidth: .infinity, alignment: .leading)", in: sidebarItem) <
+            index(of: ".contentShape(Rectangle())", in: sidebarItem))
+    }
+
+    @Test("meeting filter rows use the full row width as the hit target")
+    func meetingFilterRowsExpandBeforeApplyingHitShape() throws {
+        let source = try sidebarViewSource()
+        let meetingFilterRow = try sourceSection(
+            in: source,
+            from: "private func meetingFilterRow",
+            to: "private func folderRenameField"
+        )
+
+        #expect(meetingFilterRow.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
+        #expect(meetingFilterRow.contains(".background("))
+        #expect(meetingFilterRow.contains(".contentShape(Rectangle())"))
+        #expect(try index(of: ".frame(maxWidth: .infinity, alignment: .leading)", in: meetingFilterRow) <
+            index(of: ".contentShape(Rectangle())", in: meetingFilterRow))
+    }
+
+    private func sidebarViewSource() throws -> String {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sidebarViewURL = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("MuesliNativeApp")
+            .appendingPathComponent("SidebarView.swift")
+        return try String(contentsOf: sidebarViewURL, encoding: .utf8)
+    }
+
+    private func sourceSection(in source: String, from start: String, to end: String) throws -> String {
+        guard let startRange = source.range(of: start),
+              let endRange = source[startRange.upperBound...].range(of: end) else {
+            throw TestFailure("Could not find source section from \(start) to \(end)")
+        }
+        return String(source[startRange.lowerBound..<endRange.lowerBound])
+    }
+
+    private func index(of needle: String, in haystack: String) throws -> String.Index {
+        guard let range = haystack.range(of: needle) else {
+            throw TestFailure("Could not find \(needle)")
+        }
+        return range.lowerBound
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -177,10 +177,10 @@ struct UpdateActionRoutingTests {
         let source = try appDelegateSource()
 
         #expect(source.contains("activateBeforeSparklePresentsUI()"))
-        #expect(source.contains("DispatchQueue.main.async"))
-        #expect(source.contains("DispatchSemaphore(value: 0)"))
-        #expect(source.contains("activationCompleted.wait(timeout: .now() + .milliseconds(250))"))
-        #expect(!source.contains("DispatchQueue.main.sync"))
+        #expect(source.contains("DispatchQueue.main.sync"))
+        #expect(source.contains("Complete activation before returning"))
+        #expect(!source.contains("DispatchSemaphore(value: 0)"))
+        #expect(!source.contains("activationCompleted.wait(timeout:"))
         #expect(source.contains("NSApplication.shared.activate(ignoringOtherApps: true)"))
         #expect(!source.contains("orderFrontRegardless()"))
     }

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -79,21 +79,24 @@ struct UpdateActionRoutingTests {
     func statusBarUpdateActionUsesStandardSparkleFlow() throws {
         let source = try muesliControllerSource()
 
-        let body = try methodBody(named: "checkForUpdates", in: source)
-        #expect(body.contains("presentStandardUpdateCheck()"))
-        #expect(!body.contains("checkForUpdateInformation()"))
+        #expect(source.contains("""
+            @objc func checkForUpdates() {
+                presentStandardUpdateCheck()
+            }
+        """))
         #expect(!source.contains("func retryUpdateCheck()"))
+        #expect(!source.contains("checkForUpdateInformation()"))
     }
 
     @Test("standard update presentation does not preflight canCheckForUpdates")
     func standardUpdatePresentationLetsSparkleRefocusExistingUI() throws {
         let source = try muesliControllerSource()
-        let body = try methodBody(named: "presentStandardUpdateCheck", in: source)
 
-        #expect(body.contains("checkForUpdates(nil)"))
-        #expect(body.contains("restoreStaleUpdateCheck(generation: generation, to: restoreStatus)"))
-        #expect(!body.contains("canCheckForUpdates"))
+        #expect(source.contains("updaterController.checkForUpdates(nil)"))
+        #expect(source.contains("activateApplicationForSparkle()"))
+        #expect(!source.contains("canCheckForUpdates"))
         #expect(!source.contains("func installAvailableUpdate()"))
+        #expect(!source.contains("restoreStaleUpdateCheck(generation: generation, to: restoreStatus)"))
     }
 
     @Test("About page does not launch Sparkle directly")
@@ -114,24 +117,26 @@ struct UpdateActionRoutingTests {
         #expect(source.contains("focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)"))
         #expect(source.contains("!existingWindows.contains(ObjectIdentifier(window))"))
         #expect(source.contains("isLikelyUpdaterWindow(window)"))
+        #expect(source.contains("return false"))
         #expect(!source.contains("window.collectionBehavior ="))
+        #expect(!source.contains("return window.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty"))
         #expect(!source.contains(".moveToActiveSpace"))
         #expect(!source.contains(".fullScreenAuxiliary"))
         #expect(!source.contains(".canJoinAllSpaces"))
+        #expect(!source.contains("orderFrontRegardless()"))
     }
 
     @Test("Sparkle delegate cannot leave the About UI checking forever")
     func sparkleDelegateRestoresStaleCheckingState() throws {
         let source = try appDelegateSource()
-        let body = try methodBody(named: "restoreStaleUpdateCheck", in: source)
 
         #expect(source.contains("private var updateCycleGeneration = 0"))
         #expect(source.contains("let restoreStatus = recoverableUpdateStatus(appState?.sparkleUpdateStatus ?? .idle)"))
         #expect(source.contains("finishUpdateCheck(with:"))
-        #expect(body.contains("30_000_000_000"))
-        #expect(body.contains("self.updateCycleGeneration == generation"))
-        #expect(body.contains("guard case .checking = self.appState?.sparkleUpdateStatus else { return }"))
-        #expect(body.contains("self.finishUpdateCheck(with: restoreStatus)"))
+        #expect(source.contains("30_000_000_000"))
+        #expect(source.contains("self.updateCycleGeneration == generation"))
+        #expect(source.contains("guard case .checking = self.appState?.sparkleUpdateStatus else { return }"))
+        #expect(source.contains("self.finishUpdateCheck(with: restoreStatus)"))
     }
 
     @Test("Sparkle focus handling activates without manually ordering app windows")
@@ -180,17 +185,6 @@ struct UpdateActionRoutingTests {
             .appendingPathComponent("MuesliNativeApp")
             .appendingPathComponent("AboutView.swift")
         return try String(contentsOf: aboutViewURL, encoding: .utf8)
-    }
-
-    private func methodBody(named name: String, in source: String) throws -> String {
-        let pattern = #"(?s)func \#(name)\([^)]*\) \{\s*(.*?)\n    \}"#
-        let regex = try NSRegularExpression(pattern: pattern)
-        let range = NSRange(source.startIndex..<source.endIndex, in: source)
-        guard let match = regex.firstMatch(in: source, range: range),
-              let bodyRange = Range(match.range(at: 1), in: source) else {
-            throw TestFailure("Could not find \(name) body")
-        }
-        return String(source[bodyRange])
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/UpdateFailureGuidanceTests.swift
@@ -117,6 +117,8 @@ struct UpdateActionRoutingTests {
         #expect(source.contains("focusUpdaterWindowsCreatedAfterUpdateAction(excluding: existingWindows)"))
         #expect(source.contains("return !existingWindows.contains(ObjectIdentifier(window)) && isLikelyUpdaterWindow(window)"))
         #expect(source.contains("isLikelyUpdaterWindow(window)"))
+        #expect(source.contains("title.localizedCaseInsensitiveContains(\"update\")"))
+        #expect(source.contains("title.localizedCaseInsensitiveContains(\"new version\")"))
         #expect(source.contains("return false"))
         #expect(!source.contains("window.collectionBehavior ="))
         #expect(!source.contains("return window.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty"))
@@ -144,7 +146,7 @@ struct UpdateActionRoutingTests {
         let source = try appDelegateSource()
 
         #expect(source.contains("activateSynchronouslyBeforeSparklePresentsUI()"))
-        #expect(source.contains("NSApplication.shared.activate()"))
+        #expect(source.contains("NSApplication.shared.activate(ignoringOtherApps: true)"))
         #expect(!source.contains("orderFrontRegardless()"))
     }
 


### PR DESCRIPTION
## Summary
- route status-bar, About retry/check, and About install update actions through Sparkle's standard user-initiated update flow
- wire Sparkle's standard user-driver delegate and focus updater UI when Sparkle shows update or modal alert windows
- remove the custom silent-probe interaction policy that caused in-app update buttons to diverge from the reliable status-bar flow
- add a regression test that guards user update actions from calling `checkForUpdateInformation()`
- add `localai-org/LocalVQE` acknowledgements in About and README

## Verification
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/preprod" --filter 'Update'`
- built and installed a local signed `MuesliPreprod 0.6.8-preprod.1` against the preprod feed
- verified status-bar `Check for Updates...` opens Sparkle's native update alert in focus
- verified About `Install Update` opens Sparkle's native update alert in focus repeatedly after dismissing it

## Notes
- I did not click Sparkle's final install action during local verification because the published `0.6.8-preprod.2` artifact does not contain this fix yet.
- A full suite run had two parallel timing failures in `HotkeyMonitor` hold-threshold tests; rerunning `--filter 'HotkeyMonitor'` passed.
