### PR TITLE
Prevent browser probes from launching closed apps

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -174,8 +174,10 @@ final class BrowserMeetingActivityCollector {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
         var observedFocusedNonMeetingDocumentURL = false
         var observedBackgroundNonMeetingDocumentURL = false
+        var probedWindowIDs = Set<CFHashCode>()
 
         if let window = axWindowAttribute(kAXFocusedWindowAttribute, from: axApp) {
+            probedWindowIDs.insert(CFHash(window))
             switch documentURLProbe(from: window, isFocused: true) {
             case .meeting(let normalized, let isFocused):
                 return .meeting(normalized, isFocused: isFocused)
@@ -186,13 +188,15 @@ final class BrowserMeetingActivityCollector {
             }
         }
         if let window = axWindowAttribute(kAXMainWindowAttribute, from: axApp) {
-            switch documentURLProbe(from: window, isFocused: false) {
-            case .meeting(let normalized, let isFocused):
-                return .meeting(normalized, isFocused: isFocused)
-            case .nonMeetingDocument:
-                observedBackgroundNonMeetingDocumentURL = true
-            case .noDocumentURL:
-                break
+            if probedWindowIDs.insert(CFHash(window)).inserted {
+                switch documentURLProbe(from: window, isFocused: false) {
+                case .meeting(let normalized, let isFocused):
+                    return .meeting(normalized, isFocused: isFocused)
+                case .nonMeetingDocument:
+                    observedBackgroundNonMeetingDocumentURL = true
+                case .noDocumentURL:
+                    break
+                }
             }
         }
 
@@ -206,6 +210,9 @@ final class BrowserMeetingActivityCollector {
         }
 
         for window in windows {
+            guard probedWindowIDs.insert(CFHash(window)).inserted else {
+                continue
+            }
             switch documentURLProbe(from: window, isFocused: false) {
             case .meeting(let normalized, let isFocused):
                 return .meeting(normalized, isFocused: isFocused)
@@ -309,19 +316,20 @@ final class BrowserMeetingActivityCollector {
         return activeTab.value(forKey: "URL") as? String
     }
 
+    // Keep aligned with MeetingCandidateResolver.browserApps in
+    // native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift.
+    // This remains an explicit allowlist because these bundle IDs are known to
+    // expose window and active-tab URL fields through ScriptingBridge.
+    static let scriptingBridgeActiveTabBrowserBundleIDs: Set<String> = [
+        "com.apple.Safari",
+        "com.google.Chrome",
+        "com.brave.Browser",
+        "company.thebrowser.Browser",
+        "com.microsoft.edgemac",
+    ]
+
     private static func browserSupportsScriptingBridgeActiveTab(_ bundleID: String) -> Bool {
-        // Keep aligned with MeetingCandidateResolver.browserApps for browsers
-        // whose scripting dictionaries expose window and active-tab URL fields.
-        switch bundleID {
-        case "com.apple.Safari",
-             "com.google.Chrome",
-             "com.brave.Browser",
-             "company.thebrowser.Browser",
-             "com.microsoft.edgemac":
-            return true
-        default:
-            return false
-        }
+        scriptingBridgeActiveTabBrowserBundleIDs.contains(bundleID)
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -14,27 +14,24 @@ final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
     private let cachedMeetingTTL: TimeInterval
     private let focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)?
-    private let activeBrowserURLProvider: ((RunningAppSnapshot) -> String?)?
-    private let isBrowserProcessRunningProvider: (RunningAppSnapshot) -> Bool
+    private let activeTabURLProvider: ((RunningAppSnapshot) -> String?)?
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
     init(
         cachedMeetingTTL: TimeInterval = 30,
         focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
-        activeBrowserURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
-        isBrowserProcessRunningProvider: @escaping (RunningAppSnapshot) -> Bool = BrowserMeetingActivityCollector.browserProcessIsRunning
+        activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = nil
     ) {
         self.cachedMeetingTTL = cachedMeetingTTL
         self.focusedDocumentURLProvider = focusedDocumentURLProvider
-        self.activeBrowserURLProvider = activeBrowserURLProvider
-        self.isBrowserProcessRunningProvider = isBrowserProcessRunningProvider
+        self.activeTabURLProvider = activeTabURLProvider
     }
 
     func collect(
         runningApps: [RunningAppSnapshot],
         refresh: Bool,
         now: Date = Date(),
-        shouldAttemptAppleScript: (String) -> Bool = { _ in true }
+        shouldAttemptActiveTabFallback: (String) -> Bool = { _ in true }
     ) async -> [BrowserMeetingContext] {
         let browserApps = runningApps.filter { browserBundleIDs.contains($0.bundleID) }
         let runningBrowserIDs = Set(browserApps.map(\.bundleID))
@@ -48,7 +45,7 @@ final class BrowserMeetingActivityCollector {
         for app in browserApps {
             let probeResult = await probeFocusedMeetingURL(
                 for: app,
-                shouldAttemptAppleScript: shouldAttemptAppleScript
+                shouldAttemptActiveTabFallback: shouldAttemptActiveTabFallback
             )
 
             guard case .meeting(let normalized) = probeResult else {
@@ -78,7 +75,7 @@ final class BrowserMeetingActivityCollector {
 
     private func probeFocusedMeetingURL(
         for app: RunningAppSnapshot,
-        shouldAttemptAppleScript: (String) -> Bool
+        shouldAttemptActiveTabFallback: (String) -> Bool
     ) async -> BrowserMeetingURLProbeResult {
         if let focusedDocumentURLProvider {
             guard let rawURL = focusedDocumentURLProvider(app) else {
@@ -91,13 +88,13 @@ final class BrowserMeetingActivityCollector {
             return MeetingURLNormalizer.normalize(rawURL).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
         }
 
-        // Query the browser's active tab even after another app/overlay becomes
-        // frontmost. Strict URL normalization plus resolver media checks keep
-        // background meeting tabs from prompting by themselves.
-        guard shouldAttemptAppleScript(app.bundleID) else {
+        guard activeTabURLProvider != nil else {
+            return .noMeeting
+        }
+        guard shouldAttemptActiveTabFallback(app.bundleID) else {
             return .skipped
         }
-        guard let url = await activeBrowserURLViaAppleScript(for: app) else {
+        guard let url = activeTabURLProvider?(app) else {
             return .noMeeting
         }
         return MeetingURLNormalizer.normalize(url).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
@@ -133,74 +130,41 @@ final class BrowserMeetingActivityCollector {
 
     private func axDocumentURL(for app: RunningAppSnapshot) -> String? {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
+            if let window = axWindowAttribute(attribute, from: axApp),
+               let rawURL = axDocumentURL(from: window) {
+                return rawURL
+            }
+        }
+
+        var windowsRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+              let windows = windowsRef as? [AXUIElement] else {
+            return nil
+        }
+
+        return windows.lazy.compactMap(axDocumentURL(from:)).first
+    }
+
+    private func axWindowAttribute(_ attribute: String, from app: AXUIElement) -> AXUIElement? {
         var windowRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(axApp, kAXFocusedWindowAttribute as CFString, &windowRef) == .success,
+        guard AXUIElementCopyAttributeValue(app, attribute as CFString, &windowRef) == .success,
               let window = windowRef,
               CFGetTypeID(window) == AXUIElementGetTypeID() else {
             return nil
         }
+        return (window as! AXUIElement)
+    }
 
-        let axWindow = (window as! AXUIElement)
+    private func axDocumentURL(from window: AXUIElement) -> String? {
         var documentRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(axWindow, kAXDocumentAttribute as CFString, &documentRef) == .success,
+        guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &documentRef) == .success,
               let rawURL = documentRef as? String else {
             return nil
         }
 
         return rawURL
-    }
-
-    private func activeBrowserURLViaAppleScript(for app: RunningAppSnapshot) async -> String? {
-        // Bundle-id Apple Events can launch a closed browser. Re-check the
-        // exact process from the snapshot immediately before sending them.
-        guard isBrowserProcessRunningProvider(app) else {
-            return nil
-        }
-
-        if let activeBrowserURLProvider {
-            return activeBrowserURLProvider(app)
-        }
-
-        guard let source = activeBrowserURLAppleScriptSource(bundleID: app.bundleID) else {
-            return nil
-        }
-
-        return await Task.detached(priority: .utility) {
-            var errorInfo: NSDictionary?
-            guard let output = NSAppleScript(source: source)?.executeAndReturnError(&errorInfo).stringValue,
-                  !output.isEmpty else {
-                return nil
-            }
-            return output
-        }.value
-    }
-
-    private static func browserProcessIsRunning(_ app: RunningAppSnapshot) -> Bool {
-        NSWorkspace.shared.runningApplications.contains {
-            $0.bundleIdentifier == app.bundleID && $0.processIdentifier == app.processIdentifier
-        }
-    }
-
-    private func activeBrowserURLAppleScriptSource(bundleID: String) -> String? {
-        let escapedBundleID = bundleID.replacingOccurrences(of: "\"", with: "\\\"")
-        switch bundleID {
-        case "com.apple.Safari":
-            return """
-            tell application id "\(escapedBundleID)"
-                if (count of windows) is 0 then return ""
-                return URL of current tab of front window
-            end tell
-            """
-        case "com.google.Chrome", "com.brave.Browser", "company.thebrowser.Browser", "com.microsoft.edgemac":
-            return """
-            tell application id "\(escapedBundleID)"
-                if (count of windows) is 0 then return ""
-                return URL of active tab of front window
-            end tell
-            """
-        default:
-            return nil
-        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -14,17 +14,20 @@ final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
     private let cachedMeetingTTL: TimeInterval
     private let focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)?
-    private let activeBrowserURLProvider: ((String) -> String?)?
+    private let activeBrowserURLProvider: ((RunningAppSnapshot) -> String?)?
+    private let isBrowserProcessRunningProvider: (RunningAppSnapshot) -> Bool
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
     init(
         cachedMeetingTTL: TimeInterval = 30,
         focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
-        activeBrowserURLProvider: ((String) -> String?)? = nil
+        activeBrowserURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
+        isBrowserProcessRunningProvider: @escaping (RunningAppSnapshot) -> Bool = BrowserMeetingActivityCollector.browserProcessIsRunning
     ) {
         self.cachedMeetingTTL = cachedMeetingTTL
         self.focusedDocumentURLProvider = focusedDocumentURLProvider
         self.activeBrowserURLProvider = activeBrowserURLProvider
+        self.isBrowserProcessRunningProvider = isBrowserProcessRunningProvider
     }
 
     func collect(
@@ -94,7 +97,7 @@ final class BrowserMeetingActivityCollector {
         guard shouldAttemptAppleScript(app.bundleID) else {
             return .skipped
         }
-        guard let url = await activeBrowserURLViaAppleScript(bundleID: app.bundleID) else {
+        guard let url = await activeBrowserURLViaAppleScript(for: app) else {
             return .noMeeting
         }
         return MeetingURLNormalizer.normalize(url).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
@@ -147,12 +150,18 @@ final class BrowserMeetingActivityCollector {
         return rawURL
     }
 
-    private func activeBrowserURLViaAppleScript(bundleID: String) async -> String? {
-        if let activeBrowserURLProvider {
-            return activeBrowserURLProvider(bundleID)
+    private func activeBrowserURLViaAppleScript(for app: RunningAppSnapshot) async -> String? {
+        // Bundle-id Apple Events can launch a closed browser. Re-check the
+        // exact process from the snapshot immediately before sending them.
+        guard isBrowserProcessRunningProvider(app) else {
+            return nil
         }
 
-        guard let source = activeBrowserURLAppleScriptSource(bundleID: bundleID) else {
+        if let activeBrowserURLProvider {
+            return activeBrowserURLProvider(app)
+        }
+
+        guard let source = activeBrowserURLAppleScriptSource(bundleID: app.bundleID) else {
             return nil
         }
 
@@ -164,6 +173,12 @@ final class BrowserMeetingActivityCollector {
             }
             return output
         }.value
+    }
+
+    private static func browserProcessIsRunning(_ app: RunningAppSnapshot) -> Bool {
+        NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == app.bundleID && $0.processIdentifier == app.processIdentifier
+        }
     }
 
     private func activeBrowserURLAppleScriptSource(bundleID: String) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -16,6 +16,7 @@ final class BrowserMeetingActivityCollector {
     private let cachedMeetingTTL: TimeInterval
     private let focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)?
     private let activeTabURLProviderOverride: ((RunningAppSnapshot) -> String?)?
+    private let activeTabProbeResultProvider: ((RunningAppSnapshot) -> BrowserActiveTabProbeResult)?
     private let activeTabFallbackEnabled: Bool
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
@@ -23,11 +24,13 @@ final class BrowserMeetingActivityCollector {
         cachedMeetingTTL: TimeInterval = 30,
         focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
         activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
+        activeTabProbeResultProvider: ((RunningAppSnapshot) -> BrowserActiveTabProbeResult)? = nil,
         activeTabFallbackEnabled: Bool = true
     ) {
         self.cachedMeetingTTL = cachedMeetingTTL
         self.focusedDocumentURLProvider = focusedDocumentURLProvider
         self.activeTabURLProviderOverride = activeTabURLProvider
+        self.activeTabProbeResultProvider = activeTabProbeResultProvider
         self.activeTabFallbackEnabled = activeTabFallbackEnabled
     }
 
@@ -52,28 +55,33 @@ final class BrowserMeetingActivityCollector {
                 shouldAttemptActiveTabFallback: shouldAttemptActiveTabFallback
             )
 
-            guard case .meeting(let normalized, let isFocused) = probeResult else {
-                if case .noMeeting = probeResult {
-                    cachedMeetings.removeValue(forKey: app.bundleID)
+            switch probeResult {
+            case .meeting(let normalized, let isFocused):
+                let context = BrowserMeetingContext(
+                    bundleID: app.bundleID,
+                    appName: app.appName,
+                    pid: app.processIdentifier,
+                    url: normalized.url,
+                    normalizedID: normalized.id,
+                    platform: normalized.platform,
+                    isFocused: isFocused
+                )
+                cachedMeetings[app.bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
+                liveMeetings.append(context)
+            case .noMeeting:
+                cachedMeetings.removeValue(forKey: app.bundleID)
+            case .inconclusive:
+                if let cached = cachedMeetings[app.bundleID] {
+                    liveMeetings.append(context(cached.context, runningApps: browserApps))
                 }
+            case .skipped:
                 continue
             }
-
-            let context = BrowserMeetingContext(
-                bundleID: app.bundleID,
-                appName: app.appName,
-                pid: app.processIdentifier,
-                url: normalized.url,
-                normalizedID: normalized.id,
-                platform: normalized.platform,
-                isFocused: isFocused
-            )
-            cachedMeetings[app.bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
-            liveMeetings.append(context)
         }
 
-        // Refresh passes intentionally return only fresh probe results. Skipped
-        // probes preserve cache entries for later non-refresh passes.
+        // Refresh passes return fresh probe results except for inconclusive
+        // fallback timeouts, where a TTL-bound cache entry prevents transient
+        // ScriptingBridge stalls from flickering an active browser meeting off.
         return liveMeetings
     }
 
@@ -94,7 +102,7 @@ final class BrowserMeetingActivityCollector {
             return .meeting(axMeeting.normalized, isFocused: app.isActive && axMeeting.isFocused)
         }
 
-        guard activeTabFallbackEnabled || activeTabURLProviderOverride != nil else {
+        guard activeTabFallbackEnabled || activeTabURLProviderOverride != nil || activeTabProbeResultProvider != nil else {
             return .noMeeting
         }
         guard shouldAttemptActiveTabFallback(app.bundleID) else {
@@ -103,7 +111,7 @@ final class BrowserMeetingActivityCollector {
         let activeTabResult = await activeTabURL(for: app)
         guard case .url(let url) = activeTabResult else {
             if case .timedOut = activeTabResult {
-                return .skipped
+                return .inconclusive
             }
             return .noMeeting
         }
@@ -170,6 +178,7 @@ final class BrowserMeetingActivityCollector {
               CFGetTypeID(window) == AXUIElementGetTypeID() else {
             return nil
         }
+        // CFGetTypeID above verifies this bridge before the force cast.
         return (window as! AXUIElement)
     }
 
@@ -184,11 +193,17 @@ final class BrowserMeetingActivityCollector {
     }
 
     private func activeTabURL(for app: RunningAppSnapshot) async -> BrowserActiveTabProbeResult {
+        if let activeTabProbeResultProvider {
+            return activeTabProbeResultProvider(app)
+        }
         if let activeTabURLProviderOverride {
             return activeTabURLProviderOverride(app).map(BrowserActiveTabProbeResult.url) ?? .noURL
         }
-        return await Self.activeTabURLViaScriptingBridge(for: app, deadline: 2)
+        return await Self.activeTabURLViaScriptingBridge(for: app, deadline: Self.activeTabFallbackDeadline)
     }
+
+    private static let activeTabFallbackDeadline: TimeInterval = 1.8
+    private static let scriptingBridgeTimeoutTicks = 120
 
     private static func activeTabURLViaScriptingBridge(
         for app: RunningAppSnapshot,
@@ -218,7 +233,7 @@ final class BrowserMeetingActivityCollector {
         let errorDelegate = BrowserScriptingBridgeErrorDelegate()
         browser.delegate = errorDelegate
         // ScriptingBridge uses Apple Event ticks: 120 ticks is 2 seconds.
-        browser.timeout = 120
+        browser.timeout = Self.scriptingBridgeTimeoutTicks
 
         guard let windows = browser.value(forKey: "windows") as? SBElementArray,
               let frontWindow = windows.firstObject as? NSObject else {
@@ -234,6 +249,8 @@ final class BrowserMeetingActivityCollector {
     }
 
     private static func browserSupportsScriptingBridgeActiveTab(_ bundleID: String) -> Bool {
+        // Keep aligned with MeetingCandidateResolver.browserApps for browsers
+        // whose scripting dictionaries expose window and active-tab URL fields.
         switch bundleID {
         case "com.apple.Safari",
              "com.google.Chrome",
@@ -250,10 +267,11 @@ final class BrowserMeetingActivityCollector {
 private enum BrowserMeetingURLProbeResult {
     case meeting(NormalizedMeetingURL, isFocused: Bool)
     case noMeeting
+    case inconclusive
     case skipped
 }
 
-private enum BrowserActiveTabProbeResult {
+enum BrowserActiveTabProbeResult {
     case url(String)
     case noURL
     case timedOut

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import Foundation
+import ScriptingBridge
 
 struct RunningAppSnapshot: Sendable {
     let bundleID: String
@@ -20,7 +21,7 @@ final class BrowserMeetingActivityCollector {
     init(
         cachedMeetingTTL: TimeInterval = 30,
         focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
-        activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = nil
+        activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = BrowserMeetingActivityCollector.activeTabURLViaScriptingBridge
     ) {
         self.cachedMeetingTTL = cachedMeetingTTL
         self.focusedDocumentURLProvider = focusedDocumentURLProvider
@@ -166,6 +167,45 @@ final class BrowserMeetingActivityCollector {
 
         return rawURL
     }
+
+    private static func activeTabURLViaScriptingBridge(for app: RunningAppSnapshot) -> String? {
+        // Target the existing process by PID. Bundle-id targets can relaunch a
+        // browser after the user quits it, which passive detection must avoid.
+        guard browserSupportsScriptingBridgeActiveTab(app.bundleID),
+              let browser = SBApplication(processIdentifier: app.processIdentifier),
+              browser.isRunning else {
+            return nil
+        }
+
+        let errorDelegate = BrowserScriptingBridgeErrorDelegate()
+        browser.delegate = errorDelegate
+        browser.timeout = 2
+
+        guard let windows = browser.value(forKey: "windows") as? SBElementArray,
+              let frontWindow = windows.firstObject as? NSObject else {
+            return nil
+        }
+
+        let tabKey = app.bundleID == "com.apple.Safari" ? "currentTab" : "activeTab"
+        guard let activeTab = frontWindow.value(forKey: tabKey) as? NSObject else {
+            return nil
+        }
+
+        return activeTab.value(forKey: "URL") as? String
+    }
+
+    private static func browserSupportsScriptingBridgeActiveTab(_ bundleID: String) -> Bool {
+        switch bundleID {
+        case "com.apple.Safari",
+             "com.google.Chrome",
+             "com.brave.Browser",
+             "company.thebrowser.Browser",
+             "com.microsoft.edgemac":
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 private enum BrowserMeetingURLProbeResult {
@@ -177,4 +217,10 @@ private enum BrowserMeetingURLProbeResult {
 private struct CachedBrowserMeeting {
     let context: BrowserMeetingContext
     let observedAt: Date
+}
+
+private final class BrowserScriptingBridgeErrorDelegate: NSObject, SBApplicationDelegate {
+    func eventDidFail(_ event: UnsafePointer<AppleEvent>, withError error: Error) -> Any? {
+        nil
+    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -15,6 +15,7 @@ final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
     private let cachedMeetingTTL: TimeInterval
     private let focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)?
+    private let documentURLProbeProvider: ((RunningAppSnapshot) -> BrowserDocumentURLProbeResult)?
     private let activeTabURLProviderOverride: ((RunningAppSnapshot) -> String?)?
     private let activeTabProbeResultProvider: ((RunningAppSnapshot) -> BrowserActiveTabProbeResult)?
     private let activeTabFallbackEnabled: Bool
@@ -24,12 +25,14 @@ final class BrowserMeetingActivityCollector {
     init(
         cachedMeetingTTL: TimeInterval = 30,
         focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
+        documentURLProbeProvider: ((RunningAppSnapshot) -> BrowserDocumentURLProbeResult)? = nil,
         activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
         activeTabProbeResultProvider: ((RunningAppSnapshot) -> BrowserActiveTabProbeResult)? = nil,
         activeTabFallbackEnabled: Bool = true
     ) {
         self.cachedMeetingTTL = cachedMeetingTTL
         self.focusedDocumentURLProvider = focusedDocumentURLProvider
+        self.documentURLProbeProvider = documentURLProbeProvider
         self.activeTabURLProviderOverride = activeTabURLProvider
         self.activeTabProbeResultProvider = activeTabProbeResultProvider
         self.activeTabFallbackEnabled = activeTabFallbackEnabled
@@ -97,6 +100,7 @@ final class BrowserMeetingActivityCollector {
         for app: RunningAppSnapshot,
         shouldAttemptActiveTabFallback: (String) -> Bool
     ) async -> BrowserMeetingURLProbeResult {
+        var observedNonMeetingDocumentURL = false
         if let focusedDocumentURLProvider {
             guard let rawURL = focusedDocumentURLProvider(app) else {
                 return .noMeeting
@@ -104,22 +108,29 @@ final class BrowserMeetingActivityCollector {
             if let normalized = MeetingURLNormalizer.normalize(rawURL) {
                 return .meeting(normalized, isFocused: app.isActive)
             }
+            observedNonMeetingDocumentURL = true
         }
 
-        if let axMeeting = axMeetingURL(for: app) {
-            return .meeting(axMeeting.normalized, isFocused: app.isActive && axMeeting.isFocused)
+        let documentURLProbe = documentURLProbeProvider?(app) ?? axDocumentURLProbe(for: app)
+        switch documentURLProbe {
+        case .meeting(let normalized, let isFocused):
+            return .meeting(normalized, isFocused: app.isActive && isFocused)
+        case .nonMeetingDocument:
+            observedNonMeetingDocumentURL = true
+        case .noDocumentURL:
+            break
         }
 
         guard activeTabFallbackEnabled || activeTabURLProviderOverride != nil || activeTabProbeResultProvider != nil else {
             return .noMeeting
         }
         guard shouldAttemptActiveTabFallback(app.bundleID) else {
-            return .skipped
+            return observedNonMeetingDocumentURL ? .noMeeting : .skipped
         }
         let activeTabResult = await activeTabURL(for: app)
         guard case .url(let url) = activeTabResult else {
             if case .timedOut = activeTabResult {
-                return .inconclusive
+                return observedNonMeetingDocumentURL ? .noMeeting : .inconclusive
             }
             return .noMeeting
         }
@@ -158,26 +169,49 @@ final class BrowserMeetingActivityCollector {
         )
     }
 
-    private func axMeetingURL(for app: RunningAppSnapshot) -> (normalized: NormalizedMeetingURL, isFocused: Bool)? {
+    private func axDocumentURLProbe(for app: RunningAppSnapshot) -> BrowserDocumentURLProbeResult {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var observedNonMeetingDocumentURL = false
 
-        if let window = axWindowAttribute(kAXFocusedWindowAttribute, from: axApp),
-           let normalized = normalizedMeetingURL(from: window) {
-            return (normalized, true)
+        if let window = axWindowAttribute(kAXFocusedWindowAttribute, from: axApp) {
+            switch documentURLProbe(from: window, isFocused: true) {
+            case .meeting(let normalized, let isFocused):
+                return .meeting(normalized, isFocused: isFocused)
+            case .nonMeetingDocument:
+                observedNonMeetingDocumentURL = true
+            case .noDocumentURL:
+                break
+            }
         }
-        if let window = axWindowAttribute(kAXMainWindowAttribute, from: axApp),
-           let normalized = normalizedMeetingURL(from: window) {
-            return (normalized, false)
+        if let window = axWindowAttribute(kAXMainWindowAttribute, from: axApp) {
+            switch documentURLProbe(from: window, isFocused: false) {
+            case .meeting(let normalized, let isFocused):
+                return .meeting(normalized, isFocused: isFocused)
+            case .nonMeetingDocument:
+                observedNonMeetingDocumentURL = true
+            case .noDocumentURL:
+                break
+            }
         }
 
         var windowsRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
-              let windows = windowsRef as? [AXUIElement],
-              let normalized = windows.lazy.compactMap(normalizedMeetingURL(from:)).first else {
-            return nil
+              let windows = windowsRef as? [AXUIElement] else {
+            return observedNonMeetingDocumentURL ? .nonMeetingDocument : .noDocumentURL
         }
 
-        return (normalized, false)
+        for window in windows {
+            switch documentURLProbe(from: window, isFocused: false) {
+            case .meeting(let normalized, let isFocused):
+                return .meeting(normalized, isFocused: isFocused)
+            case .nonMeetingDocument:
+                observedNonMeetingDocumentURL = true
+            case .noDocumentURL:
+                continue
+            }
+        }
+
+        return observedNonMeetingDocumentURL ? .nonMeetingDocument : .noDocumentURL
     }
 
     private func axWindowAttribute(_ attribute: String, from app: AXUIElement) -> AXUIElement? {
@@ -191,14 +225,17 @@ final class BrowserMeetingActivityCollector {
         return (window as! AXUIElement)
     }
 
-    private func normalizedMeetingURL(from window: AXUIElement) -> NormalizedMeetingURL? {
+    private func documentURLProbe(from window: AXUIElement, isFocused: Bool) -> BrowserDocumentURLProbeResult {
         var documentRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &documentRef) == .success,
               let rawURL = documentRef as? String else {
-            return nil
+            return .noDocumentURL
         }
 
-        return MeetingURLNormalizer.normalize(rawURL)
+        if let normalized = MeetingURLNormalizer.normalize(rawURL) {
+            return .meeting(normalized, isFocused: isFocused)
+        }
+        return .nonMeetingDocument
     }
 
     private func activeTabURL(for app: RunningAppSnapshot) async -> BrowserActiveTabProbeResult {
@@ -278,6 +315,12 @@ private enum BrowserMeetingURLProbeResult {
     case noMeeting
     case inconclusive
     case skipped
+}
+
+enum BrowserDocumentURLProbeResult {
+    case meeting(NormalizedMeetingURL, isFocused: Bool)
+    case nonMeetingDocument
+    case noDocumentURL
 }
 
 enum BrowserActiveTabProbeResult {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -82,11 +82,13 @@ final class BrowserMeetingActivityCollector {
             guard let rawURL = focusedDocumentURLProvider(app) else {
                 return .noMeeting
             }
-            return MeetingURLNormalizer.normalize(rawURL).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
+            if let normalized = MeetingURLNormalizer.normalize(rawURL) {
+                return .meeting(normalized)
+            }
         }
 
-        if let rawURL = axDocumentURL(for: app) {
-            return MeetingURLNormalizer.normalize(rawURL).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
+        if let normalized = axMeetingURL(for: app) {
+            return .meeting(normalized)
         }
 
         guard activeTabURLProvider != nil else {
@@ -129,13 +131,13 @@ final class BrowserMeetingActivityCollector {
         )
     }
 
-    private func axDocumentURL(for app: RunningAppSnapshot) -> String? {
+    private func axMeetingURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
 
         for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
             if let window = axWindowAttribute(attribute, from: axApp),
-               let rawURL = axDocumentURL(from: window) {
-                return rawURL
+               let normalized = normalizedMeetingURL(from: window) {
+                return normalized
             }
         }
 
@@ -145,7 +147,7 @@ final class BrowserMeetingActivityCollector {
             return nil
         }
 
-        return windows.lazy.compactMap(axDocumentURL(from:)).first
+        return windows.lazy.compactMap(normalizedMeetingURL(from:)).first
     }
 
     private func axWindowAttribute(_ attribute: String, from app: AXUIElement) -> AXUIElement? {
@@ -158,14 +160,14 @@ final class BrowserMeetingActivityCollector {
         return (window as! AXUIElement)
     }
 
-    private func axDocumentURL(from window: AXUIElement) -> String? {
+    private func normalizedMeetingURL(from window: AXUIElement) -> NormalizedMeetingURL? {
         var documentRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &documentRef) == .success,
               let rawURL = documentRef as? String else {
             return nil
         }
 
-        return rawURL
+        return MeetingURLNormalizer.normalize(rawURL)
     }
 
     private static func activeTabURLViaScriptingBridge(for app: RunningAppSnapshot) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -15,17 +15,20 @@ final class BrowserMeetingActivityCollector {
     private let browserBundleIDs = Set(MeetingCandidateResolver.browserApps.keys)
     private let cachedMeetingTTL: TimeInterval
     private let focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)?
-    private let activeTabURLProvider: ((RunningAppSnapshot) -> String?)?
+    private let activeTabURLProviderOverride: ((RunningAppSnapshot) -> String?)?
+    private let activeTabFallbackEnabled: Bool
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
 
     init(
         cachedMeetingTTL: TimeInterval = 30,
         focusedDocumentURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
-        activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = BrowserMeetingActivityCollector.activeTabURLViaScriptingBridge
+        activeTabURLProvider: ((RunningAppSnapshot) -> String?)? = nil,
+        activeTabFallbackEnabled: Bool = true
     ) {
         self.cachedMeetingTTL = cachedMeetingTTL
         self.focusedDocumentURLProvider = focusedDocumentURLProvider
-        self.activeTabURLProvider = activeTabURLProvider
+        self.activeTabURLProviderOverride = activeTabURLProvider
+        self.activeTabFallbackEnabled = activeTabFallbackEnabled
     }
 
     func collect(
@@ -91,13 +94,13 @@ final class BrowserMeetingActivityCollector {
             return .meeting(normalized)
         }
 
-        guard activeTabURLProvider != nil else {
+        guard activeTabFallbackEnabled || activeTabURLProviderOverride != nil else {
             return .noMeeting
         }
         guard shouldAttemptActiveTabFallback(app.bundleID) else {
             return .skipped
         }
-        guard let url = activeTabURLProvider?(app) else {
+        guard let url = await activeTabURL(for: app) else {
             return .noMeeting
         }
         return MeetingURLNormalizer.normalize(url).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
@@ -141,13 +144,7 @@ final class BrowserMeetingActivityCollector {
             }
         }
 
-        var windowsRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
-              let windows = windowsRef as? [AXUIElement] else {
-            return nil
-        }
-
-        return windows.lazy.compactMap(normalizedMeetingURL(from:)).first
+        return nil
     }
 
     private func axWindowAttribute(_ attribute: String, from app: AXUIElement) -> AXUIElement? {
@@ -168,6 +165,18 @@ final class BrowserMeetingActivityCollector {
         }
 
         return MeetingURLNormalizer.normalize(rawURL)
+    }
+
+    private func activeTabURL(for app: RunningAppSnapshot) async -> String? {
+        if let activeTabURLProviderOverride {
+            return activeTabURLProviderOverride(app)
+        }
+        guard activeTabFallbackEnabled else {
+            return nil
+        }
+        return await Task.detached(priority: .utility) {
+            Self.activeTabURLViaScriptingBridge(for: app)
+        }.value
     }
 
     private static func activeTabURLViaScriptingBridge(for app: RunningAppSnapshot) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -102,13 +102,12 @@ final class BrowserMeetingActivityCollector {
     ) async -> BrowserMeetingURLProbeResult {
         var observedFocusedNonMeetingDocumentURL = false
         if let focusedDocumentURLProvider {
-            guard let rawURL = focusedDocumentURLProvider(app) else {
-                return .noMeeting
+            if let rawURL = focusedDocumentURLProvider(app) {
+                if let normalized = MeetingURLNormalizer.normalize(rawURL) {
+                    return .meeting(normalized, isFocused: app.isActive)
+                }
+                observedFocusedNonMeetingDocumentURL = true
             }
-            if let normalized = MeetingURLNormalizer.normalize(rawURL) {
-                return .meeting(normalized, isFocused: app.isActive)
-            }
-            observedFocusedNonMeetingDocumentURL = true
         }
 
         let documentURLProbe = documentURLProbeProvider?(app) ?? axDocumentURLProbe(for: app)
@@ -124,7 +123,7 @@ final class BrowserMeetingActivityCollector {
         }
 
         guard activeTabFallbackEnabled || activeTabURLProviderOverride != nil || activeTabProbeResultProvider != nil else {
-            return .noMeeting
+            return observedFocusedNonMeetingDocumentURL ? .noMeeting : .skipped
         }
         guard shouldAttemptActiveTabFallback(app.bundleID) else {
             return observedFocusedNonMeetingDocumentURL ? .noMeeting : .skipped
@@ -258,7 +257,11 @@ final class BrowserMeetingActivityCollector {
     }
 
     private static let activeTabFallbackDeadline: TimeInterval = 1.8
-    private static let scriptingBridgeTimeoutTicks = 120
+    private static let appleEventTicksPerSecond = 60
+    private static let scriptingBridgeTimeoutSlackTicks = 12
+    private static let scriptingBridgeTimeoutTicks = Int(
+        (activeTabFallbackDeadline * Double(appleEventTicksPerSecond)).rounded(.up)
+    ) + scriptingBridgeTimeoutSlackTicks
 
     private static func activeTabURLViaScriptingBridge(
         for app: RunningAppSnapshot,
@@ -287,7 +290,10 @@ final class BrowserMeetingActivityCollector {
 
         let errorDelegate = BrowserScriptingBridgeErrorDelegate()
         browser.delegate = errorDelegate
-        // ScriptingBridge uses Apple Event ticks: 120 ticks is 2 seconds.
+        // SBApplication.timeout is in Apple Event ticks (1/60 s). Keep the
+        // ScriptingBridge timeout slightly above the 1.8 s outer deadline so
+        // the async fallback reports .timedOut before a stalled Apple Event
+        // can return nil and clear cache state.
         browser.timeout = Self.scriptingBridgeTimeoutTicks
 
         guard let windows = browser.value(forKey: "windows") as? SBElementArray,

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -70,18 +70,17 @@ final class BrowserMeetingActivityCollector {
                 liveMeetings.append(context)
             case .noMeeting:
                 cachedMeetings.removeValue(forKey: app.bundleID)
-            case .inconclusive:
+            case .inconclusive, .skipped:
                 if let cached = cachedMeetings[app.bundleID] {
                     liveMeetings.append(context(cached.context, runningApps: browserApps))
                 }
-            case .skipped:
-                continue
             }
         }
 
-        // Refresh passes return fresh probe results except for inconclusive
-        // fallback timeouts, where a TTL-bound cache entry prevents transient
-        // ScriptingBridge stalls from flickering an active browser meeting off.
+        // Refresh passes return fresh probe results unless the active-tab
+        // fallback is throttled or inconclusive. In those cases, a TTL-bound
+        // cache entry prevents transient stalls from flickering a browser
+        // meeting off.
         return liveMeetings
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -52,7 +52,7 @@ final class BrowserMeetingActivityCollector {
                 shouldAttemptActiveTabFallback: shouldAttemptActiveTabFallback
             )
 
-            guard case .meeting(let normalized) = probeResult else {
+            guard case .meeting(let normalized, let isFocused) = probeResult else {
                 if case .noMeeting = probeResult {
                     cachedMeetings.removeValue(forKey: app.bundleID)
                 }
@@ -66,7 +66,7 @@ final class BrowserMeetingActivityCollector {
                 url: normalized.url,
                 normalizedID: normalized.id,
                 platform: normalized.platform,
-                isFocused: app.isActive
+                isFocused: isFocused
             )
             cachedMeetings[app.bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
             liveMeetings.append(context)
@@ -86,12 +86,12 @@ final class BrowserMeetingActivityCollector {
                 return .noMeeting
             }
             if let normalized = MeetingURLNormalizer.normalize(rawURL) {
-                return .meeting(normalized)
+                return .meeting(normalized, isFocused: app.isActive)
             }
         }
 
-        if let normalized = axMeetingURL(for: app) {
-            return .meeting(normalized)
+        if let axMeeting = axMeetingURL(for: app) {
+            return .meeting(axMeeting.normalized, isFocused: app.isActive && axMeeting.isFocused)
         }
 
         guard activeTabFallbackEnabled || activeTabURLProviderOverride != nil else {
@@ -103,7 +103,10 @@ final class BrowserMeetingActivityCollector {
         guard let url = await activeTabURL(for: app) else {
             return .noMeeting
         }
-        return MeetingURLNormalizer.normalize(url).map(BrowserMeetingURLProbeResult.meeting) ?? .noMeeting
+        guard let normalized = MeetingURLNormalizer.normalize(url) else {
+            return .noMeeting
+        }
+        return .meeting(normalized, isFocused: app.isActive)
     }
 
     private func pruneCache(runningBrowserIDs: Set<String>, now: Date) {
@@ -134,17 +137,26 @@ final class BrowserMeetingActivityCollector {
         )
     }
 
-    private func axMeetingURL(for app: RunningAppSnapshot) -> NormalizedMeetingURL? {
+    private func axMeetingURL(for app: RunningAppSnapshot) -> (normalized: NormalizedMeetingURL, isFocused: Bool)? {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
 
-        for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
-            if let window = axWindowAttribute(attribute, from: axApp),
-               let normalized = normalizedMeetingURL(from: window) {
-                return normalized
-            }
+        if let window = axWindowAttribute(kAXFocusedWindowAttribute, from: axApp),
+           let normalized = normalizedMeetingURL(from: window) {
+            return (normalized, true)
+        }
+        if let window = axWindowAttribute(kAXMainWindowAttribute, from: axApp),
+           let normalized = normalizedMeetingURL(from: window) {
+            return (normalized, false)
         }
 
-        return nil
+        var windowsRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
+              let windows = windowsRef as? [AXUIElement],
+              let normalized = windows.lazy.compactMap(normalizedMeetingURL(from:)).first else {
+            return nil
+        }
+
+        return (normalized, false)
     }
 
     private func axWindowAttribute(_ attribute: String, from app: AXUIElement) -> AXUIElement? {
@@ -190,7 +202,7 @@ final class BrowserMeetingActivityCollector {
 
         let errorDelegate = BrowserScriptingBridgeErrorDelegate()
         browser.delegate = errorDelegate
-        browser.timeout = 2
+        browser.timeout = 120
 
         guard let windows = browser.value(forKey: "windows") as? SBElementArray,
               let frontWindow = windows.firstObject as? NSObject else {
@@ -220,7 +232,7 @@ final class BrowserMeetingActivityCollector {
 }
 
 private enum BrowserMeetingURLProbeResult {
-    case meeting(NormalizedMeetingURL)
+    case meeting(NormalizedMeetingURL, isFocused: Bool)
     case noMeeting
     case skipped
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -100,7 +100,7 @@ final class BrowserMeetingActivityCollector {
         for app: RunningAppSnapshot,
         shouldAttemptActiveTabFallback: (String) -> Bool
     ) async -> BrowserMeetingURLProbeResult {
-        var observedNonMeetingDocumentURL = false
+        var observedFocusedNonMeetingDocumentURL = false
         if let focusedDocumentURLProvider {
             guard let rawURL = focusedDocumentURLProvider(app) else {
                 return .noMeeting
@@ -108,15 +108,17 @@ final class BrowserMeetingActivityCollector {
             if let normalized = MeetingURLNormalizer.normalize(rawURL) {
                 return .meeting(normalized, isFocused: app.isActive)
             }
-            observedNonMeetingDocumentURL = true
+            observedFocusedNonMeetingDocumentURL = true
         }
 
         let documentURLProbe = documentURLProbeProvider?(app) ?? axDocumentURLProbe(for: app)
         switch documentURLProbe {
         case .meeting(let normalized, let isFocused):
             return .meeting(normalized, isFocused: app.isActive && isFocused)
-        case .nonMeetingDocument:
-            observedNonMeetingDocumentURL = true
+        case .nonMeetingDocument(let isFocused):
+            if isFocused {
+                observedFocusedNonMeetingDocumentURL = true
+            }
         case .noDocumentURL:
             break
         }
@@ -125,12 +127,12 @@ final class BrowserMeetingActivityCollector {
             return .noMeeting
         }
         guard shouldAttemptActiveTabFallback(app.bundleID) else {
-            return observedNonMeetingDocumentURL ? .noMeeting : .skipped
+            return observedFocusedNonMeetingDocumentURL ? .noMeeting : .skipped
         }
         let activeTabResult = await activeTabURL(for: app)
         guard case .url(let url) = activeTabResult else {
             if case .timedOut = activeTabResult {
-                return observedNonMeetingDocumentURL ? .noMeeting : .inconclusive
+                return observedFocusedNonMeetingDocumentURL ? .noMeeting : .inconclusive
             }
             return .noMeeting
         }
@@ -171,14 +173,14 @@ final class BrowserMeetingActivityCollector {
 
     private func axDocumentURLProbe(for app: RunningAppSnapshot) -> BrowserDocumentURLProbeResult {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
-        var observedNonMeetingDocumentURL = false
+        var observedBackgroundNonMeetingDocumentURL = false
 
         if let window = axWindowAttribute(kAXFocusedWindowAttribute, from: axApp) {
             switch documentURLProbe(from: window, isFocused: true) {
             case .meeting(let normalized, let isFocused):
                 return .meeting(normalized, isFocused: isFocused)
             case .nonMeetingDocument:
-                observedNonMeetingDocumentURL = true
+                return .nonMeetingDocument(isFocused: true)
             case .noDocumentURL:
                 break
             }
@@ -188,7 +190,7 @@ final class BrowserMeetingActivityCollector {
             case .meeting(let normalized, let isFocused):
                 return .meeting(normalized, isFocused: isFocused)
             case .nonMeetingDocument:
-                observedNonMeetingDocumentURL = true
+                observedBackgroundNonMeetingDocumentURL = true
             case .noDocumentURL:
                 break
             }
@@ -197,7 +199,7 @@ final class BrowserMeetingActivityCollector {
         var windowsRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
               let windows = windowsRef as? [AXUIElement] else {
-            return observedNonMeetingDocumentURL ? .nonMeetingDocument : .noDocumentURL
+            return observedBackgroundNonMeetingDocumentURL ? .nonMeetingDocument(isFocused: false) : .noDocumentURL
         }
 
         for window in windows {
@@ -205,13 +207,13 @@ final class BrowserMeetingActivityCollector {
             case .meeting(let normalized, let isFocused):
                 return .meeting(normalized, isFocused: isFocused)
             case .nonMeetingDocument:
-                observedNonMeetingDocumentURL = true
+                observedBackgroundNonMeetingDocumentURL = true
             case .noDocumentURL:
                 continue
             }
         }
 
-        return observedNonMeetingDocumentURL ? .nonMeetingDocument : .noDocumentURL
+        return observedBackgroundNonMeetingDocumentURL ? .nonMeetingDocument(isFocused: false) : .noDocumentURL
     }
 
     private func axWindowAttribute(_ attribute: String, from app: AXUIElement) -> AXUIElement? {
@@ -235,7 +237,7 @@ final class BrowserMeetingActivityCollector {
         if let normalized = MeetingURLNormalizer.normalize(rawURL) {
             return .meeting(normalized, isFocused: isFocused)
         }
-        return .nonMeetingDocument
+        return .nonMeetingDocument(isFocused: isFocused)
     }
 
     private func activeTabURL(for app: RunningAppSnapshot) async -> BrowserActiveTabProbeResult {
@@ -319,7 +321,7 @@ private enum BrowserMeetingURLProbeResult {
 
 enum BrowserDocumentURLProbeResult {
     case meeting(NormalizedMeetingURL, isFocused: Bool)
-    case nonMeetingDocument
+    case nonMeetingDocument(isFocused: Bool)
     case noDocumentURL
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -19,6 +19,7 @@ final class BrowserMeetingActivityCollector {
     private let activeTabProbeResultProvider: ((RunningAppSnapshot) -> BrowserActiveTabProbeResult)?
     private let activeTabFallbackEnabled: Bool
     private var cachedMeetings: [String: CachedBrowserMeeting] = [:]
+    private var activeTabFallbacksAwaitingFreshResult: Set<String> = []
 
     init(
         cachedMeetingTTL: TimeInterval = 30,
@@ -67,20 +68,28 @@ final class BrowserMeetingActivityCollector {
                     isFocused: isFocused
                 )
                 cachedMeetings[app.bundleID] = CachedBrowserMeeting(context: context, observedAt: now)
+                activeTabFallbacksAwaitingFreshResult.remove(app.bundleID)
                 liveMeetings.append(context)
             case .noMeeting:
                 cachedMeetings.removeValue(forKey: app.bundleID)
-            case .inconclusive, .skipped:
+                activeTabFallbacksAwaitingFreshResult.remove(app.bundleID)
+            case .inconclusive:
+                activeTabFallbacksAwaitingFreshResult.insert(app.bundleID)
                 if let cached = cachedMeetings[app.bundleID] {
+                    liveMeetings.append(context(cached.context, runningApps: browserApps))
+                }
+            case .skipped:
+                if activeTabFallbacksAwaitingFreshResult.contains(app.bundleID),
+                   let cached = cachedMeetings[app.bundleID] {
                     liveMeetings.append(context(cached.context, runningApps: browserApps))
                 }
             }
         }
 
         // Refresh passes return fresh probe results unless the active-tab
-        // fallback is throttled or inconclusive. In those cases, a TTL-bound
-        // cache entry prevents transient stalls from flickering a browser
-        // meeting off.
+        // fallback is inconclusive. Follow-up throttled skips may reuse the
+        // TTL-bound cache only until a fresh active-tab result resolves that
+        // inconclusive state.
         return liveMeetings
     }
 
@@ -124,6 +133,7 @@ final class BrowserMeetingActivityCollector {
         cachedMeetings = cachedMeetings.filter { bundleID, cached in
             runningBrowserIDs.contains(bundleID) && now.timeIntervalSince(cached.observedAt) <= cachedMeetingTTL
         }
+        activeTabFallbacksAwaitingFreshResult.formIntersection(cachedMeetings.keys)
     }
 
     private func cachedContexts(runningApps: [RunningAppSnapshot]) -> [BrowserMeetingContext] {

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -183,15 +183,22 @@ final class BrowserMeetingActivityCollector {
         if let activeTabURLProviderOverride {
             return activeTabURLProviderOverride(app)
         }
-        guard activeTabFallbackEnabled else {
-            return nil
-        }
-        return await Task.detached(priority: .utility) {
-            Self.activeTabURLViaScriptingBridge(for: app)
-        }.value
+        return await Self.activeTabURLViaScriptingBridge(for: app, deadline: 2)
     }
 
-    private static func activeTabURLViaScriptingBridge(for app: RunningAppSnapshot) -> String? {
+    private static func activeTabURLViaScriptingBridge(for app: RunningAppSnapshot, deadline: TimeInterval) async -> String? {
+        await withCheckedContinuation { continuation in
+            let completion = BrowserActiveTabProbeCompletion(continuation)
+            DispatchQueue.global(qos: .utility).async {
+                completion.resume(Self.activeTabURLViaScriptingBridgeSync(for: app))
+            }
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + deadline) {
+                completion.resume(nil)
+            }
+        }
+    }
+
+    private static func activeTabURLViaScriptingBridgeSync(for app: RunningAppSnapshot) -> String? {
         // Target the existing process by PID. Bundle-id targets can relaunch a
         // browser after the user quits it, which passive detection must avoid.
         guard browserSupportsScriptingBridgeActiveTab(app.bundleID),
@@ -202,6 +209,7 @@ final class BrowserMeetingActivityCollector {
 
         let errorDelegate = BrowserScriptingBridgeErrorDelegate()
         browser.delegate = errorDelegate
+        // ScriptingBridge uses Apple Event ticks: 120 ticks is 2 seconds.
         browser.timeout = 120
 
         guard let windows = browser.value(forKey: "windows") as? SBElementArray,
@@ -245,5 +253,23 @@ private struct CachedBrowserMeeting {
 private final class BrowserScriptingBridgeErrorDelegate: NSObject, SBApplicationDelegate {
     func eventDidFail(_ event: UnsafePointer<AppleEvent>, withError error: Error) -> Any? {
         nil
+    }
+}
+
+private final class BrowserActiveTabProbeCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<String?, Never>?
+
+    init(_ continuation: CheckedContinuation<String?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ value: String?) {
+        lock.lock()
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+
+        continuation?.resume(returning: value)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -100,7 +100,11 @@ final class BrowserMeetingActivityCollector {
         guard shouldAttemptActiveTabFallback(app.bundleID) else {
             return .skipped
         }
-        guard let url = await activeTabURL(for: app) else {
+        let activeTabResult = await activeTabURL(for: app)
+        guard case .url(let url) = activeTabResult else {
+            if case .timedOut = activeTabResult {
+                return .skipped
+            }
             return .noMeeting
         }
         guard let normalized = MeetingURLNormalizer.normalize(url) else {
@@ -133,7 +137,7 @@ final class BrowserMeetingActivityCollector {
             url: cached.url,
             normalizedID: cached.normalizedID,
             platform: cached.platform,
-            isFocused: app?.isActive ?? false
+            isFocused: cached.isFocused && (app?.isActive ?? false)
         )
     }
 
@@ -179,21 +183,25 @@ final class BrowserMeetingActivityCollector {
         return MeetingURLNormalizer.normalize(rawURL)
     }
 
-    private func activeTabURL(for app: RunningAppSnapshot) async -> String? {
+    private func activeTabURL(for app: RunningAppSnapshot) async -> BrowserActiveTabProbeResult {
         if let activeTabURLProviderOverride {
-            return activeTabURLProviderOverride(app)
+            return activeTabURLProviderOverride(app).map(BrowserActiveTabProbeResult.url) ?? .noURL
         }
         return await Self.activeTabURLViaScriptingBridge(for: app, deadline: 2)
     }
 
-    private static func activeTabURLViaScriptingBridge(for app: RunningAppSnapshot, deadline: TimeInterval) async -> String? {
+    private static func activeTabURLViaScriptingBridge(
+        for app: RunningAppSnapshot,
+        deadline: TimeInterval
+    ) async -> BrowserActiveTabProbeResult {
         await withCheckedContinuation { continuation in
             let completion = BrowserActiveTabProbeCompletion(continuation)
             DispatchQueue.global(qos: .utility).async {
-                completion.resume(Self.activeTabURLViaScriptingBridgeSync(for: app))
+                let url = Self.activeTabURLViaScriptingBridgeSync(for: app)
+                completion.resume(url.map(BrowserActiveTabProbeResult.url) ?? .noURL)
             }
             DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + deadline) {
-                completion.resume(nil)
+                completion.resume(.timedOut)
             }
         }
     }
@@ -245,6 +253,12 @@ private enum BrowserMeetingURLProbeResult {
     case skipped
 }
 
+private enum BrowserActiveTabProbeResult {
+    case url(String)
+    case noURL
+    case timedOut
+}
+
 private struct CachedBrowserMeeting {
     let context: BrowserMeetingContext
     let observedAt: Date
@@ -258,13 +272,13 @@ private final class BrowserScriptingBridgeErrorDelegate: NSObject, SBApplication
 
 private final class BrowserActiveTabProbeCompletion: @unchecked Sendable {
     private let lock = NSLock()
-    private var continuation: CheckedContinuation<String?, Never>?
+    private var continuation: CheckedContinuation<BrowserActiveTabProbeResult, Never>?
 
-    init(_ continuation: CheckedContinuation<String?, Never>) {
+    init(_ continuation: CheckedContinuation<BrowserActiveTabProbeResult, Never>) {
         self.continuation = continuation
     }
 
-    func resume(_ value: String?) {
+    func resume(_ value: BrowserActiveTabProbeResult) {
         lock.lock()
         let continuation = continuation
         self.continuation = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/BrowserMeetingActivityCollector.swift
@@ -173,6 +173,7 @@ final class BrowserMeetingActivityCollector {
 
     private func axDocumentURLProbe(for app: RunningAppSnapshot) -> BrowserDocumentURLProbeResult {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var observedFocusedNonMeetingDocumentURL = false
         var observedBackgroundNonMeetingDocumentURL = false
 
         if let window = axWindowAttribute(kAXFocusedWindowAttribute, from: axApp) {
@@ -180,7 +181,7 @@ final class BrowserMeetingActivityCollector {
             case .meeting(let normalized, let isFocused):
                 return .meeting(normalized, isFocused: isFocused)
             case .nonMeetingDocument:
-                return .nonMeetingDocument(isFocused: true)
+                observedFocusedNonMeetingDocumentURL = true
             case .noDocumentURL:
                 break
             }
@@ -199,6 +200,9 @@ final class BrowserMeetingActivityCollector {
         var windowsRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef) == .success,
               let windows = windowsRef as? [AXUIElement] else {
+            if observedFocusedNonMeetingDocumentURL {
+                return .nonMeetingDocument(isFocused: true)
+            }
             return observedBackgroundNonMeetingDocumentURL ? .nonMeetingDocument(isFocused: false) : .noDocumentURL
         }
 
@@ -213,6 +217,9 @@ final class BrowserMeetingActivityCollector {
             }
         }
 
+        if observedFocusedNonMeetingDocumentURL {
+            return .nonMeetingDocument(isFocused: true)
+        }
         return observedBackgroundNonMeetingDocumentURL ? .nonMeetingDocument(isFocused: false) : .noDocumentURL
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -560,8 +560,8 @@ private actor MeetingDetectionService {
         if refreshDecision.refreshBrowserMeetings {
             signalRefreshState.lastBrowserRefreshAt = now
         }
-        for bundleID in collectedSignals.appleScriptAttemptedBundleIDs {
-            signalRefreshState.lastAppleScriptAttemptAtByBundleID[bundleID] = now
+        for bundleID in collectedSignals.activeTabFallbackAttemptedBundleIDs {
+            signalRefreshState.lastActiveTabFallbackAttemptAtByBundleID[bundleID] = now
         }
 
         let rawAudioInputProcesses = mergedAudioInputProcesses(
@@ -833,7 +833,7 @@ private struct MeetingCollectedSignals {
     let browserMeetings: [BrowserMeetingContext]
     let foregroundBundleID: String?
     let runningProcessIDsByBundleID: [String: pid_t]
-    let appleScriptAttemptedBundleIDs: Set<String>
+    let activeTabFallbackAttemptedBundleIDs: Set<String>
     let timings: MeetingCollectionTimings
 }
 
@@ -885,17 +885,17 @@ private actor MeetingSignalCollector {
         refreshState: MeetingSignalRefreshState,
         now: Date
     ) async -> MeetingCollectedSignals {
-        var appleScriptAttemptedBundleIDs = Set<String>()
+        var activeTabFallbackAttemptedBundleIDs = Set<String>()
         let browserStart = Date()
         let browserMeetings = await browserCollector.collect(
             runningApps: runningApps,
             refresh: refreshBrowserMeetings,
             now: now
         ) { bundleID in
-            guard refreshPolicy.allowsAppleScript(for: bundleID, state: refreshState, now: now) else {
+            guard refreshPolicy.allowsActiveTabFallbackProbe(for: bundleID, state: refreshState, now: now) else {
                 return false
             }
-            appleScriptAttemptedBundleIDs.insert(bundleID)
+            activeTabFallbackAttemptedBundleIDs.insert(bundleID)
             return true
         }
         let browserDuration = Date().timeIntervalSince(browserStart)
@@ -908,7 +908,7 @@ private actor MeetingSignalCollector {
             browserMeetings: browserMeetings,
             foregroundBundleID: foregroundBundleID,
             runningProcessIDsByBundleID: runningProcessIDsByBundleID(from: runningApps),
-            appleScriptAttemptedBundleIDs: appleScriptAttemptedBundleIDs,
+            activeTabFallbackAttemptedBundleIDs: activeTabFallbackAttemptedBundleIDs,
             timings: MeetingCollectionTimings(
                 browserDuration: browserDuration,
                 audioAttributionDuration: 0

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSignalRefreshPolicy.swift
@@ -20,7 +20,7 @@ enum MeetingDetectionMode: Equatable {
 struct MeetingSignalRefreshState: Equatable {
     var lastAudioAttributionRefreshAt: Date?
     var lastBrowserRefreshAt: Date?
-    var lastAppleScriptAttemptAtByBundleID: [String: Date] = [:]
+    var lastActiveTabFallbackAttemptAtByBundleID: [String: Date] = [:]
     var lastSuspicionAt: Date?
     var hasMicOrCameraSignal = false
     var hasRecentBrowserMeeting = false
@@ -46,7 +46,7 @@ struct MeetingSignalRefreshPolicy {
     let audioIdleThrottle: TimeInterval
     let browserSuspiciousThrottle: TimeInterval
     let browserIdleThrottle: TimeInterval
-    let appleScriptThrottle: TimeInterval
+    let activeTabFallbackThrottle: TimeInterval
 
     init(
         idleFallbackInterval: TimeInterval = 120,
@@ -57,7 +57,7 @@ struct MeetingSignalRefreshPolicy {
         audioIdleThrottle: TimeInterval = 120,
         browserSuspiciousThrottle: TimeInterval = 3,
         browserIdleThrottle: TimeInterval = 120,
-        appleScriptThrottle: TimeInterval = 15
+        activeTabFallbackThrottle: TimeInterval = 15
     ) {
         self.idleFallbackInterval = idleFallbackInterval
         self.suspiciousFallbackInterval = suspiciousFallbackInterval
@@ -67,7 +67,7 @@ struct MeetingSignalRefreshPolicy {
         self.audioIdleThrottle = audioIdleThrottle
         self.browserSuspiciousThrottle = browserSuspiciousThrottle
         self.browserIdleThrottle = browserIdleThrottle
-        self.appleScriptThrottle = appleScriptThrottle
+        self.activeTabFallbackThrottle = activeTabFallbackThrottle
     }
 
     func decision(
@@ -87,9 +87,9 @@ struct MeetingSignalRefreshPolicy {
         )
     }
 
-    func allowsAppleScript(for bundleID: String, state: MeetingSignalRefreshState, now: Date) -> Bool {
-        guard let lastAttempt = state.lastAppleScriptAttemptAtByBundleID[bundleID] else { return true }
-        return now.timeIntervalSince(lastAttempt) >= appleScriptThrottle
+    func allowsActiveTabFallbackProbe(for bundleID: String, state: MeetingSignalRefreshState, now: Date) -> Bool {
+        guard let lastAttempt = state.lastActiveTabFallbackAttemptAtByBundleID[bundleID] else { return true }
+        return now.timeIntervalSince(lastAttempt) >= activeTabFallbackThrottle
     }
 
     func suspicionDate(

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -6,6 +6,14 @@ import Testing
 struct BrowserMeetingActivityCollectorTests {
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
+    @Test("ScriptingBridge browser allowlist stays aligned with meeting browser resolver")
+    func scriptingBridgeBrowserAllowlistStaysAlignedWithMeetingBrowserResolver() {
+        #expect(
+            BrowserMeetingActivityCollector.scriptingBridgeActiveTabBrowserBundleIDs
+                == Set(MeetingCandidateResolver.browserApps.keys)
+        )
+    }
+
     private func chrome(isActive: Bool) -> RunningAppSnapshot {
         RunningAppSnapshot(
             bundleID: "com.google.Chrome",

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -126,6 +126,39 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterSkippedRefresh.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
+    @Test("refresh returns cached room when active-tab fallback times out")
+    func refreshReturnsCachedRoomWhenActiveTabFallbackTimesOut() async {
+        var activeTabResult: BrowserActiveTabProbeResult = .url("https://meet.google.com/pwm-txwq-txy")
+        let collector = BrowserMeetingActivityCollector(
+            activeTabProbeResultProvider: { _ in activeTabResult }
+        )
+
+        let first = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now,
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+
+        activeTabResult = .timedOut
+        let second = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now.addingTimeInterval(1),
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+        let cachedAfterTimeout = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: false,
+            now: now.addingTimeInterval(2),
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+
+        #expect(first.count == 1)
+        #expect(second.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(cachedAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+    }
+
     @Test("refresh clears cache when active-tab fallback probe runs and finds no meeting URL")
     func refreshClearsCacheWhenActiveTabFallbackProbeFindsNoMeetingURL() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -175,10 +175,10 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterMissingURL.isEmpty)
     }
 
-    @Test("refresh skips active-tab fallback when no provider is installed")
-    func refreshSkipsActiveTabFallbackWhenNoProviderIsInstalled() async {
+    @Test("refresh skips active-tab fallback when provider is disabled")
+    func refreshSkipsActiveTabFallbackWhenProviderIsDisabled() async {
         var didAttemptActiveTabFallbackProbe = false
-        let collector = BrowserMeetingActivityCollector()
+        let collector = BrowserMeetingActivityCollector(activeTabURLProvider: nil)
 
         let meetings = await collector.collect(
             runningApps: [brave(isActive: false)],

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -15,6 +15,15 @@ struct BrowserMeetingActivityCollectorTests {
         )
     }
 
+    private func brave(isActive: Bool) -> RunningAppSnapshot {
+        RunningAppSnapshot(
+            bundleID: "com.brave.Browser",
+            appName: "Brave Browser",
+            processIdentifier: 4321,
+            isActive: isActive
+        )
+    }
+
     @Test("refresh probes inactive uncached browsers")
     func refreshProbesInactiveUncachedBrowsers() async {
         let collector = BrowserMeetingActivityCollector(
@@ -71,7 +80,8 @@ struct BrowserMeetingActivityCollectorTests {
     func refreshPreservesCacheWhenAppleScriptProbeIsThrottled() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
-            activeBrowserURLProvider: { _ in activeTabURL }
+            activeBrowserURLProvider: { _ in activeTabURL },
+            isBrowserProcessRunningProvider: { _ in true }
         )
 
         let first = await collector.collect(
@@ -104,7 +114,8 @@ struct BrowserMeetingActivityCollectorTests {
     func refreshClearsCacheWhenAppleScriptProbeFindsNoMeetingURL() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
-            activeBrowserURLProvider: { _ in activeTabURL }
+            activeBrowserURLProvider: { _ in activeTabURL },
+            isBrowserProcessRunningProvider: { _ in true }
         )
 
         let first = await collector.collect(
@@ -131,6 +142,50 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(first.count == 1)
         #expect(second.isEmpty)
         #expect(cachedAfterFailedRefresh.isEmpty)
+    }
+
+    @Test("refresh skips AppleScript when browser process from snapshot has exited")
+    func refreshSkipsAppleScriptWhenBrowserProcessHasExited() async {
+        var didAttemptAppleScriptProbe = false
+        let collector = BrowserMeetingActivityCollector(
+            activeBrowserURLProvider: { _ in
+                didAttemptAppleScriptProbe = true
+                return "https://meet.google.com/pwm-txwq-txy"
+            },
+            isBrowserProcessRunningProvider: { _ in false }
+        )
+
+        let meetings = await collector.collect(
+            runningApps: [brave(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in true }
+        )
+
+        #expect(meetings.isEmpty)
+        #expect(didAttemptAppleScriptProbe == false)
+    }
+
+    @Test("refresh checks exact browser process before AppleScript")
+    func refreshChecksExactBrowserProcessBeforeAppleScript() async {
+        var probedPID: pid_t?
+        let collector = BrowserMeetingActivityCollector(
+            activeBrowserURLProvider: { app in
+                probedPID = app.processIdentifier
+                return "https://meet.google.com/pwm-txwq-txy"
+            },
+            isBrowserProcessRunningProvider: { app in app.processIdentifier == 1234 }
+        )
+
+        let meetings = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptAppleScript: { _ in true }
+        )
+
+        #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(probedPID == 1234)
     }
 
     @Test("non-refresh pass can reuse recent cached browser room")

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -129,7 +129,9 @@ struct BrowserMeetingActivityCollectorTests {
     @Test("refresh returns cached room when active-tab fallback times out")
     func refreshReturnsCachedRoomWhenActiveTabFallbackTimesOut() async {
         var activeTabResult: BrowserActiveTabProbeResult = .url("https://meet.google.com/pwm-txwq-txy")
+        var documentURLProbe: BrowserDocumentURLProbeResult = .noDocumentURL
         let collector = BrowserMeetingActivityCollector(
+            documentURLProbeProvider: { _ in documentURLProbe },
             activeTabProbeResultProvider: { _ in activeTabResult }
         )
 
@@ -160,19 +162,26 @@ struct BrowserMeetingActivityCollectorTests {
             shouldAttemptActiveTabFallback: { _ in false }
         )
 
-        activeTabResult = .noURL
-        let clearedByFreshResult = await collector.collect(
+        documentURLProbe = .nonMeetingDocument
+        let clearedByNonMeetingDocument = await collector.collect(
             runningApps: [chrome(isActive: true)],
             refresh: true,
             now: now.addingTimeInterval(4),
-            shouldAttemptActiveTabFallback: { _ in true }
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+        let cachedAfterNonMeetingDocument = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: false,
+            now: now.addingTimeInterval(5),
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         #expect(first.count == 1)
         #expect(second.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(cachedAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(throttledAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
-        #expect(clearedByFreshResult.isEmpty)
+        #expect(clearedByNonMeetingDocument.isEmpty)
+        #expect(cachedAfterNonMeetingDocument.isEmpty)
     }
 
     @Test("refresh clears cache when active-tab fallback probe runs and finds no meeting URL")

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -76,6 +76,23 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterFailedRefresh.isEmpty)
     }
 
+    @Test("refresh falls through to active-tab fallback when document URL is not a meeting")
+    func refreshFallsThroughToActiveTabFallbackWhenDocumentURLIsNotMeeting() async {
+        let collector = BrowserMeetingActivityCollector(
+            focusedDocumentURLProvider: { _ in "https://example.com" },
+            activeTabURLProvider: { _ in "https://meet.google.com/pwm-txwq-txy" }
+        )
+
+        let meetings = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+
+        #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+    }
+
     @Test("refresh preserves cache when active-tab fallback probe is throttled")
     func refreshPreservesCacheWhenActiveTabFallbackProbeIsThrottled() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -36,7 +36,7 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: false)],
             refresh: true,
             now: now,
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
@@ -54,7 +54,7 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: true)],
             refresh: true,
             now: now,
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         focusedURL = nil
@@ -62,13 +62,13 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: false)],
             refresh: true,
             now: now.addingTimeInterval(1),
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
         let cachedAfterFailedRefresh = await collector.collect(
             runningApps: [chrome(isActive: false)],
             refresh: false,
             now: now.addingTimeInterval(2),
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         #expect(first.count == 1)
@@ -76,19 +76,18 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterFailedRefresh.isEmpty)
     }
 
-    @Test("refresh preserves cache when AppleScript probe is throttled")
-    func refreshPreservesCacheWhenAppleScriptProbeIsThrottled() async {
+    @Test("refresh preserves cache when active-tab fallback probe is throttled")
+    func refreshPreservesCacheWhenActiveTabFallbackProbeIsThrottled() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
-            activeBrowserURLProvider: { _ in activeTabURL },
-            isBrowserProcessRunningProvider: { _ in true }
+            activeTabURLProvider: { _ in activeTabURL }
         )
 
         let first = await collector.collect(
             runningApps: [chrome(isActive: false)],
             refresh: true,
             now: now,
-            shouldAttemptAppleScript: { _ in true }
+            shouldAttemptActiveTabFallback: { _ in true }
         )
 
         activeTabURL = nil
@@ -96,13 +95,13 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: false)],
             refresh: true,
             now: now.addingTimeInterval(1),
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
         let cachedAfterSkippedRefresh = await collector.collect(
             runningApps: [chrome(isActive: false)],
             refresh: false,
             now: now.addingTimeInterval(2),
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         #expect(first.count == 1)
@@ -110,19 +109,18 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterSkippedRefresh.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
-    @Test("refresh clears cache when AppleScript probe runs and finds no meeting URL")
-    func refreshClearsCacheWhenAppleScriptProbeFindsNoMeetingURL() async {
+    @Test("refresh clears cache when active-tab fallback probe runs and finds no meeting URL")
+    func refreshClearsCacheWhenActiveTabFallbackProbeFindsNoMeetingURL() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
-            activeBrowserURLProvider: { _ in activeTabURL },
-            isBrowserProcessRunningProvider: { _ in true }
+            activeTabURLProvider: { _ in activeTabURL }
         )
 
         let first = await collector.collect(
             runningApps: [chrome(isActive: false)],
             refresh: true,
             now: now,
-            shouldAttemptAppleScript: { _ in true }
+            shouldAttemptActiveTabFallback: { _ in true }
         )
 
         activeTabURL = "https://example.com"
@@ -130,13 +128,13 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: false)],
             refresh: true,
             now: now.addingTimeInterval(1),
-            shouldAttemptAppleScript: { _ in true }
+            shouldAttemptActiveTabFallback: { _ in true }
         )
         let cachedAfterFailedRefresh = await collector.collect(
             runningApps: [chrome(isActive: false)],
             refresh: false,
             now: now.addingTimeInterval(2),
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         #expect(first.count == 1)
@@ -144,48 +142,56 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterFailedRefresh.isEmpty)
     }
 
-    @Test("refresh skips AppleScript when browser process from snapshot has exited")
-    func refreshSkipsAppleScriptWhenBrowserProcessHasExited() async {
-        var didAttemptAppleScriptProbe = false
+    @Test("refresh clears cache when active-tab fallback has no URL")
+    func refreshClearsCacheWhenActiveTabFallbackHasNoURL() async {
+        var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
-            activeBrowserURLProvider: { _ in
-                didAttemptAppleScriptProbe = true
-                return "https://meet.google.com/pwm-txwq-txy"
-            },
-            isBrowserProcessRunningProvider: { _ in false }
+            activeTabURLProvider: { _ in activeTabURL }
         )
+
+        let first = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+
+        activeTabURL = nil
+        let second = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now.addingTimeInterval(1),
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+        let cachedAfterMissingURL = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: false,
+            now: now.addingTimeInterval(2),
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+
+        #expect(first.count == 1)
+        #expect(second.isEmpty)
+        #expect(cachedAfterMissingURL.isEmpty)
+    }
+
+    @Test("refresh skips active-tab fallback when no provider is installed")
+    func refreshSkipsActiveTabFallbackWhenNoProviderIsInstalled() async {
+        var didAttemptActiveTabFallbackProbe = false
+        let collector = BrowserMeetingActivityCollector()
 
         let meetings = await collector.collect(
             runningApps: [brave(isActive: false)],
             refresh: true,
             now: now,
-            shouldAttemptAppleScript: { _ in true }
+            shouldAttemptActiveTabFallback: { _ in
+                didAttemptActiveTabFallbackProbe = true
+                return true
+            }
         )
 
         #expect(meetings.isEmpty)
-        #expect(didAttemptAppleScriptProbe == false)
-    }
-
-    @Test("refresh checks exact browser process before AppleScript")
-    func refreshChecksExactBrowserProcessBeforeAppleScript() async {
-        var probedPID: pid_t?
-        let collector = BrowserMeetingActivityCollector(
-            activeBrowserURLProvider: { app in
-                probedPID = app.processIdentifier
-                return "https://meet.google.com/pwm-txwq-txy"
-            },
-            isBrowserProcessRunningProvider: { app in app.processIdentifier == 1234 }
-        )
-
-        let meetings = await collector.collect(
-            runningApps: [chrome(isActive: false)],
-            refresh: true,
-            now: now,
-            shouldAttemptAppleScript: { _ in true }
-        )
-
-        #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
-        #expect(probedPID == 1234)
+        #expect(didAttemptActiveTabFallbackProbe == false)
     }
 
     @Test("non-refresh pass can reuse recent cached browser room")
@@ -199,7 +205,7 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: true)],
             refresh: true,
             now: now,
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         focusedURL = nil
@@ -207,7 +213,7 @@ struct BrowserMeetingActivityCollectorTests {
             runningApps: [chrome(isActive: false)],
             refresh: false,
             now: now.addingTimeInterval(1),
-            shouldAttemptAppleScript: { _ in false }
+            shouldAttemptActiveTabFallback: { _ in false }
         )
 
         #expect(cached.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -192,10 +192,10 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cachedAfterMissingURL.isEmpty)
     }
 
-    @Test("refresh skips active-tab fallback when provider is disabled")
-    func refreshSkipsActiveTabFallbackWhenProviderIsDisabled() async {
+    @Test("refresh skips active-tab fallback when fallback is disabled")
+    func refreshSkipsActiveTabFallbackWhenFallbackIsDisabled() async {
         var didAttemptActiveTabFallbackProbe = false
-        let collector = BrowserMeetingActivityCollector(activeTabURLProvider: nil)
+        let collector = BrowserMeetingActivityCollector(activeTabFallbackEnabled: false)
 
         let meetings = await collector.collect(
             runningApps: [brave(isActive: false)],

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -43,8 +43,8 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(meetings.first?.isFocused == false)
     }
 
-    @Test("refresh clears stale cached room when browser no longer reports a meeting URL")
-    func refreshClearsStaleCachedRoom() async {
+    @Test("refresh clears stale cached room when focused document is not a meeting URL")
+    func refreshClearsStaleCachedRoomWhenFocusedDocumentIsNotMeetingURL() async {
         var focusedURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
             focusedDocumentURLProvider: { _ in focusedURL }
@@ -57,7 +57,7 @@ struct BrowserMeetingActivityCollectorTests {
             shouldAttemptActiveTabFallback: { _ in false }
         )
 
-        focusedURL = nil
+        focusedURL = "https://example.com"
         let second = await collector.collect(
             runningApps: [chrome(isActive: false)],
             refresh: true,
@@ -299,6 +299,40 @@ struct BrowserMeetingActivityCollectorTests {
 
         #expect(meetings.isEmpty)
         #expect(didAttemptActiveTabFallbackProbe == false)
+    }
+
+    @Test("refresh preserves cache when fallback is disabled and document URL is unavailable")
+    func refreshPreservesCacheWhenFallbackIsDisabledAndDocumentURLIsUnavailable() async {
+        var focusedURL: String? = "https://meet.google.com/pwm-txwq-txy"
+        let collector = BrowserMeetingActivityCollector(
+            focusedDocumentURLProvider: { _ in focusedURL },
+            activeTabFallbackEnabled: false
+        )
+
+        let first = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now,
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+
+        focusedURL = nil
+        let second = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now.addingTimeInterval(1),
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+        let cachedAfterUnavailableDocument = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: false,
+            now: now.addingTimeInterval(2),
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+
+        #expect(first.count == 1)
+        #expect(second.isEmpty)
+        #expect(cachedAfterUnavailableDocument.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
     @Test("non-refresh pass can reuse recent cached browser room")

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -93,8 +93,8 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
-    @Test("refresh returns cached room when active-tab fallback probe is throttled")
-    func refreshReturnsCachedRoomWhenActiveTabFallbackProbeIsThrottled() async {
+    @Test("refresh skips cached room when ordinary active-tab fallback probe is throttled")
+    func refreshSkipsCachedRoomWhenOrdinaryActiveTabFallbackProbeIsThrottled() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
             activeTabURLProvider: { _ in activeTabURL }
@@ -122,7 +122,7 @@ struct BrowserMeetingActivityCollectorTests {
         )
 
         #expect(first.count == 1)
-        #expect(second.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(second.isEmpty)
         #expect(cachedAfterSkippedRefresh.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
@@ -153,10 +153,26 @@ struct BrowserMeetingActivityCollectorTests {
             now: now.addingTimeInterval(2),
             shouldAttemptActiveTabFallback: { _ in false }
         )
+        let throttledAfterTimeout = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now.addingTimeInterval(3),
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+
+        activeTabResult = .noURL
+        let clearedByFreshResult = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now.addingTimeInterval(4),
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
 
         #expect(first.count == 1)
         #expect(second.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(cachedAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(throttledAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(clearedByFreshResult.isEmpty)
     }
 
     @Test("refresh clears cache when active-tab fallback probe runs and finds no meeting URL")

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -93,8 +93,8 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
-    @Test("refresh preserves cache when active-tab fallback probe is throttled")
-    func refreshPreservesCacheWhenActiveTabFallbackProbeIsThrottled() async {
+    @Test("refresh returns cached room when active-tab fallback probe is throttled")
+    func refreshReturnsCachedRoomWhenActiveTabFallbackProbeIsThrottled() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"
         let collector = BrowserMeetingActivityCollector(
             activeTabURLProvider: { _ in activeTabURL }
@@ -122,7 +122,7 @@ struct BrowserMeetingActivityCollectorTests {
         )
 
         #expect(first.count == 1)
-        #expect(second.isEmpty)
+        #expect(second.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(cachedAfterSkippedRefresh.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -162,17 +162,25 @@ struct BrowserMeetingActivityCollectorTests {
             shouldAttemptActiveTabFallback: { _ in false }
         )
 
-        documentURLProbe = .nonMeetingDocument
-        let clearedByNonMeetingDocument = await collector.collect(
+        documentURLProbe = .nonMeetingDocument(isFocused: false)
+        let throttledAfterBackgroundNonMeetingDocument = await collector.collect(
             runningApps: [chrome(isActive: true)],
             refresh: true,
             now: now.addingTimeInterval(4),
             shouldAttemptActiveTabFallback: { _ in false }
         )
+
+        documentURLProbe = .nonMeetingDocument(isFocused: true)
+        let clearedByNonMeetingDocument = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now.addingTimeInterval(5),
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
         let cachedAfterNonMeetingDocument = await collector.collect(
             runningApps: [chrome(isActive: true)],
             refresh: false,
-            now: now.addingTimeInterval(5),
+            now: now.addingTimeInterval(6),
             shouldAttemptActiveTabFallback: { _ in false }
         )
 
@@ -180,6 +188,7 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(second.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(cachedAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(throttledAfterTimeout.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(throttledAfterBackgroundNonMeetingDocument.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(clearedByNonMeetingDocument.isEmpty)
         #expect(cachedAfterNonMeetingDocument.isEmpty)
     }

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -93,6 +93,29 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
     }
 
+    @Test("refresh prefers listed meeting URL over focused non-meeting document")
+    func refreshPrefersListedMeetingURLOverFocusedNonMeetingDocument() async {
+        let collector = BrowserMeetingActivityCollector(
+            focusedDocumentURLProvider: { _ in "https://example.com" },
+            documentURLProbeProvider: { _ in
+                .meeting(
+                    MeetingURLNormalizer.normalize("https://meet.google.com/pwm-txwq-txy")!,
+                    isFocused: false
+                )
+            }
+        )
+
+        let meetings = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: true,
+            now: now,
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+
+        #expect(meetings.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(meetings.first?.isFocused == false)
+    }
+
     @Test("refresh skips cached room when ordinary active-tab fallback probe is throttled")
     func refreshSkipsCachedRoomWhenOrdinaryActiveTabFallbackProbeIsThrottled() async {
         var activeTabURL: String? = "https://meet.google.com/pwm-txwq-txy"

--- a/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BrowserMeetingActivityCollectorTests.swift
@@ -236,4 +236,28 @@ struct BrowserMeetingActivityCollectorTests {
         #expect(cached.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
         #expect(cached.first?.isFocused == false)
     }
+
+    @Test("non-refresh pass does not promote cached background room to focused")
+    func nonRefreshPassDoesNotPromoteCachedBackgroundRoomToFocused() async {
+        let collector = BrowserMeetingActivityCollector(
+            activeTabURLProvider: { _ in "https://meet.google.com/pwm-txwq-txy" }
+        )
+
+        _ = await collector.collect(
+            runningApps: [chrome(isActive: false)],
+            refresh: true,
+            now: now,
+            shouldAttemptActiveTabFallback: { _ in true }
+        )
+
+        let cached = await collector.collect(
+            runningApps: [chrome(isActive: true)],
+            refresh: false,
+            now: now.addingTimeInterval(1),
+            shouldAttemptActiveTabFallback: { _ in false }
+        )
+
+        #expect(cached.map(\.normalizedID) == ["googleMeet:meet.google.com/pwm-txwq-txy"])
+        #expect(cached.first?.isFocused == false)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSignalRefreshPolicyTests.swift
@@ -69,18 +69,18 @@ struct MeetingSignalRefreshPolicyTests {
         #expect(decision.refreshBrowserMeetings == true)
     }
 
-    @Test("AppleScript fallback is throttled per browser bundle")
-    func appleScriptFallbackIsThrottledPerBundle() {
+    @Test("active-tab fallback is throttled per browser bundle")
+    func activeTabFallbackIsThrottledPerBundle() {
         let policy = MeetingSignalRefreshPolicy()
         var state = MeetingSignalRefreshState()
-        state.lastAppleScriptAttemptAtByBundleID = [
+        state.lastActiveTabFallbackAttemptAtByBundleID = [
             "com.google.Chrome": now.addingTimeInterval(-10),
             "com.apple.Safari": now.addingTimeInterval(-16),
         ]
 
-        #expect(policy.allowsAppleScript(for: "com.google.Chrome", state: state, now: now) == false)
-        #expect(policy.allowsAppleScript(for: "com.apple.Safari", state: state, now: now) == true)
-        #expect(policy.allowsAppleScript(for: "com.brave.Browser", state: state, now: now) == true)
+        #expect(policy.allowsActiveTabFallbackProbe(for: "com.google.Chrome", state: state, now: now) == false)
+        #expect(policy.allowsActiveTabFallbackProbe(for: "com.apple.Safari", state: state, now: now) == true)
+        #expect(policy.allowsActiveTabFallbackProbe(for: "com.brave.Browser", state: state, now: now) == true)
     }
 
     @Test("suspicion expires back to idle after TTL")


### PR DESCRIPTION
## Summary
- replace production bundle-id AppleScript with a PID-targeted ScriptingBridge active-tab fallback
- probe PID-scoped AX focused/main/listed browser document URLs before using the fallback
- track whether AX found the meeting in the focused window so background/listed hits are not marked focused
- fall through to the active-tab fallback when AX finds a non-meeting URL
- bound the production ScriptingBridge fallback with a 2-second evaluator-level deadline
- treat fallback timeout as inconclusive so cached browser meetings are preserved
- rename passive meeting detection throttle state away from AppleScript-specific terminology
- add cache/fallback coverage for missing URLs, non-meeting AX URLs, and cached focus provenance

## Why
Bundle-id Apple Events such as `tell application id ...` can relaunch a browser that the user just quit. Passive meeting detection now keeps active-tab coverage, but targets the already-running browser process by PID via ScriptingBridge so a stale bundle ID cannot reopen a closed app.

## Validation
- ✅ `swift test --package-path native/MuesliNative --scratch-path "/Users/pranavhari/Library/Caches/muesli-spm/test-browser-probe" --filter BrowserMeetingActivityCollector`
- ✅ `swift test --package-path native/MuesliNative --scratch-path "/Users/pranavhari/Library/Caches/muesli-spm/test-browser-probe" --filter MeetingSignalRefreshPolicy`
- ⚠️ Earlier full local `swift test` built and ran, but failed in unrelated existing `HotkeyMonitor` timing assertions. CI has passed the relevant shards on this PR.