### PR TITLE
feat: Named speakers + persistent voice profiles

### DIFF
--- a/docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md
+++ b/docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md
@@ -1,0 +1,261 @@
+---
+date: 2026-06-01
+topic: named-speakers-voice-profiles
+---
+
+# Named Speakers + Persistent Voice Profiles — Requirements
+
+## Summary
+
+Give meeting speakers real names instead of "Speaker 1/2/3". Post-meeting, the user
+renames a diarized speaker in a transcript; that saves a **persistent local voice
+profile** so the same person is auto-recognized in future meetings. Recognition is
+confidence-tiered (confident matches auto-named, borderline ones surfaced as
+suggestions to confirm). Names appear in the transcript and the AI notes, and
+profiles are managed in a dedicated Speakers library.
+
+## Problem Frame
+
+Muesli already diarizes meetings (post-meeting, on the system-audio "Others"
+stream) and labels speakers `Speaker 1/2/3` in the transcript. Those generic labels
+make transcripts and AI notes harder to read and act on — "Speaker 2 raised a
+pricing concern" is far less useful than "Bob raised a pricing concern" — and the
+labels are meaningless across calls, so a recurring participant is an anonymous
+"Speaker N" every single meeting. For someone with repeat counterparts (sales
+prospects, students, teammates), the cost is real: mentally re-mapping speakers
+every call, and notes/recaps that never refer to people by name. The diarizer
+already computes a 256-D voice embedding per speaker, so the raw material for
+recognizing the same voice across meetings is already being produced and discarded.
+
+## Key Decisions
+
+- **Cross-call recognition is the core of v1, not a follow-on.** Per-meeting naming
+  alone isn't the goal; the value is *not* re-naming the same people every call. v1
+  ships naming + the persistent voice-profile library + auto-recognition together.
+
+- **Confidence-tiered recognition.** A strongly-above-threshold voiceprint match is
+  auto-named; a borderline match is surfaced as a suggestion ("Bob?") the user
+  confirms or rejects. Chosen over always-auto (risks confident-but-wrong
+  misattribution) and always-confirm (adds friction even for obvious repeats).
+
+- **Rename-to-enroll.** Naming a diarized speaker in a transcript is the primary way
+  a voice profile is created/updated — no separate enrollment step required. A
+  dedicated Speakers library handles viewing, renaming, merging duplicates, and
+  deleting profiles.
+
+- **Automatic local enrollment, disclosed and deletable.** Naming a speaker
+  auto-saves their voiceprint locally; it never leaves the device (consistent with
+  on-device STT). A one-time note explains this on first enrollment, and any profile
+  can be deleted. Chosen over an opt-in toggle (which would ship the "magic" off by
+  default) — the friction wasn't worth it given storage is local-only.
+
+- **"You" is the mic, not a profile.** The mic stream is always the host, so the
+  "You" speaker auto-maps to the user's name (or "You" if unset). Voice profiles are
+  only for the **Others** (system-audio) participants; the user's own voiceprint is
+  never stored by this feature.
+
+- **Names land in the transcript and the AI notes.** The transcript's speaker labels
+  are structured, so naming is a display-layer remap there — corrections are instant.
+  The AI notes are generated prose with names baked in at generation time, so
+  correcting a name after the fact offers a one-tap "update notes with corrected
+  names" (reusing re-summarization). The transcript always reflects corrections
+  immediately regardless.
+
+- **Post-meeting only; built off `main`.** Recognition and naming run at the existing
+  post-meeting diarization step — there is no live (in-meeting) named coaching,
+  because there's no live per-speaker diarization. The work is orthogonal to the
+  Live Meeting Coach and is built on its own branch off upstream `main`.
+
+## Actors
+
+- A1. **Host (You)** — the Muesli user; renames speakers, confirms/rejects
+  recognition suggestions, and manages the Speakers library. Always the mic speaker.
+- A2. **Other participants** — remote speakers captured via system audio and
+  diarized; the subjects of voice profiles and cross-call recognition.
+- A3. **Diarizer + recognizer** — the on-device diarization + voiceprint-matching
+  system that produces speaker clusters with embeddings and matches them against the
+  profile library.
+
+## Key Flows
+
+- F1. Name a speaker (enrollment)
+  - **Trigger:** Host opens a completed meeting's transcript showing `Speaker N`.
+  - **Actors:** A1, A2
+  - **Steps:** Host renames `Speaker 2` → "Bob" → the transcript remaps instantly →
+    Bob's voice profile is created/updated from that speaker's embedding → on first
+    ever enrollment, the one-time local-storage note is shown.
+  - **Covered by:** R1, R2, R3, R4, R12
+
+- F2. Auto-recognition in a later meeting
+  - **Trigger:** A new meeting finishes and is diarized.
+  - **Actors:** A3, A1
+  - **Steps:** Each diarized speaker's voiceprint is matched against the library →
+    confident matches are auto-named in the transcript → borderline matches appear
+    as suggestions ("Bob?") → host confirms (name applied, profile refined) or
+    rejects (falls back to Speaker N / manual naming).
+  - **Covered by:** R5, R6, R7, R10
+
+- F3. Correct a wrong recognition
+  - **Trigger:** A speaker was auto-named Bob but is actually Carol.
+  - **Actors:** A1
+  - **Steps:** Host renames Bob → Carol → transcript updates instantly → Bob's
+    profile is not polluted, Carol's is created/updated → host is offered "update
+    notes with corrected names".
+  - **Covered by:** R6, R11
+
+- F4. Manage the Speakers library
+  - **Trigger:** Host opens the Speakers library.
+  - **Actors:** A1
+  - **Steps:** View saved profiles → rename, merge duplicates, or delete a profile
+    (deletion removes the stored voiceprint).
+  - **Covered by:** R8, R9, R12
+
+## Requirements
+
+**Naming**
+
+- R1. Post-meeting, the user can rename a diarized speaker label in a transcript, and
+  the name applies across that meeting's transcript.
+- R2. The mic speaker is auto-labeled with the user's name (or "You" if unset) and is
+  never stored as a voice profile.
+- R3. Renaming is a display-layer remap of the transcript — corrections apply
+  instantly without re-running ASR, diarization, or the LLM.
+
+**Voice profiles & recognition**
+
+- R4. Renaming a diarized (Others) speaker creates or updates a persistent local
+  voice profile (name + voiceprint) for that person.
+- R5. In later meetings, each diarized speaker's voiceprint is matched against the
+  library: strongly-confident matches are auto-named; borderline matches surface as
+  suggestions the user confirms or rejects.
+- R6. Confirming or correcting a recognized name refines the relevant profile;
+  correcting a wrong auto-match reassigns to the correct profile (or creates a new
+  one) without polluting the mismatched profile.
+- R7. Recognition runs at the existing post-meeting diarization step; there is no
+  live (in-meeting) recognition.
+
+**Speakers library**
+
+- R8. A Speakers library lists saved profiles by name and supports rename, merge
+  (combine duplicate profiles of one person), and delete.
+- R9. Deleting a profile removes its stored voiceprint.
+
+**Where names appear**
+
+- R10. Names appear in the post-meeting transcript and in the AI notes/summary
+  (which is generated from the named transcript, so names flow through naturally).
+- R11. Because the AI notes are generated prose, correcting a name after generation
+  offers a one-tap "update notes with corrected names" (reuses re-summarization); the
+  transcript reflects corrections immediately regardless.
+
+**Privacy**
+
+- R12. Voice profiles are stored locally and never leave the device; a one-time note
+  explains voiceprint storage on first enrollment, and any profile is deletable.
+- R13. Enrollment is automatic on naming (no opt-in toggle) — the privacy posture is
+  carried by local-only storage, the one-time disclosure, and deletability, not by a
+  default-off switch.
+
+## Acceptance Examples
+
+- AE1. **Covers R4, R5.** Given Bob was named in a past meeting, when a new meeting is
+  diarized and a speaker strongly matches Bob's voiceprint, then that speaker is
+  auto-named "Bob" in the transcript.
+- AE2. **Covers R5.** Given a borderline match to Bob, then the speaker is shown as a
+  suggestion ("Bob?") the user can confirm or reject; rejecting leaves it as a
+  generic label the user can name manually.
+- AE3. **Covers R6.** Given a speaker was auto-named Bob but is actually Carol, when
+  the user corrects it, then the transcript updates instantly, Bob's profile is left
+  intact, and Carol's profile is created/updated.
+- AE4. **Covers R10, R11.** Given names were corrected after the AI notes were
+  generated, then the transcript reflects the names immediately and the user is
+  offered "update notes with corrected names".
+- AE5. **Covers R2.** Given any meeting, the mic speaker is labeled with the user's
+  name (or "You"), and no voice profile is created for the user.
+- AE6. **Covers R9, R12.** Given a saved profile, when the user deletes it in the
+  Speakers library, then its voiceprint is removed; at no point does a voiceprint
+  leave the device.
+
+## Success Criteria
+
+- Recognition is accurate enough that confident auto-names are usually correct, and
+  any correction is a single action that also improves future accuracy.
+- Transcripts and AI notes read with real names, eliminating manual re-labeling of
+  recurring participants across calls.
+- Privacy holds: voiceprints are local-only, disclosed once, and deletable.
+- Handoff quality: `ce-plan` can plan implementation without inventing naming
+  behavior, recognition semantics, or the privacy posture.
+
+## Scope Boundaries
+
+### Deferred for later
+
+- Live (in-meeting) named coaching / streaming diarization — the coach stays
+  You/Others.
+- Names in the **coach recap** — deferred until this work merges with the Live
+  Meeting Coach branch (the recap is generated from live You/Others insights).
+- Dedicated enrollment capture (record or import a voice sample to pre-seed a
+  profile before someone appears in a meeting).
+- Retroactive re-diarization of pre-existing meetings to recognize them against the
+  library (renaming still works on any already-diarized meeting).
+
+### Outside this product's identity
+
+- Cloud-based voiceprint storage or sending biometric embeddings off-device. Voice
+  profiles stay on-device, consistent with Muesli's local-first promise.
+
+## Dependencies / Assumptions
+
+- **FluidAudio speaker-identity APIs are available and sufficient** (verified):
+  `Speaker` is `Codable` with `name` + 256-D `currentEmbedding`; `SpeakerManager`
+  exposes `findSpeaker(with:speakerThreshold:)` (cosine distance, default ~0.45),
+  `initializeKnownSpeakers`, `findMatchingSpeakers`, `mergeSpeaker`; `DiarizerManager`
+  exposes `initializeKnownSpeakers` and `extractSpeakerEmbedding`. Each
+  `TimedSpeakerSegment` already carries its `embedding`.
+- **Diarization is post-meeting on the system-audio ("Others") stream; the mic is the
+  host.** Voice profiles therefore apply only to Others. This matches today's
+  pipeline (`TranscriptionRuntime.diarizeSystemAudio` → `TranscriptFormatter`).
+- **Instant transcript remap assumes structured speaker labels are available to
+  re-render.** The stored transcript is currently a text blob; supporting a
+  display-layer remap may require persisting per-segment speaker ids (or a
+  speakerId↔name map) — to be resolved in planning.
+- Built on its own branch off upstream `main`, orthogonal to `feat/live-meeting-coach`.
+
+## Outstanding Questions
+
+### Resolve before planning
+
+- None blocking. The scope above is agreed.
+
+### Deferred to planning
+
+- Exact confidence thresholds for the auto-name vs suggest tiers, and how
+  `findSpeaker` distance maps onto them.
+- Profile storage shape (e.g., a SQLite table vs JSON sidecar) and embedding
+  serialization; how/whether `Speaker.updateCount`/`rawEmbeddings` are used to refine
+  profiles over time.
+- Whether to seed `initializeKnownSpeakers` before diarizing vs. post-hoc
+  `findSpeaker` matching of resulting clusters.
+- How transcript speaker labels are persisted to enable instant display-layer remap
+  (per-segment speaker ids vs. a stored map).
+- Merge-duplicates UX details in the Speakers library.
+
+## Sources / Research
+
+- `native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift` —
+  `diarizeSystemAudio`, `DiarizerManager` lifecycle; diarization is post-meeting on
+  system audio.
+- `native/MuesliNative/Sources/MuesliNativeApp/TranscriptFormatter.swift` — current
+  `speakerId` → "Speaker N" mapping and segment-to-speaker assignment.
+- `native/MuesliNative/Sources/MuesliNativeApp/TranscriptReconciler.swift`,
+  `MeetingSession.swift` — where diarization segments merge into the final transcript
+  at `stop()`.
+- `native/MuesliNative/Sources/MuesliCore/DictationStore.swift`,
+  `StorageModels.swift` — meeting/transcript persistence; new profile storage attaches
+  here.
+- FluidAudio package: `Diarizer/Clustering/SpeakerManager.swift` (`findSpeaker`,
+  `findMatchingSpeakers`, `mergeSpeaker`, `initializeKnownSpeakers`),
+  `Diarizer/Core/DiarizerManager.swift` (`initializeKnownSpeakers`,
+  `extractSpeakerEmbedding`), `Diarizer/Clustering/SpeakerTypes.swift` (`Speaker`:
+  Codable, name + embedding), `Diarizer/Core/DiarizerTypes.swift`
+  (`TimedSpeakerSegment.embedding`).

