### PR TITLE
Make dictation warmup route-aware

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -4,13 +4,9 @@ import Foundation
 final class AppScopedDictationRecorder: DictationAudioRecording {
     var preferredInputDeviceID: AudioObjectID? {
         get {
-            lock.lock()
-            defer { lock.unlock() }
             return recorder.preferredInputDeviceID
         }
         set {
-            lock.lock()
-            defer { lock.unlock() }
             recorder.preferredInputDeviceID = newValue
         }
     }
@@ -32,20 +28,23 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     private var noAudioTimeoutWorkItem: DispatchWorkItem?
     private var activeRecordingID: UUID?
     private var explicitPreparation: ExplicitPreparation?
+    private var lifecycleGeneration: UInt64 = 0
     private var hasReceivedFirstAudioBuffer = false
     private var hasDetectedSpeech = false
     private var hasReportedNoAudioTimeout = false
 
     private final class ExplicitPreparation {
         let inputDeviceID: AudioObjectID?
+        let generation: UInt64
         let group = DispatchGroup()
         private let lock = NSLock()
         private var completed = false
         private var cancelled = false
         private var resultStorage: Result<Void, Error>?
 
-        init(inputDeviceID: AudioObjectID?) {
+        init(inputDeviceID: AudioObjectID?, generation: UInt64) {
             self.inputDeviceID = inputDeviceID
+            self.generation = generation
             group.enter()
         }
 
@@ -107,13 +106,11 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     }
 
     func prepare() throws {
-        lock.lock()
-        defer { lock.unlock() }
-
         try recorder.prepare()
     }
 
     func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
+        var shouldCancelRecorder = false
         lock.lock()
         if let explicitPreparation,
            explicitPreparation.inputDeviceID == preferredInputDeviceID,
@@ -125,19 +122,28 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
                 return
             case .failure?:
                 self.explicitPreparation = nil
-                recorder.cancel()
+                lifecycleGeneration &+= 1
+                shouldCancelRecorder = true
             }
         }
         guard activeRecordingID == nil else {
             lock.unlock()
+            if shouldCancelRecorder {
+                recorder.cancel()
+            }
             return
         }
 
-        recorder.preferredInputDeviceID = preferredInputDeviceID
-        let preparation = ExplicitPreparation(inputDeviceID: preferredInputDeviceID)
+        lifecycleGeneration &+= 1
+        let generation = lifecycleGeneration
+        let preparation = ExplicitPreparation(inputDeviceID: preferredInputDeviceID, generation: generation)
         explicitPreparation = preparation
         lock.unlock()
 
+        if shouldCancelRecorder {
+            recorder.cancel()
+        }
+        recorder.preferredInputDeviceID = preferredInputDeviceID
         onLatencyEvent?("app_scoped_explicit_prepare_begin", Date())
         prepareQueue.async { [weak self, preparation] in
             guard let self else {
@@ -146,37 +152,42 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
             }
 
             self.lock.lock()
-            let shouldPrepare = self.explicitPreparation === preparation && !preparation.isCancelled
+            let shouldPrepare = self.isCurrentPreparationLocked(preparation)
+            self.lock.unlock()
             guard shouldPrepare else {
-                self.lock.unlock()
                 preparation.complete(.failure(Self.cancelledPreparationError()))
                 self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
                 return
             }
 
-            // Keep cancellation and prepare serialized: once cancel/coolDown returns,
-            // a previously queued warmup cannot start opening mic resources.
             let result = Result { try self.recorder.prepare() }
             var shouldTearDown = false
-            if self.explicitPreparation === preparation && !preparation.isCancelled {
+            var didCompleteCurrentPreparation = false
+            self.lock.lock()
+            if self.isCurrentPreparationLocked(preparation) {
                 _ = preparation.complete(result)
+                didCompleteCurrentPreparation = true
                 if case .failure = result {
                     if self.activeRecordingID == nil {
                         self.explicitPreparation = nil
+                        self.lifecycleGeneration &+= 1
                         shouldTearDown = true
                     }
                 }
-            } else if self.activeRecordingID == nil {
-                shouldTearDown = true
+            } else {
+                _ = preparation.complete(.failure(Self.cancelledPreparationError()))
+                if self.activeRecordingID == nil {
+                    shouldTearDown = true
+                }
             }
+            self.lock.unlock()
 
             if shouldTearDown {
                 self.recorder.cancel()
             }
-            self.lock.unlock()
             switch result {
             case .success:
-                self.onLatencyEvent?("app_scoped_explicit_prepare_end", Date())
+                self.onLatencyEvent?(didCompleteCurrentPreparation ? "app_scoped_explicit_prepare_end" : "app_scoped_explicit_prepare_cancelled", Date())
             case .failure:
                 self.onLatencyEvent?("app_scoped_explicit_prepare_failed", Date())
             }
@@ -184,18 +195,12 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
-        lock.lock()
-        defer { lock.unlock() }
-
         recorder.preferredInputDeviceID = preferredInputDeviceID
         try recorder.prepare()
         fputs("[dictation-engine-recorder] warmed preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
     }
 
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
-        lock.lock()
-        defer { lock.unlock() }
-
         recorder.preferredInputDeviceID = preferredInputDeviceID
         try recorder.prepare()
         fputs("[dictation-engine-recorder] activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
@@ -203,11 +208,14 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
     func coolDown() {
         lock.lock()
-        defer { lock.unlock() }
-
-        guard activeRecordingID == nil else { return }
+        guard activeRecordingID == nil else {
+            lock.unlock()
+            return
+        }
         explicitPreparation?.cancel()
         explicitPreparation = nil
+        lifecycleGeneration &+= 1
+        lock.unlock()
         recorder.cancel()
     }
 
@@ -228,10 +236,9 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         do {
             try awaitExplicitPreparationIfNeeded(preparation)
         } catch {
-            lock.lock()
-            activeRecordingID = nil
-            lock.unlock()
-            recorder.cancel()
+            if clearActiveRecordingIfCurrent(recordingID) {
+                recorder.cancel()
+            }
             throw error
         }
         lock.lock()
@@ -241,13 +248,25 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
                 NSLocalizedDescriptionKey: "Dictation recording was cancelled before microphone startup finished",
             ])
         }
+        lock.unlock()
         do {
             try recorder.start()
         } catch {
-            activeRecordingID = nil
-            lock.unlock()
-            recorder.cancel()
+            if clearActiveRecordingIfCurrent(recordingID) {
+                recorder.cancel()
+            }
             throw error
+        }
+        lock.lock()
+        guard activeRecordingID == recordingID else {
+            let shouldCancel = activeRecordingID == nil
+            lock.unlock()
+            if shouldCancel {
+                recorder.cancel()
+            }
+            throw NSError(domain: "AppScopedDictationRecorder", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Dictation recording was cancelled before microphone startup finished",
+            ])
         }
         scheduleNoAudioTimeoutLocked()
         lock.unlock()
@@ -256,22 +275,22 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
     func stop() -> URL? {
         lock.lock()
-        defer { lock.unlock() }
-
         cancelTimersLocked()
         activeRecordingID = nil
         explicitPreparation = nil
+        lifecycleGeneration &+= 1
+        lock.unlock()
         return recorder.stop()
     }
 
     func cancel() {
         lock.lock()
-        defer { lock.unlock() }
-
         cancelTimersLocked()
         activeRecordingID = nil
         explicitPreparation?.cancel()
         explicitPreparation = nil
+        lifecycleGeneration &+= 1
+        lock.unlock()
         recorder.cancel()
     }
 
@@ -294,18 +313,35 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         hasReportedNoAudioTimeout = false
     }
 
