### PR TITLE
Share SwiftPM scratch cache across builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Local build scripts resolve a shared SwiftPM scratch path through `scripts/muesl
 - If `MUESLI_EXTERNAL_SPM_CACHE_ROOT` is set, it replaces the default `/Volumes/MuesliBuildCache/muesli-spm` external cache root.
 - Otherwise, if `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
 - Otherwise, scripts fall back to `$HOME/Library/Caches/muesli-spm`.
-- Set `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` to intentionally use SwiftPM's package-local `.build`.
+- Set `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` to intentionally use SwiftPM's package-local `.build`; this takes precedence over all scratch path settings.
 
 The external cache lives in an APFS sparse bundle at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`; attach it before build-heavy work:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,11 @@ SwiftPM can write build artifacts to `native/MuesliNative/.build` inside the act
 Local build scripts resolve a shared SwiftPM scratch path through `scripts/muesli_spm_cache.sh`:
 
 - If `MUESLI_SWIFTPM_SCRATCH_PATH` is set, that explicit path wins.
+- If `MUESLI_SWIFTPM_SCRATCH_CHANNEL` is set, scripts use that channel under the resolved cache root.
+- If `MUESLI_EXTERNAL_SPM_CACHE_ROOT` is set, it replaces the default `/Volumes/MuesliBuildCache/muesli-spm` external cache root.
 - Otherwise, if `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
 - Otherwise, scripts fall back to `$HOME/Library/Caches/muesli-spm`.
+- Set `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` to intentionally use SwiftPM's package-local `.build`.
 
 The external cache lives in an APFS sparse bundle at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`; attach it before build-heavy work:
 
@@ -16,10 +19,12 @@ The external cache lives in an APFS sparse bundle at `/Volumes/eSSD/MuesliBuildC
 hdiutil attach /Volumes/eSSD/MuesliBuildCache.sparsebundle
 ```
 
+`/Volumes/eSSD/MuesliBuildCache.sparsebundle` is the maintainer's local SSD path. Contributors can substitute their own volume path or skip the attach step; scripts fall back to `~/Library/Caches/muesli-spm` when the external cache is not mounted.
+
 Default channels:
 
 ```bash
-./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/dev when mounted
+./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/worktrees/<worktree>/dev when mounted
 ./scripts/build_native_app.sh release # /Volumes/MuesliBuildCache/muesli-spm/release when mounted
 ./scripts/release-preprod.sh          # /Volumes/MuesliBuildCache/muesli-spm/preprod when mounted
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,21 +2,41 @@
 
 ## Build Artifacts and Worktrees
 
-SwiftPM writes build artifacts to `native/MuesliNative/.build` inside the active worktree by default. That can consume several GB per worktree when multiple feature worktrees are used.
+SwiftPM can write build artifacts to `native/MuesliNative/.build` inside the active worktree. That can consume several GB per worktree when multiple feature worktrees are used.
 
-For local app builds, set `MUESLI_SWIFTPM_SCRATCH_PATH` so `scripts/build_native_app.sh` passes a shared `--scratch-path` to SwiftPM:
+Local build scripts resolve a shared SwiftPM scratch path through `scripts/muesli_spm_cache.sh`:
+
+- If `MUESLI_SWIFTPM_SCRATCH_PATH` is set, that explicit path wins.
+- Otherwise, if `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
+- Otherwise, scripts fall back to `$HOME/Library/Caches/muesli-spm`.
+
+The external cache lives in an APFS sparse bundle at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`; attach it before build-heavy work:
 
 ```bash
-MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" ./scripts/dev-test.sh
-MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/preprod" ./scripts/build_native_app.sh release
+hdiutil attach /Volumes/eSSD/MuesliBuildCache.sparsebundle
 ```
 