--- a/docs/plans/2026-06-01-001-feat-named-speakers-voice-profiles-plan.md
+++ b/docs/plans/2026-06-01-001-feat-named-speakers-voice-profiles-plan.md
@@ -1,0 +1,531 @@
+---
+title: "feat: Named speakers + persistent voice profiles"
+type: feat
+status: active
+date: 2026-06-01
+origin: docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md
+---
+
+# feat: Named speakers + persistent voice profiles
+
+## Summary
+
+Replace `Speaker 1/2/3` in meeting transcripts and AI notes with real names, and
+remember voices across meetings. After a meeting, the user renames a diarized
+speaker; that saves a persistent local **voice profile** (name + voiceprint) and,
+in future meetings, confidence-tiered recognition auto-names confident matches and
+surfaces borderline ones as suggestions to confirm. Names are a **render-time
+overlay** over stable `Speaker N` tokens, so corrections are instant; profiles are
+managed in a Speakers library. Post-meeting only; built off upstream `main`.
+
+---
+
+## Problem Frame
+
+Muesli diarizes meetings post-meeting (FluidAudio on the system-audio "Others"
+stream) and labels speakers `Speaker 1/2/3` in the transcript. Those labels make
+transcripts and notes hard to read ("Speaker 2 raised a pricing concern") and carry
+no identity across calls, so a recurring participant is an anonymous "Speaker N"
+every meeting. The diarizer already computes a 256-D voice embedding per speaker —
+the exact material needed to recognize the same voice later — but the transcript is
+stored as a plain-text blob and the embeddings are discarded after formatting
+(`TranscriptFormatter.merge`), so today there is nothing to recognize against. See
+origin: `docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md`.
+
+---
+
+## Key Technical Decisions
+
+- **Names are a render-time overlay, not rewritten stored text.** The stored
+  transcript keeps stable `Speaker N` / `You` / `Others` tokens. A per-meeting
+  `label → resolved name` map drives display substitution and AI-notes generation.
+  Renames update the map (instant in the UI), never a fragile string-replace on the
+  blob, and the existing transcript parser (which only accepts `You`/`Others`/`Speaker N`)
+  stays unchanged. (see origin: Key Decisions — display-layer remap)
+
+- **Capture per-speaker embeddings at meeting-stop.** Today `TimedSpeakerSegment.embedding`
+  is thrown away after `TranscriptFormatter.merge`. We must persist one representative
+  embedding per diarized cluster at stop — this is the prerequisite for both stable
+  renaming and cross-call recognition. Consequence: auto-recognition applies only to
+  meetings recorded after this ships (older meetings can still be renamed manually).
+
+- **Recognition runs post-diarization via `SpeakerManager.findSpeaker`, not by
+  pre-seeding the diarizer.** After `performCompleteDiarization`, each cluster's
+  representative embedding is matched against loaded profiles; diarization output is
+  unchanged. Confidence-tiered: distance below a strong threshold auto-names; between
+  strong and suggest thresholds surfaces as a suggestion; above is unmatched. Exact
+  thresholds are tuned in implementation (FluidAudio default `speakerThreshold` ≈ 0.65).
+
+- **Two new DB tables; embeddings as JSON text.** `speaker_profiles` (the library)
+  and `meeting_speakers` (per-meeting cluster → label, representative embedding,
+  resolved profile/name/state). Embeddings serialize as JSON `[Float]` text, matching
+  the existing `trace_json` precedent — the repo has **no** `sqlite3_*_blob` usage, so
+  BLOB is deliberately avoided (corrects the brainstorm's "BLOB" wording).
+
+- **"You" maps to the user's name at display time.** The mic stream stays the
+  reserved `You` token in storage (the parser and `isUser` depend on it); the UI
+  substitutes `config.userName` when rendering. Voice profiles are for **Others** only;
+  the user's own voiceprint is never stored.
+
+- **Notes reuse the existing re-summarize path.** AI notes are generated from a
+  name-substituted transcript; a name correction offers a one-tap "update notes with
+  corrected names" that reuses `MuesliController.resummarize` /
+  `resummarizeAfterTranscriptEdit`.
+
+- **Speaker profiles are DB-backed, the Speakers library mirrors the personas
+  manager.** Unlike templates/personas (config-stored), profiles carry embeddings and
+  are row-shaped, so they live in `DictationStore`; the management UI clones
+  `CoachPersonasManagerView` with controller helpers delegating to the store.
+
+- **Labels in the map must match labels realized in the stored blob.** `TranscriptFormatter`
+  builds the `Speaker N` map over *all* diarization clusters, but a `Speaker N` token only
+  lands in the transcript where a surviving (post-`TranscriptReconciler`) system ASR segment
+  overlaps that cluster — and unmatched text falls back to the literal `Others`. So the
+  per-meeting map must be derived from the *same post-reconcile assignment* that produces the
+  blob: only emit `meeting_speakers` rows for labels actually realized in the transcript, and
+  decide how `Others`-fallback text is handled. (Mismatched labels would make the overlay
+  target speakers the user never sees.)
+
+- **Embedding math mirrors FluidAudio.** A representative embedding is computed by
+  L2-normalizing each segment embedding, averaging, then L2-normalizing the result (mirroring
+  FluidAudio's `recalculateMainEmbedding`), and every embedding is validated as exactly 256-D
+  before persist/load (FluidAudio silently drops wrong-sized vectors). The match threshold is
+  ~0.65 cosine (`SpeakerManager.speakerThreshold`); the origin doc's "~0.45" was the unrelated
+  `embeddingThreshold` — disregard it.
+
+- **Profiles refine only on explicit user confirm, never on auto-recognition, and
+  recoverably.** A confirm/rename re-averages stored raw embeddings (recoverable) rather than
+  a blind irreversible EMA, and a borderline-confirmed sample is not allowed to drag a profile's
+  centroid uncontrolled. Auto-recognition never mutates a profile. This prevents drift/poisoning
+  over time. (Resolves the brainstorm's deferred "store raw embeddings" question.)
+
+- **First-pass notes do not bake in auto-recognized names before the user reviews them.**
+  Because notes are generated prose that can be exported/shared, the initial post-meeting
+  summary uses `Speaker N` (or names only with a clearly-marked "auto" indicator); names enter
+  the notes via the existing update-notes flow after the user has seen the transcript. This
+  keeps the brainstorm's anti-misattribution rationale intact for the highest-stakes surface.
+
+- **Automatic local enrollment, post-meeting only, off `main`.** Naming auto-saves a
+  local profile (one-time note, deletable); nothing leaves the device; all of this
+  runs in the post-meeting flow (no live recognition); developed on its own branch.
+
+---
+
+## High-Level Technical Design
+
+Data model — profiles are the cross-call library; per-meeting rows link a meeting's
+diarized clusters to profiles and carry the embedding captured at stop:
+
+```mermaid
+erDiagram
+    meetings ||--o{ meeting_speakers : "has clusters"
+    speaker_profiles ||--o{ meeting_speakers : "recognized as"
+    meetings {
+        int id PK
+        text raw_transcript "stable Speaker N / You tokens"
+    }
+    meeting_speakers {
+        int id PK
+        int meeting_id FK
+        text speaker_label "Speaker 1, Speaker 2..."
+        text embedding "JSON [Float], representative"
+        text profile_id FK "nullable"
+        text display_name "nullable, resolved name"
+        real match_distance "nullable"
+        text match_state "unmatched|suggested|auto|confirmed"
+    }
+    speaker_profiles {
+        text id PK "FluidAudio Speaker.id"
+        text name
+        text embedding "JSON [Float]"
+        text created_at
+        text updated_at
+    }
+```
+
+Recognition at meeting stop (post-diarization), confidence-tiered:
+
+```mermaid
+flowchart TB
+    A[stop: performCompleteDiarization → TimedSpeakerSegments] --> B[aggregate one representative embedding per cluster]
+    B --> C[load speaker_profiles into SpeakerManager]
+    C --> D{findSpeaker distance}
+    D -->|<= strong| E[match_state = auto, display_name set]
+    D -->|strong..suggest| F[match_state = suggested 'Bob?']
+    D -->|> suggest| G[match_state = unmatched, Speaker N]
+    E --> H[persist meeting_speakers rows]
+    F --> H
+    G --> H
+```
+
+Per-cluster recognition/naming state (one `meeting_speakers` row):
+
+```mermaid
+stateDiagram-v2
+    [*] --> unmatched: no profile match
+    [*] --> auto: confident match
+    [*] --> suggested: borderline match
+    suggested --> confirmed: user confirms
+    suggested --> unmatched: user rejects
+    unmatched --> confirmed: user renames manually
+    auto --> confirmed: user corrects/accepts (rename)
+    confirmed --> [*]: profile upserted, notes update offered
+```
+
+---
+
+## Requirements
+
+Origin R-IDs cited where this plan carries a brainstorm requirement.
+
+**Naming & display**
+
+- R1. Post-meeting, the user can rename a diarized speaker in a transcript; the name
+  applies across that meeting via the per-meeting label map. (origin R1)
+- R2. The mic speaker renders as the user's name (or "You" if unset) at display time;
+  no voice profile is created for the user. (origin R2)
+- R3. Renaming updates the label map and re-renders instantly — no ASR/diarization/LLM
+  re-run, no rewrite of the stored transcript text. (origin R3)
+
+**Voice profiles & recognition**
+
+- R4. Renaming a diarized (Others) speaker creates/updates a persistent local voice
+  profile (name + representative embedding) and links the meeting's cluster to it. (origin R4)
+- R5. In later meetings, each diarized cluster's embedding is matched against the
+  profile library: confident matches are auto-named; borderline matches are surfaced
+  as suggestions to confirm or reject. (origin R5)
+- R6. Confirming/correcting a recognized name refines the linked profile; correcting a
+  wrong auto-match relinks to the correct profile (or creates a new one) without
+  polluting the mismatched profile. (origin R6)
+- R7. Recognition and embedding capture run at the existing post-meeting diarization
+  step; there is no live recognition. (origin R7)
+
+**Speakers library**
+
+- R8. A Speakers library lists saved profiles and supports rename, merge, and delete. (origin R8)
+- R9. Deleting a profile removes its stored voiceprint. (origin R9)
+
+**Notes**
+
+- R10. Names appear in the transcript and in the AI notes (generated from a
+  name-substituted transcript). (origin R10)
+- R11. Correcting a name after notes are generated offers a one-tap "update notes with
+  corrected names" (reuses re-summarize); the transcript reflects corrections
+  immediately regardless. (origin R11)
+
+**Privacy**
+
+- R12. Voice profiles are stored locally, never leave the device, are disclosed by a
+  one-time note on first enrollment, and are deletable. (origin R12, R13)
+
+---
+
+## Implementation Units
+
+### U1. Persistence: speaker profiles + per-meeting speaker map
+
+- **Goal:** Add the two tables and CRUD that everything else builds on.
+- **Requirements:** R4, R8, R9, R12
+- **Dependencies:** none
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliCore/DictationStore.swift` (migration + CRUD)
+  - `native/MuesliNative/Sources/MuesliCore/StorageModels.swift` (`SpeakerProfile`, `MeetingSpeaker` structs)
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift` (new)
+- **Approach:** In `migrateIfNeeded()` add `CREATE TABLE IF NOT EXISTS speaker_profiles (id TEXT PRIMARY KEY, name TEXT NOT NULL, embedding TEXT NOT NULL, raw_embeddings TEXT, observation_count INTEGER NOT NULL DEFAULT 1, created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now')))` (raw_embeddings + observation_count enable recoverable re-averaging refinement, not blind EMA) and `meeting_speakers (id INTEGER PRIMARY KEY AUTOINCREMENT, meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE, speaker_label TEXT NOT NULL, embedding TEXT NOT NULL, profile_id TEXT REFERENCES speaker_profiles(id) ON DELETE SET NULL, display_name TEXT, match_distance REAL, match_state TEXT NOT NULL DEFAULT 'unmatched')` plus indexes on `meeting_id` and `profile_id`. Embeddings (`[Float]`) serialize via `JSONEncoder` to text (mirror `insertComputerUseTrace`'s `trace_json`). Add CRUD: profiles (`upsertSpeakerProfile`, `speakerProfiles`, `renameSpeakerProfile`, `mergeSpeakerProfiles`, `deleteSpeakerProfile`) and per-meeting (`insertMeetingSpeaker`, `meetingSpeakers(for:)`, `updateMeetingSpeakerName`). Merge mirrors `deleteFolder`'s BEGIN/COMMIT/ROLLBACK transaction. **Delete must truly remove the voiceprint (R9):** the FK is `ON DELETE SET NULL` (keep the meeting's cluster row/label), but `deleteSpeakerProfile` also scrubs the `embedding` (and resolved name/state) on every linked `meeting_speakers` row in the same transaction — otherwise the per-meeting copies of the voiceprint survive. **Backup/at-rest hardening:** set `isExcludedFromBackup = true` on `muesli.db` and its `-wal`/`-shm` peers, and `0o600` perms, mirroring `ChatGPTAuthManager`/`ConfigStore` — biometric data must not silently replicate into iCloud/Time Machine.
+- **Patterns to follow:** `meeting_folders` / `meeting_insights` table creation + idempotent ALTER (none needed for brand-new tables), `createFolder`/`renameFolder`/`deleteFolder` CRUD, `insertComputerUseTrace` JSON-text encoding, parameterized `?` binds throughout.
+- **Test scenarios:**
+  - Fresh DB creates both tables; migration is idempotent on re-run.
+  - Upsert + fetch a profile round-trips name and embedding (JSON `[Float]` preserved within float tolerance).
+  - `insertMeetingSpeaker` + `meetingSpeakers(for:)` round-trips label, embedding, profile_id, display_name, distance, state.
+  - Deleting a meeting cascades its `meeting_speakers` rows (FK `ON DELETE CASCADE`, `PRAGMA foreign_keys=ON`).
+  - Deleting a profile nulls `meeting_speakers.profile_id` (`ON DELETE SET NULL`) and removes the profile.
+  - `mergeSpeakerProfiles(keep:remove:)` repoints `meeting_speakers.profile_id` and deletes the merged-away profile in one transaction.
+  - `Covers R9.` Deleting a profile removes it from `speaker_profiles` AND scrubs the
+    `embedding`/name on its linked `meeting_speakers` rows (no per-meeting voiceprint copy survives).
+- **Verification:** Both tables migrate cleanly on fresh and existing DBs; profile/meeting-speaker CRUD round-trips; cascade/merge behave transactionally.
+
+### U2. Capture cluster embeddings at meeting stop
+
+- **Goal:** Persist one representative embedding per diarized cluster (and the `Speaker N` label mapping) before the segments are discarded.
+- **Requirements:** R4, R7
+- **Dependencies:** U1
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift` (capture in `stop()` after diarization, before finalize)
+  - `native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift` (same capture on the import path)
+  - `native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift` (`retranscribe` path: recompute `meeting_speakers` + re-run recognition when the blob is rewritten)
+  - `native/MuesliNative/Sources/MuesliNativeApp/SpeakerClusterAggregator.swift` (new — pure helper: segments → per-cluster representative embedding + label)
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerClusterAggregatorTests.swift` (new)
+- **Approach:** Add a pure `SpeakerClusterAggregator` that takes the post-reconcile
+  `diarizationSegments` and returns, per cluster, a representative embedding + the `Speaker N`
+  label + raw id. **Label derivation:** reuse `TranscriptFormatter`'s actual assignment (the
+  overlap match + `Others` fallback), not just first-appearance ordering, and only emit rows
+  for labels actually realized in the stored blob — a cluster whose text was dropped by
+  `TranscriptReconciler` or rendered as `Others` must not produce a dangling `Speaker N` row.
+  **Representative embedding:** L2-normalize each segment embedding → average → L2-normalize
+  (mirror FluidAudio `recalculateMainEmbedding`; prefer reusing `Speaker` semantics over
+  re-implementing); validate 256-D. In `MeetingSession.stop()`, after `diarizeSystemAudio`
+  and within the awaited drain-before-finalize ordering, persist `meeting_speakers` rows
+  (state `unmatched`; U3 fills recognition). Mirror on the file-import path **and** the
+  re-transcribe path (`retranscribe` re-runs diarization and rewrites the blob with fresh
+  cluster numbering — it must delete-and-recompute that meeting's `meeting_speakers` rows and
+  re-run recognition, never leave stale name→cluster mappings). Keep all of it inside the
+  awaited flow so nothing writes post-finalize. The two-step `unmatched`-then-recognize split
+  (U2/U3) is intentional for independent delivery/testing.
+- **Execution note:** Add characterization coverage of `TranscriptFormatter`'s label
+  assignment (overlap + `Others` fallback) first so the aggregator's labels match the blob exactly.
+- **Patterns to follow:** `TranscriptFormatter.merge` first-appearance label map; `MeetingChunkCollector` drain-before-finalize ordering in `stop()`.
+- **Test scenarios:**
+  - Aggregator groups segments by `speakerId` and emits one row per cluster with the correct `Speaker N` label (first-appearance order matching `TranscriptFormatter`).
+  - Representative embedding is L2-normalized-mean-normalized, deterministic, and 256-D; a wrong-sized vector is rejected, not silently dropped.
+  - A cluster whose ASR text was dropped by reconcile or rendered as `Others` produces NO dangling `meeting_speakers` row (labels match the blob).
+  - Empty/no-diarization input yields no rows (meeting with only "Others" fallback or mic-only produces none).
+  - `Covers R4.` After a stop with 2 diarized speakers, exactly 2 `meeting_speakers` rows exist with embeddings.
+- **Verification:** A completed meeting persists one `meeting_speakers` row per diarized cluster with a usable embedding and a label matching the transcript.
+
+### U3. Recognition against the profile library
+
+- **Goal:** Match each captured cluster against saved profiles and assign confidence-tiered names at stop.
+- **Requirements:** R5, R6, R7
+- **Dependencies:** U1, U2
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliNativeApp/SpeakerRecognizer.swift` (new)
+  - `native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift` (invoke after capture) or `MuesliController` finalize path
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerRecognizerTests.swift` (new)
+- **Approach:** `SpeakerRecognizer` loads `speaker_profiles` and, for each captured cluster embedding, computes the best match. Reuse FluidAudio matching by feeding profiles into a `SpeakerManager` (or `DiarizerManager.speakerManager`) via `initializeKnownSpeakers` and calling `findSpeaker(with:)` / `findMatchingSpeakers(with:)`; do not rely on FluidAudio's in-memory DB surviving launches — always load from our table. Apply two thresholds: `distance <= strongThreshold` → `match_state = auto` (set `display_name`, `profile_id`); `strongThreshold < distance <= suggestThreshold` → `suggested`; else `unmatched`. Persist results onto the `meeting_speakers` rows. Thresholds are named config/constants tuned in implementation. **Within-meeting assignment pass:** after per-cluster scoring, enforce at most one cluster per profile in a meeting — assign the closest cluster to a profile and demote the rest to `suggested`/`unmatched` (avoids two "Bob"s); and when two clusters strongly match each other (likely one person split), surface a merge suggestion rather than two names.
+- **Patterns to follow:** `SpeakerManager.findSpeaker`/`findMatchingSpeakers` (cosine distance), the post-diarization seam in `TranscriptionRuntime`/`MeetingSession.stop()`.
+- **Test scenarios:**
+  - A cluster embedding near a stored profile (distance below strong) is marked `auto` with that profile's name and id.
+  - A borderline embedding (between thresholds) is marked `suggested` with the candidate profile.
+  - An embedding far from all profiles is `unmatched` (stays `Speaker N`).
+  - With an empty profile library, all clusters are `unmatched` (first-ever meeting).
+  - Tie-break: closest profile wins when multiple are within threshold.
+  - Two clusters both matching one profile: only the closest is named; the other is demoted (no duplicate names in one meeting).
+  - `Covers R5.` Given a saved "Bob" profile, a strongly-matching cluster is auto-named Bob.
+- **Verification:** Recognition assigns correct tier/name/profile per cluster against the library, deterministic for given embeddings + thresholds.
+
+### U4. Render-time name overlay in the transcript
+
+- **Goal:** Display resolved names (and the user's name for "You") without changing stored transcript text.
+- **Requirements:** R2, R3, R10
+- **Dependencies:** U1
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift` (`MeetingTranscriptView` / `TranscriptChatMessage` rendering)
+  - `native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameResolver.swift` (new — pure: label + map + userName → display name)
+  - `native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift` (`meetingSpeakers(for:)` accessor)
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerNameResolverTests.swift` (new)
+- **Approach:** A pure `SpeakerNameResolver` maps a parsed speaker label to its display name: `You` → `config.userName` (or "You" if empty); `Speaker N` → the `meeting_speakers.display_name` when `match_state` is `auto`/`confirmed`, else the raw `Speaker N`; suggested matches render the label plus a suggestion affordance (U5). `MeetingTranscriptView` loads the meeting's speaker map and applies the resolver when building `TranscriptChatMessage`s; it already re-renders on transcript change, but a rename does NOT change the stored transcript string — so `MeetingTranscriptView` (which today takes only a `String`) must take the speaker map as an explicit observed input and re-render when the map mutates, not via `onChange(of: transcript)`. Keep `isUser` keyed on the underlying `You` token. **Auto vs confirmed:** `auto`-named speakers render with a subtle "auto-recognized" indicator (distinct from user-confirmed names) so the user knows to verify them before trusting/sharing — `confirmed` names show no indicator.
+- **Patterns to follow:** `TranscriptChatMessage.messages(from:)` parsing + `.onChange` re-render; `config.userName` usage elsewhere.
+- **Test scenarios:**
+  - `You` resolves to `config.userName`; falls back to "You" when unset.
+  - `Speaker 1` with a confirmed map entry resolves to the name; with no entry stays "Speaker 1".
+  - A `suggested` entry resolves to the base label (name shown only as a suggestion, not applied).
+  - `isUser` stays true for the mic speaker regardless of the displayed name.
+  - Empty map (no `meeting_speakers` rows — pre-feature or no-diarization meeting): all speakers render with raw labels, no crash, no substitution.
+  - `auto` entries render with the auto-recognized indicator; `confirmed` entries do not.
+  - `Covers R2, R10.` Mic renders as the user's name; named Others render with their names.
+- **Verification:** Transcript shows resolved names without altering stored text; unset/edge cases fall back cleanly.
+
+### U5. Rename + recognition-confirm UI
+
+- **Goal:** Let the user name/correct speakers and confirm/reject suggestions in the transcript.
+- **Requirements:** R1, R3, R4, R5, R6, R11
+- **Dependencies:** U1, U4
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift` (rename affordance on speaker labels + suggestion chips)
+  - `native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift` (`renameMeetingSpeaker`, `confirmSuggestedSpeaker`, `rejectSuggestedSpeaker`)
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerNamingControllerLogicTests.swift` (new — pure helpers where extractable)
+- **Approach:** Tapping a speaker label (on its metadata line) opens an inline rename field
+  pre-filled with the current display name; commit on Return, cancel on Escape/click-away; the
+  rename applies to **all** lines of that speaker (per-meeting map) with a brief highlight so
+  the user sees it propagated. Borderline (`suggested`) speakers show one "Name?" chip per
+  speaker (not per line) with confirm/reject. On rename/confirm: update the `meeting_speakers`
+  row (`display_name`, `match_state = confirmed`), upsert the `speaker_profiles` entry and
+  **refine recoverably** — append this cluster's embedding to the profile's `raw_embeddings`
+  and re-average (bounded), never a blind EMA, and refine **only** on this explicit user action
+  (never on auto-recognition); link `profile_id`; re-render instantly. Correcting a wrong
+  auto-match relinks to the correct/new profile without touching the mismatched one. Reject
+  clears the suggestion to `unmatched`. **Update-notes affordance:** a single debounced
+  "Update notes with corrected names" action (toolbar button, enabled after any name change),
+  not an alert per rename, and suppressed when no notes exist yet.
+- **Patterns to follow:** existing `isEditingTranscript`/inline-edit affordances in `MeetingDetailView`; the "Re-summarize Notes?" alert + `resummarizeAfterTranscriptEdit`.
+- **Test scenarios:**
+  - Renaming `Speaker 1` → "Bob" sets the map entry to confirmed/Bob and upserts a Bob profile linked by `profile_id`.
+  - Confirming a "Bob?" suggestion sets confirmed + links the existing profile; rejecting returns it to unmatched.
+  - Correcting an auto-named Bob → Carol relinks to Carol and leaves Bob's profile unchanged. `Covers R6.`
+  - Renaming offers the notes-update affordance and updates the transcript instantly. `Covers R11.`
+- **Verification:** Naming/confirming/correcting updates the map + profiles correctly, re-renders instantly, and never pollutes a mismatched profile.
+
+### U6. Speakers library UI
+
+- **Goal:** Manage saved voice profiles (view/rename/merge/delete) and the one-time privacy note.
+- **Requirements:** R8, R9, R12
+- **Dependencies:** U1
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliNativeApp/SpeakersManagerView.swift` (new — modeled on `MeetingTemplatesManagerView`; the coach personas manager lives on a separate branch, so do not look for it here)
+  - `native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift` (entry point)
+  - `native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift` (`speakerProfiles`, `renameSpeakerProfile`, `mergeSpeakerProfiles`, `deleteSpeakerProfile`)
+  - `native/MuesliNative/Sources/MuesliNativeApp/Models.swift` (`hasSeenVoiceProfileNote` config flag — three-place add)
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift` (extend for merge/delete via controller-agnostic store calls)
+- **Approach:** A `SpeakersManagerView` listing profiles by name with rename, merge, and delete (confirm alert). Present from Settings via a `@State showingSpeakersManager` + `.sheet`, modeled on `MeetingTemplatesManagerView`. **Merge UX:** multi-select two profiles + a "Merge" action; the kept profile's name wins (or user picks); confirm step states that past meetings repoint to the kept profile. **Empty state:** explain the enrollment path ("Name a speaker in a meeting transcript to create a profile"). Also expose a path to this library from the transcript naming flow (e.g., from the one-time note), not Settings-only. Controller helpers delegate to `DictationStore` then `syncAppState()`. A one-time note (gated by a tolerant-decoded config bool) explains local voiceprint storage on first enrollment (shown from U5's first rename).
+- **Patterns to follow:** `CoachPersonasManagerView` + `SettingsView` sheet/`actionButton` wiring; three-place `AppConfig` add (member + snake_case CodingKey + tolerant decode).
+- **Test scenarios:**
+  - `Test expectation: UI behavior verified manually; unit tests cover the store merge/delete + the config-flag round-trip (one-time note shows once).`
+  - Config round-trip: `hasSeenVoiceProfileNote` persists; missing key decodes false (note shows once).
+- **Verification:** Profiles are listable, renamable, mergeable, deletable; the one-time note shows exactly once; deletion removes voiceprints.
+
+### U7. Notes integration (names in summary + update-on-correction)
+
+- **Goal:** Make AI notes use names, and let a correction refresh them.
+- **Requirements:** R10, R11
+- **Dependencies:** U1, U4, U5
+- **Files:**
+  - `native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift` (apply name substitution to the transcript fed to summarization; wire "update notes" to re-summarize)
+  - `native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift` (reference — summarize input)
+  - `native/MuesliNative/Tests/MuesliTests/SpeakerNameSubstitutionTests.swift` (new — pure substitution over a transcript blob)
+- **Approach:** Add a pure substitution that rewrites a transcript blob's speaker labels to
+  resolved names (meeting map + userName) for the *summarizer input only* (the stored blob keeps
+  tokens); `unmatched`/`suggested` labels stay `Speaker N`. There is no existing seam to inject a
+  substituted transcript — `resummarize`/the `stop()` summarize both read `meeting.rawTranscript`
+  directly — so thread a `transcriptOverride: String?` param through the private
+  `resummarize(meeting:using:completion:)` and the `MeetingSession.stop()` summarize call. **First-pass
+  notes do NOT bake in auto-recognized names** (a wrong auto-name would propagate into shared/exported
+  notes before the user ever reviews it): the initial post-meeting summary uses `Speaker N`, and names
+  enter the notes only after the user reviews the transcript, via the debounced "update notes with
+  corrected names" affordance (U5) which calls `resummarize` with the name-substituted transcript.
+- **Patterns to follow:** `MuesliController.resummarize` → `MeetingSummaryClient.summarize`; the existing "Re-summarize Notes?" alert.
+- **Test scenarios:**
+  - Substitution replaces `Speaker 1:` / `You:` line labels with resolved names, leaving timestamps and text intact.
+  - Unmatched/`suggested` labels are left as `Speaker N` in the summarizer input.
+  - `You` substitutes to `config.userName` (or stays "You" when unset).
+  - `Covers R10.` Summarizer input for a meeting with named speakers contains the names, not `Speaker N`.
+- **Verification:** Notes generate with names; correcting a name and choosing "update notes" regenerates them with the corrected names.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R4, R5.** Given Bob was named in a past meeting, when a new meeting is
+  diarized and a cluster strongly matches Bob's voiceprint, then that cluster is
+  `auto`-named "Bob" in the transcript.
+- AE2. **Covers R5.** Given a borderline match to Bob, then the speaker shows a "Bob?"
+  suggestion the user can confirm or reject; rejecting leaves it as `Speaker N`.
+- AE3. **Covers R6.** Given a cluster was auto-named Bob but is actually Carol, when
+  the user corrects it, then the transcript updates instantly, Bob's profile is
+  untouched, and Carol's profile is created/updated and linked.
+- AE4. **Covers R10, R11.** Given names were corrected after notes were generated, then
+  the transcript reflects names immediately and the user is offered "update notes with
+  corrected names".
+- AE5. **Covers R2.** The mic speaker renders as the user's name (or "You"), and no
+  voice profile is created for the user.
+- AE6. **Covers R9, R12.** Deleting a profile in the Speakers library removes its
+  voiceprint; voiceprints never leave the device.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later (from origin)
+
+- Live (in-meeting) named coaching / streaming diarization — recognition stays
+  post-meeting.
+- Names in the coach recap — deferred until this merges with the Live Meeting Coach
+  branch.
+- Dedicated enrollment capture (record/import a voice sample to pre-seed a profile).
+- Retroactive re-diarization of pre-existing meetings to recognize them (renaming
+  still works on any already-diarized meeting).
+
+### Outside this product's identity (from origin)
+
+- Cloud-based voiceprint storage or sending biometric embeddings off-device. Profiles
+  stay on-device, consistent with Muesli's local-first promise.
+
+### Deferred to Follow-Up Work
+
+- Exposing voice profiles / per-speaker data via `MuesliCLI` — out of scope here
+  (parallels the coach CLI follow-up).
+- Switching embedding storage from JSON text to a true BLOB column — JSON text is the
+  v1 choice; revisit only if storage size becomes a concern.
+
+---
+
+## Risks & Dependencies
+
+- **Embedding is the load-bearing prerequisite.** All recognition depends on capturing
+  `TimedSpeakerSegment.embedding` at stop (U2) before it's discarded; if capture is
+  wrong/missing, the library never populates. Verified the field exists and is 256-D.
+- **Recognition is probabilistic.** Threshold tuning (strong vs suggest) directly sets
+  the false-name rate; the confidence tiers + easy correction (U5) are the mitigation.
+  Defaults anchor on FluidAudio's `speakerThreshold` ≈ 0.65 and are tuned in implementation.
+- **In-memory `SpeakerManager` does not persist across launches**, and
+  `getDiarizerManager()` can be nil if model download/init failed — recognition must
+  load our `speaker_profiles` each run and degrade gracefully when the diarizer is
+  unavailable (no names, no crash).
+- **Transcript parser only accepts `You`/`Others`/`Speaker N`.** The render-time
+  overlay keeps those tokens stored, so the parser is unchanged — do not introduce
+  arbitrary names into the stored blob.
+- **Drain-before-finalize.** Embedding capture/recognition at stop must complete within
+  the awaited `stop()` flow so nothing writes after the transcript is persisted
+  (`MeetingChunkCollector` precedent).
+- **First-BLOB-avoidance.** Embeddings are JSON text; do not assume BLOB plumbing
+  exists (it doesn't).
+- **Third-party biometric consent.** Voiceprints are captured for participants who never
+  consented; the one-time note addresses the *host*, not the subjects. Accepted under the
+  local-only posture, but BIPA/CUBI/GDPR Art. 9 exposure is real for regulated users — record
+  it as an accepted risk; it elevates if cloud backup or enterprise use is ever added.
+- **Named transcripts now cross the cloud boundary.** Once names substitute into the summarizer
+  input, real participant names (previously pseudonymous `Speaker N`) are sent to the chosen
+  cloud LLM backend. Update the cloud-summary disclosure to say participant names are included.
+- **Day-one value gap.** Recognition only works for meetings recorded after ship (no retroactive
+  re-diarization), so existing users get manual naming immediately but cross-call recognition
+  only after recurring participants reappear. Set this expectation in the Speakers library empty
+  state, and treat "dedicated enrollment capture" as the natural fast-follow for immediate value.
+
+---
+
+## System-Wide Impact
+
+- **New persisted data:** `speaker_profiles` (biometric voiceprints) and
+  `meeting_speakers`, both local, additive migrations. Deleting a meeting cascades its
+  speaker rows; deleting a profile nulls links.
+- **Config surface:** one new tolerant-decoded flag (`hasSeenVoiceProfileNote`).
+- **Meeting-stop path touched:** embedding capture + recognition added post-diarization
+  inside the awaited finalize ordering.
+- **Privacy posture:** introduces stored voiceprints of other participants — local-only,
+  disclosed once, deletable (a deliberate, scoped expansion of on-device data).
+
+---
+
+## Open Questions (Deferred to Implementation)
+
+- Exact `strongThreshold` / `suggestThreshold` values and whether to expose them.
+- Bound for the recoverable re-average (max raw embeddings kept per profile). The rule is
+  decided (normalize-mean-normalize; refine only on explicit confirm); only the cap is open.
+- Whether recognition seeds `initializeKnownSpeakers` before diarizing (future) vs
+  post-hoc `findSpeaker` matching (this plan's choice).
+- Final styling of the "auto-recognized" indicator and the rename/merge affordances —
+  mechanics are specified in U4/U5/U6; visual polish is deferred.
+
+---
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md`
+- Transcript formatting + storage: `native/MuesliNative/Sources/MuesliNativeApp/TranscriptFormatter.swift`
+  (`Speaker N` label map, line format), `MeetingDetailView.swift` (`TranscriptChatMessage`
+  parsing, `isLikelySpeakerLabel`/`isUser`, `.onChange` re-render), `MeetingSession.swift`
+  (`stop()` diarize→reconcile→summarize ordering), `DictationStore.swift`
+  (`meetings.raw_transcript` blob; `meeting_folders`/`computer_use_traces` table + JSON-text precedents).
+- Diarization + recognition: `native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift`
+  (`diarizeSystemAudio`, long-lived `DiarizerManager`), FluidAudio
+  `Diarizer/Core/DiarizerManager.swift` (`speakerManager`, `initializeKnownSpeakers`,
+  `extractSpeakerEmbedding`), `Diarizer/Clustering/SpeakerManager.swift`
+  (`findSpeaker`, `findMatchingSpeakers`, `mergeSpeaker`; default `speakerThreshold` ≈ 0.65),
+  `Diarizer/Clustering/SpeakerTypes.swift` (`Speaker`: Codable, name + `currentEmbedding`),
+  `Diarizer/Core/DiarizerTypes.swift` (`TimedSpeakerSegment.embedding`, 256-D).
+- Management UI + config: `native/MuesliNative/Sources/MuesliNativeApp/CoachPersonasManagerView.swift`,
+  `SettingsView.swift` (sheet/actionButton), `Models.swift` (three-place config add, `userName`).
+- Notes regeneration: `native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift`
+  (`resummarize`), `MeetingSummaryClient.swift` (`summarize`), `MeetingDetailView.swift`
+  ("Re-summarize Notes?" alert).
+- Conventions: `docs/reports/2026-03-19-audit-hardening-report.md` (parameterized binds;
+  drain-before-finalize), `CLAUDE.md` (diarization is post-processing; DictationStore conventions; App Nap).

--- a/docs/plans/2026-06-01-001-feat-named-speakers-voice-profiles-plan.md
+++ b/docs/plans/2026-06-01-001-feat-named-speakers-voice-profiles-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Named speakers + persistent voice profiles"
 type: feat
-status: active
+status: completed
 date: 2026-06-01
 origin: docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md
 ---

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -167,7 +167,8 @@ public final class DictationStore {
         CREATE INDEX IF NOT EXISTS idx_meeting_speakers_profile ON meeting_speakers(profile_id);
         """
         try exec(speakersSQL, db: db)
-
+        // Hardening also runs on every openDatabase() (below) so it survives
+        // SQLite recreating the -wal/-shm sidecars; this call covers fresh DBs.
         hardenDatabaseFiles()
     }
 
@@ -1218,19 +1219,42 @@ public final class DictationStore {
         return makeSpeakerProfile(statement)
     }
 
+    /// Rename a profile and propagate the new name to the resolved `display_name`
+    /// snapshot on every linked per-meeting row, so past meetings' overlays don't
+    /// go stale. Done in one transaction.
     public func renameSpeakerProfile(id: String, name: String) throws {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
-        let sql = "UPDATE speaker_profiles SET name = ?, updated_at = datetime('now') WHERE id = ?"
-        var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+        guard sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil) == SQLITE_OK else {
             throw lastError(db)
         }
-        defer { sqlite3_finalize(statement) }
-        sqlite3_bind_text(statement, 1, (name as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(statement, 2, (id as NSString).utf8String, -1, nil)
-        guard sqlite3_step(statement) == SQLITE_DONE else {
-            throw lastError(db)
+        do {
+            var s1: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "UPDATE speaker_profiles SET name = ?, updated_at = datetime('now') WHERE id = ?", -1, &s1, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(s1) }
+            sqlite3_bind_text(s1, 1, (name as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(s1, 2, (id as NSString).utf8String, -1, nil)
+            guard sqlite3_step(s1) == SQLITE_DONE else { throw lastError(db) }
+
+            // Refresh the display_name snapshot only on rows that already show a
+            // name (auto/confirmed); unmatched/suggested rows keep their label.
+            var s2: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "UPDATE meeting_speakers SET display_name = ? WHERE profile_id = ? AND display_name IS NOT NULL", -1, &s2, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(s2) }
+            sqlite3_bind_text(s2, 1, (name as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(s2, 2, (id as NSString).utf8String, -1, nil)
+            guard sqlite3_step(s2) == SQLITE_DONE else { throw lastError(db) }
+
+            guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+        } catch {
+            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
         }
     }
 
@@ -1426,6 +1450,50 @@ public final class DictationStore {
         }
     }
 
+    /// Atomically replace a meeting's captured cluster rows: delete existing rows
+    /// and insert the new set in one transaction, so a mid-insert failure can't
+    /// leave a partial/empty speaker set. New rows start `unmatched` (recognition
+    /// fills them in afterward). Idempotent on re-persist.
+    public func replaceMeetingSpeakers(
+        meetingID: Int64,
+        speakers: [(label: String, embedding: [Float])]
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        do {
+            var del: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "DELETE FROM meeting_speakers WHERE meeting_id = ?", -1, &del, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_int64(del, 1, meetingID)
+            guard sqlite3_step(del) == SQLITE_DONE else { sqlite3_finalize(del); throw lastError(db) }
+            sqlite3_finalize(del)
+
+            for speaker in speakers {
+                var ins: OpaquePointer?
+                guard sqlite3_prepare_v2(db, "INSERT INTO meeting_speakers (meeting_id, speaker_label, embedding, match_state) VALUES (?, ?, ?, 'unmatched')", -1, &ins, nil) == SQLITE_OK else {
+                    throw lastError(db)
+                }
+                sqlite3_bind_int64(ins, 1, meetingID)
+                sqlite3_bind_text(ins, 2, (speaker.label as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(ins, 3, (Self.encodeEmbedding(speaker.embedding) as NSString).utf8String, -1, nil)
+                let stepped = sqlite3_step(ins)
+                sqlite3_finalize(ins)
+                guard stepped == SQLITE_DONE else { throw lastError(db) }
+            }
+
+            guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+        } catch {
+            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
     private func makeSpeakerProfile(_ statement: OpaquePointer?) -> SpeakerProfile {
         SpeakerProfile(
             id: stringColumn(statement, index: 0),
@@ -1562,6 +1630,11 @@ public final class DictationStore {
         if sqlite3_exec(db, "PRAGMA journal_mode=WAL", nil, nil, nil) != SQLITE_OK {
             throw lastError(db)
         }
+        // Enabling WAL (re)creates the -wal/-shm sidecars, which SQLite deletes on
+        // checkpoint and recreates with default perms. Re-harden on every open so
+        // biometric embeddings written to the WAL never land in an unprotected,
+        // backup-included sidecar.
+        hardenDatabaseFiles()
         return db
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -140,6 +140,55 @@ public final class DictationStore {
             // Column may already exist.
         }
         let _ = sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_meetings_folder ON meetings(folder_id)", nil, nil, nil)
+
+        // Named speakers + persistent voice profiles. Embeddings serialize as JSON
+        // [Float] text (the repo has no BLOB plumbing — mirrors trace_json).
+        let speakersSQL = """
+        CREATE TABLE IF NOT EXISTS speaker_profiles (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            embedding TEXT NOT NULL,
+            raw_embeddings TEXT,
+            observation_count INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS meeting_speakers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+            speaker_label TEXT NOT NULL,
+            embedding TEXT NOT NULL,
+            profile_id TEXT REFERENCES speaker_profiles(id) ON DELETE SET NULL,
+            display_name TEXT,
+            match_distance REAL,
+            match_state TEXT NOT NULL DEFAULT 'unmatched'
+        );
+        CREATE INDEX IF NOT EXISTS idx_meeting_speakers_meeting ON meeting_speakers(meeting_id);
+        CREATE INDEX IF NOT EXISTS idx_meeting_speakers_profile ON meeting_speakers(profile_id);
+        """
+        try exec(speakersSQL, db: db)
+
+        hardenDatabaseFiles()
+    }
+
+    /// Voiceprints are biometric data — keep the database out of iCloud/Time
+    /// Machine backups and readable only by the owner, mirroring
+    /// `ChatGPTAuthManager`/`ConfigStore` token-file hardening.
+    private func hardenDatabaseFiles() {
+        let base = databaseURL.deletingLastPathComponent()
+        let name = databaseURL.lastPathComponent
+        let peers = [
+            databaseURL,
+            base.appendingPathComponent("\(name)-wal"),
+            base.appendingPathComponent("\(name)-shm"),
+        ]
+        for url in peers where FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            var mutableURL = url
+            try? mutableURL.setResourceValues(resourceValues)
+        }
     }
 
     @discardableResult
@@ -1097,6 +1146,327 @@ public final class DictationStore {
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
+    }
+
+    // MARK: - Speaker profiles (voice library)
+
+    /// Create or update a profile in place. Uses `ON CONFLICT ... DO UPDATE`
+    /// (not `INSERT OR REPLACE`) so the row is never deleted-and-reinserted —
+    /// a REPLACE would fire the `ON DELETE SET NULL` FK and orphan every linked
+    /// `meeting_speakers` row.
+    public func upsertSpeakerProfile(
+        id: String,
+        name: String,
+        embedding: [Float],
+        rawEmbeddings: [[Float]] = [],
+        observationCount: Int = 1
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = """
+        INSERT INTO speaker_profiles (id, name, embedding, raw_embeddings, observation_count, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+        ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            embedding = excluded.embedding,
+            raw_embeddings = excluded.raw_embeddings,
+            observation_count = excluded.observation_count,
+            updated_at = datetime('now')
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (id as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (name as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 3, (Self.encodeEmbedding(embedding) as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 4, (Self.encodeRawEmbeddings(rawEmbeddings) as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(statement, 5, Int32(observationCount))
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    public func speakerProfiles() throws -> [SpeakerProfile] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "SELECT id, name, embedding, raw_embeddings, observation_count, created_at, updated_at FROM speaker_profiles ORDER BY name COLLATE NOCASE ASC"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        var rows: [SpeakerProfile] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append(makeSpeakerProfile(statement))
+        }
+        return rows
+    }
+
+    public func speakerProfile(id: String) throws -> SpeakerProfile? {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "SELECT id, name, embedding, raw_embeddings, observation_count, created_at, updated_at FROM speaker_profiles WHERE id = ? LIMIT 1"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (id as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return makeSpeakerProfile(statement)
+    }
+
+    public func renameSpeakerProfile(id: String, name: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "UPDATE speaker_profiles SET name = ?, updated_at = datetime('now') WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (name as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (id as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    /// Fold `removeID` into `keepID`: every `meeting_speakers` row pointing at
+    /// the removed profile is repointed (and its display name aligned to the kept
+    /// profile), then the removed profile is deleted — all in one transaction.
+    public func mergeSpeakerProfiles(keepID: String, removeID: String) throws {
+        guard keepID != removeID else { return }
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        do {
+            // Resolve the kept profile's name so repointed rows display consistently.
+            var keepName = ""
+            var nameStmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "SELECT name FROM speaker_profiles WHERE id = ?", -1, &nameStmt, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_text(nameStmt, 1, (keepID as NSString).utf8String, -1, nil)
+            if sqlite3_step(nameStmt) == SQLITE_ROW {
+                keepName = stringColumn(nameStmt, index: 0)
+            }
+            sqlite3_finalize(nameStmt)
+
+            var s1: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "UPDATE meeting_speakers SET profile_id = ?, display_name = ? WHERE profile_id = ?", -1, &s1, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(s1) }
+            sqlite3_bind_text(s1, 1, (keepID as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(s1, 2, (keepName as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(s1, 3, (removeID as NSString).utf8String, -1, nil)
+            guard sqlite3_step(s1) == SQLITE_DONE else { throw lastError(db) }
+
+            var s2: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "DELETE FROM speaker_profiles WHERE id = ?", -1, &s2, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(s2) }
+            sqlite3_bind_text(s2, 1, (removeID as NSString).utf8String, -1, nil)
+            guard sqlite3_step(s2) == SQLITE_DONE else { throw lastError(db) }
+
+            guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+        } catch {
+            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    /// Delete a profile AND scrub every per-meeting copy of its voiceprint (R9).
+    /// The FK is `ON DELETE SET NULL`, which keeps the cluster's label/row but
+    /// would leave the captured `embedding` behind — so we explicitly null the
+    /// embedding/name/state on linked rows in the same transaction.
+    public func deleteSpeakerProfile(id: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        do {
+            var s1: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "UPDATE meeting_speakers SET embedding = '[]', display_name = NULL, match_distance = NULL, match_state = 'unmatched', profile_id = NULL WHERE profile_id = ?", -1, &s1, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(s1) }
+            sqlite3_bind_text(s1, 1, (id as NSString).utf8String, -1, nil)
+            guard sqlite3_step(s1) == SQLITE_DONE else { throw lastError(db) }
+
+            var s2: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "DELETE FROM speaker_profiles WHERE id = ?", -1, &s2, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(s2) }
+            sqlite3_bind_text(s2, 1, (id as NSString).utf8String, -1, nil)
+            guard sqlite3_step(s2) == SQLITE_DONE else { throw lastError(db) }
+
+            guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+        } catch {
+            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    // MARK: - Per-meeting speakers
+
+    @discardableResult
+    public func insertMeetingSpeaker(
+        meetingID: Int64,
+        speakerLabel: String,
+        embedding: [Float],
+        profileID: String? = nil,
+        displayName: String? = nil,
+        matchDistance: Double? = nil,
+        matchState: SpeakerMatchState = .unmatched
+    ) throws -> Int64 {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = """
+        INSERT INTO meeting_speakers
+        (meeting_id, speaker_label, embedding, profile_id, display_name, match_distance, match_state)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        sqlite3_bind_text(statement, 2, (speakerLabel as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 3, (Self.encodeEmbedding(embedding) as NSString).utf8String, -1, nil)
+        bindOptionalText(profileID, at: 4, statement: statement)
+        bindOptionalText(displayName, at: 5, statement: statement)
+        if let matchDistance {
+            sqlite3_bind_double(statement, 6, matchDistance)
+        } else {
+            sqlite3_bind_null(statement, 6)
+        }
+        sqlite3_bind_text(statement, 7, (matchState.rawValue as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+        return sqlite3_last_insert_rowid(db)
+    }
+
+    public func meetingSpeakers(for meetingID: Int64) throws -> [MeetingSpeaker] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "SELECT id, meeting_id, speaker_label, embedding, profile_id, display_name, match_distance, match_state FROM meeting_speakers WHERE meeting_id = ? ORDER BY id ASC"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        var rows: [MeetingSpeaker] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append(makeMeetingSpeaker(statement))
+        }
+        return rows
+    }
+
+    /// Update the resolved name/profile/state of a single cluster row (used by
+    /// recognition in U3 and by user naming in U5).
+    public func updateMeetingSpeaker(
+        id: Int64,
+        profileID: String?,
+        displayName: String?,
+        matchDistance: Double?,
+        matchState: SpeakerMatchState
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "UPDATE meeting_speakers SET profile_id = ?, display_name = ?, match_distance = ?, match_state = ? WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        bindOptionalText(profileID, at: 1, statement: statement)
+        bindOptionalText(displayName, at: 2, statement: statement)
+        if let matchDistance {
+            sqlite3_bind_double(statement, 3, matchDistance)
+        } else {
+            sqlite3_bind_null(statement, 3)
+        }
+        sqlite3_bind_text(statement, 4, (matchState.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_int64(statement, 5, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    /// Drop all cluster rows for a meeting. Used by the re-transcribe path, which
+    /// re-runs diarization with fresh cluster numbering and must recompute the map.
+    public func deleteMeetingSpeakers(for meetingID: Int64) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "DELETE FROM meeting_speakers WHERE meeting_id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    private func makeSpeakerProfile(_ statement: OpaquePointer?) -> SpeakerProfile {
+        SpeakerProfile(
+            id: stringColumn(statement, index: 0),
+            name: stringColumn(statement, index: 1),
+            embedding: Self.decodeEmbedding(stringColumn(statement, index: 2)),
+            rawEmbeddings: Self.decodeRawEmbeddings(sqlite3_column_type(statement, 3) == SQLITE_NULL ? "" : stringColumn(statement, index: 3)),
+            observationCount: Int(sqlite3_column_int(statement, 4)),
+            createdAt: stringColumn(statement, index: 5),
+            updatedAt: stringColumn(statement, index: 6)
+        )
+    }
+
+    private func makeMeetingSpeaker(_ statement: OpaquePointer?) -> MeetingSpeaker {
+        MeetingSpeaker(
+            id: sqlite3_column_int64(statement, 0),
+            meetingID: sqlite3_column_int64(statement, 1),
+            speakerLabel: stringColumn(statement, index: 2),
+            embedding: Self.decodeEmbedding(stringColumn(statement, index: 3)),
+            profileID: sqlite3_column_type(statement, 4) == SQLITE_NULL ? nil : stringColumn(statement, index: 4),
+            displayName: sqlite3_column_type(statement, 5) == SQLITE_NULL ? nil : stringColumn(statement, index: 5),
+            matchDistance: sqlite3_column_type(statement, 6) == SQLITE_NULL ? nil : sqlite3_column_double(statement, 6),
+            matchState: SpeakerMatchState(rawValue: stringColumn(statement, index: 7)) ?? .unmatched
+        )
+    }
+
+    static func encodeEmbedding(_ embedding: [Float]) -> String {
+        (try? String(data: JSONEncoder().encode(embedding), encoding: .utf8) ?? "[]") ?? "[]"
+    }
+
+    static func decodeEmbedding(_ json: String) -> [Float] {
+        guard !json.isEmpty else { return [] }
+        return (try? JSONDecoder().decode([Float].self, from: Data(json.utf8))) ?? []
+    }
+
+    static func encodeRawEmbeddings(_ embeddings: [[Float]]) -> String {
+        (try? String(data: JSONEncoder().encode(embeddings), encoding: .utf8) ?? "[]") ?? "[]"
+    }
+
+    static func decodeRawEmbeddings(_ json: String) -> [[Float]] {
+        guard !json.isEmpty else { return [] }
+        return (try? JSONDecoder().decode([[Float]].self, from: Data(json.utf8))) ?? []
     }
 
     public func databasePath() -> URL {

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -262,6 +262,84 @@ public struct MeetingFolder: Identifiable, Codable, Sendable {
     }
 }
 
+/// Confidence tier for a diarized cluster's link to a saved voice profile.
+public enum SpeakerMatchState: String, Codable, Sendable {
+    /// No profile matched (renders as the raw `Speaker N`).
+    case unmatched
+    /// Borderline match surfaced as a suggestion for the user to confirm or reject.
+    case suggested
+    /// Confident automatic match (display name shown with an "auto-recognized" hint).
+    case auto
+    /// User explicitly named/confirmed this speaker.
+    case confirmed
+}
+
+/// A persistent, cross-meeting voice profile (the Speakers library).
+///
+/// `embedding` is the representative 256-D voiceprint used for recognition;
+/// `rawEmbeddings` retains the per-confirmation samples so the centroid can be
+/// recomputed recoverably (re-average) rather than via a lossy in-place EMA.
+public struct SpeakerProfile: Identifiable, Codable, Sendable {
+    public let id: String
+    public var name: String
+    public var embedding: [Float]
+    public var rawEmbeddings: [[Float]]
+    public var observationCount: Int
+    public let createdAt: String
+    public let updatedAt: String
+
+    public init(
+        id: String,
+        name: String,
+        embedding: [Float],
+        rawEmbeddings: [[Float]] = [],
+        observationCount: Int = 1,
+        createdAt: String = "",
+        updatedAt: String = ""
+    ) {
+        self.id = id
+        self.name = name
+        self.embedding = embedding
+        self.rawEmbeddings = rawEmbeddings
+        self.observationCount = observationCount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Links one diarized cluster of a single meeting to a `Speaker N` label, its
+/// representative embedding captured at stop, and its resolved name/profile.
+public struct MeetingSpeaker: Identifiable, Codable, Sendable {
+    public let id: Int64
+    public let meetingID: Int64
+    public let speakerLabel: String
+    public var embedding: [Float]
+    public var profileID: String?
+    public var displayName: String?
+    public var matchDistance: Double?
+    public var matchState: SpeakerMatchState
+
+    public init(
+        id: Int64,
+        meetingID: Int64,
+        speakerLabel: String,
+        embedding: [Float],
+        profileID: String? = nil,
+        displayName: String? = nil,
+        matchDistance: Double? = nil,
+        matchState: SpeakerMatchState = .unmatched
+    ) {
+        self.id = id
+        self.meetingID = meetingID
+        self.speakerLabel = speakerLabel
+        self.embedding = embedding
+        self.profileID = profileID
+        self.displayName = displayName
+        self.matchDistance = matchDistance
+        self.matchState = matchState
+    }
+}
+
 public struct DictationStats: Codable, Sendable {
     public let totalWords: Int
     public let totalSessions: Int

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -279,7 +279,7 @@ public enum SpeakerMatchState: String, Codable, Sendable {
 /// `embedding` is the representative 256-D voiceprint used for recognition;
 /// `rawEmbeddings` retains the per-confirmation samples so the centroid can be
 /// recomputed recoverably (re-average) rather than via a lossy in-place EMA.
-public struct SpeakerProfile: Identifiable, Codable, Sendable {
+public struct SpeakerProfile: Identifiable, Codable, Sendable, Equatable {
     public let id: String
     public var name: String
     public var embedding: [Float]
@@ -309,7 +309,7 @@ public struct SpeakerProfile: Identifiable, Codable, Sendable {
 
 /// Links one diarized cluster of a single meeting to a `Speaker N` label, its
 /// representative embedding captured at stop, and its resolved name/profile.
-public struct MeetingSpeaker: Identifiable, Codable, Sendable {
+public struct MeetingSpeaker: Identifiable, Codable, Sendable, Equatable {
     public let id: Int64
     public let meetingID: Int64
     public let speakerLabel: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -50,6 +50,7 @@ final class AppState {
     var selectedFolderID: Int64?  // nil = "All Meetings"
     var meetingsNavigationState: MeetingsNavigationState = .browser
     var isMeetingTemplatesManagerPresented: Bool = false
+    var isSpeakersManagerPresented: Bool = false
     var dictationStats: DictationStats = DictationStats(
         totalWords: 0, totalSessions: 0, averageWordsPerSession: 0,
         averageWPM: 0, currentStreakDays: 0, longestStreakDays: 0

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -196,6 +196,7 @@ enum AudioFileImportController {
 
         // Run speaker diarization if available
         var diarizedTranscript = rawTranscript
+        var speakerClusters: [SpeakerCluster] = []
         if let diarizerManager = await transcriptionCoordinator.getDiarizerManager(),
            diarizerManager.isAvailable {
             progress("Identifying speakers...")
@@ -212,6 +213,11 @@ enum AudioFileImportController {
                         transcription: transcription,
                         diarizationSegments: diarizationResult.segments,
                         meetingStart: importedTranscriptTimelineStart()
+                    )
+                    // Capture voiceprints aligned to the labels realized in the blob.
+                    speakerClusters = SpeakerClusterAggregator.aggregate(
+                        diarizationSegments: diarizationResult.segments,
+                        transcript: diarizedTranscript
                     )
                 }
             } catch is CancellationError {
@@ -278,7 +284,8 @@ enum AudioFileImportController {
             selectedTemplateID: templateSnapshot.id,
             selectedTemplateName: templateSnapshot.name,
             selectedTemplateKind: templateSnapshot.kind,
-            selectedTemplatePrompt: templateSnapshot.prompt
+            selectedTemplatePrompt: templateSnapshot.prompt,
+            speakerClusters: speakerClusters
         )
 
         return ImportResult(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -50,6 +50,10 @@ struct MeetingDetailView: View {
     @State private var showFolderPopover = false
     @State private var showNewFolderPrompt = false
     @State private var newFolderName = ""
+    /// Label → per-meeting speaker row, driving the render-time name overlay.
+    /// Refreshed on meeting change and after renames so the transcript re-renders
+    /// even though the stored transcript string is unchanged.
+    @State private var speakerMap: [String: MeetingSpeaker] = [:]
 
     init(
         meeting: MeetingRecord?,
@@ -71,6 +75,7 @@ struct MeetingDetailView: View {
         _loadedMeetingID = State(initialValue: meeting?.id)
         _pendingTemplateID = State(initialValue: initialTemplateID)
         _documentMode = State(initialValue: meeting.map(Self.defaultDocumentMode(for:)) ?? .notes)
+        _speakerMap = State(initialValue: Self.loadSpeakerMap(controller: controller, meeting: meeting))
     }
 
     var body: some View {
@@ -291,7 +296,11 @@ struct MeetingDetailView: View {
                         .allowsHitTesting(documentMode == .notes)
                         .accessibilityHidden(documentMode != .notes)
 
-                    MeetingTranscriptView(transcript: meeting.rawTranscript)
+                    MeetingTranscriptView(
+                        transcript: meeting.rawTranscript,
+                        speakerMap: speakerMap,
+                        userName: appState.config.userName
+                    )
                         .opacity(documentMode == .transcript ? 1 : 0)
                         .allowsHitTesting(documentMode == .transcript)
                         .accessibilityHidden(documentMode != .transcript)
@@ -1291,6 +1300,7 @@ struct MeetingDetailView: View {
         }
         pendingTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         if meetingChanged {
+            speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
             documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
             isEditingNotes = false
             isEditingTranscript = false
@@ -1298,6 +1308,11 @@ struct MeetingDetailView: View {
             showNewFolderPrompt = false
             newFolderName = ""
         }
+    }
+
+    static func loadSpeakerMap(controller: MuesliController, meeting: MeetingRecord?) -> [String: MeetingSpeaker] {
+        guard let meeting else { return [:] }
+        return SpeakerNameResolver.speakerMap(from: controller.meetingSpeakers(for: meeting.id))
     }
 
     private func syncManualNotesState(with meeting: MeetingRecord?) {
@@ -1563,10 +1578,14 @@ struct TranscriptChatMessage: Identifiable, Equatable {
 
 private struct MeetingTranscriptView: View {
     let transcript: String
+    let speakerMap: [String: MeetingSpeaker]
+    let userName: String
     @State private var messages: [TranscriptChatMessage]
 
-    init(transcript: String) {
+    init(transcript: String, speakerMap: [String: MeetingSpeaker], userName: String) {
         self.transcript = transcript
+        self.speakerMap = speakerMap
+        self.userName = userName
         _messages = State(initialValue: TranscriptChatMessage.messages(from: transcript))
     }
 
@@ -1581,7 +1600,15 @@ private struct MeetingTranscriptView: View {
                         .padding(MuesliTheme.spacing24)
                 } else {
                     ForEach(messages) { message in
-                        TranscriptChatBubble(message: message)
+                        // Resolve the display name at render time; the parsed
+                        // message keeps its raw `Speaker N`/`You` token so
+                        // `isUser` and re-parsing stay correct.
+                        TranscriptChatBubble(
+                            message: message,
+                            resolved: message.speaker.map {
+                                SpeakerNameResolver.resolve(label: $0, speakers: speakerMap, userName: userName)
+                            }
+                        )
                     }
                 }
             }
@@ -1598,6 +1625,7 @@ private struct MeetingTranscriptView: View {
 
 private struct TranscriptChatBubble: View {
     let message: TranscriptChatMessage
+    var resolved: ResolvedSpeakerName?
 
     var body: some View {
         HStack(alignment: .bottom, spacing: MuesliTheme.spacing8) {
@@ -1607,10 +1635,20 @@ private struct TranscriptChatBubble: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 if let metadata = metadata {
-                    Text(metadata)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                        .textSelection(.enabled)
+                    HStack(spacing: 4) {
+                        Text(metadata)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .textSelection(.enabled)
+                        if resolved?.isAutoRecognized == true {
+                            // Distinguish an auto-recognized (unconfirmed) name from
+                            // a user-confirmed one so it can be verified before trust.
+                            Image(systemName: "wand.and.stars")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                                .help("Auto-recognized — confirm to verify")
+                        }
+                    }
                 }
                 Text(message.text)
                     .font(.system(size: 14))
@@ -1636,7 +1674,9 @@ private struct TranscriptChatBubble: View {
     }
 
     private var metadata: String? {
-        switch (message.speaker, message.timestamp) {
+        // Prefer the resolved display name; fall back to the raw parsed label.
+        let speaker = resolved?.display ?? message.speaker
+        switch (speaker, message.timestamp) {
         case let (speaker?, timestamp?):
             return "\(speaker) \(timestamp)"
         case let (speaker?, nil):

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -1343,9 +1343,12 @@ struct MeetingDetailView: View {
 
     private func renameSpeaker(meeting: MeetingRecord, label: String, to newName: String) {
         let shouldNote = controller.shouldShowVoiceProfileNote
+        let before = speakerMap
         controller.renameMeetingSpeaker(meetingID: meeting.id, label: label, to: newName)
         speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
-        speakerNamesChanged = true
+        // Only offer "Update notes" when something actually changed — a blank
+        // rename is a no-op and shouldn't trigger a needless re-summary.
+        if speakerMap != before { speakerNamesChanged = true }
         // Show the one-time disclosure only when a profile was actually enrolled.
         if shouldNote, speakerMap[label]?.profileID != nil {
             showVoiceProfileNote = true
@@ -1354,9 +1357,10 @@ struct MeetingDetailView: View {
 
     private func confirmSpeaker(meeting: MeetingRecord, label: String) {
         let shouldNote = controller.shouldShowVoiceProfileNote
+        let before = speakerMap
         controller.confirmSuggestedSpeaker(meetingID: meeting.id, label: label)
         speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
-        speakerNamesChanged = true
+        if speakerMap != before { speakerNamesChanged = true }
         if shouldNote, speakerMap[label]?.profileID != nil {
             showVoiceProfileNote = true
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -1666,10 +1666,7 @@ struct TranscriptChatMessage: Identifiable, Equatable {
         guard !label.isEmpty, label.count <= 32 else { return false }
         if label.localizedCaseInsensitiveCompare("You") == .orderedSame { return true }
         if label.localizedCaseInsensitiveCompare("Others") == .orderedSame { return true }
-        if label.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil {
-            return true
-        }
-        return false
+        return SpeakerNameResolver.isSpeakerClusterLabel(label)
     }
 }
 
@@ -1753,7 +1750,7 @@ private struct TranscriptChatBubble: View {
     /// are not. The stored token stays `Speaker N` even after naming.
     private var renameableLabel: String? {
         guard let speaker = message.speaker,
-              speaker.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil
+              SpeakerNameResolver.isSpeakerClusterLabel(speaker)
         else { return nil }
         return speaker
     }
@@ -1854,11 +1851,13 @@ private struct TranscriptChatBubble: View {
                 }
                 .buttonStyle(.plain)
                 .help("Confirm \(candidate)")
+                .accessibilityLabel("Confirm \(candidate)")
                 Button { onReject(label) } label: {
                     Image(systemName: "xmark.circle")
                 }
                 .buttonStyle(.plain)
                 .help("Not \(candidate)")
+                .accessibilityLabel("Not \(candidate)")
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 2)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -54,6 +54,9 @@ struct MeetingDetailView: View {
     /// Refreshed on meeting change and after renames so the transcript re-renders
     /// even though the stored transcript string is unchanged.
     @State private var speakerMap: [String: MeetingSpeaker] = [:]
+    /// Set when a speaker name changes, enabling the "Update notes with corrected
+    /// names" affordance (wired in the notes-integration unit).
+    @State private var speakerNamesChanged = false
 
     init(
         meeting: MeetingRecord?,
@@ -299,7 +302,10 @@ struct MeetingDetailView: View {
                     MeetingTranscriptView(
                         transcript: meeting.rawTranscript,
                         speakerMap: speakerMap,
-                        userName: appState.config.userName
+                        userName: appState.config.userName,
+                        onRename: { label, name in renameSpeaker(meeting: meeting, label: label, to: name) },
+                        onConfirm: { label in confirmSpeaker(meeting: meeting, label: label) },
+                        onReject: { label in rejectSpeaker(meeting: meeting, label: label) }
                     )
                         .opacity(documentMode == .transcript ? 1 : 0)
                         .allowsHitTesting(documentMode == .transcript)
@@ -1301,6 +1307,7 @@ struct MeetingDetailView: View {
         pendingTemplateID = meeting.map { controller.meetingTemplateSnapshot(for: $0).id } ?? controller.defaultMeetingTemplate().id
         if meetingChanged {
             speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
+            speakerNamesChanged = false
             documentMode = meeting.map(Self.defaultDocumentMode(for:)) ?? .notes
             isEditingNotes = false
             isEditingTranscript = false
@@ -1313,6 +1320,23 @@ struct MeetingDetailView: View {
     static func loadSpeakerMap(controller: MuesliController, meeting: MeetingRecord?) -> [String: MeetingSpeaker] {
         guard let meeting else { return [:] }
         return SpeakerNameResolver.speakerMap(from: controller.meetingSpeakers(for: meeting.id))
+    }
+
+    private func renameSpeaker(meeting: MeetingRecord, label: String, to newName: String) {
+        controller.renameMeetingSpeaker(meetingID: meeting.id, label: label, to: newName)
+        speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
+        speakerNamesChanged = true
+    }
+
+    private func confirmSpeaker(meeting: MeetingRecord, label: String) {
+        controller.confirmSuggestedSpeaker(meetingID: meeting.id, label: label)
+        speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
+        speakerNamesChanged = true
+    }
+
+    private func rejectSpeaker(meeting: MeetingRecord, label: String) {
+        controller.rejectSuggestedSpeaker(meetingID: meeting.id, label: label)
+        speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
     }
 
     private func syncManualNotesState(with meeting: MeetingRecord?) {
@@ -1580,12 +1604,25 @@ private struct MeetingTranscriptView: View {
     let transcript: String
     let speakerMap: [String: MeetingSpeaker]
     let userName: String
+    var onRename: (String, String) -> Void = { _, _ in }
+    var onConfirm: (String) -> Void = { _ in }
+    var onReject: (String) -> Void = { _ in }
     @State private var messages: [TranscriptChatMessage]
 
-    init(transcript: String, speakerMap: [String: MeetingSpeaker], userName: String) {
+    init(
+        transcript: String,
+        speakerMap: [String: MeetingSpeaker],
+        userName: String,
+        onRename: @escaping (String, String) -> Void = { _, _ in },
+        onConfirm: @escaping (String) -> Void = { _ in },
+        onReject: @escaping (String) -> Void = { _ in }
+    ) {
         self.transcript = transcript
         self.speakerMap = speakerMap
         self.userName = userName
+        self.onRename = onRename
+        self.onConfirm = onConfirm
+        self.onReject = onReject
         _messages = State(initialValue: TranscriptChatMessage.messages(from: transcript))
     }
 
@@ -1607,7 +1644,11 @@ private struct MeetingTranscriptView: View {
                             message: message,
                             resolved: message.speaker.map {
                                 SpeakerNameResolver.resolve(label: $0, speakers: speakerMap, userName: userName)
-                            }
+                            },
+                            speakerRow: message.speaker.flatMap { speakerMap[$0] },
+                            onRename: onRename,
+                            onConfirm: onConfirm,
+                            onReject: onReject
                         )
                     }
                 }
@@ -1626,6 +1667,23 @@ private struct MeetingTranscriptView: View {
 private struct TranscriptChatBubble: View {
     let message: TranscriptChatMessage
     var resolved: ResolvedSpeakerName?
+    var speakerRow: MeetingSpeaker?
+    var onRename: (String, String) -> Void = { _, _ in }
+    var onConfirm: (String) -> Void = { _ in }
+    var onReject: (String) -> Void = { _ in }
+
+    @State private var isRenaming = false
+    @State private var draftName = ""
+    @FocusState private var renameFocused: Bool
+
+    /// Only diarized clusters (`Speaker N` tokens) are renameable; `You`/`Others`
+    /// are not. The stored token stays `Speaker N` even after naming.
+    private var renameableLabel: String? {
+        guard let speaker = message.speaker,
+              speaker.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil
+        else { return nil }
+        return speaker
+    }
 
     var body: some View {
         HStack(alignment: .bottom, spacing: MuesliTheme.spacing8) {
@@ -1634,22 +1692,7 @@ private struct TranscriptChatBubble: View {
             }
 
             VStack(alignment: .leading, spacing: 4) {
-                if let metadata = metadata {
-                    HStack(spacing: 4) {
-                        Text(metadata)
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .textSelection(.enabled)
-                        if resolved?.isAutoRecognized == true {
-                            // Distinguish an auto-recognized (unconfirmed) name from
-                            // a user-confirmed one so it can be verified before trust.
-                            Image(systemName: "wand.and.stars")
-                                .font(.system(size: 9, weight: .medium))
-                                .foregroundStyle(MuesliTheme.textTertiary)
-                                .help("Auto-recognized — confirm to verify")
-                        }
-                    }
-                }
+                metadataRow
                 Text(message.text)
                     .font(.system(size: 14))
                     .foregroundStyle(MuesliTheme.textPrimary)
@@ -1671,6 +1714,97 @@ private struct TranscriptChatBubble: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: message.isUser ? .trailing : .leading)
+    }
+
+    @ViewBuilder
+    private var metadataRow: some View {
+        if isRenaming, let label = renameableLabel {
+            HStack(spacing: 4) {
+                TextField("Speaker name", text: $draftName)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11))
+                    .frame(maxWidth: 160)
+                    .focused($renameFocused)
+                    .onSubmit { commitRename(label: label) }
+                Button { commitRename(label: label) } label: {
+                    Image(systemName: "checkmark")
+                }
+                .buttonStyle(.plain)
+                Button { isRenaming = false } label: {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.plain)
+            }
+            .font(.system(size: 10))
+            .foregroundStyle(MuesliTheme.textSecondary)
+        } else if let metadata = metadata {
+            HStack(spacing: 4) {
+                if let label = renameableLabel {
+                    Button { beginRename() } label: {
+                        Text(metadata)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Rename this speaker")
+                    .accessibilityLabel("Rename \(resolved?.display ?? label)")
+                } else {
+                    Text(metadata)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .textSelection(.enabled)
+                }
+                if resolved?.isAutoRecognized == true {
+                    // Distinguish an auto-recognized (unconfirmed) name from a
+                    // user-confirmed one so it can be verified before trust.
+                    Image(systemName: "wand.and.stars")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .help("Auto-recognized — confirm to verify")
+                }
+                suggestionChip
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var suggestionChip: some View {
+        if let label = renameableLabel,
+           speakerRow?.matchState == .suggested,
+           let candidate = speakerRow?.displayName, !candidate.isEmpty {
+            HStack(spacing: 2) {
+                Text("\(candidate)?")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.accent)
+                Button { onConfirm(label) } label: {
+                    Image(systemName: "checkmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .help("Confirm \(candidate)")
+                Button { onReject(label) } label: {
+                    Image(systemName: "xmark.circle")
+                }
+                .buttonStyle(.plain)
+                .help("Not \(candidate)")
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(MuesliTheme.accent.opacity(0.12))
+            .clipShape(Capsule())
+        }
+    }
+
+    private func beginRename() {
+        draftName = resolved?.display ?? message.speaker ?? ""
+        isRenaming = true
+        renameFocused = true
+    }
+
+    private func commitRename(label: String) {
+        let trimmed = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
+        isRenaming = false
+        guard !trimmed.isEmpty else { return }
+        onRename(label, trimmed)
     }
 
     private var metadata: String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -55,8 +55,12 @@ struct MeetingDetailView: View {
     /// even though the stored transcript string is unchanged.
     @State private var speakerMap: [String: MeetingSpeaker] = [:]
     /// Set when a speaker name changes, enabling the "Update notes with corrected
-    /// names" affordance (wired in the notes-integration unit).
+    /// names" affordance.
     @State private var speakerNamesChanged = false
+    @State private var isUpdatingNotesWithNames = false
+    /// One-time "voiceprints are stored locally" disclosure, shown on first
+    /// enrollment.
+    @State private var showVoiceProfileNote = false
 
     init(
         meeting: MeetingRecord?,
@@ -151,6 +155,17 @@ struct MeetingDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Are you sure you want to delete this meeting? Saved notes, transcript, and any retained recording will be removed.")
+        }
+        .alert("Voice profile saved on this device", isPresented: $showVoiceProfileNote) {
+            Button("Manage Speakers…") {
+                controller.markVoiceProfileNoteSeen()
+                controller.showSpeakersManager()
+            }
+            Button("Got it", role: .cancel) {
+                controller.markVoiceProfileNoteSeen()
+            }
+        } message: {
+            Text("Naming a speaker saves a local voiceprint so Muesli can recognize them in future meetings. Voiceprints never leave this device and can be deleted anytime in the Speakers library.")
         }
     }
 
@@ -292,6 +307,10 @@ struct MeetingDetailView: View {
         } else {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 contentToolbar(for: meeting)
+
+                if speakerNamesChanged, meeting.notesState != .missing {
+                    updateNotesBanner(for: meeting)
+                }
 
                 ZStack(alignment: .topLeading) {
                     MeetingNotesView(markdown: Self.notesContent(for: meeting))
@@ -1323,15 +1342,69 @@ struct MeetingDetailView: View {
     }
 
     private func renameSpeaker(meeting: MeetingRecord, label: String, to newName: String) {
+        let shouldNote = controller.shouldShowVoiceProfileNote
         controller.renameMeetingSpeaker(meetingID: meeting.id, label: label, to: newName)
         speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
         speakerNamesChanged = true
+        // Show the one-time disclosure only when a profile was actually enrolled.
+        if shouldNote, speakerMap[label]?.profileID != nil {
+            showVoiceProfileNote = true
+        }
     }
 
     private func confirmSpeaker(meeting: MeetingRecord, label: String) {
+        let shouldNote = controller.shouldShowVoiceProfileNote
         controller.confirmSuggestedSpeaker(meetingID: meeting.id, label: label)
         speakerMap = Self.loadSpeakerMap(controller: controller, meeting: meeting)
         speakerNamesChanged = true
+        if shouldNote, speakerMap[label]?.profileID != nil {
+            showVoiceProfileNote = true
+        }
+    }
+
+    @ViewBuilder
+    private func updateNotesBanner(for meeting: MeetingRecord) -> some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: "person.text.rectangle")
+                .font(.system(size: 12))
+                .foregroundStyle(MuesliTheme.accent)
+            Text("Speaker names changed. Update the notes to use the corrected names?")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            Spacer()
+            Button {
+                updateNotesWithCorrectedNames(meeting: meeting)
+            } label: {
+                HStack(spacing: 6) {
+                    if isUpdatingNotesWithNames {
+                        ProgressView().controlSize(.small)
+                    }
+                    Text(isUpdatingNotesWithNames ? "Updating…" : "Update notes")
+                        .font(.system(size: 12, weight: .medium))
+                }
+            }
+            .buttonStyle(.plain)
+            .disabled(isUpdatingNotesWithNames)
+            .foregroundStyle(MuesliTheme.accent)
+        }
+        .padding(.horizontal, MuesliTheme.spacing12)
+        .padding(.vertical, 8)
+        .background(MuesliTheme.accent.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .padding(.horizontal, 40)
+    }
+
+    private func updateNotesWithCorrectedNames(meeting: MeetingRecord) {
+        guard !isUpdatingNotesWithNames else { return }
+        isUpdatingNotesWithNames = true
+        controller.updateNotesWithCorrectedNames(meeting: meeting) { result in
+            isUpdatingNotesWithNames = false
+            if case .success = result {
+                speakerNamesChanged = false
+            } else if case .failure = result {
+                summaryErrorMessage = "The notes could not be updated with the corrected names."
+            }
+        }
     }
 
     private func rejectSpeaker(meeting: MeetingRecord, label: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -66,6 +66,9 @@ struct MeetingSessionResult {
     let retainedRecordingError: Error?
     let systemRecordingURL: URL?
     let templateSnapshot: MeetingTemplateSnapshot
+    /// Per-diarized-cluster representative voiceprints captured at stop, for
+    /// persistence into `meeting_speakers` (empty when no diarization ran).
+    var speakerClusters: [SpeakerCluster] = []
 }
 
 enum MeetingProcessingStage {
@@ -438,6 +441,14 @@ final class MeetingSession {
             meetingStart: meetingStart
         )
 
+        // Capture one representative voiceprint per realized diarized cluster
+        // before the segments (and their embeddings) are discarded. Derived from
+        // the just-built blob so labels match exactly.
+        let speakerClusters = SpeakerClusterAggregator.aggregate(
+            diarizationSegments: protectedTranscriptInputs.diarizationSegments ?? [],
+            transcript: rawTranscript
+        )
+
         let generatedTitle: String
         onProgress?(.generatingTitle)
         if let liveTitle = await userEditedLiveTitle() {
@@ -512,7 +523,8 @@ final class MeetingSession {
             retainedRecordingURL: retainedRecordingURL,
             retainedRecordingError: retainedRecordingWriterError,
             systemRecordingURL: systemAudioURL,
-            templateSnapshot: templateSnapshot
+            templateSnapshot: templateSnapshot,
+            speakerClusters: speakerClusters
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -193,6 +193,18 @@ struct MeetingsView: View {
                 onClose: { appState.isMeetingTemplatesManagerPresented = false }
             )
         }
+        .sheet(
+            isPresented: Binding(
+                get: { appState.isSpeakersManagerPresented },
+                set: { appState.isSpeakersManagerPresented = $0 }
+            )
+        ) {
+            SpeakersManagerView(
+                appState: appState,
+                controller: controller,
+                onClose: { appState.isSpeakersManagerPresented = false }
+            )
+        }
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -769,6 +769,7 @@ struct AppConfig: Codable {
     var activePostProcessorId: String = PostProcessorOption.defaultOption.id
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     var enableScreenContext: Bool = false
+    var hasSeenVoiceProfileNote: Bool = false
     var useCoreAudioTap: Bool = true
     var meetingHookEnabled: Bool = false
     var meetingHookPath: String = ""
@@ -845,6 +846,7 @@ struct AppConfig: Codable {
         case activePostProcessorId = "active_post_processor_id"
         case postProcessorSystemPrompt = "post_processor_system_prompt"
         case enableScreenContext = "enable_screen_context"
+        case hasSeenVoiceProfileNote = "has_seen_voice_profile_note"
         case useCoreAudioTap = "use_core_audio_tap"
         case meetingHookEnabled = "meeting_hook_enabled"
         case meetingHookPath = "meeting_hook_path"
@@ -951,6 +953,7 @@ struct AppConfig: Codable {
         activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
+        hasSeenVoiceProfileNote = (try? c.decode(Bool.self, forKey: .hasSeenVoiceProfileNote)) ?? defaults.hasSeenVoiceProfileNote
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap
         meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled
         meetingHookPath = (try? c.decode(String.self, forKey: .meetingHookPath)) ?? defaults.meetingHookPath

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3811,6 +3811,37 @@ final class MuesliController: NSObject {
         (try? dictationStore.meetingSpeakers(for: meetingID)) ?? []
     }
 
+    /// Name or correct a speaker in a meeting transcript (creates/refines a
+    /// voice profile when a voiceprint is present).
+    func renameMeetingSpeaker(meetingID: Int64, label: String, to newName: String) {
+        do {
+            try SpeakerNamingService(store: dictationStore).rename(meetingID: meetingID, label: label, to: newName)
+        } catch {
+            fputs("[muesli-native] rename speaker failed (\(meetingID)/\(label)): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
+    /// Confirm a borderline recognition suggestion.
+    func confirmSuggestedSpeaker(meetingID: Int64, label: String) {
+        do {
+            try SpeakerNamingService(store: dictationStore).confirm(meetingID: meetingID, label: label)
+        } catch {
+            fputs("[muesli-native] confirm speaker failed (\(meetingID)/\(label)): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
+    /// Reject a borderline recognition suggestion (returns to `Speaker N`).
+    func rejectSuggestedSpeaker(meetingID: Int64, label: String) {
+        do {
+            try SpeakerNamingService(store: dictationStore).reject(meetingID: meetingID, label: label)
+        } catch {
+            fputs("[muesli-native] reject speaker failed (\(meetingID)/\(label)): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
     /// Persist the per-cluster voiceprints captured at stop into `meeting_speakers`
     /// (replacing any prior rows so re-persist is idempotent), then run recognition
     /// against the saved profile library. A failure here must never block meeting

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3825,10 +3825,29 @@ final class MuesliController: NSObject {
         recognizeMeetingSpeakers(meetingID: meetingID)
     }
 
-    /// Placeholder for U3 recognition; capture (U2) lands rows as `unmatched`.
-    /// Overridden behavior is filled in by the recognition unit.
+    /// Match this meeting's captured clusters against the saved profile library
+    /// and persist confidence-tiered names. Best-effort: failures (or a missing
+    /// diarizer/empty library) leave rows as `unmatched`, never crash.
     func recognizeMeetingSpeakers(meetingID: Int64) {
-        // U3 wires SpeakerRecognizer here.
+        do {
+            let speakers = try dictationStore.meetingSpeakers(for: meetingID)
+            guard !speakers.isEmpty else { return }
+            let profiles = try dictationStore.speakerProfiles()
+            guard !profiles.isEmpty else { return } // first-ever meeting: nothing to match
+            let clusters = speakers.map { SpeakerRecognizer.Cluster(label: $0.speakerLabel, embedding: $0.embedding) }
+            let results = SpeakerRecognizer.recognize(clusters: clusters, profiles: profiles)
+            for (speaker, result) in zip(speakers, results) where result.state != .unmatched {
+                try dictationStore.updateMeetingSpeaker(
+                    id: speaker.id,
+                    profileID: result.profileID,
+                    displayName: result.displayName,
+                    matchDistance: result.distance,
+                    matchState: result.state
+                )
+            }
+        } catch {
+            fputs("[muesli-native] speaker recognition failed for \(meetingID): \(error)\n", stderr)
+        }
     }
 
     private func liveMeetingTitle(id: Int64) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2315,6 +2315,9 @@ final class MuesliController: NSObject {
                         selectedTemplateKind: templateSnapshot.kind,
                         selectedTemplatePrompt: templateSnapshot.prompt
                     )
+                    // This path rewrites the blob without diarization labels, so any
+                    // prior cluster→name mapping is now stale — drop it.
+                    try? self.dictationStore.deleteMeetingSpeakers(for: meeting.id)
                 } catch {
                     throw MeetingRetranscriptionError.failedToSave(underlying: error)
                 }
@@ -3150,9 +3153,10 @@ final class MuesliController: NSObject {
         selectedTemplateID: String?,
         selectedTemplateName: String?,
         selectedTemplateKind: MeetingTemplateKind?,
-        selectedTemplatePrompt: String?
+        selectedTemplatePrompt: String?,
+        speakerClusters: [SpeakerCluster] = []
     ) throws -> Int64 {
-        try dictationStore.insertMeeting(
+        let meetingID = try dictationStore.insertMeeting(
             title: title,
             calendarEventID: calendarEventID,
             startTime: startTime,
@@ -3168,6 +3172,8 @@ final class MuesliController: NSObject {
             selectedTemplatePrompt: selectedTemplatePrompt,
             source: .audioImport
         )
+        persistMeetingSpeakers(speakerClusters, meetingID: meetingID)
+        return meetingID
     }
 
     func cancelMeetingPreparation() {
@@ -3794,7 +3800,35 @@ final class MuesliController: NSObject {
                 selectedTemplatePrompt: result.templateSnapshot.prompt
             )
         }
+        persistMeetingSpeakers(result.speakerClusters, meetingID: meetingID)
         return CompletedMeetingPersistenceResult(meetingID: meetingID, recordingSaveError: recordingSaveError)
+    }
+
+    /// Persist the per-cluster voiceprints captured at stop into `meeting_speakers`
+    /// (replacing any prior rows so re-persist is idempotent), then run recognition
+    /// against the saved profile library. A failure here must never block meeting
+    /// persistence, so errors are logged and swallowed.
+    func persistMeetingSpeakers(_ clusters: [SpeakerCluster], meetingID: Int64) {
+        do {
+            try dictationStore.deleteMeetingSpeakers(for: meetingID)
+            for cluster in clusters {
+                try dictationStore.insertMeetingSpeaker(
+                    meetingID: meetingID,
+                    speakerLabel: cluster.label,
+                    embedding: cluster.embedding
+                )
+            }
+        } catch {
+            fputs("[muesli-native] failed to persist meeting speakers for \(meetingID): \(error)\n", stderr)
+            return
+        }
+        recognizeMeetingSpeakers(meetingID: meetingID)
+    }
+
+    /// Placeholder for U3 recognition; capture (U2) lands rows as `unmatched`.
+    /// Overridden behavior is filled in by the recognition unit.
+    func recognizeMeetingSpeakers(meetingID: Int64) {
+        // U3 wires SpeakerRecognizer here.
     }
 
     private func liveMeetingTitle(id: Int64) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2186,6 +2186,20 @@ final class MuesliController: NSObject {
         resummarize(meeting: meeting, using: templateSnapshot, completion: completion)
     }
 
+    /// Regenerate notes from a name-substituted transcript (the stored blob keeps
+    /// its `Speaker N`/`You` tokens). Only auto/confirmed names are substituted;
+    /// unmatched/suggested speakers stay `Speaker N`.
+    func updateNotesWithCorrectedNames(meeting: MeetingRecord, completion: @escaping (Result<Void, Error>) -> Void) {
+        let speakers = SpeakerNameResolver.speakerMap(from: meetingSpeakers(for: meeting.id))
+        let substituted = SpeakerNameSubstitution.substitute(
+            transcript: meeting.rawTranscript,
+            speakers: speakers,
+            userName: config.userName
+        )
+        let templateSnapshot = meetingTemplateSnapshot(for: meeting)
+        resummarize(meeting: meeting, using: templateSnapshot, transcriptOverride: substituted, completion: completion)
+    }
+
     func applyMeetingTemplate(id: String, to meeting: MeetingRecord, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let templateSnapshot = MeetingTemplates.resolveExactSnapshot(
             id: id,
@@ -2200,6 +2214,7 @@ final class MuesliController: NSObject {
     private func resummarize(
         meeting: MeetingRecord,
         using templateSnapshot: MeetingTemplateSnapshot,
+        transcriptOverride: String? = nil,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         Task { [weak self] in
@@ -2207,7 +2222,7 @@ final class MuesliController: NSObject {
             let plan = MeetingResummarizationPolicy.plan(for: meeting)
             do {
                 let notes = try await MeetingSummaryClient.summarize(
-                    transcript: meeting.rawTranscript,
+                    transcript: transcriptOverride ?? meeting.rawTranscript,
                     meetingTitle: plan.promptTitle,
                     config: self.config,
                     template: templateSnapshot,
@@ -3840,6 +3855,57 @@ final class MuesliController: NSObject {
             fputs("[muesli-native] reject speaker failed (\(meetingID)/\(label)): \(error)\n", stderr)
         }
         syncAppState()
+    }
+
+    // MARK: - Speakers library (voice profiles)
+
+    func speakerProfiles() -> [SpeakerProfile] {
+        (try? dictationStore.speakerProfiles()) ?? []
+    }
+
+    func renameSpeakerProfile(id: String, name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            try dictationStore.renameSpeakerProfile(id: id, name: trimmed)
+        } catch {
+            fputs("[muesli-native] rename speaker profile failed (\(id)): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
+    func mergeSpeakerProfiles(keepID: String, removeID: String) {
+        do {
+            try dictationStore.mergeSpeakerProfiles(keepID: keepID, removeID: removeID)
+        } catch {
+            fputs("[muesli-native] merge speaker profiles failed (\(keepID)<-\(removeID)): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
+    func deleteSpeakerProfile(id: String) {
+        do {
+            try dictationStore.deleteSpeakerProfile(id: id)
+        } catch {
+            fputs("[muesli-native] delete speaker profile failed (\(id)): \(error)\n", stderr)
+        }
+        syncAppState()
+    }
+
+    func showSpeakersManager() {
+        appState.selectedTab = .meetings
+        appState.isSpeakersManagerPresented = true
+    }
+
+    /// Whether the one-time "voiceprints are stored locally" note still needs to
+    /// be shown (on first enrollment).
+    var shouldShowVoiceProfileNote: Bool {
+        !config.hasSeenVoiceProfileNote
+    }
+
+    func markVoiceProfileNoteSeen() {
+        guard !config.hasSeenVoiceProfileNote else { return }
+        updateConfig { $0.hasSeenVoiceProfileNote = true }
     }
 
     /// Persist the per-cluster voiceprints captured at stop into `meeting_speakers`

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3885,7 +3885,10 @@ final class MuesliController: NSObject {
             let profiles = try dictationStore.speakerProfiles()
             if let keep = profiles.first(where: { $0.id == keepID }),
                let remove = profiles.first(where: { $0.id == removeID }) {
-                var combined = keep.rawEmbeddings + remove.rawEmbeddings
+                // Fall back to the representative embedding when a profile has no
+                // retained raw samples, so the removed voiceprint still folds into
+                // the kept centroid (otherwise an embedding-only profile is lost).
+                var combined = rawSamples(of: keep) + rawSamples(of: remove)
                 let cap = SpeakerProfileRefiner.maxRawEmbeddings
                 if cap > 0, combined.count > cap {
                     combined.removeFirst(combined.count - cap)
@@ -3914,6 +3917,15 @@ final class MuesliController: NSObject {
             fputs("[muesli-native] delete speaker profile failed (\(id)): \(error)\n", stderr)
         }
         syncAppState()
+    }
+
+    /// Retained voiceprint samples for a profile, falling back to the
+    /// representative embedding when no raw samples were kept (so merge/refine
+    /// never silently discards an embedding-only profile's voice).
+    private func rawSamples(of profile: SpeakerProfile) -> [[Float]] {
+        if !profile.rawEmbeddings.isEmpty { return profile.rawEmbeddings }
+        if profile.embedding.count == SpeakerClusterAggregator.embeddingDimension { return [profile.embedding] }
+        return []
     }
 
     func showSpeakersManager() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3804,6 +3804,13 @@ final class MuesliController: NSObject {
         return CompletedMeetingPersistenceResult(meetingID: meetingID, recordingSaveError: recordingSaveError)
     }
 
+    /// The per-meeting speaker rows (cluster → resolved name/state), label-keyed
+    /// for the render-time overlay. Returns empty on any error or for pre-feature
+    /// meetings with no rows.
+    func meetingSpeakers(for meetingID: Int64) -> [MeetingSpeaker] {
+        (try? dictationStore.meetingSpeakers(for: meetingID)) ?? []
+    }
+
     /// Persist the per-cluster voiceprints captured at stop into `meeting_speakers`
     /// (replacing any prior rows so re-persist is idempotent), then run recognition
     /// against the saved profile library. A failure here must never block meeting

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2426,6 +2426,9 @@ final class MuesliController: NSObject {
     func updateMeetingTranscript(id: Int64, transcript: String) {
         do {
             try dictationStore.updateMeetingTranscript(id: id, rawTranscript: transcript)
+            // A manual edit can change/renumber `Speaker N` labels, so any captured
+            // cluster→name mapping is no longer guaranteed to align with the blob.
+            try? dictationStore.deleteMeetingSpeakers(for: id)
         } catch {
             fputs("[muesli-native] failed to update meeting transcript \(id): \(error)\n", stderr)
         }
@@ -3876,6 +3879,27 @@ final class MuesliController: NSObject {
 
     func mergeSpeakerProfiles(keepID: String, removeID: String) {
         do {
+            // Fold the removed profile's voiceprint samples into the kept profile
+            // and recompute its centroid before deleting, so merging two profiles
+            // of the same person improves (not degrades) future recognition.
+            let profiles = try dictationStore.speakerProfiles()
+            if let keep = profiles.first(where: { $0.id == keepID }),
+               let remove = profiles.first(where: { $0.id == removeID }) {
+                var combined = keep.rawEmbeddings + remove.rawEmbeddings
+                let cap = SpeakerProfileRefiner.maxRawEmbeddings
+                if cap > 0, combined.count > cap {
+                    combined.removeFirst(combined.count - cap)
+                }
+                if let centroid = SpeakerClusterAggregator.representativeEmbedding(from: combined) {
+                    try dictationStore.upsertSpeakerProfile(
+                        id: keepID,
+                        name: keep.name,
+                        embedding: centroid,
+                        rawEmbeddings: combined,
+                        observationCount: keep.observationCount + remove.observationCount
+                    )
+                }
+            }
             try dictationStore.mergeSpeakerProfiles(keepID: keepID, removeID: removeID)
         } catch {
             fputs("[muesli-native] merge speaker profiles failed (\(keepID)<-\(removeID)): \(error)\n", stderr)
@@ -3914,14 +3938,11 @@ final class MuesliController: NSObject {
     /// persistence, so errors are logged and swallowed.
     func persistMeetingSpeakers(_ clusters: [SpeakerCluster], meetingID: Int64) {
         do {
-            try dictationStore.deleteMeetingSpeakers(for: meetingID)
-            for cluster in clusters {
-                try dictationStore.insertMeetingSpeaker(
-                    meetingID: meetingID,
-                    speakerLabel: cluster.label,
-                    embedding: cluster.embedding
-                )
-            }
+            // Atomic delete+insert so a mid-insert failure can't leave a partial set.
+            try dictationStore.replaceMeetingSpeakers(
+                meetingID: meetingID,
+                speakers: clusters.map { (label: $0.label, embedding: $0.embedding) }
+            )
         } catch {
             fputs("[muesli-native] failed to persist meeting speakers for \(meetingID): \(error)\n", stderr)
             return

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -653,6 +653,12 @@ struct SettingsView: View {
                         controller.showMeetingTemplatesManager()
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Speakers", controlWidth: meetingControlWidth) {
+                    actionButton("Manage Speakers…") {
+                        controller.showSpeakersManager()
+                    }
+                }
             }
 
             settingsSection("Recording") {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerClusterAggregator.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerClusterAggregator.swift
@@ -1,0 +1,90 @@
+import FluidAudio
+import Foundation
+
+/// One diarized cluster of a single meeting: its raw FluidAudio speaker id, the
+/// `Speaker N` label realized in the transcript, and a representative voiceprint.
+struct SpeakerCluster: Equatable, Sendable {
+    let speakerId: String
+    let label: String
+    let embedding: [Float]
+}
+
+/// Pure helper that turns post-reconcile diarization output into the per-cluster
+/// `meeting_speakers` rows we persist at meeting stop.
+///
+/// Correctness hinge: a `Speaker N` label only appears in the stored blob where a
+/// surviving system ASR segment overlaps that cluster (and unmatched text falls
+/// back to the literal `Others`). So realized labels are derived from the *actual
+/// transcript text*, not from re-running assignment — this keeps the captured
+/// rows aligned with what the user sees, across both the live-stop and audio-import
+/// paths (which share `TranscriptFormatter.merge`).
+enum SpeakerClusterAggregator {
+    /// FluidAudio speaker embeddings are 256-D. Wrong-sized vectors are rejected.
+    static let embeddingDimension = 256
+
+    static func aggregate(
+        diarizationSegments: [TimedSpeakerSegment],
+        transcript: String
+    ) -> [SpeakerCluster] {
+        guard !diarizationSegments.isEmpty else { return [] }
+
+        let labelMap = TranscriptFormatter.speakerLabelMap(for: diarizationSegments)
+
+        // Group raw embeddings per cluster.
+        var embeddingsByID: [String: [[Float]]] = [:]
+        for seg in diarizationSegments {
+            embeddingsByID[seg.speakerId, default: []].append(seg.embedding)
+        }
+
+        // Emit clusters in Speaker N order, but only for labels realized in the blob.
+        let ordered = labelMap.sorted { speakerNumber($0.value) < speakerNumber($1.value) }
+        var clusters: [SpeakerCluster] = []
+        for (rawID, label) in ordered {
+            guard transcriptRealizes(label: label, in: transcript) else { continue }
+            guard let representative = representativeEmbedding(from: embeddingsByID[rawID] ?? []) else { continue }
+            clusters.append(SpeakerCluster(speakerId: rawID, label: label, embedding: representative))
+        }
+        return clusters
+    }
+
+    /// A label is realized when a transcript line attributes text to it, i.e. the
+    /// line `[HH:mm:ss] Speaker N: ...` exists. The trailing colon makes the match
+    /// unambiguous (`Speaker 1:` never matches `Speaker 10:`).
+    static func transcriptRealizes(label: String, in transcript: String) -> Bool {
+        transcript.contains("] \(label):")
+    }
+
+    /// Representative embedding mirroring FluidAudio's centroid math, hardened:
+    /// L2-normalize each valid sample → average → L2-normalize. Returns nil when
+    /// no sample is the expected dimension (rejected, not silently zero-filled).
+    static func representativeEmbedding(from embeddings: [[Float]]) -> [Float]? {
+        let valid = embeddings.filter { $0.count == embeddingDimension }
+        guard !valid.isEmpty else { return nil }
+
+        var mean = [Float](repeating: 0, count: embeddingDimension)
+        for embedding in valid {
+            let normalized = l2Normalize(embedding)
+            for i in 0..<embeddingDimension {
+                mean[i] += normalized[i]
+            }
+        }
+        let count = Float(valid.count)
+        for i in 0..<embeddingDimension {
+            mean[i] /= count
+        }
+        let result = l2Normalize(mean)
+        guard result.count == embeddingDimension else { return nil }
+        return result
+    }
+
+    static func l2Normalize(_ vector: [Float]) -> [Float] {
+        let magnitude = vector.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+        guard magnitude > 0 else { return vector }
+        return vector.map { $0 / magnitude }
+    }
+
+    /// Extracts the numeric suffix of a `Speaker N` label for stable ordering.
+    private static func speakerNumber(_ label: String) -> Int {
+        Int(label.split(separator: " ").last.map(String.init) ?? "") ?? Int.max
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameResolver.swift
@@ -1,0 +1,51 @@
+import Foundation
+import MuesliCore
+
+/// The display result for one transcript speaker label.
+struct ResolvedSpeakerName: Equatable {
+    /// What to render in place of the raw label.
+    let display: String
+    /// The mic speaker (`You`), kept distinct so bubble alignment stays correct.
+    let isUser: Bool
+    /// An auto-recognized (not yet user-confirmed) name — UI flags it so the
+    /// user knows to verify before trusting/sharing.
+    let isAutoRecognized: Bool
+}
+
+/// Pure render-time mapping from a stored transcript label to a display name.
+///
+/// The stored blob always keeps `You` / `Others` / `Speaker N` tokens; this
+/// resolver overlays names without mutating the text, so renames are instant and
+/// the transcript parser stays unchanged.
+enum SpeakerNameResolver {
+    static func resolve(
+        label: String,
+        speakers: [String: MeetingSpeaker],
+        userName: String
+    ) -> ResolvedSpeakerName {
+        if label.localizedCaseInsensitiveCompare("You") == .orderedSame {
+            let trimmed = userName.trimmingCharacters(in: .whitespacesAndNewlines)
+            return ResolvedSpeakerName(display: trimmed.isEmpty ? "You" : trimmed, isUser: true, isAutoRecognized: false)
+        }
+
+        // Only auto/confirmed entries apply a name; suggestions render the raw
+        // label (the suggestion affordance is shown separately by the UI).
+        if let entry = speakers[label],
+           entry.matchState == .auto || entry.matchState == .confirmed,
+           let name = entry.displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            return ResolvedSpeakerName(
+                display: name,
+                isUser: false,
+                isAutoRecognized: entry.matchState == .auto
+            )
+        }
+
+        return ResolvedSpeakerName(display: label, isUser: false, isAutoRecognized: false)
+    }
+
+    /// Convenience: build the label-keyed lookup the resolver expects.
+    static func speakerMap(from speakers: [MeetingSpeaker]) -> [String: MeetingSpeaker] {
+        Dictionary(speakers.map { ($0.speakerLabel, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameResolver.swift
@@ -48,4 +48,17 @@ enum SpeakerNameResolver {
     static func speakerMap(from speakers: [MeetingSpeaker]) -> [String: MeetingSpeaker] {
         Dictionary(speakers.map { ($0.speakerLabel, $0) }, uniquingKeysWith: { first, _ in first })
     }
+
+    /// Whether a label is a diarized cluster token (`Speaker N`). Single source of
+    /// truth shared by the transcript parser, the rename affordance, and the notes
+    /// substitution — a cheap allocation-light check (no per-render regex compile).
+    static func isSpeakerClusterLabel(_ label: String) -> Bool {
+        guard label.count <= 32 else { return false }
+        let parts = label.split(separator: " ", omittingEmptySubsequences: true)
+        guard parts.count == 2,
+              parts[0].caseInsensitiveCompare("Speaker") == .orderedSame,
+              !parts[1].isEmpty,
+              parts[1].allSatisfy(\.isNumber) else { return false }
+        return true
+    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameSubstitution.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameSubstitution.swift
@@ -46,6 +46,6 @@ enum SpeakerNameSubstitution {
     private static func isSpeakerLabel(_ label: String) -> Bool {
         if label.localizedCaseInsensitiveCompare("You") == .orderedSame { return true }
         if label.localizedCaseInsensitiveCompare("Others") == .orderedSame { return true }
-        return label.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil
+        return SpeakerNameResolver.isSpeakerClusterLabel(label)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameSubstitution.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNameSubstitution.swift
@@ -1,0 +1,51 @@
+import Foundation
+import MuesliCore
+
+/// Pure rewrite of a transcript blob's speaker labels to resolved display names,
+/// for the *summarizer input only* — the stored blob keeps its `Speaker N`/`You`
+/// tokens. Unmatched/suggested speakers stay `Speaker N` so unconfirmed guesses
+/// never enter generated notes.
+enum SpeakerNameSubstitution {
+    static func substitute(
+        transcript: String,
+        speakers: [String: MeetingSpeaker],
+        userName: String
+    ) -> String {
+        let normalized = transcript.replacingOccurrences(of: "\r\n", with: "\n")
+        let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        return lines
+            .map { rewrite(line: $0, speakers: speakers, userName: userName) }
+            .joined(separator: "\n")
+    }
+
+    private static func rewrite(line: String, speakers: [String: MeetingSpeaker], userName: String) -> String {
+        // Split an optional "[timestamp] " prefix off the front.
+        var prefix = ""
+        var remainder = line
+        if line.hasPrefix("["), let close = line.firstIndex(of: "]") {
+            let afterClose = line.index(after: close)
+            prefix = String(line[..<afterClose])
+            // Preserve the original spacing between the bracket and the label.
+            var cursor = afterClose
+            while cursor < line.endIndex, line[cursor] == " " {
+                prefix.append(" ")
+                cursor = line.index(after: cursor)
+            }
+            remainder = String(line[cursor...])
+        }
+
+        guard let colon = remainder.firstIndex(of: ":") else { return line }
+        let label = String(remainder[..<colon]).trimmingCharacters(in: .whitespaces)
+        guard isSpeakerLabel(label) else { return line }
+
+        let resolved = SpeakerNameResolver.resolve(label: label, speakers: speakers, userName: userName)
+        let body = String(remainder[colon...]) // includes the ":"
+        return prefix + resolved.display + body
+    }
+
+    private static func isSpeakerLabel(_ label: String) -> Bool {
+        if label.localizedCaseInsensitiveCompare("You") == .orderedSame { return true }
+        if label.localizedCaseInsensitiveCompare("Others") == .orderedSame { return true }
+        return label.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNamingService.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNamingService.swift
@@ -1,0 +1,154 @@
+import Foundation
+import MuesliCore
+
+/// Pure, recoverable profile-centroid refinement.
+///
+/// We never apply a blind in-place EMA. Instead each confirmed sample is appended
+/// to the profile's retained `rawEmbeddings` (bounded), and the representative
+/// embedding is recomputed from that set — so a bad sample can be recovered from
+/// and a single borderline confirmation can't drag the centroid uncontrolled.
+enum SpeakerProfileRefiner {
+    static let maxRawEmbeddings = 20
+
+    struct Refinement: Equatable {
+        let embedding: [Float]
+        let rawEmbeddings: [[Float]]
+        let observationCount: Int
+    }
+
+    static func refine(
+        existingRaw: [[Float]],
+        adding embedding: [Float],
+        cap: Int = maxRawEmbeddings
+    ) -> Refinement {
+        var raw = existingRaw
+        raw.append(embedding)
+        if cap > 0, raw.count > cap {
+            raw.removeFirst(raw.count - cap)
+        }
+        let representative = SpeakerClusterAggregator.representativeEmbedding(from: raw) ?? embedding
+        return Refinement(embedding: representative, rawEmbeddings: raw, observationCount: raw.count)
+    }
+}
+
+/// Applies naming/confirmation decisions to the store: updates the per-meeting
+/// row and creates/refines the linked voice profile. Operates directly on
+/// `DictationStore` so it is testable without the full controller.
+struct SpeakerNamingService {
+    let store: DictationStore
+    var maxRawEmbeddings: Int = SpeakerProfileRefiner.maxRawEmbeddings
+    private let dimension = SpeakerClusterAggregator.embeddingDimension
+
+    /// Generates new profile IDs. Injectable for deterministic tests.
+    var makeID: () -> String = { UUID().uuidString }
+
+    /// Manually name (or correct) a speaker. A correction to a *different* name
+    /// never touches the previously-linked profile (R6): we resolve a target
+    /// profile by the new name (or create one), leaving the mismatched profile
+    /// untouched.
+    func rename(meetingID: Int64, label: String, to newName: String) throws {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let rows = try store.meetingSpeakers(for: meetingID)
+        let existing = rows.first { $0.speakerLabel == label }
+        let embedding = existing?.embedding ?? []
+
+        var profileID: String? = nil
+        if embedding.count == dimension {
+            profileID = try resolveProfile(preferredID: nil, name: trimmed, embedding: embedding)
+        }
+
+        if let existing {
+            try store.updateMeetingSpeaker(
+                id: existing.id,
+                profileID: profileID,
+                displayName: trimmed,
+                matchDistance: nil,
+                matchState: .confirmed
+            )
+        } else {
+            // Older meeting with no captured voiceprint: still allow the rename as
+            // a display-only overlay (no profile, so no cross-call recognition).
+            try store.insertMeetingSpeaker(
+                meetingID: meetingID,
+                speakerLabel: label,
+                embedding: embedding,
+                profileID: profileID,
+                displayName: trimmed,
+                matchDistance: nil,
+                matchState: .confirmed
+            )
+        }
+    }
+
+    /// Confirm a borderline suggestion: refine the *specific* suggested profile
+    /// and mark the row confirmed.
+    func confirm(meetingID: Int64, label: String) throws {
+        let rows = try store.meetingSpeakers(for: meetingID)
+        guard let row = rows.first(where: { $0.speakerLabel == label }),
+              let name = row.displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !name.isEmpty else { return }
+
+        var profileID = row.profileID
+        if row.embedding.count == dimension {
+            profileID = try resolveProfile(preferredID: row.profileID, name: name, embedding: row.embedding)
+        }
+        try store.updateMeetingSpeaker(
+            id: row.id,
+            profileID: profileID,
+            displayName: name,
+            matchDistance: row.matchDistance,
+            matchState: .confirmed
+        )
+    }
+
+    /// Reject a suggestion: drop back to an unnamed `Speaker N`. Profiles untouched.
+    func reject(meetingID: Int64, label: String) throws {
+        let rows = try store.meetingSpeakers(for: meetingID)
+        guard let row = rows.first(where: { $0.speakerLabel == label }) else { return }
+        try store.updateMeetingSpeaker(
+            id: row.id,
+            profileID: nil,
+            displayName: nil,
+            matchDistance: nil,
+            matchState: .unmatched
+        )
+    }
+
+    /// Find the profile to attach to and refine it, or create a new one.
+    /// `preferredID` (confirm path) refines that exact profile; otherwise we
+    /// match by name so renames don't pollute a mismatched profile.
+    private func resolveProfile(preferredID: String?, name: String, embedding: [Float]) throws -> String {
+        let profiles = try store.speakerProfiles()
+        let target = preferredID.flatMap { id in profiles.first { $0.id == id } }
+            ?? profiles.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }
+
+        if let target {
+            let refinement = SpeakerProfileRefiner.refine(
+                existingRaw: target.rawEmbeddings,
+                adding: embedding,
+                cap: maxRawEmbeddings
+            )
+            try store.upsertSpeakerProfile(
+                id: target.id,
+                name: name,
+                embedding: refinement.embedding,
+                rawEmbeddings: refinement.rawEmbeddings,
+                observationCount: refinement.observationCount
+            )
+            return target.id
+        }
+
+        let newID = makeID()
+        let refinement = SpeakerProfileRefiner.refine(existingRaw: [], adding: embedding, cap: maxRawEmbeddings)
+        try store.upsertSpeakerProfile(
+            id: newID,
+            name: name,
+            embedding: refinement.embedding,
+            rawEmbeddings: refinement.rawEmbeddings,
+            observationCount: refinement.observationCount
+        )
+        return newID
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNamingService.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerNamingService.swift
@@ -1,3 +1,4 @@
+import FluidAudio
 import Foundation
 import MuesliCore
 
@@ -38,6 +39,11 @@ struct SpeakerNamingService {
     let store: DictationStore
     var maxRawEmbeddings: Int = SpeakerProfileRefiner.maxRawEmbeddings
     private let dimension = SpeakerClusterAggregator.embeddingDimension
+
+    /// When a manual rename matches an existing profile *by name* but the voice is
+    /// this far apart, treat it as a different person sharing a name and create a
+    /// new profile rather than poisoning the existing centroid.
+    var sameNameMaxDistance: Float = SpeakerRecognizer.defaultSuggestThreshold
 
     /// Generates new profile IDs. Injectable for deterministic tests.
     var makeID: () -> String = { UUID().uuidString }
@@ -117,38 +123,44 @@ struct SpeakerNamingService {
     }
 
     /// Find the profile to attach to and refine it, or create a new one.
-    /// `preferredID` (confirm path) refines that exact profile; otherwise we
-    /// match by name so renames don't pollute a mismatched profile.
+    /// `preferredID` (confirm path) refines that exact profile; otherwise we match
+    /// by name — but only when the voice is close enough, so two different people
+    /// who happen to share a name don't get folded into one poisoned centroid.
     private func resolveProfile(preferredID: String?, name: String, embedding: [Float]) throws -> String {
         let profiles = try store.speakerProfiles()
-        let target = preferredID.flatMap { id in profiles.first { $0.id == id } }
-            ?? profiles.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }
 
-        if let target {
-            let refinement = SpeakerProfileRefiner.refine(
-                existingRaw: target.rawEmbeddings,
-                adding: embedding,
-                cap: maxRawEmbeddings
-            )
-            try store.upsertSpeakerProfile(
-                id: target.id,
-                name: name,
-                embedding: refinement.embedding,
-                rawEmbeddings: refinement.rawEmbeddings,
-                observationCount: refinement.observationCount
-            )
-            return target.id
+        if let preferredID, let target = profiles.first(where: { $0.id == preferredID }) {
+            return try refine(target, name: name, embedding: embedding)
         }
 
-        let newID = makeID()
-        let refinement = SpeakerProfileRefiner.refine(existingRaw: [], adding: embedding, cap: maxRawEmbeddings)
+        if let target = profiles.first(where: { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }) {
+            // Attach when the matched profile has no usable voiceprint yet
+            // (non-finite distance) or the voice is close; otherwise split.
+            let distance = SpeakerUtilities.cosineDistance(embedding, target.embedding)
+            if !distance.isFinite || distance <= sameNameMaxDistance {
+                return try refine(target, name: name, embedding: embedding)
+            }
+        }
+
+        return try refine(nil, name: name, embedding: embedding)
+    }
+
+    /// Refine an existing profile (or create a new one when `target` is nil) by
+    /// re-averaging its retained raw embeddings with the new sample.
+    private func refine(_ target: SpeakerProfile?, name: String, embedding: [Float]) throws -> String {
+        let id = target?.id ?? makeID()
+        let refinement = SpeakerProfileRefiner.refine(
+            existingRaw: target?.rawEmbeddings ?? [],
+            adding: embedding,
+            cap: maxRawEmbeddings
+        )
         try store.upsertSpeakerProfile(
-            id: newID,
+            id: id,
             name: name,
             embedding: refinement.embedding,
             rawEmbeddings: refinement.rawEmbeddings,
             observationCount: refinement.observationCount
         )
-        return newID
+        return id
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerRecognizer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerRecognizer.swift
@@ -43,6 +43,8 @@ enum SpeakerRecognizer {
         }
 
         var matches: [Match] = clusters.map { cluster in
+            // Empty (e.g. scrubbed `[]`) or wrong-dimension embeddings yield a
+            // non-finite cosineDistance below and fall through to unmatched.
             guard !profiles.isEmpty else {
                 return Match(profileID: nil, name: nil, distance: .infinity, tier: .unmatched)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakerRecognizer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakerRecognizer.swift
@@ -1,0 +1,103 @@
+import FluidAudio
+import Foundation
+import MuesliCore
+
+/// The recognition decision for a single diarized cluster: which profile (if any)
+/// it matched, the resolved/candidate name, the cosine distance, and the tier.
+struct SpeakerRecognition: Equatable {
+    let label: String
+    let profileID: String?
+    let displayName: String?
+    let distance: Double?
+    let state: SpeakerMatchState
+}
+
+/// Pure, post-diarization recognizer. Matches each captured cluster embedding
+/// against the saved profile library by cosine distance, assigns a confidence
+/// tier, then enforces within-meeting uniqueness (at most one cluster per profile)
+/// so a single meeting never shows the same name twice.
+enum SpeakerRecognizer {
+    /// Distance ≤ this → confident auto-match. Cosine distance, 0 (identical)…2.
+    static let defaultStrongThreshold: Float = 0.5
+    /// strong < distance ≤ this → borderline suggestion. Anchored on FluidAudio's
+    /// `SpeakerManager.speakerThreshold` (≈ 0.65).
+    static let defaultSuggestThreshold: Float = 0.65
+
+    struct Cluster {
+        let label: String
+        let embedding: [Float]
+    }
+
+    static func recognize(
+        clusters: [Cluster],
+        profiles: [SpeakerProfile],
+        strongThreshold: Float = defaultStrongThreshold,
+        suggestThreshold: Float = defaultSuggestThreshold
+    ) -> [SpeakerRecognition] {
+        // Step 1: best profile match per cluster.
+        struct Match {
+            var profileID: String?
+            var name: String?
+            var distance: Float
+            var tier: SpeakerMatchState
+        }
+
+        var matches: [Match] = clusters.map { cluster in
+            guard !profiles.isEmpty else {
+                return Match(profileID: nil, name: nil, distance: .infinity, tier: .unmatched)
+            }
+            var best: (profile: SpeakerProfile, distance: Float)?
+            for profile in profiles {
+                let distance = SpeakerUtilities.cosineDistance(cluster.embedding, profile.embedding)
+                guard distance.isFinite else { continue }
+                if best == nil || distance < best!.distance {
+                    best = (profile, distance)
+                }
+            }
+            guard let best else {
+                return Match(profileID: nil, name: nil, distance: .infinity, tier: .unmatched)
+            }
+            let tier: SpeakerMatchState
+            if best.distance <= strongThreshold {
+                tier = .auto
+            } else if best.distance <= suggestThreshold {
+                tier = .suggested
+            } else {
+                tier = .unmatched
+            }
+            return Match(
+                profileID: tier == .unmatched ? nil : best.profile.id,
+                name: tier == .unmatched ? nil : best.profile.name,
+                distance: best.distance,
+                tier: tier
+            )
+        }
+
+        // Step 2: within-meeting uniqueness — for each profile claimed by 2+
+        // clusters, keep only the closest; demote the rest to unmatched so the
+        // same person's name never appears on two speakers in one meeting.
+        var claimants: [String: [Int]] = [:]
+        for (index, match) in matches.enumerated() where match.tier != .unmatched {
+            if let profileID = match.profileID {
+                claimants[profileID, default: []].append(index)
+            }
+        }
+        for (_, indices) in claimants where indices.count > 1 {
+            let winner = indices.min { matches[$0].distance < matches[$1].distance }!
+            for index in indices where index != winner {
+                matches[index] = Match(profileID: nil, name: nil, distance: .infinity, tier: .unmatched)
+            }
+        }
+
+        // Step 3: project to recognition decisions.
+        return zip(clusters, matches).map { cluster, match in
+            SpeakerRecognition(
+                label: cluster.label,
+                profileID: match.profileID,
+                displayName: match.name,
+                distance: match.distance.isFinite ? Double(match.distance) : nil,
+                state: match.tier
+            )
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakersManagerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakersManagerView.swift
@@ -14,8 +14,13 @@ struct SpeakersManagerView: View {
     @State private var profileToDelete: SpeakerProfile?
     @State private var selectedForMerge: Set<String> = []
     @State private var showMergeConfirmation = false
+    /// Loaded once on appear and refreshed after each mutation — never read from
+    /// SQLite inside `body`.
+    @State private var profiles: [SpeakerProfile] = []
 
-    private var profiles: [SpeakerProfile] { controller.speakerProfiles() }
+    private func reload() {
+        profiles = controller.speakerProfiles()
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
@@ -39,6 +44,7 @@ struct SpeakersManagerView: View {
         .padding(MuesliTheme.spacing24)
         .frame(minWidth: 720, minHeight: 480)
         .background(MuesliTheme.backgroundBase)
+        .onAppear { reload() }
         .alert(
             "Delete \"\(profileToDelete?.name ?? "")\"?",
             isPresented: Binding(
@@ -51,6 +57,7 @@ struct SpeakersManagerView: View {
                 if let profile = profileToDelete {
                     controller.deleteSpeakerProfile(id: profile.id)
                     selectedForMerge.remove(profile.id)
+                    reload()
                 }
                 profileToDelete = nil
             }
@@ -193,6 +200,7 @@ struct SpeakersManagerView: View {
             controller.mergeSpeakerProfiles(keepID: keepID, removeID: removeID)
         }
         selectedForMerge.removeAll()
+        reload()
     }
 
     private func beginRename(_ profile: SpeakerProfile) {
@@ -205,6 +213,7 @@ struct SpeakersManagerView: View {
         editingProfileID = nil
         guard !trimmed.isEmpty else { return }
         controller.renameSpeakerProfile(id: profile.id, name: trimmed)
+        reload()
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/SpeakersManagerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SpeakersManagerView.swift
@@ -1,0 +1,240 @@
+import SwiftUI
+import MuesliCore
+
+/// The Speakers library: view, rename, merge, and delete saved voice profiles.
+/// Modeled on `MeetingTemplatesManagerView` (the coach personas manager lives on
+/// a separate branch and is not present here).
+struct SpeakersManagerView: View {
+    let appState: AppState
+    let controller: MuesliController
+    let onClose: () -> Void
+
+    @State private var editingProfileID: String?
+    @State private var draftName = ""
+    @State private var profileToDelete: SpeakerProfile?
+    @State private var selectedForMerge: Set<String> = []
+    @State private var showMergeConfirmation = false
+
+    private var profiles: [SpeakerProfile] { controller.speakerProfiles() }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+            header
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                    if profiles.isEmpty {
+                        emptyState
+                    } else {
+                        VStack(spacing: MuesliTheme.spacing8) {
+                            ForEach(profiles) { profile in
+                                profileRow(profile)
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, MuesliTheme.spacing4)
+            }
+        }
+        .padding(MuesliTheme.spacing24)
+        .frame(minWidth: 720, minHeight: 480)
+        .background(MuesliTheme.backgroundBase)
+        .alert(
+            "Delete \"\(profileToDelete?.name ?? "")\"?",
+            isPresented: Binding(
+                get: { profileToDelete != nil },
+                set: { if !$0 { profileToDelete = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) { profileToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let profile = profileToDelete {
+                    controller.deleteSpeakerProfile(id: profile.id)
+                    selectedForMerge.remove(profile.id)
+                }
+                profileToDelete = nil
+            }
+        } message: {
+            Text("This permanently removes the saved voiceprint. Past meetings keep their labels but lose the link to this speaker.")
+        }
+        .alert("Merge \(selectedForMerge.count) speakers?", isPresented: $showMergeConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Merge") { performMerge() }
+        } message: {
+            Text("Past meetings linked to the other speaker(s) will be repointed to \"\(mergeKeepName)\". This can't be undone.")
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Speakers")
+                    .font(MuesliTheme.title2())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text("Voice profiles are stored on this device only and are used to recognize the same speaker across meetings.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                if selectedForMerge.count >= 2 {
+                    actionButton("Merge \(selectedForMerge.count)", systemImage: "arrow.triangle.merge") {
+                        showMergeConfirmation = true
+                    }
+                }
+                actionButton("Done", systemImage: "checkmark") { onClose() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                Image(systemName: "person.crop.circle.badge.questionmark")
+                    .font(.system(size: 11))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                Text("No saved speakers yet.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            Text("Name a speaker in a meeting transcript to create a profile. Recognition only applies to meetings recorded after that.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(MuesliTheme.spacing12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func profileRow(_ profile: SpeakerProfile) -> some View {
+        HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+            Button {
+                toggleMergeSelection(profile.id)
+            } label: {
+                Image(systemName: selectedForMerge.contains(profile.id) ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 14))
+                    .foregroundStyle(selectedForMerge.contains(profile.id) ? MuesliTheme.accent : MuesliTheme.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .help("Select for merge")
+
+            if editingProfileID == profile.id {
+                TextField("Name", text: $draftName)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 220)
+                    .onSubmit { commitRename(profile) }
+                actionButton("Save", systemImage: "checkmark") { commitRename(profile) }
+                actionButton("Cancel", systemImage: "xmark") { editingProfileID = nil }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(profile.name)
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text(observationLabel(profile))
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+                Spacer()
+                HStack(spacing: MuesliTheme.spacing8) {
+                    actionButton("Rename", systemImage: "pencil") { beginRename(profile) }
+                    actionButton("Delete", systemImage: "trash", role: .destructive) { profileToDelete = profile }
+                }
+            }
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(
+                    selectedForMerge.contains(profile.id) ? MuesliTheme.accent.opacity(0.4) : MuesliTheme.surfaceBorder,
+                    lineWidth: 1
+                )
+        )
+    }
+
+    private func observationLabel(_ profile: SpeakerProfile) -> String {
+        let count = max(profile.observationCount, 0)
+        return count == 1 ? "1 sample" : "\(count) samples"
+    }
+
+    private var mergeKeepName: String {
+        guard let keepID = mergeKeepID, let keep = profiles.first(where: { $0.id == keepID }) else { return "" }
+        return keep.name
+    }
+
+    /// The profile selected first / shown earliest wins as the kept profile.
+    private var mergeKeepID: String? {
+        profiles.first(where: { selectedForMerge.contains($0.id) })?.id
+    }
+
+    private func toggleMergeSelection(_ id: String) {
+        if selectedForMerge.contains(id) {
+            selectedForMerge.remove(id)
+        } else {
+            selectedForMerge.insert(id)
+        }
+    }
+
+    private func performMerge() {
+        guard let keepID = mergeKeepID else { return }
+        for removeID in selectedForMerge where removeID != keepID {
+            controller.mergeSpeakerProfiles(keepID: keepID, removeID: removeID)
+        }
+        selectedForMerge.removeAll()
+    }
+
+    private func beginRename(_ profile: SpeakerProfile) {
+        editingProfileID = profile.id
+        draftName = profile.name
+    }
+
+    private func commitRename(_ profile: SpeakerProfile) {
+        let trimmed = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
+        editingProfileID = nil
+        guard !trimmed.isEmpty else { return }
+        controller.renameSpeakerProfile(id: profile.id, name: trimmed)
+    }
+
+    @ViewBuilder
+    private func actionButton(
+        _ title: String,
+        systemImage: String,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        let isDestructive = role == .destructive
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .foregroundStyle(isDestructive ? MuesliTheme.recording : MuesliTheme.textPrimary)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .padding(.vertical, 7)
+            .background(isDestructive ? MuesliTheme.recording.opacity(0.1) : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(
+                        isDestructive ? MuesliTheme.recording.opacity(0.2) : MuesliTheme.surfaceBorder,
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptFormatter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptFormatter.swift
@@ -23,14 +23,7 @@ enum TranscriptFormatter {
         let taggedSystem: [TaggedSegment]
         if let diarizationSegments, !diarizationSegments.isEmpty {
             // Build speaker label map: raw ID → "Speaker 1", "Speaker 2", etc. in first-appearance order
-            var speakerLabelMap: [String: String] = [:]
-            var nextSpeakerNumber = 1
-            for seg in diarizationSegments.sorted(by: { $0.startTimeSeconds < $1.startTimeSeconds }) {
-                if speakerLabelMap[seg.speakerId] == nil {
-                    speakerLabelMap[seg.speakerId] = "Speaker \(nextSpeakerNumber)"
-                    nextSpeakerNumber += 1
-                }
-            }
+            let speakerLabelMap = speakerLabelMap(for: diarizationSegments)
 
             taggedSystem = systemSegments.map { segment in
                 let speaker = findSpeaker(for: segment, in: diarizationSegments, labelMap: speakerLabelMap)
@@ -55,6 +48,23 @@ enum TranscriptFormatter {
             let text = taggedSegment.segment.text.trimmingCharacters(in: .whitespaces)
             return "[\(formatter.string(from: timestamp))] \(taggedSegment.speaker): \(text)"
         }.joined(separator: "\n")
+    }
+
+    /// Maps each diarization cluster's raw speaker ID to its `Speaker N` label
+    /// in first-appearance (earliest start time) order. This is the single source
+    /// of truth for cluster→label numbering, shared by `merge` and by
+    /// `SpeakerClusterAggregator` so captured embeddings line up with the labels
+    /// that actually land in the transcript.
+    static func speakerLabelMap(for diarizationSegments: [TimedSpeakerSegment]) -> [String: String] {
+        var speakerLabelMap: [String: String] = [:]
+        var nextSpeakerNumber = 1
+        for seg in diarizationSegments.sorted(by: { $0.startTimeSeconds < $1.startTimeSeconds }) {
+            if speakerLabelMap[seg.speakerId] == nil {
+                speakerLabelMap[seg.speakerId] = "Speaker \(nextSpeakerNumber)"
+                nextSpeakerNumber += 1
+            }
+        }
+        return speakerLabelMap
     }
 
     /// Merge consecutive segments from the same speaker into single entries,

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerClusterAggregatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerClusterAggregatorTests.swift
@@ -1,0 +1,159 @@
+import Testing
+import Foundation
+import FluidAudio
+@testable import MuesliNativeApp
+
+@Suite("Speaker cluster aggregator")
+struct SpeakerClusterAggregatorTests {
+    private let dim = SpeakerClusterAggregator.embeddingDimension
+
+    /// A deterministic 256-D vector seeded by `value`.
+    private func vec(_ value: Float, count: Int? = nil) -> [Float] {
+        let n = count ?? dim
+        return (0..<n).map { Float($0) * 0.001 + value }
+    }
+
+    private func seg(_ speakerId: String, start: Float, end: Float, embedding: [Float]) -> TimedSpeakerSegment {
+        TimedSpeakerSegment(
+            speakerId: speakerId,
+            embedding: embedding,
+            startTimeSeconds: start,
+            endTimeSeconds: end,
+            qualityScore: 1.0
+        )
+    }
+
+    private func magnitude(_ v: [Float]) -> Float {
+        v.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+    }
+
+    // MARK: - Label map characterization (must match TranscriptFormatter.merge)
+
+    @Test("speaker label map numbers clusters in first-appearance order")
+    func labelMapOrdering() {
+        let segments = [
+            seg("spkB", start: 5, end: 6, embedding: vec(0.2)),
+            seg("spkA", start: 0, end: 1, embedding: vec(0.1)),
+            seg("spkA", start: 2, end: 3, embedding: vec(0.1)),
+        ]
+        let map = TranscriptFormatter.speakerLabelMap(for: segments)
+        #expect(map["spkA"] == "Speaker 1") // earliest start
+        #expect(map["spkB"] == "Speaker 2")
+    }
+
+    // MARK: - Aggregation
+
+    @Test("groups by speakerId and emits one row per realized cluster")
+    func groupsByCluster() {
+        let segments = [
+            seg("spkA", start: 0, end: 1, embedding: vec(0.1)),
+            seg("spkA", start: 2, end: 3, embedding: vec(0.1)),
+            seg("spkB", start: 5, end: 6, embedding: vec(0.2)),
+        ]
+        let transcript = "[10:00:00] Speaker 1: hello there\n[10:00:05] Speaker 2: hi back"
+
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: segments, transcript: transcript)
+
+        #expect(clusters.count == 2)
+        #expect(clusters[0].label == "Speaker 1")
+        #expect(clusters[0].speakerId == "spkA")
+        #expect(clusters[1].label == "Speaker 2")
+        #expect(clusters[1].speakerId == "spkB")
+    }
+
+    // Covers R4.
+    @Test("two diarized speakers yield two rows with 256-D embeddings")
+    func twoSpeakersTwoEmbeddings() {
+        let segments = [
+            seg("spkA", start: 0, end: 1, embedding: vec(0.1)),
+            seg("spkB", start: 5, end: 6, embedding: vec(0.2)),
+        ]
+        let transcript = "[10:00:00] Speaker 1: a\n[10:00:05] Speaker 2: b"
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: segments, transcript: transcript)
+        #expect(clusters.count == 2)
+        #expect(clusters.allSatisfy { $0.embedding.count == 256 })
+    }
+
+    @Test("a cluster not realized in the blob produces no row")
+    func unrealizedClusterDropped() {
+        // Both speakers diarized, but only Speaker 1 survives in the transcript
+        // (Speaker 2's text was dropped by reconcile or rendered as Others).
+        let segments = [
+            seg("spkA", start: 0, end: 1, embedding: vec(0.1)),
+            seg("spkB", start: 5, end: 6, embedding: vec(0.2)),
+        ]
+        let transcript = "[10:00:00] Speaker 1: hello\n[10:00:05] Others: muffled"
+
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: segments, transcript: transcript)
+        #expect(clusters.count == 1)
+        #expect(clusters.first?.label == "Speaker 1")
+    }
+
+    @Test("Speaker 1 label is not confused with Speaker 10")
+    func labelBoundaryColon() {
+        let segments = [seg("spkA", start: 0, end: 1, embedding: vec(0.1))]
+        // Only "Speaker 10:" present — must NOT realize "Speaker 1".
+        let transcript = "[10:00:00] Speaker 10: hi"
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: segments, transcript: transcript)
+        #expect(clusters.isEmpty)
+    }
+
+    @Test("no diarization yields no rows")
+    func noDiarization() {
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: [], transcript: "[10:00:00] Others: hi")
+        #expect(clusters.isEmpty)
+    }
+
+    @Test("transcript with only Others produces no rows")
+    func onlyOthers() {
+        let segments = [seg("spkA", start: 0, end: 1, embedding: vec(0.1))]
+        let transcript = "[10:00:00] Others: ambient"
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: segments, transcript: transcript)
+        #expect(clusters.isEmpty)
+    }
+
+    // MARK: - Representative embedding math
+
+    @Test("representative embedding is unit-length and 256-D")
+    func representativeIsNormalized() {
+        let rep = SpeakerClusterAggregator.representativeEmbedding(from: [vec(0.1), vec(0.5)])
+        let result = try! #require(rep)
+        #expect(result.count == 256)
+        #expect(abs(magnitude(result) - 1.0) < 1e-4)
+    }
+
+    @Test("representative embedding is deterministic")
+    func representativeDeterministic() {
+        let a = SpeakerClusterAggregator.representativeEmbedding(from: [vec(0.1), vec(0.5)])
+        let b = SpeakerClusterAggregator.representativeEmbedding(from: [vec(0.1), vec(0.5)])
+        #expect(a == b)
+    }
+
+    @Test("wrong-sized vectors are rejected, not silently averaged")
+    func rejectsWrongSized() {
+        // One valid 256-D, one 10-D garbage — representative must equal the
+        // normalized single valid vector (the garbage is dropped).
+        let valid = vec(0.3)
+        let rep = SpeakerClusterAggregator.representativeEmbedding(from: [valid, vec(0.9, count: 10)])
+        let result = try! #require(rep)
+        let expected = SpeakerClusterAggregator.l2Normalize(valid)
+        #expect(result.count == 256)
+        for (lhs, rhs) in zip(result, expected) {
+            #expect(abs(lhs - rhs) < 1e-5)
+        }
+    }
+
+    @Test("all wrong-sized input yields nil (no representative)")
+    func allWrongSizedNil() {
+        let rep = SpeakerClusterAggregator.representativeEmbedding(from: [vec(0.1, count: 5), vec(0.2, count: 7)])
+        #expect(rep == nil)
+    }
+
+    @Test("a cluster with no valid embedding produces no row")
+    func clusterWithoutValidEmbeddingDropped() {
+        let segments = [seg("spkA", start: 0, end: 1, embedding: vec(0.1, count: 5))]
+        let transcript = "[10:00:00] Speaker 1: hi"
+        let clusters = SpeakerClusterAggregator.aggregate(diarizationSegments: segments, transcript: transcript)
+        #expect(clusters.isEmpty)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerClusterAggregatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerClusterAggregatorTests.swift
@@ -143,6 +143,14 @@ struct SpeakerClusterAggregatorTests {
         }
     }
 
+    @Test("l2Normalize returns a zero vector unchanged (no NaN)")
+    func l2NormalizeZeroVector() {
+        let zero = [Float](repeating: 0, count: 8)
+        let out = SpeakerClusterAggregator.l2Normalize(zero)
+        #expect(out == zero)
+        #expect(out.allSatisfy { !$0.isNaN })
+    }
+
     @Test("all wrong-sized input yields nil (no representative)")
     func allWrongSizedNil() {
         let rep = SpeakerClusterAggregator.representativeEmbedding(from: [vec(0.1, count: 5), vec(0.2, count: 7)])

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerNameResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerNameResolverTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import Foundation
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Speaker name resolver")
+struct SpeakerNameResolverTests {
+    private func speaker(
+        _ label: String,
+        name: String?,
+        state: SpeakerMatchState,
+        profileID: String? = "p1"
+    ) -> MeetingSpeaker {
+        MeetingSpeaker(
+            id: 1,
+            meetingID: 1,
+            speakerLabel: label,
+            embedding: [0.1],
+            profileID: profileID,
+            displayName: name,
+            matchDistance: 0.2,
+            matchState: state
+        )
+    }
+
+    @Test("You resolves to the configured user name")
+    func userNameResolved() {
+        let r = SpeakerNameResolver.resolve(label: "You", speakers: [:], userName: "Spencer")
+        #expect(r.display == "Spencer")
+        #expect(r.isUser)
+        #expect(!r.isAutoRecognized)
+    }
+
+    @Test("You falls back to 'You' when the user name is unset")
+    func userNameFallback() {
+        let r = SpeakerNameResolver.resolve(label: "You", speakers: [:], userName: "   ")
+        #expect(r.display == "You")
+        #expect(r.isUser)
+    }
+
+    @Test("confirmed Speaker N resolves to the name without an auto indicator")
+    func confirmedResolved() {
+        let map = ["Speaker 1": speaker("Speaker 1", name: "Bob", state: .confirmed)]
+        let r = SpeakerNameResolver.resolve(label: "Speaker 1", speakers: map, userName: "Me")
+        #expect(r.display == "Bob")
+        #expect(!r.isAutoRecognized)
+        #expect(!r.isUser)
+    }
+
+    @Test("auto Speaker N resolves to the name with the auto indicator")
+    func autoResolved() {
+        let map = ["Speaker 1": speaker("Speaker 1", name: "Bob", state: .auto)]
+        let r = SpeakerNameResolver.resolve(label: "Speaker 1", speakers: map, userName: "Me")
+        #expect(r.display == "Bob")
+        #expect(r.isAutoRecognized)
+    }
+
+    @Test("suggested Speaker N renders the raw label (name not applied)")
+    func suggestedNotApplied() {
+        let map = ["Speaker 1": speaker("Speaker 1", name: "Bob", state: .suggested)]
+        let r = SpeakerNameResolver.resolve(label: "Speaker 1", speakers: map, userName: "Me")
+        #expect(r.display == "Speaker 1")
+        #expect(!r.isAutoRecognized)
+    }
+
+    @Test("Speaker N with no map entry stays the raw label")
+    func noEntry() {
+        let r = SpeakerNameResolver.resolve(label: "Speaker 2", speakers: [:], userName: "Me")
+        #expect(r.display == "Speaker 2")
+    }
+
+    @Test("empty map leaves all labels raw and does not crash")
+    func emptyMap() {
+        let others = SpeakerNameResolver.resolve(label: "Others", speakers: [:], userName: "Me")
+        #expect(others.display == "Others")
+        #expect(!others.isUser)
+    }
+
+    @Test("auto/confirmed entry with blank name falls back to the raw label")
+    func blankNameFallback() {
+        let map = ["Speaker 1": speaker("Speaker 1", name: "  ", state: .auto)]
+        let r = SpeakerNameResolver.resolve(label: "Speaker 1", speakers: map, userName: "Me")
+        #expect(r.display == "Speaker 1")
+    }
+
+    @Test("speakerMap builds a label-keyed lookup")
+    func buildsLookup() {
+        let speakers = [
+            speaker("Speaker 1", name: "Bob", state: .confirmed),
+            MeetingSpeaker(id: 2, meetingID: 1, speakerLabel: "Speaker 2", embedding: [0.2]),
+        ]
+        let map = SpeakerNameResolver.speakerMap(from: speakers)
+        #expect(map["Speaker 1"]?.displayName == "Bob")
+        #expect(map["Speaker 2"]?.matchState == .unmatched)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerNameSubstitutionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerNameSubstitutionTests.swift
@@ -80,6 +80,14 @@ struct SpeakerNameSubstitutionTests {
         #expect(out == transcript)
     }
 
+    @Test("CRLF line endings are normalized and substituted")
+    func crlfNormalized() {
+        let transcript = "[10:00:00] Speaker 1: hi\r\n[10:00:05] You: yo"
+        let speakers = map([speaker("Speaker 1", name: "Bob", state: .confirmed)])
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: speakers, userName: "Sam")
+        #expect(out == "[10:00:00] Bob: hi\n[10:00:05] Sam: yo")
+    }
+
     @Test("labels without a timestamp prefix are also substituted")
     func noTimestampPrefix() {
         let transcript = "Speaker 1: hello"

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerNameSubstitutionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerNameSubstitutionTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Speaker name substitution")
+struct SpeakerNameSubstitutionTests {
+    private func speaker(
+        _ label: String,
+        name: String?,
+        state: SpeakerMatchState
+    ) -> MeetingSpeaker {
+        MeetingSpeaker(
+            id: 1, meetingID: 1, speakerLabel: label, embedding: [0.1],
+            profileID: name == nil ? nil : "p", displayName: name, matchDistance: nil, matchState: state
+        )
+    }
+
+    private func map(_ speakers: [MeetingSpeaker]) -> [String: MeetingSpeaker] {
+        SpeakerNameResolver.speakerMap(from: speakers)
+    }
+
+    @Test("replaces Speaker N and You labels, preserving timestamps and text")
+    func replacesLabels() {
+        let transcript = "[10:00:00] Speaker 1: Hello there\n[10:00:05] You: Hi"
+        let speakers = map([speaker("Speaker 1", name: "Bob", state: .confirmed)])
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: speakers, userName: "Spencer")
+        #expect(out == "[10:00:00] Bob: Hello there\n[10:00:05] Spencer: Hi")
+    }
+
+    // Covers R10.
+    @Test("named speakers appear in the summarizer input")
+    func namesInInput() {
+        let transcript = "[10:00:00] Speaker 1: pricing question"
+        let speakers = map([speaker("Speaker 1", name: "Bob", state: .auto)])
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: speakers, userName: "Me")
+        #expect(out.contains("Bob:"))
+        #expect(!out.contains("Speaker 1:"))
+    }
+
+    @Test("unmatched and suggested labels stay Speaker N")
+    func unmatchedStays() {
+        let transcript = "[10:00:00] Speaker 1: a\n[10:00:05] Speaker 2: b"
+        let speakers = map([
+            speaker("Speaker 1", name: nil, state: .unmatched),
+            speaker("Speaker 2", name: "Bob", state: .suggested),
+        ])
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: speakers, userName: "Me")
+        #expect(out == "[10:00:00] Speaker 1: a\n[10:00:05] Speaker 2: b")
+    }
+
+    @Test("You substitutes to the user name, or stays You when unset")
+    func userNameSubstitution() {
+        let transcript = "[10:00:00] You: hello"
+        let named = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: [:], userName: "Spencer")
+        #expect(named == "[10:00:00] Spencer: hello")
+        let unset = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: [:], userName: "")
+        #expect(unset == "[10:00:00] You: hello")
+    }
+
+    @Test("Others is left untouched")
+    func othersUntouched() {
+        let transcript = "[10:00:00] Others: muffled audio"
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: [:], userName: "Me")
+        #expect(out == transcript)
+    }
+
+    @Test("text containing colons is not mistaken for a speaker label")
+    func colonInBody() {
+        let transcript = "[10:00:00] Speaker 1: the ratio was 3:1 today"
+        let speakers = map([speaker("Speaker 1", name: "Bob", state: .confirmed)])
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: speakers, userName: "Me")
+        #expect(out == "[10:00:00] Bob: the ratio was 3:1 today")
+    }
+
+    @Test("lines without a recognized label pass through unchanged")
+    func nonLabelLines() {
+        let transcript = "## Summary\nSome free-form note: with a colon"
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: [:], userName: "Me")
+        #expect(out == transcript)
+    }
+
+    @Test("labels without a timestamp prefix are also substituted")
+    func noTimestampPrefix() {
+        let transcript = "Speaker 1: hello"
+        let speakers = map([speaker("Speaker 1", name: "Bob", state: .confirmed)])
+        let out = SpeakerNameSubstitution.substitute(transcript: transcript, speakers: speakers, userName: "Me")
+        #expect(out == "Bob: hello")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerNamingControllerLogicTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerNamingControllerLogicTests.swift
@@ -1,0 +1,183 @@
+import Testing
+import Foundation
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Speaker naming service", .serialized)
+struct SpeakerNamingControllerLogicTests {
+    private let dim = SpeakerClusterAggregator.embeddingDimension
+
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-naming-test-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    private func vec(_ value: Float) -> [Float] {
+        (0..<dim).map { Float($0) * 0.001 + value }
+    }
+
+    private func service(_ store: DictationStore, ids: [String] = []) -> SpeakerNamingService {
+        var svc = SpeakerNamingService(store: store)
+        if !ids.isEmpty {
+            var queue = ids
+            svc.makeID = { queue.isEmpty ? UUID().uuidString : queue.removeFirst() }
+        }
+        return svc
+    }
+
+    private func makeMeetingWithSpeaker(
+        _ store: DictationStore,
+        label: String = "Speaker 1",
+        embedding: [Float],
+        profileID: String? = nil,
+        displayName: String? = nil,
+        state: SpeakerMatchState = .unmatched
+    ) throws -> (meetingID: Int64, rowID: Int64) {
+        let meetingID = try store.createLiveMeeting(title: "M", calendarEventID: nil, startTime: Date())
+        let rowID = try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: label, embedding: embedding,
+            profileID: profileID, displayName: displayName, matchDistance: nil, matchState: state
+        )
+        return (meetingID, rowID)
+    }
+
+    // MARK: - SpeakerProfileRefiner (pure)
+
+    @Test("refine appends a sample and re-averages recoverably")
+    func refineAppends() {
+        let r = SpeakerProfileRefiner.refine(existingRaw: [vec(0.1)], adding: vec(0.5))
+        #expect(r.rawEmbeddings.count == 2)        // raw retained → recoverable
+        #expect(r.observationCount == 2)
+        #expect(r.embedding.count == 256)
+        let mag = r.embedding.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+        #expect(abs(mag - 1.0) < 1e-4)             // unit-length
+    }
+
+    @Test("refine caps retained raw embeddings, dropping oldest")
+    func refineCaps() {
+        let existing = (0..<20).map { vec(Float($0) * 0.01) }
+        let r = SpeakerProfileRefiner.refine(existingRaw: existing, adding: vec(9.0), cap: 20)
+        #expect(r.rawEmbeddings.count == 20)       // capped
+        #expect(r.rawEmbeddings.last == vec(9.0))  // newest kept
+        #expect(r.rawEmbeddings.first == vec(0.01)) // oldest (index 0) dropped
+    }
+
+    // MARK: - rename
+
+    @Test("renaming an unmatched speaker creates and links a profile")
+    func renameCreatesProfile() throws {
+        let store = try makeStore()
+        let emb = vec(0.2)
+        let (meetingID, _) = try makeMeetingWithSpeaker(store, embedding: emb)
+
+        try service(store, ids: ["bob-id"]).rename(meetingID: meetingID, label: "Speaker 1", to: "Bob")
+
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.matchState == .confirmed)
+        #expect(row.displayName == "Bob")
+        #expect(row.profileID == "bob-id")
+        let profile = try #require(try store.speakerProfile(id: "bob-id"))
+        #expect(profile.name == "Bob")
+        #expect(profile.observationCount == 1)
+    }
+
+    @Test("renaming to an existing profile name links and refines it")
+    func renameRefinesExisting() throws {
+        let store = try makeStore()
+        try store.upsertSpeakerProfile(id: "bob-id", name: "Bob", embedding: vec(0.2), rawEmbeddings: [vec(0.2)], observationCount: 1)
+        let (meetingID, _) = try makeMeetingWithSpeaker(store, embedding: vec(0.25))
+
+        try service(store).rename(meetingID: meetingID, label: "Speaker 1", to: "Bob")
+
+        let profiles = try store.speakerProfiles()
+        #expect(profiles.count == 1)               // no duplicate Bob
+        #expect(profiles.first?.observationCount == 2) // refined
+        #expect(try store.meetingSpeakers(for: meetingID).first?.profileID == "bob-id")
+    }
+
+    // Covers R6.
+    @Test("correcting a wrong auto-match does not pollute the mismatched profile")
+    func correctionLeavesMismatchedProfileUntouched() throws {
+        let store = try makeStore()
+        // Auto-matched to Bob, but it's really Carol.
+        try store.upsertSpeakerProfile(id: "bob-id", name: "Bob", embedding: vec(0.2), rawEmbeddings: [vec(0.2)], observationCount: 1)
+        let carolEmb = vec(0.9)
+        let (meetingID, _) = try makeMeetingWithSpeaker(
+            store, embedding: carolEmb, profileID: "bob-id", displayName: "Bob", state: .auto
+        )
+
+        try service(store, ids: ["carol-id"]).rename(meetingID: meetingID, label: "Speaker 1", to: "Carol")
+
+        // Bob untouched.
+        let bob = try #require(try store.speakerProfile(id: "bob-id"))
+        #expect(bob.observationCount == 1)
+        #expect(bob.rawEmbeddings.count == 1)
+        // Carol created and linked.
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.profileID == "carol-id")
+        #expect(row.displayName == "Carol")
+        #expect(try store.speakerProfile(id: "carol-id")?.name == "Carol")
+    }
+
+    @Test("renaming a speaker with no voiceprint is display-only (no profile)")
+    func renameWithoutEmbedding() throws {
+        let store = try makeStore()
+        let (meetingID, _) = try makeMeetingWithSpeaker(store, embedding: []) // older meeting
+
+        try service(store).rename(meetingID: meetingID, label: "Speaker 1", to: "Bob")
+
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.displayName == "Bob")
+        #expect(row.matchState == .confirmed)
+        #expect(row.profileID == nil)
+        #expect(try store.speakerProfiles().isEmpty)
+    }
+
+    @Test("blank rename is a no-op")
+    func renameBlankNoOp() throws {
+        let store = try makeStore()
+        let (meetingID, _) = try makeMeetingWithSpeaker(store, embedding: vec(0.2))
+        try service(store).rename(meetingID: meetingID, label: "Speaker 1", to: "   ")
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.matchState == .unmatched)
+        #expect(row.displayName == nil)
+    }
+
+    // MARK: - confirm / reject
+
+    @Test("confirming a suggestion links the suggested profile and refines it")
+    func confirmSuggestion() throws {
+        let store = try makeStore()
+        try store.upsertSpeakerProfile(id: "bob-id", name: "Bob", embedding: vec(0.2), rawEmbeddings: [vec(0.2)], observationCount: 1)
+        let (meetingID, _) = try makeMeetingWithSpeaker(
+            store, embedding: vec(0.22), profileID: "bob-id", displayName: "Bob", state: .suggested
+        )
+
+        try service(store).confirm(meetingID: meetingID, label: "Speaker 1")
+
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.matchState == .confirmed)
+        #expect(row.profileID == "bob-id")
+        #expect(try store.speakerProfile(id: "bob-id")?.observationCount == 2)
+    }
+
+    @Test("rejecting a suggestion returns to unmatched without touching profiles")
+    func rejectSuggestion() throws {
+        let store = try makeStore()
+        try store.upsertSpeakerProfile(id: "bob-id", name: "Bob", embedding: vec(0.2), rawEmbeddings: [vec(0.2)], observationCount: 1)
+        let (meetingID, _) = try makeMeetingWithSpeaker(
+            store, embedding: vec(0.22), profileID: "bob-id", displayName: "Bob", state: .suggested
+        )
+
+        try service(store).reject(meetingID: meetingID, label: "Speaker 1")
+
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.matchState == .unmatched)
+        #expect(row.profileID == nil)
+        #expect(row.displayName == nil)
+        #expect(try store.speakerProfile(id: "bob-id")?.observationCount == 1) // untouched
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerNamingControllerLogicTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerNamingControllerLogicTests.swift
@@ -19,6 +19,14 @@ struct SpeakerNamingControllerLogicTests {
         (0..<dim).map { Float($0) * 0.001 + value }
     }
 
+    /// A 256-D unit basis vector (1 at `axis`, 0 elsewhere) — distinct axes are
+    /// cosine-orthogonal (distance 1.0), the same axis is distance 0.
+    private func basis(_ axis: Int) -> [Float] {
+        var v = [Float](repeating: 0, count: dim)
+        v[axis] = 1
+        return v
+    }
+
     private func service(_ store: DictationStore, ids: [String] = []) -> SpeakerNamingService {
         var svc = SpeakerNamingService(store: store)
         if !ids.isEmpty {
@@ -162,6 +170,52 @@ struct SpeakerNamingControllerLogicTests {
         #expect(row.matchState == .confirmed)
         #expect(row.profileID == "bob-id")
         #expect(try store.speakerProfile(id: "bob-id")?.observationCount == 2)
+    }
+
+    @Test("same name + close voice refines one profile")
+    func sameNameCloseVoiceRefines() throws {
+        let store = try makeStore()
+        let m1 = try makeMeetingWithSpeaker(store, label: "Speaker 1", embedding: basis(0))
+        let m2 = try makeMeetingWithSpeaker(store, label: "Speaker 1", embedding: basis(0))
+
+        try service(store, ids: ["bob-1", "bob-2"]).rename(meetingID: m1.meetingID, label: "Speaker 1", to: "Bob")
+        try service(store, ids: ["bob-2"]).rename(meetingID: m2.meetingID, label: "Speaker 1", to: "Bob")
+
+        let profiles = try store.speakerProfiles()
+        #expect(profiles.count == 1)                 // same voice → one Bob
+        #expect(profiles.first?.observationCount == 2)
+    }
+
+    @Test("same name + far voice creates a separate profile (no centroid poisoning)")
+    func sameNameFarVoiceSplits() throws {
+        let store = try makeStore()
+        let m1 = try makeMeetingWithSpeaker(store, label: "Speaker 1", embedding: basis(0))
+        let m2 = try makeMeetingWithSpeaker(store, label: "Speaker 1", embedding: basis(1)) // orthogonal → distance 1.0
+
+        try service(store, ids: ["bob-1"]).rename(meetingID: m1.meetingID, label: "Speaker 1", to: "Bob")
+        try service(store, ids: ["bob-2"]).rename(meetingID: m2.meetingID, label: "Speaker 1", to: "Bob")
+
+        let profiles = try store.speakerProfiles()
+        #expect(profiles.count == 2)                 // two different people sharing a name
+        #expect(profiles.allSatisfy { $0.name == "Bob" })
+        #expect(profiles.allSatisfy { $0.observationCount == 1 })
+    }
+
+    @Test("confirming a row with no candidate name is a no-op")
+    func confirmNoNameNoOp() throws {
+        let store = try makeStore()
+        let (meetingID, _) = try makeMeetingWithSpeaker(store, embedding: vec(0.2), state: .unmatched)
+        try service(store).confirm(meetingID: meetingID, label: "Speaker 1")
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.matchState == .unmatched)
+        #expect(try store.speakerProfiles().isEmpty)
+    }
+
+    @Test("refiner with cap=0 keeps all raw embeddings unbounded")
+    func refinerUnbounded() {
+        let existing = (0..<30).map { vec(Float($0) * 0.01) }
+        let r = SpeakerProfileRefiner.refine(existingRaw: existing, adding: vec(9.0), cap: 0)
+        #expect(r.rawEmbeddings.count == 31) // no trimming
     }
 
     @Test("rejecting a suggestion returns to unmatched without touching profiles")

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift
@@ -202,6 +202,21 @@ struct SpeakerProfileStoreTests {
         #expect(row.displayName == "Robert") // aligned to kept profile's name
     }
 
+    @Test("hasSeenVoiceProfileNote round-trips; missing key decodes false")
+    func voiceProfileNoteFlag() throws {
+        var config = AppConfig()
+        #expect(config.hasSeenVoiceProfileNote == false) // default
+        config.hasSeenVoiceProfileNote = true
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.hasSeenVoiceProfileNote == true)
+
+        // A config JSON missing the key decodes to false (note shows once).
+        let legacy = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+        #expect(legacy.hasSeenVoiceProfileNote == false)
+    }
+
     // Covers R9.
     @Test("deleting a profile removes it AND scrubs linked voiceprint copies")
     func deleteScrubsVoiceprint() throws {

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift
@@ -202,6 +202,67 @@ struct SpeakerProfileStoreTests {
         #expect(row.displayName == "Robert") // aligned to kept profile's name
     }
 
+    @Test("upsert + fetch round-trips rawEmbeddings")
+    func rawEmbeddingsRoundTrip() throws {
+        let store = try makeStore()
+        let raw: [[Float]] = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1, 0.2, 0.3], rawEmbeddings: raw, observationCount: 2)
+        let fetched = try #require(try store.speakerProfile(id: "p1"))
+        #expect(fetched.rawEmbeddings.count == 2)
+        expectClose(fetched.rawEmbeddings[0], raw[0])
+        expectClose(fetched.rawEmbeddings[1], raw[1])
+    }
+
+    @Test("replaceMeetingSpeakers atomically replaces the row set and is idempotent")
+    func replaceMeetingSpeakers() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.replaceMeetingSpeakers(meetingID: meetingID, speakers: [
+            (label: "Speaker 1", embedding: [0.1]),
+            (label: "Speaker 2", embedding: [0.2]),
+        ])
+        #expect(try store.meetingSpeakers(for: meetingID).count == 2)
+
+        // Re-run with a smaller set: old rows are fully replaced, not appended.
+        try store.replaceMeetingSpeakers(meetingID: meetingID, speakers: [
+            (label: "Speaker 1", embedding: [0.9]),
+        ])
+        let rows = try store.meetingSpeakers(for: meetingID)
+        #expect(rows.count == 1)
+        #expect(rows.first?.speakerLabel == "Speaker 1")
+        #expect(rows.first?.matchState == .unmatched)
+        expectClose(rows.first!.embedding, [0.9])
+
+        // Empty set clears all rows.
+        try store.replaceMeetingSpeakers(meetingID: meetingID, speakers: [])
+        #expect(try store.meetingSpeakers(for: meetingID).isEmpty)
+    }
+
+    @Test("renaming a profile propagates the new name to linked named rows only")
+    func renamePropagatesToMeetingRows() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1])
+        // A confirmed (named) row and an unmatched row both linkable to the profile.
+        let namedID = try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.1],
+            profileID: "p1", displayName: "Bob", matchState: .confirmed
+        )
+        let unmatchedID = try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: "Speaker 2", embedding: [0.2],
+            profileID: "p1", displayName: nil, matchState: .unmatched
+        )
+
+        try store.renameSpeakerProfile(id: "p1", name: "Robert")
+
+        let rows = try store.meetingSpeakers(for: meetingID)
+        let named = rows.first { $0.id == namedID }
+        let unmatched = rows.first { $0.id == unmatchedID }
+        #expect(try store.speakerProfile(id: "p1")?.name == "Robert")
+        #expect(named?.displayName == "Robert")     // named snapshot refreshed
+        #expect(unmatched?.displayName == nil)       // unnamed row untouched
+    }
+
     @Test("hasSeenVoiceProfileNote round-trips; missing key decodes false")
     func voiceProfileNoteFlag() throws {
         var config = AppConfig()

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerProfileStoreTests.swift
@@ -1,0 +1,225 @@
+import Testing
+import Foundation
+import MuesliCore
+import SQLite3
+@testable import MuesliNativeApp
+
+@Suite("Speaker profile store", .serialized)
+struct SpeakerProfileStoreTests {
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-speakers-test-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    /// A pre-feature schema (no speaker tables) to verify additive migration.
+    private func makeLegacyStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-speakers-legacy-\(UUID().uuidString).db")
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let sql = """
+        CREATE TABLE meetings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            calendar_event_id TEXT,
+            start_time TEXT NOT NULL,
+            end_time TEXT,
+            duration_seconds REAL,
+            raw_transcript TEXT,
+            formatted_notes TEXT,
+            mic_audio_path TEXT,
+            system_audio_path TEXT,
+            word_count INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'meeting',
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+        #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+        return DictationStore(databaseURL: url)
+    }
+
+    private func makeMeeting(_ store: DictationStore) throws -> Int64 {
+        try store.createLiveMeeting(title: "M", calendarEventID: nil, startTime: Date())
+    }
+
+    private func expectClose(_ a: [Float], _ b: [Float], tolerance: Float = 1e-5) {
+        #expect(a.count == b.count)
+        for (lhs, rhs) in zip(a, b) {
+            #expect(abs(lhs - rhs) < tolerance)
+        }
+    }
+
+    @Test("fresh DB creates speaker tables; migration is idempotent")
+    func freshMigration() throws {
+        let store = try makeStore()
+        try store.migrateIfNeeded() // idempotent re-run
+        #expect(try store.speakerProfiles().isEmpty)
+    }
+
+    @Test("additive migration upgrades a legacy schema")
+    func legacyMigration() throws {
+        let store = try makeLegacyStore()
+        try store.migrateIfNeeded()
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1, 0.2])
+        #expect(try store.speakerProfiles().count == 1)
+    }
+
+    @Test("upsert + fetch round-trips name and embedding")
+    func profileRoundTrip() throws {
+        let store = try makeStore()
+        let embedding: [Float] = (0..<256).map { Float($0) / 256.0 }
+        try store.upsertSpeakerProfile(id: "bob-1", name: "Bob", embedding: embedding, observationCount: 3)
+
+        let fetched = try #require(try store.speakerProfile(id: "bob-1"))
+        #expect(fetched.name == "Bob")
+        #expect(fetched.observationCount == 3)
+        expectClose(fetched.embedding, embedding)
+    }
+
+    @Test("upsert updates in place without orphaning linked rows")
+    func upsertUpdatesInPlace() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1, 0.2])
+        try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.1, 0.2],
+            profileID: "p1", displayName: "Bob", matchDistance: 0.1, matchState: .confirmed
+        )
+
+        // Re-upsert (refine) the same profile.
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.3, 0.4], observationCount: 2)
+
+        let profiles = try store.speakerProfiles()
+        #expect(profiles.count == 1)
+        // The linked row must still point at the profile (no REPLACE-induced SET NULL).
+        let speakers = try store.meetingSpeakers(for: meetingID)
+        #expect(speakers.first?.profileID == "p1")
+    }
+
+    @Test("rename changes the stored profile name")
+    func renameProfile() throws {
+        let store = try makeStore()
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1])
+        try store.renameSpeakerProfile(id: "p1", name: "Robert")
+        #expect(try store.speakerProfile(id: "p1")?.name == "Robert")
+    }
+
+    @Test("insertMeetingSpeaker + fetch round-trips all fields")
+    func meetingSpeakerRoundTrip() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1])
+        let embedding: [Float] = [0.5, 0.25, 0.125]
+        try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: "Speaker 2", embedding: embedding,
+            profileID: "p1", displayName: "Bob", matchDistance: 0.42, matchState: .auto
+        )
+
+        let rows = try store.meetingSpeakers(for: meetingID)
+        #expect(rows.count == 1)
+        let row = try #require(rows.first)
+        #expect(row.speakerLabel == "Speaker 2")
+        #expect(row.profileID == "p1")
+        #expect(row.displayName == "Bob")
+        #expect(row.matchDistance == 0.42)
+        #expect(row.matchState == .auto)
+        expectClose(row.embedding, embedding)
+    }
+
+    @Test("unmatched cluster persists with nil profile/name")
+    func unmatchedSpeaker() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.insertMeetingSpeaker(meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.1, 0.2])
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.profileID == nil)
+        #expect(row.displayName == nil)
+        #expect(row.matchDistance == nil)
+        #expect(row.matchState == .unmatched)
+    }
+
+    @Test("updateMeetingSpeaker applies recognition/naming results")
+    func updateSpeaker() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1])
+        let id = try store.insertMeetingSpeaker(meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.1])
+
+        try store.updateMeetingSpeaker(id: id, profileID: "p1", displayName: "Bob", matchDistance: 0.3, matchState: .confirmed)
+
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.matchState == .confirmed)
+        #expect(row.displayName == "Bob")
+        #expect(row.profileID == "p1")
+    }
+
+    @Test("deleting a meeting cascades its speaker rows")
+    func cascadeDelete() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.insertMeetingSpeaker(meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.1])
+        try store.insertMeetingSpeaker(meetingID: meetingID, speakerLabel: "Speaker 2", embedding: [0.2])
+        #expect(try store.meetingSpeakers(for: meetingID).count == 2)
+
+        try store.deleteMeeting(id: meetingID)
+        #expect(try store.meetingSpeakers(for: meetingID).isEmpty)
+    }
+
+    @Test("deleteMeetingSpeakers clears only the target meeting")
+    func deleteMeetingSpeakersScoped() throws {
+        let store = try makeStore()
+        let m1 = try makeMeeting(store)
+        let m2 = try makeMeeting(store)
+        try store.insertMeetingSpeaker(meetingID: m1, speakerLabel: "Speaker 1", embedding: [0.1])
+        try store.insertMeetingSpeaker(meetingID: m2, speakerLabel: "Speaker 1", embedding: [0.2])
+
+        try store.deleteMeetingSpeakers(for: m1)
+        #expect(try store.meetingSpeakers(for: m1).isEmpty)
+        #expect(try store.meetingSpeakers(for: m2).count == 1)
+    }
+
+    @Test("merge repoints linked rows and deletes the merged-away profile")
+    func mergeProfiles() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.upsertSpeakerProfile(id: "keep", name: "Robert", embedding: [0.1])
+        try store.upsertSpeakerProfile(id: "remove", name: "Bob", embedding: [0.2])
+        try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.2],
+            profileID: "remove", displayName: "Bob", matchState: .confirmed
+        )
+
+        try store.mergeSpeakerProfiles(keepID: "keep", removeID: "remove")
+
+        #expect(try store.speakerProfile(id: "remove") == nil)
+        #expect(try store.speakerProfiles().count == 1)
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.profileID == "keep")
+        #expect(row.displayName == "Robert") // aligned to kept profile's name
+    }
+
+    // Covers R9.
+    @Test("deleting a profile removes it AND scrubs linked voiceprint copies")
+    func deleteScrubsVoiceprint() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(store)
+        try store.upsertSpeakerProfile(id: "p1", name: "Bob", embedding: [0.1, 0.2, 0.3])
+        try store.insertMeetingSpeaker(
+            meetingID: meetingID, speakerLabel: "Speaker 1", embedding: [0.1, 0.2, 0.3],
+            profileID: "p1", displayName: "Bob", matchDistance: 0.1, matchState: .confirmed
+        )
+
+        try store.deleteSpeakerProfile(id: "p1")
+
+        #expect(try store.speakerProfile(id: "p1") == nil)
+        let row = try #require(try store.meetingSpeakers(for: meetingID).first)
+        #expect(row.profileID == nil)             // FK SET NULL
+        #expect(row.displayName == nil)           // name scrubbed
+        #expect(row.matchState == .unmatched)     // state reset
+        #expect(row.embedding.isEmpty)            // per-meeting voiceprint copy gone
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerRecognizerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerRecognizerTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Speaker recognizer")
+struct SpeakerRecognizerTests {
+    /// A 2-D unit vector at the given cosine similarity to `[1, 0]`.
+    /// cosineDistance to [1,0] is then `1 - similarity`.
+    private func vectorAtSimilarity(_ sim: Float) -> [Float] {
+        [sim, (1 - sim * sim).squareRoot()]
+    }
+
+    private func profile(_ id: String, _ name: String, embedding: [Float] = [1, 0]) -> SpeakerProfile {
+        SpeakerProfile(id: id, name: name, embedding: embedding)
+    }
+
+    // Covers R5.
+    @Test("a strongly matching cluster is auto-named")
+    func autoMatch() {
+        let bob = profile("bob-1", "Bob")
+        let cluster = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: vectorAtSimilarity(0.97)) // dist 0.03
+        let results = SpeakerRecognizer.recognize(clusters: [cluster], profiles: [bob])
+        #expect(results.count == 1)
+        #expect(results[0].state == .auto)
+        #expect(results[0].displayName == "Bob")
+        #expect(results[0].profileID == "bob-1")
+    }
+
+    @Test("a borderline cluster is a suggestion")
+    func borderlineSuggested() {
+        let bob = profile("bob-1", "Bob")
+        // similarity 0.4 → distance 0.6 (between strong 0.5 and suggest 0.65)
+        let cluster = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: vectorAtSimilarity(0.4))
+        let results = SpeakerRecognizer.recognize(clusters: [cluster], profiles: [bob])
+        #expect(results[0].state == .suggested)
+        #expect(results[0].displayName == "Bob") // candidate name carried for the chip
+        #expect(results[0].profileID == "bob-1")
+    }
+
+    @Test("a far cluster stays unmatched")
+    func farUnmatched() {
+        let bob = profile("bob-1", "Bob")
+        // similarity 0.2 → distance 0.8 (> suggest 0.65)
+        let cluster = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: vectorAtSimilarity(0.2))
+        let results = SpeakerRecognizer.recognize(clusters: [cluster], profiles: [bob])
+        #expect(results[0].state == .unmatched)
+        #expect(results[0].profileID == nil)
+        #expect(results[0].displayName == nil)
+    }
+
+    @Test("empty library leaves every cluster unmatched")
+    func emptyLibrary() {
+        let clusters = [
+            SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: vectorAtSimilarity(0.99)),
+            SpeakerRecognizer.Cluster(label: "Speaker 2", embedding: vectorAtSimilarity(0.5)),
+        ]
+        let results = SpeakerRecognizer.recognize(clusters: clusters, profiles: [])
+        #expect(results.allSatisfy { $0.state == .unmatched })
+    }
+
+    @Test("closest profile wins when several are within threshold")
+    func tieBreakClosest() {
+        let bob = profile("bob-1", "Bob", embedding: [1, 0])
+        let carol = profile("carol-1", "Carol", embedding: vectorAtSimilarity(0.9)) // a bit off-axis
+        // Cluster aligned with Bob exactly.
+        let cluster = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: [1, 0])
+        let results = SpeakerRecognizer.recognize(clusters: [cluster], profiles: [bob, carol])
+        #expect(results[0].profileID == "bob-1")
+        #expect(results[0].displayName == "Bob")
+    }
+
+    @Test("two clusters matching one profile: only the closest is named")
+    func withinMeetingUniqueness() {
+        let bob = profile("bob-1", "Bob")
+        let near = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: vectorAtSimilarity(0.99)) // dist .01
+        let alsoNear = SpeakerRecognizer.Cluster(label: "Speaker 2", embedding: vectorAtSimilarity(0.95)) // dist .05
+        let results = SpeakerRecognizer.recognize(clusters: [near, alsoNear], profiles: [bob])
+
+        let speaker1 = results.first { $0.label == "Speaker 1" }!
+        let speaker2 = results.first { $0.label == "Speaker 2" }!
+        #expect(speaker1.state == .auto)            // closest keeps the name
+        #expect(speaker1.profileID == "bob-1")
+        #expect(speaker2.state == .unmatched)       // demoted — no duplicate "Bob"
+        #expect(speaker2.profileID == nil)
+    }
+
+    @Test("two clusters matching two distinct profiles both keep their names")
+    func distinctProfilesBothNamed() {
+        let bob = profile("bob-1", "Bob", embedding: [1, 0])
+        let carol = profile("carol-1", "Carol", embedding: [0, 1])
+        let c1 = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: [1, 0])
+        let c2 = SpeakerRecognizer.Cluster(label: "Speaker 2", embedding: [0, 1])
+        let results = SpeakerRecognizer.recognize(clusters: [c1, c2], profiles: [bob, carol])
+        #expect(results[0].displayName == "Bob")
+        #expect(results[1].displayName == "Carol")
+        #expect(results.allSatisfy { $0.state == .auto })
+    }
+
+    @Test("results preserve input cluster order")
+    func preservesOrder() {
+        let bob = profile("bob-1", "Bob")
+        let clusters = (1...3).map { SpeakerRecognizer.Cluster(label: "Speaker \($0)", embedding: vectorAtSimilarity(0.1)) }
+        let results = SpeakerRecognizer.recognize(clusters: clusters, profiles: [bob])
+        #expect(results.map(\.label) == ["Speaker 1", "Speaker 2", "Speaker 3"])
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SpeakerRecognizerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SpeakerRecognizerTests.swift
@@ -97,6 +97,15 @@ struct SpeakerRecognizerTests {
         #expect(results.allSatisfy { $0.state == .auto })
     }
 
+    @Test("a wrong-dimension or empty cluster embedding stays unmatched")
+    func malformedEmbeddingUnmatched() {
+        let bob = profile("bob-1", "Bob", embedding: Array(repeating: Float(0), count: 256).enumerated().map { $0.offset == 0 ? 1 : 0 })
+        let empty = SpeakerRecognizer.Cluster(label: "Speaker 1", embedding: [])
+        let wrongSize = SpeakerRecognizer.Cluster(label: "Speaker 2", embedding: [1, 0, 0])
+        let results = SpeakerRecognizer.recognize(clusters: [empty, wrongSize], profiles: [bob])
+        #expect(results.allSatisfy { $0.state == .unmatched })
+    }
+
     @Test("results preserve input cluster order")
     func preservesOrder() {
         let bob = profile("bob-1", "Bob")


### PR DESCRIPTION
## Named speakers + persistent voice profiles

Replaces `Speaker 1/2/3` in meeting transcripts and AI notes with real names, and remembers voices across meetings. After a meeting, you rename a diarized speaker; that saves a persistent **local** voice profile (name + 256-D voiceprint) and, in future meetings, confidence-tiered recognition auto-names confident matches and surfaces borderline ones as confirmable suggestions. Names are a **render-time overlay** over stable `Speaker N` tokens, so corrections are instant. Post-meeting only; built off `main`.

Plan: `docs/plans/2026-06-01-001-feat-named-speakers-voice-profiles-plan.md` · Brainstorm: `docs/brainstorms/2026-06-01-named-speakers-voice-profiles-requirements.md`

### What's in it (7 units)
- **U1 — Persistence:** `speaker_profiles` + `meeting_speakers` tables, CRUD, FK cascade/set-null, voiceprint scrub-on-delete, DB backup-exclusion + `0o600` hardening.
- **U2 — Capture:** one representative 256-D voiceprint per *realized* diarized cluster at meeting stop; labels derived from the actual transcript blob so they never mis-attach (live + audio-import paths).
- **U3 — Recognition:** confidence-tiered cosine matching (auto / suggested / unmatched) with a within-meeting uniqueness pass (no duplicate names).
- **U4 — Overlay:** pure render-time name resolver over stable tokens; auto-recognized names get a "verify" indicator.
- **U5 — Naming UI:** inline rename + confirm/reject chips; recoverable profile refinement (re-average retained samples, only on explicit confirm; corrections never pollute the mismatched profile).
- **U6 — Speakers library:** list / rename / merge / delete, empty state, one-time local-voiceprint disclosure.
- **U7 — Notes:** names flow into AI notes via a pure substitution + opt-in "update notes" re-summarize; first-pass notes keep `Speaker N`.

### Privacy
Voiceprints are stored **on-device only** (never sent off-device), excluded from iCloud/Time Machine backups, `0o600`, disclosed once on first enrollment, and deletable. Naming a speaker means real participant names enter the (already cloud-bound) transcript only when you choose to update notes.

### Testing
~98 new tests covering persistence, capture/label-alignment, recognition, resolver, naming/refinement, and notes substitution. Full suite green (one unrelated `HotkeyMonitor` timing test is flaky under parallel load; passes in isolation).

### Reviewed
Ran multi-persona code review (correctness, security, adversarial, swift-ios, data-migration, performance, reliability, maintainability, testing). All P1 + P2 findings fixed, including: durable WAL/sidecar hardening, atomic `meeting_speakers` replace, merge-folds-voiceprints, rename-propagation to past meetings, stale-row invalidation on manual transcript edit, and same-name-different-voice profile splitting.

### Known follow-ups (not blocking)
- Re-recognizing pre-existing meetings after a new profile is enrolled (building block exists, not wired).
- Persist+recognize currently run on the MainActor at stop (bounded N; deferred an off-main refactor to avoid restructuring the awaited finalize path).
- Recognition thresholds pinned to FluidAudio defaults (0.5 / 0.65).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782944302&installation_id=136549638&pr_number=195&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F195&signature=de6a0f9623bf3487eac666ca496b911d08e9d2261616f96662abaeebac540603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->