### PR TITLE
Update preprod appcast for v0.7.0-preprod.1

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,6 +6,32 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
+            <title>0.7.0-preprod.1</title>
+            <pubDate>Thu, 11 Jun 2026 11:27:00 -0700</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.7.0-preprod.1</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.7.0-preprod.1.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>7000001</sparkle:version>
+            <sparkle:shortVersionString>0.7.0-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>10.13</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.7.0-preprod.1/MuesliPreprod-0.7.0-preprod.1.dmg" length="73687088" type="application/octet-stream" sparkle:edSignature="/lRdRT8OW/5BYQa0UTlgVd3VC7zn3GmZDrOnAue+80Fc+4hs7uBN5MJvxWwANdYwKKJ5r8QhogmGXaP+bh8gBQ=="/>
+        </item>
+        <item>
             <title>0.6.9-preprod.1</title>
             <pubDate>Wed, 27 May 2026 23:00:51 +0530</pubDate>
             <description><![CDATA[
@@ -39,15 +65,6 @@
             <sparkle:minimumSystemVersion>10.13</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.6.8-preprod.3/MuesliPreprod-0.6.8-preprod.3.dmg" length="73407490" type="application/octet-stream" sparkle:edSignature="FvyBmnkZ3ZIjuiJZCO7xM0lnT7lrwOGBDA0H8W6syRBHOo8FOByP/nT52KupY3yysNA+i+b3LWfv3KLzyqBQBg=="/>
-        </item>
-        <item>
-            <title>0.6.8-preprod.2</title>
-            <pubDate>Mon, 25 May 2026 10:17:26 +0530</pubDate>
-            <sparkle:version>6008002</sparkle:version>
-            <sparkle:shortVersionString>0.6.8-preprod.2</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>10.13</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.6.8-preprod.2/MuesliPreprod-0.6.8-preprod.2.dmg" length="73401948" type="application/octet-stream" sparkle:edSignature="oAf3qRTGYhKj+dgPQIQR5OJI9mocq+3WqKoEDb1OQdXJA7sQYA9Ti7sGAhazeamxIzDxO//1BbCncvwrN8EYBQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary
- update `docs/appcast-preprod.xml` for `v0.7.0-preprod.1`
- point the preprod enclosure at the published `Muesli-HQ/muesli` GitHub Release asset
- keep stable production appcast/site/Homebrew unchanged

## Preprod verification
- `./scripts/release-preprod.sh 0.7.0-preprod.1`
- full test stage passed: 984 tests across 111 suites
- app notarization accepted and stapled
- DMG notarization accepted and stapled
- hosted DMG SHA256 matched local artifact
- `verify_update_flow` passed for Sparkle build `7000001`

## Release
- https://github.com/Muesli-HQ/muesli/releases/tag/v0.7.0-preprod.1

## Notes
- This PR only updates the preprod appcast file. The hosted GitHub Pages appcast will not show this update until this PR is merged to `main` and Pages deploys.
- Requires Greptile review and maintainer approval before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783794579&installation_id=136549638&pr_number=210&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F210&signature=db4a58a45139ee823085e28b145a32d1812e745bba1d6fee07483a73eb366b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->