-Caveat: do not run concurrent builds from different worktrees into the same scratch path. Use separate paths per channel, agent, or simultaneous build, such as `dev`, `preprod`, `test`, or `agent-1`.
+Default channels:
+
+```bash
+./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/dev when mounted
+./scripts/build_native_app.sh release # /Volumes/MuesliBuildCache/muesli-spm/release when mounted
+./scripts/release-preprod.sh          # /Volumes/MuesliBuildCache/muesli-spm/preprod when mounted
+```
+
+For direct or concurrent worktree builds, pass a specific path:
+
+```bash
+MUESLI_SWIFTPM_SCRATCH_PATH="/Volumes/MuesliBuildCache/muesli-spm/worktrees/pr182/dev" ./scripts/dev-test.sh
+swift test --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/worktrees/pr182/test"
+```
+
+Caveat: do not run concurrent builds from different worktrees into the same scratch path. Use separate paths per channel, agent, or simultaneous build, such as `worktrees/pr182/dev`, `worktrees/pr188/dev`, or `agent-1`.
 
 Deleting a scratch path only removes rebuildable SwiftPM artifacts. It does not delete installed app bundles or app data under `~/Library/Application Support/`.
 
 For direct SwiftPM test runs, pass the scratch path yourself:
 
 ```bash
-swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test"
+swift test --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/test"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,14 +38,35 @@ Local-first macOS app for **dictation** and **meeting transcription** on Apple S
 MuesliDev uses bundle ID `com.muesli.dev` and stores data at `~/Library/Application Support/MuesliDev/`. Production data is never touched.
 
 ### SwiftPM build artifacts in worktrees
-SwiftPM writes build artifacts to `native/MuesliNative/.build` inside the active worktree by default. That can consume several GB per worktree. For worktree-heavy local testing, set `MUESLI_SWIFTPM_SCRATCH_PATH` when invoking `scripts/build_native_app.sh` directly or through helper scripts such as `scripts/dev-test.sh`:
+SwiftPM can write build artifacts to `native/MuesliNative/.build` inside the active worktree. That can consume several GB per worktree. Local scripts now resolve a shared SwiftPM scratch path through `scripts/muesli_spm_cache.sh`:
+
+- Explicit `MUESLI_SWIFTPM_SCRATCH_PATH` wins.
+- If `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
+- Otherwise scripts fall back to `~/Library/Caches/muesli-spm`.
+
+The preferred local cache is an APFS sparse bundle stored on the external SSD at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`. Mount it before build-heavy local work:
 
 ```bash
-MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/dev" ./scripts/dev-test.sh
-MUESLI_SWIFTPM_SCRATCH_PATH="$HOME/Library/Caches/muesli-spm/preprod" ./scripts/build_native_app.sh release
+hdiutil attach /Volumes/eSSD/MuesliBuildCache.sparsebundle
 ```
 
-The build script passes that value to SwiftPM as `--scratch-path`, so multiple worktrees can reuse one scratch directory instead of each growing its own `.build`. Caveat: do not run concurrent builds from different worktrees into the same scratch path; use separate paths per channel, agent, or simultaneous build. Deleting a scratch path only removes rebuildable SwiftPM artifacts, not installed apps or app data.
+Default script channels:
+
+```bash
+./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/dev when mounted
+./scripts/build_native_app.sh release # /Volumes/MuesliBuildCache/muesli-spm/release when mounted
+./scripts/release-preprod.sh          # /Volumes/MuesliBuildCache/muesli-spm/preprod when mounted
+./scripts/release-alpha.sh            # /Volumes/MuesliBuildCache/muesli-spm/alpha when mounted
+```
+
+For parallel PR/worktree work, use isolated paths:
+
+```bash
+MUESLI_SWIFTPM_SCRATCH_PATH="/Volumes/MuesliBuildCache/muesli-spm/worktrees/pr182/dev" ./scripts/dev-test.sh
+swift test --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/worktrees/pr182/test"
+```
+
+The build script passes the resolved path to SwiftPM as `--scratch-path`, so multiple worktrees do not each grow their own `.build`. Caveat: do not run concurrent builds from different worktrees into the same scratch path; use separate paths per channel, agent, or simultaneous build. Deleting a scratch path only removes rebuildable SwiftPM artifacts, not installed apps or app data. Set `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` only when you intentionally want package-local `.build`.
 
 ### Tests
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ SwiftPM can write build artifacts to `native/MuesliNative/.build` inside the act
 - `MUESLI_EXTERNAL_SPM_CACHE_ROOT` overrides the default `/Volumes/MuesliBuildCache/muesli-spm` external cache root.
 - If `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
 - Otherwise scripts fall back to `~/Library/Caches/muesli-spm`.
