### PR TITLE
Default dictation to AudioQueue recorder

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
@@ -145,6 +145,7 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
         primary.preferredInputDeviceID = preferredInputDeviceIDStorage
         try primary.prepare()
         activeRecorder = .primary
+        emitRecorderSelection(slot: .primary, recorder: primary)
     }
 
     private func prepareFallbackLocked() throws {
@@ -152,7 +153,16 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
         emitLatency("streaming_recorder_fallback_prepare_begin")
         try fallback.prepare()
         activeRecorder = .fallback
+        emitRecorderSelection(slot: .fallback, recorder: fallback)
         emitLatency("streaming_recorder_fallback_prepare_end")
+    }
+
+    private func emitRecorderSelection(slot: ActiveRecorder, recorder: StreamingDictationRecording) {
+        let slotName = slot == .primary ? "primary" : "fallback"
+        let preferredInput = preferredInputDeviceIDStorage.map(String.init) ?? "default"
+        emitLatency(
+            "streaming_recorder_selected slot=\(slotName) recorder=\(String(describing: type(of: recorder))) preferredInput=\(preferredInput)"
+        )
     }
 
     private func wireCallbacks() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -254,6 +254,7 @@ final class MuesliController: NSObject {
     private var pendingDictationStopStartedAt: Date?
     private var pendingDictationStopSessionID: UUID?
     private var pendingReleaseSoundSessionID: UUID?
+    private var pendingPreparingIndicatorWorkItem: DispatchWorkItem?
     private var computerUseCommandStartedAt: Date?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
@@ -4216,6 +4217,8 @@ final class MuesliController: NSObject {
     }
 
     private func setState(_ state: DictationState) {
+        pendingPreparingIndicatorWorkItem?.cancel()
+        pendingPreparingIndicatorWorkItem = nil
         dictationState = state
         appState.dictationState = state
         let status: String
@@ -4227,7 +4230,16 @@ final class MuesliController: NSObject {
         }
         statusBarController?.setStatus(status)
         if !isDictationTestMode {
-            indicator.setState(state, config: config)
+            if state == .preparing {
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self, self.dictationState == .preparing else { return }
+                    self.indicator.setPreparingWaveformWaiting(config: self.config)
+                }
+                pendingPreparingIndicatorWorkItem = workItem
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
+            } else {
+                indicator.setState(state, config: config)
+            }
         }
     }
 