+    private func isCurrentPreparationLocked(_ preparation: ExplicitPreparation) -> Bool {
+        explicitPreparation === preparation
+            && preparation.generation == lifecycleGeneration
+            && !preparation.isCancelled
+    }
+
+    private func clearActiveRecordingIfCurrent(_ recordingID: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if activeRecordingID == recordingID {
+            activeRecordingID = nil
+            return true
+        }
+        return activeRecordingID == nil
+    }
+
     private func awaitExplicitPreparationIfNeeded(_ preparation: ExplicitPreparation?) throws {
         guard let preparation else { return }
         onLatencyEvent?("app_scoped_explicit_prepare_wait_begin", Date())
         preparation.group.wait()
         onLatencyEvent?("app_scoped_explicit_prepare_wait_end", Date())
         lock.lock()
-        let isCurrentPreparation = explicitPreparation === preparation
+        let isCurrentPreparation = isCurrentPreparationLocked(preparation)
         if isCurrentPreparation, case .failure? = preparation.result {
             explicitPreparation = nil
+            lifecycleGeneration &+= 1
         }
         lock.unlock()
-        guard isCurrentPreparation, !preparation.isCancelled else {
+        guard isCurrentPreparation else {
             throw Self.cancelledPreparationError()
         }
         switch preparation.result {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -20,6 +20,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     var onFirstSpeechDetected: ((Date) -> Void)?
     var onNoAudioTimeout: ((Date) -> Void)?
     var onRecordingFailed: ((Error, UUID) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
 
     private static let speechThresholdDB: Float = -58
     private static let noAudioTimeout: TimeInterval = 1.5
@@ -32,6 +33,12 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     private var hasReceivedFirstAudioBuffer = false
     private var hasDetectedSpeech = false
     private var hasReportedNoAudioTimeout = false
+
+    init() {
+        recorder.onLatencyEvent = { [weak self] event, date in
+            self?.onLatencyEvent?(event, date)
+        }
+    }
 
     deinit {
         cancel()

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -25,10 +25,10 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     private static let speechThresholdDB: Float = -58
     private static let noAudioTimeout: TimeInterval = 1.5
 
-    private let recorder = StreamingMicRecorder(directoryName: "muesli-native-dictation")
+    private let recorder: StreamingDictationRecording
     private let lock = NSRecursiveLock()
-    private let prepareQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-prepare")
-    private let callbackQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-callbacks")
+    private let prepareQueue: DispatchQueue
+    private let callbackQueue: DispatchQueue
     private var noAudioTimeoutWorkItem: DispatchWorkItem?
     private var activeRecordingID: UUID?
     private var explicitPreparation: ExplicitPreparation?
@@ -39,16 +39,62 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     private final class ExplicitPreparation {
         let inputDeviceID: AudioObjectID?
         let group = DispatchGroup()
-        var result: Result<Void, Error>?
+        private let lock = NSLock()
+        private var completed = false
+        private var cancelled = false
+        private var resultStorage: Result<Void, Error>?
 
         init(inputDeviceID: AudioObjectID?) {
             self.inputDeviceID = inputDeviceID
             group.enter()
         }
+
+        var result: Result<Void, Error>? {
+            lock.withLock { resultStorage }
+        }
+
+        var isCancelled: Bool {
+            lock.withLock { cancelled }
+        }
+
+        @discardableResult
+        func complete(_ result: Result<Void, Error>) -> Bool {
+            lock.withLock {
+                guard !completed else { return false }
+                resultStorage = result
+                completed = true
+                group.leave()
+                return true
+            }
+        }
+
+        func cancel() {
+            lock.withLock {
+                cancelled = true
+                guard !completed else { return }
+                resultStorage = .failure(Self.cancelledError())
+                completed = true
+                group.leave()
+            }
+        }
+
+        private static func cancelledError() -> NSError {
+            NSError(domain: "AppScopedDictationRecorder", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Dictation microphone preparation was cancelled",
+            ])
+        }
     }
 
-    init() {
-        recorder.onLatencyEvent = { [weak self] event, date in
+    init(
+        recorder: StreamingDictationRecording = StreamingMicRecorder(directoryName: "muesli-native-dictation"),
+        prepareQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-prepare"),
+        callbackQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-callbacks")
+    ) {
+        self.recorder = recorder
+        self.prepareQueue = prepareQueue
+        self.callbackQueue = callbackQueue
+
+        (recorder as? StreamingMicRecorder)?.onLatencyEvent = { [weak self] event, date in
             self?.onLatencyEvent?(event, date)
         }
     }
@@ -67,10 +113,17 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
         lock.lock()
         if let explicitPreparation,
-           explicitPreparation.inputDeviceID == preferredInputDeviceID {
-            lock.unlock()
-            onLatencyEvent?("app_scoped_explicit_prepare_reused", Date())
-            return
+           explicitPreparation.inputDeviceID == preferredInputDeviceID,
+           !explicitPreparation.isCancelled {
+            switch explicitPreparation.result {
+            case nil, .success?:
+                lock.unlock()
+                onLatencyEvent?("app_scoped_explicit_prepare_reused", Date())
+                return
+            case .failure?:
+                self.explicitPreparation = nil
+                recorder.cancel()
+            }
         }
         guard activeRecordingID == nil else {
             lock.unlock()
@@ -85,25 +138,44 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         onLatencyEvent?("app_scoped_explicit_prepare_begin", Date())
         prepareQueue.async { [weak self, preparation] in
             guard let self else {
-                preparation.result = .success(())
-                preparation.group.leave()
+                preparation.complete(.success(()))
+                return
+            }
+
+            self.lock.lock()
+            let shouldPrepare = self.explicitPreparation === preparation && !preparation.isCancelled
+            self.lock.unlock()
+            guard shouldPrepare else {
+                preparation.complete(.failure(Self.cancelledPreparationError()))
+                self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
                 return
             }
 
             let result = Result { try self.recorder.prepare() }
+            var shouldTearDown = false
             self.lock.lock()
-            if self.explicitPreparation === preparation {
-                preparation.result = result
+            if self.explicitPreparation === preparation && !preparation.isCancelled {
+                _ = preparation.complete(result)
+                if case .failure = result {
+                    if self.activeRecordingID == nil {
+                        self.explicitPreparation = nil
+                        shouldTearDown = true
+                    }
+                }
+            } else if self.activeRecordingID == nil {
+                shouldTearDown = true
             }
             self.lock.unlock()
 
+            if shouldTearDown {
+                self.recorder.cancel()
+            }
             switch result {
             case .success:
                 self.onLatencyEvent?("app_scoped_explicit_prepare_end", Date())
             case .failure:
                 self.onLatencyEvent?("app_scoped_explicit_prepare_failed", Date())
             }
-            preparation.group.leave()
         }
     }
 
@@ -191,6 +263,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
         cancelTimersLocked()
         activeRecordingID = nil
+        explicitPreparation?.cancel()
         explicitPreparation = nil
         recorder.cancel()
     }
@@ -219,6 +292,15 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         onLatencyEvent?("app_scoped_explicit_prepare_wait_begin", Date())
         preparation.group.wait()
         onLatencyEvent?("app_scoped_explicit_prepare_wait_end", Date())
+        lock.lock()
+        let isCurrentPreparation = explicitPreparation === preparation
+        if isCurrentPreparation, case .failure? = preparation.result {
+            explicitPreparation = nil
+        }
+        lock.unlock()
+        guard isCurrentPreparation, !preparation.isCancelled else {
+            throw Self.cancelledPreparationError()
+        }
         switch preparation.result {
         case .success?:
             return
@@ -258,6 +340,12 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         }
         lock.unlock()
         onRecordingFailed?(error, activeRecordingID)
+    }
+
+    private static func cancelledPreparationError() -> NSError {
+        NSError(domain: "AppScopedDictationRecorder", code: 2, userInfo: [
+            NSLocalizedDescriptionKey: "Dictation microphone preparation was cancelled",
+        ])
     }
 
     private func scheduleNoAudioTimeoutLocked() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -153,6 +153,14 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
                 self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
                 return
             }
+            self.lock.lock()
+            let isStillCurrent = self.explicitPreparation === preparation && !preparation.isCancelled
+            self.lock.unlock()
+            guard isStillCurrent else {
+                preparation.complete(.failure(Self.cancelledPreparationError()))
+                self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
+                return
+            }
 
             let result = Result { try self.recorder.prepare() }
             var shouldTearDown = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -86,7 +86,10 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     }
 
     init(
-        recorder: StreamingDictationRecording = StreamingMicRecorder(directoryName: "muesli-native-dictation"),
+        recorder: StreamingDictationRecording = FallbackStreamingDictationRecorder(
+            primary: AudioQueueInputRecorder(directoryName: "muesli-native-dictation"),
+            fallback: StreamingMicRecorder(directoryName: "muesli-native-dictation")
+        ),
         prepareQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-prepare"),
         callbackQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-callbacks")
     ) {
@@ -94,7 +97,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         self.prepareQueue = prepareQueue
         self.callbackQueue = callbackQueue
 
-        (recorder as? StreamingMicRecorder)?.onLatencyEvent = { [weak self] event, date in
+        (recorder as? StreamingDictationLatencyReporting)?.onLatencyEvent = { [weak self] event, date in
             self?.onLatencyEvent?(event, date)
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -205,6 +205,8 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         defer { lock.unlock() }
 
         guard activeRecordingID == nil else { return }
+        explicitPreparation?.cancel()
+        explicitPreparation = nil
         recorder.cancel()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -168,6 +168,9 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
                     guard shouldPrepare else {
                         throw Self.cancelledPreparationError()
                     }
+                    // recorderQueue serializes this prepare against cancelChildRecorder().
+                    // If cancellation arrives after this check, cancel() waits behind
+                    // the prepare and the post-check below tears the child graph down.
                     didTouchChildRecorder = true
                     self.recorder.preferredInputDeviceID = preferredInputDeviceID
                     try self.recorder.prepare()
@@ -277,7 +280,9 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         lifecycleGeneration &+= 1
         lock.unlock()
         return recorderQueue.sync {
-            recorder.stop()
+            let url = recorder.stop()
+            recorder.cancel()
+            return url
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -27,12 +27,25 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
     private let recorder = StreamingMicRecorder(directoryName: "muesli-native-dictation")
     private let lock = NSRecursiveLock()
+    private let prepareQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-prepare")
     private let callbackQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-callbacks")
     private var noAudioTimeoutWorkItem: DispatchWorkItem?
     private var activeRecordingID: UUID?
+    private var explicitPreparation: ExplicitPreparation?
     private var hasReceivedFirstAudioBuffer = false
     private var hasDetectedSpeech = false
     private var hasReportedNoAudioTimeout = false
+
+    private final class ExplicitPreparation {
+        let inputDeviceID: AudioObjectID?
+        let group = DispatchGroup()
+        var result: Result<Void, Error>?
+
+        init(inputDeviceID: AudioObjectID?) {
+            self.inputDeviceID = inputDeviceID
+            group.enter()
+        }
+    }
 
     init() {
         recorder.onLatencyEvent = { [weak self] event, date in
@@ -49,6 +62,49 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         defer { lock.unlock() }
 
         try recorder.prepare()
+    }
+
+    func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
+        lock.lock()
+        if let explicitPreparation,
+           explicitPreparation.inputDeviceID == preferredInputDeviceID {
+            lock.unlock()
+            onLatencyEvent?("app_scoped_explicit_prepare_reused", Date())
+            return
+        }
+        guard activeRecordingID == nil else {
+            lock.unlock()
+            return
+        }
+
+        recorder.preferredInputDeviceID = preferredInputDeviceID
+        let preparation = ExplicitPreparation(inputDeviceID: preferredInputDeviceID)
+        explicitPreparation = preparation
+        lock.unlock()
+
+        onLatencyEvent?("app_scoped_explicit_prepare_begin", Date())
+        prepareQueue.async { [weak self, preparation] in
+            guard let self else {
+                preparation.result = .success(())
+                preparation.group.leave()
+                return
+            }
+
+            let result = Result { try self.recorder.prepare() }
+            self.lock.lock()
+            if self.explicitPreparation === preparation {
+                preparation.result = result
+            }
+            self.lock.unlock()
+
+            switch result {
+            case .success:
+                self.onLatencyEvent?("app_scoped_explicit_prepare_end", Date())
+            case .failure:
+                self.onLatencyEvent?("app_scoped_explicit_prepare_failed", Date())
+            }
+            preparation.group.leave()
+        }
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
@@ -80,22 +136,43 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     @discardableResult
     func start() throws -> UUID {
         lock.lock()
-        defer { lock.unlock() }
-
-        if let activeRecordingID { return activeRecordingID }
+        if let activeRecordingID {
+            lock.unlock()
+            return activeRecordingID
+        }
 
         resetCaptureStateLocked()
         configureRecorderCallbacksLocked()
         let recordingID = UUID()
         activeRecordingID = recordingID
+        let preparation = explicitPreparation
+        lock.unlock()
+        do {
+            try awaitExplicitPreparationIfNeeded(preparation)
+        } catch {
+            lock.lock()
+            activeRecordingID = nil
+            lock.unlock()
+            recorder.cancel()
+            throw error
+        }
+        lock.lock()
+        guard activeRecordingID == recordingID else {
+            lock.unlock()
+            throw NSError(domain: "AppScopedDictationRecorder", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Dictation recording was cancelled before microphone startup finished",
+            ])
+        }
         do {
             try recorder.start()
         } catch {
             activeRecordingID = nil
+            lock.unlock()
             recorder.cancel()
             throw error
         }
         scheduleNoAudioTimeoutLocked()
+        lock.unlock()
         return recordingID
     }
 
@@ -114,6 +191,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
         cancelTimersLocked()
         activeRecordingID = nil
+        explicitPreparation = nil
         recorder.cancel()
     }
 
@@ -134,6 +212,21 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         hasReceivedFirstAudioBuffer = false
         hasDetectedSpeech = false
         hasReportedNoAudioTimeout = false
+    }
+
+    private func awaitExplicitPreparationIfNeeded(_ preparation: ExplicitPreparation?) throws {
+        guard let preparation else { return }
+        onLatencyEvent?("app_scoped_explicit_prepare_wait_begin", Date())
+        preparation.group.wait()
+        onLatencyEvent?("app_scoped_explicit_prepare_wait_end", Date())
+        switch preparation.result {
+        case .success?:
+            return
+        case .failure(let error)?:
+            throw error
+        case nil:
+            return
+        }
     }
 
     private func handleAudioBuffer(_ samples: [Float]) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -260,6 +260,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
         cancelTimersLocked()
         activeRecordingID = nil
+        explicitPreparation = nil
         return recorder.stop()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -4,10 +4,14 @@ import Foundation
 final class AppScopedDictationRecorder: DictationAudioRecording {
     var preferredInputDeviceID: AudioObjectID? {
         get {
-            return recorder.preferredInputDeviceID
+            recorderQueue.sync {
+                recorder.preferredInputDeviceID
+            }
         }
         set {
-            recorder.preferredInputDeviceID = newValue
+            recorderQueue.sync {
+                recorder.preferredInputDeviceID = newValue
+            }
         }
     }
 
@@ -24,6 +28,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     private let recorder: StreamingDictationRecording
     private let lock = NSRecursiveLock()
     private let prepareQueue: DispatchQueue
+    private let recorderQueue: DispatchQueue
     private let callbackQueue: DispatchQueue
     private var noAudioTimeoutWorkItem: DispatchWorkItem?
     private var activeRecordingID: UUID?
@@ -90,10 +95,12 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
             fallback: StreamingMicRecorder(directoryName: "muesli-native-dictation")
         ),
         prepareQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-prepare"),
+        recorderQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-child"),
         callbackQueue: DispatchQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-callbacks")
     ) {
         self.recorder = recorder
         self.prepareQueue = prepareQueue
+        self.recorderQueue = recorderQueue
         self.callbackQueue = callbackQueue
 
         (recorder as? StreamingDictationLatencyReporting)?.onLatencyEvent = { [weak self] event, date in
@@ -106,7 +113,9 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     }
 
     func prepare() throws {
-        try recorder.prepare()
+        try recorderQueue.sync {
+            try recorder.prepare()
+        }
     }
 
     func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
@@ -129,7 +138,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         guard activeRecordingID == nil else {
             lock.unlock()
             if shouldCancelRecorder {
-                recorder.cancel()
+                cancelChildRecorder()
             }
             return
         }
@@ -141,9 +150,8 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         lock.unlock()
 
         if shouldCancelRecorder {
-            recorder.cancel()
+            cancelChildRecorder()
         }
-        recorder.preferredInputDeviceID = preferredInputDeviceID
         onLatencyEvent?("app_scoped_explicit_prepare_begin", Date())
         prepareQueue.async { [weak self, preparation] in
             guard let self else {
@@ -151,16 +159,20 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
                 return
             }
 
-            self.lock.lock()
-            let shouldPrepare = self.isCurrentPreparationLocked(preparation)
-            self.lock.unlock()
-            guard shouldPrepare else {
-                preparation.complete(.failure(Self.cancelledPreparationError()))
-                self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
-                return
+            var didTouchChildRecorder = false
+            let result = Result {
+                try self.recorderQueue.sync {
+                    self.lock.lock()
+                    let shouldPrepare = self.isCurrentPreparationLocked(preparation)
+                    self.lock.unlock()
+                    guard shouldPrepare else {
+                        throw Self.cancelledPreparationError()
+                    }
+                    didTouchChildRecorder = true
+                    self.recorder.preferredInputDeviceID = preferredInputDeviceID
+                    try self.recorder.prepare()
+                }
             }
-
-            let result = Result { try self.recorder.prepare() }
             var shouldTearDown = false
             var didCompleteCurrentPreparation = false
             self.lock.lock()
@@ -176,14 +188,14 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
                 }
             } else {
                 _ = preparation.complete(.failure(Self.cancelledPreparationError()))
-                if self.activeRecordingID == nil {
+                if self.activeRecordingID == nil && didTouchChildRecorder {
                     shouldTearDown = true
                 }
             }
             self.lock.unlock()
 
             if shouldTearDown {
-                self.recorder.cancel()
+                self.cancelChildRecorder()
             }
             switch result {
             case .success:
@@ -195,14 +207,18 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
-        recorder.preferredInputDeviceID = preferredInputDeviceID
-        try recorder.prepare()
+        try recorderQueue.sync {
+            recorder.preferredInputDeviceID = preferredInputDeviceID
+            try recorder.prepare()
+        }
         fputs("[dictation-engine-recorder] warmed preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
     }
 
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
-        recorder.preferredInputDeviceID = preferredInputDeviceID
-        try recorder.prepare()
+        try recorderQueue.sync {
+            recorder.preferredInputDeviceID = preferredInputDeviceID
+            try recorder.prepare()
+        }
         fputs("[dictation-engine-recorder] activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
     }
 
@@ -216,7 +232,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         explicitPreparation = nil
         lifecycleGeneration &+= 1
         lock.unlock()
-        recorder.cancel()
+        cancelChildRecorder()
     }
 
     @discardableResult
@@ -231,45 +247,25 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         configureRecorderCallbacksLocked()
         let recordingID = UUID()
         activeRecordingID = recordingID
+        let startGeneration = lifecycleGeneration
         let preparation = explicitPreparation
         lock.unlock()
         do {
             try awaitExplicitPreparationIfNeeded(preparation)
         } catch {
             if clearActiveRecordingIfCurrent(recordingID) {
-                recorder.cancel()
+                cancelChildRecorder()
             }
             throw error
         }
-        lock.lock()
-        guard activeRecordingID == recordingID else {
-            lock.unlock()
-            throw NSError(domain: "AppScopedDictationRecorder", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Dictation recording was cancelled before microphone startup finished",
-            ])
-        }
-        lock.unlock()
         do {
-            try recorder.start()
+            try startChildRecorderIfCurrent(recordingID: recordingID, generation: startGeneration)
         } catch {
             if clearActiveRecordingIfCurrent(recordingID) {
-                recorder.cancel()
+                cancelChildRecorder()
             }
             throw error
         }
-        lock.lock()
-        guard activeRecordingID == recordingID else {
-            let shouldCancel = activeRecordingID == nil
-            lock.unlock()
-            if shouldCancel {
-                recorder.cancel()
-            }
-            throw NSError(domain: "AppScopedDictationRecorder", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Dictation recording was cancelled before microphone startup finished",
-            ])
-        }
-        scheduleNoAudioTimeoutLocked()
-        lock.unlock()
         return recordingID
     }
 
@@ -280,7 +276,9 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         explicitPreparation = nil
         lifecycleGeneration &+= 1
         lock.unlock()
-        return recorder.stop()
+        return recorderQueue.sync {
+            recorder.stop()
+        }
     }
 
     func cancel() {
@@ -291,7 +289,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         explicitPreparation = nil
         lifecycleGeneration &+= 1
         lock.unlock()
-        recorder.cancel()
+        cancelChildRecorder()
     }
 
     func currentPower() -> Float {
@@ -327,6 +325,44 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
             return true
         }
         return activeRecordingID == nil
+    }
+
+    private func cancelChildRecorder() {
+        recorderQueue.sync {
+            recorder.cancel()
+        }
+    }
+
+    private func startChildRecorderIfCurrent(recordingID: UUID, generation: UInt64) throws {
+        try recorderQueue.sync {
+            lock.lock()
+            let shouldStart = activeRecordingID == recordingID && lifecycleGeneration == generation
+            lock.unlock()
+            guard shouldStart else {
+                throw Self.cancelledStartupError()
+            }
+
+            do {
+                try recorder.start()
+            } catch {
+                if clearActiveRecordingIfCurrent(recordingID) {
+                    recorder.cancel()
+                }
+                throw error
+            }
+
+            lock.lock()
+            guard activeRecordingID == recordingID && lifecycleGeneration == generation else {
+                let shouldCancel = activeRecordingID == nil
+                lock.unlock()
+                if shouldCancel {
+                    recorder.cancel()
+                }
+                throw Self.cancelledStartupError()
+            }
+            scheduleNoAudioTimeoutLocked()
+            lock.unlock()
+        }
     }
 
     private func awaitExplicitPreparationIfNeeded(_ preparation: ExplicitPreparation?) throws {
@@ -388,6 +424,12 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
     private static func cancelledPreparationError() -> NSError {
         NSError(domain: "AppScopedDictationRecorder", code: 2, userInfo: [
             NSLocalizedDescriptionKey: "Dictation microphone preparation was cancelled",
+        ])
+    }
+
+    private static func cancelledStartupError() -> NSError {
+        NSError(domain: "AppScopedDictationRecorder", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Dictation recording was cancelled before microphone startup finished",
         ])
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -329,7 +329,7 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
             activeRecordingID = nil
             return true
         }
-        return activeRecordingID == nil
+        return false
     }
 
     private func cancelChildRecorder() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -147,24 +147,17 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
 
             self.lock.lock()
             let shouldPrepare = self.explicitPreparation === preparation && !preparation.isCancelled
-            self.lock.unlock()
             guard shouldPrepare else {
-                preparation.complete(.failure(Self.cancelledPreparationError()))
-                self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
-                return
-            }
-            self.lock.lock()
-            let isStillCurrent = self.explicitPreparation === preparation && !preparation.isCancelled
-            self.lock.unlock()
-            guard isStillCurrent else {
+                self.lock.unlock()
                 preparation.complete(.failure(Self.cancelledPreparationError()))
                 self.onLatencyEvent?("app_scoped_explicit_prepare_cancelled", Date())
                 return
             }
 
+            // Keep cancellation and prepare serialized: once cancel/coolDown returns,
+            // a previously queued warmup cannot start opening mic resources.
             let result = Result { try self.recorder.prepare() }
             var shouldTearDown = false
-            self.lock.lock()
             if self.explicitPreparation === preparation && !preparation.isCancelled {
                 _ = preparation.complete(result)
                 if case .failure = result {
@@ -176,11 +169,11 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
             } else if self.activeRecordingID == nil {
                 shouldTearDown = true
             }
-            self.lock.unlock()
 
             if shouldTearDown {
                 self.recorder.cancel()
             }
+            self.lock.unlock()
             switch result {
             case .success:
                 self.onLatencyEvent?("app_scoped_explicit_prepare_end", Date())

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -1,0 +1,198 @@
+import CoreAudio
+import Foundation
+
+final class AppScopedDictationRecorder: DictationAudioRecording {
+    var preferredInputDeviceID: AudioObjectID? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return recorder.preferredInputDeviceID
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            recorder.preferredInputDeviceID = newValue
+        }
+    }
+
+    var keepsAudioGraphWarm = false
+    var onFirstCapturedAudioBuffer: ((Date) -> Void)?
+    var onFirstSpeechDetected: ((Date) -> Void)?
+    var onNoAudioTimeout: ((Date) -> Void)?
+    var onRecordingFailed: ((Error, UUID) -> Void)?
+
+    private static let speechThresholdDB: Float = -58
+    private static let noAudioTimeout: TimeInterval = 1.5
+
+    private let recorder = StreamingMicRecorder(directoryName: "muesli-native-dictation")
+    private let lock = NSRecursiveLock()
+    private let callbackQueue = DispatchQueue(label: "com.muesli.app-scoped-dictation-recorder-callbacks")
+    private var noAudioTimeoutWorkItem: DispatchWorkItem?
+    private var activeRecordingID: UUID?
+    private var hasReceivedFirstAudioBuffer = false
+    private var hasDetectedSpeech = false
+    private var hasReportedNoAudioTimeout = false
+
+    deinit {
+        cancel()
+    }
+
+    func prepare() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        try recorder.prepare()
+    }
+
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        recorder.preferredInputDeviceID = preferredInputDeviceID
+        try recorder.prepare()
+        fputs("[dictation-engine-recorder] warmed preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
+    }
+
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        recorder.preferredInputDeviceID = preferredInputDeviceID
+        try recorder.prepare()
+        fputs("[dictation-engine-recorder] activated preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")\n", stderr)
+    }
+
+    func coolDown() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard activeRecordingID == nil else { return }
+        recorder.cancel()
+    }
+
+    @discardableResult
+    func start() throws -> UUID {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let activeRecordingID { return activeRecordingID }
+
+        resetCaptureStateLocked()
+        configureRecorderCallbacksLocked()
+        let recordingID = UUID()
+        activeRecordingID = recordingID
+        do {
+            try recorder.start()
+        } catch {
+            activeRecordingID = nil
+            recorder.cancel()
+            throw error
+        }
+        scheduleNoAudioTimeoutLocked()
+        return recordingID
+    }
+
+    func stop() -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        cancelTimersLocked()
+        activeRecordingID = nil
+        return recorder.stop()
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        cancelTimersLocked()
+        activeRecordingID = nil
+        recorder.cancel()
+    }
+
+    func currentPower() -> Float {
+        recorder.currentPower()
+    }
+
+    private func configureRecorderCallbacksLocked() {
+        recorder.onAudioBuffer = { [weak self] samples in
+            self?.handleAudioBuffer(samples)
+        }
+        recorder.onRecordingFailed = { [weak self] error in
+            self?.handleRecordingFailed(error)
+        }
+    }
+
+    private func resetCaptureStateLocked() {
+        hasReceivedFirstAudioBuffer = false
+        hasDetectedSpeech = false
+        hasReportedNoAudioTimeout = false
+    }
+
+    private func handleAudioBuffer(_ samples: [Float]) {
+        lock.lock()
+        let firstBuffer = !hasReceivedFirstAudioBuffer && !samples.isEmpty
+        if firstBuffer {
+            hasReceivedFirstAudioBuffer = true
+        }
+        let power = Self.powerDB(samples)
+        let firstSpeech = !hasDetectedSpeech && power >= Self.speechThresholdDB
+        if firstSpeech {
+            hasDetectedSpeech = true
+        }
+        lock.unlock()
+
+        if firstBuffer {
+            onFirstCapturedAudioBuffer?(Date())
+        }
+        if firstSpeech {
+            onFirstSpeechDetected?(Date())
+        }
+    }
+
+    private func handleRecordingFailed(_ error: Error) {
+        lock.lock()
+        guard let activeRecordingID else {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+        onRecordingFailed?(error, activeRecordingID)
+    }
+
+    private func scheduleNoAudioTimeoutLocked() {
+        noAudioTimeoutWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.notifyNoAudioTimeoutIfNeeded()
+        }
+        noAudioTimeoutWorkItem = workItem
+        callbackQueue.asyncAfter(deadline: .now() + Self.noAudioTimeout, execute: workItem)
+    }
+
+    private func notifyNoAudioTimeoutIfNeeded() {
+        lock.lock()
+        guard activeRecordingID != nil, !hasDetectedSpeech, !hasReportedNoAudioTimeout else {
+            lock.unlock()
+            return
+        }
+        hasReportedNoAudioTimeout = true
+        lock.unlock()
+        onNoAudioTimeout?(Date())
+    }
+
+    private func cancelTimersLocked() {
+        noAudioTimeoutWorkItem?.cancel()
+        noAudioTimeoutWorkItem = nil
+    }
+
+    private static func powerDB(_ samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return -160 }
+        var sumSquares: Float = 0
+        for sample in samples {
+            sumSquares += sample * sample
+        }
+        let rms = sqrt(sumSquares / Float(samples.count))
+        let rawDB = rms > 0.000_001 ? 20 * log10(rms) : -160
+        return max(-160, min(0, rawDB))
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -1,0 +1,394 @@
+import AudioToolbox
+import CoreAudio
+import Foundation
+import os
+
+final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
+
+    private static let sampleRate: Double = 16_000
+    private static let framesPerBuffer: UInt32 = 4096
+    private static let bufferCount = 3
+
+    private let directoryName: String
+    private let queueLock = NSRecursiveLock()
+    private let stateLock = OSAllocatedUnfairLock(initialState: FileState())
+    private let processingQueue = DispatchQueue(label: "com.muesli.audio-queue-input-recorder-processing")
+    private let failureCallbackQueue = DispatchQueue(label: "com.muesli.audio-queue-input-recorder-failures")
+
+    private var audioQueue: AudioQueueRef?
+    private var buffers: [AudioQueueBufferRef] = []
+    private var preparedInputDeviceID: AudioObjectID?
+    private var isPrepared = false
+    private var isRunning = false
+    private var captureGeneration: UInt64 = 0
+
+    private struct FileState {
+        var fileHandle: FileHandle?
+        var fileURL: URL?
+        var bytesWritten = 0
+        var latestPowerDB: Float = -160
+    }
+
+    init(directoryName: String = "muesli-native-dictation") {
+        self.directoryName = directoryName
+    }
+
+    deinit {
+        cancel()
+    }
+
+    func prepare() throws {
+        queueLock.lock()
+        defer { queueLock.unlock() }
+
+        try prepareLocked()
+    }
+
+    func start() throws {
+        queueLock.lock()
+        defer { queueLock.unlock() }
+
+        guard !isRunning else { return }
+        try prepareLocked()
+
+        guard let audioQueue else {
+            throw Self.runtimeError(code: 1, message: "Audio queue was not initialized")
+        }
+
+        stateLock.withLock { $0 = FileState() }
+        let fileState = try createNewFile()
+        stateLock.withLock { $0 = fileState }
+
+        for buffer in buffers {
+            let status = AudioQueueEnqueueBuffer(audioQueue, buffer, 0, nil)
+            guard status == noErr else {
+                cleanupAfterStartFailure()
+                throw Self.runtimeError(code: 2, message: "AudioQueueEnqueueBuffer failed: \(status)")
+            }
+        }
+
+        captureGeneration &+= 1
+        isRunning = true
+        emitLatency("audio_queue_start_begin")
+        let status = AudioQueueStart(audioQueue, nil)
+        emitLatency("audio_queue_start_end")
+        guard status == noErr else {
+            isRunning = false
+            captureGeneration &+= 1
+            cleanupAfterStartFailure()
+            throw Self.runtimeError(code: 3, message: "AudioQueueStart failed: \(status)")
+        }
+    }
+
+    func stop() -> URL? {
+        queueLock.lock()
+        guard isRunning else {
+            queueLock.unlock()
+            return nil
+        }
+        isRunning = false
+        let generationToFinish = captureGeneration
+        let queueToStop = audioQueue
+        queueLock.unlock()
+
+        if let queueToStop {
+            emitLatency("audio_queue_stop_begin")
+            AudioQueueStop(queueToStop, true)
+            emitLatency("audio_queue_stop_end")
+        }
+
+        emitLatency("audio_queue_processing_drain_begin")
+        processingQueue.sync {}
+        emitLatency("audio_queue_processing_drain_end")
+
+        queueLock.lock()
+        if captureGeneration == generationToFinish {
+            captureGeneration &+= 1
+        }
+        queueLock.unlock()
+
+        emitLatency("audio_queue_finalize_begin")
+        let finalState = stateLock.withLock { state -> FileState in
+            let old = state
+            state = FileState()
+            return old
+        }
+        let url = finalizeFile(finalState)
+        emitLatency("audio_queue_finalize_end")
+        return url
+    }
+
+    func cancel() {
+        queueLock.lock()
+        isRunning = false
+        captureGeneration &+= 1
+        let queueToDispose = audioQueue
+        audioQueue = nil
+        buffers.removeAll()
+        preparedInputDeviceID = nil
+        isPrepared = false
+        queueLock.unlock()
+
+        if let queueToDispose {
+            emitLatency("audio_queue_cancel_stop_begin")
+            AudioQueueStop(queueToDispose, true)
+            emitLatency("audio_queue_cancel_stop_end")
+            AudioQueueDispose(queueToDispose, true)
+        }
+
+        processingQueue.sync {}
+
+        let state = stateLock.withLock { state -> FileState in
+            let old = state
+            state = FileState()
+            return old
+        }
+        if let url = state.fileURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    func currentPower() -> Float {
+        stateLock.withLock { $0.latestPowerDB }
+    }
+
+    private func prepareLocked() throws {
+        if isPrepared, preparedInputDeviceID == preferredInputDeviceID {
+            emitLatency("audio_queue_prepare_reused")
+            return
+        }
+
+        disposeQueueLocked()
+        emitLatency("audio_queue_prepare_begin")
+
+        var format = AudioStreamBasicDescription(
+            mSampleRate: Self.sampleRate,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 4,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 4,
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+
+        var queue: AudioQueueRef?
+        emitLatency("audio_queue_new_input_begin")
+        let newInputStatus = AudioQueueNewInput(
+            &format,
+            Self.inputCallback,
+            Unmanaged.passUnretained(self).toOpaque(),
+            nil,
+            nil,
+            0,
+            &queue
+        )
+        emitLatency("audio_queue_new_input_end")
+        guard newInputStatus == noErr, let queue else {
+            throw Self.runtimeError(code: 4, message: "AudioQueueNewInput failed: \(newInputStatus)")
+        }
+        audioQueue = queue
+
+        if let preferredInputDeviceID {
+            try applyPreferredInputDeviceID(preferredInputDeviceID, to: queue)
+        } else {
+            emitLatency("audio_queue_preferred_input_default_route")
+        }
+
+        let bytesPerBuffer = Self.framesPerBuffer * format.mBytesPerFrame
+        emitLatency("audio_queue_allocate_buffers_begin")
+        for _ in 0..<Self.bufferCount {
+            var buffer: AudioQueueBufferRef?
+            let status = AudioQueueAllocateBuffer(queue, bytesPerBuffer, &buffer)
+            guard status == noErr, let buffer else {
+                disposeQueueLocked()
+                throw Self.runtimeError(code: 5, message: "AudioQueueAllocateBuffer failed: \(status)")
+            }
+            buffers.append(buffer)
+        }
+        emitLatency("audio_queue_allocate_buffers_end")
+
+        preparedInputDeviceID = preferredInputDeviceID
+        isPrepared = true
+        emitLatency("audio_queue_prepare_end")
+    }
+
+    private func applyPreferredInputDeviceID(_ deviceID: AudioObjectID, to queue: AudioQueueRef) throws {
+        emitLatency("audio_queue_device_uid_lookup_begin")
+        guard var deviceUID = Self.deviceUID(for: deviceID) as CFString? else {
+            throw Self.runtimeError(code: 6, message: "Could not resolve device UID for \(deviceID)")
+        }
+        emitLatency("audio_queue_device_uid_lookup_end")
+
+        emitLatency("audio_queue_set_current_device_begin")
+        let status = withUnsafePointer(to: &deviceUID) { pointer in
+            AudioQueueSetProperty(
+                queue,
+                kAudioQueueProperty_CurrentDevice,
+                pointer,
+                UInt32(MemoryLayout<CFString>.size)
+            )
+        }
+        emitLatency("audio_queue_set_current_device_end")
+        guard status == noErr else {
+            throw Self.runtimeError(code: 7, message: "AudioQueueSetProperty current device failed: \(status)")
+        }
+    }
+
+    private static let inputCallback: AudioQueueInputCallback = { userData, queue, buffer, _, _, _ in
+        guard let userData else { return }
+        let recorder = Unmanaged<AudioQueueInputRecorder>.fromOpaque(userData).takeUnretainedValue()
+        recorder.handleInputBuffer(queue: queue, buffer: buffer)
+    }
+
+    private func handleInputBuffer(queue: AudioQueueRef, buffer: AudioQueueBufferRef) {
+        queueLock.lock()
+        let shouldProcess = isRunning
+        let generation = captureGeneration
+        queueLock.unlock()
+        guard shouldProcess else { return }
+
+        let byteCount = Int(buffer.pointee.mAudioDataByteSize)
+        guard byteCount > 0 else {
+            AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+            return
+        }
+
+        let audioData = Data(bytes: buffer.pointee.mAudioData, count: byteCount)
+        let enqueueStatus = AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+        if enqueueStatus != noErr {
+            reportFailure(Self.runtimeError(code: 8, message: "AudioQueueEnqueueBuffer failed: \(enqueueStatus)"))
+            return
+        }
+
+        processingQueue.async { [weak self] in
+            self?.processAudioData(audioData, generation: generation)
+        }
+    }
+
+    private func processAudioData(_ data: Data, generation: UInt64) {
+        queueLock.lock()
+        let shouldProcess = captureGeneration == generation
+        queueLock.unlock()
+        guard shouldProcess else { return }
+
+        let sampleCount = data.count / MemoryLayout<Float>.size
+        guard sampleCount > 0 else { return }
+
+        let samples = data.withUnsafeBytes { rawBuffer -> [Float] in
+            var decoded = [Float]()
+            decoded.reserveCapacity(sampleCount)
+            for offset in stride(from: 0, to: sampleCount * MemoryLayout<Float>.size, by: MemoryLayout<Float>.size) {
+                decoded.append(rawBuffer.loadUnaligned(fromByteOffset: offset, as: Float.self))
+            }
+            return decoded
+        }
+        guard !samples.isEmpty else { return }
+
+        var int16Samples = [Int16](repeating: 0, count: sampleCount)
+        var sumSquares: Float = 0
+        for index in samples.indices {
+            let sample = samples[index]
+            let clamped = max(-1.0, min(1.0, sample))
+            int16Samples[index] = Int16(clamped * 32767)
+            sumSquares += sample * sample
+        }
+        let rms = sqrt(sumSquares / Float(sampleCount))
+        let rawDB = rms > 0.000_001 ? 20 * log10(rms) : -160
+        let powerDB = max(-160, min(0, rawDB))
+        let pcmData = int16Samples.withUnsafeBufferPointer { Data(buffer: $0) }
+
+        stateLock.withLock { state in
+            state.fileHandle?.write(pcmData)
+            state.bytesWritten += pcmData.count
+            state.latestPowerDB = powerDB
+        }
+        onAudioBuffer?(samples)
+    }
+
+    private func cleanupAfterStartFailure() {
+        disposeQueueLocked()
+        let state = stateLock.withLock { state -> FileState in
+            let old = state
+            state = FileState()
+            return old
+        }
+        if let url = state.fileURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private func disposeQueueLocked() {
+        if let audioQueue {
+            captureGeneration &+= 1
+            AudioQueueStop(audioQueue, true)
+            AudioQueueDispose(audioQueue, true)
+        }
+        audioQueue = nil
+        buffers.removeAll()
+        preparedInputDeviceID = nil
+        isPrepared = false
+    }
+
+    private func reportFailure(_ error: Error) {
+        failureCallbackQueue.async { [onRecordingFailed] in
+            onRecordingFailed?(error)
+        }
+    }
+
+    private func emitLatency(_ event: String, at date: Date = Date()) {
+        onLatencyEvent?(event, date)
+    }
+
+    private static func runtimeError(code: Int, message: String) -> NSError {
+        NSError(domain: "AudioQueueInputRecorder", code: code, userInfo: [
+            NSLocalizedDescriptionKey: message,
+        ])
+    }
+
+    private static func deviceUID(for deviceID: AudioObjectID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var uid: Unmanaged<CFString>?
+        var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &dataSize, &uid) == noErr,
+              let uid else {
+            return nil
+        }
+        return uid.takeRetainedValue() as String
+    }
+
+    private func createNewFile() throws -> FileState {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        guard let handle = FileHandle(forWritingAtPath: url.path) else {
+            throw Self.runtimeError(code: 9, message: "Could not open file for writing")
+        }
+        handle.write(WavWriter.header(dataSize: 0))
+        return FileState(fileHandle: handle, fileURL: url, bytesWritten: 0)
+    }
+
+    private func finalizeFile(_ state: FileState) -> URL? {
+        guard let handle = state.fileHandle, let url = state.fileURL else { return nil }
+        handle.seek(toFileOffset: 0)
+        handle.write(WavWriter.header(dataSize: UInt32(state.bytesWritten)))
+        handle.closeFile()
+
+        if state.bytesWritten == 0 {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        return url
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -20,6 +20,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     private let failureCallbackQueue = DispatchQueue(label: "com.muesli.audio-queue-input-recorder-failures")
 
     private var audioQueue: AudioQueueRef?
+    private var queueCallbackUserData: UnsafeMutableRawPointer?
     private var buffers: [AudioQueueBufferRef] = []
     private var preparedInputDeviceID: AudioObjectID?
     private var isPrepared = false
@@ -127,7 +128,9 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         isRunning = false
         captureGeneration &+= 1
         let queueToDispose = audioQueue
+        let callbackUserDataToRelease = queueCallbackUserData
         audioQueue = nil
+        queueCallbackUserData = nil
         buffers.removeAll()
         preparedInputDeviceID = nil
         isPrepared = false
@@ -139,6 +142,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
             emitLatency("audio_queue_cancel_stop_end")
             AudioQueueDispose(queueToDispose, true)
         }
+        Self.releaseCallbackUserData(callbackUserDataToRelease)
 
         processingQueue.sync {}
 
@@ -178,11 +182,12 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         )
 
         var queue: AudioQueueRef?
+        let callbackUserData = Unmanaged.passRetained(self).toOpaque()
         emitLatency("audio_queue_new_input_begin")
         let newInputStatus = AudioQueueNewInput(
             &format,
             Self.inputCallback,
-            Unmanaged.passUnretained(self).toOpaque(),
+            callbackUserData,
             nil,
             nil,
             0,
@@ -190,28 +195,34 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         )
         emitLatency("audio_queue_new_input_end")
         guard newInputStatus == noErr, let queue else {
+            Self.releaseCallbackUserData(callbackUserData)
             throw Self.runtimeError(code: 4, message: "AudioQueueNewInput failed: \(newInputStatus)")
         }
         audioQueue = queue
+        queueCallbackUserData = callbackUserData
 
-        if let preferredInputDeviceID {
-            try applyPreferredInputDeviceID(preferredInputDeviceID, to: queue)
-        } else {
-            emitLatency("audio_queue_preferred_input_default_route")
-        }
-
-        let bytesPerBuffer = Self.framesPerBuffer * format.mBytesPerFrame
-        emitLatency("audio_queue_allocate_buffers_begin")
-        for _ in 0..<Self.bufferCount {
-            var buffer: AudioQueueBufferRef?
-            let status = AudioQueueAllocateBuffer(queue, bytesPerBuffer, &buffer)
-            guard status == noErr, let buffer else {
-                disposeQueueLocked()
-                throw Self.runtimeError(code: 5, message: "AudioQueueAllocateBuffer failed: \(status)")
+        do {
+            if let preferredInputDeviceID {
+                try applyPreferredInputDeviceID(preferredInputDeviceID, to: queue)
+            } else {
+                emitLatency("audio_queue_preferred_input_default_route")
             }
-            buffers.append(buffer)
+
+            let bytesPerBuffer = Self.framesPerBuffer * format.mBytesPerFrame
+            emitLatency("audio_queue_allocate_buffers_begin")
+            for _ in 0..<Self.bufferCount {
+                var buffer: AudioQueueBufferRef?
+                let status = AudioQueueAllocateBuffer(queue, bytesPerBuffer, &buffer)
+                guard status == noErr, let buffer else {
+                    throw Self.runtimeError(code: 5, message: "AudioQueueAllocateBuffer failed: \(status)")
+                }
+                buffers.append(buffer)
+            }
+            emitLatency("audio_queue_allocate_buffers_end")
+        } catch {
+            disposeQueueLocked()
+            throw error
         }
-        emitLatency("audio_queue_allocate_buffers_end")
 
         preparedInputDeviceID = preferredInputDeviceID
         isPrepared = true
@@ -324,15 +335,18 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     }
 
     private func disposeQueueLocked() {
+        let callbackUserDataToRelease = queueCallbackUserData
         if let audioQueue {
             captureGeneration &+= 1
             AudioQueueStop(audioQueue, true)
             AudioQueueDispose(audioQueue, true)
         }
         audioQueue = nil
+        queueCallbackUserData = nil
         buffers.removeAll()
         preparedInputDeviceID = nil
         isPrepared = false
+        Self.releaseCallbackUserData(callbackUserDataToRelease)
     }
 
     private func reportFailure(_ error: Error) {
@@ -349,6 +363,11 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         NSError(domain: "AudioQueueInputRecorder", code: code, userInfo: [
             NSLocalizedDescriptionKey: message,
         ])
+    }
+
+    private static func releaseCallbackUserData(_ userData: UnsafeMutableRawPointer?) {
+        guard let userData else { return }
+        Unmanaged<AudioQueueInputRecorder>.fromOpaque(userData).release()
     }
 
     private static func deviceUID(for deviceID: AudioObjectID) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -119,6 +119,7 @@ protocol DictationAudioRouting: AnyObject {
     func isDefaultOutputHeadphoneLike() -> Bool
     func currentOutputRouteKindForDebug() -> AudioOutputRouteKind
     func currentRouteDebugDescription() -> String
+    func systemDefaultInputIsBuiltInForDictation() -> Bool
     func refreshRouteAfterDictationSession()
 }
 
@@ -127,7 +128,13 @@ final class DictationAudioRouteController: DictationAudioRouting {
         var outputRouteKind: AudioOutputRouteKind = .unknown
         var outputIsAmbiguousBluetooth: Bool = false
         var builtInInputDeviceID: AudioObjectID?
+        var defaultInputDeviceID: AudioObjectID?
         var selectedInputDeviceID: AudioObjectID?
+
+        var systemDefaultInputIsBuiltIn: Bool {
+            guard let defaultInputDeviceID, let builtInInputDeviceID else { return false }
+            return defaultInputDeviceID == builtInInputDeviceID
+        }
     }
 
     private let inspector: CoreAudioDeviceInspecting
@@ -173,6 +180,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
             outputRouteKind: initialOutputClassification?.kind ?? .unknown,
             outputIsAmbiguousBluetooth: initialOutputClassification?.isAmbiguousBluetooth ?? false,
             builtInInputDeviceID: inspector.builtInInputDeviceID(),
+            defaultInputDeviceID: inspector.defaultInputDeviceID(),
             selectedInputDeviceID: nil
         )
         if observesDefaultOutputChanges {
@@ -258,7 +266,11 @@ final class DictationAudioRouteController: DictationAudioRouting {
         let current = lock.withLock { snapshot }
         let preferredInput = Self.preferredInputDeviceID(for: current)
             .map(String.init) ?? "default"
-        return "output=\(current.outputRouteKind.description) preferredInput=\(preferredInput)"
+        return "output=\(current.outputRouteKind.description) preferredInput=\(preferredInput) defaultInputBuiltIn=\(current.systemDefaultInputIsBuiltIn)"
+    }
+
+    func systemDefaultInputIsBuiltInForDictation() -> Bool {
+        lock.withLock { snapshot.systemDefaultInputIsBuiltIn }
     }
 
     func refreshRouteAfterDictationSession() {
@@ -299,6 +311,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
             outputRouteKind: outputClassification.kind,
             outputIsAmbiguousBluetooth: outputClassification.isAmbiguousBluetooth,
             builtInInputDeviceID: inspector.builtInInputDeviceID(),
+            defaultInputDeviceID: inspector.defaultInputDeviceID(),
             selectedInputDeviceID: selectedInputDeviceUID.flatMap {
                 inspector.inputDeviceID(matchingUID: $0)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -45,6 +45,15 @@ struct AudioOutputDeviceDescription: Equatable {
     }
 }
 
+struct AudioInputDeviceInfo: Equatable, Identifiable {
+    let uid: String
+    let name: String
+    let deviceID: AudioObjectID
+    let isBuiltIn: Bool
+
+    var id: String { uid }
+}
+
 enum AudioRouteClassifier {
     struct Classification: Equatable {
         let kind: AudioOutputRouteKind
@@ -101,10 +110,12 @@ enum AudioRouteClassifier {
 
 protocol DictationAudioRouting: AnyObject {
     var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)? { get set }
+    var selectedInputDeviceUID: String? { get set }
 
     func refreshRouteCache()
     func preferredInputDeviceIDForDictation() -> AudioObjectID?
     func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID?
+    func availableInputDevices() -> [AudioInputDeviceInfo]
     func isDefaultOutputHeadphoneLike() -> Bool
     func currentOutputRouteKindForDebug() -> AudioOutputRouteKind
     func currentRouteDebugDescription() -> String
@@ -116,6 +127,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         var outputRouteKind: AudioOutputRouteKind = .unknown
         var outputIsAmbiguousBluetooth: Bool = false
         var builtInInputDeviceID: AudioObjectID?
+        var selectedInputDeviceID: AudioObjectID?
     }
 
     private let inspector: CoreAudioDeviceInspecting
@@ -123,9 +135,20 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private let queueKey = DispatchSpecificKey<Void>()
     private let lock = NSLock()
     private var snapshot = RouteSnapshot()
+    private var selectedInputDeviceUIDStorage: String?
     private var defaultOutputListener: AudioObjectPropertyListenerBlock?
     private var defaultInputListener: AudioObjectPropertyListenerBlock?
     private var onPreferredInputDeviceChangedStorage: ((AudioObjectID?) -> Void)?
+    var selectedInputDeviceUID: String? {
+        get {
+            lock.withLock { selectedInputDeviceUIDStorage }
+        }
+        set {
+            let normalized = newValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+            lock.withLock { selectedInputDeviceUIDStorage = normalized?.isEmpty == false ? normalized : nil }
+            refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+        }
+    }
     var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)? {
         get {
             lock.withLock { onPreferredInputDeviceChangedStorage }
@@ -149,7 +172,8 @@ final class DictationAudioRouteController: DictationAudioRouting {
         self.snapshot = RouteSnapshot(
             outputRouteKind: initialOutputClassification?.kind ?? .unknown,
             outputIsAmbiguousBluetooth: initialOutputClassification?.isAmbiguousBluetooth ?? false,
-            builtInInputDeviceID: inspector.builtInInputDeviceID()
+            builtInInputDeviceID: inspector.builtInInputDeviceID(),
+            selectedInputDeviceID: nil
         )
         if observesDefaultOutputChanges {
             installDefaultOutputListener()
@@ -214,6 +238,10 @@ final class DictationAudioRouteController: DictationAudioRouting {
         Self.preferredInputDeviceID(for: lock.withLock { snapshot })
     }
 
+    func availableInputDevices() -> [AudioInputDeviceInfo] {
+        inspector.availableInputDevices()
+    }
+
     func isDefaultOutputHeadphoneLike() -> Bool {
         // Unknown outputs are treated as non-speaker for lifecycle sounds so we
         // avoid playing cues into headphones during CoreAudio route transitions.
@@ -251,6 +279,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     private static func preferredInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
+        if let selectedInputDeviceID = snapshot.selectedInputDeviceID {
+            return selectedInputDeviceID
+        }
         switch snapshot.outputRouteKind {
         case .headphoneLike:
             return snapshot.builtInInputDeviceID
@@ -263,10 +294,14 @@ final class DictationAudioRouteController: DictationAudioRouting {
 
     private func makeRouteSnapshot() -> RouteSnapshot {
         let outputClassification = currentOutputRouteClassification()
+        let selectedInputDeviceUID = lock.withLock { selectedInputDeviceUIDStorage }
         return RouteSnapshot(
             outputRouteKind: outputClassification.kind,
             outputIsAmbiguousBluetooth: outputClassification.isAmbiguousBluetooth,
-            builtInInputDeviceID: inspector.builtInInputDeviceID()
+            builtInInputDeviceID: inspector.builtInInputDeviceID(),
+            selectedInputDeviceID: selectedInputDeviceUID.flatMap {
+                inspector.inputDeviceID(matchingUID: $0)
+            }
         )
     }
 
@@ -330,6 +365,8 @@ protocol CoreAudioDeviceInspecting {
     func defaultOutputDeviceID() -> AudioObjectID?
     func defaultInputDeviceID() -> AudioObjectID?
     func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool
+    func availableInputDevices() -> [AudioInputDeviceInfo]
+    func inputDeviceID(matchingUID uid: String) -> AudioObjectID?
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool
     func nominalSampleRate(for deviceID: AudioObjectID) -> Double?
     func outputRouteClassification(for deviceID: AudioObjectID) -> AudioRouteClassifier.Classification
@@ -361,6 +398,31 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
             dataSize,
             &mutableDeviceID
         ) == noErr
+    }
+
+    func availableInputDevices() -> [AudioInputDeviceInfo] {
+        allDeviceIDs()
+            .filter { hasStreams(deviceID: $0, scope: kAudioDevicePropertyScopeInput) }
+            .compactMap { deviceID in
+                guard let uid = deviceUID(for: deviceID) else { return nil }
+                let name = deviceName(for: deviceID) ?? "Microphone \(deviceID)"
+                return AudioInputDeviceInfo(
+                    uid: uid,
+                    name: name,
+                    deviceID: deviceID,
+                    isBuiltIn: transportType(for: deviceID) == kAudioDeviceTransportTypeBuiltIn
+                )
+            }
+            .sorted { lhs, rhs in
+                inputDeviceSortKey(lhs.deviceID) < inputDeviceSortKey(rhs.deviceID)
+            }
+    }
+
+    func inputDeviceID(matchingUID uid: String) -> AudioObjectID? {
+        allDeviceIDs().first { deviceID in
+            hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput)
+                && deviceUID(for: deviceID) == uid
+        }
     }
 
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {
@@ -491,6 +553,10 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
         return name.takeRetainedValue() as String
     }
 
+    private func deviceUID(for deviceID: AudioObjectID) -> String? {
+        stringProperty(kAudioDevicePropertyDeviceUID, objectID: deviceID)
+    }
+
     private func transportType(for deviceID: AudioObjectID) -> UInt32? {
         var transportType = UInt32(0)
         guard getUInt32(
@@ -503,6 +569,21 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
             return nil
         }
         return transportType
+    }
+
+    private func stringProperty(_ selector: AudioObjectPropertySelector, objectID: AudioObjectID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFString>?
+        var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        guard AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr,
+              let value else {
+            return nil
+        }
+        return value.takeRetainedValue() as String
     }
 
     private func hasStreams(deviceID: AudioObjectID, scope: AudioObjectPropertyScope) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -405,6 +405,7 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
             .filter { hasStreams(deviceID: $0, scope: kAudioDevicePropertyScopeInput) }
             .compactMap { deviceID in
                 guard let uid = deviceUID(for: deviceID) else { return nil }
+                guard !Self.isSystemDefaultAggregateDeviceUID(uid) else { return nil }
                 let name = deviceName(for: deviceID) ?? "Microphone \(deviceID)"
                 return AudioInputDeviceInfo(
                     uid: uid,
@@ -419,7 +420,8 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     func inputDeviceID(matchingUID uid: String) -> AudioObjectID? {
-        allDeviceIDs().first { deviceID in
+        guard !Self.isSystemDefaultAggregateDeviceUID(uid) else { return nil }
+        return allDeviceIDs().first { deviceID in
             hasStreams(deviceID: deviceID, scope: kAudioDevicePropertyScopeInput)
                 && deviceUID(for: deviceID) == uid
         }
@@ -555,6 +557,10 @@ final class CoreAudioDeviceInspector: CoreAudioDeviceInspecting {
 
     private func deviceUID(for deviceID: AudioObjectID) -> String? {
         stringProperty(kAudioDevicePropertyDeviceUID, objectID: deviceID)
+    }
+
+    private static func isSystemDefaultAggregateDeviceUID(_ uid: String) -> Bool {
+        uid.hasPrefix("CADefaultDeviceAggregate")
     }
 
     private func transportType(for deviceID: AudioObjectID) -> UInt32? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -330,6 +330,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
                 return
             }
             self.emitLatency("stop")
+            self.recorder.keepsAudioGraphWarm = false
             let wavURL = self.recorder.stop()
             self.activeRecorderRunID = nil
             self.recorder.preferredInputDeviceID = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -75,6 +75,7 @@ protocol DictationAudioRecording: AnyObject {
     var onFirstSpeechDetected: ((Date) -> Void)? { get set }
     var onNoAudioTimeout: ((Date) -> Void)? { get set }
     var onRecordingFailed: ((Error, UUID) -> Void)? { get set }
+    var onLatencyEvent: ((String, Date) -> Void)? { get set }
 
     func prepare() throws
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws
@@ -104,6 +105,10 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         let routeKind: AudioOutputRouteKind
         let preferredInputDeviceID: AudioObjectID?
         let debugDescription: String
+
+        var usesSpeakerDefaultRecorder: Bool {
+            routeKind == .speakerLike && preferredInputDeviceID == nil
+        }
 
         var shouldDuck: Bool {
             // Unknown routes are ducked to avoid speaker bleed during route
@@ -163,6 +168,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         recorder.onRecordingFailed = { [weak self] error, recorderRunID in
             self?.handleRecordingFailure(error: error, recorderRunID: recorderRunID)
         }
+        recorder.onLatencyEvent = { [weak self] event, date in
+            self?.emitLatency(event, at: date)
+        }
     }
 
     var currentState: DictationAudioSessionState {
@@ -196,8 +204,15 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.stateStorage = .armed(sessionID)
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
-            self.recorder.keepsAudioGraphWarm = true
             let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
+            self.recorder.preferredInputDeviceID = recorderInputDeviceID
+            guard self.routeSnapshot.usesSpeakerDefaultRecorder else {
+                self.recorder.keepsAudioGraphWarm = false
+                self.emitLatency("activation_skipped:\(source):app_scoped_route")
+                fputs("[dictation-session] armed source=\(source) skipped activation \(self.routeSnapshot.debugDescription)\n", stderr)
+                return
+            }
+            self.recorder.keepsAudioGraphWarm = true
             do {
                 self.emitLatency("activation_begin:\(source)")
                 try self.recorder.activateWarmEngine(preferredInputDeviceID: recorderInputDeviceID)
@@ -243,10 +258,14 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.duckingController.ensureCurrentDefaultDucked()
             let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
             self.recorder.preferredInputDeviceID = recorderInputDeviceID
-            self.recorder.keepsAudioGraphWarm = true
+            self.recorder.keepsAudioGraphWarm = self.routeSnapshot.usesSpeakerDefaultRecorder
             do {
                 self.emitLatency("activation_begin:\(mode)")
-                try self.recorder.activateWarmEngine(preferredInputDeviceID: recorderInputDeviceID)
+                if self.routeSnapshot.usesSpeakerDefaultRecorder {
+                    try self.recorder.activateWarmEngine(preferredInputDeviceID: recorderInputDeviceID)
+                } else {
+                    self.emitLatency("activation_prepare_skipped:\(mode):app_scoped_start")
+                }
                 self.activeRecorderRunID = try self.recorder.start()
                 self.emitLatency("activation_end:\(mode)")
                 fputs("[dictation-session] recording mode=\(mode) \(self.routeSnapshot.debugDescription)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -43,15 +43,6 @@ enum DictationWarmupIntent: Equatable {
             return "post_dictation_\(trigger.debugName)"
         }
     }
-
-    var shouldCoolDownOnSkippedWarmup: Bool {
-        switch self {
-        case .idlePrewarm:
-            return true
-        case .postDictation:
-            return false
-        }
-    }
 }
 
 enum IdlePrewarmTrigger: String {
@@ -440,9 +431,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         guard stateStorage == .idle, !externalSessionActive else { return }
         if let skipReason = idleWarmupSkipReason(route: routeSnapshot, canWarmUp: canWarmUp) {
             recorder.keepsAudioGraphWarm = false
-            if intent.shouldCoolDownOnSkippedWarmup {
-                recorder.coolDown()
-            }
+            recorder.coolDown()
             emitLatency("warmup_skipped:\(intent.debugName):\(skipReason)")
             fputs("[dictation-session] warmup skipped intent=\(intent.debugName) reason=\(skipReason) \(routeSnapshot.debugDescription)\n", stderr)
             return

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -43,6 +43,15 @@ enum DictationWarmupIntent: Equatable {
             return "post_dictation_\(trigger.debugName)"
         }
     }
+
+    var shouldCoolDownOnSkippedWarmup: Bool {
+        switch self {
+        case .idlePrewarm:
+            return true
+        case .postDictation:
+            return false
+        }
+    }
 }
 
 enum IdlePrewarmTrigger: String {
@@ -78,6 +87,7 @@ protocol DictationAudioRecording: AnyObject {
     var onLatencyEvent: ((String, Date) -> Void)? { get set }
 
     func prepare() throws
+    func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?)
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws
     func coolDown()
@@ -104,10 +114,19 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private struct RouteSnapshot {
         let routeKind: AudioOutputRouteKind
         let preferredInputDeviceID: AudioObjectID?
+        let systemDefaultInputIsBuiltIn: Bool
         let debugDescription: String
 
         var usesSpeakerDefaultRecorder: Bool {
             routeKind == .speakerLike && preferredInputDeviceID == nil
+        }
+
+        var usesAppScopedRecorder: Bool {
+            preferredInputDeviceID != nil
+        }
+
+        var canSpeculativelyWarmRecorder: Bool {
+            usesSpeakerDefaultRecorder && systemDefaultInputIsBuiltIn
         }
 
         var shouldDuck: Bool {
@@ -153,6 +172,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         self.routeSnapshot = RouteSnapshot(
             routeKind: routingController.currentOutputRouteKindForDebug(),
             preferredInputDeviceID: routingController.cachedPreferredInputDeviceIDForDictation(),
+            systemDefaultInputIsBuiltIn: routingController.systemDefaultInputIsBuiltInForDictation(),
             debugDescription: routingController.currentRouteDebugDescription()
         )
 
@@ -206,9 +226,14 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
             let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
             self.recorder.preferredInputDeviceID = recorderInputDeviceID
-            guard self.routeSnapshot.usesSpeakerDefaultRecorder else {
+            guard self.routeSnapshot.canSpeculativelyWarmRecorder else {
                 self.recorder.keepsAudioGraphWarm = false
-                self.emitLatency("activation_skipped:\(source):app_scoped_route")
+                if self.routeSnapshot.usesAppScopedRecorder {
+                    self.recorder.beginExplicitWarmup(preferredInputDeviceID: recorderInputDeviceID)
+                    self.emitLatency("activation_async_prepare_started:\(source):app_scoped_route")
+                } else {
+                    self.emitLatency("activation_skipped:\(source):\(self.activationWarmupSkipReason(route: self.routeSnapshot))")
+                }
                 fputs("[dictation-session] armed source=\(source) skipped activation \(self.routeSnapshot.debugDescription)\n", stderr)
                 return
             }
@@ -258,13 +283,13 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.duckingController.ensureCurrentDefaultDucked()
             let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
             self.recorder.preferredInputDeviceID = recorderInputDeviceID
-            self.recorder.keepsAudioGraphWarm = self.routeSnapshot.usesSpeakerDefaultRecorder
+            self.recorder.keepsAudioGraphWarm = self.routeSnapshot.canSpeculativelyWarmRecorder
             do {
                 self.emitLatency("activation_begin:\(mode)")
-                if self.routeSnapshot.usesSpeakerDefaultRecorder {
+                if self.routeSnapshot.canSpeculativelyWarmRecorder {
                     try self.recorder.activateWarmEngine(preferredInputDeviceID: recorderInputDeviceID)
                 } else {
-                    self.emitLatency("activation_prepare_skipped:\(mode):app_scoped_start")
+                    self.emitLatency("activation_prepare_skipped:\(mode):\(self.activationWarmupSkipReason(route: self.routeSnapshot))")
                 }
                 self.activeRecorderRunID = try self.recorder.start()
                 self.emitLatency("activation_end:\(mode)")
@@ -415,7 +440,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         guard stateStorage == .idle, !externalSessionActive else { return }
         if let skipReason = idleWarmupSkipReason(route: routeSnapshot, canWarmUp: canWarmUp) {
             recorder.keepsAudioGraphWarm = false
-            recorder.coolDown()
+            if intent.shouldCoolDownOnSkippedWarmup {
+                recorder.coolDown()
+            }
             emitLatency("warmup_skipped:\(intent.debugName):\(skipReason)")
             fputs("[dictation-session] warmup skipped intent=\(intent.debugName) reason=\(skipReason) \(routeSnapshot.debugDescription)\n", stderr)
             return
@@ -437,10 +464,20 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         guard canWarmUp else { return "not_allowed" }
         switch route.routeKind {
         case .speakerLike:
+            if !route.systemDefaultInputIsBuiltIn {
+                return "risky_default_input"
+            }
             return nil
         case .headphoneLike, .unknown:
             return "risky_route"
         }
+    }
+
+    private func activationWarmupSkipReason(route: RouteSnapshot) -> String {
+        if route.usesSpeakerDefaultRecorder {
+            return route.systemDefaultInputIsBuiltIn ? "not_needed" : "risky_default_input"
+        }
+        return "app_scoped_route"
     }
 
     private func recorderInputDeviceID(for route: RouteSnapshot) -> AudioObjectID? {
@@ -477,6 +514,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         return RouteSnapshot(
             routeKind: routingController.currentOutputRouteKindForDebug(),
             preferredInputDeviceID: preferredInputDeviceID,
+            systemDefaultInputIsBuiltIn: routingController.systemDefaultInputIsBuiltInForDictation(),
             debugDescription: routingController.currentRouteDebugDescription()
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -140,7 +140,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private var externalSessionActive = false
     private var routeRefreshGeneration = 0
     private var activeRecorderRunID: UUID?
-    private var failedSessionIDs = Set<UUID>()
+    private var failedSessionID: UUID?
     private let sessionHintLock = NSLock()
     private var sessionHint: UUID?
     private var externalSessionHint = false
@@ -250,7 +250,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
                 self.emitLatency("stale_session_ignored:\(mode)")
                 return
             }
-            guard !self.failedSessionIDs.contains(sessionID) else {
+            guard self.failedSessionID != sessionID else {
                 self.emitLatency("stale_session_ignored:\(mode)")
                 return
             }
@@ -399,7 +399,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         if stateStorage.sessionID == nil {
             stateStorage = .armed(sessionID)
         }
-        failedSessionIDs.remove(sessionID)
+        if failedSessionID != sessionID {
+            failedSessionID = nil
+        }
     }
 
     private func clearSessionHint(_ sessionID: UUID?) {
@@ -519,7 +521,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private func failCurrentSession(error: Error) {
         let sessionID = stateStorage.sessionID
         if let sessionID {
-            failedSessionIDs.insert(sessionID)
+            failedSessionID = sessionID
         }
         stateStorage = .idle
         activeRecorderRunID = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -416,7 +416,12 @@ final class DictationAudioSessionManager: @unchecked Sendable {
 
     private func idleWarmupSkipReason(route: RouteSnapshot, canWarmUp: Bool) -> String? {
         guard canWarmUp else { return "not_allowed" }
-        return route.routeKind == .speakerLike ? nil : "risky_route"
+        switch route.routeKind {
+        case .speakerLike:
+            return nil
+        case .headphoneLike, .unknown:
+            return "risky_route"
+        }
     }
 
     private func recorderInputDeviceID(for route: RouteSnapshot) -> AudioObjectID? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -140,6 +140,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     private var externalSessionActive = false
     private var routeRefreshGeneration = 0
     private var activeRecorderRunID: UUID?
+    private var failedSessionIDs = Set<UUID>()
     private let sessionHintLock = NSLock()
     private var sessionHint: UUID?
     private var externalSessionHint = false
@@ -249,6 +250,10 @@ final class DictationAudioSessionManager: @unchecked Sendable {
                 self.emitLatency("stale_session_ignored:\(mode)")
                 return
             }
+            guard !self.failedSessionIDs.contains(sessionID) else {
+                self.emitLatency("stale_session_ignored:\(mode)")
+                return
+            }
             let previousState = self.stateStorage
             self.ensureSessionStateLocked(sessionID)
             guard self.isCurrent(sessionID) else { return }
@@ -263,10 +268,12 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.emit(.acquiringAudio(sessionID))
             self.emitLatency("threshold_met:\(mode)")
             if case .armed = previousState {
-                // arm() already refreshed the preferred input; keep threshold
-                // transition on the cached hotkey path.
-                self.routeSnapshot = self.makeRouteSnapshot(refreshInput: false)
-                self.emitLatency("route_snapshot_cached:\(mode) \(self.routeSnapshot.debugDescription)")
+                // AirPods can become the active route between hotkey arm and
+                // threshold. Refresh here so a stale speaker snapshot does not
+                // start the system-default recorder while CoreAudio is moving
+                // the route to headphones.
+                self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
+                self.emitLatency("route_snapshot_refreshed:\(mode) \(self.routeSnapshot.debugDescription)")
             } else {
                 self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             }
@@ -392,6 +399,7 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         if stateStorage.sessionID == nil {
             stateStorage = .armed(sessionID)
         }
+        failedSessionIDs.remove(sessionID)
     }
 
     private func clearSessionHint(_ sessionID: UUID?) {
@@ -510,6 +518,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
 
     private func failCurrentSession(error: Error) {
         let sessionID = stateStorage.sessionID
+        if let sessionID {
+            failedSessionIDs.insert(sessionID)
+        }
         stateStorage = .idle
         activeRecorderRunID = nil
         recorder.preferredInputDeviceID = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -31,6 +31,43 @@ enum DictationAudioSessionEvent {
     case latency(String, Date)
 }
 
+enum DictationWarmupIntent: Equatable {
+    case idlePrewarm(IdlePrewarmTrigger)
+    case postDictation(PostDictationTrigger)
+
+    var debugName: String {
+        switch self {
+        case .idlePrewarm(let trigger):
+            return "idle_\(trigger.debugName)"
+        case .postDictation(let trigger):
+            return "post_dictation_\(trigger.debugName)"
+        }
+    }
+}
+
+enum IdlePrewarmTrigger: String {
+    case startup
+    case routeChange
+    case configChange
+    case permissionsReady
+    case meetingStateChanged
+    case backendRecovery
+
+    var debugName: String { rawValue }
+}
+
+enum PostDictationTrigger: String {
+    case cancel
+    case stopWithoutWav
+    case shortRecording
+    case dictationStop
+    case transcriptionComplete
+    case transcriptionCancelled
+    case transcriptionFailed
+
+    var debugName: String { rawValue }
+}
+
 protocol DictationAudioRecording: AnyObject {
     var preferredInputDeviceID: AudioObjectID? { get set }
     var keepsAudioGraphWarm: Bool { get set }
@@ -160,14 +197,10 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.routeSnapshot = self.makeRouteSnapshot(refreshInput: true)
             self.emitLatency("route_snapshot \(self.routeSnapshot.debugDescription)")
             self.recorder.keepsAudioGraphWarm = true
-            guard self.routeSnapshot.routeKind != .headphoneLike else {
-                self.emitLatency("activation_deferred:\(source)")
-                fputs("[dictation-session] armed without warm activation source=\(source) \(self.routeSnapshot.debugDescription)\n", stderr)
-                return
-            }
+            let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
             do {
                 self.emitLatency("activation_begin:\(source)")
-                try self.recorder.activateWarmEngine(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
+                try self.recorder.activateWarmEngine(preferredInputDeviceID: recorderInputDeviceID)
                 self.emitLatency("activation_end:\(source)")
                 fputs("[dictation-session] armed source=\(source) \(self.routeSnapshot.debugDescription)\n", stderr)
             } catch {
@@ -208,14 +241,12 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             }
             self.beginSessionAudioControls(duckingEnabled: duckingEnabled, mediaPauseEnabled: mediaPauseEnabled)
             self.duckingController.ensureCurrentDefaultDucked()
-            self.recorder.preferredInputDeviceID = self.routeSnapshot.preferredInputDeviceID
+            let recorderInputDeviceID = self.recorderInputDeviceID(for: self.routeSnapshot)
+            self.recorder.preferredInputDeviceID = recorderInputDeviceID
             self.recorder.keepsAudioGraphWarm = true
             do {
                 self.emitLatency("activation_begin:\(mode)")
-                try self.recorder.activateWarmEngine(preferredInputDeviceID: self.routeSnapshot.preferredInputDeviceID)
-                self.emitLatency("engine_prepare_begin")
-                try self.recorder.prepare()
-                self.emitLatency("engine_prepare_end")
+                try self.recorder.activateWarmEngine(preferredInputDeviceID: recorderInputDeviceID)
                 self.activeRecorderRunID = try self.recorder.start()
                 self.emitLatency("activation_end:\(mode)")
                 fputs("[dictation-session] recording mode=\(mode) \(self.routeSnapshot.debugDescription)\n", stderr)
@@ -286,18 +317,18 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
-    func refreshRoute(reason: String, delay: TimeInterval = 0, canWarmUp: Bool) {
+    func refreshRoute(intent: DictationWarmupIntent, delay: TimeInterval = 0, canWarmUp: Bool) {
         routingController.refreshRouteCache()
         queue.async { [self] in
             self.routeRefreshGeneration += 1
             let generation = self.routeRefreshGeneration
             guard delay > 0 else {
-                self.performRouteRefreshLocked(reason: reason, canWarmUp: canWarmUp, generation: generation)
+                self.performRouteRefreshLocked(intent: intent, canWarmUp: canWarmUp, generation: generation)
                 return
             }
-            self.emitLatency("route_refresh_deferred:\(reason)")
+            self.emitLatency("route_refresh_deferred:\(intent.debugName)")
             self.queue.asyncAfter(deadline: .now() + delay) { [self] in
-                self.performRouteRefreshLocked(reason: reason, canWarmUp: canWarmUp, generation: generation)
+                self.performRouteRefreshLocked(intent: intent, canWarmUp: canWarmUp, generation: generation)
             }
         }
     }
@@ -355,30 +386,41 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         routeRefreshGeneration += 1
     }
 
-    private func performRouteRefreshLocked(reason: String, canWarmUp: Bool, generation: Int) {
+    private func performRouteRefreshLocked(intent: DictationWarmupIntent, canWarmUp: Bool, generation: Int) {
         guard routeRefreshGeneration == generation else {
-            emitLatency("route_refresh_cancelled:\(reason)")
+            emitLatency("route_refresh_cancelled:\(intent.debugName)")
             return
         }
         routeSnapshot = makeRouteSnapshot(refreshInput: false)
-        emitLatency("route_refresh:\(reason) \(routeSnapshot.debugDescription)")
+        emitLatency("route_refresh:\(intent.debugName) \(routeSnapshot.debugDescription)")
         guard stateStorage == .idle, !externalSessionActive else { return }
-        guard canWarmUp else {
+        if let skipReason = idleWarmupSkipReason(route: routeSnapshot, canWarmUp: canWarmUp) {
             recorder.keepsAudioGraphWarm = false
             recorder.coolDown()
+            emitLatency("warmup_skipped:\(intent.debugName):\(skipReason)")
+            fputs("[dictation-session] warmup skipped intent=\(intent.debugName) reason=\(skipReason) \(routeSnapshot.debugDescription)\n", stderr)
             return
         }
         recorder.keepsAudioGraphWarm = true
         recorder.coolDown()
         do {
-            emitLatency("engine_prepare_begin:warmup:\(reason)")
+            emitLatency("engine_prepare_begin:warmup:\(intent.debugName)")
             try recorder.warmUp(preferredInputDeviceID: routeSnapshot.preferredInputDeviceID)
-            emitLatency("engine_prepare_end:warmup:\(reason)")
-            fputs("[dictation-session] warmed reason=\(reason) \(routeSnapshot.debugDescription)\n", stderr)
+            emitLatency("engine_prepare_end:warmup:\(intent.debugName)")
+            fputs("[dictation-session] warmed intent=\(intent.debugName) \(routeSnapshot.debugDescription)\n", stderr)
         } catch {
-            emitLatency("engine_prepare_failed:warmup:\(reason)")
-            fputs("[dictation-session] warmup failed reason=\(reason) error=\(error)\n", stderr)
+            emitLatency("engine_prepare_failed:warmup:\(intent.debugName)")
+            fputs("[dictation-session] warmup failed intent=\(intent.debugName) error=\(error)\n", stderr)
         }
+    }
+
+    private func idleWarmupSkipReason(route: RouteSnapshot, canWarmUp: Bool) -> String? {
+        guard canWarmUp else { return "not_allowed" }
+        return route.routeKind == .speakerLike ? nil : "risky_route"
+    }
+
+    private func recorderInputDeviceID(for route: RouteSnapshot) -> AudioObjectID? {
+        route.preferredInputDeviceID
     }
 
     private func beginSessionAudioControls(duckingEnabled: Bool, mediaPauseEnabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
@@ -49,7 +49,14 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
         } catch {
             emitLatency("streaming_recorder_primary_prepare_failed")
             primary.cancel()
-            try prepareFallbackLocked()
+            wireCallbacks()
+            do {
+                try prepareFallbackLocked()
+            } catch {
+                fallback.cancel()
+                wireCallbacks()
+                throw error
+            }
         }
     }
 
@@ -64,11 +71,30 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
             } catch {
                 emitLatency("streaming_recorder_primary_start_failed")
                 primary.cancel()
-                try prepareFallbackLocked()
-                try fallback.start()
+                wireCallbacks()
+                do {
+                    try prepareFallbackLocked()
+                } catch {
+                    fallback.cancel()
+                    wireCallbacks()
+                    throw error
+                }
+                do {
+                    try fallback.start()
+                } catch {
+                    fallback.cancel()
+                    wireCallbacks()
+                    throw error
+                }
             }
         case .fallback:
-            try fallback.start()
+            do {
+                try fallback.start()
+            } catch {
+                fallback.cancel()
+                wireCallbacks()
+                throw error
+            }
         }
     }
 
@@ -80,6 +106,7 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
 
         let url = recorder.stop()
         inactive.cancel()
+        wireCallbacks()
         return url
     }
 
@@ -90,6 +117,7 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
 
         primary.cancel()
         fallback.cancel()
+        wireCallbacks()
     }
 
     func currentPower() -> Float {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
@@ -1,0 +1,174 @@
+import CoreAudio
+import Foundation
+
+final class FallbackStreamingDictationRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
+    var preferredInputDeviceID: AudioObjectID? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return preferredInputDeviceIDStorage
+        }
+        set {
+            lock.lock()
+            preferredInputDeviceIDStorage = newValue
+            primary.preferredInputDeviceID = newValue
+            fallback.preferredInputDeviceID = newValue
+            lock.unlock()
+        }
+    }
+
+    private enum ActiveRecorder {
+        case primary
+        case fallback
+    }
+
+    private let primary: StreamingDictationRecording
+    private let fallback: StreamingDictationRecording
+    private let lock = NSRecursiveLock()
+    private var activeRecorder: ActiveRecorder = .primary
+    private var preferredInputDeviceIDStorage: AudioObjectID?
+
+    init(
+        primary: StreamingDictationRecording,
+        fallback: StreamingDictationRecording
+    ) {
+        self.primary = primary
+        self.fallback = fallback
+        wireCallbacks()
+    }
+
+    func prepare() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        do {
+            try preparePrimaryLocked()
+        } catch {
+            emitLatency("streaming_recorder_primary_prepare_failed")
+            primary.cancel()
+            try prepareFallbackLocked()
+        }
+    }
+
+    func start() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        switch activeRecorder {
+        case .primary:
+            do {
+                try primary.start()
+            } catch {
+                emitLatency("streaming_recorder_primary_start_failed")
+                primary.cancel()
+                try prepareFallbackLocked()
+                try fallback.start()
+            }
+        case .fallback:
+            try fallback.start()
+        }
+    }
+
+    func stop() -> URL? {
+        lock.lock()
+        let recorder = activeRecorderLocked()
+        let inactive = inactiveRecorderLocked()
+        lock.unlock()
+
+        let url = recorder.stop()
+        inactive.cancel()
+        return url
+    }
+
+    func cancel() {
+        lock.lock()
+        activeRecorder = .primary
+        lock.unlock()
+
+        primary.cancel()
+        fallback.cancel()
+    }
+
+    func currentPower() -> Float {
+        lock.lock()
+        let recorder = activeRecorderLocked()
+        lock.unlock()
+        return recorder.currentPower()
+    }
+
+    private func preparePrimaryLocked() throws {
+        primary.preferredInputDeviceID = preferredInputDeviceIDStorage
+        try primary.prepare()
+        activeRecorder = .primary
+    }
+
+    private func prepareFallbackLocked() throws {
+        fallback.preferredInputDeviceID = preferredInputDeviceIDStorage
+        emitLatency("streaming_recorder_fallback_prepare_begin")
+        try fallback.prepare()
+        activeRecorder = .fallback
+        emitLatency("streaming_recorder_fallback_prepare_end")
+    }
+
+    private func wireCallbacks() {
+        primary.onAudioBuffer = { [weak self] samples in
+            self?.forwardAudioBuffer(samples, from: .primary)
+        }
+        fallback.onAudioBuffer = { [weak self] samples in
+            self?.forwardAudioBuffer(samples, from: .fallback)
+        }
+        primary.onRecordingFailed = { [weak self] error in
+            self?.forwardRecordingFailure(error, from: .primary)
+        }
+        fallback.onRecordingFailed = { [weak self] error in
+            self?.forwardRecordingFailure(error, from: .fallback)
+        }
+        (primary as? StreamingDictationLatencyReporting)?.onLatencyEvent = { [weak self] event, date in
+            self?.onLatencyEvent?(event, date)
+        }
+        (fallback as? StreamingDictationLatencyReporting)?.onLatencyEvent = { [weak self] event, date in
+            self?.onLatencyEvent?(event, date)
+        }
+    }
+
+    private func forwardAudioBuffer(_ samples: [Float], from recorder: ActiveRecorder) {
+        lock.lock()
+        let shouldForward = activeRecorder == recorder
+        lock.unlock()
+        guard shouldForward else { return }
+        onAudioBuffer?(samples)
+    }
+
+    private func forwardRecordingFailure(_ error: Error, from recorder: ActiveRecorder) {
+        lock.lock()
+        let shouldForward = activeRecorder == recorder
+        lock.unlock()
+        guard shouldForward else { return }
+        onRecordingFailed?(error)
+    }
+
+    private func activeRecorderLocked() -> StreamingDictationRecording {
+        switch activeRecorder {
+        case .primary:
+            return primary
+        case .fallback:
+            return fallback
+        }
+    }
+
+    private func inactiveRecorderLocked() -> StreamingDictationRecording {
+        switch activeRecorder {
+        case .primary:
+            return fallback
+        case .fallback:
+            return primary
+        }
+    }
+
+    private func emitLatency(_ event: String, at date: Date = Date()) {
+        onLatencyEvent?(event, date)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -233,6 +233,17 @@ final class FloatingIndicatorController: NSObject {
         }
     }
 
+    func setPreparingWaveformWaiting(config: AppConfig) {
+        recordingWaveformMode = .waiting
+        guard state == .preparing else {
+            setState(.preparing, config: config)
+            return
+        }
+        if let panel {
+            ensureWaveformAnimation(in: panel.frame.size, mode: .waiting)
+        }
+    }
+
     func setMeetingRecordingPaused(_ paused: Bool, config: AppConfig) {
         guard isMeetingRecordingPaused != paused else { return }
         isMeetingRecordingPaused = paused

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -9,6 +9,7 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
     var onFirstSpeechDetected: ((Date) -> Void)?
     var onNoAudioTimeout: ((Date) -> Void)?
     var onRecordingFailed: ((Error, UUID) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
 
     private static let sampleRate: Double = 16_000
     private static let speechThresholdDB: Float = -58

--- a/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MicrophoneRecorder.swift
@@ -86,6 +86,14 @@ final class MicrophoneRecorder: NSObject, AVAudioRecorderDelegate, @unchecked Se
         }
     }
 
+    func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
+        do {
+            try activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
+        } catch {
+            onLatencyEvent?("explicit_warmup_failed:system_default", Date())
+        }
+    }
+
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
         lock.lock()
         defer { lock.unlock() }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -708,6 +708,7 @@ struct AppConfig: Codable {
     var computerUseTimeoutSeconds: Int = 120
     var sttBackend: String = BackendOption.whisper.backend
     var sttModel: String = BackendOption.whisper.model
+    var dictationInputDeviceUID: String? = nil
     var cohereLanguage: String = CohereTranscribeLanguage.defaultLanguage.rawValue
     var meetingTranscriptionBackend: String = BackendOption.whisper.backend
     var meetingTranscriptionModel: String = BackendOption.whisper.model
@@ -786,6 +787,7 @@ struct AppConfig: Codable {
         case computerUseTimeoutSeconds = "computer_use_timeout_seconds"
         case sttBackend = "stt_backend"
         case sttModel = "stt_model"
+        case dictationInputDeviceUID = "dictation_input_device_uid"
         case cohereLanguage = "cohere_language"
         case meetingTranscriptionBackend = "meeting_transcription_backend"
         case meetingTranscriptionModel = "meeting_transcription_model"
@@ -871,6 +873,7 @@ struct AppConfig: Codable {
         computerUseTimeoutSeconds = (try? c.decode(Int.self, forKey: .computerUseTimeoutSeconds)) ?? defaults.computerUseTimeoutSeconds
         sttBackend = (try? c.decode(String.self, forKey: .sttBackend)) ?? defaults.sttBackend
         sttModel = (try? c.decode(String.self, forKey: .sttModel)) ?? defaults.sttModel
+        dictationInputDeviceUID = try? c.decode(String.self, forKey: .dictationInputDeviceUID)
         cohereLanguage = CohereTranscribeLanguage.resolvedCode(try? c.decode(String.self, forKey: .cohereLanguage))
         meetingTranscriptionBackend = (try? c.decode(String.self, forKey: .meetingTranscriptionBackend)) ?? sttBackend
         meetingTranscriptionModel = (try? c.decode(String.self, forKey: .meetingTranscriptionModel)) ?? sttModel

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -190,10 +190,11 @@ final class MuesliController: NSObject {
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let meetingRecordingHotkeyMonitor = HotkeyMonitor()
     private let recorder = MicrophoneRecorder()
+    private let dictationRecorder = AppScopedDictationRecorder()
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
     private lazy var dictationAudioSessionManager = DictationAudioSessionManager(
-        recorder: recorder,
+        recorder: dictationRecorder,
         duckingController: audioDuckingController,
         routingController: dictationAudioRoutingController
     )
@@ -338,7 +339,7 @@ final class MuesliController: NSObject {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.syncDictationRecorderWarmup(
-                    reason: "route-change",
+                    intent: .idlePrewarm(.routeChange),
                     delay: DictationAudioRouteTiming.stabilizationDelay
                 )
             }
@@ -414,7 +415,7 @@ final class MuesliController: NSObject {
         if canRunMainApp {
             startMeetingRecordingHotkeyMonitorIfNeeded()
         }
-        syncDictationRecorderWarmup(reason: "startup")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.startup))
         indicator.onStopMeeting = { [weak self] in self?.stopMeetingRecording() }
         indicator.onDiscardMeeting = { [weak self] in self?.discardMeetingWithConfirmation() }
         indicator.onToggleMeetingPause = { [weak self] in self?.toggleMeetingRecordingPause() }
@@ -882,7 +883,7 @@ final class MuesliController: NSObject {
         syncCalendarMonitor()
         syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
-        syncDictationRecorderWarmup(reason: "config")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.configChange))
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -1980,7 +1981,7 @@ final class MuesliController: NSObject {
         hotkeyMonitor.configure(keyCode: config.dictationHotkey.keyCode)
         hotkeyMonitor.start()
         startComputerUseHotkeyMonitorIfNeeded()
-        syncDictationRecorderWarmup(reason: "permissions-ready")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
         TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
             "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
             "to_use_case": OnboardingUseCase.dictation.rawValue,
@@ -2945,7 +2946,7 @@ final class MuesliController: NSObject {
         // Keep this after backend normalization and live-meeting creation so
         // a failed meeting start does not silently cancel an active dictation.
         cancelDictationAudioSessionForMeetingRecordingIfNeeded()
-        syncDictationRecorderWarmup(reason: "meeting-start")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
         meetingStartMeetingID = meetingID
         updateMeetingStartStatus("Meeting transcription will start shortly.")
         indicator.setState(.preparing, config: config)
@@ -2976,7 +2977,7 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.setState(.idle)
                     self.endMeetingActivity()
-                    self.syncDictationRecorderWarmup(reason: "meeting-start-cancelled")
+                    self.syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
                 }
             } catch {
                 if self.meetingStartMeetingID == meetingID {
@@ -2990,7 +2991,7 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.setState(.idle)
                     self.endMeetingActivity()
-                    self.syncDictationRecorderWarmup(reason: "meeting-start-failed")
+                    self.syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
 
                     self.presentMeetingStartFailureAlert(error: error)
                 }
@@ -3183,7 +3184,7 @@ final class MuesliController: NSObject {
             meetingMonitor.refreshState()
             meetingStartTask = nil
             meetingStartMeetingID = nil
-            syncDictationRecorderWarmup(reason: "meeting-start-cancelled")
+            syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
         } else {
             // Audio import cancellation
             importTask?.cancel()
@@ -3218,7 +3219,7 @@ final class MuesliController: NSObject {
             meetingRecordingHotkeyMonitor.cancelToggleMode()
         }
         syncAppState()
-        syncDictationRecorderWarmup(reason: "meeting-start-finished")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
     }
 
     private func cancelMeetingRecordingHotkeyToggleAfterFailedStart(meetingID: Int64) {
@@ -3520,7 +3521,7 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         syncAppState()
         updateMeetingNotificationVisibility()
-        syncDictationRecorderWarmup(reason: "meeting-discard")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
     }
 
     private func resolveLiveMeetingAfterDiscard(id: Int64, resolution: MeetingDiscardResolution) {
@@ -3657,7 +3658,7 @@ final class MuesliController: NSObject {
         backgroundMeetingProcessingCount += 1
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
-        syncDictationRecorderWarmup(reason: "meeting-stop")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
 
         Task { [weak self] in
             guard let self else { return }
@@ -4854,9 +4855,9 @@ final class MuesliController: NSObject {
         dictationAudioSessionManager.coolDown(reason: reason)
     }
 
-    private func syncDictationRecorderWarmup(reason: String, delay: TimeInterval = 0) {
+    private func syncDictationRecorderWarmup(intent: DictationWarmupIntent, delay: TimeInterval = 0) {
         dictationAudioSessionManager.refreshRoute(
-            reason: reason,
+            intent: intent,
             delay: delay,
             canWarmUp: canPrimeDictationRecorder && selectedBackend.backend != "nemotron"
         )
@@ -5130,7 +5131,7 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
         finishDictationLatencyTrace("nemotron_start_failed")
-        syncDictationRecorderWarmup(reason: "nemotron-start-failed")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
 
     @MainActor
@@ -5149,7 +5150,7 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
         finishDictationLatencyTrace("nemotron_runtime_failed")
-        syncDictationRecorderWarmup(reason: "nemotron-runtime-failed")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
 
     private func handleCancel() {
@@ -5177,7 +5178,7 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
         meetingMonitor.refreshState()
         finishDictationLatencyTrace("cancelled")
-        syncDictationRecorderWarmup(reason: "cancel")
+        syncDictationRecorderWarmup(intent: .postDictation(.cancel))
     }
 
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
@@ -5316,7 +5317,7 @@ final class MuesliController: NSObject {
         }
         meetingMonitor.refreshState()
         finishDictationLatencyTrace("meeting_active_cancel")
-        syncDictationRecorderWarmup(reason: "meeting-active")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
     }
 
     private func finishNemotronStreamingStop(
@@ -5356,7 +5357,7 @@ final class MuesliController: NSObject {
         meetingMonitor.resumeAfterCooldown()
         fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
         finishDictationLatencyTrace("nemotron_stop")
-        syncDictationRecorderWarmup(reason: "nemotron-stop")
+        syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
 
     private func finishStandardDictationStop(wavURL stoppedWavURL: URL?, startedAt: Date) {
@@ -5367,7 +5368,7 @@ final class MuesliController: NSObject {
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             finishDictationLatencyTrace("stop_without_wav")
-            syncDictationRecorderWarmup(reason: "stop-without-wav")
+            syncDictationRecorderWarmup(intent: .postDictation(.stopWithoutWav))
             return
         }
         let duration = max(Date().timeIntervalSince(startedAt), 0)
@@ -5381,13 +5382,13 @@ final class MuesliController: NSObject {
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             finishDictationLatencyTrace("short_recording")
-            syncDictationRecorderWarmup(reason: "short-recording")
+            syncDictationRecorderWarmup(intent: .postDictation(.shortRecording))
             return
         }
 
         setState(.transcribing)
         finishDictationLatencyTrace("ready_for_transcription")
-        syncDictationRecorderWarmup(reason: "dictation-stop")
+        syncDictationRecorderWarmup(intent: .postDictation(.dictationStop))
         let isTestMode = isDictationTestMode
         let outputMode = currentDictationOutputMode
         let transcriptionBackend = isTestMode ? (dictationTestBackend ?? selectedBackend) : selectedBackend
@@ -5421,7 +5422,7 @@ final class MuesliController: NSObject {
                         self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
-                        self.syncDictationRecorderWarmup(reason: "transcription-complete")
+                        self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
                     }
                     return
                 }
@@ -5434,7 +5435,7 @@ final class MuesliController: NSObject {
                         self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
-                        self.syncDictationRecorderWarmup(reason: "transcription-complete")
+                        self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
                     }
                     return
                 }
@@ -5456,7 +5457,7 @@ final class MuesliController: NSObject {
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
-                    self.syncDictationRecorderWarmup(reason: "transcription-complete")
+                    self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
                     TelemetryDeck.signal("dictation.completed", parameters: [
                         "backend": self.selectedBackend.backend,
                         "paste_method": outputMode.pasteMethod,
@@ -5468,7 +5469,7 @@ final class MuesliController: NSObject {
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
-                    self.syncDictationRecorderWarmup(reason: "transcription-cancelled")
+                    self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionCancelled))
                 }
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
@@ -5479,7 +5480,7 @@ final class MuesliController: NSObject {
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
-                    self.syncDictationRecorderWarmup(reason: "transcription-failed")
+                    self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionFailed))
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4819,6 +4819,7 @@ final class MuesliController: NSObject {
             meetingMonitor.suppressWhileActive()
             meetingMonitor.refreshState()
             setState(.preparing)
+            dictationAudioSessionManager.arm(source: "hotkey_prepare")
         }
     }
 
@@ -4832,7 +4833,9 @@ final class MuesliController: NSObject {
             setState(.preparing)
             meetingMonitor.suppressWhileActive()
             meetingMonitor.refreshState()
-            dictationAudioSessionManager.arm(source: "hotkey_arm")
+            if !dictationAudioSessionManager.hasActiveSession {
+                dictationAudioSessionManager.arm(source: "hotkey_arm")
+            }
         }
     }
 
@@ -4931,6 +4934,7 @@ final class MuesliController: NSObject {
             break
         case .acquiringAudio:
             markDictationLatency("acquiring_audio")
+            activateDictationPreparingIndicator()
         case .streamActive(_, let capturedAt):
             handleDictationStreamActive(capturedAt: capturedAt)
         case .speechDetected(_, let capturedAt):
@@ -4982,11 +4986,19 @@ final class MuesliController: NSObject {
         }
     }
 
-    private func handleDictationStreamActive(capturedAt: Date) {
-        if dictationStartedAt == nil {
-            dictationStartedAt = capturedAt
+    private func activateDictationPreparingIndicator() {
+        if dictationState != .preparing {
+            setState(.preparing)
         }
-        capturedDictationContext = nil
+        if !isDictationTestMode {
+            indicator.powerProvider = { [weak self] in
+                self?.dictationAudioSessionManager.currentPower() ?? -160
+            }
+            indicator.setPreparingWaveformWaiting(config: config)
+        }
+    }
+
+    private func activateDictationRecordingIndicator() {
         if hotkeyMonitor.isToggleRecording {
             setState(.recording)
             indicator.setToggleDictation(true, config: config)
@@ -5000,6 +5012,16 @@ final class MuesliController: NSObject {
                 self?.dictationAudioSessionManager.currentPower() ?? -160
             }
         }
+    }
+
+    private func handleDictationStreamActive(capturedAt: Date) {
+        markDictationLatency("ui_stream_active_handling_begin")
+        markDictationLatency("ui_stream_active_received", at: capturedAt)
+        if dictationStartedAt == nil {
+            dictationStartedAt = capturedAt
+        }
+        capturedDictationContext = nil
+        activateDictationRecordingIndicator()
         markDictationLatency("sound_start_requested:stream-active")
         SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         markDictationLatency("ui_stream_active")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -308,6 +308,7 @@ final class MuesliController: NSObject {
         self.launchAtLoginCoordinator = LaunchAtLoginCoordinator(manager: launchAtLoginManager)
         self.audioDuckingController = audioDuckingController
         self.dictationAudioRoutingController = dictationAudioRoutingController
+        self.dictationAudioRoutingController.selectedInputDeviceUID = loadedConfig.dictationInputDeviceUID
         self.config = loadedConfig
         if loadedConfig.recordingColorHex != "1e1e2e" {
             MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
@@ -614,6 +615,7 @@ final class MuesliController: NSObject {
             self.activeMeetingID = nil
         }
         endMeetingActivity()
+        dictationAudioSessionManager.cancel(reason: "shutdown")
         recorder.cancel()
         Task {
             await transcriptionCoordinator.shutdown()
@@ -869,6 +871,7 @@ final class MuesliController: NSObject {
         if hotkeyTriggerThresholdChanged {
             configureHotkeyMonitorTiming()
         }
+        dictationAudioRoutingController.selectedInputDeviceUID = config.dictationInputDeviceUID
         historyWindowController?.updateBackendLabel()
         if config.showFloatingIndicator {
             indicator.ensureVisible(config: config)
@@ -884,6 +887,14 @@ final class MuesliController: NSObject {
         syncMeetingDetectionMonitor()
         updateMeetingNotificationVisibility()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.configChange))
+    }
+
+    func availableDictationInputDevices() -> [AudioInputDeviceInfo] {
+        dictationAudioRoutingController.availableInputDevices()
+    }
+
+    func selectDictationInputDeviceUID(_ uid: String?) {
+        updateConfig { $0.dictationInputDeviceUID = uid }
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -1725,6 +1736,7 @@ final class MuesliController: NSObject {
     func cancelTestDictation() {
         dictationTestTask?.cancel()
         dictationTestTask = nil
+        dictationAudioSessionManager.cancel(reason: "test-cancel")
         recorder.cancel()
         setState(.idle)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -190,7 +190,7 @@ final class MuesliController: NSObject {
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let meetingRecordingHotkeyMonitor = HotkeyMonitor()
     private let recorder = MicrophoneRecorder()
-    private let dictationRecorder = AppScopedDictationRecorder()
+    private let dictationRecorder = RouteAwareDictationRecorder()
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
     private lazy var dictationAudioSessionManager = DictationAudioSessionManager(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -189,7 +189,7 @@ final class MuesliController: NSObject {
     private let hotkeyMonitor = HotkeyMonitor()
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let meetingRecordingHotkeyMonitor = HotkeyMonitor()
-    private let recorder = MicrophoneRecorder()
+    private let computerUseRecorder = MicrophoneRecorder()
     private let dictationRecorder = RouteAwareDictationRecorder()
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
@@ -616,7 +616,7 @@ final class MuesliController: NSObject {
         }
         endMeetingActivity()
         dictationAudioSessionManager.cancel(reason: "shutdown")
-        recorder.cancel()
+        computerUseRecorder.cancel()
         Task {
             await transcriptionCoordinator.shutdown()
         }
@@ -1737,7 +1737,6 @@ final class MuesliController: NSObject {
         dictationTestTask?.cancel()
         dictationTestTask = nil
         dictationAudioSessionManager.cancel(reason: "test-cancel")
-        recorder.cancel()
         setState(.idle)
     }
 
@@ -4420,13 +4419,13 @@ final class MuesliController: NSObject {
         fputs("[cua] prepare\n", stderr)
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
-        recorder.preferredInputDeviceID = nil
+        computerUseRecorder.preferredInputDeviceID = nil
         setState(.preparing)
         do {
-            try recorder.prepare()
+            try computerUseRecorder.prepare()
         } catch {
             fputs("[cua] recorder prepare failed: \(error)\n", stderr)
-            recorder.cancel()
+            computerUseRecorder.cancel()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
@@ -4437,18 +4436,18 @@ final class MuesliController: NSObject {
         guard canStartComputerUseCommand else { return }
         fputs("[cua] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
-        recorder.preferredInputDeviceID = nil
+        computerUseRecorder.preferredInputDeviceID = nil
         do {
-            try recorder.start()
+            try computerUseRecorder.start()
             computerUseCommandStartedAt = Date()
             indicator.powerProvider = { [weak self] in
-                self?.recorder.currentPower() ?? -160
+                self?.computerUseRecorder.currentPower() ?? -160
             }
             setState(.recording)
             SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
         } catch {
             fputs("[cua] recorder start failed: \(error)\n", stderr)
-            recorder.cancel()
+            computerUseRecorder.cancel()
             computerUseCommandStartedAt = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -4476,7 +4475,7 @@ final class MuesliController: NSObject {
         fputs("[cua] cancel\n", stderr)
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
-        recorder.cancel()
+        computerUseRecorder.cancel()
         computerUseCommandStartedAt = nil
         indicator.isToggleDictation = false
         setState(.idle)
@@ -4489,7 +4488,7 @@ final class MuesliController: NSObject {
         let startedAt = computerUseCommandStartedAt ?? Date()
         computerUseCommandStartedAt = nil
 
-        guard let wavURL = recorder.stop() else {
+        guard let wavURL = computerUseRecorder.stop() else {
             fputs("[cua] stop without wav\n", stderr)
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -1,0 +1,184 @@
+import CoreAudio
+import Foundation
+
+final class RouteAwareDictationRecorder: DictationAudioRecording {
+    enum ActiveRecorderKind: Equatable {
+        case systemDefault
+        case appScoped
+    }
+
+    var preferredInputDeviceID: AudioObjectID? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return preferredInputDeviceIDStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            preferredInputDeviceIDStorage = newValue
+            activeRecorderLocked().preferredInputDeviceID = newValue
+        }
+    }
+
+    var keepsAudioGraphWarm: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return keepsAudioGraphWarmStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            keepsAudioGraphWarmStorage = newValue
+            systemDefaultRecorder.keepsAudioGraphWarm = newValue
+            appScopedRecorder.keepsAudioGraphWarm = newValue
+        }
+    }
+
+    var onFirstCapturedAudioBuffer: ((Date) -> Void)?
+    var onFirstSpeechDetected: ((Date) -> Void)?
+    var onNoAudioTimeout: ((Date) -> Void)?
+    var onRecordingFailed: ((Error, UUID) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
+
+    private let systemDefaultRecorder: DictationAudioRecording
+    private let appScopedRecorder: DictationAudioRecording
+    private let lock = NSRecursiveLock()
+    private var preferredInputDeviceIDStorage: AudioObjectID?
+    private var keepsAudioGraphWarmStorage = false
+    private var activeRecorderKindStorage: ActiveRecorderKind = .systemDefault
+
+    init(
+        systemDefaultRecorder: DictationAudioRecording = MicrophoneRecorder(),
+        appScopedRecorder: DictationAudioRecording = AppScopedDictationRecorder()
+    ) {
+        self.systemDefaultRecorder = systemDefaultRecorder
+        self.appScopedRecorder = appScopedRecorder
+        wireCallbacks()
+    }
+
+    func activeRecorderKindForDebug() -> ActiveRecorderKind {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeRecorderKindStorage
+    }
+
+    func prepare() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceIDStorage)
+        try activeRecorderLocked().prepare()
+    }
+
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceID)
+        try activeRecorderLocked().warmUp(preferredInputDeviceID: preferredInputDeviceID)
+    }
+
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceID)
+        try activeRecorderLocked().activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
+    }
+
+    func coolDown() {
+        lock.lock()
+        defer { lock.unlock() }
+        systemDefaultRecorder.coolDown()
+        appScopedRecorder.coolDown()
+    }
+
+    @discardableResult
+    func start() throws -> UUID {
+        lock.lock()
+        defer { lock.unlock() }
+        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceIDStorage)
+        return try activeRecorderLocked().start()
+    }
+
+    func stop() -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        let url = activeRecorderLocked().stop()
+        inactiveRecorderLocked().cancel()
+        return url
+    }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+        systemDefaultRecorder.cancel()
+        appScopedRecorder.cancel()
+    }
+
+    func currentPower() -> Float {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeRecorderLocked().currentPower()
+    }
+
+    private func wireCallbacks() {
+        for recorder in [systemDefaultRecorder, appScopedRecorder] {
+            recorder.onFirstCapturedAudioBuffer = { [weak self] date in
+                self?.onFirstCapturedAudioBuffer?(date)
+            }
+            recorder.onFirstSpeechDetected = { [weak self] date in
+                self?.onFirstSpeechDetected?(date)
+            }
+            recorder.onNoAudioTimeout = { [weak self] date in
+                self?.onNoAudioTimeout?(date)
+            }
+            recorder.onRecordingFailed = { [weak self] error, id in
+                self?.onRecordingFailed?(error, id)
+            }
+            recorder.onLatencyEvent = { [weak self] event, date in
+                self?.onLatencyEvent?(event, date)
+            }
+        }
+    }
+
+    private func selectRecorderLocked(preferredInputDeviceID: AudioObjectID?) {
+        let nextKind: ActiveRecorderKind = preferredInputDeviceID == nil ? .systemDefault : .appScoped
+        preferredInputDeviceIDStorage = preferredInputDeviceID
+        guard nextKind != activeRecorderKindStorage else {
+            activeRecorderLocked().preferredInputDeviceID = preferredInputDeviceID
+            activeRecorderLocked().keepsAudioGraphWarm = keepsAudioGraphWarmStorage
+            return
+        }
+
+        inactiveRecorder(for: nextKind).cancel()
+        activeRecorderKindStorage = nextKind
+        activeRecorderLocked().preferredInputDeviceID = preferredInputDeviceID
+        activeRecorderLocked().keepsAudioGraphWarm = keepsAudioGraphWarmStorage
+    }
+
+    private func activeRecorderLocked() -> DictationAudioRecording {
+        recorder(for: activeRecorderKindStorage)
+    }
+
+    private func inactiveRecorderLocked() -> DictationAudioRecording {
+        inactiveRecorder(for: activeRecorderKindStorage)
+    }
+
+    private func recorder(for kind: ActiveRecorderKind) -> DictationAudioRecording {
+        switch kind {
+        case .systemDefault:
+            return systemDefaultRecorder
+        case .appScoped:
+            return appScopedRecorder
+        }
+    }
+
+    private func inactiveRecorder(for kind: ActiveRecorderKind) -> DictationAudioRecording {
+        switch kind {
+        case .systemDefault:
+            return appScopedRecorder
+        case .appScoped:
+            return systemDefaultRecorder
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -129,23 +129,34 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
     }
 
     private func wireCallbacks() {
-        for recorder in [systemDefaultRecorder, appScopedRecorder] {
-            recorder.onFirstCapturedAudioBuffer = { [weak self] date in
-                self?.onFirstCapturedAudioBuffer?(date)
-            }
-            recorder.onFirstSpeechDetected = { [weak self] date in
-                self?.onFirstSpeechDetected?(date)
-            }
-            recorder.onNoAudioTimeout = { [weak self] date in
-                self?.onNoAudioTimeout?(date)
-            }
-            recorder.onRecordingFailed = { [weak self] error, id in
-                self?.onRecordingFailed?(error, id)
-            }
-            recorder.onLatencyEvent = { [weak self] event, date in
-                self?.onLatencyEvent?(event, date)
-            }
+        wireCallbacks(for: systemDefaultRecorder, kind: .systemDefault)
+        wireCallbacks(for: appScopedRecorder, kind: .appScoped)
+    }
+
+    private func wireCallbacks(for recorder: DictationAudioRecording, kind: ActiveRecorderKind) {
+        recorder.onFirstCapturedAudioBuffer = { [weak self] date in
+            self?.forwardIfActive(kind) { $0.onFirstCapturedAudioBuffer?(date) }
         }
+        recorder.onFirstSpeechDetected = { [weak self] date in
+            self?.forwardIfActive(kind) { $0.onFirstSpeechDetected?(date) }
+        }
+        recorder.onNoAudioTimeout = { [weak self] date in
+            self?.forwardIfActive(kind) { $0.onNoAudioTimeout?(date) }
+        }
+        recorder.onRecordingFailed = { [weak self] error, id in
+            self?.forwardIfActive(kind) { $0.onRecordingFailed?(error, id) }
+        }
+        recorder.onLatencyEvent = { [weak self] event, date in
+            self?.forwardIfActive(kind) { $0.onLatencyEvent?(event, date) }
+        }
+    }
+
+    private func forwardIfActive(_ kind: ActiveRecorderKind, _ body: (RouteAwareDictationRecorder) -> Void) {
+        lock.lock()
+        let shouldForward = activeRecorderKindStorage == kind
+        lock.unlock()
+        guard shouldForward else { return }
+        body(self)
     }
 
     private func selectRecorderLocked(preferredInputDeviceID: AudioObjectID?) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -15,9 +15,10 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         }
         set {
             lock.lock()
-            defer { lock.unlock() }
             preferredInputDeviceIDStorage = newValue
-            activeRecorderLocked().preferredInputDeviceID = newValue
+            let recorder = activeRecorderLocked()
+            lock.unlock()
+            recorder.preferredInputDeviceID = newValue
         }
     }
 
@@ -29,10 +30,12 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         }
         set {
             lock.lock()
-            defer { lock.unlock() }
             keepsAudioGraphWarmStorage = newValue
-            systemDefaultRecorder.keepsAudioGraphWarm = newValue
-            appScopedRecorder.keepsAudioGraphWarm = newValue
+            let systemDefault = systemDefaultRecorder
+            let appScoped = appScopedRecorder
+            lock.unlock()
+            systemDefault.keepsAudioGraphWarm = newValue
+            appScoped.keepsAudioGraphWarm = newValue
         }
     }
 
@@ -65,7 +68,7 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
     }
 
     func prepare() throws {
-        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceIDStorage)
+        let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
         try recorder.prepare()
     }
 
@@ -91,7 +94,7 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
 
     @discardableResult
     func start() throws -> UUID {
-        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceIDStorage)
+        let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
         return try recorder.start()
     }
 
@@ -146,6 +149,13 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         lock.unlock()
         guard shouldForward else { return }
         body(self)
+    }
+
+    private func currentPreferredInputDeviceID() -> AudioObjectID? {
+        lock.lock()
+        let preferredInputDeviceID = preferredInputDeviceIDStorage
+        lock.unlock()
+        return preferredInputDeviceID
     }
 
     private func selectRecorder(preferredInputDeviceID: AudioObjectID?) -> DictationAudioRecording {

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -14,11 +14,13 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
             return preferredInputDeviceIDStorage
         }
         set {
-            lock.lock()
-            preferredInputDeviceIDStorage = newValue
-            let recorder = activeRecorderLocked()
-            lock.unlock()
-            recorder.preferredInputDeviceID = newValue
+            lifecycleQueue.sync {
+                lock.lock()
+                preferredInputDeviceIDStorage = newValue
+                let recorder = activeRecorderLocked()
+                lock.unlock()
+                recorder.preferredInputDeviceID = newValue
+            }
         }
     }
 
@@ -29,13 +31,15 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
             return keepsAudioGraphWarmStorage
         }
         set {
-            lock.lock()
-            keepsAudioGraphWarmStorage = newValue
-            let systemDefault = systemDefaultRecorder
-            let appScoped = appScopedRecorder
-            lock.unlock()
-            systemDefault.keepsAudioGraphWarm = newValue
-            appScoped.keepsAudioGraphWarm = newValue
+            lifecycleQueue.sync {
+                lock.lock()
+                keepsAudioGraphWarmStorage = newValue
+                let systemDefault = systemDefaultRecorder
+                let appScoped = appScopedRecorder
+                lock.unlock()
+                systemDefault.keepsAudioGraphWarm = newValue
+                appScoped.keepsAudioGraphWarm = newValue
+            }
         }
     }
 
@@ -47,6 +51,7 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
 
     private let systemDefaultRecorder: DictationAudioRecording
     private let appScopedRecorder: DictationAudioRecording
+    private let lifecycleQueue: DispatchQueue
     private let lock = NSRecursiveLock()
     private var preferredInputDeviceIDStorage: AudioObjectID?
     private var keepsAudioGraphWarmStorage = false
@@ -54,10 +59,12 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
 
     init(
         systemDefaultRecorder: DictationAudioRecording = MicrophoneRecorder(),
-        appScopedRecorder: DictationAudioRecording = AppScopedDictationRecorder()
+        appScopedRecorder: DictationAudioRecording = AppScopedDictationRecorder(),
+        lifecycleQueue: DispatchQueue = DispatchQueue(label: "com.muesli.route-aware-dictation-recorder-lifecycle")
     ) {
         self.systemDefaultRecorder = systemDefaultRecorder
         self.appScopedRecorder = appScopedRecorder
+        self.lifecycleQueue = lifecycleQueue
         wireCallbacks()
     }
 
@@ -68,49 +75,65 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
     }
 
     func prepare() throws {
-        let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
-        try recorder.prepare()
+        try lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
+            try recorder.prepare()
+        }
     }
 
     func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
-        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
-        recorder.beginExplicitWarmup(preferredInputDeviceID: preferredInputDeviceID)
+        lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
+            recorder.beginExplicitWarmup(preferredInputDeviceID: preferredInputDeviceID)
+        }
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
-        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
-        try recorder.warmUp(preferredInputDeviceID: preferredInputDeviceID)
+        try lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
+            try recorder.warmUp(preferredInputDeviceID: preferredInputDeviceID)
+        }
     }
 
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
-        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
-        try recorder.activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
+        try lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
+            try recorder.activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
+        }
     }
 
     func coolDown() {
-        systemDefaultRecorder.coolDown()
-        appScopedRecorder.coolDown()
+        lifecycleQueue.sync {
+            systemDefaultRecorder.coolDown()
+            appScopedRecorder.coolDown()
+        }
     }
 
     @discardableResult
     func start() throws -> UUID {
-        let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
-        return try recorder.start()
+        try lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
+            return try recorder.start()
+        }
     }
 
     func stop() -> URL? {
-        lock.lock()
-        let activeRecorder = activeRecorderLocked()
-        let inactiveRecorder = inactiveRecorderLocked()
-        lock.unlock()
-        let url = activeRecorder.stop()
-        inactiveRecorder.cancel()
-        return url
+        lifecycleQueue.sync {
+            lock.lock()
+            let activeRecorder = activeRecorderLocked()
+            let inactiveRecorder = inactiveRecorderLocked()
+            lock.unlock()
+            let url = activeRecorder.stop()
+            inactiveRecorder.cancel()
+            return url
+        }
     }
 
     func cancel() {
-        systemDefaultRecorder.cancel()
-        appScopedRecorder.cancel()
+        lifecycleQueue.sync {
+            systemDefaultRecorder.cancel()
+            appScopedRecorder.cancel()
+        }
     }
 
     func currentPower() -> Float {

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -71,6 +71,13 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         try activeRecorderLocked().prepare()
     }
 
+    func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
+        lock.lock()
+        defer { lock.unlock() }
+        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceID)
+        activeRecorderLocked().beginExplicitWarmup(preferredInputDeviceID: preferredInputDeviceID)
+    }
+
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
         lock.lock()
         defer { lock.unlock() }

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -65,67 +65,56 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
     }
 
     func prepare() throws {
-        lock.lock()
-        defer { lock.unlock() }
-        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceIDStorage)
-        try activeRecorderLocked().prepare()
+        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceIDStorage)
+        try recorder.prepare()
     }
 
     func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
-        lock.lock()
-        defer { lock.unlock() }
-        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceID)
-        activeRecorderLocked().beginExplicitWarmup(preferredInputDeviceID: preferredInputDeviceID)
+        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
+        recorder.beginExplicitWarmup(preferredInputDeviceID: preferredInputDeviceID)
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
-        lock.lock()
-        defer { lock.unlock() }
-        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceID)
-        try activeRecorderLocked().warmUp(preferredInputDeviceID: preferredInputDeviceID)
+        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
+        try recorder.warmUp(preferredInputDeviceID: preferredInputDeviceID)
     }
 
     func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
-        lock.lock()
-        defer { lock.unlock() }
-        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceID)
-        try activeRecorderLocked().activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
+        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceID)
+        try recorder.activateWarmEngine(preferredInputDeviceID: preferredInputDeviceID)
     }
 
     func coolDown() {
-        lock.lock()
-        defer { lock.unlock() }
         systemDefaultRecorder.coolDown()
         appScopedRecorder.coolDown()
     }
 
     @discardableResult
     func start() throws -> UUID {
-        lock.lock()
-        defer { lock.unlock() }
-        selectRecorderLocked(preferredInputDeviceID: preferredInputDeviceIDStorage)
-        return try activeRecorderLocked().start()
+        let recorder = selectRecorder(preferredInputDeviceID: preferredInputDeviceIDStorage)
+        return try recorder.start()
     }
 
     func stop() -> URL? {
         lock.lock()
-        defer { lock.unlock() }
-        let url = activeRecorderLocked().stop()
-        inactiveRecorderLocked().cancel()
+        let activeRecorder = activeRecorderLocked()
+        let inactiveRecorder = inactiveRecorderLocked()
+        lock.unlock()
+        let url = activeRecorder.stop()
+        inactiveRecorder.cancel()
         return url
     }
 
     func cancel() {
-        lock.lock()
-        defer { lock.unlock() }
         systemDefaultRecorder.cancel()
         appScopedRecorder.cancel()
     }
 
     func currentPower() -> Float {
         lock.lock()
-        defer { lock.unlock() }
-        return activeRecorderLocked().currentPower()
+        let recorder = activeRecorderLocked()
+        lock.unlock()
+        return recorder.currentPower()
     }
 
     private func wireCallbacks() {
@@ -159,19 +148,20 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         body(self)
     }
 
-    private func selectRecorderLocked(preferredInputDeviceID: AudioObjectID?) {
+    private func selectRecorder(preferredInputDeviceID: AudioObjectID?) -> DictationAudioRecording {
+        lock.lock()
         let nextKind: ActiveRecorderKind = preferredInputDeviceID == nil ? .systemDefault : .appScoped
+        let inactiveRecorderToCancel = nextKind == activeRecorderKindStorage ? nil : activeRecorderLocked()
         preferredInputDeviceIDStorage = preferredInputDeviceID
-        guard nextKind != activeRecorderKindStorage else {
-            activeRecorderLocked().preferredInputDeviceID = preferredInputDeviceID
-            activeRecorderLocked().keepsAudioGraphWarm = keepsAudioGraphWarmStorage
-            return
-        }
-
-        inactiveRecorder(for: nextKind).cancel()
         activeRecorderKindStorage = nextKind
-        activeRecorderLocked().preferredInputDeviceID = preferredInputDeviceID
-        activeRecorderLocked().keepsAudioGraphWarm = keepsAudioGraphWarmStorage
+        let selectedRecorder = activeRecorderLocked()
+        let keepsAudioGraphWarm = keepsAudioGraphWarmStorage
+        lock.unlock()
+
+        selectedRecorder.preferredInputDeviceID = preferredInputDeviceID
+        selectedRecorder.keepsAudioGraphWarm = keepsAudioGraphWarm
+        inactiveRecorderToCancel?.cancel()
+        return selectedRecorder
     }
 
     private func activeRecorderLocked() -> DictationAudioRecording {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -416,12 +416,13 @@ struct SettingsView: View {
                     let options = dictationMicrophoneOptions
                     FixedWidthPopUp(
                         selection: selectedDictationMicrophoneLabel,
-                        options: options.map(\.label)
-                    ) { index in
-                        guard index >= 0, index < options.count else { return }
-                        controller.selectDictationInputDeviceUID(options[index].uid)
-                        refreshDictationInputDevices()
-                    }
+                        options: options.map(\.label),
+                        onSelectIndex: { index in
+                            guard index >= 0, index < options.count else { return }
+                            controller.selectDictationInputDeviceUID(options[index].uid)
+                            refreshDictationInputDevices()
+                        }
+                    )
                     .frame(height: 24)
                 }
                 Divider().background(MuesliTheme.surfaceBorder)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -10,6 +10,13 @@ private struct MeetingDetectionAppOption: Identifiable {
     var id: String { bundleID }
 }
 
+private struct DictationMicrophoneOption: Identifiable {
+    let uid: String?
+    let label: String
+
+    var id: String { uid ?? "__automatic__" }
+}
+
 struct SettingsView: View {
     private enum PendingDataDestruction {
         case dictations
@@ -75,6 +82,7 @@ struct SettingsView: View {
     @State private var selectedPane: SettingsPane = .general
     @State private var downloadedBackendOptions: [BackendOption] = []
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
+    @State private var dictationInputDevices: [AudioInputDeviceInfo] = []
     @State private var permissionPollTimer: Timer?
     @State private var micGranted = false
     @State private var accessibilityGranted = false
@@ -124,6 +132,23 @@ struct SettingsView: View {
         appState.config.resolvedCohereLanguage
     }
 
+    private var dictationMicrophoneOptions: [DictationMicrophoneOption] {
+        var options = [DictationMicrophoneOption(uid: nil, label: "Automatic")]
+        options += dictationInputDevices.map { device in
+            DictationMicrophoneOption(uid: device.uid, label: device.name)
+        }
+        if let selectedUID = appState.config.dictationInputDeviceUID,
+           !options.contains(where: { $0.uid == selectedUID }) {
+            options.append(DictationMicrophoneOption(uid: selectedUID, label: "Selected microphone unavailable"))
+        }
+        return options
+    }
+
+    private var selectedDictationMicrophoneLabel: String {
+        let selectedUID = appState.config.dictationInputDeviceUID
+        return dictationMicrophoneOptions.first(where: { $0.uid == selectedUID })?.label ?? "Automatic"
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
@@ -139,6 +164,7 @@ struct SettingsView: View {
         .background(MuesliTheme.backgroundBase)
         .onAppear {
             refreshDownloadedModelOptions()
+            refreshDictationInputDevices()
             startPermissionPolling()
             if appState.selectedMeetingSummaryBackend == .openRouter {
                 loadOpenRouterFreeModelsIfNeeded()
@@ -152,6 +178,7 @@ struct SettingsView: View {
         .onChange(of: appState.selectedTab) { _, tab in
             if tab == .settings {
                 refreshDownloadedModelOptions()
+                refreshDictationInputDevices()
                 refreshPermissionStatuses()
             }
         }
@@ -196,6 +223,10 @@ struct SettingsView: View {
         controller.refreshMeetingTranscriptionSelectionForAvailability()
         downloadedBackendOptions = BackendOption.downloaded
         downloadedPostProcOptions = PostProcessorOption.downloaded
+    }
+
+    private func refreshDictationInputDevices() {
+        dictationInputDevices = controller.availableDictationInputDevices()
     }
 
     private func backendOptions(including selection: BackendOption) -> [BackendOption] {
@@ -376,6 +407,22 @@ struct SettingsView: View {
                             controller.selectCohereLanguage(language)
                         }
                     }
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow(
+                    "Microphone",
+                    description: "Automatic uses the system input on speakers and the Mac mic on AirPods or headphones."
+                ) {
+                    let options = dictationMicrophoneOptions
+                    FixedWidthPopUp(
+                        selection: selectedDictationMicrophoneLabel,
+                        options: options.map(\.label)
+                    ) { index in
+                        guard index >= 0, index < options.count else { return }
+                        controller.selectDictationInputDeviceUID(options[index].uid)
+                        refreshDictationInputDevices()
+                    }
+                    .frame(height: 24)
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("AI transcript cleanup") {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -411,7 +411,7 @@ struct SettingsView: View {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(
                     "Microphone",
-                    description: "Automatic uses the system input on speakers and the Mac mic on AirPods or headphones."
+                    description: "Automatic uses system input, or Mac mic with AirPods."
                 ) {
                     let options = dictationMicrophoneOptions
                     FixedWidthPopUp(

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -17,7 +17,11 @@ protocol StreamingDictationRecording: AnyObject {
     func currentPower() -> Float
 }
 
-final class StreamingMicRecorder: StreamingDictationRecording {
+protocol StreamingDictationLatencyReporting: AnyObject {
+    var onLatencyEvent: ((String, Date) -> Void)? { get set }
+}
+
+final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting {
     /// Called with 4096-sample Float chunks (256ms at 16kHz) for VAD processing.
     var onAudioBuffer: (([Float]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?
@@ -80,7 +84,6 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         emitLatency("app_scoped_preferred_input_applied")
 
         let inputNode = engine.inputNode
-        emitLatency("app_scoped_input_node_ready")
         let hwFormat = inputNode.outputFormat(forBus: 0)
         guard hwFormat.sampleRate > 0 else {
             isGraphPrepared = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -14,6 +14,7 @@ protocol StreamingDictationRecording: AnyObject {
     func start() throws
     func stop() -> URL?
     func cancel()
+    func currentPower() -> Float
 }
 
 final class StreamingMicRecorder: StreamingDictationRecording {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -25,6 +25,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     var preferredInputDeviceID: AudioObjectID?
 
     private let engine = AVAudioEngine()
+    private let directoryName: String
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
     private let failureLock = OSAllocatedUnfairLock(initialState: FailureState())
     private let failureCallbackQueue = DispatchQueue(label: "com.muesli.streaming-mic-recorder-failures")
@@ -46,6 +47,10 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     private static let sampleRate: Double = 16_000
     private static let bufferSize: AVAudioFrameCount = 4096 // 256ms at 16kHz
+
+    init(directoryName: String = "muesli-meeting-mic") {
+        self.directoryName = directoryName
+    }
 
     func prepare() throws {
         AudioInputDeviceSelection.applyPreferredInputDeviceID(
@@ -318,7 +323,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     private func createNewFile() throws -> FileState {
         let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("muesli-meeting-mic", isDirectory: true)
+            .appendingPathComponent(directoryName, isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let url = dir.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
         FileManager.default.createFile(atPath: url.path, contents: nil)

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -27,11 +27,14 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     private let engine = AVAudioEngine()
     private let directoryName: String
+    private let graphLock = NSRecursiveLock()
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
     private let failureLock = OSAllocatedUnfairLock(initialState: FailureState())
     private let failureCallbackQueue = DispatchQueue(label: "com.muesli.streaming-mic-recorder-failures")
     private var isRunning = false
     private var tapInstalled = false
+    private var graphPreparedInputDeviceID: AudioObjectID?
+    private var isGraphPrepared = false
 
     private struct FailureState {
         var activeRecordingID: UUID?
@@ -54,6 +57,19 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     }
 
     func prepare() throws {
+        graphLock.lock()
+        defer { graphLock.unlock() }
+
+        try prepareLocked()
+    }
+
+    private func prepareLocked() throws {
+        if isGraphPrepared,
+           graphPreparedInputDeviceID == preferredInputDeviceID {
+            emitLatency("app_scoped_prepare_reused")
+            return
+        }
+
         emitLatency("app_scoped_prepare_begin")
         AudioInputDeviceSelection.applyPreferredInputDeviceID(
             preferredInputDeviceID,
@@ -66,16 +82,24 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         emitLatency("app_scoped_input_node_ready")
         let hwFormat = inputNode.outputFormat(forBus: 0)
         guard hwFormat.sampleRate > 0 else {
+            isGraphPrepared = false
+            graphPreparedInputDeviceID = nil
             throw NSError(domain: "StreamingMicRecorder", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "No audio input available",
             ])
         }
+        engine.prepare()
+        isGraphPrepared = true
+        graphPreparedInputDeviceID = preferredInputDeviceID
         emitLatency("app_scoped_prepare_end")
     }
 
     func start() throws {
+        graphLock.lock()
+        defer { graphLock.unlock() }
+
         guard !isRunning else { return }
-        try prepare()
+        try prepareLocked()
         let recordingID = UUID()
         failureLock.withLock {
             $0.activeRecordingID = recordingID
@@ -237,6 +261,9 @@ final class StreamingMicRecorder: StreamingDictationRecording {
 
     /// Stop recording. Returns the final WAV URL.
     func stop() -> URL? {
+        graphLock.lock()
+        defer { graphLock.unlock() }
+
         guard isRunning else { return nil }
         isRunning = false
         clearFailureState()
@@ -269,10 +296,15 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     }
 
     func cancel() {
+        graphLock.lock()
+        defer { graphLock.unlock() }
+
         isRunning = false
         clearFailureState()
         removeTapIfNeeded()
         engine.stop()
+        isGraphPrepared = false
+        graphPreparedInputDeviceID = nil
         onAudioBuffer = nil
         onPCMSamples = nil
         onRecordingFailed = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -20,6 +20,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     /// Called with 4096-sample Float chunks (256ms at 16kHz) for VAD processing.
     var onAudioBuffer: (([Float]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
     /// Called with 16-bit PCM mono samples for retained meeting recording.
     var onPCMSamples: (([Int16]) -> Void)?
     var preferredInputDeviceID: AudioObjectID?
@@ -53,19 +54,23 @@ final class StreamingMicRecorder: StreamingDictationRecording {
     }
 
     func prepare() throws {
+        emitLatency("app_scoped_prepare_begin")
         AudioInputDeviceSelection.applyPreferredInputDeviceID(
             preferredInputDeviceID,
             to: engine,
             logPrefix: "streaming-mic"
         )
+        emitLatency("app_scoped_preferred_input_applied")
 
         let inputNode = engine.inputNode
+        emitLatency("app_scoped_input_node_ready")
         let hwFormat = inputNode.outputFormat(forBus: 0)
         guard hwFormat.sampleRate > 0 else {
             throw NSError(domain: "StreamingMicRecorder", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "No audio input available",
             ])
         }
+        emitLatency("app_scoped_prepare_end")
     }
 
     func start() throws {
@@ -101,6 +106,7 @@ final class StreamingMicRecorder: StreamingDictationRecording {
         let fileState = try createNewFile()
         lock.withLock { $0 = fileState }
 
+        emitLatency("app_scoped_tap_install_begin")
         inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
             guard let self else { return }
             guard self.isCurrentRecording(recordingID) else { return }
@@ -185,9 +191,12 @@ final class StreamingMicRecorder: StreamingDictationRecording {
             self.onAudioBuffer?(floats)
         }
         tapInstalled = true
+        emitLatency("app_scoped_tap_install_end")
 
         do {
+            emitLatency("app_scoped_engine_start_begin")
             try engine.start()
+            emitLatency("app_scoped_engine_start_end")
             isRunning = true
         } catch {
             removeTapIfNeeded()
@@ -298,6 +307,10 @@ final class StreamingMicRecorder: StreamingDictationRecording {
             $0.activeRecordingID = nil
             $0.hasReportedFailure = true
         }
+    }
+
+    private func emitLatency(_ event: String, at date: Date = Date()) {
+        onLatencyEvent?(event, date)
     }
 
     private func reportRecordingFailure(_ error: Error, recordingID: UUID) {

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -1,0 +1,108 @@
+import CoreAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("AppScopedDictationRecorder")
+struct AppScopedDictationRecorderTests {
+    @Test("cancelled queued explicit warmup does not prepare microphone")
+    func cancelledQueuedExplicitWarmupDoesNotPrepareMicrophone() {
+        let streamingRecorder = FakeStreamingRecorder()
+        let prepareQueue = DispatchQueue(label: "test.app-scoped-dictation.prepare.cancelled")
+        prepareQueue.suspend()
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: prepareQueue
+        )
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        recorder.cancel()
+        prepareQueue.resume()
+        prepareQueue.sync {}
+
+        #expect(streamingRecorder.prepareCalls == 0)
+        #expect(streamingRecorder.cancelCalls == 1)
+    }
+
+    @Test("failed explicit warmup is retried on next hotkey prepare")
+    func failedExplicitWarmupIsRetriedOnNextHotkeyPrepare() {
+        let error = NSError(domain: "AppScopedDictationRecorderTests", code: 1)
+        let streamingRecorder = FakeStreamingRecorder()
+        streamingRecorder.prepareResults = [
+            .failure(error),
+            .success(()),
+        ]
+        let prepareQueue = DispatchQueue(label: "test.app-scoped-dictation.prepare.retry")
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: prepareQueue
+        )
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+
+        #expect(streamingRecorder.prepareCalls == 2)
+        #expect(streamingRecorder.cancelCalls == 1)
+        #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
+    }
+
+    @Test("successful explicit warmup is reused by start")
+    func successfulExplicitWarmupIsReusedByStart() throws {
+        let streamingRecorder = FakeStreamingRecorder()
+        let prepareQueue = DispatchQueue(label: "test.app-scoped-dictation.prepare.reuse")
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: prepareQueue
+        )
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+        _ = try recorder.start()
+
+        #expect(streamingRecorder.prepareCalls == 1)
+        #expect(streamingRecorder.startCalls == 1)
+        #expect(streamingRecorder.startedInputDeviceID == 82)
+    }
+}
+
+private final class FakeStreamingRecorder: StreamingDictationRecording {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
+
+    var prepareResults: [Result<Void, Error>] = []
+    var preparedInputDeviceIDs: [AudioObjectID?] = []
+    var prepareCalls = 0
+    var startCalls = 0
+    var stopCalls = 0
+    var cancelCalls = 0
+    var startedInputDeviceID: AudioObjectID?
+
+    func prepare() throws {
+        prepareCalls += 1
+        preparedInputDeviceIDs.append(preferredInputDeviceID)
+        if !prepareResults.isEmpty {
+            try prepareResults.removeFirst().get()
+        }
+    }
+
+    func start() throws {
+        startCalls += 1
+        startedInputDeviceID = preferredInputDeviceID
+    }
+
+    func stop() -> URL? {
+        stopCalls += 1
+        return nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -160
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -66,6 +66,28 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.startedInputDeviceID == 82)
     }
 
+    @Test("stop clears explicit preparation so rapid re-arm re-prepares")
+    func stopClearsExplicitPreparationBeforeRapidRearm() throws {
+        let streamingRecorder = FakeStreamingRecorder()
+        let prepareQueue = DispatchQueue(label: "test.app-scoped-dictation.prepare.stop-rearm")
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: prepareQueue
+        )
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+        _ = try recorder.start()
+        _ = recorder.stop()
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+
+        #expect(streamingRecorder.prepareCalls == 2)
+        #expect(streamingRecorder.stopCalls == 1)
+        #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
+    }
+
     @Test("cool down clears explicit preparation so next arm re-warms")
     func coolDownClearsExplicitPreparation() {
         let streamingRecorder = FakeStreamingRecorder()

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -124,6 +124,22 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
     }
 
+    @Test("stop tears down child recorder graph after finalizing recording")
+    func stopTearsDownChildRecorderGraphAfterFinalizingRecording() throws {
+        let streamingRecorder = FakeStreamingRecorder()
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: DispatchQueue(label: "test.app-scoped-dictation.prepare.stop-teardown")
+        )
+
+        _ = try recorder.start()
+        _ = recorder.stop()
+
+        #expect(streamingRecorder.startCalls == 1)
+        #expect(streamingRecorder.stopCalls == 1)
+        #expect(streamingRecorder.cancelCalls == 1)
+    }
+
     @Test("cool down clears explicit preparation so next arm re-warms")
     func coolDownClearsExplicitPreparation() {
         let streamingRecorder = FakeStreamingRecorder()

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -194,6 +194,43 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.startCalls == 1)
         #expect(streamingRecorder.cancelCalls >= 1)
     }
+
+    @Test("stale startup failure after cancel does not cancel child twice")
+    func staleStartupFailureAfterCancelDoesNotCancelChildTwice() throws {
+        let error = NSError(domain: "AppScopedDictationRecorderTests", code: 2)
+        let streamingRecorder = FakeStreamingRecorder()
+        let startStarted = DispatchSemaphore(value: 0)
+        let finishStart = DispatchSemaphore(value: 0)
+        let cancelReturned = DispatchSemaphore(value: 0)
+        streamingRecorder.onStartStarted = {
+            startStarted.signal()
+        }
+        streamingRecorder.startSemaphore = finishStart
+        streamingRecorder.startError = error
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: DispatchQueue(label: "test.app-scoped-dictation.prepare.stale-start-failure")
+        )
+
+        let startQueue = DispatchQueue(label: "test.app-scoped-dictation.stale-start-failure")
+        startQueue.async {
+            _ = try? recorder.start()
+        }
+
+        #expect(startStarted.wait(timeout: .now() + 1) == .success)
+        DispatchQueue.global(qos: .userInitiated).async {
+            recorder.cancel()
+            cancelReturned.signal()
+        }
+
+        #expect(cancelReturned.wait(timeout: .now() + 0.1) == .timedOut)
+        finishStart.signal()
+        #expect(cancelReturned.wait(timeout: .now() + 1) == .success)
+        startQueue.sync {}
+
+        #expect(streamingRecorder.startCalls == 1)
+        #expect(streamingRecorder.cancelCalls == 1)
+    }
 }
 
 private final class FakeStreamingRecorder: StreamingDictationRecording {
@@ -212,6 +249,7 @@ private final class FakeStreamingRecorder: StreamingDictationRecording {
     var prepareSemaphore: DispatchSemaphore?
     var onStartStarted: (() -> Void)?
     var startSemaphore: DispatchSemaphore?
+    var startError: Error?
 
     func prepare() throws {
         prepareCalls += 1
@@ -228,6 +266,9 @@ private final class FakeStreamingRecorder: StreamingDictationRecording {
         startedInputDeviceID = preferredInputDeviceID
         onStartStarted?()
         startSemaphore?.wait()
+        if let startError {
+            throw startError
+        }
     }
 
     func stop() -> URL? {

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -41,8 +41,14 @@ struct AppScopedDictationRecorderTests {
 
         recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
         #expect(prepareStarted.wait(timeout: .now() + 1) == .success)
-        recorder.cancel()
+        let cancelReturned = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            recorder.cancel()
+            cancelReturned.signal()
+        }
+        #expect(cancelReturned.wait(timeout: .now() + 0.1) == .timedOut)
         finishPrepare.signal()
+        #expect(cancelReturned.wait(timeout: .now() + 1) == .success)
         prepareQueue.sync {}
 
         streamingRecorder.prepareSemaphore = nil
@@ -137,6 +143,41 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.cancelCalls == 1)
         #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
     }
+
+    @Test("cancel waits for in-flight child startup before returning")
+    func cancelWaitsForInFlightChildStartupBeforeReturning() throws {
+        let streamingRecorder = FakeStreamingRecorder()
+        let startStarted = DispatchSemaphore(value: 0)
+        let finishStart = DispatchSemaphore(value: 0)
+        let cancelReturned = DispatchSemaphore(value: 0)
+        streamingRecorder.onStartStarted = {
+            startStarted.signal()
+        }
+        streamingRecorder.startSemaphore = finishStart
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: DispatchQueue(label: "test.app-scoped-dictation.prepare.startup-cancel")
+        )
+
+        let startQueue = DispatchQueue(label: "test.app-scoped-dictation.start")
+        startQueue.async {
+            _ = try? recorder.start()
+        }
+
+        #expect(startStarted.wait(timeout: .now() + 1) == .success)
+        DispatchQueue.global(qos: .userInitiated).async {
+            recorder.cancel()
+            cancelReturned.signal()
+        }
+
+        #expect(cancelReturned.wait(timeout: .now() + 0.1) == .timedOut)
+        finishStart.signal()
+        #expect(cancelReturned.wait(timeout: .now() + 1) == .success)
+        startQueue.sync {}
+
+        #expect(streamingRecorder.startCalls == 1)
+        #expect(streamingRecorder.cancelCalls >= 1)
+    }
 }
 
 private final class FakeStreamingRecorder: StreamingDictationRecording {
@@ -153,6 +194,8 @@ private final class FakeStreamingRecorder: StreamingDictationRecording {
     var startedInputDeviceID: AudioObjectID?
     var onPrepareStarted: (() -> Void)?
     var prepareSemaphore: DispatchSemaphore?
+    var onStartStarted: (() -> Void)?
+    var startSemaphore: DispatchSemaphore?
 
     func prepare() throws {
         prepareCalls += 1
@@ -167,6 +210,8 @@ private final class FakeStreamingRecorder: StreamingDictationRecording {
     func start() throws {
         startCalls += 1
         startedInputDeviceID = preferredInputDeviceID
+        onStartStarted?()
+        startSemaphore?.wait()
     }
 
     func stop() -> URL? {

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -65,6 +65,26 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.startCalls == 1)
         #expect(streamingRecorder.startedInputDeviceID == 82)
     }
+
+    @Test("cool down clears explicit preparation so next arm re-warms")
+    func coolDownClearsExplicitPreparation() {
+        let streamingRecorder = FakeStreamingRecorder()
+        let prepareQueue = DispatchQueue(label: "test.app-scoped-dictation.prepare.cooldown")
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: prepareQueue
+        )
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+        recorder.coolDown()
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+
+        #expect(streamingRecorder.prepareCalls == 2)
+        #expect(streamingRecorder.cancelCalls == 1)
+        #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
+    }
 }
 
 private final class FakeStreamingRecorder: StreamingDictationRecording {

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -24,6 +24,36 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.cancelCalls == 1)
     }
 
+    @Test("cancelled in-flight explicit warmup is torn down and not reused")
+    func cancelledInFlightExplicitWarmupIsTornDownAndNotReused() {
+        let streamingRecorder = FakeStreamingRecorder()
+        let prepareStarted = DispatchSemaphore(value: 0)
+        let finishPrepare = DispatchSemaphore(value: 0)
+        streamingRecorder.onPrepareStarted = {
+            prepareStarted.signal()
+        }
+        streamingRecorder.prepareSemaphore = finishPrepare
+        let prepareQueue = DispatchQueue(label: "test.app-scoped-dictation.prepare.in-flight-cancel")
+        let recorder = AppScopedDictationRecorder(
+            recorder: streamingRecorder,
+            prepareQueue: prepareQueue
+        )
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        #expect(prepareStarted.wait(timeout: .now() + 1) == .success)
+        recorder.cancel()
+        finishPrepare.signal()
+        prepareQueue.sync {}
+
+        streamingRecorder.prepareSemaphore = nil
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        prepareQueue.sync {}
+
+        #expect(streamingRecorder.prepareCalls == 2)
+        #expect(streamingRecorder.cancelCalls == 2)
+        #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
+    }
+
     @Test("failed explicit warmup is retried on next hotkey prepare")
     func failedExplicitWarmupIsRetriedOnNextHotkeyPrepare() {
         let error = NSError(domain: "AppScopedDictationRecorderTests", code: 1)
@@ -121,10 +151,14 @@ private final class FakeStreamingRecorder: StreamingDictationRecording {
     var stopCalls = 0
     var cancelCalls = 0
     var startedInputDeviceID: AudioObjectID?
+    var onPrepareStarted: (() -> Void)?
+    var prepareSemaphore: DispatchSemaphore?
 
     func prepare() throws {
         prepareCalls += 1
         preparedInputDeviceIDs.append(preferredInputDeviceID)
+        onPrepareStarted?()
+        prepareSemaphore?.wait()
         if !prepareResults.isEmpty {
             try prepareResults.removeFirst().get()
         }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -134,6 +134,29 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
     }
 
+    @Test("system default aggregate is not treated as a selectable microphone")
+    func systemDefaultAggregateIsNotSelectable() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "CADefaultDeviceAggregate-28219-0", name: "CADefaultDeviceAggregate-28219-0", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.system-aggregate"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.availableInputDevices().map(\.uid) == ["built-in-mic"])
+
+        controller.selectedInputDeviceUID = "CADefaultDeviceAggregate-28219-0"
+        #expect(controller.preferredInputDeviceIDForDictation() == nil)
+    }
+
     @Test("default input refresh can notify even when preferred route is unchanged")
     func defaultInputRefreshCanNotifyEvenWhenPreferredRouteIsUnchanged() {
         let inspector = FakeCoreAudioDeviceInspector(
@@ -191,11 +214,12 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     func availableInputDevices() -> [AudioInputDeviceInfo] {
-        inputDevices
+        inputDevices.filter { !$0.uid.hasPrefix("CADefaultDeviceAggregate") }
     }
 
     func inputDeviceID(matchingUID uid: String) -> AudioObjectID? {
-        inputDevices.first(where: { $0.uid == uid })?.deviceID
+        guard !uid.hasPrefix("CADefaultDeviceAggregate") else { return nil }
+        return inputDevices.first(where: { $0.uid == uid })?.deviceID
     }
 
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -26,6 +26,7 @@ struct DictationAudioRouteControllerTests {
         let inspector = FakeCoreAudioDeviceInspector(
             defaultOutputDeviceID: 10,
             outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 82,
             builtInInputDeviceID: 82
         )
         let controller = DictationAudioRouteController(
@@ -36,6 +37,25 @@ struct DictationAudioRouteControllerTests {
 
         #expect(controller.preferredInputDeviceIDForDictation() == nil)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
+        #expect(controller.systemDefaultInputIsBuiltInForDictation())
+    }
+
+    @Test("speaker output with non-built-in default input is not warmup-safe")
+    func speakerOutputWithNonBuiltInDefaultInputIsNotWarmupSafe() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 91,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.speaker-like-risky-input"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForDictation() == nil)
+        #expect(!controller.systemDefaultInputIsBuiltInForDictation())
     }
 
     @Test("dictation prefers built-in mic for ambiguous Bluetooth unknown output")
@@ -182,6 +202,7 @@ struct DictationAudioRouteControllerTests {
 
 private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     var defaultOutputDeviceIDValue: AudioObjectID?
+    var defaultInputDeviceIDValue: AudioObjectID?
     var outputRouteKindValue: AudioOutputRouteKind
     var outputIsAmbiguousBluetoothValue: Bool
     var builtInInputDeviceIDValue: AudioObjectID?
@@ -191,10 +212,12 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
         defaultOutputDeviceID: AudioObjectID?,
         outputRouteKind: AudioOutputRouteKind,
         outputIsAmbiguousBluetooth: Bool = false,
+        defaultInputDeviceID: AudioObjectID? = nil,
         builtInInputDeviceID: AudioObjectID?,
         inputDevices: [AudioInputDeviceInfo] = []
     ) {
         self.defaultOutputDeviceIDValue = defaultOutputDeviceID
+        self.defaultInputDeviceIDValue = defaultInputDeviceID
         self.outputRouteKindValue = outputRouteKind
         self.outputIsAmbiguousBluetoothValue = outputIsAmbiguousBluetooth
         self.builtInInputDeviceIDValue = builtInInputDeviceID
@@ -206,7 +229,7 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     func defaultInputDeviceID() -> AudioObjectID? {
-        nil
+        defaultInputDeviceIDValue
     }
 
     func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -91,6 +91,49 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
     }
 
+    @Test("user selected microphone overrides automatic route policy")
+    func userSelectedMicrophoneOverridesAutomaticRoutePolicy() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.selected-input"),
+            observesDefaultOutputChanges: false
+        )
+        controller.selectedInputDeviceUID = "external-mic"
+
+        #expect(controller.preferredInputDeviceIDForDictation() == 91)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == 91)
+    }
+
+    @Test("unavailable selected microphone falls back to automatic route policy")
+    func unavailableSelectedMicrophoneFallsBackToAutomaticRoutePolicy() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.missing-selected-input"),
+            observesDefaultOutputChanges: false
+        )
+        controller.selectedInputDeviceUID = "missing-mic"
+
+        #expect(controller.preferredInputDeviceIDForDictation() == 82)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
+    }
+
     @Test("default input refresh can notify even when preferred route is unchanged")
     func defaultInputRefreshCanNotifyEvenWhenPreferredRouteIsUnchanged() {
         let inspector = FakeCoreAudioDeviceInspector(
@@ -119,17 +162,20 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     var outputRouteKindValue: AudioOutputRouteKind
     var outputIsAmbiguousBluetoothValue: Bool
     var builtInInputDeviceIDValue: AudioObjectID?
+    var inputDevices: [AudioInputDeviceInfo]
 
     init(
         defaultOutputDeviceID: AudioObjectID?,
         outputRouteKind: AudioOutputRouteKind,
         outputIsAmbiguousBluetooth: Bool = false,
-        builtInInputDeviceID: AudioObjectID?
+        builtInInputDeviceID: AudioObjectID?,
+        inputDevices: [AudioInputDeviceInfo] = []
     ) {
         self.defaultOutputDeviceIDValue = defaultOutputDeviceID
         self.outputRouteKindValue = outputRouteKind
         self.outputIsAmbiguousBluetoothValue = outputIsAmbiguousBluetooth
         self.builtInInputDeviceIDValue = builtInInputDeviceID
+        self.inputDevices = inputDevices
     }
 
     func defaultOutputDeviceID() -> AudioObjectID? {
@@ -142,6 +188,14 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
 
     func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {
         false
+    }
+
+    func availableInputDevices() -> [AudioInputDeviceInfo] {
+        inputDevices
+    }
+
+    func inputDeviceID(matchingUID uid: String) -> AudioObjectID? {
+        inputDevices.first(where: { $0.uid == uid })?.deviceID
     }
 
     func isDeviceAvailable(_ deviceID: AudioObjectID) -> Bool {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -691,6 +691,7 @@ private final class FakeMediaPlaybackManager: MediaPlaybackManaging {
 
 private final class FakeDictationRoute: DictationAudioRouting {
     var onPreferredInputDeviceChanged: ((AudioObjectID?) -> Void)?
+    var selectedInputDeviceUID: String?
     var routeKind: AudioOutputRouteKind
     var preferredInputDeviceID: AudioObjectID?
     var cachedPreferredInputDeviceID: AudioObjectID?
@@ -716,6 +717,10 @@ private final class FakeDictationRoute: DictationAudioRouting {
 
     func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID? {
         cachedPreferredInputDeviceID
+    }
+
+    func availableInputDevices() -> [AudioInputDeviceInfo] {
+        []
     }
 
     func isDefaultOutputHeadphoneLike() -> Bool {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -90,7 +90,8 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.ducking.beginCalls.allSatisfy { $0 == false })
-        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.startCalls == 1)
         #expect(harness.recorder.preferredInputDeviceID == 82)
     }
 
@@ -107,8 +108,8 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
     }
 
-    @Test("headphone arm activates with app-scoped built-in mic")
-    func armRefreshesPreferredInput() {
+    @Test("headphone arm refreshes preferred input without activating app-scoped mic")
+    func headphoneArmRefreshesPreferredInputWithoutActivatingMic() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
 
@@ -116,11 +117,12 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.activateCalls == 1)
-        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.preferredInputDeviceID == 82)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "activation_end:hotkey"
+                return name == "activation_skipped:hotkey:app_scoped_route"
             }
             return false
         })
@@ -135,9 +137,15 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.activateCalls == 0)
         #expect(harness.recorder.preferredInputDeviceID == 82)
         #expect(harness.recorder.startCalls == 1)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "activation_prepare_skipped:toggle:app_scoped_start"
+            }
+            return false
+        })
     }
 
     @Test("external session refreshes preferred input instead of using stale route cache")
@@ -166,7 +174,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.activateCalls == 2)
+        #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.ducking.beginCalls == [true])
@@ -330,8 +338,8 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.activateCalls == 0)
     }
 
-    @Test("delayed route refresh does not block explicit headphone activation")
-    func delayedRouteRefreshDoesNotBlockExplicitHeadphoneActivation() {
+    @Test("delayed route refresh does not arm-activate headphone route")
+    func delayedRouteRefreshDoesNotArmActivateHeadphoneRoute() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
         harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), delay: 0.2, canWarmUp: true)
@@ -339,7 +347,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.activateCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
 
         Thread.sleep(forTimeInterval: 0.25)
@@ -401,8 +409,8 @@ struct DictationAudioSessionManagerTests {
 
         #expect(harness.recorder.cancelCalls == 1)
         #expect(harness.recorder.startCalls == 1)
-        #expect(harness.recorder.activateCalls == 1)
-        #expect(harness.recorder.lastWarmInputDeviceID == 82)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.manager.currentSessionID == nil)
         #expect(harness.events.contains { if case .failed = $0 { return true }; return false })
         #expect(!harness.events.contains { event in
@@ -579,6 +587,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
     var onFirstSpeechDetected: ((Date) -> Void)?
     var onNoAudioTimeout: ((Date) -> Void)?
     var onRecordingFailed: ((Error, UUID) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
 
     var prepareCalls = 0
     var warmUpCalls = 0

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -90,6 +90,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.ducking.beginCalls.allSatisfy { $0 == false })
+        #expect(harness.recorder.explicitWarmupCalls == 1)
         #expect(harness.recorder.activateCalls == 0)
         #expect(harness.recorder.startCalls == 1)
         #expect(harness.recorder.preferredInputDeviceID == 82)
@@ -117,12 +118,13 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.recorder.explicitWarmupCalls == 1)
         #expect(harness.recorder.activateCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.preferredInputDeviceID == 82)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "activation_skipped:hotkey:app_scoped_route"
+                return name == "activation_async_prepare_started:hotkey:app_scoped_route"
             }
             return false
         })
@@ -142,7 +144,7 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "activation_prepare_skipped:toggle:app_scoped_start"
+                return name == "activation_prepare_skipped:toggle:app_scoped_route"
             }
             return false
         })
@@ -288,6 +290,67 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.activateCalls == 0)
     }
 
+    @Test("speaker route skips idle warmup when default input is not built in")
+    func speakerRouteSkipsIdleWarmupWhenDefaultInputIsNotBuiltIn() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.route.systemDefaultInputIsBuiltIn = false
+
+        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.warmUpCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "warmup_skipped:idle_routeChange:risky_default_input"
+            }
+            return false
+        })
+    }
+
+    @Test("speaker route with non built-in default input does not arm-activate")
+    func speakerRouteWithNonBuiltInDefaultInputDoesNotArmActivate() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.route.systemDefaultInputIsBuiltIn = false
+
+        harness.manager.arm(source: "hotkey")
+        harness.wait()
+
+        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "activation_skipped:hotkey:risky_default_input"
+            }
+            return false
+        })
+    }
+
+    @Test("explicit speaker recording with non built-in default input still starts cold")
+    func explicitSpeakerRecordingWithNonBuiltInDefaultInputStillStartsCold() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.route.systemDefaultInputIsBuiltIn = false
+
+        harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: false)
+        harness.wait()
+
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.startCalls == 1)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "activation_prepare_skipped:toggle:risky_default_input"
+            }
+            return false
+        })
+    }
+
     @Test("headphone route refresh skips idle mic warmup")
     func headphoneRouteRefreshSkipsIdleMicWarmup() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
@@ -332,7 +395,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)
@@ -590,6 +653,7 @@ private final class FakeDictationRecorder: DictationAudioRecording {
     var onLatencyEvent: ((String, Date) -> Void)?
 
     var prepareCalls = 0
+    var explicitWarmupCalls = 0
     var warmUpCalls = 0
     var activateCalls = 0
     var coolDownCalls = 0
@@ -604,6 +668,11 @@ private final class FakeDictationRecorder: DictationAudioRecording {
 
     func prepare() throws {
         prepareCalls += 1
+    }
+
+    func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
+        explicitWarmupCalls += 1
+        self.preferredInputDeviceID = preferredInputDeviceID
     }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
@@ -704,6 +773,7 @@ private final class FakeDictationRoute: DictationAudioRouting {
     var routeKind: AudioOutputRouteKind
     var preferredInputDeviceID: AudioObjectID?
     var cachedPreferredInputDeviceID: AudioObjectID?
+    var systemDefaultInputIsBuiltIn = true
     var refreshCalls = 0
     var restoreCalls = 0
     var preferredInputCalls = 0
@@ -741,7 +811,11 @@ private final class FakeDictationRoute: DictationAudioRouting {
     }
 
     func currentRouteDebugDescription() -> String {
-        "output=\(routeKind.description) preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default")"
+        "output=\(routeKind.description) preferredInput=\(preferredInputDeviceID.map(String.init) ?? "default") defaultInputBuiltIn=\(systemDefaultInputIsBuiltIn)"
+    }
+
+    func systemDefaultInputIsBuiltInForDictation() -> Bool {
+        systemDefaultInputIsBuiltIn
     }
 
     func refreshRouteAfterDictationSession() {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -395,7 +395,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 0)
+        #expect(harness.recorder.coolDownCalls == 1)
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -175,15 +175,15 @@ struct DictationAudioSessionManagerTests {
         harness.manager.beginRecording(mode: "prepare", duckingEnabled: true, mediaPauseEnabled: false)
         harness.wait()
 
-        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.route.preferredInputCalls == 2)
         #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.ducking.beginCalls == [true])
     }
 
-    @Test("hold start uses cached route snapshot from arm path")
-    func holdStartUsesCachedRouteSnapshot() {
+    @Test("hold start refreshes route snapshot from arm path")
+    func holdStartRefreshesRouteSnapshot() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
         harness.manager.arm(source: "hotkey")
@@ -191,10 +191,10 @@ struct DictationAudioSessionManagerTests {
         harness.manager.beginRecording(mode: "hold-start", duckingEnabled: false, mediaPauseEnabled: false)
         harness.wait()
 
-        #expect(harness.route.preferredInputCalls == 1)
+        #expect(harness.route.preferredInputCalls == 2)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name.hasPrefix("route_snapshot_cached:hold-start")
+                return name.hasPrefix("route_snapshot_refreshed:hold-start")
             }
             return false
         })

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -24,7 +24,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .speakerLike)
         harness.recorder.warmUpDelay = 0.2
 
