### PR TITLE
[codex] Update Sparkle to 2.9.3

### DIFF
--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
-        "version" : "2.9.0"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Ghost Pepper uses this LLM.swift fork for local Qwen cleanup. Before production, replace it with upstream
         // eastriverlee/LLM.swift once explicit Qwen/ChatML template behavior is validated against our GGUF models.
         .package(url: "https://github.com/obra/LLM.swift.git", revision: "f1e1e11982dbc59662be191b8bed408dfb48e9df"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3"),
         .package(url: "https://github.com/TelemetryDeck/SwiftSDK", from: "2.0.0"),
         .package(url: "https://github.com/MimicScribe/dtln-aec-coreml.git", from: "0.4.0-beta"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),


### PR DESCRIPTION
## Summary

- Update Sparkle from 2.9.0 to 2.9.3 in `native/MuesliNative/Package.resolved`.
- Raise the SwiftPM Sparkle requirement floor from `2.6.0` to `2.9.3`.

## Why

Dependabot alerts #1 and #2 flag Sparkle versions `<= 2.9.1` in `native/MuesliNative/Package.resolved`.

Upstream Sparkle 2.9.2 includes the relevant hardening fixes:

- Guard against symlinks when applying delta update files.
- Enforce installer connection validation before receiving appcast item data.

Sparkle 2.9.3 includes those 2.9.2 fixes and is the current latest release.

Muesli's release flow already strips Sparkle delta enclosures and `scripts/verify_update_flow.sh` rejects `sparkle:deltaFrom`; this PR also moves the bundled runtime dependency outside the alerted range.

## Validation

- `./scripts/verify_update_flow.sh --version 0.6.9 --skip-dmg --require-release-notes`
- `swift test --package-path native/MuesliNative --scratch-path "$SCRATCH" --filter Update`

Focused updater tests passed: 18 tests in 5 suites.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783547427&installation_id=136549638&pr_number=204&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F204&signature=ba599f54767b7997df2d357dc6fb98dd81756204a56b7e22faa2649902ba485e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->