-- `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` intentionally opts out and uses SwiftPM's package-local `.build`.
+- `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` intentionally opts out and uses SwiftPM's package-local `.build`; this takes precedence over all scratch path settings.
 
 The preferred local cache is an APFS sparse bundle stored on the external SSD at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`. Mount it before build-heavy local work:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,11 @@ MuesliDev uses bundle ID `com.muesli.dev` and stores data at `~/Library/Applicat
 SwiftPM can write build artifacts to `native/MuesliNative/.build` inside the active worktree. That can consume several GB per worktree. Local scripts now resolve a shared SwiftPM scratch path through `scripts/muesli_spm_cache.sh`:
 
 - Explicit `MUESLI_SWIFTPM_SCRATCH_PATH` wins.
+- `MUESLI_SWIFTPM_SCRATCH_CHANNEL` overrides the channel segment under the resolved cache root.
+- `MUESLI_EXTERNAL_SPM_CACHE_ROOT` overrides the default `/Volumes/MuesliBuildCache/muesli-spm` external cache root.
 - If `/Volumes/MuesliBuildCache/muesli-spm` is mounted, scripts use that external APFS cache.
 - Otherwise scripts fall back to `~/Library/Caches/muesli-spm`.
+- `MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1` intentionally opts out and uses SwiftPM's package-local `.build`.
 
 The preferred local cache is an APFS sparse bundle stored on the external SSD at `/Volumes/eSSD/MuesliBuildCache.sparsebundle`. Mount it before build-heavy local work:
 
@@ -50,10 +53,12 @@ The preferred local cache is an APFS sparse bundle stored on the external SSD at
 hdiutil attach /Volumes/eSSD/MuesliBuildCache.sparsebundle
 ```
 
+That sparse-bundle path is the maintainer's local SSD path. Contributors can substitute their own volume path or skip the attach step; scripts fall back to `~/Library/Caches/muesli-spm` when the external cache is not mounted.
+
 Default script channels:
 
 ```bash
-./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/dev when mounted
+./scripts/dev-test.sh                 # /Volumes/MuesliBuildCache/muesli-spm/worktrees/<worktree>/dev when mounted
 ./scripts/build_native_app.sh release # /Volumes/MuesliBuildCache/muesli-spm/release when mounted
 ./scripts/release-preprod.sh          # /Volumes/MuesliBuildCache/muesli-spm/preprod when mounted
 ./scripts/release-alpha.sh            # /Volumes/MuesliBuildCache/muesli-spm/alpha when mounted

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/muesli_spm_cache.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
 DIST_DIR="$ROOT/dist-native"
 INSTALL_DIR="${MUESLI_INSTALL_DIR:-/Applications}"
@@ -31,10 +32,15 @@ if [[ "$CODESIGN_TIMESTAMP" == "none" ]]; then
 fi
 
 SWIFT_BUILD_ARGS=(--package-path "$PACKAGE_DIR" -c "$BUILD_CONFIG")
-if [[ -n "${MUESLI_SWIFTPM_SCRATCH_PATH:-}" ]]; then
-  mkdir -p "$MUESLI_SWIFTPM_SCRATCH_PATH"
-  SWIFT_BUILD_ARGS+=(--scratch-path "$MUESLI_SWIFTPM_SCRATCH_PATH")
-  echo "Using SwiftPM scratch path: $MUESLI_SWIFTPM_SCRATCH_PATH"
+if [[ "${MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH:-0}" != "1" ]]; then
+  DEFAULT_SCRATCH_CHANNEL="release"
+  if [[ "$BUILD_CONFIG" == "debug" ]]; then
+    DEFAULT_SCRATCH_CHANNEL="dev"
+  fi
+  SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path "$DEFAULT_SCRATCH_CHANNEL")"
+  mkdir -p "$SWIFTPM_SCRATCH_PATH"
+  SWIFT_BUILD_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")
+  echo "Using SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
 fi
 
 mkdir -p "$DIST_DIR"

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -32,10 +32,10 @@ if [[ "$CODESIGN_TIMESTAMP" == "none" ]]; then
 fi
 
 SWIFT_BUILD_ARGS=(--package-path "$PACKAGE_DIR" -c "$BUILD_CONFIG")