-        harness.manager.refreshRoute(reason: "route-change", canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
         let startedAt = Date()
         harness.manager.arm(source: "hotkey")
         let elapsed = Date().timeIntervalSince(startedAt)
@@ -45,7 +45,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.recorder.activateCalls == 2)
-        #expect(harness.recorder.prepareCalls == 1)
+        #expect(harness.recorder.prepareCalls == 0)
         #expect(harness.recorder.startCalls == 1)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
@@ -81,7 +81,7 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
-    @Test("headphone route skips ducking and selects built-in mic")
+    @Test("headphone route skips ducking and selects built-in mic app-locally")
     func headphoneRouteSkipsDucking() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
@@ -107,7 +107,7 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
     }
 
-    @Test("headphone arm refreshes preferred input without opening mic")
+    @Test("headphone arm activates with app-scoped built-in mic")
     func armRefreshesPreferredInput() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
         harness.route.cachedPreferredInputDeviceID = nil
@@ -116,11 +116,11 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.activateCalls == 0)
-        #expect(harness.recorder.lastWarmInputDeviceID == nil)
+        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.lastWarmInputDeviceID == 82)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "activation_deferred:hotkey"
+                return name == "activation_end:hotkey"
             }
             return false
         })
@@ -166,7 +166,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.preferredInputCalls == 1)
-        #expect(harness.recorder.activateCalls == 1)
+        #expect(harness.recorder.activateCalls == 2)
         #expect(harness.recorder.lastWarmInputDeviceID == nil)
         #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.ducking.beginCalls == [true])
