### PR TITLE
Fix SwiftPM test runner setup

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/HotkeyMonitor.swift
@@ -65,15 +65,23 @@ final class HotkeyMonitor {
     private var prepareDelay: TimeInterval
     private var startDelay: TimeInterval
     private var doubleTapWindow: TimeInterval
+    private let scheduleAfter: (TimeInterval, DispatchWorkItem) -> Void
+    private let now: () -> Date
 
     init(
         prepareDelay: TimeInterval = 0.15,
         startDelay: TimeInterval = 0.25,
-        doubleTapWindow: TimeInterval = 0.35
+        doubleTapWindow: TimeInterval = 0.35,
+        scheduleAfter: @escaping (TimeInterval, DispatchWorkItem) -> Void = { delay, item in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+        },
+        now: @escaping () -> Date = Date.init
     ) {
         self.prepareDelay = prepareDelay
         self.startDelay = startDelay
         self.doubleTapWindow = doubleTapWindow
+        self.scheduleAfter = scheduleAfter
+        self.now = now
     }
 
     func configureTriggerThreshold(milliseconds: Int) {
@@ -316,7 +324,7 @@ final class HotkeyMonitor {
             self.fireCombinationToggle()
         }
         combinationWorkItem = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + startDelay, execute: item)
+        scheduleAfter(startDelay, item)
         fputs("[hotkey] combination armed\n", stderr)
         return true
     }