-if [[ "${MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH:-0}" != "1" ]]; then
+if ! muesli_spm_scratch_disabled; then
   DEFAULT_SCRATCH_CHANNEL="release"
   if [[ "$BUILD_CONFIG" == "debug" ]]; then
-    DEFAULT_SCRATCH_CHANNEL="dev"
+    DEFAULT_SCRATCH_CHANNEL="$(muesli_worktree_spm_scratch_channel dev "$ROOT")"
   fi
   SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path "$DEFAULT_SCRATCH_CHANNEL")"
   mkdir -p "$SWIFTPM_SCRATCH_PATH"

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 # - Signed with Developer ID by default (Accessibility permission persists across rebuilds)
 # - External contributors can set MUESLI_SKIP_SIGN=1 to build without the
 #   maintainer signing certificate
+# - Uses a shared, worktree-isolated SwiftPM scratch path by default; set
+#   MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1 to use package-local .build instead
 # - Installs to /Applications/MuesliDev.app
 #
 # Usage:

--- a/scripts/muesli_spm_cache.sh
+++ b/scripts/muesli_spm_cache.sh
@@ -2,13 +2,16 @@
 
 # Shared SwiftPM scratch-path resolution for local Muesli builds.
 #
-# Precedence:
+# Resolution precedence, unless disabled:
 #   1. MUESLI_SWIFTPM_SCRATCH_PATH, when explicitly set
 #   2. MUESLI_EXTERNAL_SPM_CACHE_ROOT/<channel>, when that root exists
 #   3. ~/Library/Caches/muesli-spm/<channel>
 #
