### PR TITLE
Replace TelemetryDeck analytics with a local-only event log

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -162,11 +162,11 @@
     <li><strong>Calendar</strong> &mdash; to read upcoming events from your local macOS calendar (EventKit)</li>
   </ul>
 
-  <h2>Anonymous Usage Analytics</h2>
-  <p>Muesli uses <a href="https://telemetrydeck.com">TelemetryDeck</a> to collect minimal, anonymized usage signals (e.g., which features are used, app launch counts). TelemetryDeck is privacy-first by design &mdash; it does not collect IP addresses, device identifiers, or any information that could identify you personally. No audio, transcripts, calendar data, or personal content is ever included in analytics. You can learn more about TelemetryDeck's privacy practices on their <a href="https://telemetrydeck.com/privacy">privacy page</a>.</p>
+  <h2>Local Usage Log</h2>
+  <p>Muesli does not use any analytics service. Minimal usage events (e.g., which features are used, app launch counts) are recorded only to a local file on your Mac (<code>events.jsonl</code> in the application's support directory) and never leave your device. No audio, transcripts, calendar data, or personal content is included. You can disable this log entirely by setting <code>enable_event_log</code> to <code>false</code> in the application's <code>config.json</code>.</p>
 
   <h2>No Personal Data Collection</h2>
-  <p><strong>Muesli does not collect, transmit, or store any personal data on external servers.</strong> Apart from the anonymous usage signals described above, no data leaves your device. The application is fully functional without an internet connection (except for optional cloud summarization and calendar sync).</p>
+  <p><strong>Muesli does not collect, transmit, or store any personal data on external servers.</strong> No usage data leaves your device. The application is fully functional without an internet connection (except for optional cloud summarization and calendar sync).</p>
 
   <h2>Open Source</h2>
   <p>Muesli's source code is publicly available on <a href="https://github.com/Muesli-HQ/muesli">GitHub</a> under the MIT license. You can inspect exactly what the application does with your data.</p>

--- a/native/MuesliNative/Package.resolved
+++ b/native/MuesliNative/Package.resolved
@@ -144,15 +144,6 @@
       }
     },
     {
-      "identity" : "swiftsdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/TelemetryDeck/SwiftSDK",
-      "state" : {
-        "revision" : "8f332c1c256ba26cc46f74c9e5af94f7b1c37a9c",
-        "version" : "2.11.0"
-      }
-    },
-    {
       "identity" : "whisperkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/WhisperKit.git",

--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
         // eastriverlee/LLM.swift once explicit Qwen/ChatML template behavior is validated against our GGUF models.
         .package(url: "https://github.com/obra/LLM.swift.git", revision: "f1e1e11982dbc59662be191b8bed408dfb48e9df"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3"),
-        .package(url: "https://github.com/TelemetryDeck/SwiftSDK", from: "2.0.0"),
         .package(url: "https://github.com/MimicScribe/dtln-aec-coreml.git", from: "0.4.0-beta"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
     ],
@@ -40,7 +39,6 @@ let package = Package(
                 .product(name: "LLM", package: "LLM.swift"),
                 .product(name: "WhisperKit", package: "WhisperKit"),
                 .product(name: "Sparkle", package: "Sparkle"),
-                .product(name: "TelemetryDeck", package: "SwiftSDK"),
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "DTLNAecCoreML", package: "dtln-aec-coreml"),
                 .product(name: "DTLNAec512", package: "dtln-aec-coreml"),

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Foundation
 import Sparkle
-import TelemetryDeck
 import MuesliCore
 
 @MainActor
@@ -12,10 +11,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         installStandardEditMenu()
-
-        let telemetryConfig = TelemetryDeck.Config(appID: "7F2B7846-1CB5-4FE6-8ABC-56F217B06A86")
-        TelemetryDeck.initialize(config: telemetryConfig)
-        TelemetryDeck.signal("app.launched")
 
         do {
             let runtime = try RuntimePaths.resolve()
@@ -36,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             self.controller = controller
             controller.start()
+            LocalTelemetry.signal("app.launched")
         } catch {
             let alert = NSAlert()
             alert.messageText = "\(AppIdentity.displayName) failed to start"
@@ -47,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         controller?.shutdown()
+        LocalTelemetry.flush()
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/native/MuesliNative/Sources/MuesliNativeApp/LocalTelemetry.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/LocalTelemetry.swift
@@ -1,0 +1,151 @@
+import Darwin
+import Foundation
+
+/// Appends app lifecycle/usage events as JSON Lines to `events.jsonl` in the
+/// app support directory. Events stay on this machine — this is the local
+/// replacement for the removed TelemetryDeck analytics.
+final class EventLogWriter: @unchecked Sendable {
+    private let fileURL: URL
+    private let rotatedFileURL: URL
+    private let maxBytes: Int
+    private let appVersion: String?
+    private let queue = DispatchQueue(label: "com.muesli.event-log")
+    private let stateLock = NSLock()
+    private var enabled: Bool
+
+    private static let timestampFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    init(
+        directory: URL,
+        isEnabled: Bool,
+        maxBytes: Int = 5 * 1024 * 1024,
+        appVersion: String? = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    ) {
+        self.fileURL = directory.appendingPathComponent("events.jsonl")
+        self.rotatedFileURL = directory.appendingPathComponent("events.jsonl.1")
+        self.enabled = isEnabled
+        self.maxBytes = maxBytes
+        self.appVersion = appVersion
+    }
+
+    var logURL: URL { fileURL }
+
+    var isEnabled: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return enabled
+    }
+
+    func setEnabled(_ value: Bool) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        enabled = value
+    }
+
+    func write(_ name: String, parameters: [String: String] = [:]) {
+        guard isEnabled else { return }
+        guard let line = encodeLine(name: name, parameters: parameters) else {
+            fputs("[event-log] failed to encode event \(name)\n", stderr)
+            return
+        }
+        queue.async { [self] in
+            append(line)
+        }
+    }
+
+    /// Blocks until queued writes have landed. Called at app termination and
+    /// from tests.
+    func flush() {
+        queue.sync {}
+    }
+
+    private func encodeLine(name: String, parameters: [String: String]) -> Data? {
+        var payload: [String: Any] = [
+            "ts": Self.timestampFormatter.string(from: Date()),
+            "event": name,
+        ]
+        if let appVersion {
+            payload["app_version"] = appVersion
+        }
+        if !parameters.isEmpty {
+            payload["params"] = parameters
+        }
+        guard var data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            return nil
+        }
+        data.append(0x0A)
+        return data
+    }
+
+    private func append(_ line: Data) {
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            rotateIfNeeded()
+            // O_APPEND never truncates an existing file and keeps concurrent
+            // line-sized appends atomic; mode 0600 applies on create.
+            let fd = open(fileURL.path, O_WRONLY | O_CREAT | O_APPEND, 0o600)
+            guard fd >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+            defer { try? handle.close() }
+            // Tighten permissions even when the file pre-existed with a looser mode.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+            try handle.write(contentsOf: line)
+        } catch {
+            fputs("[event-log] failed to append event: \(error)\n", stderr)
+        }
+    }
+
+    private func rotateIfNeeded() {
+        let fileManager = FileManager.default
+        guard
+            let size = (try? fileManager.attributesOfItem(atPath: fileURL.path))?[.size] as? Int,
+            size >= maxBytes
+        else {
+            return
+        }
+        do {
+            if fileManager.fileExists(atPath: rotatedFileURL.path) {
+                try fileManager.removeItem(at: rotatedFileURL)
+            }
+            try fileManager.moveItem(at: fileURL, to: rotatedFileURL)
+        } catch {
+            fputs("[event-log] failed to rotate event log: \(error)\n", stderr)
+        }
+    }
+}
+
+/// Drop-in replacement for `TelemetryDeck.signal` that records events locally.
+/// Stays disabled until `configure(enabled:)` is called with the loaded config
+/// value (`enable_event_log` in config.json); MuesliController re-applies it on
+/// every config change, so toggling the flag takes effect immediately.
+enum LocalTelemetry {
+    private static let writer = EventLogWriter(
+        directory: AppIdentity.supportDirectoryURL,
+        isEnabled: false
+    )
+
+    static func configure(enabled: Bool) {
+        writer.setEnabled(enabled)
+    }
+
+    static func signal(_ name: String, parameters: [String: String] = [:]) {
+        writer.write(name, parameters: parameters)
+    }
+
+    /// Drains pending writes; called from applicationWillTerminate.
+    static func flush() {
+        writer.flush()
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -775,6 +775,7 @@ struct AppConfig: Codable {
     var meetingHookEnabled: Bool = false
     var meetingHookPath: String = ""
     var meetingHookTimeoutSeconds: Int = 30
+    var enableEventLog: Bool = true
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -853,6 +854,7 @@ struct AppConfig: Codable {
         case meetingHookEnabled = "meeting_hook_enabled"
         case meetingHookPath = "meeting_hook_path"
         case meetingHookTimeoutSeconds = "meeting_hook_timeout_seconds"
+        case enableEventLog = "enable_event_log"
     }
 
     init() {}
@@ -963,6 +965,7 @@ struct AppConfig: Codable {
         meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled
         meetingHookPath = (try? c.decode(String.self, forKey: .meetingHookPath)) ?? defaults.meetingHookPath
         meetingHookTimeoutSeconds = (try? c.decode(Int.self, forKey: .meetingHookTimeoutSeconds)) ?? defaults.meetingHookTimeoutSeconds
+        enableEventLog = (try? c.decode(Bool.self, forKey: .enableEventLog)) ?? defaults.enableEventLog
     }
 
     var resolvedCohereLanguage: CohereTranscribeLanguage {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3,7 +3,6 @@ import AVFoundation
 import CoreAudio
 import Foundation
 import Sparkle
-import TelemetryDeck
 import MuesliCore
 
 private enum DictationOutputMode {
@@ -313,6 +312,7 @@ final class MuesliController: NSObject {
         self.dictationAudioRoutingController = dictationAudioRoutingController
         self.dictationAudioRoutingController.selectedInputDeviceUID = loadedConfig.dictationInputDeviceUID
         self.config = loadedConfig
+        LocalTelemetry.configure(enabled: loadedConfig.enableEventLog)
         if loadedConfig.recordingColorHex != "1e1e2e" {
             MuesliTheme.accentOverrideHex = loadedConfig.recordingColorHex
         }
@@ -863,6 +863,7 @@ final class MuesliController: NSObject {
             || config.computerUseHotkeyTriggerThresholdMS != previousComputerUseHotkeyTriggerThresholdMS
             || config.meetingRecordingHotkeyTriggerThresholdMS != previousMeetingRecordingHotkeyTriggerThresholdMS
         configStore.save(config)
+        LocalTelemetry.configure(enabled: config.enableEventLog)
         MuesliTheme.accentOverrideHex = config.recordingColorHex == "1e1e2e" ? nil : config.recordingColorHex
         selectedBackend = BackendOption.all.first(where: {
             $0.backend == config.sttBackend && $0.model == config.sttModel
@@ -1973,7 +1974,7 @@ final class MuesliController: NSObject {
             if shouldRunMeetingFeatureMonitors {
                 startMeetingFeatureMonitors(includeMaraudersMap: false)
             }
-            TelemetryDeck.signal("onboarding.completed", parameters: [
+            LocalTelemetry.signal("onboarding.completed", parameters: [
                 "use_case": onboardingUseCase.rawValue,
                 "voice_notes_selected": onboardingUseCase.includesVoiceNotes ? "true" : "false",
                 "dictation_selected": onboardingUseCase.includesDictation ? "true" : "false",
@@ -2048,7 +2049,7 @@ final class MuesliController: NSObject {
         hotkeyMonitor.start()
         startComputerUseHotkeyMonitorIfNeeded()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.permissionsReady))
-        TelemetryDeck.signal("onboarding.use_case_reclassified", parameters: [
+        LocalTelemetry.signal("onboarding.use_case_reclassified", parameters: [
             "from_use_case": OnboardingUseCase.voiceNotes.rawValue,
             "to_use_case": OnboardingUseCase.dictation.rawValue,
             "reason": "dictation_permissions_granted",
@@ -3163,7 +3164,7 @@ final class MuesliController: NSObject {
                 self.syncAppState()
                 self.historyWindowController?.reload()
                 self.showMeetingDocument(id: result.meetingID)
-                TelemetryDeck.signal("meeting.imported")
+                LocalTelemetry.signal("meeting.imported")
             }
         } catch is CancellationError {
             await MainActor.run {
@@ -3873,7 +3874,7 @@ final class MuesliController: NSObject {
                 if let meetingResult {
                     self.cleanupTemporaryMeetingAudioFiles(for: meetingResult)
                 }
-                TelemetryDeck.signal("meeting.completed")
+                LocalTelemetry.signal("meeting.completed")
 
                 self.enqueueOrShowMeetingCompletionNotification(
                     meetingID: completedMeetingID,
@@ -4681,7 +4682,7 @@ final class MuesliController: NSObject {
                 try Task.checkCancellation()
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 await MainActor.run {
-                    TelemetryDeck.signal("computer_use.command_parsed", parameters: [
+                    LocalTelemetry.signal("computer_use.command_parsed", parameters: [
                         "planner_enabled": self.config.enableComputerUsePlanner ? "true" : "false",
                     ])
                 }
@@ -4758,7 +4759,7 @@ final class MuesliController: NSObject {
             computerUseCommandTask = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
-            TelemetryDeck.signal("computer_use.command_finished", parameters: [
+            LocalTelemetry.signal("computer_use.command_finished", parameters: [
                 "status": "\(result.status)",
             ])
             return
@@ -4768,7 +4769,7 @@ final class MuesliController: NSObject {
         await waitForComputerUseFloatingStatusDwell()
         presentComputerUseRuntimeResult(result)
         meetingMonitor.resumeAfterCooldown()
-        TelemetryDeck.signal("computer_use.command_finished", parameters: [
+        LocalTelemetry.signal("computer_use.command_finished", parameters: [
             "status": "\(result.status)",
         ])
     }
@@ -5646,7 +5647,7 @@ final class MuesliController: NSObject {
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
-                    TelemetryDeck.signal("dictation.completed", parameters: [
+                    LocalTelemetry.signal("dictation.completed", parameters: [
                         "backend": self.selectedBackend.backend,
                         "paste_method": outputMode.pasteMethod,
                     ])

--- a/native/MuesliNative/Tests/MuesliTests/LocalTelemetryTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/LocalTelemetryTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("EventLogWriter")
+struct EventLogWriterTests {
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("event-log-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func readLines(_ url: URL) throws -> [[String: Any]] {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        return try contents.split(separator: "\n").map { line in
+            try JSONSerialization.jsonObject(with: Data(line.utf8)) as! [String: Any]
+        }
+    }
+
+    @Test("writes one JSON line per event")
+    func writesOneLinePerEvent() throws {
+        let directory = makeTemporaryDirectory()
+        let writer = EventLogWriter(directory: directory, isEnabled: true, appVersion: "1.2.3")
+
+        writer.write("app.launched")
+        writer.write("dictation.completed", parameters: ["backend": "parakeet", "paste_method": "cmd_v"])
+        writer.flush()
+
+        let lines = try readLines(writer.logURL)
+        #expect(lines.count == 2)
+        #expect(lines[0]["event"] as? String == "app.launched")
+        #expect(lines[0]["params"] == nil)
+        #expect(lines[0]["app_version"] as? String == "1.2.3")
+        #expect(lines[1]["event"] as? String == "dictation.completed")
+        let params = lines[1]["params"] as? [String: String]
+        #expect(params == ["backend": "parakeet", "paste_method": "cmd_v"])
+        #expect(lines.allSatisfy { $0["ts"] is String })
+    }
+
+    @Test("disabled writer produces no file")
+    func disabledWriterIsNoOp() {
+        let directory = makeTemporaryDirectory()
+        let writer = EventLogWriter(directory: directory, isEnabled: false)
+
+        writer.write("app.launched")
+        writer.flush()
+
+        #expect(FileManager.default.fileExists(atPath: writer.logURL.path) == false)
+    }
+
+    @Test("setEnabled toggles logging at runtime")
+    func setEnabledTogglesLogging() throws {
+        let directory = makeTemporaryDirectory()
+        let writer = EventLogWriter(directory: directory, isEnabled: false)
+
+        writer.write("dropped.event")
+        writer.setEnabled(true)
+        writer.write("kept.event")
+        writer.setEnabled(false)
+        writer.write("dropped.again")
+        writer.flush()
+
+        let events = try readLines(writer.logURL).compactMap { $0["event"] as? String }
+        #expect(events == ["kept.event"])
+    }
+
+    @Test("creates the log file with owner-only permissions")
+    func createsFileWithOwnerOnlyPermissions() throws {
+        let directory = makeTemporaryDirectory()
+        let writer = EventLogWriter(directory: directory, isEnabled: true)
+
+        writer.write("app.launched")
+        writer.flush()
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: writer.logURL.path)
+        #expect((attributes[.posixPermissions] as? Int) == 0o600)
+    }
+
+    @Test("tightens permissions on a pre-existing world-readable log")
+    func tightensLoosePermissions() throws {
+        let directory = makeTemporaryDirectory()
+        let writer = EventLogWriter(directory: directory, isEnabled: true)
+        FileManager.default.createFile(
+            atPath: writer.logURL.path,
+            contents: Data(),
+            attributes: [.posixPermissions: 0o644]
+        )
+
+        writer.write("app.launched")
+        writer.flush()
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: writer.logURL.path)
+        #expect((attributes[.posixPermissions] as? Int) == 0o600)
+    }
+
+    @Test("rotates the log once it reaches the size cap")
+    func rotatesAtSizeCap() throws {
+        let directory = makeTemporaryDirectory()
+        let writer = EventLogWriter(directory: directory, isEnabled: true, maxBytes: 200)
+
+        for index in 0..<10 {
+            writer.write("event.\(index)", parameters: ["padding": String(repeating: "x", count: 60)])
+        }
+        writer.flush()
+
+        // Single rotation slot: the active file stays bounded, the previous
+        // generation is kept in events.jsonl.1, and older generations are
+        // discarded. The newest event must always be in the active file.
+        let rotatedURL = directory.appendingPathComponent("events.jsonl.1")
+        #expect(FileManager.default.fileExists(atPath: rotatedURL.path))
+        let activeSize = (try FileManager.default.attributesOfItem(atPath: writer.logURL.path))[.size] as? Int
+        #expect(activeSize != nil && activeSize! < 400)
+
+        let activeEvents = try readLines(writer.logURL).compactMap { $0["event"] as? String }
+        #expect(activeEvents.last == "event.9")
+    }
+
+    @Test("creates missing directories")
+    func createsMissingDirectories() throws {
+        let directory = makeTemporaryDirectory().appendingPathComponent("nested/sub")
+        let writer = EventLogWriter(directory: directory, isEnabled: true)
+
+        writer.write("app.launched")
+        writer.flush()
+
+        #expect(try readLines(writer.logURL).count == 1)
+    }
+}


### PR DESCRIPTION
## What this does

Removes the TelemetryDeck SDK entirely and replaces it with a local JSONL event log. Usage events are written to `events.jsonl` in the app support directory and never leave the machine. After this change the app makes no analytics network requests at all.

## Why

TelemetryDeck was initialized unconditionally on every launch with no opt-out, sending feature-usage and permission-grant events to nom.telemetrydeck.com. The event taxonomy itself is useful for local debugging, so the instrumentation points are kept — only the destination changes.

## What changed

- **Removed** the TelemetryDeck/SwiftSDK package dependency, its initialization in `AppDelegate`, and all nine `TelemetryDeck.signal` call sites.
- **Added** `LocalTelemetry` / `EventLogWriter`: appends one JSON line per event (`ts`, `event`, `app_version`, optional `params`) on a background serial queue. Files are opened with `O_CREAT|O_APPEND` and mode 0600; permissions are re-tightened on every append in case the file pre-existed with a looser mode. The log is capped at 5 MB with a single rotation slot (`events.jsonl.1`), so disk use is bounded and the newest events are always retained.
- **No identifiers**: unlike TelemetryDeck there is no install ID, session ID, or device metadata — just timestamp, event name, app version, and the existing per-event params.
- **Opt-out**: new `enable_event_log` config key (default true). Logging stays disabled until `MuesliController` applies the loaded config, and the flag is re-applied on every `updateConfig`, so toggling it takes effect immediately without a restart.
- **Lifecycle**: `app.launched` now fires after controller startup (so the enable flag is respected); pending writes are flushed in `applicationWillTerminate` so events aren't dropped on quit.
- **Privacy policy** (`docs/privacy.html`) updated to describe the local log instead of TelemetryDeck.

## How it was verified

- Full test suite passes: 991 tests in 112 suites (7 new tests covering line format, enable/disable toggling, 0600 permissions on create and on pre-existing world-readable files, rotation at the size cap, and directory creation).
- Grep confirms no remaining TelemetryDeck references in sources, scripts, or CI.

## After merge

`events.jsonl` starts accumulating locally for users on the next update; anyone who wants it off sets `enable_event_log: false` in config.json. A possible follow-up is a `muesli-cli events` reader, which would argue for moving `EventLogWriter` into MuesliCore.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783762277&installation_id=136549638&pr_number=208&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F208&signature=305c34a799f1541a475f1152b8fdc8c97a21c8230e122781215d81df3f38ce5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->