### PR TITLE
[codex] Add route-aware meeting mic capture

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -36,6 +36,11 @@ enum GoogleCalendarListLoadState: Equatable {
     case failed(String)
 }
 
+struct ActiveMeetingAudioWarning: Equatable {
+    let meetingID: Int64
+    let message: String
+}
+
 @MainActor
 @Observable
 final class AppState {
@@ -71,6 +76,7 @@ final class AppState {
     var meetingStartStatus: String?
     var liveMeetingTranscript: String = ""
     var liveMeetingTranscriptOwnerID: Int64? = nil
+    var activeMeetingAudioWarning: ActiveMeetingAudioWarning?
     var dictationState: DictationState = .idle
     var isVoiceNoteRecording: Bool = false
     var isChatGPTAuthenticated: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -3,7 +3,7 @@ import CoreAudio
 import Foundation
 import os
 
-final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting {
+final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting, PausableStreamingDictationRecording {
     var onAudioBuffer: (([Float]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?
     var onLatencyEvent: ((String, Date) -> Void)?
@@ -25,6 +25,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     private var preparedInputDeviceID: AudioObjectID?
     private var isPrepared = false
     private var isRunning = false
+    private var isPaused = false
     private var captureGeneration: UInt64 = 0
 
     private struct FileState {
@@ -63,6 +64,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         stateLock.withLock { $0 = FileState() }
         let fileState = try createNewFile()
         stateLock.withLock { $0 = fileState }
+        isPaused = false
 
         for buffer in buffers {
             let status = AudioQueueEnqueueBuffer(audioQueue, buffer, 0, nil)
@@ -110,6 +112,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         if captureGeneration == generationToFinish {
             captureGeneration &+= 1
         }
+        isPaused = false
         queueLock.unlock()
 
         emitLatency("audio_queue_finalize_begin")
@@ -126,6 +129,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     func cancel() {
         queueLock.lock()
         isRunning = false
+        isPaused = false
         captureGeneration &+= 1
         let queueToDispose = audioQueue
         let callbackUserDataToRelease = queueCallbackUserData
@@ -158,6 +162,27 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
 
     func currentPower() -> Float {
         stateLock.withLock { $0.latestPowerDB }
+    }
+
+    func pause() {
+        queueLock.lock()
+        guard isRunning else {
+            queueLock.unlock()
+            return
+        }
+        isPaused = true
+        queueLock.unlock()
+        stateLock.withLock { $0.latestPowerDB = -160 }
+    }
+
+    func resume() {
+        queueLock.lock()
+        guard isRunning else {
+            queueLock.unlock()
+            return
+        }
+        isPaused = false
+        queueLock.unlock()
     }
 
     private func prepareLocked() throws {
@@ -284,7 +309,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
 
     private func processAudioData(_ data: Data, generation: UInt64) {
         queueLock.lock()
-        let shouldProcess = captureGeneration == generation
+        let shouldProcess = captureGeneration == generation && !isPaused
         queueLock.unlock()
         guard shouldProcess else { return }
 
@@ -338,6 +363,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         let callbackUserDataToRelease = queueCallbackUserData
         if let audioQueue {
             captureGeneration &+= 1
+            isPaused = false
             AudioQueueStop(audioQueue, true)
             AudioQueueDispose(audioQueue, true)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -114,13 +114,36 @@ protocol DictationAudioRouting: AnyObject {
 
     func refreshRouteCache()
     func preferredInputDeviceIDForDictation() -> AudioObjectID?
+    func preferredInputDeviceIDForMeeting() -> AudioObjectID?
     func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID?
+    func meetingInputRouteSnapshot() -> MeetingMicRouteDiagnosticsSnapshot
     func availableInputDevices() -> [AudioInputDeviceInfo]
     func isDefaultOutputHeadphoneLike() -> Bool
     func currentOutputRouteKindForDebug() -> AudioOutputRouteKind
     func currentRouteDebugDescription() -> String
     func systemDefaultInputIsBuiltInForDictation() -> Bool
     func refreshRouteAfterDictationSession()
+}
+
+extension DictationAudioRouting {
+    func preferredInputDeviceIDForMeeting() -> AudioObjectID? {
+        preferredInputDeviceIDForDictation()
+    }
+
+    func meetingInputRouteSnapshot() -> MeetingMicRouteDiagnosticsSnapshot {
+        MeetingMicRouteDiagnosticsSnapshot(
+            outputRouteKind: currentOutputRouteKindForDebug().description,
+            outputIsAmbiguousBluetooth: false,
+            selectedInputDeviceUID: selectedInputDeviceUID,
+            selectedInputDeviceResolved: true,
+            preferredInputDeviceID: preferredInputDeviceIDForMeeting(),
+            preferredInputDeviceName: nil,
+            defaultInputDeviceID: nil,
+            defaultInputDeviceName: nil,
+            builtInInputDeviceID: nil,
+            systemDefaultInputIsBuiltIn: systemDefaultInputIsBuiltInForDictation()
+        )
+    }
 }
 
 final class DictationAudioRouteController: DictationAudioRouting {
@@ -242,8 +265,49 @@ final class DictationAudioRouteController: DictationAudioRouting {
         return Self.preferredInputDeviceID(for: lock.withLock { snapshot })
     }
 
+    func preferredInputDeviceIDForMeeting() -> AudioObjectID? {
+        syncOnRouteQueue {
+            let next = makeRouteSnapshot()
+            lock.withLock {
+                snapshot = next
+            }
+        }
+        return Self.preferredMeetingInputDeviceID(for: lock.withLock { snapshot })
+    }
+
     func cachedPreferredInputDeviceIDForDictation() -> AudioObjectID? {
         Self.preferredInputDeviceID(for: lock.withLock { snapshot })
+    }
+
+    func meetingInputRouteSnapshot() -> MeetingMicRouteDiagnosticsSnapshot {
+        syncOnRouteQueue {
+            let next = makeRouteSnapshot()
+            lock.withLock {
+                snapshot = next
+            }
+        }
+        let current = lock.withLock { snapshot }
+        let preferredInputDeviceID = Self.preferredMeetingInputDeviceID(for: current)
+        let selectedInputDeviceUID = lock.withLock { selectedInputDeviceUIDStorage }
+        let devices = inspector.availableInputDevices()
+        let preferredDevice = preferredInputDeviceID.flatMap { id in
+            devices.first(where: { $0.deviceID == id })
+        }
+        let defaultInputDevice = current.defaultInputDeviceID.flatMap { id in
+            devices.first(where: { $0.deviceID == id })
+        }
+        return MeetingMicRouteDiagnosticsSnapshot(
+            outputRouteKind: current.outputRouteKind.description,
+            outputIsAmbiguousBluetooth: current.outputIsAmbiguousBluetooth,
+            selectedInputDeviceUID: selectedInputDeviceUID,
+            selectedInputDeviceResolved: selectedInputDeviceUID == nil || current.selectedInputDeviceID != nil,
+            preferredInputDeviceID: preferredInputDeviceID,
+            preferredInputDeviceName: preferredDevice?.name,
+            defaultInputDeviceID: current.defaultInputDeviceID,
+            defaultInputDeviceName: defaultInputDevice?.name,
+            builtInInputDeviceID: current.builtInInputDeviceID,
+            systemDefaultInputIsBuiltIn: current.systemDefaultInputIsBuiltIn
+        )
     }
 
     func availableInputDevices() -> [AudioInputDeviceInfo] {
@@ -302,6 +366,13 @@ final class DictationAudioRouteController: DictationAudioRouting {
         case .unknown:
             return snapshot.outputIsAmbiguousBluetooth ? snapshot.builtInInputDeviceID : nil
         }
+    }
+
+    private static func preferredMeetingInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
+        if let selectedInputDeviceID = snapshot.selectedInputDeviceID {
+            return selectedInputDeviceID
+        }
+        return snapshot.builtInInputDeviceID
     }
 
     private func makeRouteSnapshot() -> RouteSnapshot {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
@@ -1,7 +1,7 @@
 import CoreAudio
 import Foundation
 
-final class FallbackStreamingDictationRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting {
+final class FallbackStreamingDictationRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting, PausableStreamingDictationRecording {
     var onAudioBuffer: (([Float]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?
     var onLatencyEvent: ((String, Date) -> Void)?
@@ -118,6 +118,20 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
         primary.cancel()
         fallback.cancel()
         wireCallbacks()
+    }
+
+    func pause() {
+        lock.lock()
+        let recorder = activeRecorderLocked()
+        lock.unlock()
+        (recorder as? PausableStreamingDictationRecording)?.pause()
+    }
+
+    func resume() {
+        lock.lock()
+        let recorder = activeRecorderLocked()
+        lock.unlock()
+        (recorder as? PausableStreamingDictationRecording)?.resume()
     }
 
     func currentPower() -> Float {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -224,6 +224,8 @@ struct MeetingDetailView: View {
                 MeetingRecordingPlayerView(recordingPath: savedRecordingPath)
             }
 
+            activeMeetingAudioWarningBanner(for: meeting)
+
             if !showsManualNotesEditor(for: meeting), isRawTranscript(meeting), documentMode == .notes {
                 transcriptCTA
             }
@@ -525,20 +527,24 @@ struct MeetingDetailView: View {
                 .padding(.horizontal, MuesliTheme.spacing8)
             } else {
                 iconButton("arrow.clockwise", label: "Re-transcribe") {
-                    isRetranscribing = true
-                    controller.retranscribe(meeting: meeting) { [meeting] result in
-                        isRetranscribing = false
-                        switch result {
-                        case .success:
-                            if let updated = controller.meeting(id: meeting.id) {
-                                syncLocalState(with: updated)
-                            }
-                        case .failure(let error):
-                            retranscriptionErrorMessage = error.localizedDescription
-                        }
-                    }
+                    startRetranscription(for: meeting)
                 }
                 .disabled(meeting.status == .recording || meeting.status == .processing || isEditingNotes || isEditingTranscript)
+            }
+        }
+    }
+
+    private func startRetranscription(for meeting: MeetingRecord) {
+        isRetranscribing = true
+        controller.retranscribe(meeting: meeting) { [meeting] result in
+            isRetranscribing = false
+            switch result {
+            case .success:
+                if let updated = controller.meeting(id: meeting.id) {
+                    syncLocalState(with: updated)
+                }
+            case .failure(let error):
+                retranscriptionErrorMessage = error.localizedDescription
             }
         }
     }
@@ -1103,6 +1109,30 @@ struct MeetingDetailView: View {
         .padding(MuesliTheme.spacing12)
         .background(MuesliTheme.accent.opacity(0.08))
         .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+    }
+
+    @ViewBuilder
+    private func activeMeetingAudioWarningBanner(for meeting: MeetingRecord) -> some View {
+        if meeting.status == .recording,
+           let warning = appState.activeMeetingAudioWarning,
+           warning.meetingID == meeting.id {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.orange)
+                Text(warning.message)
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Spacer(minLength: MuesliTheme.spacing8)
+            }
+            .padding(MuesliTheme.spacing12)
+            .background(Color.orange.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(Color.orange.opacity(0.35), lineWidth: 1)
+            )
+        }
     }
 
     private var hasApiKey: Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicHealthTracker.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicHealthTracker.swift
@@ -1,0 +1,170 @@
+import Foundation
+import os
+
+enum MeetingMicHealthState: String, Codable, Equatable {
+    case healthy
+    case waitingForAudio
+    case micCallbacksMissing
+    case micAllZeroWhileSystemActive
+
+    var userMessage: String? {
+        switch self {
+        case .healthy, .waitingForAudio:
+            return nil
+        case .micCallbacksMissing:
+            return "Microphone audio is not reaching Muesli. This meeting transcript may miss your side."
+        case .micAllZeroWhileSystemActive:
+            return "Microphone audio is silent. This meeting transcript may miss your side."
+        }
+    }
+}
+
+struct MeetingMicHealthTransition: Codable, Equatable {
+    let timestamp: Date
+    let state: MeetingMicHealthState
+    let reason: String
+}
+
+struct MeetingMicHealthSnapshot: Codable {
+    let state: MeetingMicHealthState
+    let rawMic: AudioSampleStatsSnapshot
+    let systemAudio: AudioSampleStatsSnapshot
+    let firstRawMicCallbackAt: Date?
+    let firstNonZeroMicAt: Date?
+    let firstSystemAudioAt: Date?
+    let lastRawMicCallbackAt: Date?
+    let lastNonZeroMicAt: Date?
+    let lastSystemAudioAt: Date?
+    let transitions: [MeetingMicHealthTransition]
+
+    var warningMessage: String? {
+        state.userMessage
+    }
+}
+
+final class MeetingMicHealthTracker {
+    private struct State {
+        var healthState: MeetingMicHealthState = .waitingForAudio
+        var rawMicStats = AudioSampleStats()
+        var systemAudioStats = AudioSampleStats()
+        var firstRawMicCallbackAt: Date?
+        var firstNonZeroMicAt: Date?
+        var firstSystemAudioAt: Date?
+        var lastRawMicCallbackAt: Date?
+        var lastNonZeroMicAt: Date?
+        var lastSystemAudioAt: Date?
+        var lastRawMicWasEffectivelyZero = true
+        var activeSystemSamplesWhileMicMissing = 0
+        var activeSystemSamplesWhileMicZero = 0
+        var transitions: [MeetingMicHealthTransition] = []
+    }
+
+    private static let sampleRate = 16_000
+    private static let activeSystemPeakThreshold = 0.01
+    private static let nonZeroMicPeakThreshold = 0.0001
+    private static let zeroRatioThreshold = 0.999
+    private static let degradedConfirmationSamples = sampleRate * 3
+    private static let micCallbackStaleThreshold: TimeInterval = 1.0
+    private static let maxTransitions = 32
+
+    private let lock = OSAllocatedUnfairLock(initialState: State())
+
+    func noteRawMicSamples(_ samples: [Int16], now: Date = Date()) -> MeetingMicHealthSnapshot {
+        lock.withLock { state in
+            state.rawMicStats.addInt16(samples)
+            state.firstRawMicCallbackAt = state.firstRawMicCallbackAt ?? now
+            state.lastRawMicCallbackAt = now
+            state.activeSystemSamplesWhileMicMissing = 0
+
+            let stats = statsForSamples(samples)
+            let zeroRatio = stats.sampleCount > 0
+                ? Double(stats.zeroSampleCount) / Double(stats.sampleCount)
+                : 1
+            let hasSignal = stats.peak > Self.nonZeroMicPeakThreshold
+                || zeroRatio < Self.zeroRatioThreshold
+            state.lastRawMicWasEffectivelyZero = !hasSignal
+            if hasSignal {
+                state.firstNonZeroMicAt = state.firstNonZeroMicAt ?? now
+                state.lastNonZeroMicAt = now
+                state.activeSystemSamplesWhileMicMissing = 0
+                state.activeSystemSamplesWhileMicZero = 0
+                transitionLocked(&state, to: .healthy, reason: "raw_mic_signal_detected", now: now)
+            }
+            return snapshotLocked(state)
+        }
+    }
+
+    func noteSystemSamples(_ samples: [Int16], now: Date = Date()) -> MeetingMicHealthSnapshot {
+        lock.withLock { state in
+            state.systemAudioStats.addInt16(samples)
+            let stats = statsForSamples(samples)
+            guard stats.peak > Self.activeSystemPeakThreshold else {
+                return snapshotLocked(state)
+            }
+
+            state.firstSystemAudioAt = state.firstSystemAudioAt ?? now
+            state.lastSystemAudioAt = now
+
+            if state.lastRawMicCallbackAt == nil {
+                state.activeSystemSamplesWhileMicMissing += samples.count
+                if state.activeSystemSamplesWhileMicMissing >= Self.degradedConfirmationSamples {
+                    transitionLocked(&state, to: .micCallbacksMissing, reason: "system_audio_active_without_mic_callbacks", now: now)
+                }
+            } else if state.lastRawMicWasEffectivelyZero {
+                state.activeSystemSamplesWhileMicZero += samples.count
+                if state.activeSystemSamplesWhileMicZero >= Self.degradedConfirmationSamples {
+                    transitionLocked(&state, to: .micAllZeroWhileSystemActive, reason: "system_audio_active_with_zero_mic", now: now)
+                }
+            } else if let lastRawMicCallbackAt = state.lastRawMicCallbackAt,
+                      now.timeIntervalSince(lastRawMicCallbackAt) >= Self.micCallbackStaleThreshold {
+                state.activeSystemSamplesWhileMicMissing += samples.count
+                if state.activeSystemSamplesWhileMicMissing >= Self.degradedConfirmationSamples {
+                    transitionLocked(&state, to: .micCallbacksMissing, reason: "system_audio_active_after_mic_callbacks_stopped", now: now)
+                }
+            } else {
+                state.activeSystemSamplesWhileMicMissing = 0
+                state.activeSystemSamplesWhileMicZero = 0
+            }
+            return snapshotLocked(state)
+        }
+    }
+
+    func snapshot() -> MeetingMicHealthSnapshot {
+        lock.withLock { snapshotLocked($0) }
+    }
+
+    private func transitionLocked(
+        _ state: inout State,
+        to nextState: MeetingMicHealthState,
+        reason: String,
+        now: Date
+    ) {
+        guard state.healthState != nextState else { return }
+        state.healthState = nextState
+        state.transitions.append(MeetingMicHealthTransition(timestamp: now, state: nextState, reason: reason))
+        if state.transitions.count > Self.maxTransitions {
+            state.transitions.removeFirst(state.transitions.count - Self.maxTransitions)
+        }
+    }
+
+    private func snapshotLocked(_ state: State) -> MeetingMicHealthSnapshot {
+        MeetingMicHealthSnapshot(
+            state: state.healthState,
+            rawMic: state.rawMicStats.snapshot(),
+            systemAudio: state.systemAudioStats.snapshot(),
+            firstRawMicCallbackAt: state.firstRawMicCallbackAt,
+            firstNonZeroMicAt: state.firstNonZeroMicAt,
+            firstSystemAudioAt: state.firstSystemAudioAt,
+            lastRawMicCallbackAt: state.lastRawMicCallbackAt,
+            lastNonZeroMicAt: state.lastNonZeroMicAt,
+            lastSystemAudioAt: state.lastSystemAudioAt,
+            transitions: state.transitions
+        )
+    }
+
+    private func statsForSamples(_ samples: [Int16]) -> AudioSampleStatsSnapshot {
+        var stats = AudioSampleStats()
+        stats.addInt16(samples)
+        return stats.snapshot()
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecording.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecording.swift
@@ -1,0 +1,315 @@
+import CoreAudio
+import Foundation
+import os
+
+enum MeetingMicRecorderKind: String, Codable, Equatable {
+    case systemDefaultStreaming
+    case appScopedAudioQueue
+}
+
+struct MeetingMicRouteDiagnosticsSnapshot: Codable, Equatable {
+    let outputRouteKind: String
+    let outputIsAmbiguousBluetooth: Bool
+    let selectedInputDeviceUID: String?
+    let selectedInputDeviceResolved: Bool
+    let preferredInputDeviceID: AudioObjectID?
+    let preferredInputDeviceName: String?
+    let defaultInputDeviceID: AudioObjectID?
+    let defaultInputDeviceName: String?
+    let builtInInputDeviceID: AudioObjectID?
+    let systemDefaultInputIsBuiltIn: Bool
+}
+
+struct MeetingMicRecorderDiagnosticsSnapshot: Codable, Equatable {
+    let recorderKind: MeetingMicRecorderKind
+    let preferredInputDeviceID: AudioObjectID?
+    let route: MeetingMicRouteDiagnosticsSnapshot?
+}
+
+protocol MeetingMicRecording: AnyObject {
+    var preferredInputDeviceID: AudioObjectID? { get set }
+    var onRawPCMSamples: (([Int16]) -> Void)? { get set }
+    var onRecordingFailed: ((Error) -> Void)? { get set }
+
+    func prepare() throws
+    func start() throws
+    func pause()
+    func resume()
+    func stop() -> URL?
+    func cancel()
+    func currentPower() -> Float
+    func diagnosticsSnapshot() -> MeetingMicRecorderDiagnosticsSnapshot
+}
+
+final class StreamingMeetingMicRecorderAdapter: MeetingMicRecording {
+    var preferredInputDeviceID: AudioObjectID? {
+        get { recorder.preferredInputDeviceID }
+        set { recorder.preferredInputDeviceID = newValue }
+    }
+    var onRawPCMSamples: (([Int16]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)? {
+        get { recorder.onRecordingFailed }
+        set { recorder.onRecordingFailed = newValue }
+    }
+
+    private let recorder: StreamingDictationRecording
+    private let kind: MeetingMicRecorderKind
+    private let lock = OSAllocatedUnfairLock(initialState: false)
+
+    init(
+        recorder: StreamingDictationRecording,
+        kind: MeetingMicRecorderKind
+    ) {
+        self.recorder = recorder
+        self.kind = kind
+        wireCallbacks()
+    }
+
+    func prepare() throws {
+        try recorder.prepare()
+    }
+
+    func start() throws {
+        lock.withLock { $0 = false }
+        try recorder.start()
+    }
+
+    func pause() {
+        lock.withLock { $0 = true }
+        (recorder as? PausableStreamingDictationRecording)?.pause()
+    }
+
+    func resume() {
+        lock.withLock { $0 = false }
+        (recorder as? PausableStreamingDictationRecording)?.resume()
+    }
+
+    func stop() -> URL? {
+        recorder.stop()
+    }
+
+    func cancel() {
+        recorder.cancel()
+    }
+
+    func currentPower() -> Float {
+        recorder.currentPower()
+    }
+
+    func diagnosticsSnapshot() -> MeetingMicRecorderDiagnosticsSnapshot {
+        MeetingMicRecorderDiagnosticsSnapshot(
+            recorderKind: kind,
+            preferredInputDeviceID: preferredInputDeviceID,
+            route: nil
+        )
+    }
+
+    private func wireCallbacks() {
+        recorder.onAudioBuffer = { [weak self] samples in
+            guard let self else { return }
+            guard !self.lock.withLock({ $0 }) else { return }
+            let int16Samples = samples.map { sample -> Int16 in
+                Int16(max(-1.0, min(1.0, sample)) * 32767)
+            }
+            self.onRawPCMSamples?(int16Samples)
+        }
+    }
+}
+
+final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
+    enum ActiveRecorderKind: Equatable {
+        case systemDefault
+        case appScoped
+    }
+
+    var preferredInputDeviceID: AudioObjectID? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return preferredInputDeviceIDStorage
+        }
+        set {
+            lifecycleQueue.sync {
+                lock.lock()
+                preferredInputDeviceIDStorage = newValue
+                let recorder = activeRecorderLocked()
+                lock.unlock()
+                recorder.preferredInputDeviceID = newValue
+            }
+        }
+    }
+
+    var onRawPCMSamples: (([Int16]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+
+    private let systemDefaultRecorder: MeetingMicRecording
+    private let appScopedRecorder: MeetingMicRecording
+    private let routeSnapshotProvider: () -> MeetingMicRouteDiagnosticsSnapshot?
+    private let lifecycleQueue: DispatchQueue
+    private let lock = NSRecursiveLock()
+    private var preferredInputDeviceIDStorage: AudioObjectID?
+    private var activeRecorderKindStorage: ActiveRecorderKind = .systemDefault
+
+    init(
+        systemDefaultRecorder: MeetingMicRecording = StreamingMeetingMicRecorderAdapter(
+            recorder: StreamingMicRecorder(directoryName: "muesli-meeting-mic"),
+            kind: .systemDefaultStreaming
+        ),
+        appScopedRecorder: MeetingMicRecording = StreamingMeetingMicRecorderAdapter(
+            recorder: FallbackStreamingDictationRecorder(
+                primary: AudioQueueInputRecorder(directoryName: "muesli-meeting-mic-audioqueue"),
+                fallback: StreamingMicRecorder(directoryName: "muesli-meeting-mic-app-scoped-fallback")
+            ),
+            kind: .appScopedAudioQueue
+        ),
+        routeSnapshotProvider: @escaping () -> MeetingMicRouteDiagnosticsSnapshot? = { nil },
+        lifecycleQueue: DispatchQueue = DispatchQueue(label: "com.muesli.route-aware-meeting-mic-recorder-lifecycle")
+    ) {
+        self.systemDefaultRecorder = systemDefaultRecorder
+        self.appScopedRecorder = appScopedRecorder
+        self.routeSnapshotProvider = routeSnapshotProvider
+        self.lifecycleQueue = lifecycleQueue
+        wireCallbacks()
+    }
+
+    func activeRecorderKindForDebug() -> ActiveRecorderKind {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeRecorderKindStorage
+    }
+
+    func prepare() throws {
+        try lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
+            try recorder.prepare()
+        }
+    }
+
+    func start() throws {
+        try lifecycleQueue.sync {
+            let recorder = selectRecorder(preferredInputDeviceID: currentPreferredInputDeviceID())
+            try recorder.start()
+        }
+    }
+
+    func pause() {
+        lifecycleQueue.sync {
+            activeRecorder().pause()
+        }
+    }
+
+    func resume() {
+        lifecycleQueue.sync {
+            activeRecorder().resume()
+        }
+    }
+
+    func stop() -> URL? {
+        lifecycleQueue.sync {
+            lock.lock()
+            let activeRecorder = activeRecorderLocked()
+            let inactiveRecorder = inactiveRecorderLocked()
+            lock.unlock()
+            let url = activeRecorder.stop()
+            inactiveRecorder.cancel()
+            return url
+        }
+    }
+
+    func cancel() {
+        lifecycleQueue.sync {
+            systemDefaultRecorder.cancel()
+            appScopedRecorder.cancel()
+        }
+    }
+
+    func currentPower() -> Float {
+        activeRecorder().currentPower()
+    }
+
+    func diagnosticsSnapshot() -> MeetingMicRecorderDiagnosticsSnapshot {
+        var snapshot = activeRecorder().diagnosticsSnapshot()
+        if snapshot.route == nil {
+            snapshot = MeetingMicRecorderDiagnosticsSnapshot(
+                recorderKind: snapshot.recorderKind,
+                preferredInputDeviceID: snapshot.preferredInputDeviceID,
+                route: routeSnapshotProvider()
+            )
+        }
+        return snapshot
+    }
+
+    private func wireCallbacks() {
+        wireCallbacks(for: systemDefaultRecorder, kind: .systemDefault)
+        wireCallbacks(for: appScopedRecorder, kind: .appScoped)
+    }
+
+    private func wireCallbacks(for recorder: MeetingMicRecording, kind: ActiveRecorderKind) {
+        recorder.onRawPCMSamples = { [weak self] samples in
+            self?.forwardIfActive(kind) { $0.onRawPCMSamples?(samples) }
+        }
+        recorder.onRecordingFailed = { [weak self] error in
+            self?.forwardIfActive(kind) { $0.onRecordingFailed?(error) }
+        }
+    }
+
+    private func forwardIfActive(_ kind: ActiveRecorderKind, _ body: (RouteAwareMeetingMicRecorder) -> Void) {
+        lock.lock()
+        let shouldForward = activeRecorderKindStorage == kind
+        lock.unlock()
+        guard shouldForward else { return }
+        body(self)
+    }
+
+    private func currentPreferredInputDeviceID() -> AudioObjectID? {
+        lock.lock()
+        defer { lock.unlock() }
+        return preferredInputDeviceIDStorage
+    }
+
+    private func selectRecorder(preferredInputDeviceID: AudioObjectID?) -> MeetingMicRecording {
+        lock.lock()
+        let nextKind: ActiveRecorderKind = preferredInputDeviceID == nil ? .systemDefault : .appScoped
+        let inactiveRecorderToCancel = nextKind == activeRecorderKindStorage ? nil : activeRecorderLocked()
+        preferredInputDeviceIDStorage = preferredInputDeviceID
+        activeRecorderKindStorage = nextKind
+        let selectedRecorder = activeRecorderLocked()
+        lock.unlock()
+
+        selectedRecorder.preferredInputDeviceID = preferredInputDeviceID
+        inactiveRecorderToCancel?.cancel()
+        return selectedRecorder
+    }
+
+    private func activeRecorder() -> MeetingMicRecording {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeRecorderLocked()
+    }
+
+    private func activeRecorderLocked() -> MeetingMicRecording {
+        recorder(for: activeRecorderKindStorage)
+    }
+
+    private func inactiveRecorderLocked() -> MeetingMicRecording {
+        inactiveRecorder(for: activeRecorderKindStorage)
+    }
+
+    private func recorder(for kind: ActiveRecorderKind) -> MeetingMicRecording {
+        switch kind {
+        case .systemDefault:
+            return systemDefaultRecorder
+        case .appScoped:
+            return appScopedRecorder
+        }
+    }
+
+    private func inactiveRecorder(for kind: ActiveRecorderKind) -> MeetingMicRecording {
+        switch kind {
+        case .systemDefault:
+            return appScopedRecorder
+        case .appScoped:
+            return systemDefaultRecorder
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -119,8 +119,8 @@ final class MeetingSession {
     private let systemAudioRecorder: SystemAudioCapturing
     private let neuralAec = MeetingNeuralAec()
 
-    /// Streaming mic recorder with real-time buffer access (AVAudioEngine)
-    private var streamingMicRecorder = StreamingMicRecorder()
+    /// Route-aware mic recorder with real-time 16 kHz mono PCM access.
+    private var meetingMicRecorder: MeetingMicRecording
     private var rawMicChunkRecorder: PCMChunkRecorder?
     private var retainedRecordingWriter: MeetingRecordingWriter?
     private var retainedRecordingWriterError: Error?
@@ -131,12 +131,14 @@ final class MeetingSession {
     private let systemChunkCollector = MeetingChunkCollector()
     private let micChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let systemChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
+    private let micHealthTracker = MeetingMicHealthTracker()
     private let chunkRotationQueue = DispatchQueue(label: "MuesliNative.MeetingSession.chunkRotation")
     private let pausedDisplayLock = OSAllocatedUnfairLock(initialState: false)
     private var chunkTimingTracker = MeetingChunkTimingTracker()
     private var systemChunkTimingTracker = MeetingChunkTimingTracker()
     private var systemChunkRecorder: PCMChunkRecorder?
     var onProgress: ((MeetingProcessingStage) -> Void)?
+    var onMicHealthChanged: ((MeetingMicHealthSnapshot) -> Void)?
     var manualNotesProvider: (() async -> String?)?
     var liveTitleProvider: (() async -> String?)?
     var onChunkTranscribed: (([SpeechSegment], String) -> Void)?
@@ -148,7 +150,7 @@ final class MeetingSession {
         if pausedDisplayLock.withLock({ $0 }) {
             return -160
         }
-        return streamingMicRecorder.currentPower()
+        return meetingMicRecorder.currentPower()
     }
 
     private(set) var startTime: Date?
@@ -166,7 +168,8 @@ final class MeetingSession {
         backend: BackendOption,
         runtime: RuntimePaths,
         config: AppConfig,
-        transcriptionCoordinator: TranscriptionCoordinator
+        transcriptionCoordinator: TranscriptionCoordinator,
+        meetingMicRecorder: MeetingMicRecording = RouteAwareMeetingMicRecorder()
     ) {
         self.title = title
         self.calendarEventID = calendarEventID
@@ -174,6 +177,7 @@ final class MeetingSession {
         self.runtime = runtime
         self.config = config
         self.transcriptionCoordinator = transcriptionCoordinator
+        self.meetingMicRecorder = meetingMicRecorder
         if config.useCoreAudioTap {
             self.systemAudioRecorder = CoreAudioSystemRecorder()
         } else {
@@ -207,17 +211,16 @@ final class MeetingSession {
 
         do {
             try prepareRealtimeAudioPipeline(vadManager: vadManager)
-            try streamingMicRecorder.prepare()
+            try meetingMicRecorder.prepare()
             setupRetainedRecordingWriterIfNeeded()
             try await systemAudioRecorder.start()
-            try streamingMicRecorder.start()
+            try meetingMicRecorder.start()
         } catch {
             vadController?.stop()
             vadController = nil
             systemVadController?.stop()
             systemVadController = nil
-            streamingMicRecorder.onAudioBuffer = nil
-            streamingMicRecorder.onPCMSamples = nil
+            meetingMicRecorder.onRawPCMSamples = nil
             systemAudioRecorder.onPCMSamples = nil
             retainedRecordingWriter?.cancel()
             retainedRecordingWriter = nil
@@ -232,7 +235,7 @@ final class MeetingSession {
                 chunkTimingTracker.discard()
                 systemChunkTimingTracker.discard()
             }
-            streamingMicRecorder.cancel()
+            meetingMicRecorder.cancel()
             if let url = systemAudioRecorder.stop() {
                 try? FileManager.default.removeItem(at: url)
             }
@@ -263,7 +266,7 @@ final class MeetingSession {
         }
         guard shouldPause else { return }
 
-        streamingMicRecorder.pause()
+        meetingMicRecorder.pause()
         systemAudioRecorder.pause()
         Task { await screenContextCollector.setPaused(true) }
         fputs("[meeting] recording paused\n", stderr)
@@ -277,7 +280,7 @@ final class MeetingSession {
         }
         guard shouldResume else { return }
 
-        streamingMicRecorder.resume()
+        meetingMicRecorder.resume()
         systemAudioRecorder.resume()
         Task { await screenContextCollector.setPaused(false) }
         fputs("[meeting] recording resumed\n", stderr)
@@ -306,9 +309,8 @@ final class MeetingSession {
         retainedRecordingWriterError = nil
         rawRecorder?.cancel()
         systemRecorder?.cancel()
-        streamingMicRecorder.onAudioBuffer = nil
-        streamingMicRecorder.onPCMSamples = nil
-        streamingMicRecorder.cancel()
+        meetingMicRecorder.onRawPCMSamples = nil
+        meetingMicRecorder.cancel()
         systemAudioRecorder.onPCMSamples = nil
         if let url = systemAudioRecorder.stop() {
             try? FileManager.default.removeItem(at: url)
@@ -329,8 +331,7 @@ final class MeetingSession {
         vadController = nil
         systemVadController?.stop()
         systemVadController = nil
-        streamingMicRecorder.onAudioBuffer = nil
-        streamingMicRecorder.onPCMSamples = nil
+        meetingMicRecorder.onRawPCMSamples = nil
         systemAudioRecorder.onPCMSamples = nil
         let (meetingStart, lastChunkTiming, lastRawMicURL, lastSystemChunkTiming, lastSystemChunkURL) = chunkRotationQueue.sync { () -> (Date, MeetingChunkTimingSnapshot?, URL?, MeetingChunkTimingSnapshot?, URL?) in
             isRecording = false
@@ -348,7 +349,7 @@ final class MeetingSession {
             let lastSystemChunkTiming = systemChunkTimingTracker.finish()
             return (meetingStart, lastChunkTiming, lastRawMicURL, lastSystemChunkTiming, lastSystemChunkURL)
         }
-        let rawStreamingMicURL = streamingMicRecorder.stop()
+        let rawStreamingMicURL = meetingMicRecorder.stop()
         let retainedRecordingURL = retainedRecordingWriter?.stop()
         retainedRecordingWriter = nil
         defer {
@@ -520,6 +521,8 @@ final class MeetingSession {
             rawMicURL: rawStreamingMicURL,
             systemAudioURL: systemAudioURL,
             systemCapture: (systemAudioRecorder as? SystemAudioDiagnosticsProviding)?.diagnosticsSnapshot,
+            micRecorder: meetingMicRecorder.diagnosticsSnapshot(),
+            micHealth: micHealthTracker.snapshot(),
             aec: neuralAec.diagnosticsSnapshot,
             micChunks: micChunkHealthTracker.snapshot(),
             systemChunks: systemChunkHealthTracker.snapshot(),
@@ -727,9 +730,7 @@ final class MeetingSession {
             systemVadController = nil
         }
         neuralAec.resetForStreaming()
-        streamingMicRecorder.onAudioBuffer = nil
-
-        streamingMicRecorder.onPCMSamples = { [weak self] samples in
+        meetingMicRecorder.onRawPCMSamples = { [weak self] samples in
             self?.enqueueRealtimeMicSamples(samples)
         }
         systemAudioRecorder.onPCMSamples = { [weak self] samples in
@@ -743,6 +744,8 @@ final class MeetingSession {
         chunkRotationQueue.async { [weak self] in
             guard let self, self.isRecording, !self.isPaused else { return }
 
+            let healthSnapshot = self.micHealthTracker.noteRawMicSamples(rawSamples)
+            self.onMicHealthChanged?(healthSnapshot)
             self.retainedRecordingWriter?.appendMic(rawSamples)
 
             let floatSamples = rawSamples.map { Float($0) / 32767.0 }
@@ -766,6 +769,8 @@ final class MeetingSession {
         chunkRotationQueue.async { [weak self] in
             guard let self, self.isRecording, !self.isPaused else { return }
 
+            let healthSnapshot = self.micHealthTracker.noteSystemSamples(samples)
+            self.onMicHealthChanged?(healthSnapshot)
             self.retainedRecordingWriter?.appendSystem(samples)
             self.systemChunkRecorder?.append(samples)
             self.systemChunkTimingTracker.append(sampleCount: samples.count)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
@@ -127,6 +127,8 @@ final class MeetingSessionDiagnostics {
         let endedAt: String
         let durationSeconds: Double
         let systemCapture: SystemAudioCaptureDiagnosticsSnapshot?
+        let micRecorder: MeetingMicRecorderDiagnosticsSnapshot?
+        let micHealth: MeetingMicHealthSnapshot?
         let aec: MeetingAecDiagnosticsSnapshot
         let micChunks: ChunkStats
         let systemChunks: ChunkStats
@@ -227,6 +229,8 @@ final class MeetingSessionDiagnostics {
         rawMicURL: URL?,
         systemAudioURL: URL?,
         systemCapture: SystemAudioCaptureDiagnosticsSnapshot?,
+        micRecorder: MeetingMicRecorderDiagnosticsSnapshot?,
+        micHealth: MeetingMicHealthSnapshot?,
         aec: MeetingAecDiagnosticsSnapshot,
         micChunks: MeetingTranscriptChunkHealthSnapshot,
         systemChunks: MeetingTranscriptChunkHealthSnapshot,
@@ -254,6 +258,8 @@ final class MeetingSessionDiagnostics {
             endedAt: Self.iso8601.string(from: endedAt),
             durationSeconds: max(endedAt.timeIntervalSince(startedAt), 0),
             systemCapture: systemCapture,
+            micRecorder: micRecorder,
+            micHealth: micHealth,
             aec: aec,
             micChunks: ChunkStats(
                 successful: micChunks.successfulChunkCount,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -237,6 +237,7 @@ final class MuesliController: NSObject {
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
+    private var activeMeetingAudioWarning: ActiveMeetingAudioWarning?
     private var liveMeetingTitleCache: [Int64: String] = [:]
     private var liveManualNotesCache: [Int64: String] = [:]
     private var liveManualNotesLastPersistedAt: [Int64: Date] = [:]
@@ -614,6 +615,7 @@ final class MuesliController: NSObject {
             resolveLiveMeetingAfterStopFailure(id: activeMeetingID)
             self.activeMeetingID = nil
         }
+        activeMeetingAudioWarning = nil
         endMeetingActivity()
         dictationAudioSessionManager.cancel(reason: "shutdown")
         computerUseRecorder.cancel()
@@ -718,6 +720,7 @@ final class MuesliController: NSObject {
         appState.isMeetingRecordingPaused = isMeetingRecordingPaused()
         appState.isMeetingStarting = isStartingMeetingRecording
         appState.meetingStartStatus = meetingStartStatus
+        appState.activeMeetingAudioWarning = activeMeetingAudioWarning
         indicator.setMeetingRecordingPaused(appState.isMeetingRecordingPaused, config: config)
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
@@ -2946,6 +2949,7 @@ final class MuesliController: NSObject {
                 selectedTemplatePrompt: templateSnapshot.prompt
             )
             activeMeetingID = meetingID
+            activeMeetingAudioWarning = nil
             syncAppState()
             if openDocument {
                 showMeetingDocument(id: meetingID)
@@ -3264,13 +3268,19 @@ final class MuesliController: NSObject {
         while true {
             try Task.checkCancellation()
             try checkMeetingStartStillCurrent(meetingID)
+            let routeSnapshot = dictationAudioRoutingController.meetingInputRouteSnapshot()
+            let meetingMicRecorder = RouteAwareMeetingMicRecorder(
+                routeSnapshotProvider: { routeSnapshot }
+            )
+            meetingMicRecorder.preferredInputDeviceID = routeSnapshot.preferredInputDeviceID
             let meetingSession = MeetingSession(
                 title: title,
                 calendarEventID: calendarEventID,
                 backend: backend,
                 runtime: runtime,
                 config: config,
-                transcriptionCoordinator: transcriptionCoordinator
+                transcriptionCoordinator: transcriptionCoordinator,
+                meetingMicRecorder: meetingMicRecorder
             )
 
             do {
@@ -3325,6 +3335,21 @@ final class MuesliController: NSObject {
                 }
                 appState.liveMeetingTranscriptOwnerID = meetingID
                 appState.liveMeetingTranscript = ""
+                let micHealthWarningLock = NSLock()
+                var lastForwardedMicHealthWarning: String?
+                meetingSession.onMicHealthChanged = { [weak self] snapshot in
+                    let warningMessage = snapshot.warningMessage
+                    micHealthWarningLock.lock()
+                    let shouldForward = warningMessage != lastForwardedMicHealthWarning
+                    lastForwardedMicHealthWarning = warningMessage
+                    micHealthWarningLock.unlock()
+                    guard shouldForward else { return }
+                    Task { @MainActor in
+                        guard let self,
+                              self.activeMeetingID == meetingID || self.meetingStartMeetingID == meetingID else { return }
+                        self.updateActiveMeetingAudioWarning(meetingID: meetingID, health: snapshot)
+                    }
+                }
                 try await meetingSession.start()
                 if Task.isCancelled || canceledMeetingStartIDs.contains(meetingID) {
                     meetingSession.discard()
@@ -3547,6 +3572,9 @@ final class MuesliController: NSObject {
             indicator.setMeetingRecording(false, config: config)
             if let meetingID = activeMeetingID {
                 activeMeetingID = nil
+                if activeMeetingAudioWarning?.meetingID == meetingID {
+                    activeMeetingAudioWarning = nil
+                }
                 resolveLiveMeetingAfterDiscard(id: meetingID, resolution: resolution)
             } else {
                 finishDiscardMeetingRecording()
@@ -3559,6 +3587,9 @@ final class MuesliController: NSObject {
         indicator.setMeetingRecording(false, config: config)
         if let meetingID = activeMeetingID {
             activeMeetingID = nil
+            if activeMeetingAudioWarning?.meetingID == meetingID {
+                activeMeetingAudioWarning = nil
+            }
             resolveLiveMeetingAfterDiscard(id: meetingID, resolution: resolution)
         } else {
             finishDiscardMeetingRecording()
@@ -3637,6 +3668,9 @@ final class MuesliController: NSObject {
         if activeMeetingID == id {
             activeMeetingID = nil
         }
+        if activeMeetingAudioWarning?.meetingID == id {
+            activeMeetingAudioWarning = nil
+        }
         syncAppState()
     }
 
@@ -3658,6 +3692,18 @@ final class MuesliController: NSObject {
             clearCachedMeetingManualNotes(id: id)
             clearCachedMeetingTitle(id: id)
         }
+        if activeMeetingAudioWarning?.meetingID == id {
+            activeMeetingAudioWarning = nil
+        }
+        syncAppState()
+    }
+
+    private func updateActiveMeetingAudioWarning(meetingID: Int64, health: MeetingMicHealthSnapshot) {
+        let nextWarning = health.warningMessage.map {
+            ActiveMeetingAudioWarning(meetingID: meetingID, message: $0)
+        }
+        guard activeMeetingAudioWarning != nextWarning else { return }
+        activeMeetingAudioWarning = nextWarning
         syncAppState()
     }
 
@@ -3670,6 +3716,9 @@ final class MuesliController: NSObject {
             disarmMeetingAutoStop()
             if let activeMeetingID {
                 resolveLiveMeetingAfterStopFailure(id: activeMeetingID)
+                if activeMeetingAudioWarning?.meetingID == activeMeetingID {
+                    activeMeetingAudioWarning = nil
+                }
                 self.activeMeetingID = nil
             }
             indicator.setMeetingRecording(false, config: config)
@@ -3707,6 +3756,9 @@ final class MuesliController: NSObject {
         // Unblock new recordings immediately — transcription runs in the background
         activeMeetingSession = nil
         activeMeetingID = nil
+        if let liveMeetingID, activeMeetingAudioWarning?.meetingID == liveMeetingID {
+            activeMeetingAudioWarning = nil
+        }
         isStoppingMeetingRecording = false
         backgroundMeetingProcessingCount += 1
         meetingMonitor.resumeAfterCooldown()

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -21,7 +21,12 @@ protocol StreamingDictationLatencyReporting: AnyObject {
     var onLatencyEvent: ((String, Date) -> Void)? { get set }
 }
 
-final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting {
+protocol PausableStreamingDictationRecording: AnyObject {
+    func pause()
+    func resume()
+}
+
+final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictationLatencyReporting, PausableStreamingDictationRecording {
     /// Called with 4096-sample Float chunks (256ms at 16kHz) for VAD processing.
     var onAudioBuffer: (([Float]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -21,6 +21,24 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == 82)
     }
 
+    @Test("meeting reuses route-aware preferred input policy")
+    func meetingReusesRouteAwarePreferredInputPolicy() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.meeting-headphone-like"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == 82)
+        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == 82)
+        #expect(controller.meetingInputRouteSnapshot().outputRouteKind == "headphone-like")
+    }
+
     @Test("dictation preserves default input for speaker output")
     func dictationPreservesDefaultInputForSpeakerOutput() {
         let inspector = FakeCoreAudioDeviceInspector(
@@ -38,6 +56,8 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.preferredInputDeviceIDForDictation() == nil)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
         #expect(controller.systemDefaultInputIsBuiltInForDictation())
+        #expect(controller.preferredInputDeviceIDForMeeting() == 82)
+        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == 82)
     }
 
     @Test("speaker output with non-built-in default input is not warmup-safe")
@@ -131,6 +151,7 @@ struct DictationAudioRouteControllerTests {
 
         #expect(controller.preferredInputDeviceIDForDictation() == 91)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == 91)
+        #expect(controller.preferredInputDeviceIDForMeeting() == 91)
     }
 
     @Test("unavailable selected microphone falls back to automatic route policy")

--- a/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
@@ -109,9 +109,27 @@ struct FallbackStreamingDictationRecorderTests {
         #expect(bufferCount == 1)
         #expect(failureCount == 0)
     }
+
+    @Test("pause and resume delegate to active recorder")
+    func pauseAndResumeDelegateToActiveRecorder() throws {
+        let error = NSError(domain: "FallbackStreamingDictationRecorderTests", code: 5)
+        let primary = FakeFallbackStreamingRecorder()
+        primary.prepareResults = [.failure(error)]
+        let fallback = FakeFallbackStreamingRecorder()
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+
+        try recorder.prepare()
+        recorder.pause()
+        recorder.resume()
+
+        #expect(primary.pauseCalls == 0)
+        #expect(primary.resumeCalls == 0)
+        #expect(fallback.pauseCalls == 1)
+        #expect(fallback.resumeCalls == 1)
+    }
 }
 
-private final class FakeFallbackStreamingRecorder: StreamingDictationRecording {
+private final class FakeFallbackStreamingRecorder: StreamingDictationRecording, PausableStreamingDictationRecording {
     var onAudioBuffer: (([Float]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?
     var preferredInputDeviceID: AudioObjectID?
@@ -124,6 +142,8 @@ private final class FakeFallbackStreamingRecorder: StreamingDictationRecording {
     var startCalls = 0
     var stopCalls = 0
     var cancelCalls = 0
+    var pauseCalls = 0
+    var resumeCalls = 0
     var clearsCallbacksOnCancel = false
 
     func prepare() throws {
@@ -153,6 +173,14 @@ private final class FakeFallbackStreamingRecorder: StreamingDictationRecording {
             onAudioBuffer = nil
             onRecordingFailed = nil
         }
+    }
+
+    func pause() {
+        pauseCalls += 1
+    }
+
+    func resume() {
+        resumeCalls += 1
     }
 
     func currentPower() -> Float {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMicHealthTrackerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMicHealthTrackerTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingMicHealthTracker")
+struct MeetingMicHealthTrackerTests {
+    @Test("all-zero raw mic with active system audio raises degraded warning")
+    func allZeroRawMicWithActiveSystemAudioRaisesWarning() {
+        let tracker = MeetingMicHealthTracker()
+        let now = Date()
+
+        _ = tracker.noteRawMicSamples(Array(repeating: 0, count: 16_000), now: now)
+        var snapshot = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(1))
+        #expect(snapshot.state == .waitingForAudio)
+
+        snapshot = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(2))
+        #expect(snapshot.state == .waitingForAudio)
+
+        snapshot = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(3))
+        #expect(snapshot.state == .micAllZeroWhileSystemActive)
+        #expect(snapshot.warningMessage != nil)
+    }
+
+    @Test("system audio without mic callbacks is distinguishable from all-zero mic")
+    func systemAudioWithoutMicCallbacksIsMissingCallbacks() {
+        let tracker = MeetingMicHealthTracker()
+        let now = Date()
+
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now)
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(1))
+        let snapshot = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(2))
+
+        #expect(snapshot.state == .micCallbacksMissing)
+        #expect(snapshot.warningMessage != nil)
+    }
+
+    @Test("mid-meeting mic callback loss after healthy input raises warning")
+    func midMeetingMicCallbackLossRaisesWarning() {
+        let tracker = MeetingMicHealthTracker()
+        let now = Date()
+
+        _ = tracker.noteRawMicSamples(Array(repeating: 400, count: 1_000), now: now)
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(2))
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(3))
+        let snapshot = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(4))
+
+        #expect(snapshot.state == .micCallbacksMissing)
+        #expect(snapshot.warningMessage != nil)
+    }
+
+    @Test("mid-meeting mic callback loss still warns when system audio starts during grace window")
+    func midMeetingMicCallbackLossWithGraceWindowRaisesWarning() {
+        let tracker = MeetingMicHealthTracker()
+        let now = Date()
+
+        _ = tracker.noteRawMicSamples(Array(repeating: 400, count: 1_000), now: now)
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 1_600), now: now.addingTimeInterval(0.5))
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(2))
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(3))
+        let snapshot = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000), now: now.addingTimeInterval(4))
+
+        #expect(snapshot.state == .micCallbacksMissing)
+        #expect(snapshot.warningMessage != nil)
+    }
+
+    @Test("silence without active system audio does not warn")
+    func silenceWithoutActiveSystemAudioDoesNotWarn() {
+        let tracker = MeetingMicHealthTracker()
+
+        _ = tracker.noteRawMicSamples(Array(repeating: 0, count: 16_000))
+        _ = tracker.noteSystemSamples(Array(repeating: 0, count: 16_000))
+        _ = tracker.noteSystemSamples(Array(repeating: 0, count: 16_000))
+        let snapshot = tracker.noteSystemSamples(Array(repeating: 0, count: 16_000))
+
+        #expect(snapshot.state == .waitingForAudio)
+        #expect(snapshot.warningMessage == nil)
+    }
+
+    @Test("non-zero raw mic clears degraded warning")
+    func nonZeroRawMicClearsWarning() {
+        let tracker = MeetingMicHealthTracker()
+
+        _ = tracker.noteRawMicSamples(Array(repeating: 0, count: 16_000))
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000))
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000))
+        _ = tracker.noteSystemSamples(Array(repeating: 6_000, count: 16_000))
+        let recovered = tracker.noteRawMicSamples(Array(repeating: 400, count: 1_000))
+
+        #expect(recovered.state == .healthy)
+        #expect(recovered.warningMessage == nil)
+        #expect(recovered.firstNonZeroMicAt != nil)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
@@ -1,0 +1,164 @@
+import CoreAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("RouteAwareMeetingMicRecorder")
+struct RouteAwareMeetingMicRecorderTests {
+    @Test("default input uses system default recorder")
+    func defaultInputUsesSystemDefaultRecorder() throws {
+        let system = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let appScoped = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
+        let recorder = RouteAwareMeetingMicRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        try recorder.prepare()
+        try recorder.start()
+
+        #expect(recorder.activeRecorderKindForDebug() == .systemDefault)
+        #expect(system.prepareCalls == 1)
+        #expect(system.startCalls == 1)
+        #expect(appScoped.prepareCalls == 0)
+        #expect(appScoped.startCalls == 0)
+    }
+
+    @Test("preferred input uses app scoped recorder")
+    func preferredInputUsesAppScopedRecorder() throws {
+        let system = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let appScoped = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
+        let recorder = RouteAwareMeetingMicRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+
+        recorder.preferredInputDeviceID = 82
+        try recorder.prepare()
+        try recorder.start()
+
+        #expect(recorder.activeRecorderKindForDebug() == .appScoped)
+        #expect(system.prepareCalls == 0)
+        #expect(system.startCalls == 0)
+        #expect(appScoped.prepareCalls == 1)
+        #expect(appScoped.startCalls == 1)
+        #expect(appScoped.preferredInputDeviceID == 82)
+    }
+
+    @Test("callbacks from inactive recorder are ignored")
+    func callbacksFromInactiveRecorderAreIgnored() throws {
+        let system = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let appScoped = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
+        let recorder = RouteAwareMeetingMicRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+        var forwardedSamples: [[Int16]] = []
+        var failureCount = 0
+        recorder.onRawPCMSamples = { forwardedSamples.append($0) }
+        recorder.onRecordingFailed = { _ in failureCount += 1 }
+
+        try recorder.start()
+        appScoped.onRawPCMSamples?([1, 2, 3])
+        appScoped.onRecordingFailed?(NSError(domain: "RouteAwareMeetingMicRecorderTests", code: 1))
+        system.onRawPCMSamples?([4, 5])
+
+        #expect(forwardedSamples == [[4, 5]])
+        #expect(failureCount == 0)
+    }
+
+    @Test("lifecycle delegates to active recorder and cancels inactive recorder on stop")
+    func lifecycleDelegatesToActiveRecorderAndCancelsInactiveRecorderOnStop() throws {
+        let system = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let appScoped = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
+        let recorder = RouteAwareMeetingMicRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+        recorder.preferredInputDeviceID = 91
+
+        try recorder.start()
+        recorder.pause()
+        recorder.resume()
+        _ = recorder.stop()
+
+        #expect(appScoped.startCalls == 1)
+        #expect(appScoped.pauseCalls == 1)
+        #expect(appScoped.resumeCalls == 1)
+        #expect(appScoped.stopCalls == 1)
+        #expect(system.cancelCalls >= 1)
+    }
+
+    @Test("diagnostics include active recorder kind and route snapshot")
+    func diagnosticsIncludeActiveRecorderKindAndRouteSnapshot() throws {
+        let appScoped = FakeMeetingMicRecorder(kind: .appScopedAudioQueue)
+        let route = MeetingMicRouteDiagnosticsSnapshot(
+            outputRouteKind: "headphone-like",
+            outputIsAmbiguousBluetooth: false,
+            selectedInputDeviceUID: "built-in",
+            selectedInputDeviceResolved: true,
+            preferredInputDeviceID: 82,
+            preferredInputDeviceName: "MacBook Microphone",
+            defaultInputDeviceID: 90,
+            defaultInputDeviceName: "Headset Mic",
+            builtInInputDeviceID: 82,
+            systemDefaultInputIsBuiltIn: false
+        )
+        let recorder = RouteAwareMeetingMicRecorder(
+            systemDefaultRecorder: FakeMeetingMicRecorder(kind: .systemDefaultStreaming),
+            appScopedRecorder: appScoped,
+            routeSnapshotProvider: { route }
+        )
+        recorder.preferredInputDeviceID = 82
+        try recorder.start()
+
+        let diagnostics = recorder.diagnosticsSnapshot()
+
+        #expect(diagnostics.recorderKind == .appScopedAudioQueue)
+        #expect(diagnostics.preferredInputDeviceID == 82)
+        #expect(diagnostics.route == route)
+    }
+}
+
+private final class FakeMeetingMicRecorder: MeetingMicRecording {
+    var preferredInputDeviceID: AudioObjectID?
+    var onRawPCMSamples: (([Int16]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+
+    let kind: MeetingMicRecorderKind
+    var prepareCalls = 0
+    var startCalls = 0
+    var pauseCalls = 0
+    var resumeCalls = 0
+    var stopCalls = 0
+    var cancelCalls = 0
+
+    init(kind: MeetingMicRecorderKind) {
+        self.kind = kind
+    }
+
+    func prepare() throws {
+        prepareCalls += 1
+    }
+
+    func start() throws {
+        startCalls += 1
+    }
+
+    func pause() {
+        pauseCalls += 1
+    }
+
+    func resume() {
+        resumeCalls += 1
+    }
+
+    func stop() -> URL? {
+        stopCalls += 1
+        return nil
+    }
+
+    func cancel() {
+        cancelCalls += 1
+    }
+
+    func currentPower() -> Float {
+        -80
+    }
+
+    func diagnosticsSnapshot() -> MeetingMicRecorderDiagnosticsSnapshot {
+        MeetingMicRecorderDiagnosticsSnapshot(
+            recorderKind: kind,
+            preferredInputDeviceID: preferredInputDeviceID,
+            route: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #197 by making meeting microphone capture route-aware instead of directly depending on the system-default `StreamingMicRecorder` path.

The meeting recorder now resolves a meeting-safe preferred input before capture starts, uses the selected dictation input when explicitly configured, and otherwise prefers the built-in Mac microphone when available. This avoids silent/default input routes observed during WhatsApp calls while preserving the existing system-audio capture path.

## What changed

- Added a `MeetingMicRecording` abstraction for meeting-specific continuous 16 kHz mono PCM capture.
- Added `RouteAwareMeetingMicRecorder` to choose between system-default streaming capture and an app-scoped AudioQueue preferred-input path before meeting start.
- Added meeting-specific route resolution to `AudioRouteController`.
- Updated `MeetingSession` to use injected meeting mic recording instead of owning `StreamingMicRecorder` directly.
- Added pause/resume support through the app-scoped AudioQueue fallback recorder path.
- Added live mic health tracking for raw RMS/peak, zero-sample ratio, missing callbacks, stale callbacks, and system-audio-correlated degradation.
- Surfaced active meeting mic warnings in the meeting detail UI while continuing system-audio capture.
- Expanded meeting diagnostics with route, recorder, and mic health snapshots.
- Added focused tests for route selection, route-aware recorder behavior, fallback recorder pause/resume, and mic health warning transitions.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-route-aware-meeting-pr" --filter 'FallbackStreamingDictationRecorder|MeetingSessionDiagnostics|MeetingsNavigationTests/retranscribe|MeetingMicHealthTracker|RouteAwareMeetingMicRecorder|DictationAudioRouteController'`
- `git diff --check`
- Earlier MuesliDev validation build: `./scripts/dev-test.sh`
- Manual WhatsApp validation in MuesliDev:
  - recorder kind: `appScopedAudioQueue`
  - selected input: MacBook Air Microphone
  - `micHealth.state`: `healthy`
  - raw mic RMS/peak: non-zero
  - transcript included `You:` segments
  - mic chunks succeeded with no failed mic chunks

## Known non-goals

This PR does not add separate retained mic persistence, gain normalization, diarization cleanup, chunk de-duplication, saved-recording retranscription protection, or live mid-meeting route switching. It focuses on making live meeting mic capture select a capturable route, warning if that route still degrades, and writing enough diagnostics to prove the route and recorder path used.

Fixes #197