-# Set MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1 to let SwiftPM use the package-local
-# .build directory.
+# MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1 takes precedence over all other path
+# settings and lets SwiftPM use the package-local .build directory.
+
+[[ -n "${_MUESLI_SPM_CACHE_LOADED:-}" ]] && return 0
+_MUESLI_SPM_CACHE_LOADED=1
 
 muesli_spm_scratch_disabled() {
   [[ "${MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH:-0}" == "1" ]]
@@ -45,7 +48,7 @@ muesli_worktree_spm_scratch_channel() {
   printf 'worktrees/%s-%s/%s\n' "$root_name" "$root_hash" "$channel"
 }
 
-muesli_spm_artifacts_root() {
+muesli_spm_artifacts_dir() {
   local package_dir="$1"
   local scratch_path="${2:-}"
   if [[ -n "$scratch_path" ]]; then

--- a/scripts/muesli_spm_cache.sh
+++ b/scripts/muesli_spm_cache.sh
@@ -10,6 +10,10 @@
 # Set MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1 to let SwiftPM use the package-local
 # .build directory.
 
+muesli_spm_scratch_disabled() {
+  [[ "${MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH:-0}" == "1" ]]
+}
+
 muesli_default_spm_cache_root() {
   local external_root="${MUESLI_EXTERNAL_SPM_CACHE_ROOT:-/Volumes/MuesliBuildCache/muesli-spm}"
   if [[ -d "$external_root" ]]; then
@@ -29,4 +33,24 @@ muesli_resolve_spm_scratch_path() {
     channel="$MUESLI_SWIFTPM_SCRATCH_CHANNEL"
   fi
   printf '%s/%s\n' "$(muesli_default_spm_cache_root)" "$channel"
+}
+
+muesli_worktree_spm_scratch_channel() {
+  local channel="${1:-dev}"
+  local root="${2:-$PWD}"
+  local root_name
+  local root_hash
+  root_name="$(basename "$root")"
+  root_hash="$(printf '%s' "$root" | cksum | awk '{print $1}')"
+  printf 'worktrees/%s-%s/%s\n' "$root_name" "$root_hash" "$channel"
+}
+
+muesli_spm_artifacts_root() {
+  local package_dir="$1"
+  local scratch_path="${2:-}"
+  if [[ -n "$scratch_path" ]]; then
+    printf '%s/artifacts\n' "$scratch_path"
+  else
+    printf '%s/.build/artifacts\n' "$package_dir"
+  fi
 }

--- a/scripts/muesli_spm_cache.sh
+++ b/scripts/muesli_spm_cache.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Shared SwiftPM scratch-path resolution for local Muesli builds.
+#
+# Precedence:
+#   1. MUESLI_SWIFTPM_SCRATCH_PATH, when explicitly set
+#   2. MUESLI_EXTERNAL_SPM_CACHE_ROOT/<channel>, when that root exists
+#   3. ~/Library/Caches/muesli-spm/<channel>
+#
+# Set MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1 to let SwiftPM use the package-local
+# .build directory.
+
+muesli_default_spm_cache_root() {
+  local external_root="${MUESLI_EXTERNAL_SPM_CACHE_ROOT:-/Volumes/MuesliBuildCache/muesli-spm}"
+  if [[ -d "$external_root" ]]; then
+    printf '%s\n' "$external_root"
+  else
+    printf '%s\n' "$HOME/Library/Caches/muesli-spm"
+  fi
+}
+
+muesli_resolve_spm_scratch_path() {
+  local channel="${1:-dev}"
+  if [[ -n "${MUESLI_SWIFTPM_SCRATCH_PATH:-}" ]]; then
+    printf '%s\n' "$MUESLI_SWIFTPM_SCRATCH_PATH"
+    return 0
+  fi
+  if [[ -n "${MUESLI_SWIFTPM_SCRATCH_CHANNEL:-}" ]]; then
+    channel="$MUESLI_SWIFTPM_SCRATCH_CHANNEL"
+  fi
+  printf '%s/%s\n' "$(muesli_default_spm_cache_root)" "$channel"
+}

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -24,8 +24,9 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+source "$ROOT/scripts/muesli_spm_cache.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
-SWIFTPM_SCRATCH_PATH="${MUESLI_SWIFTPM_SCRATCH_PATH:-$HOME/Library/Caches/muesli-spm/alpha}"
+SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path alpha)"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 APP_DIR="/Applications/MuesliCanary.app"

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -26,7 +26,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 source "$ROOT/scripts/muesli_spm_cache.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
-SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path alpha)"
+SWIFTPM_SCRATCH_PATH=""
+SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
+BUILD_ENV=()
+if ! muesli_spm_scratch_disabled; then
+  SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path alpha)"
+  SWIFT_TEST_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")
+  BUILD_ENV+=(MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH")
+else
+  BUILD_ENV+=(MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1)
+fi
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 APP_DIR="/Applications/MuesliCanary.app"
@@ -118,21 +127,27 @@ mkdir -p "$OUTPUT_DIR"
 
 # --- Step 1: Run tests ---
 echo "[1/10] Running tests..."
-mkdir -p "$SWIFTPM_SCRATCH_PATH"
-echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
-swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
+if [[ -n "$SWIFTPM_SCRATCH_PATH" ]]; then
+  mkdir -p "$SWIFTPM_SCRATCH_PATH"
+  echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
+else
+  echo "  SwiftPM scratch path: package-local .build"
+fi
+swift test "${SWIFT_TEST_ARGS[@]}"
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/10] Building and signing (version: ${VERSION})..."
-echo "y" | MUESLI_BUILD_VERSION="$VERSION" \
-  MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
-  MUESLI_APP_NAME=MuesliCanary \
-  MUESLI_BUNDLE_ID=com.muesli.canary \
-  MUESLI_DISPLAY_NAME=MuesliCanary \
-  MUESLI_SUPPORT_DIR_NAME=MuesliCanary \
-  MUESLI_SPARKLE_FEED_URL="" \
-  "$ROOT/scripts/build_native_app.sh" > /dev/null
+ALPHA_BUILD_ENV=(
+  MUESLI_BUILD_VERSION="$VERSION"
+  "${BUILD_ENV[@]}"
+  MUESLI_APP_NAME=MuesliCanary
+  MUESLI_BUNDLE_ID=com.muesli.canary
+  MUESLI_DISPLAY_NAME=MuesliCanary
+  MUESLI_SUPPORT_DIR_NAME=MuesliCanary
+  MUESLI_SPARKLE_FEED_URL=""
+)
+echo "y" | env "${ALPHA_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
 
 FLAGS=$(codesign -dvvv "$APP_DIR" 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)')

--- a/scripts/release-alpha.sh
+++ b/scripts/release-alpha.sh
@@ -29,6 +29,9 @@ PACKAGE_DIR="$ROOT/native/MuesliNative"
 SWIFTPM_SCRATCH_PATH=""
 SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
 BUILD_ENV=()
+# The alpha channel is intentionally shared across worktrees. Do not run this
+# script concurrently from multiple worktrees unless you set an isolated
+# MUESLI_SWIFTPM_SCRATCH_PATH or MUESLI_SWIFTPM_SCRATCH_CHANNEL.
 if ! muesli_spm_scratch_disabled; then
   SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path alpha)"
   SWIFT_TEST_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -19,9 +19,10 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+source "$ROOT/scripts/muesli_spm_cache.sh"
 
 PACKAGE_DIR="$ROOT/native/MuesliNative"
