### PR TITLE
Stabilize streaming VAD boundary test

### DIFF
--- a/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
@@ -24,6 +24,21 @@ private actor StreamingVadTestProbe {
     }
 }
 
+private final class StreamingVadBoundaryProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var countStorage = 0
+
+    var count: Int {
+        lock.withLock { countStorage }
+    }
+
+    func boundaryTriggered() {
+        lock.withLock {
+            countStorage += 1
+        }
+    }
+}
+
 @Suite("StreamingVadController", .serialized)
 struct StreamingVadControllerTests {
     @Test("serializes streaming VAD processing to a single in-flight chunk")
@@ -92,6 +107,7 @@ struct StreamingVadControllerTests {
     @Test("emits a chunk boundary when streaming VAD detects speech end")
     func emitsChunkBoundaryOnSpeechEnd() async throws {
         let probe = StreamingVadTestProbe()
+        let boundaryProbe = StreamingVadBoundaryProbe()
         let controller = StreamingVadController(
             minChunkDuration: 0,
             maxChunkDuration: 3600,
@@ -108,19 +124,19 @@ struct StreamingVadControllerTests {
         )
 
         controller.onChunkBoundary = {
-            Task { await probe.boundaryTriggered() }
+            boundaryProbe.boundaryTriggered()
         }
 
         controller.start()
         controller.processAudio([Float](repeating: 0, count: VadManager.chunkSize))
 
         let deadline = ContinuousClock.now + .seconds(3)
-        while await probe.boundaryCount < 1, ContinuousClock.now < deadline {
+        while boundaryProbe.count < 1, ContinuousClock.now < deadline {
             try? await Task.sleep(for: .milliseconds(20))
         }
         controller.stop()
 
-        #expect(await probe.boundaryCount == 1)
+        #expect(boundaryProbe.count == 1)
     }
 
     @Test("ignores stale VAD results after stop and restart")


### PR DESCRIPTION
## Summary
- make the StreamingVadController boundary test count the synchronous callback directly
- remove the unstructured Task hop that can miss the assertion window under full-suite release runs

## Validation
- swift test --package-path native/MuesliNative --scratch-path "/Users/pranavhari/Library/Caches/muesli-spm/preprod" --filter StreamingVadController
- swift test --package-path native/MuesliNative --scratch-path "/Users/pranavhari/Library/Caches/muesli-spm/preprod"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783744805&installation_id=136549638&pr_number=207&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F207&signature=306d648f2fa1fe3a722b0363cb1fe257311e57abfedab18823972f22259d8022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->