@@ -266,11 +266,11 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
-    @Test("route refresh warms graph without opening mic")
-    func routeRefreshWarmsGraphWithoutOpeningMic() {
-        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+    @Test("speaker route refresh warms graph without opening mic")
+    func speakerRouteRefreshWarmsGraphWithoutOpeningMic() {
+        let harness = Harness(routeKind: .speakerLike)
 
-        harness.manager.refreshRoute(reason: "route-change", canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
@@ -280,16 +280,66 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.activateCalls == 0)
     }
 
-    @Test("delayed route refresh does not block hotkey arm")
-    func delayedRouteRefreshDoesNotBlockHotkeyArm() {
+    @Test("headphone route refresh skips idle mic warmup")
+    func headphoneRouteRefreshSkipsIdleMicWarmup() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.refreshRoute(reason: "route-change", delay: 0.2, canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.warmUpCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "warmup_skipped:idle_routeChange:risky_route"
+            }
+            return false
+        })
+    }
+
+    @Test("unknown route refresh skips idle mic warmup")
+    func unknownRouteRefreshSkipsIdleMicWarmup() {
+        let harness = Harness(routeKind: .unknown)
+
+        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.warmUpCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.activateCalls == 0)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
+    }
+
+    @Test("headphone post-dictation refresh skips mic warmup")
+    func headphonePostDictationRefreshSkipsMicWarmup() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.refreshRoute(intent: .postDictation(.transcriptionComplete), canWarmUp: true)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.warmUpCalls == 0)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.activateCalls == 0)
+    }
+
+    @Test("delayed route refresh does not block explicit headphone activation")
+    func delayedRouteRefreshDoesNotBlockExplicitHeadphoneActivation() {
+        let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
+
+        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), delay: 0.2, canWarmUp: true)
         harness.manager.arm(source: "hotkey")
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.warmUpCalls == 0)
 
         Thread.sleep(forTimeInterval: 0.25)
