### PR TITLE
Reduce scheduled meeting notification false positives

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MaraudersMapCountdownController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MaraudersMapCountdownController.swift
@@ -12,14 +12,14 @@ final class MaraudersMapCountdownController {
     private var audioClipID: String = "bbc_world_news"
     private var customAudioPath: String?
     private var onStatusBarUpdate: ((String?) -> Void)?
-    private var onCountdownFinished: (((id: String, title: String)) -> Void)?
+    private var onCountdownFinished: (((id: String, title: String, startDate: Date)) -> Void)?
 
     func startMonitoring(
         eventProvider: @escaping () -> (id: String, title: String, startDate: Date)?,
         audioClipID: String,
         customAudioPath: String?,
         onStatusBarUpdate: @escaping (String?) -> Void,
-        onCountdownFinished: @escaping ((id: String, title: String)) -> Void
+        onCountdownFinished: @escaping ((id: String, title: String, startDate: Date)) -> Void
     ) {
         self.eventProvider = eventProvider
         self.audioClipID = audioClipID
@@ -89,7 +89,7 @@ final class MaraudersMapCountdownController {
             maybeTimer?.invalidate()
             SoundController.stopMaraudersMapClip()
             onStatusBarUpdate?(nil)
-            onCountdownFinished?((id: event.id, title: event.title))
+            onCountdownFinished?((id: event.id, title: event.title, startDate: event.startDate))
             activeEventID = nil
             startPolling()
             return

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -718,6 +718,7 @@ struct AppConfig: Codable {
     var idleTimeout: Double = 120
     var autoRecordMeetings: Bool = false
     var showScheduledMeetingNotifications: Bool = true
+    var scheduledMeetingNotificationLeadTime: ScheduledMeetingNotificationLeadTime = .atStart
     var showMeetingDetectionNotification: Bool = true
     var mutedMeetingDetectionAppBundleIDs: [String] = []
     var meetingRecordingSavePolicy: MeetingRecordingSavePolicy = .never
@@ -797,6 +798,7 @@ struct AppConfig: Codable {
         case idleTimeout = "idle_timeout"
         case autoRecordMeetings = "auto_record_meetings"
         case showScheduledMeetingNotifications = "show_scheduled_meeting_notifications"
+        case scheduledMeetingNotificationLeadTime = "scheduled_meeting_notification_lead_time"
         case showMeetingDetectionNotification = "show_meeting_detection_notification"
         case mutedMeetingDetectionAppBundleIDs = "muted_meeting_detection_app_bundle_ids"
         case meetingRecordingSavePolicy = "meeting_recording_save_policy"
@@ -887,6 +889,9 @@ struct AppConfig: Codable {
             (try? c.decode(Bool.self, forKey: .showScheduledMeetingNotifications))
             ?? decodedShowMeetingDetectionNotification
             ?? defaults.showScheduledMeetingNotifications
+        scheduledMeetingNotificationLeadTime =
+            (try? c.decode(ScheduledMeetingNotificationLeadTime.self, forKey: .scheduledMeetingNotificationLeadTime))
+            ?? defaults.scheduledMeetingNotificationLeadTime
         showMeetingDetectionNotification = decodedShowMeetingDetectionNotification ?? defaults.showMeetingDetectionNotification
         mutedMeetingDetectionAppBundleIDs = (try? c.decode([String].self, forKey: .mutedMeetingDetectionAppBundleIDs)) ?? defaults.mutedMeetingDetectionAppBundleIDs
         meetingRecordingSavePolicy = (try? c.decode(MeetingRecordingSavePolicy.self, forKey: .meetingRecordingSavePolicy)) ?? defaults.meetingRecordingSavePolicy

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5756,7 +5756,7 @@ final class MuesliController: NSObject {
                 // Reuse the same notification method as the timer path
                 self.showMeetingStartingNowNotification(
                     title: event.title,
-                    calendarEventID: self.notificationKey(id: event.id, startDate: event.startDate),
+                    calendarEventID: event.id,
                     meetingURL: event.meetingURL,
                     endDate: event.endDate
                 )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1372,9 +1372,12 @@ final class MuesliController: NSObject {
             return Date(timeIntervalSince1970: ts) > cutoff
         }
 
-        let candidates = appState.upcomingCalendarEvents.filter {
-            !$0.isAllDay && $0.startDate > now && $0.startDate <= fiveMinutesFromNow
-        }
+        let candidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
+            from: appState.upcomingCalendarEvents,
+            now: now,
+            hiddenEventIDs: appState.hiddenCalendarEventIDs,
+            leadTime: fiveMinutesFromNow.timeIntervalSince(now)
+        )
         for event in candidates {
             let key = notificationKey(id: event.id, startDate: event.startDate)
             guard !notifiedUpcomingEventIDs.contains(key) else { continue }
@@ -1394,15 +1397,26 @@ final class MuesliController: NSObject {
             // Schedule a second "Meeting starting now" notification at event start time
             let delay = event.startDate.timeIntervalSinceNow
             if delay > 15 { // Only if there's enough gap after the first notification auto-dismisses
-                let meetingURL = event.meetingURL
-                let endDate = event.endDate
-                let title = event.title
+                let eventID = event.id
+                let startDate = event.startDate
                 meetingStartingNowTimers[key]?.invalidate()
                 meetingStartingNowTimers[key] = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
                     DispatchQueue.main.async { [weak self] in
-                        guard let self, !self.isMeetingRecording() else { return }
+                        guard let self else { return }
                         self.meetingStartingNowTimers.removeValue(forKey: key)
-                        self.showMeetingStartingNowNotification(title: title, calendarEventID: key, meetingURL: meetingURL, endDate: endDate)
+                        guard !self.isMeetingRecording(),
+                              let event = ScheduledMeetingNotificationPolicy.startingNowCandidate(
+                                from: self.appState.upcomingCalendarEvents,
+                                eventID: eventID,
+                                startDate: startDate,
+                                hiddenEventIDs: self.appState.hiddenCalendarEventIDs
+                              ) else { return }
+                        self.showMeetingStartingNowNotification(
+                            title: event.title,
+                            calendarEventID: key,
+                            meetingURL: event.meetingURL,
+                            endDate: event.endDate
+                        )
                     }
                 }
             }
@@ -1413,7 +1427,8 @@ final class MuesliController: NSObject {
 
     /// Show a "Meeting starting now" notification — independent of Marauder's Map.
     private func showMeetingStartingNowNotification(title: String, calendarEventID: String?, meetingURL: URL?, endDate: Date?) {
-        guard config.showScheduledMeetingNotifications,
+        guard ScheduledMeetingNotificationPolicy.shouldShowStartingNowPrompt(meetingURL: meetingURL),
+              config.showScheduledMeetingNotifications,
               !isMeetingRecording(),
               !isStartingMeetingRecording else { return }
         isShowingCalendarNotification = true
@@ -5542,9 +5557,12 @@ final class MuesliController: NSObject {
                 guard let self else { return nil }
                 let now = Date()
                 let hidden = self.appState.hiddenCalendarEventIDs
-                guard let event = self.appState.upcomingCalendarEvents
-                    .filter({ !$0.isAllDay && $0.startDate > now && !hidden.contains($0.id) })
-                    .min(by: { $0.startDate < $1.startDate }) else { return nil }
+                guard let event = (self.appState.upcomingCalendarEvents
+                    .filter {
+                        ScheduledMeetingNotificationPolicy.isJoinableMeeting($0, hiddenEventIDs: hidden)
+                            && $0.startDate > now
+                    }
+                    .min(by: { $0.startDate < $1.startDate })) else { return nil }
                 return (id: event.id, title: event.title, startDate: event.startDate)
             },
             audioClipID: config.maraudersMapAudioClip,
@@ -5564,13 +5582,18 @@ final class MuesliController: NSObject {
                     timer.invalidate()
                     self.meetingStartingNowTimers.removeValue(forKey: key)
                 }
-                let event = self.appState.upcomingCalendarEvents.first(where: { $0.id == info.id })
+                guard let event = ScheduledMeetingNotificationPolicy.startingNowCandidate(
+                    from: self.appState.upcomingCalendarEvents,
+                    eventID: info.id,
+                    startDate: info.startDate,
+                    hiddenEventIDs: self.appState.hiddenCalendarEventIDs
+                ) else { return }
                 // Reuse the same notification method as the timer path
                 self.showMeetingStartingNowNotification(
-                    title: info.title,
-                    calendarEventID: info.id,
-                    meetingURL: event?.meetingURL,
-                    endDate: event?.endDate
+                    title: event.title,
+                    calendarEventID: self.notificationKey(id: event.id, startDate: event.startDate),
+                    meetingURL: event.meetingURL,
+                    endDate: event.endDate
                 )
             }
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -215,6 +215,7 @@ final class MuesliController: NSObject {
     private var calendarMonitoringStarted = false
     private var meetingStartingNowTimers = [String: Timer]()
     private var notifiedUpcomingEventIDs = Set<String>()
+    private var autoRecordedCalendarEventIDs = Set<String>()
     private var meetingFeatureMonitorsAllowed = false
     private var meetingDetectionMonitorStarted = false
 
@@ -603,6 +604,8 @@ final class MuesliController: NSObject {
         calendarMonitoringStarted = false
         meetingStartingNowTimers.values.forEach { $0.invalidate() }
         meetingStartingNowTimers.removeAll()
+        notifiedUpcomingEventIDs.removeAll()
+        autoRecordedCalendarEventIDs.removeAll()
         meetingFeatureMonitorsAllowed = false
         disarmMeetingAutoStop()
         meetingMonitor.stop()
@@ -1390,14 +1393,43 @@ final class MuesliController: NSObject {
                   let ts = TimeInterval(tsString) else { return false }
             return Date(timeIntervalSince1970: ts) > cutoff
         }
+        autoRecordedCalendarEventIDs = autoRecordedCalendarEventIDs.filter { key in
+            guard let tsString = key.split(separator: "|").last,
+                  let ts = TimeInterval(tsString) else { return false }
+            return Date(timeIntervalSince1970: ts) > cutoff
+        }
 
-        let candidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
+        if config.autoRecordMeetings {
+            let autoRecordCandidates = ScheduledMeetingNotificationPolicy.autoRecordCandidates(
+                from: appState.upcomingCalendarEvents,
+                now: now,
+                hiddenEventIDs: appState.hiddenCalendarEventIDs
+            )
+            for event in autoRecordCandidates {
+                let key = notificationKey(id: event.id, startDate: event.startDate)
+                guard !autoRecordedCalendarEventIDs.contains(key) else { continue }
+                autoRecordedCalendarEventIDs.insert(key)
+
+                startMeetingRecording(
+                    title: event.title,
+                    calendarEventID: event.id,
+                    openDocument: true,
+                    endDate: event.endDate,
+                    autoStopSource: event.meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
+                )
+                return
+            }
+        }
+
+        guard config.showScheduledMeetingNotifications else { return }
+
+        let notificationCandidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
             from: appState.upcomingCalendarEvents,
             now: now,
             hiddenEventIDs: appState.hiddenCalendarEventIDs,
             leadTime: leadTime
         )
-        for event in candidates {
+        for event in notificationCandidates {
             let key = notificationKey(id: event.id, startDate: event.startDate)
             guard !notifiedUpcomingEventIDs.contains(key) else { continue }
 
@@ -5753,17 +5785,6 @@ final class MuesliController: NSObject {
         let calendarEndDate = calendarEvent?.endDate
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
         let autoStopSource = meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
-
-        if config.autoRecordMeetings, !isMeetingRecording() {
-            startMeetingRecording(
-                title: event.title,
-                calendarEventID: event.id,
-                openDocument: true,
-                endDate: calendarEndDate,
-                autoStopSource: autoStopSource
-            )
-            return
-        }
 
         // Show notification panel for calendar events (if not auto-recording)
         guard config.showScheduledMeetingNotifications,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1366,9 +1366,10 @@ final class MuesliController: NSObject {
         }
     }
 
-    /// Check all upcoming calendar events (EventKit + Google) for events starting within 5 minutes.
-    /// Shows a notification when the event enters the 5-minute window, and schedules a second
-    /// "Meeting starting now" notification at event start time.
+    /// Check all upcoming calendar events (EventKit + Google) for events entering the configured prompt window.
+    /// With a pre-start lead time, shows a notification when the event enters that window and schedules a second
+    /// "Meeting starting now" notification at event start time. With the default start-time policy, waits until
+    /// the event has started so calendar prompts do not fire before the user is expected to join.
     /// This is the single notification path for all calendar sources.
     /// Composite dedup key: same event rescheduled to a new time gets a fresh notification.
     private func notificationKey(id: String, startDate: Date) -> String {
@@ -1380,7 +1381,7 @@ final class MuesliController: NSObject {
               !isStartingMeetingRecording else { return }
 
         let now = Date()
-        let fiveMinutesFromNow = now.addingTimeInterval(5 * 60)
+        let leadTime = config.scheduledMeetingNotificationLeadTime.seconds
 
         // Prune stale entries (events that started more than 1 hour ago)
         let cutoff = now.addingTimeInterval(-3600)
@@ -1394,7 +1395,7 @@ final class MuesliController: NSObject {
             from: appState.upcomingCalendarEvents,
             now: now,
             hiddenEventIDs: appState.hiddenCalendarEventIDs,
-            leadTime: fiveMinutesFromNow.timeIntervalSince(now)
+            leadTime: leadTime
         )
         for event in candidates {
             let key = notificationKey(id: event.id, startDate: event.startDate)
@@ -1412,9 +1413,9 @@ final class MuesliController: NSObject {
             // Show "starts in X min" notification now
             handleUpcomingMeeting(upcomingEvent)
 
-            // Schedule a second "Meeting starting now" notification at event start time
+            // Schedule a second "Meeting starting now" notification at event start time for pre-start prompts.
             let delay = event.startDate.timeIntervalSinceNow
-            if delay > 15 { // Only if there's enough gap after the first notification auto-dismisses
+            if leadTime > 0, delay > 15 { // Only if there's enough gap after the first notification auto-dismisses
                 let eventID = event.id
                 let startDate = event.startDate
                 meetingStartingNowTimers[key]?.invalidate()
@@ -5783,8 +5784,9 @@ final class MuesliController: NSObject {
         }
 
         let title = event.title
+        let notificationTitle = minutesUntil <= 0 ? "Meeting starting now" : "Upcoming meeting"
         meetingNotification.show(
-            title: "Upcoming meeting",
+            title: notificationTitle,
             subtitle: "\(title) · \(timeLabel)",
             meetingURL: meetingURL,
             onStartRecording: { [weak self] in

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationLeadTime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationLeadTime.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum ScheduledMeetingNotificationLeadTime: String, Codable, CaseIterable {
+    case atStart = "at_start"
+    case oneMinute = "one_minute"
+    case threeMinutes = "three_minutes"
+    case fiveMinutes = "five_minutes"
+
+    var seconds: TimeInterval {
+        switch self {
+        case .atStart:
+            return 0
+        case .oneMinute:
+            return 60
+        case .threeMinutes:
+            return 3 * 60
+        case .fiveMinutes:
+            return 5 * 60
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
@@ -40,6 +40,8 @@ enum ScheduledMeetingNotificationPolicy {
         now: Date,
         hiddenEventIDs: Set<String>
     ) -> [UnifiedCalendarEvent] {
+        // Auto-record follows the same joinable-meeting eligibility as scheduled prompts,
+        // but it always waits until the event start window instead of using reminder lead time.
         events
             .filter { event in
                 shouldShowStartTimePrompt(

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 enum ScheduledMeetingNotificationPolicy {
-    static let defaultLeadTime: TimeInterval = 5 * 60
+    static let defaultLeadTime: TimeInterval = 0
+    static let startPromptGracePeriod: TimeInterval = 90
 
     static func upcomingCandidates(
         from events: [UnifiedCalendarEvent],
@@ -9,6 +10,18 @@ enum ScheduledMeetingNotificationPolicy {
         hiddenEventIDs: Set<String>,
         leadTime: TimeInterval = defaultLeadTime
     ) -> [UnifiedCalendarEvent] {
+        guard leadTime > 0 else {
+            return events
+                .filter { event in
+                    shouldShowStartTimePrompt(
+                        for: event,
+                        now: now,
+                        hiddenEventIDs: hiddenEventIDs
+                    )
+                }
+                .sorted { $0.startDate < $1.startDate }
+        }
+
         let windowEnd = now.addingTimeInterval(leadTime)
         return events
             .filter { event in
@@ -30,6 +43,16 @@ enum ScheduledMeetingNotificationPolicy {
     ) -> Bool {
         guard isJoinableMeeting(event, hiddenEventIDs: hiddenEventIDs) else { return false }
         return event.startDate > now && event.startDate <= windowEnd
+    }
+
+    static func shouldShowStartTimePrompt(
+        for event: UnifiedCalendarEvent,
+        now: Date,
+        hiddenEventIDs: Set<String>,
+        gracePeriod: TimeInterval = startPromptGracePeriod
+    ) -> Bool {
+        guard isJoinableMeeting(event, hiddenEventIDs: hiddenEventIDs) else { return false }
+        return event.startDate <= now && event.startDate > now.addingTimeInterval(-gracePeriod)
     }
 
     static func shouldShowStartingNowPrompt(meetingURL: URL?) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum ScheduledMeetingNotificationPolicy {
+    static let defaultLeadTime: TimeInterval = 5 * 60
+
+    static func upcomingCandidates(
+        from events: [UnifiedCalendarEvent],
+        now: Date,
+        hiddenEventIDs: Set<String>,
+        leadTime: TimeInterval = defaultLeadTime
+    ) -> [UnifiedCalendarEvent] {
+        let windowEnd = now.addingTimeInterval(leadTime)
+        return events
+            .filter { event in
+                shouldShowUpcomingPrompt(
+                    for: event,
+                    now: now,
+                    windowEnd: windowEnd,
+                    hiddenEventIDs: hiddenEventIDs
+                )
+            }
+            .sorted { $0.startDate < $1.startDate }
+    }
+
+    static func shouldShowUpcomingPrompt(
+        for event: UnifiedCalendarEvent,
+        now: Date,
+        windowEnd: Date,
+        hiddenEventIDs: Set<String>
+    ) -> Bool {
+        guard isJoinableMeeting(event, hiddenEventIDs: hiddenEventIDs) else { return false }
+        return event.startDate > now && event.startDate <= windowEnd
+    }
+
+    static func shouldShowStartingNowPrompt(meetingURL: URL?) -> Bool {
+        meetingURL != nil
+    }
+
+    static func startingNowCandidate(
+        from events: [UnifiedCalendarEvent],
+        eventID: String,
+        startDate: Date,
+        hiddenEventIDs: Set<String>
+    ) -> UnifiedCalendarEvent? {
+        events.first { event in
+            event.id == eventID
+                && Int(event.startDate.timeIntervalSince1970) == Int(startDate.timeIntervalSince1970)
+                && isJoinableMeeting(event, hiddenEventIDs: hiddenEventIDs)
+        }
+    }
+
+    static func isJoinableMeeting(
+        _ event: UnifiedCalendarEvent,
+        hiddenEventIDs: Set<String>
+    ) -> Bool {
+        event.meetingURL != nil
+            && !event.isAllDay
+            && !hiddenEventIDs.contains(event.id)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScheduledMeetingNotificationPolicy.swift
@@ -35,6 +35,22 @@ enum ScheduledMeetingNotificationPolicy {
             .sorted { $0.startDate < $1.startDate }
     }
 
+    static func autoRecordCandidates(
+        from events: [UnifiedCalendarEvent],
+        now: Date,
+        hiddenEventIDs: Set<String>
+    ) -> [UnifiedCalendarEvent] {
+        events
+            .filter { event in
+                shouldShowStartTimePrompt(
+                    for: event,
+                    now: now,
+                    hiddenEventIDs: hiddenEventIDs
+                )
+            }
+            .sorted { $0.startDate < $1.startDate }
+    }
+
     static func shouldShowUpcomingPrompt(
         for event: UnifiedCalendarEvent,
         now: Date,

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -727,7 +727,22 @@ struct SettingsView: View {
                         controller.updateConfig { $0.showScheduledMeetingNotifications = newValue }
                     }
                 }
-                settingsDescription("Show notifications before calendar meetings with a join link start.")
+                settingsDescription("Show notifications for calendar meetings with a join link.")
+
+                if appState.config.showScheduledMeetingNotifications {
+                    Divider().background(MuesliTheme.surfaceBorder)
+
+                    settingsRow("Notify") {
+                        settingsMenu(
+                            selection: scheduledMeetingLeadTimeLabel(for: appState.config.scheduledMeetingNotificationLeadTime),
+                            options: ScheduledMeetingNotificationLeadTime.allCases.map(scheduledMeetingLeadTimeLabel(for:))
+                        ) { label in
+                            guard let leadTime = scheduledMeetingLeadTime(for: label) else { return }
+                            controller.updateConfig { $0.scheduledMeetingNotificationLeadTime = leadTime }
+                        }
+                    }
+                    settingsDescription("At start time avoids early calendar-only prompts before you join.")
+                }
 
                 Divider().background(MuesliTheme.surfaceBorder)
 
@@ -2056,6 +2071,29 @@ struct SettingsView: View {
             assertionFailure("Unexpected recording save label: \(label)")
         }
         return policy
+    }
+
+    private func scheduledMeetingLeadTimeLabel(for leadTime: ScheduledMeetingNotificationLeadTime) -> String {
+        switch leadTime {
+        case .atStart:
+            return "At start time"
+        case .oneMinute:
+            return "1 min before"
+        case .threeMinutes:
+            return "3 min before"
+        case .fiveMinutes:
+            return "5 min before"
+        }
+    }
+
+    private func scheduledMeetingLeadTime(for label: String) -> ScheduledMeetingNotificationLeadTime? {
+        let leadTime = ScheduledMeetingNotificationLeadTime.allCases.first {
+            scheduledMeetingLeadTimeLabel(for: $0) == label
+        }
+        if leadTime == nil {
+            assertionFailure("Unexpected scheduled meeting notification lead time label: \(label)")
+        }
+        return leadTime
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -732,7 +732,7 @@ struct SettingsView: View {
                 if appState.config.showScheduledMeetingNotifications {
                     Divider().background(MuesliTheme.surfaceBorder)
 
-                    settingsRow("Notify") {
+                    settingsRow("Reminder timing") {
                         settingsMenu(
                             selection: scheduledMeetingLeadTimeLabel(for: appState.config.scheduledMeetingNotificationLeadTime),
                             options: ScheduledMeetingNotificationLeadTime.allCases.map(scheduledMeetingLeadTimeLabel(for:))

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -679,7 +679,7 @@ struct SettingsView: View {
                         controller.updateConfig { $0.showScheduledMeetingNotifications = newValue }
                     }
                 }
-                settingsDescription("Show notifications before meetings start based on your calendar.")
+                settingsDescription("Show notifications before calendar meetings with a join link start.")
 
                 Divider().background(MuesliTheme.surfaceBorder)
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -156,6 +156,29 @@ struct MeetingNotificationControllerTests {
         #expect(candidates.map(\.id) == ["started"])
     }
 
+    @Test("Auto-record candidates ignore reminder lead time")
+    func autoRecordCandidatesIgnoreReminderLeadTime() {
+        let now = Date(timeIntervalSinceReferenceDate: 2_750)
+        let meetingURL = URL(string: "https://meet.google.com/abc-defg-hij")!
+        let beforeStart = unifiedCalendarEvent(id: "before", startDate: now.addingTimeInterval(5 * 60), meetingURL: meetingURL)
+        let justStarted = unifiedCalendarEvent(id: "started", startDate: now.addingTimeInterval(-30), meetingURL: meetingURL)
+
+        let reminderCandidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
+            from: [beforeStart, justStarted],
+            now: now,
+            hiddenEventIDs: [],
+            leadTime: 5 * 60
+        )
+        let autoRecordCandidates = ScheduledMeetingNotificationPolicy.autoRecordCandidates(
+            from: [beforeStart, justStarted],
+            now: now,
+            hiddenEventIDs: []
+        )
+
+        #expect(reminderCandidates.map(\.id) == ["before"])
+        #expect(autoRecordCandidates.map(\.id) == ["started"])
+    }
+
     @Test("Starting now scheduled prompts require a join link")
     func startingNowScheduledPromptsRequireJoinLink() {
         #expect(ScheduledMeetingNotificationPolicy.shouldShowStartingNowPrompt(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -162,6 +162,7 @@ struct MeetingNotificationControllerTests {
         let meetingURL = URL(string: "https://meet.google.com/abc-defg-hij")!
         let beforeStart = unifiedCalendarEvent(id: "before", startDate: now.addingTimeInterval(5 * 60), meetingURL: meetingURL)
         let justStarted = unifiedCalendarEvent(id: "started", startDate: now.addingTimeInterval(-30), meetingURL: meetingURL)
+        let noLink = unifiedCalendarEvent(id: "no-link", startDate: now.addingTimeInterval(-30), meetingURL: nil)
 
         let reminderCandidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
             from: [beforeStart, justStarted],
@@ -170,7 +171,7 @@ struct MeetingNotificationControllerTests {
             leadTime: 5 * 60
         )
         let autoRecordCandidates = ScheduledMeetingNotificationPolicy.autoRecordCandidates(
-            from: [beforeStart, justStarted],
+            from: [beforeStart, justStarted, noLink],
             now: now,
             hiddenEventIDs: []
         )

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -132,10 +132,28 @@ struct MeetingNotificationControllerTests {
         let candidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
             from: [later, personal, hidden, sooner],
             now: now,
-            hiddenEventIDs: ["hidden"]
+            hiddenEventIDs: ["hidden"],
+            leadTime: 5 * 60
         )
 
         #expect(candidates.map(\.id) == ["sooner", "later"])
+    }
+
+    @Test("Default scheduled prompts wait until meeting start")
+    func defaultScheduledPromptsWaitUntilMeetingStart() {
+        let now = Date(timeIntervalSinceReferenceDate: 2_500)
+        let meetingURL = URL(string: "https://meet.google.com/abc-defg-hij")!
+        let beforeStart = unifiedCalendarEvent(id: "before", startDate: now.addingTimeInterval(60), meetingURL: meetingURL)
+        let justStarted = unifiedCalendarEvent(id: "started", startDate: now.addingTimeInterval(-30), meetingURL: meetingURL)
+        let stale = unifiedCalendarEvent(id: "stale", startDate: now.addingTimeInterval(-120), meetingURL: meetingURL)
+
+        let candidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
+            from: [beforeStart, justStarted, stale],
+            now: now,
+            hiddenEventIDs: []
+        )
+
+        #expect(candidates.map(\.id) == ["started"])
     }
 
     @Test("Starting now scheduled prompts require a join link")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -54,4 +54,154 @@ struct MeetingNotificationControllerTests {
             isMeetingNotificationVisible: true
         ))
     }
+
+    @Test("Scheduled meeting prompts require a joinable calendar event")
+    func scheduledMeetingPromptsRequireJoinableCalendarEvent() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        let windowEnd = now.addingTimeInterval(5 * 60)
+        let meetingURL = URL(string: "https://meet.google.com/abc-defg-hij")!
+
+        let joinable = unifiedCalendarEvent(
+            id: "joinable",
+            startDate: now.addingTimeInterval(60),
+            meetingURL: meetingURL
+        )
+        let lunch = unifiedCalendarEvent(
+            id: "lunch",
+            startDate: now.addingTimeInterval(60),
+            meetingURL: nil
+        )
+        let allDay = unifiedCalendarEvent(
+            id: "all-day",
+            startDate: now.addingTimeInterval(60),
+            isAllDay: true,
+            meetingURL: meetingURL
+        )
+        let hidden = unifiedCalendarEvent(
+            id: "hidden",
+            startDate: now.addingTimeInterval(60),
+            meetingURL: meetingURL
+        )
+        let later = unifiedCalendarEvent(
+            id: "later",
+            startDate: now.addingTimeInterval(10 * 60),
+            meetingURL: meetingURL
+        )
+
+        #expect(ScheduledMeetingNotificationPolicy.shouldShowUpcomingPrompt(
+            for: joinable,
+            now: now,
+            windowEnd: windowEnd,
+            hiddenEventIDs: []
+        ))
+        #expect(!ScheduledMeetingNotificationPolicy.shouldShowUpcomingPrompt(
+            for: lunch,
+            now: now,
+            windowEnd: windowEnd,
+            hiddenEventIDs: []
+        ))
+        #expect(!ScheduledMeetingNotificationPolicy.shouldShowUpcomingPrompt(
+            for: allDay,
+            now: now,
+            windowEnd: windowEnd,
+            hiddenEventIDs: []
+        ))
+        #expect(!ScheduledMeetingNotificationPolicy.shouldShowUpcomingPrompt(
+            for: hidden,
+            now: now,
+            windowEnd: windowEnd,
+            hiddenEventIDs: ["hidden"]
+        ))
+        #expect(!ScheduledMeetingNotificationPolicy.shouldShowUpcomingPrompt(
+            for: later,
+            now: now,
+            windowEnd: windowEnd,
+            hiddenEventIDs: []
+        ))
+    }
+
+    @Test("Scheduled meeting prompt candidates are sorted")
+    func scheduledMeetingPromptCandidatesAreSorted() {
+        let now = Date(timeIntervalSinceReferenceDate: 2_000)
+        let meetingURL = URL(string: "https://us02web.zoom.us/j/123456789")!
+        let later = unifiedCalendarEvent(id: "later", startDate: now.addingTimeInterval(240), meetingURL: meetingURL)
+        let sooner = unifiedCalendarEvent(id: "sooner", startDate: now.addingTimeInterval(60), meetingURL: meetingURL)
+        let hidden = unifiedCalendarEvent(id: "hidden", startDate: now.addingTimeInterval(30), meetingURL: meetingURL)
+        let personal = unifiedCalendarEvent(id: "personal", startDate: now.addingTimeInterval(45), meetingURL: nil)
+
+        let candidates = ScheduledMeetingNotificationPolicy.upcomingCandidates(
+            from: [later, personal, hidden, sooner],
+            now: now,
+            hiddenEventIDs: ["hidden"]
+        )
+
+        #expect(candidates.map(\.id) == ["sooner", "later"])
+    }
+
+    @Test("Starting now scheduled prompts require a join link")
+    func startingNowScheduledPromptsRequireJoinLink() {
+        #expect(ScheduledMeetingNotificationPolicy.shouldShowStartingNowPrompt(
+            meetingURL: URL(string: "https://teams.microsoft.com/l/meetup-join/abc")
+        ))
+        #expect(!ScheduledMeetingNotificationPolicy.shouldShowStartingNowPrompt(meetingURL: nil))
+    }
+
+    @Test("Starting now scheduled prompts revalidate current calendar event policy")
+    func startingNowScheduledPromptsRevalidateCurrentCalendarEventPolicy() {
+        let startDate = Date(timeIntervalSinceReferenceDate: 3_000)
+        let meetingURL = URL(string: "https://meet.google.com/abc-defg-hij")!
+        let joinable = unifiedCalendarEvent(id: "meeting", startDate: startDate, meetingURL: meetingURL)
+        let hidden = unifiedCalendarEvent(id: "meeting", startDate: startDate, meetingURL: meetingURL)
+        let noLink = unifiedCalendarEvent(id: "meeting", startDate: startDate, meetingURL: nil)
+        let allDay = unifiedCalendarEvent(id: "meeting", startDate: startDate, isAllDay: true, meetingURL: meetingURL)
+        let rescheduled = unifiedCalendarEvent(id: "meeting", startDate: startDate.addingTimeInterval(60), meetingURL: meetingURL)
+
+        #expect(ScheduledMeetingNotificationPolicy.startingNowCandidate(
+            from: [joinable],
+            eventID: "meeting",
+            startDate: startDate,
+            hiddenEventIDs: []
+        ) == joinable)
+        #expect(ScheduledMeetingNotificationPolicy.startingNowCandidate(
+            from: [hidden],
+            eventID: "meeting",
+            startDate: startDate,
+            hiddenEventIDs: ["meeting"]
+        ) == nil)
+        #expect(ScheduledMeetingNotificationPolicy.startingNowCandidate(
+            from: [noLink],
+            eventID: "meeting",
+            startDate: startDate,
+            hiddenEventIDs: []
+        ) == nil)
+        #expect(ScheduledMeetingNotificationPolicy.startingNowCandidate(
+            from: [allDay],
+            eventID: "meeting",
+            startDate: startDate,
+            hiddenEventIDs: []
+        ) == nil)
+        #expect(ScheduledMeetingNotificationPolicy.startingNowCandidate(
+            from: [rescheduled],
+            eventID: "meeting",
+            startDate: startDate,
+            hiddenEventIDs: []
+        ) == nil)
+    }
+
+    private func unifiedCalendarEvent(
+        id: String,
+        startDate: Date,
+        isAllDay: Bool = false,
+        meetingURL: URL?
+    ) -> UnifiedCalendarEvent {
+        UnifiedCalendarEvent(
+            id: id,
+            title: id,
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(30 * 60),
+            isAllDay: isAllDay,
+            source: .eventKit,
+            meetingURL: meetingURL
+        )
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -419,6 +419,7 @@ struct AppConfigTests {
         #expect(config.defaultMeetingTemplateID == MeetingTemplates.autoID)
         #expect(config.meetingRecordingSavePolicy == .never)
         #expect(config.showScheduledMeetingNotifications == true)
+        #expect(config.scheduledMeetingNotificationLeadTime == .atStart)
         #expect(config.showMeetingDetectionNotification == true)
         #expect(config.mutedMeetingDetectionAppBundleIDs.isEmpty)
         #expect(config.openAIAPIKey.isEmpty)
@@ -474,6 +475,7 @@ struct AppConfigTests {
         config.meetingHookPath = "/tmp/meeting-hook.sh"
         config.meetingHookTimeoutSeconds = 45
         config.showScheduledMeetingNotifications = false
+        config.scheduledMeetingNotificationLeadTime = .threeMinutes
         config.showMeetingDetectionNotification = false
         config.mutedMeetingDetectionAppBundleIDs = ["com.google.Chrome", "com.tinyspeck.slackmacgap"]
         config.computerUseHotkey = HotkeyConfig(keyCode: 62, label: "Right Ctrl")
@@ -508,6 +510,7 @@ struct AppConfigTests {
         #expect(decoded.meetingHookPath == "/tmp/meeting-hook.sh")
         #expect(decoded.meetingHookTimeoutSeconds == 45)
         #expect(decoded.showScheduledMeetingNotifications == false)
+        #expect(decoded.scheduledMeetingNotificationLeadTime == .threeMinutes)
         #expect(decoded.showMeetingDetectionNotification == false)
         #expect(decoded.mutedMeetingDetectionAppBundleIDs == ["com.google.Chrome", "com.tinyspeck.slackmacgap"])
         #expect(decoded.meetingTranscriptionBackend == config.meetingTranscriptionBackend)


### PR DESCRIPTION
## Summary
- Add a shared scheduled meeting notification policy for joinable calendar events
- Skip no-link, all-day, and hidden events for scheduled prompts
- Apply the same joinable-meeting eligibility to calendar auto-record, while keeping auto-record timing separate from reminder timing
- Add a persisted scheduled notification timing policy: At start time, 1 min before, 3 min before, or 5 min before
- Default scheduled prompts to At start time so calendar-only prompts do not fire before the user is expected to join
- Revalidate deferred `Meeting starting now` prompts against current calendar state before showing them
- Keep Marauder's Map countdown selection and completion aligned with the same joinable-meeting filter
- Clarify scheduled notification settings copy

## Why
#198 reports two scheduled-notification false positives: non-meeting calendar events triggering meeting prompts, and calendar prompts firing several minutes before the user has joined or activated mic/camera.

The joinable-meeting policy fixes the non-meeting case by requiring a meeting URL and skipping all-day or hidden events. Calendar auto-record intentionally follows that same joinable-meeting eligibility so lunch, focus time, and other no-link calendar events are not auto-recorded either. The new lead-time setting fixes the early-prompt case by making notification timing explicit and defaulting to `At start time`; users can still opt into earlier calendar reminders from Settings. Reminder timing does not control auto-record timing.

The deferred start-time prompt also re-checks current event state before showing, so hidden, all-day, rescheduled, removed, or no-longer-joinable events do not show a stale scheduled notification at start time.

This addresses the scheduled calendar notification behavior reported in #198 without changing the separate audio-detection notification path.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/pr199/test" --filter 'MeetingNotificationControllerTests|AppConfigTests'`
- MuesliDev smoke test from the original PR: no-link calendar event did not show a notification; Google Meet event showed an `Upcoming meeting` notification with `Join & Record`

Fixes #198