@@ -396,7 +404,7 @@ final class HotkeyMonitor {
                     if doubleTapEnabled,
                        lastTapWasShort,
                        let lastUp = lastTapUpTime,
-                       Date().timeIntervalSince(lastUp) < doubleTapWindow {
+                       now().timeIntervalSince(lastUp) < doubleTapWindow {
                         // Double-tap detected!
                         fputs("[hotkey] double-tap → toggle start\n", stderr)
                         lastTapWasShort = false
@@ -432,7 +440,7 @@ final class HotkeyMonitor {
                 // should still count as a tap.
                 if wasDown && !active && !otherKeyPressed {
                     lastTapWasShort = true
-                    lastTapUpTime = Date()
+                    lastTapUpTime = now()
                 } else {
                     lastTapWasShort = false
                 }
@@ -565,8 +573,8 @@ final class HotkeyMonitor {
         }
         prepareWorkItem = prepare
         startWorkItem = start
-        DispatchQueue.main.asyncAfter(deadline: .now() + delays.prepare, execute: prepare)
-        DispatchQueue.main.asyncAfter(deadline: .now() + delays.start, execute: start)
+        scheduleAfter(delays.prepare, prepare)
+        scheduleAfter(delays.start, start)
     }
 
     private func scheduleArmCancel() {
@@ -582,7 +590,7 @@ final class HotkeyMonitor {
             self.onCancel?()
         }
         armCancelWorkItem = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + doubleTapWindow, execute: item)
+        scheduleAfter(doubleTapWindow, item)
     }
 
     private func timerDelays() -> (prepare: TimeInterval, start: TimeInterval) {

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -940,6 +940,56 @@ struct AppConfigTests {
 
 @Suite("HotkeyMonitor")
 struct HotkeyMonitorTests {
+    final class ManualHotkeyScheduler {
+        private struct ScheduledItem {
+            let deadline: TimeInterval
+            let order: Int
+            let item: DispatchWorkItem
+        }
+
+        private static let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
+
+        private var now: TimeInterval = 0
+        private var nextOrder = 0
+        private var scheduled: [ScheduledItem] = []
+
+        func schedule(after delay: TimeInterval, item: DispatchWorkItem) {
+            scheduled.append(ScheduledItem(deadline: now + delay, order: nextOrder, item: item))
+            nextOrder += 1
+        }
+
+        func currentDate() -> Date {
+            Date(timeInterval: now, since: Self.referenceDate)
+        }
+
+        func advance(by interval: TimeInterval) {
+            now += interval
+            while let next = scheduled
+                .filter({ $0.deadline <= now })
+                .min(by: { lhs, rhs in
+                    lhs.deadline == rhs.deadline ? lhs.order < rhs.order : lhs.deadline < rhs.deadline
+                }) {
+                scheduled.removeAll { $0.order == next.order }
+                if !next.item.isCancelled {
+                    next.item.perform()
+                }
+            }
+        }
+
+        func makeMonitor(
+            prepareDelay: TimeInterval = 0.15,
+            startDelay: TimeInterval = 0.25,
+            doubleTapWindow: TimeInterval = 0.35
+        ) -> HotkeyMonitor {
+            HotkeyMonitor(
+                prepareDelay: prepareDelay,
+                startDelay: startDelay,
+                doubleTapWindow: doubleTapWindow,
+                scheduleAfter: { self.schedule(after: $0, item: $1) },
+                now: currentDate
+            )
+        }
+    }
 
     @Test("escape still cancels active hold dictation immediately")
     func escapeCancelsActiveHoldDictation() async throws {
@@ -1028,8 +1078,9 @@ struct HotkeyMonitorTests {
 
     @Test("low trigger threshold still allows double-tap toggle")
     @MainActor
-    func lowTriggerThresholdStillAllowsDoubleTapToggle() async throws {
-        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+    func lowTriggerThresholdStillAllowsDoubleTapToggle() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
         monitor.configureTriggerThreshold(milliseconds: 75)
         var prepareCount = 0
         var toggleStartCount = 0
@@ -1041,18 +1092,44 @@ struct HotkeyMonitorTests {
         }
 
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
-        try await Task.sleep(for: .milliseconds(100))
+        scheduler.advance(by: 0.10)
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        scheduler.advance(by: 0.10)
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
 
         #expect(prepareCount == 0)
         #expect(toggleStartCount == 1)
     }
 
+    @Test("double-tap outside window arms instead of toggling")
+    @MainActor
+    func doubleTapOutsideWindowArmsInsteadOfToggling() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
+        monitor.configureTriggerThreshold(milliseconds: 75)
+        var toggleStartCount = 0
+        var armCount = 0
+        monitor.onToggleStart = {
+            toggleStartCount += 1
+        }
+        monitor.onArm = {
+            armCount += 1
+        }
+
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+        monitor.handleFlagsChanged(keyCode: 55, flags: [])
+        scheduler.advance(by: 0.40)
+        monitor.handleFlagsChanged(keyCode: 55, flags: .command)
+
+        #expect(toggleStartCount == 0)
+        #expect(armCount == 2)
+    }
+
     @Test("low trigger threshold arms immediately but defers audio while double-tap is possible")
     @MainActor
-    func lowTriggerThresholdArmsImmediatelyButDefersAudio() async throws {
-        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+    func lowTriggerThresholdArmsImmediatelyButDefersAudio() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
         monitor.configureTriggerThreshold(milliseconds: 75)
         var armCount = 0
         var prepareCount = 0
@@ -1069,7 +1146,7 @@ struct HotkeyMonitorTests {
 
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
         #expect(armCount == 1)
-        try await Task.sleep(for: .milliseconds(100))
+        scheduler.advance(by: 0.10)
         #expect(prepareCount == 0)
         #expect(startCount == 0)
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
@@ -1077,8 +1154,9 @@ struct HotkeyMonitorTests {
 
     @Test("quick armed tap cancels after double-tap window")
     @MainActor
-    func quickArmedTapCancelsAfterDoubleTapWindow() async throws {
-        let monitor = HotkeyMonitor(doubleTapWindow: 0.05)
+    func quickArmedTapCancelsAfterDoubleTapWindow() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.05)
         monitor.configureTriggerThreshold(milliseconds: 75)
         var cancelCount = 0
         monitor.onArm = {}
@@ -1090,14 +1168,15 @@ struct HotkeyMonitorTests {
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
         #expect(cancelCount == 0)
 
-        try await Task.sleep(for: .milliseconds(80))
+        scheduler.advance(by: 0.08)
         #expect(cancelCount == 1)
     }
 
     @Test("low trigger threshold starts quickly when double-tap is disabled")
     @MainActor
-    func lowTriggerThresholdStartsQuicklyWhenDoubleTapDisabled() async throws {
-        let monitor = HotkeyMonitor(doubleTapWindow: 0.35)
+    func lowTriggerThresholdStartsQuicklyWhenDoubleTapDisabled() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.35)
         monitor.configureTriggerThreshold(milliseconds: 75)
         monitor.doubleTapEnabled = false
         var startCount = 0
@@ -1106,7 +1185,7 @@ struct HotkeyMonitorTests {
         }
 
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
-        try await Task.sleep(for: .milliseconds(100))
+        scheduler.advance(by: 0.10)
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
 
         #expect(startCount == 1)
@@ -1154,8 +1233,9 @@ struct HotkeyMonitorTests {
 
     @Test("changing trigger threshold during pending double tap cancel preserves cleanup")
     @MainActor
-    func configureTriggerThresholdDuringPendingDoubleTapCancelPreservesCleanup() async throws {
-        let monitor = HotkeyMonitor(doubleTapWindow: 0.05)
+    func configureTriggerThresholdDuringPendingDoubleTapCancelPreservesCleanup() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(doubleTapWindow: 0.05)
         monitor.configureTriggerThreshold(milliseconds: 75)
         var cancelCount = 0
         monitor.onArm = {}
@@ -1166,15 +1246,16 @@ struct HotkeyMonitorTests {
         monitor.handleFlagsChanged(keyCode: 55, flags: .command)
         monitor.handleFlagsChanged(keyCode: 55, flags: [])
         monitor.configureTriggerThreshold(milliseconds: 125)
-        try await Task.sleep(for: .milliseconds(80))
+        scheduler.advance(by: 0.08)
 
         #expect(cancelCount == 1)
     }
 
     @Test("combination shortcut requires hold threshold before toggling")
     @MainActor
-    func combinationShortcutRequiresHoldThresholdBeforeToggling() async throws {
-        let monitor = HotkeyMonitor(startDelay: 0.05)
+    func combinationShortcutRequiresHoldThresholdBeforeToggling() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(startDelay: 0.05)
         monitor.configure(HotkeyConfig.combination(modifiers: [.command, .shift], keyCode: 15))
         var toggleStartCount = 0
         monitor.onToggleStart = {
@@ -1182,17 +1263,18 @@ struct HotkeyMonitorTests {
         }
 
         monitor.handleCombinationForTests(type: .keyDown, keyCode: 15, flags: [.command, .shift])
-        try await Task.sleep(for: .milliseconds(20))
+        scheduler.advance(by: 0.02)
         monitor.handleCombinationForTests(type: .keyUp, keyCode: 15, flags: [.command, .shift])
-        try await Task.sleep(for: .milliseconds(50))
+        scheduler.advance(by: 0.05)
 
         #expect(toggleStartCount == 0)
     }
 
     @Test("combination shortcut toggles after hold threshold")
     @MainActor
-    func combinationShortcutTogglesAfterHoldThreshold() async throws {
-        let monitor = HotkeyMonitor(startDelay: 0.03)
+    func combinationShortcutTogglesAfterHoldThreshold() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(startDelay: 0.03)
         monitor.configure(HotkeyConfig.combination(modifiers: [.command, .shift], keyCode: 15))
         var toggleStartCount = 0
         monitor.onToggleStart = {
@@ -1200,15 +1282,16 @@ struct HotkeyMonitorTests {
         }
 
         monitor.handleCombinationForTests(type: .keyDown, keyCode: 15, flags: [.command, .shift])
-        try await Task.sleep(for: .milliseconds(50))
+        scheduler.advance(by: 0.05)
 
         #expect(toggleStartCount == 1)
     }
 
     @Test("combination toggle cancellation resets without firing stop")
     @MainActor
-    func combinationToggleCancellationResetsWithoutFiringStop() async throws {
-        let monitor = HotkeyMonitor(startDelay: 0.03)
+    func combinationToggleCancellationResetsWithoutFiringStop() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(startDelay: 0.03)
         monitor.configure(HotkeyConfig.combination(modifiers: [.command, .shift], keyCode: 15))
         var toggleStartCount = 0
         var toggleStopCount = 0
@@ -1220,7 +1303,7 @@ struct HotkeyMonitorTests {
         }
 
         monitor.handleCombinationForTests(type: .keyDown, keyCode: 15, flags: [.command, .shift])
-        try await Task.sleep(for: .milliseconds(50))
+        scheduler.advance(by: 0.05)
         #expect(monitor.isToggleRecording)
 
         monitor.cancelToggleMode()
@@ -1232,8 +1315,9 @@ struct HotkeyMonitorTests {
 
     @Test("combination shortcut cancels when modifiers release before threshold")
     @MainActor
-    func combinationShortcutCancelsWhenModifiersReleaseBeforeThreshold() async throws {
-        let monitor = HotkeyMonitor(startDelay: 0.05)
+    func combinationShortcutCancelsWhenModifiersReleaseBeforeThreshold() {
+        let scheduler = ManualHotkeyScheduler()
+        let monitor = scheduler.makeMonitor(startDelay: 0.05)
         monitor.configure(HotkeyConfig.combination(modifiers: [.command, .shift], keyCode: 15))
         var toggleStartCount = 0
         monitor.onToggleStart = {
@@ -1241,9 +1325,9 @@ struct HotkeyMonitorTests {
         }
 
         monitor.handleCombinationForTests(type: .keyDown, keyCode: 15, flags: [.command, .shift])
-        try await Task.sleep(for: .milliseconds(20))
+        scheduler.advance(by: 0.02)
         monitor.handleCombinationForTests(type: .flagsChanged, keyCode: 56, flags: .command)
-        try await Task.sleep(for: .milliseconds(50))
+        scheduler.advance(by: 0.05)
 
         #expect(toggleStartCount == 0)
     }


### PR DESCRIPTION
## Summary

Fixes `swift test --package-path native/MuesliNative` so the SwiftPM test suite compiles and runs
from the command line.

## What was breaking

The test files import Swift Testing with `import Testing`, but `Package.swift` did not declare Swift
Testing as a test dependency. As a result, SwiftPM failed while compiling the test target with:

`no such module 'Testing'`

After adding Swift Testing, a few `HotkeyMonitor` tests were still timing-sensitive under the full
concurrent suite because they used short wall-clock sleeps.

## What changed

- Adds `swift-testing` as a test-only package dependency.
- Pins Swift Testing to `6.2.x` to stay compatible with the existing `swift-syntax` 602 dependency
graph.
- Links the `Testing` product into the `MuesliTests` target.
- Adds an injectable timer scheduler to `HotkeyMonitor`, preserving the production default behaviour.
- Updates hotkey timing tests to use a manual scheduler instead of short real-time sleeps.

## Validation

Ran:

`swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-spm-test`

Result:

`923 tests in 106 suites passed`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783349131&installation_id=136549638&pr_number=200&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F200&signature=4d372835f7be16f6ceca0c1a7599c1727eb112024433fb71e9f1dc63cec9105e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->