@@ -298,7 +348,7 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "route_refresh_cancelled:route-change"
+                return name == "route_refresh_cancelled:idle_routeChange"
             }
             return false
         })
@@ -340,8 +390,8 @@ struct DictationAudioSessionManagerTests {
         #expect(!harness.events.contains { if case .noAudioTimeout = $0 { return true }; return false })
     }
 
-    @Test("no audio timeout on headphone preferred input does not retry default input")
-    func noAudioTimeoutOnHeadphonePreferredInputDoesNotRetryDefaultInput() {
+    @Test("no audio timeout on headphone preferred input does not retry system default")
+    func noAudioTimeoutOnHeadphonePreferredInputDoesNotRetrySystemDefault() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
         harness.manager.beginRecording(mode: "toggle", duckingEnabled: true, mediaPauseEnabled: false)
@@ -353,7 +403,6 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.startCalls == 1)
         #expect(harness.recorder.activateCalls == 1)
         #expect(harness.recorder.lastWarmInputDeviceID == 82)
-        #expect(harness.recorder.preferredInputDeviceID == nil)
         #expect(harness.manager.currentSessionID == nil)
         #expect(harness.events.contains { if case .failed = $0 { return true }; return false })
         #expect(!harness.events.contains { event in

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -212,6 +212,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.recorder.stopCalls == 1)
+        #expect(!harness.recorder.keepsAudioGraphWarm)
         #expect(harness.ducking.restoreCalls == 1)
         #expect(harness.route.restoreCalls == 1)
         #expect(harness.events.contains { event in

