### PR TITLE
Add LM Studio and custom summary backends

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -950,6 +950,10 @@ struct MeetingDetailView: View {
             return appState.isChatGPTAuthenticated
         } else if appState.selectedMeetingSummaryBackend == .openAI {
             return !config.openAIAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENAI_API_KEY"] != nil
+        } else if appState.selectedMeetingSummaryBackend == .ollama
+                    || appState.selectedMeetingSummaryBackend == .lmStudio
+                    || appState.selectedMeetingSummaryBackend == .customLLM {
+            return true
         } else {
             return !config.openRouterAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -951,9 +951,10 @@ struct MeetingDetailView: View {
         } else if appState.selectedMeetingSummaryBackend == .openAI {
             return !config.openAIAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENAI_API_KEY"] != nil
         } else if appState.selectedMeetingSummaryBackend == .ollama
-                    || appState.selectedMeetingSummaryBackend == .lmStudio
-                    || appState.selectedMeetingSummaryBackend == .customLLM {
+                    || appState.selectedMeetingSummaryBackend == .lmStudio {
             return true
+        } else if appState.selectedMeetingSummaryBackend == .customLLM {
+            return !MeetingSummaryClient.customLLMRequiresAPIKey(config: config) || !config.customLLMAPIKey.isEmpty
         } else {
             return !config.openRouterAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -950,11 +950,12 @@ struct MeetingDetailView: View {
             return appState.isChatGPTAuthenticated
         } else if appState.selectedMeetingSummaryBackend == .openAI {
             return !config.openAIAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENAI_API_KEY"] != nil
-        } else if appState.selectedMeetingSummaryBackend == .ollama
-                    || appState.selectedMeetingSummaryBackend == .lmStudio {
+        } else if appState.selectedMeetingSummaryBackend == .ollama {
             return true
+        } else if appState.selectedMeetingSummaryBackend == .lmStudio {
+            return MeetingSummaryClient.lmStudioHasRequiredSettings(config: config)
         } else if appState.selectedMeetingSummaryBackend == .customLLM {
-            return !MeetingSummaryClient.customLLMRequiresAPIKey(config: config) || !config.customLLMAPIKey.isEmpty
+            return MeetingSummaryClient.customLLMHasRequiredSettings(config: config)
         } else {
             return !config.openRouterAPIKey.isEmpty || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -26,6 +26,7 @@ enum MeetingSummaryClient {
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
+    private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
     private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
     private static let defaultChatGPTModel = "gpt-5.4-mini"
@@ -33,6 +34,10 @@ enum MeetingSummaryClient {
     private static let defaultSummaryMaxOutputTokens = 2500
     private static let ollamaSummaryTimeout: TimeInterval = 300
     private static let ollamaTitleTimeout: TimeInterval = 120
+    private static let lmStudioSummaryTimeout: TimeInterval = 300
+    private static let lmStudioTitleTimeout: TimeInterval = 120
+    private static let customLLMSummaryTimeout: TimeInterval = 300
+    private static let customLLMTitleTimeout: TimeInterval = 120
 
     private static let titleInstructions = """
     Generate a short, descriptive meeting title (3-7 words) from these transcript excerpts. \
@@ -85,6 +90,30 @@ enum MeetingSummaryClient {
         }
         if backend == MeetingSummaryBackendOption.ollama.backend {
             generatedNotes = try await summarizeWithOllama(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
+        if backend == MeetingSummaryBackendOption.lmStudio.backend {
+            generatedNotes = try await summarizeWithLMStudio(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotesToRetain,
+                config: config,
+                template: template,
+                visualContext: visualContext
+            )
+            return notesByRetainingManualNotes(generatedNotes: generatedNotes, manualNotes: manualNotesToRetain)
+        }
+        if backend == MeetingSummaryBackendOption.customLLM.backend {
+            generatedNotes = try await summarizeWithCustomLLM(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -482,6 +511,213 @@ enum MeetingSummaryClient {
         }
     }
 
+    private static func summarizeWithLMStudio(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil
+    ) async throws -> String {
+        guard let requestURL = resolveLMStudioURL(config: config) else {
+            throw MeetingSummaryError.backendFailed(backend: "LM Studio", statusCode: nil, message: "Invalid LM Studio URL: \(config.lmStudioURL)")
+        }
+        let configuredModel = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredModel.isEmpty else {
+            throw MeetingSummaryError.backendFailed(
+                backend: "LM Studio",
+                statusCode: nil,
+                message: "No model selected. Select an LM Studio model in Settings."
+            )
+        }
+        return try await summarizeWithChatCompletions(
+            backend: "LM Studio",
+            requestURL: requestURL,
+            apiKey: "",
+            model: configuredModel,
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            config: config,
+            template: template,
+            visualContext: visualContext,
+            timeout: lmStudioSummaryTimeout
+        )
+    }
+
+    private static func summarizeWithCustomLLM(
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String? = nil
+    ) async throws -> String {
+        let format = CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI
+        guard let requestURL = resolveCustomLLMURL(config: config, format: format) else {
+            throw MeetingSummaryError.backendFailed(backend: "Custom LLM", statusCode: nil, message: "Invalid custom URL: \(config.customLLMURL)")
+        }
+        let configuredModel = config.customLLMModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = configuredModel.isEmpty ? (format == .anthropic ? "claude-3-5-sonnet-20241022" : "custom-model") : configuredModel
+        let apiKey = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch format {
+        case .openAI:
+            return try await summarizeWithChatCompletions(
+                backend: "Custom LLM",
+                requestURL: requestURL,
+                apiKey: apiKey,
+                model: model,
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotes,
+                config: config,
+                template: template,
+                visualContext: visualContext,
+                timeout: customLLMSummaryTimeout
+            )
+        case .anthropic:
+            return try await summarizeWithAnthropicMessages(
+                backend: "Custom LLM",
+                requestURL: requestURL,
+                apiKey: apiKey,
+                model: model,
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                existingNotes: existingNotes,
+                manualNotes: manualNotes,
+                config: config,
+                template: template,
+                visualContext: visualContext,
+                timeout: customLLMSummaryTimeout
+            )
+        }
+    }
+
+    private static func summarizeWithChatCompletions(
+        backend: String,
+        requestURL: URL,
+        apiKey: String,
+        model: String,
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String?,
+        timeout: TimeInterval
+    ) async throws -> String {
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
+        let userPrompt = summaryUserPrompt(
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            visualContext: visualContext
+        )
+        let isOpenAI = requestURL.host?.contains("openai.com") == true
+        var body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": instructions],
+                ["role": "user", "content": userPrompt],
+            ],
+        ]
+        body[isOpenAI ? "max_completion_tokens" : "max_tokens"] = defaultSummaryMaxOutputTokens
+
+        var request = URLRequest(url: requestURL)
+        request.timeoutInterval = timeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: backend)
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let text = extractOpenRouterText(from: json),
+                !text.isEmpty
+            else {
+                if let message = extractErrorMessage(from: data) {
+                    throw MeetingSummaryError.backendFailed(backend: backend, statusCode: nil, message: message)
+                }
+                throw MeetingSummaryError.emptyResponse(backend: backend)
+            }
+            return text
+        } catch {
+            throw summaryRequestError(backend: backend, error: error)
+        }
+    }
+
+    private static func summarizeWithAnthropicMessages(
+        backend: String,
+        requestURL: URL,
+        apiKey: String,
+        model: String,
+        transcript: String,
+        meetingTitle: String,
+        existingNotes: String?,
+        manualNotes: String?,
+        config: AppConfig,
+        template: MeetingTemplateSnapshot,
+        visualContext: String?,
+        timeout: TimeInterval
+    ) async throws -> String {
+        let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
+        let userPrompt = summaryUserPrompt(
+            transcript: transcript,
+            meetingTitle: meetingTitle,
+            existingNotes: existingNotes,
+            manualNotes: manualNotes,
+            visualContext: visualContext
+        )
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": defaultSummaryMaxOutputTokens,
+            "system": instructions,
+            "messages": [
+                ["role": "user", "content": userPrompt],
+            ],
+        ]
+
+        var request = URLRequest(url: requestURL)
+        request.timeoutInterval = timeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        if !apiKey.isEmpty {
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: backend)
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let text = extractAnthropicText(from: json),
+                !text.isEmpty
+            else {
+                if let message = extractErrorMessage(from: data) {
+                    throw MeetingSummaryError.backendFailed(backend: backend, statusCode: nil, message: message)
+                }
+                throw MeetingSummaryError.emptyResponse(backend: backend)
+            }
+            return text
+        } catch {
+            throw summaryRequestError(backend: backend, error: error)
+        }
+    }
+
     /// Call the WHAM streaming API and collect the full response text.
     private static func callWHAM(systemPrompt: String, userPrompt: String, model: String) async throws -> String? {
         let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
@@ -635,6 +871,63 @@ enum MeetingSummaryClient {
         return nil
     }
 
+    static func extractAnthropicText(from payload: [String: Any]) -> String? {
+        guard let content = payload["content"] as? [[String: Any]] else { return nil }
+        let parts = content.compactMap { entry -> String? in
+            guard (entry["type"] as? String) == "text",
+                  let text = entry["text"] as? String,
+                  !text.isEmpty else {
+                return nil
+            }
+            return text
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func resolveCustomLLMURL(config: AppConfig, format: CustomLLMFormat) -> URL? {
+        let rawURL = config.customLLMURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultURL: String
+        let endpointSuffix: String
+        switch format {
+        case .openAI:
+            defaultURL = "http://localhost:8080/v1/chat/completions"
+            endpointSuffix = "v1/chat/completions"
+        case .anthropic:
+            defaultURL = "https://api.anthropic.com/v1/messages"
+            endpointSuffix = "v1/messages"
+        }
+        return resolveEndpointURL(rawURL.isEmpty ? defaultURL : rawURL, endpointSuffix: endpointSuffix)
+    }
+
+    static func resolveLMStudioURL(config: AppConfig) -> URL? {
+        let rawURL = config.lmStudioURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        return resolveEndpointURL(
+            rawURL.isEmpty ? defaultLMStudioBaseURL.absoluteString : rawURL,
+            endpointSuffix: "v1/chat/completions"
+        )
+    }
+
+    private static func resolveEndpointURL(_ rawURL: String, endpointSuffix: String) -> URL? {
+        guard var components = URLComponents(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)),
+              components.scheme != nil,
+              components.host != nil else {
+            return nil
+        }
+
+        let suffixParts = endpointSuffix.split(separator: "/").map(String.init)
+        var pathParts = components.path.split(separator: "/").map(String.init)
+
+        if pathParts.isEmpty || pathParts == ["v1"] {
+            pathParts = suffixParts
+        } else if !pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+            pathParts.append(contentsOf: suffixParts)
+        }
+
+        components.path = "/" + pathParts.joined(separator: "/")
+        return components.url
+    }
+
     static func generateTitle(transcript: String, config: AppConfig) async -> String? {
         let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.chatGPT.backend : config.meetingSummaryBackend).lowercased()
 
@@ -662,6 +955,14 @@ enum MeetingSummaryClient {
 
         if backend == MeetingSummaryBackendOption.ollama.backend {
             return await generateTitleWithOllama(transcript: excerpt, config: config)
+        }
+
+        if backend == MeetingSummaryBackendOption.lmStudio.backend {
+            return await generateTitleWithLMStudio(transcript: excerpt, config: config)
+        }
+
+        if backend == MeetingSummaryBackendOption.customLLM.backend {
+            return await generateTitleWithCustomLLM(transcript: excerpt, config: config)
         }
 
         let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey
@@ -707,7 +1008,7 @@ enum MeetingSummaryClient {
     private static func callChatCompletions(
         url: URL, apiKey: String, model: String,
         systemPrompt: String, userPrompt: String,
-        maxTokens: Int?, extraHeaders: [String: String]
+        maxTokens: Int?, extraHeaders: [String: String], timeout: TimeInterval? = nil
     ) async -> String? {
         let isOpenAI = url.host?.contains("openai.com") == true
         var body: [String: Any] = [
@@ -723,9 +1024,14 @@ enum MeetingSummaryClient {
         }
 
         var request = URLRequest(url: url)
+        if let timeout {
+            request.timeoutInterval = timeout
+        }
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
         for (key, value) in extraHeaders {
             request.setValue(value, forHTTPHeaderField: key)
         }
@@ -772,6 +1078,78 @@ enum MeetingSummaryClient {
         } catch {
             fputs("[summary] ChatGPT title generation failed: \(error)\n", stderr)
             return nil
+        }
+    }
+
+    private static func generateTitleWithLMStudio(transcript: String, config: AppConfig) async -> String? {
+        guard let requestURL = resolveLMStudioURL(config: config) else {
+            fputs("[summary] LM Studio title generation: invalid URL \(config.lmStudioURL)\n", stderr)
+            return nil
+        }
+        let model = config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else {
+            fputs("[summary] LM Studio title generation: no model selected\n", stderr)
+            return nil
+        }
+        return await callChatCompletions(
+            url: requestURL,
+            apiKey: "",
+            model: model,
+            systemPrompt: titleInstructions,
+            userPrompt: transcript,
+            maxTokens: 100,
+            extraHeaders: [:],
+            timeout: lmStudioTitleTimeout
+        )
+    }
+
+    private static func generateTitleWithCustomLLM(transcript: String, config: AppConfig) async -> String? {
+        let format = CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI
+        guard let requestURL = resolveCustomLLMURL(config: config, format: format) else { return nil }
+        let apiKey = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let configuredModel = config.customLLMModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = configuredModel.isEmpty ? (format == .anthropic ? "claude-3-5-sonnet-20241022" : "custom-model") : configuredModel
+
+        switch format {
+        case .openAI:
+            return await callChatCompletions(
+                url: requestURL,
+                apiKey: apiKey,
+                model: model,
+                systemPrompt: titleInstructions,
+                userPrompt: transcript,
+                maxTokens: 100,
+                extraHeaders: [:],
+                timeout: customLLMTitleTimeout
+            )
+        case .anthropic:
+            let body: [String: Any] = [
+                "model": model,
+                "max_tokens": 100,
+                "system": titleInstructions,
+                "messages": [
+                    ["role": "user", "content": transcript],
+                ],
+            ]
+            var request = URLRequest(url: requestURL)
+            request.timeoutInterval = customLLMTitleTimeout
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            if !apiKey.isEmpty {
+                request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+            }
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                try validateHTTPResponse(response, data: data, backend: "Custom LLM")
+                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+                return extractAnthropicText(from: json)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+            } catch {
+                fputs("[summary] Custom LLM title generation failed: \(error)\n", stderr)
+                return nil
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -561,8 +561,21 @@ enum MeetingSummaryClient {
             throw MeetingSummaryError.backendFailed(backend: "Custom LLM", statusCode: nil, message: "Invalid custom URL: \(config.customLLMURL)")
         }
         let configuredModel = config.customLLMModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let model = configuredModel.isEmpty ? (format == .anthropic ? "claude-3-5-sonnet-20241022" : "custom-model") : configuredModel
+        guard !configuredModel.isEmpty else {
+            throw MeetingSummaryError.backendFailed(
+                backend: "Custom LLM",
+                statusCode: nil,
+                message: "No model selected. Enter a model in Settings."
+            )
+        }
         let apiKey = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if customLLMRequiresAPIKey(config: config) && apiKey.isEmpty {
+            throw MeetingSummaryError.backendFailed(
+                backend: "Custom LLM",
+                statusCode: nil,
+                message: "Enter an API key for the selected Custom LLM format."
+            )
+        }
 
         switch format {
         case .openAI:
@@ -570,7 +583,7 @@ enum MeetingSummaryClient {
                 backend: "Custom LLM",
                 requestURL: requestURL,
                 apiKey: apiKey,
-                model: model,
+                model: configuredModel,
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -585,7 +598,7 @@ enum MeetingSummaryClient {
                 backend: "Custom LLM",
                 requestURL: requestURL,
                 apiKey: apiKey,
-                model: model,
+                model: configuredModel,
                 transcript: transcript,
                 meetingTitle: meetingTitle,
                 existingNotes: existingNotes,
@@ -596,6 +609,10 @@ enum MeetingSummaryClient {
                 timeout: customLLMSummaryTimeout
             )
         }
+    }
+
+    static func customLLMRequiresAPIKey(config: AppConfig) -> Bool {
+        (CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI) == .anthropic
     }
 
     private static func summarizeWithChatCompletions(
@@ -918,8 +935,10 @@ enum MeetingSummaryClient {
         let suffixParts = endpointSuffix.split(separator: "/").map(String.init)
         var pathParts = components.path.split(separator: "/").map(String.init)
 
-        if pathParts.isEmpty || pathParts == ["v1"] {
+        if pathParts.isEmpty {
             pathParts = suffixParts
+        } else if pathParts.last == suffixParts.first {
+            pathParts = Array(pathParts.dropLast()) + suffixParts
         } else if !pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
             pathParts.append(contentsOf: suffixParts)
         }
@@ -1064,6 +1083,51 @@ enum MeetingSummaryClient {
         }
     }
 
+    private static func callAnthropicMessages(
+        url: URL,
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userPrompt: String,
+        maxTokens: Int,
+        timeout: TimeInterval? = nil
+    ) async -> String? {
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": maxTokens,
+            "system": systemPrompt,
+            "messages": [
+                ["role": "user", "content": userPrompt],
+            ],
+        ]
+
+        var request = URLRequest(url: url)
+        if let timeout {
+            request.timeoutInterval = timeout
+        }
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        if !apiKey.isEmpty {
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try validateHTTPResponse(response, data: data, backend: "Custom LLM")
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                fputs("[summary] Anthropic title generation: invalid JSON response\n", stderr)
+                return nil
+            }
+            return extractAnthropicText(from: json)?
+                .trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+        } catch {
+            fputs("[summary] Anthropic title generation failed: \(error)\n", stderr)
+            return nil
+        }
+    }
+
     private static func generateTitleWithChatGPT(transcript: String, config: AppConfig) async -> String? {
         do {
             let model = config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel
@@ -1108,14 +1172,21 @@ enum MeetingSummaryClient {
         guard let requestURL = resolveCustomLLMURL(config: config, format: format) else { return nil }
         let apiKey = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let configuredModel = config.customLLMModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let model = configuredModel.isEmpty ? (format == .anthropic ? "claude-3-5-sonnet-20241022" : "custom-model") : configuredModel
+        guard !configuredModel.isEmpty else {
+            fputs("[summary] Custom LLM title generation: no model selected\n", stderr)
+            return nil
+        }
+        if customLLMRequiresAPIKey(config: config) && apiKey.isEmpty {
+            fputs("[summary] Custom LLM title generation: no API key configured\n", stderr)
+            return nil
+        }
 
         switch format {
         case .openAI:
             return await callChatCompletions(
                 url: requestURL,
                 apiKey: apiKey,
-                model: model,
+                model: configuredModel,
                 systemPrompt: titleInstructions,
                 userPrompt: transcript,
                 maxTokens: 100,
@@ -1123,33 +1194,15 @@ enum MeetingSummaryClient {
                 timeout: customLLMTitleTimeout
             )
         case .anthropic:
-            let body: [String: Any] = [
-                "model": model,
-                "max_tokens": 100,
-                "system": titleInstructions,
-                "messages": [
-                    ["role": "user", "content": transcript],
-                ],
-            ]
-            var request = URLRequest(url: requestURL)
-            request.timeoutInterval = customLLMTitleTimeout
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-            if !apiKey.isEmpty {
-                request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-            }
-            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-            do {
-                let (data, response) = try await URLSession.shared.data(for: request)
-                try validateHTTPResponse(response, data: data, backend: "Custom LLM")
-                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-                return extractAnthropicText(from: json)?
-                    .trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
-            } catch {
-                fputs("[summary] Custom LLM title generation failed: \(error)\n", stderr)
-                return nil
-            }
+            return await callAnthropicMessages(
+                url: requestURL,
+                apiKey: apiKey,
+                model: configuredModel,
+                systemPrompt: titleInstructions,
+                userPrompt: transcript,
+                maxTokens: 100,
+                timeout: customLLMTitleTimeout
+            )
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -949,14 +949,25 @@ enum MeetingSummaryClient {
             pathParts = suffixParts
         } else if pathParts.last == suffixParts.first {
             pathParts = Array(pathParts.dropLast()) + suffixParts
-        } else if pathParts.last == suffixParts.last || pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
-            // Already points at a completion/messages endpoint, including provider-specific paths.
-        } else {
+        } else if !isCompleteEndpointPath(pathParts, endpointSuffixParts: suffixParts) {
             pathParts.append(contentsOf: suffixParts)
         }
 
         components.path = "/" + pathParts.joined(separator: "/")
         return components.url
+    }
+
+    private static func isCompleteEndpointPath(_ pathParts: [String], endpointSuffixParts suffixParts: [String]) -> Bool {
+        if pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+            return true
+        }
+        if suffixParts == ["v1", "chat", "completions"] {
+            return pathParts.suffix(2).elementsEqual(["chat", "completions"])
+        }
+        if suffixParts == ["v1", "messages"] {
+            return pathParts.count >= suffixParts.count && pathParts.last == "messages"
+        }
+        return false
     }
 
     static func generateTitle(transcript: String, config: AppConfig) async -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -615,6 +615,16 @@ enum MeetingSummaryClient {
         (CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI) == .anthropic
     }
 
+    static func lmStudioHasRequiredSettings(config: AppConfig) -> Bool {
+        !config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    static func customLLMHasRequiredSettings(config: AppConfig) -> Bool {
+        let model = config.customLLMModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !model.isEmpty && (!customLLMRequiresAPIKey(config: config) || !apiKey.isEmpty)
+    }
+
     private static func summarizeWithChatCompletions(
         backend: String,
         requestURL: URL,
@@ -939,7 +949,9 @@ enum MeetingSummaryClient {
             pathParts = suffixParts
         } else if pathParts.last == suffixParts.first {
             pathParts = Array(pathParts.dropLast()) + suffixParts
-        } else if !pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+        } else if pathParts.last == suffixParts.last || pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+            // Already points at a completion/messages endpoint, including provider-specific paths.
+        } else {
             pathParts.append(contentsOf: suffixParts)
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -344,13 +344,37 @@ struct MeetingSummaryBackendOption: Equatable {
         label: "Ollama"
     )
 
-    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama]
+    static let lmStudio = MeetingSummaryBackendOption(
+        backend: "lmstudio",
+        label: "LM Studio"
+    )
+
+    static let customLLM = MeetingSummaryBackendOption(
+        backend: "custom_llm",
+        label: "Custom LLM"
+    )
+
+    static let all: [MeetingSummaryBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .lmStudio, .customLLM]
 
     static func resolved(_ backend: String?) -> MeetingSummaryBackendOption {
         guard let backend, let option = all.first(where: { $0.backend == backend }) else {
             return .chatGPT
         }
         return option
+    }
+}
+
+enum CustomLLMFormat: String, Codable, CaseIterable {
+    case openAI = "openai"
+    case anthropic = "anthropic"
+
+    var label: String {
+        switch self {
+        case .openAI:
+            return "OpenAI-compatible"
+        case .anthropic:
+            return "Anthropic Messages"
+        }
     }
 }
 
@@ -714,6 +738,12 @@ struct AppConfig: Codable {
     var chatGPTModel: String = ""
     var ollamaURL: String = "http://localhost:11434"
     var ollamaModel: String = "qwen3.5"
+    var lmStudioURL: String = "http://localhost:1234"
+    var lmStudioModel: String = ""
+    var customLLMURL: String = ""
+    var customLLMAPIKey: String = ""
+    var customLLMModel: String = ""
+    var customLLMFormat: String = CustomLLMFormat.openAI.rawValue
     var summaryModel: String = ""
     var meetingSummaryModel: String = ""
     var hasCompletedOnboarding: Bool = false
@@ -786,6 +816,12 @@ struct AppConfig: Codable {
         case chatGPTModel = "chatgpt_model"
         case ollamaURL = "ollama_url"
         case ollamaModel = "ollama_model"
+        case lmStudioURL = "lmstudio_url"
+        case lmStudioModel = "lmstudio_model"
+        case customLLMURL = "custom_llm_url"
+        case customLLMAPIKey = "custom_llm_api_key"
+        case customLLMModel = "custom_llm_model"
+        case customLLMFormat = "custom_llm_format"
         case summaryModel = "summary_model"
         case meetingSummaryModel = "meeting_summary_model"
         case hasCompletedOnboarding = "has_completed_onboarding"
@@ -877,6 +913,13 @@ struct AppConfig: Codable {
         chatGPTModel = (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
         ollamaURL = (try? c.decode(String.self, forKey: .ollamaURL)) ?? defaults.ollamaURL
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
+        lmStudioURL = (try? c.decode(String.self, forKey: .lmStudioURL)) ?? defaults.lmStudioURL
+        lmStudioModel = (try? c.decode(String.self, forKey: .lmStudioModel)) ?? defaults.lmStudioModel
+        customLLMURL = (try? c.decode(String.self, forKey: .customLLMURL)) ?? defaults.customLLMURL
+        customLLMAPIKey = (try? c.decode(String.self, forKey: .customLLMAPIKey)) ?? defaults.customLLMAPIKey
+        customLLMModel = (try? c.decode(String.self, forKey: .customLLMModel)) ?? defaults.customLLMModel
+        let decodedCustomLLMFormat = (try? c.decode(String.self, forKey: .customLLMFormat)) ?? defaults.customLLMFormat
+        customLLMFormat = CustomLLMFormat(rawValue: decodedCustomLLMFormat)?.rawValue ?? defaults.customLLMFormat
         summaryModel = (try? c.decode(String.self, forKey: .summaryModel)) ?? defaults.summaryModel
         meetingSummaryModel = (try? c.decode(String.self, forKey: .meetingSummaryModel)) ?? defaults.meetingSummaryModel
         hasCompletedOnboarding = (try? c.decode(Bool.self, forKey: .hasCompletedOnboarding)) ?? defaults.hasCompletedOnboarding

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -561,6 +561,61 @@ struct SettingsView: View {
                             placeholder: "qwen3.5"
                         ) { val in controller.updateConfig { $0.ollamaModel = val } }
                     }
+                } else if appState.selectedMeetingSummaryBackend == .lmStudio {
+                    settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.lmStudioURL,
+                            placeholder: "http://localhost:1234",
+                            onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model", controlWidth: meetingControlWidth) {
+                        settingsModelTextField(
+                            currentModel: appState.config.lmStudioModel,
+                            placeholder: "Select a loaded LM Studio model"
+                        ) { val in controller.updateConfig { $0.lmStudioModel = val } }
+                    }
+                } else if appState.selectedMeetingSummaryBackend == .customLLM {
+                    settingsRow("API Format", controlWidth: meetingControlWidth) {
+                        settingsMenu(
+                            selection: CustomLLMFormat(rawValue: appState.config.customLLMFormat)?.label ?? CustomLLMFormat.openAI.label,
+                            options: CustomLLMFormat.allCases.map(\.label)
+                        ) { label in
+                            guard let format = CustomLLMFormat.allCases.first(where: { $0.label == label }) else { return }
+                            controller.updateConfig { $0.customLLMFormat = format.rawValue }
+                        }
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Endpoint", controlWidth: meetingControlWidth) {
+                        PastableTextField(
+                            text: appState.config.customLLMURL,
+                            placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
+                                ? "https://api.anthropic.com"
+                                : "http://localhost:8080/v1",
+                            onChange: { val in controller.updateConfig { $0.customLLMURL = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("API Key", controlWidth: meetingControlWidth) {
+                        PastableSecureField(
+                            text: appState.config.customLLMAPIKey,
+                            placeholder: "Optional for local servers",
+                            onChange: { val in controller.updateConfig { $0.customLLMAPIKey = val } }
+                        )
+                        .frame(height: 22)
+                    }
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Model", controlWidth: meetingControlWidth) {
+                        settingsModelTextField(
+                            currentModel: appState.config.customLLMModel,
+                            placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
+                                ? "claude-3-5-sonnet-20241022"
+                                : "custom-model-id"
+                        ) { val in controller.updateConfig { $0.customLLMModel = val } }
+                    }
                 } else {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -602,7 +602,9 @@ struct SettingsView: View {
                     settingsRow("API Key", controlWidth: meetingControlWidth) {
                         PastableSecureField(
                             text: appState.config.customLLMAPIKey,
-                            placeholder: "Optional for local servers",
+                            placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
+                                ? "Required for Anthropic API"
+                                : "Optional for local servers",
                             onChange: { val in controller.updateConfig { $0.customLLMAPIKey = val } }
                         )
                         .frame(height: 22)

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -385,4 +385,158 @@ struct MeetingSummaryClientTests {
             #expect(summaryError != nil)
         }
     }
+
+    @Test("resolveCustomLLMURL expands OpenAI-compatible endpoints")
+    func resolveCustomLLMOpenAIURL() {
+        var config = AppConfig()
+
+        config.customLLMURL = ""
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "http://localhost:8080/v1/chat/completions"
+        )
+
+        config.customLLMURL = "https://models.example.com"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/v1/chat/completions"
+        )
+
+        config.customLLMURL = "https://models.example.com/v1/"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/v1/chat/completions"
+        )
+
+        config.customLLMURL = "https://models.example.com/v1/chat/completions/"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/v1/chat/completions"
+        )
+    }
+
+    @Test("resolveLMStudioURL expands chat completion endpoints")
+    func resolveLMStudioURL() {
+        var config = AppConfig()
+
+        config.lmStudioURL = ""
+        #expect(
+            MeetingSummaryClient.resolveLMStudioURL(config: config)?.absoluteString ==
+                "http://localhost:1234/v1/chat/completions"
+        )
+
+        config.lmStudioURL = "http://localhost:1234/v1"
+        #expect(
+            MeetingSummaryClient.resolveLMStudioURL(config: config)?.absoluteString ==
+                "http://localhost:1234/v1/chat/completions"
+        )
+
+        config.lmStudioURL = "http://localhost:1234/v1/chat/completions"
+        #expect(
+            MeetingSummaryClient.resolveLMStudioURL(config: config)?.absoluteString ==
+                "http://localhost:1234/v1/chat/completions"
+        )
+    }
+
+    @Test("resolveCustomLLMURL expands Anthropic endpoints")
+    func resolveCustomLLMAnthropicURL() {
+        var config = AppConfig()
+
+        config.customLLMURL = ""
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
+                "https://api.anthropic.com/v1/messages"
+        )
+
+        config.customLLMURL = "https://models.example.com/anthropic"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
+                "https://models.example.com/anthropic/v1/messages"
+        )
+
+        config.customLLMURL = "https://models.example.com/v1/messages/"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
+                "https://models.example.com/v1/messages"
+        )
+    }
+
+    @Test("extractAnthropicText joins text blocks")
+    func extractAnthropicText() {
+        let payload: [String: Any] = [
+            "content": [
+                ["type": "text", "text": "First"],
+                ["type": "text", "text": "Second"],
+            ],
+        ]
+
+        #expect(MeetingSummaryClient.extractAnthropicText(from: payload) == "First\nSecond")
+        #expect(MeetingSummaryClient.extractAnthropicText(from: [:]) == nil)
+    }
+
+    @Test("summarize routes to LM Studio when configured")
+    func routesToLMStudio() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "http://localhost:1"
+        config.lmStudioModel = "local-model"
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            let summaryError = error as? MeetingSummaryError
+            #expect(summaryError != nil)
+            if case .requestFailed(let backend, _) = summaryError! {
+                #expect(backend == "LM Studio")
+            } else {
+                #expect(Bool(false), "Expected requestFailed error, got \(String(describing: error))")
+            }
+        }
+    }
+
+    @Test("summarize routes to custom LLM without requiring an API key")
+    func routesToCustomLLMWithoutKey() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "custom_llm"
+        config.customLLMFormat = "openai"
+        config.customLLMURL = "http://localhost:1"
+        config.customLLMAPIKey = ""
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Custom Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            let summaryError = error as? MeetingSummaryError
+            #expect(summaryError != nil)
+            if case .requestFailed(let backend, _) = summaryError! {
+                #expect(backend == "Custom LLM")
+            } else {
+                #expect(Bool(false), "Expected requestFailed error, got \(String(describing: error))")
+            }
+        }
+    }
+
+    @Test("generateTitle returns nil for LM Studio when unreachable")
+    func titleLMStudioUnreachable() async {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "lmstudio"
+        config.lmStudioURL = "http://localhost:1"
+        config.lmStudioModel = "local-model"
+
+        let title = await MeetingSummaryClient.generateTitle(
+            transcript: "Sprint planning discussion",
+            config: config
+        )
+
+        #expect(title == nil)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -408,6 +408,12 @@ struct MeetingSummaryClientTests {
                 "https://models.example.com/v1/chat/completions"
         )
 
+        config.customLLMURL = "https://models.example.com/openai/v1"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/openai/v1/chat/completions"
+        )
+
         config.customLLMURL = "https://models.example.com/v1/chat/completions/"
         #expect(
             MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
@@ -431,6 +437,12 @@ struct MeetingSummaryClientTests {
                 "http://localhost:1234/v1/chat/completions"
         )
 
+        config.lmStudioURL = "http://localhost:1234/proxy/v1"
+        #expect(
+            MeetingSummaryClient.resolveLMStudioURL(config: config)?.absoluteString ==
+                "http://localhost:1234/proxy/v1/chat/completions"
+        )
+
         config.lmStudioURL = "http://localhost:1234/v1/chat/completions"
         #expect(
             MeetingSummaryClient.resolveLMStudioURL(config: config)?.absoluteString ==
@@ -449,6 +461,12 @@ struct MeetingSummaryClientTests {
         )
 
         config.customLLMURL = "https://models.example.com/anthropic"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
+                "https://models.example.com/anthropic/v1/messages"
+        )
+
+        config.customLLMURL = "https://models.example.com/anthropic/v1"
         #expect(
             MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
                 "https://models.example.com/anthropic/v1/messages"
@@ -506,6 +524,7 @@ struct MeetingSummaryClientTests {
         config.customLLMFormat = "openai"
         config.customLLMURL = "http://localhost:1"
         config.customLLMAPIKey = ""
+        config.customLLMModel = "local-model"
 
         do {
             _ = try await MeetingSummaryClient.summarize(
@@ -523,6 +542,67 @@ struct MeetingSummaryClientTests {
                 #expect(Bool(false), "Expected requestFailed error, got \(String(describing: error))")
             }
         }
+    }
+
+    @Test("custom LLM summary requires explicit model")
+    func customLLMRequiresModel() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "custom_llm"
+        config.customLLMFormat = "openai"
+        config.customLLMURL = "http://localhost:1"
+        config.customLLMModel = ""
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Custom Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            guard case .backendFailed(let backend, _, let message) = error as? MeetingSummaryError else {
+                #expect(Bool(false), "Expected backendFailed error, got \(String(describing: error))")
+                return
+            }
+            #expect(backend == "Custom LLM")
+            #expect(message.contains("No model selected"))
+        }
+    }
+
+    @Test("Anthropic custom LLM requires API key")
+    func anthropicCustomLLMRequiresAPIKey() async throws {
+        var config = AppConfig()
+        config.meetingSummaryBackend = "custom_llm"
+        config.customLLMFormat = "anthropic"
+        config.customLLMAPIKey = ""
+        config.customLLMModel = "claude-test"
+
+        #expect(MeetingSummaryClient.customLLMRequiresAPIKey(config: config))
+
+        do {
+            _ = try await MeetingSummaryClient.summarize(
+                transcript: "Test transcript",
+                meetingTitle: "My Custom Meeting",
+                config: config
+            )
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            guard case .backendFailed(let backend, _, let message) = error as? MeetingSummaryError else {
+                #expect(Bool(false), "Expected backendFailed error, got \(String(describing: error))")
+                return
+            }
+            #expect(backend == "Custom LLM")
+            #expect(message.contains("API key"))
+        }
+    }
+
+    @Test("OpenAI-compatible custom LLM does not require API key")
+    func openAICustomLLMDoesNotRequireAPIKey() {
+        var config = AppConfig()
+        config.customLLMFormat = "openai"
+        config.customLLMAPIKey = ""
+
+        #expect(!MeetingSummaryClient.customLLMRequiresAPIKey(config: config))
     }
 
     @Test("generateTitle returns nil for LM Studio when unreachable")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -420,6 +420,12 @@ struct MeetingSummaryClientTests {
                 "https://models.example.com/llm/v2/chat/completions"
         )
 
+        config.customLLMURL = "https://models.example.com/llm/v2/completions"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/llm/v2/completions/v1/chat/completions"
+        )
+
         config.customLLMURL = "https://models.example.com/openai/deployments/my-model/chat/completions?api-version=2024-10-21"
         #expect(
             MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
@@ -488,6 +494,12 @@ struct MeetingSummaryClientTests {
         #expect(
             MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
                 "https://models.example.com/anthropic/v2/messages"
+        )
+
+        config.customLLMURL = "https://models.example.com/messages"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
+                "https://models.example.com/messages/v1/messages"
         )
 
         config.customLLMURL = "https://models.example.com/v1/messages/"

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -414,6 +414,18 @@ struct MeetingSummaryClientTests {
                 "https://models.example.com/openai/v1/chat/completions"
         )
 
+        config.customLLMURL = "https://models.example.com/llm/v2/chat/completions"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/llm/v2/chat/completions"
+        )
+
+        config.customLLMURL = "https://models.example.com/openai/deployments/my-model/chat/completions?api-version=2024-10-21"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
+                "https://models.example.com/openai/deployments/my-model/chat/completions?api-version=2024-10-21"
+        )
+
         config.customLLMURL = "https://models.example.com/v1/chat/completions/"
         #expect(
             MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .openAI)?.absoluteString ==
@@ -470,6 +482,12 @@ struct MeetingSummaryClientTests {
         #expect(
             MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
                 "https://models.example.com/anthropic/v1/messages"
+        )
+
+        config.customLLMURL = "https://models.example.com/anthropic/v2/messages"
+        #expect(
+            MeetingSummaryClient.resolveCustomLLMURL(config: config, format: .anthropic)?.absoluteString ==
+                "https://models.example.com/anthropic/v2/messages"
         )
 
         config.customLLMURL = "https://models.example.com/v1/messages/"
@@ -603,6 +621,46 @@ struct MeetingSummaryClientTests {
         config.customLLMAPIKey = ""
 
         #expect(!MeetingSummaryClient.customLLMRequiresAPIKey(config: config))
+    }
+
+    @Test("LM Studio readiness requires model")
+    func lmStudioReadinessRequiresModel() {
+        var config = AppConfig()
+
+        config.lmStudioModel = ""
+        #expect(!MeetingSummaryClient.lmStudioHasRequiredSettings(config: config))
+
+        config.lmStudioModel = "   "
+        #expect(!MeetingSummaryClient.lmStudioHasRequiredSettings(config: config))
+
+        config.lmStudioModel = "local-model"
+        #expect(MeetingSummaryClient.lmStudioHasRequiredSettings(config: config))
+    }
+
+    @Test("Custom LLM readiness requires model and Anthropic key")
+    func customLLMReadinessRequiresModelAndAnthropicKey() {
+        var config = AppConfig()
+
+        config.customLLMFormat = "openai"
+        config.customLLMModel = ""
+        config.customLLMAPIKey = ""
+        #expect(!MeetingSummaryClient.customLLMHasRequiredSettings(config: config))
+
+        config.customLLMModel = "   "
+        #expect(!MeetingSummaryClient.customLLMHasRequiredSettings(config: config))
+
+        config.customLLMModel = "local-model"
+        #expect(MeetingSummaryClient.customLLMHasRequiredSettings(config: config))
+
+        config.customLLMFormat = "anthropic"
+        config.customLLMAPIKey = ""
+        #expect(!MeetingSummaryClient.customLLMHasRequiredSettings(config: config))
+
+        config.customLLMAPIKey = "   "
+        #expect(!MeetingSummaryClient.customLLMHasRequiredSettings(config: config))
+
+        config.customLLMAPIKey = "sk-ant-test"
+        #expect(MeetingSummaryClient.customLLMHasRequiredSettings(config: config))
     }
 
     @Test("generateTitle returns nil for LM Studio when unreachable")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -368,11 +368,13 @@ struct MeetingSummaryBackendTests {
 
     @Test("all options listed")
     func allOptions() {
-        #expect(MeetingSummaryBackendOption.all.count == 4)
+        #expect(MeetingSummaryBackendOption.all.count == 6)
         #expect(MeetingSummaryBackendOption.all.contains(.openAI))
         #expect(MeetingSummaryBackendOption.all.contains(.openRouter))
         #expect(MeetingSummaryBackendOption.all.contains(.chatGPT))
         #expect(MeetingSummaryBackendOption.all.contains(.ollama))
+        #expect(MeetingSummaryBackendOption.all.contains(.lmStudio))
+        #expect(MeetingSummaryBackendOption.all.contains(.customLLM))
     }
 
     @Test("backend strings are lowercase")
@@ -380,6 +382,8 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.openAI.backend == "openai")
         #expect(MeetingSummaryBackendOption.openRouter.backend == "openrouter")
         #expect(MeetingSummaryBackendOption.ollama.backend == "ollama")
+        #expect(MeetingSummaryBackendOption.lmStudio.backend == "lmstudio")
+        #expect(MeetingSummaryBackendOption.customLLM.backend == "custom_llm")
     }
 
     @Test("configured values resolve with ChatGPT fallback")
@@ -387,8 +391,16 @@ struct MeetingSummaryBackendTests {
         #expect(MeetingSummaryBackendOption.resolved("chatgpt") == .chatGPT)
         #expect(MeetingSummaryBackendOption.resolved("openrouter") == .openRouter)
         #expect(MeetingSummaryBackendOption.resolved("ollama") == .ollama)
+        #expect(MeetingSummaryBackendOption.resolved("lmstudio") == .lmStudio)
+        #expect(MeetingSummaryBackendOption.resolved("custom_llm") == .customLLM)
         #expect(MeetingSummaryBackendOption.resolved("unknown") == .chatGPT)
         #expect(MeetingSummaryBackendOption.resolved(nil) == .chatGPT)
+    }
+
+    @Test("Custom LLM format labels")
+    func customLLMFormatLabels() {
+        #expect(CustomLLMFormat.openAI.label == "OpenAI-compatible")
+        #expect(CustomLLMFormat.anthropic.label == "Anthropic Messages")
     }
 }
 
@@ -413,6 +425,12 @@ struct AppConfigTests {
         #expect(config.openRouterAPIKey.isEmpty)
         #expect(config.ollamaURL == "http://localhost:11434")
         #expect(config.ollamaModel == "qwen3.5")
+        #expect(config.lmStudioURL == "http://localhost:1234")
+        #expect(config.lmStudioModel.isEmpty)
+        #expect(config.customLLMURL.isEmpty)
+        #expect(config.customLLMAPIKey.isEmpty)
+        #expect(config.customLLMModel.isEmpty)
+        #expect(config.customLLMFormat == "openai")
         #expect(config.dictationHotkey == .default)
         #expect(config.computerUseHotkey == .computerUseDefault)
         #expect(config.enableComputerUseHotkey == false)
@@ -466,6 +484,12 @@ struct AppConfigTests {
         config.hotkeyTriggerThresholdMS = 125
         config.computerUseHotkeyTriggerThresholdMS = 350
         config.meetingRecordingHotkeyTriggerThresholdMS = 900
+        config.lmStudioURL = "http://localhost:1234"
+        config.lmStudioModel = "local-model"
+        config.customLLMURL = "https://example.com"
+        config.customLLMAPIKey = "custom-key"
+        config.customLLMModel = "custom-model"
+        config.customLLMFormat = "anthropic"
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -496,6 +520,12 @@ struct AppConfigTests {
         #expect(decoded.hotkeyTriggerThresholdMS == 125)
         #expect(decoded.computerUseHotkeyTriggerThresholdMS == 350)
         #expect(decoded.meetingRecordingHotkeyTriggerThresholdMS == 900)
+        #expect(decoded.lmStudioURL == "http://localhost:1234")
+        #expect(decoded.lmStudioModel == "local-model")
+        #expect(decoded.customLLMURL == "https://example.com")
+        #expect(decoded.customLLMAPIKey == "custom-key")
+        #expect(decoded.customLLMModel == "custom-model")
+        #expect(decoded.customLLMFormat == "anthropic")
     }
 
     @Test("JSON coding keys use snake_case")
@@ -531,6 +561,12 @@ struct AppConfigTests {
         #expect(json["meeting_hook_enabled"] != nil)
         #expect(json["meeting_hook_path"] != nil)
         #expect(json["meeting_hook_timeout_seconds"] != nil)
+        #expect(json["lmstudio_url"] != nil)
+        #expect(json["lmstudio_model"] != nil)
+        #expect(json["custom_llm_url"] != nil)
+        #expect(json["custom_llm_api_key"] != nil)
+        #expect(json["custom_llm_model"] != nil)
+        #expect(json["custom_llm_format"] != nil)
     }
 
     @Test("decodes with missing fields using defaults")
@@ -562,6 +598,12 @@ struct AppConfigTests {
         #expect(config.meetingHookEnabled == false)
         #expect(config.meetingHookPath.isEmpty)
         #expect(config.meetingHookTimeoutSeconds == 30)
+        #expect(config.lmStudioURL == "http://localhost:1234")
+        #expect(config.lmStudioModel.isEmpty)
+        #expect(config.customLLMURL.isEmpty)
+        #expect(config.customLLMAPIKey.isEmpty)
+        #expect(config.customLLMModel.isEmpty)
+        #expect(config.customLLMFormat == "openai")
     }
 
     @Test("legacy completed onboarding enables meetings when use case is missing")


### PR DESCRIPTION
## Summary
- adds LM Studio as a local OpenAI-compatible meeting summary backend
- adds a Custom LLM summary backend supporting OpenAI-compatible chat completions and Anthropic Messages APIs
- exposes Settings config for endpoint, API key, model, and custom API format
- normalizes endpoint URLs so base URLs, /v1 URLs, and full endpoints work
- fixes summary availability so local/custom backends are not blocked by OpenRouter API key checks

## Related PRs
- Supersedes/integrates backend scope from #148 (LM Studio)
- Supersedes/integrates backend scope from #170 (custom OpenAI-compatible/Anthropic endpoint)

## Notes
- This intentionally does not include the custom command backend from #150, per current scope.
- This intentionally leaves onboarding unchanged; the new providers are configured through Settings.
- Follow-up candidates: onboarding layout for additional providers and LM Studio model discovery.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-summary-backends" --filter MeetingSummaryBackendTests --filter AppConfigTests --filter MeetingSummaryClientTests`
- `git diff --check`