@@ -5133,14 +5145,11 @@ final class MuesliController: NSObject {
     }
 
     private func activateDictationPreparingIndicator() {
-        if dictationState != .preparing {
-            setState(.preparing)
-        }
+        setState(.preparing)
         if !isDictationTestMode {
             indicator.powerProvider = { [weak self] in
                 self?.dictationAudioSessionManager.currentPower() ?? -160
             }
-            indicator.setPreparingWaveformWaiting(config: config)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -58,7 +58,7 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
     private var activeRecorderKindStorage: ActiveRecorderKind = .systemDefault
 
     init(
-        systemDefaultRecorder: DictationAudioRecording = MicrophoneRecorder(),
+        systemDefaultRecorder: DictationAudioRecording = AppScopedDictationRecorder(),
         appScopedRecorder: DictationAudioRecording = AppScopedDictationRecorder(),
         lifecycleQueue: DispatchQueue = DispatchQueue(label: "com.muesli.route-aware-dictation-recorder-lifecycle")
     ) {
@@ -193,8 +193,22 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
 
         selectedRecorder.preferredInputDeviceID = preferredInputDeviceID
         selectedRecorder.keepsAudioGraphWarm = keepsAudioGraphWarm
+        emitRecorderSelection(kind: nextKind, recorder: selectedRecorder, preferredInputDeviceID: preferredInputDeviceID)
         inactiveRecorderToCancel?.cancel()
         return selectedRecorder
+    }
+
+    private func emitRecorderSelection(
+        kind: ActiveRecorderKind,
+        recorder: DictationAudioRecording,
+        preferredInputDeviceID: AudioObjectID?
+    ) {
+        let route = kind == .systemDefault ? "system_default" : "app_scoped"
+        let preferredInput = preferredInputDeviceID.map(String.init) ?? "default"
+        onLatencyEvent?(
+            "recorder_selected route=\(route) recorder=\(String(describing: type(of: recorder))) preferredInput=\(preferredInput)",
+            Date()
+        )
     }
 
     private func activeRecorderLocked() -> DictationAudioRecording {

--- a/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FallbackStreamingDictationRecorderTests.swift
@@ -24,7 +24,23 @@ struct FallbackStreamingDictationRecorderTests {
         #expect(primary.preparedInputDeviceIDs == [82])
         #expect(fallback.preparedInputDeviceIDs == [82])
         #expect(latencyEvents.contains("streaming_recorder_primary_prepare_failed"))
+        #expect(latencyEvents.contains("streaming_recorder_selected slot=fallback recorder=FakeFallbackStreamingRecorder preferredInput=82"))
         #expect(latencyEvents.contains("streaming_recorder_fallback_prepare_end"))
+    }
+
+    @Test("prepare emits selected primary recorder latency event")
+    func prepareEmitsSelectedPrimaryRecorderLatencyEvent() throws {
+        let primary = FakeFallbackStreamingRecorder()
+        let fallback = FakeFallbackStreamingRecorder()
+        let recorder = FallbackStreamingDictationRecorder(primary: primary, fallback: fallback)
+        var latencyEvents: [String] = []
+        recorder.onLatencyEvent = { event, _ in latencyEvents.append(event) }
+
+        try recorder.prepare()
+
+        #expect(latencyEvents == [
+            "streaming_recorder_selected slot=primary recorder=FakeFallbackStreamingRecorder preferredInput=default",
+        ])
     }
 
     @Test("start falls back when prepared primary start fails")

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -84,7 +84,25 @@ struct RouteAwareDictationRecorderTests {
         _ = try recorder.start()
         appScoped.onLatencyEvent?("app_scoped_engine_start_end", Date())
 
-        #expect(events == ["app_scoped_engine_start_end"])
+        #expect(events == [
+            "recorder_selected route=app_scoped recorder=FakeRouteAwareChildRecorder preferredInput=82",
+            "app_scoped_engine_start_end",
+        ])
+    }
+
+    @Test("recorder selection latency event describes automatic route")
+    func recorderSelectionLatencyEventDescribesAutomaticRoute() throws {
+        let system = FakeRouteAwareChildRecorder()
+        let appScoped = FakeRouteAwareChildRecorder()
+        let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
+        var events: [String] = []
+        recorder.onLatencyEvent = { event, _ in events.append(event) }
+
+        _ = try recorder.start()
+
+        #expect(events == [
+            "recorder_selected route=system_default recorder=FakeRouteAwareChildRecorder preferredInput=default",
+        ])
     }
 
     @Test("callbacks from inactive child recorder are ignored")
@@ -116,7 +134,10 @@ struct RouteAwareDictationRecorderTests {
         #expect(speechCount == 0)
         #expect(timeoutCount == 0)
         #expect(failureCount == 0)
-        #expect(latencyEvents == ["active_latency"])
+        #expect(latencyEvents == [
+            "recorder_selected route=system_default recorder=FakeRouteAwareChildRecorder preferredInput=default",
+            "active_latency",
+        ])
     }
 
     @Test("switching recorder cancels inactive warmed graph")


### PR DESCRIPTION
## Summary
- route Automatic/system-default dictation through the AudioQueue-backed app-scoped recorder
- debounce the floating dictation preparing indicator so fast activations avoid the stuck intermediate visual state
- add explicit latency diagnostics for route-level recorder selection and actual streaming backend selection

Expected new diagnostics include:
```text
recorder_selected route=system_default recorder=AppScopedDictationRecorder preferredInput=default
streaming_recorder_selected slot=primary recorder=AudioQueueInputRecorder preferredInput=default
```

## Tests
```bash
swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-audioqueue-default" --filter RouteAwareDictationRecorderTests --filter FallbackStreamingDictationRecorderTests --filter AppScopedDictationRecorderTests --filter DictationAudioSessionManagerTests
```

Result: 58 tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783643336&installation_id=136549638&pr_number=205&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F205&signature=2930d3d04f2a40d6aeed9fc543e7d0fa4db8c3c4daf0b752a3ff08073d99a97e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->