--- a/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
@@ -47,6 +47,48 @@ struct FallbackStreamingDictationRecorderTests {
         #expect(fallback.startedInputDeviceID == 82)
     }
 
+    @Test("fallback start failure cleans up fallback recorder")
+    func fallbackStartFailureCleansUpFallbackRecorder() throws {
+        let primaryError = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 20)
+        let fallbackError = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 21)
+        let primary = FakeFallbackStreamingRecorder()
+        primary.startResults = [.failure(primaryError)]
+        let fallback = FakeFallbackStreamingRecorder()
+        fallback.startResults = [.failure(fallbackError)]
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+
+        try recorder.prepare()
+        #expect(throws: Error.self) {
+            try recorder.start()
+        }
+
+        #expect(primary.cancelCalls == 1)
+        #expect(fallback.prepareCalls == 1)
+        #expect(fallback.startCalls == 1)
+        #expect(fallback.cancelCalls == 1)
+    }
+
+    @Test("callbacks are rewired after child cancel")
+    func callbacksAreRewiredAfterChildCancel() throws {
+        let error = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 4)
+        let primary = FakeFallbackStreamingRecorder()
+        primary.startResults = [.failure(error)]
+        let fallback = FakeFallbackStreamingRecorder()
+        fallback.clearsCallbacksOnCancel = true
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+        var bufferCount = 0
+        recorder.onAudioBuffer = { _ in bufferCount += 1 }
+
+        recorder.cancel()
+        try recorder.prepare()
+        try recorder.start()
+        fallback.onAudioBuffer?([0.3])
+
+        #expect(fallback.cancelCalls == 1)
+        #expect(fallback.startCalls == 1)
+        #expect(bufferCount == 1)
+    }
+
     @Test("callbacks from inactive recorder are ignored after fallback")
     func callbacksFromInactiveRecorderAreIgnoredAfterFallback() throws {
         let error = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 3)