-SWIFTPM_SCRATCH_PATH="${MUESLI_SWIFTPM_SCRATCH_PATH:-$HOME/Library/Caches/muesli-spm/preprod}"
+SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path preprod)"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 APP_NAME="MuesliPreprod"

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -22,7 +22,16 @@ cd "$ROOT"
 source "$ROOT/scripts/muesli_spm_cache.sh"
 
 PACKAGE_DIR="$ROOT/native/MuesliNative"
-SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path preprod)"
+SWIFTPM_SCRATCH_PATH=""
+SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
+BUILD_ENV=()
+if ! muesli_spm_scratch_disabled; then
+  SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path preprod)"
+  SWIFT_TEST_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")
+  BUILD_ENV+=(MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH")
+else
+  BUILD_ENV+=(MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1)
+fi
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 APP_NAME="MuesliPreprod"
@@ -33,7 +42,7 @@ OUTPUT_DIR="$ROOT/dist-preprod"
 INSTALL_DIR="$OUTPUT_DIR/install-root"
 APP_DIR="$INSTALL_DIR/${APP_NAME}.app"
 APPCAST_PATH="$ROOT/docs/appcast-preprod.xml"
-GENERATE_APPCAST="$SWIFTPM_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/generate_appcast"
+GENERATE_APPCAST="$(muesli_spm_artifacts_root "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 VERIFY_DIR=""
 HOSTED_MOUNT_POINT=""
@@ -130,26 +139,32 @@ mkdir -p "$INSTALL_DIR"
 
 # --- Step 1: Run tests ---
 echo "[1/11] Running tests..."
-mkdir -p "$SWIFTPM_SCRATCH_PATH"
-echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
-swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
+if [[ -n "$SWIFTPM_SCRATCH_PATH" ]]; then
+  mkdir -p "$SWIFTPM_SCRATCH_PATH"
+  echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
+else
+  echo "  SwiftPM scratch path: package-local .build"
+fi
+swift test "${SWIFT_TEST_ARGS[@]}"
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/11] Building and signing..."
-MUESLI_INSTALL_DIR="$INSTALL_DIR" \
-  MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
-  MUESLI_BUILD_VERSION="$VERSION" \
-  MUESLI_BUNDLE_VERSION="$SPARKLE_BUILD_VERSION" \
-  MUESLI_SHORT_VERSION="$VERSION" \
-  MUESLI_APP_NAME="$APP_NAME" \
-  MUESLI_APP_BUNDLE_NAME="${APP_NAME}.app" \
-  MUESLI_BUNDLE_ID="$BUNDLE_ID" \
-  MUESLI_DISPLAY_NAME="$APP_NAME" \
-  MUESLI_SUPPORT_DIR_NAME="$SUPPORT_DIR_NAME" \
-  MUESLI_SPARKLE_FEED_URL="$PREPROD_FEED_URL" \
-  MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY" \
-  "$ROOT/scripts/build_native_app.sh" > /dev/null
+PREPROD_BUILD_ENV=(
+  MUESLI_INSTALL_DIR="$INSTALL_DIR"
+  "${BUILD_ENV[@]}"
+  MUESLI_BUILD_VERSION="$VERSION"
+  MUESLI_BUNDLE_VERSION="$SPARKLE_BUILD_VERSION"
+  MUESLI_SHORT_VERSION="$VERSION"
+  MUESLI_APP_NAME="$APP_NAME"
+  MUESLI_APP_BUNDLE_NAME="${APP_NAME}.app"
+  MUESLI_BUNDLE_ID="$BUNDLE_ID"
+  MUESLI_DISPLAY_NAME="$APP_NAME"
+  MUESLI_SUPPORT_DIR_NAME="$SUPPORT_DIR_NAME"
+  MUESLI_SPARKLE_FEED_URL="$PREPROD_FEED_URL"
+  MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY"
+)
+env "${PREPROD_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
 if [[ ! -x "$GENERATE_APPCAST" ]]; then
   echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -25,6 +25,9 @@ PACKAGE_DIR="$ROOT/native/MuesliNative"
 SWIFTPM_SCRATCH_PATH=""
 SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
 BUILD_ENV=()
