### PR TITLE
[codex] Fix browser audio meeting false positives

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -447,22 +447,6 @@ final class MeetingCandidateResolver {
             )
         }
 
-        if let foregroundBrowser = snapshot.runningApps.first(where: {
-            $0.bundleID == snapshot.foregroundBundleID && Self.browserApps[$0.bundleID] != nil
-        }), let appName = Self.browserApps[foregroundBrowser.bundleID] {
-            return candidate(
-                id: "browser:\(foregroundBrowser.bundleID)",
-                platform: .unknown,
-                appName: appName,
-                url: nil,
-                title: nil,
-                evidence: mediaEvidence(from: snapshot).union([.foregroundApp]),
-                sourceBundleID: foregroundBrowser.bundleID,
-                sourcePID: nil,
-                now: snapshot.now
-            )
-        }
-
         return nil
     }
 
@@ -493,6 +477,7 @@ final class MeetingCandidateResolver {
     ) -> AudioProcessActivity? {
         let candidates = processes.filter { process in
             guard process.bundleID != selfBundleID else { return false }
+            guard process.isRunningInput else { return false }
             guard Self.dedicatedApps[process.bundleID] != nil else { return false }
             if !Self.weakDedicatedAppBundleIDs.contains(process.bundleID) {
                 return true
@@ -517,6 +502,7 @@ final class MeetingCandidateResolver {
     ) -> (process: AudioProcessActivity, bundleID: String, appName: String)? {
         let candidates = processes.compactMap { process -> (process: AudioProcessActivity, bundleID: String, appName: String)? in
             guard process.bundleID != selfBundleID,
+                  process.isRunningInput,
                   let browserBundleID = browserBundleID(for: process.bundleID),
                   let appName = Self.browserApps[browserBundleID] else {
                 return nil
@@ -572,7 +558,7 @@ final class MeetingCandidateResolver {
     }
 
     private func hasMediaActivity(_ snapshot: MeetingSignalSnapshot) -> Bool {
-        snapshot.micActive || snapshot.cameraActive || !snapshot.audioInputProcesses.isEmpty
+        snapshot.micActive || snapshot.cameraActive || snapshot.audioInputProcesses.contains { $0.isRunningInput }
     }
 
     private func activeInputProcess(
@@ -580,7 +566,7 @@ final class MeetingCandidateResolver {
         in snapshot: MeetingSignalSnapshot
     ) -> AudioProcessActivity? {
         snapshot.audioInputProcesses.first {
-            $0.bundleID == bundleID || isHelperBundleID($0.bundleID, for: bundleID)
+            $0.isRunningInput && ($0.bundleID == bundleID || isHelperBundleID($0.bundleID, for: bundleID))
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -98,6 +98,40 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.evidence.contains(.audioInputProcess) == true)
     }
 
+    @Test("Meet URL with browser output-only helper does not claim audio input attribution")
+    func meetURLWithBrowserOutputOnlyHelperDoesNotClaimAudioInput() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            browserMeetings: [
+                BrowserMeetingContext(
+                    bundleID: "com.google.Chrome",
+                    appName: "Chrome",
+                    pid: 1234,
+                    url: "meet.google.com/pwm-txwq-txy",
+                    normalizedID: "googleMeet:meet.google.com/pwm-txwq-txy",
+                    platform: .googleMeet,
+                    isFocused: true
+                ),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "com.google.Chrome.helper",
+                    appName: "Google Chrome Helper",
+                    isRunningInput: false,
+                    isRunningOutput: true
+                ),
+            ],
+            foregroundBundleID: "com.google.Chrome"
+        ))
+
+        #expect(candidate?.id == "googleMeet:meet.google.com/pwm-txwq-txy")
+        #expect(candidate?.sourcePID == 1234)
+        #expect(candidate?.evidence.contains(.audioInputProcess) == false)
+        #expect(candidate?.suppressionID == candidate?.id)
+    }
+
     @Test("Chrome Meet audio input resolves after transient foreground loss")
     func chromeMeetAudioInputResolvesAfterForegroundLoss() {
         let candidate = resolver().resolve(snapshot(
@@ -249,6 +283,89 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.appName == "Chrome")
         #expect(candidate?.sourceBundleID == "com.google.Chrome")
         #expect(candidate?.evidence.contains(.foregroundApp) == true)
+    }
+
+    @Test("foreground browser with global mic activity does not resolve without URL or input attribution")
+    func foregroundBrowserWithGlobalMicDoesNotResolve() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: true,
+            cameraActive: false,
+            runningApps: [
+                RunningAppInfo(bundleID: "company.thebrowser.Browser", isActive: true),
+            ],
+            browserMeetings: [],
+            audioInputProcesses: [],
+            foregroundBundleID: "company.thebrowser.Browser"
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("browser output-only process does not resolve without URL")
+    func browserOutputOnlyProcessDoesNotResolve() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 9876,
+                    bundleID: "company.thebrowser.Browser.helper",
+                    appName: "Arc Helper",
+                    isRunningInput: false,
+                    isRunningOutput: true
+                ),
+            ],
+            foregroundBundleID: "company.thebrowser.Browser"
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("dedicated app output-only process does not resolve without URL")
+    func dedicatedAppOutputOnlyProcessDoesNotResolve() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            runningApps: [
+                RunningAppInfo(bundleID: "us.zoom.xos", isActive: true),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 4321,
+                    bundleID: "us.zoom.xos",
+                    appName: "Zoom",
+                    isRunningInput: false,
+                    isRunningOutput: true
+                ),
+            ],
+            foregroundBundleID: "us.zoom.xos"
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("calendar plus output-only app process does not resolve without input activity")
+    func calendarPlusOutputOnlyAppProcessDoesNotResolve() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: false,
+            calendarEvent: CalendarEventContext(id: "evt-zoom", title: "Team sync"),
+            runningApps: [
+                RunningAppInfo(bundleID: "us.zoom.xos", isActive: true),
+            ],
+            audioInputProcesses: [
+                AudioProcessActivity(
+                    pid: 4321,
+                    bundleID: "us.zoom.xos",
+                    appName: "Zoom",
+                    isRunningInput: false,
+                    isRunningOutput: true
+                ),
+            ],
+            foregroundBundleID: "us.zoom.xos"
+        ))
+
+        #expect(candidate == nil)
     }
 
     @Test("synthetic browser audio PID is not exposed as source PID")


### PR DESCRIPTION
## Summary
- remove the no-URL foreground-browser fallback that could turn global media or mic state into a meeting prompt
- require confirmed `isRunningInput` before browser or dedicated app audio processes can create no-URL meeting candidates
- add regression coverage for foreground browser + global mic, browser output-only helpers, and dedicated app output-only processes

## Root cause
0.6.8 could show `Meeting detected` for Arc/Chrome/Safari without a meeting URL when weak media activity was present and the browser was foreground. On some macOS/audio setups, output playback or unrelated global input state could therefore look like browser meeting intent.

## Validation
- `MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/test-browser-audio-fp" swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-browser-audio-fp" --filter MeetingCandidateResolverTests`
- Passed: 24 tests in `MeetingCandidateResolver`

Existing Swift warnings appeared in unrelated auth/screen-capture files during the build; no test failures.