@@ -82,6 +124,7 @@ private final class FakeFallbackStreamingRecorder: StreamingDictationRecording {
     var startCalls = 0
     var stopCalls = 0
     var cancelCalls = 0
+    var clearsCallbacksOnCancel = false
 
     func prepare() throws {
         prepareCalls += 1
@@ -106,6 +149,10 @@ private final class FakeFallbackStreamingRecorder: StreamingDictationRecording {
 
     func cancel() {
         cancelCalls += 1
+        if clearsCallbacksOnCancel {
+            onAudioBuffer = nil
+            onRecordingFailed = nil
+        }
     }
 
     func currentPower() -> Float {

--- a/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
@@ -1,0 +1,114 @@
+import CoreAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("FallbackStreamingDictationRecorder")
+struct FallbackStreamingDictationRecorderTests {
+    @Test("prepare falls back when primary prepare fails")
+    func prepareFallsBackWhenPrimaryPrepareFails() throws {
+        let error = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 1)
+        let primary = FakeFallbackStreamingRecorder()
+        primary.prepareResults = [.failure(error)]
+        let fallback = FakeFallbackStreamingRecorder()
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+        recorder.preferredInputDeviceID = 82
+        var latencyEvents: [String] = []
+        recorder.onLatencyEvent = { event, _ in latencyEvents.append(event) }
+
+        try recorder.prepare()
+
+        #expect(primary.prepareCalls == 1)
+        #expect(primary.cancelCalls == 1)
+        #expect(fallback.prepareCalls == 1)
+        #expect(primary.preparedInputDeviceIDs == [82])
+        #expect(fallback.preparedInputDeviceIDs == [82])
+        #expect(latencyEvents.contains("streaming_recorder_primary_prepare_failed"))
+        #expect(latencyEvents.contains("streaming_recorder_fallback_prepare_end"))
+    }
+
+    @Test("start falls back when prepared primary start fails")
+    func startFallsBackWhenPreparedPrimaryStartFails() throws {
+        let error = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 2)
+        let primary = FakeFallbackStreamingRecorder()
+        primary.startResults = [.failure(error)]
+        let fallback = FakeFallbackStreamingRecorder()
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+        recorder.preferredInputDeviceID = 82
+
+        try recorder.prepare()
+        try recorder.start()
+
+        #expect(primary.prepareCalls == 1)
+        #expect(primary.startCalls == 1)
+        #expect(primary.cancelCalls == 1)
+        #expect(fallback.prepareCalls == 1)
+        #expect(fallback.startCalls == 1)
+        #expect(fallback.startedInputDeviceID == 82)
+    }
+
+    @Test("callbacks from inactive recorder are ignored after fallback")
+    func callbacksFromInactiveRecorderAreIgnoredAfterFallback() throws {
+        let error = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 3)
+        let primary = FakeFallbackStreamingRecorder()
+        primary.prepareResults = [.failure(error)]
+        let fallback = FakeFallbackStreamingRecorder()
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+        var bufferCount = 0
+        var failureCount = 0
+        recorder.onAudioBuffer = { _ in bufferCount += 1 }
+        recorder.onRecordingFailed = { _ in failureCount += 1 }
+
+        try recorder.prepare()
+        primary.onAudioBuffer?([0.1])
+        primary.onRecordingFailed?(error)
+        fallback.onAudioBuffer?([0.2])
+
+        #expect(bufferCount == 1)
+        #expect(failureCount == 0)
+    }
+}
+
+private final class FakeFallbackStreamingRecorder: StreamingDictationRecording {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
+
+    var prepareResults: [Result<Void, Error>] = []
+    var startResults: [Result<Void, Error>] = []
+    var preparedInputDeviceIDs: [AudioObjectID?] = []
+    var startedInputDeviceID: AudioObjectID?
+    var prepareCalls = 0
+    var startCalls = 0
+    var stopCalls = 0
+    var cancelCalls = 0
+
+    func prepare() throws {
+        prepareCalls += 1
+        preparedInputDeviceIDs.append(preferredInputDeviceID)
+        if !prepareResults.isEmpty {
+            try prepareResults.removeFirst().get()
+        }
+    }
+
+    func start() throws {
+        startCalls += 1
+        startedInputDeviceID = preferredInputDeviceID
+        if !startResults.isEmpty {
+            try startResults.removeFirst().get()
+        }
+    }
+
+    func stop() -> URL? {
+        stopCalls += 1
+        return nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -160
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -412,6 +412,10 @@ private final class FailingStreamingDictationRecorder: StreamingDictationRecordi
     func cancel() {
         cancelCalls += 1
     }
+
+    func currentPower() -> Float {
+        -160
+    }
 }
 
 @available(macOS 15, *)
@@ -464,6 +468,10 @@ private final class InspectableStreamingDictationRecorder: StreamingDictationRec
 
     func cancel() {
         cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -160
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -145,6 +145,41 @@ struct RouteAwareDictationRecorderTests {
         #expect(system.coolDownCalls == 1)
         #expect(appScoped.coolDownCalls == 1)
     }
+
+    @Test("route switch waits for in-flight app scoped explicit warmup teardown")
+    func routeSwitchWaitsForInFlightAppScopedExplicitWarmupTeardown() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScopedStreaming = FakeRouteAwareStreamingRecorder()
+        let prepareStarted = DispatchSemaphore(value: 0)
+        let finishPrepare = DispatchSemaphore(value: 0)
+        let routeSwitchReturned = DispatchSemaphore(value: 0)
+        appScopedStreaming.onPrepareStarted = {
+            prepareStarted.signal()
+        }
+        appScopedStreaming.prepareSemaphore = finishPrepare
+        let appScoped = AppScopedDictationRecorder(
+            recorder: appScopedStreaming,
+            prepareQueue: DispatchQueue(label: "test.route-aware.app-scoped.prepare.route-switch")
+        )
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+        #expect(prepareStarted.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? recorder.warmUp(preferredInputDeviceID: nil)
+            routeSwitchReturned.signal()
+        }
+
+        #expect(routeSwitchReturned.wait(timeout: .now() + 0.1) == .timedOut)
+        finishPrepare.signal()
+        #expect(routeSwitchReturned.wait(timeout: .now() + 1) == .success)
+
+        #expect(recorder.activeRecorderKindForDebug() == .systemDefault)
+        #expect(system.warmUpCalls == 1)
+        #expect(appScopedStreaming.prepareCalls == 1)
+        #expect(appScopedStreaming.cancelCalls >= 1)
+    }
 }
 
 private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