+# The preprod channel is intentionally shared across worktrees. Do not run this
+# script concurrently from multiple worktrees unless you set an isolated
+# MUESLI_SWIFTPM_SCRATCH_PATH or MUESLI_SWIFTPM_SCRATCH_CHANNEL.
 if ! muesli_spm_scratch_disabled; then
   SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path preprod)"
   SWIFT_TEST_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")
@@ -42,7 +45,7 @@ OUTPUT_DIR="$ROOT/dist-preprod"
 INSTALL_DIR="$OUTPUT_DIR/install-root"
 APP_DIR="$INSTALL_DIR/${APP_NAME}.app"
 APPCAST_PATH="$ROOT/docs/appcast-preprod.xml"
-GENERATE_APPCAST="$(muesli_spm_artifacts_root "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
+GENERATE_APPCAST="$(muesli_spm_artifacts_dir "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 VERIFY_DIR=""
 HOSTED_MOUNT_POINT=""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,6 +35,9 @@ PACKAGE_DIR="$ROOT/native/MuesliNative"
 SWIFTPM_SCRATCH_PATH=""
 SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
 BUILD_ENV=()
+# The release channel is intentionally shared across worktrees. Do not run this
+# script concurrently from multiple worktrees unless you set an isolated
+# MUESLI_SWIFTPM_SCRATCH_PATH or MUESLI_SWIFTPM_SCRATCH_CHANNEL.
 if ! muesli_spm_scratch_disabled; then
   SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path release)"
   SWIFT_TEST_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")
@@ -47,7 +50,7 @@ SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Gur
 OUTPUT_DIR="$ROOT/dist-release"
 INSTALL_DIR="${MUESLI_RELEASE_INSTALL_DIR:-$OUTPUT_DIR/install-root}"
 APP_DIR="${MUESLI_RELEASE_APP_DIR:-$INSTALL_DIR/Muesli.app}"
-GENERATE_APPCAST="$(muesli_spm_artifacts_root "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
+GENERATE_APPCAST="$(muesli_spm_artifacts_dir "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 TAP_REPO="${MUESLI_TAP_REPO:-Muesli-HQ/homebrew-muesli}"
 TAP_CASK_REL_PATH="${MUESLI_TAP_CASK_REL_PATH:-Casks/m/muesli.rb}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,8 +30,9 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+source "$ROOT/scripts/muesli_spm_cache.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