@@ -160,6 +195,7 @@ private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
     var explicitWarmupCalls = 0
     var activateCalls = 0
     var startCalls = 0
+    var stopCalls = 0
     var coolDownCalls = 0
     var cancelCalls = 0
 
@@ -190,7 +226,44 @@ private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
     }
 
     func stop() -> URL? {
-        nil
+        stopCalls += 1
+        return nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -160
+    }
+}
+
+private final class FakeRouteAwareStreamingRecorder: StreamingDictationRecording {
+    var onAudioBuffer: (([Float]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+    var preferredInputDeviceID: AudioObjectID?
+
+    var prepareCalls = 0
+    var startCalls = 0
+    var stopCalls = 0
+    var cancelCalls = 0
+    var onPrepareStarted: (() -> Void)?
+    var prepareSemaphore: DispatchSemaphore?
+
+    func prepare() throws {
+        prepareCalls += 1
+        onPrepareStarted?()
+        prepareSemaphore?.wait()
+    }
+
+    func start() throws {
+        startCalls += 1
+    }
+
+    func stop() -> URL? {
+        stopCalls += 1
+        return nil
     }
 
     func cancel() {

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -55,6 +55,21 @@ struct RouteAwareDictationRecorderTests {
         #expect(appScoped.preferredInputDeviceID == 82)
     }
 
+    @Test("preferred input explicit warmup uses app scoped recorder")
+    func preferredInputExplicitWarmupUsesAppScopedRecorder() {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        recorder.beginExplicitWarmup(preferredInputDeviceID: 82)
+
+        #expect(recorder.activeRecorderKindForDebug() == .appScoped)
+        #expect(system.explicitWarmupCalls == 0)
+        #expect(appScoped.explicitWarmupCalls == 1)
+        #expect(appScoped.preferredInputDeviceID == 82)
+    }
+
+
     @Test("latency events are forwarded from active child recorder")
     func latencyEventsAreForwardedFromActiveChildRecorder() throws {
         let system = FakeRouteAwareChildRecorder()
@@ -98,11 +113,17 @@ private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
     var onLatencyEvent: ((String, Date) -> Void)?
 
     var warmUpCalls = 0
+    var explicitWarmupCalls = 0
     var activateCalls = 0
     var startCalls = 0
     var cancelCalls = 0
 
     func prepare() throws {}
+
+    func beginExplicitWarmup(preferredInputDeviceID: AudioObjectID?) {
+        explicitWarmupCalls += 1
+        self.preferredInputDeviceID = preferredInputDeviceID
+    }
 
     func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
         warmUpCalls += 1

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -101,6 +101,18 @@ struct RouteAwareDictationRecorderTests {
         #expect(system.cancelCalls == 1)
         #expect(appScoped.activateCalls == 1)
     }
+
+    @Test("cool down tears down both recorder graphs")
+    func coolDownTearsDownBothRecorderGraphs() {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        recorder.coolDown()
+
+        #expect(system.coolDownCalls == 1)
+        #expect(appScoped.coolDownCalls == 1)
+    }
 }
 
 private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
@@ -116,6 +128,7 @@ private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
     var explicitWarmupCalls = 0
     var activateCalls = 0
     var startCalls = 0
+    var coolDownCalls = 0
     var cancelCalls = 0
 
     func prepare() throws {}
@@ -135,7 +148,9 @@ private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
         self.preferredInputDeviceID = preferredInputDeviceID
     }
 
-    func coolDown() {}
+    func coolDown() {
+        coolDownCalls += 1
+    }
 
     func start() throws -> UUID {
         startCalls += 1

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -87,6 +87,38 @@ struct RouteAwareDictationRecorderTests {
         #expect(events == ["app_scoped_engine_start_end"])
     }
 
+    @Test("callbacks from inactive child recorder are ignored")
+    func callbacksFromInactiveChildRecorderAreIgnored() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+        var firstBufferCount = 0
+        var speechCount = 0
+        var timeoutCount = 0
+        var failureCount = 0
+        var latencyEvents: [String] = []
+        recorder.onFirstCapturedAudioBuffer = { _ in firstBufferCount += 1 }
+        recorder.onFirstSpeechDetected = { _ in speechCount += 1 }
+        recorder.onNoAudioTimeout = { _ in timeoutCount += 1 }
+        recorder.onRecordingFailed = { _, _ in failureCount += 1 }
+        recorder.onLatencyEvent = { event, _ in latencyEvents.append(event) }
+
+        _ = try recorder.start()
+        appScoped.onFirstCapturedAudioBuffer?(Date())
+        appScoped.onFirstSpeechDetected?(Date())
+        appScoped.onNoAudioTimeout?(Date())
+        appScoped.onRecordingFailed?(NSError(domain: "RouteAwareDictationRecorderTests", code: 1), UUID())
+        appScoped.onLatencyEvent?("inactive_latency", Date())
+        system.onFirstCapturedAudioBuffer?(Date())
+        system.onLatencyEvent?("active_latency", Date())
+
+        #expect(firstBufferCount == 1)
+        #expect(speechCount == 0)
+        #expect(timeoutCount == 0)
+        #expect(failureCount == 0)
+        #expect(latencyEvents == ["active_latency"])
+    }
+
     @Test("switching recorder cancels inactive warmed graph")
     func switchingRecorderCancelsInactiveWarmedGraph() throws {
         let system = FakeRouteAwareChildRecorder()

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -1,0 +1,135 @@
+import CoreAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("RouteAwareDictationRecorder")
+struct RouteAwareDictationRecorderTests {
+    @Test("default input uses system default recorder")
+    func defaultInputUsesSystemDefaultRecorder() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        try recorder.activateWarmEngine(preferredInputDeviceID: nil)
+        _ = try recorder.start()
+
+        #expect(recorder.activeRecorderKindForDebug() == .systemDefault)
+        #expect(system.activateCalls == 1)
+        #expect(system.startCalls == 1)
+        #expect(appScoped.activateCalls == 0)
+        #expect(appScoped.startCalls == 0)
+    }
+
+    @Test("preferred input uses app scoped recorder")
+    func preferredInputUsesAppScopedRecorder() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        try recorder.activateWarmEngine(preferredInputDeviceID: 82)
+        _ = try recorder.start()
+
+        #expect(recorder.activeRecorderKindForDebug() == .appScoped)
+        #expect(system.activateCalls == 0)
+        #expect(system.startCalls == 0)
+        #expect(appScoped.activateCalls == 1)
+        #expect(appScoped.startCalls == 1)
+        #expect(appScoped.preferredInputDeviceID == 82)
+    }
+
+    @Test("preferred input start without pre-activation uses app scoped recorder")
+    func preferredInputStartWithoutPreActivationUsesAppScopedRecorder() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        recorder.preferredInputDeviceID = 82
+        _ = try recorder.start()
+
+        #expect(recorder.activeRecorderKindForDebug() == .appScoped)
+        #expect(system.activateCalls == 0)
+        #expect(system.startCalls == 0)
+        #expect(appScoped.activateCalls == 0)
+        #expect(appScoped.startCalls == 1)
+        #expect(appScoped.preferredInputDeviceID == 82)
+    }
+
+    @Test("latency events are forwarded from active child recorder")
+    func latencyEventsAreForwardedFromActiveChildRecorder() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+        var events: [String] = []
+        recorder.onLatencyEvent = { event, _ in
+            events.append(event)
+        }
+
+        recorder.preferredInputDeviceID = 82
+        _ = try recorder.start()
+        appScoped.onLatencyEvent?("app_scoped_engine_start_end", Date())
+
+        #expect(events == ["app_scoped_engine_start_end"])
+    }
+
+    @Test("switching recorder cancels inactive warmed graph")
+    func switchingRecorderCancelsInactiveWarmedGraph() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        try recorder.warmUp(preferredInputDeviceID: nil)
+        try recorder.activateWarmEngine(preferredInputDeviceID: 82)
+
+        #expect(recorder.activeRecorderKindForDebug() == .appScoped)
+        #expect(system.warmUpCalls == 1)
+        #expect(system.cancelCalls == 1)
+        #expect(appScoped.activateCalls == 1)
+    }
+}
+
+private final class FakeRouteAwareChildRecorder: DictationAudioRecording {
+    var preferredInputDeviceID: AudioObjectID?
+    var keepsAudioGraphWarm = false
+    var onFirstCapturedAudioBuffer: ((Date) -> Void)?
+    var onFirstSpeechDetected: ((Date) -> Void)?
+    var onNoAudioTimeout: ((Date) -> Void)?
+    var onRecordingFailed: ((Error, UUID) -> Void)?
+    var onLatencyEvent: ((String, Date) -> Void)?
+
+    var warmUpCalls = 0
+    var activateCalls = 0
+    var startCalls = 0
+    var cancelCalls = 0
+
+    func prepare() throws {}
+
+    func warmUp(preferredInputDeviceID: AudioObjectID?) throws {
+        warmUpCalls += 1
+        self.preferredInputDeviceID = preferredInputDeviceID
+    }
+
+    func activateWarmEngine(preferredInputDeviceID: AudioObjectID?) throws {
+        activateCalls += 1
+        self.preferredInputDeviceID = preferredInputDeviceID
+    }
+
+    func coolDown() {}
+
+    func start() throws -> UUID {
+        startCalls += 1
+        return UUID()
+    }
+
+    func stop() -> URL? {
+        nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -160
+    }
+}


### PR DESCRIPTION
## Summary
- make dictation recorder warmup route-aware
- keep idle/full warmup on speaker-like routes for low-latency dictation
- skip idle and post-dictation mic warmup on headphone-like or unknown routes to avoid AirPods/Bluetooth focus stealing
- keep explicit hotkey/toggle dictation activation working on headphone routes

## RCA / Why
Muesli currently keeps the dictation recorder prepared while idle. On AirPods/Bluetooth routes, preparing an `AVAudioRecorder` and applying preferred input state can make macOS look like it wants microphone ownership even when the user did not invoke dictation. That can trigger AirPods to switch from another Apple device or compete with an active call.

This change centralizes the ownership rule: idle warmup is allowed only on safe speaker-like routes. Risky routes are cooled down unless the user explicitly starts dictation.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"`
- Result: 926 tests passed, 0 failures

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782963581&installation_id=136549638&pr_number=196&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F196&signature=2c22daf81adf540e81da2c9bfa2a6f6396f5a2b7700e6253cd64199c55dc29a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->