-SWIFTPM_SCRATCH_PATH="${MUESLI_SWIFTPM_SCRATCH_PATH:-$HOME/Library/Caches/muesli-spm/release}"
+SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path release)"
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 OUTPUT_DIR="$ROOT/dist-release"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,13 +32,22 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 source "$ROOT/scripts/muesli_spm_cache.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
-SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path release)"
+SWIFTPM_SCRATCH_PATH=""
+SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
+BUILD_ENV=()
+if ! muesli_spm_scratch_disabled; then
+  SWIFTPM_SCRATCH_PATH="$(muesli_resolve_spm_scratch_path release)"
+  SWIFT_TEST_ARGS+=(--scratch-path "$SWIFTPM_SCRATCH_PATH")
+  BUILD_ENV+=(MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH")
+else
+  BUILD_ENV+=(MUESLI_DISABLE_SWIFTPM_SCRATCH_PATH=1)
+fi
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
 OUTPUT_DIR="$ROOT/dist-release"
 INSTALL_DIR="${MUESLI_RELEASE_INSTALL_DIR:-$OUTPUT_DIR/install-root}"
 APP_DIR="${MUESLI_RELEASE_APP_DIR:-$INSTALL_DIR/Muesli.app}"
-GENERATE_APPCAST="$SWIFTPM_SCRATCH_PATH/artifacts/sparkle/Sparkle/bin/generate_appcast"
+GENERATE_APPCAST="$(muesli_spm_artifacts_root "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 TAP_REPO="${MUESLI_TAP_REPO:-Muesli-HQ/homebrew-muesli}"
 TAP_CASK_REL_PATH="${MUESLI_TAP_CASK_REL_PATH:-Casks/m/muesli.rb}"
@@ -149,18 +158,24 @@ sed -i '' "s/^DEFAULT_APP_VERSION=.*/DEFAULT_APP_VERSION=\"${VERSION}\"/" "$ROOT
 
 # --- Step 1: Run tests ---
 echo "[1/13] Running tests..."
-mkdir -p "$SWIFTPM_SCRATCH_PATH"
-echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
-swift test --package-path "$PACKAGE_DIR" --scratch-path "$SWIFTPM_SCRATCH_PATH"
+if [[ -n "$SWIFTPM_SCRATCH_PATH" ]]; then
+  mkdir -p "$SWIFTPM_SCRATCH_PATH"
+  echo "  SwiftPM scratch path: $SWIFTPM_SCRATCH_PATH"
+else
+  echo "  SwiftPM scratch path: package-local .build"
+fi
+swift test "${SWIFT_TEST_ARGS[@]}"
 echo "  Tests passed."
 
 # --- Step 2: Build and sign ---
 echo "[2/13] Building and signing..."
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
-echo "y" | MUESLI_INSTALL_DIR="$INSTALL_DIR" \
-  MUESLI_SWIFTPM_SCRATCH_PATH="$SWIFTPM_SCRATCH_PATH" \
-  "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
+RELEASE_BUILD_ENV=(
+  MUESLI_INSTALL_DIR="$INSTALL_DIR"
+  "${BUILD_ENV[@]}"
+)
+echo "y" | env "${RELEASE_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
 echo "  Installed to $APP_DIR"
 if [[ ! -x "$GENERATE_APPCAST" ]]; then
   echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2


### PR DESCRIPTION
## Summary
- add shared SwiftPM scratch-cache resolver for local/dev/release scripts
- prefer mounted external cache when available, with env override and disable escape hatch
- document the cache workflow in AGENTS.md and CLAUDE.md

## Validation
- bash -n scripts/muesli_spm_cache.sh scripts/build_native_app.sh scripts/release-alpha.sh scripts/release-preprod.sh scripts/release.sh scripts/dev-test.sh
- git diff --check
- helper resolution smoke test for default, explicit path, and channel override

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366732&installation_id=136549638&pr_number=201&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F201&signature=fe5612fc500e418f37c964f57c6782c2467f944d837da83aeac6136aed592352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->