### PR TITLE
Fix issue #209: Feature: add FunASR/SenseVoice as optional local transcription backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Local-first macOS app for **dictation** and **meeting transcription** on Apple S
 - **Meeting transcription:** Captures mic (You) + system audio (Others) → VAD-driven chunking → speaker diarization → AI-powered meeting notes
 - **Meeting export:** Export notes or transcript as PDF (paginated US Letter) or Markdown via `MeetingExporter.swift`
 - **Screen context:** Accessibility API captures app name + text around cursor for dictation context-awareness (opt-in, off by default)
-- **7 ASR models:** Parakeet v3/v2, Whisper Small/Medium/Large Turbo, Qwen3 ASR, Nemotron Streaming
+- **8 ASR models:** Parakeet v3/v2, Whisper Small/Medium/Large Turbo, Qwen3 ASR, Nemotron Streaming, SenseVoice Small
 - **3 summarization backends:** OpenAI API key, OpenRouter API key, ChatGPT OAuth (subscription-based)
 - **Camera-based meeting detection:** Requires mic + camera + recognized meeting app (camera alone won't trigger)
 - **Join & Record:** Extract meeting URLs from calendar events (Zoom, Meet, Teams, Webex, Chime, FaceTime), split button with "Join & Record" / "Join Only" / "Record Only", platform icons in notifications

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Important meeting fields:
 | **Parakeet v3** (recommended) | FluidAudio | CoreML / Neural Engine | ~450 MB | 25 languages | ~0.13s |
 | Parakeet v2 | FluidAudio | CoreML / Neural Engine | ~450 MB | English only | ~0.13s |
 | **Cohere Transcribe 2B** | CoreML | FP16 encoder + INT8 decoder | ~3.8 GB | English | ~1s |
-| SenseVoice Small | FluidAudio | CoreML / Neural Engine | ~900 MB | 50+ languages | ~1s |
+| SenseVoice Small | FluidAudio | CoreML / Neural Engine | ~1.6 GB | 50+ languages | ~1s |
 | Qwen3 ASR | FluidAudio | CoreML / Neural Engine | ~1.3 GB | 52 languages | ~2-3s |
 | Whisper Small | WhisperKit | CoreML / Neural Engine | ~190 MB | English only | ~1-2s |
 | Whisper Medium | WhisperKit | CoreML / Neural Engine | ~1.5 GB | English only | ~2-3s |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Important meeting fields:
 | **Parakeet v3** (recommended) | FluidAudio | CoreML / Neural Engine | ~450 MB | 25 languages | ~0.13s |
 | Parakeet v2 | FluidAudio | CoreML / Neural Engine | ~450 MB | English only | ~0.13s |
 | **Cohere Transcribe 2B** | CoreML | FP16 encoder + INT8 decoder | ~3.8 GB | English | ~1s |
-| SenseVoice Small | FluidAudio | CoreML / Neural Engine | ~1.6 GB | 50+ languages | ~1s |
+| SenseVoice Small | FluidAudio | INT8 CoreML / Neural Engine | ~240 MB | 50+ languages | ~1s |
 | Qwen3 ASR | FluidAudio | CoreML / Neural Engine | ~1.3 GB | 52 languages | ~2-3s |
 | Whisper Small | WhisperKit | CoreML / Neural Engine | ~190 MB | English only | ~1-2s |
 | Whisper Medium | WhisperKit | CoreML / Neural Engine | ~1.5 GB | English only | ~2-3s |

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Important meeting fields:
 | **Parakeet v3** (recommended) | FluidAudio | CoreML / Neural Engine | ~450 MB | 25 languages | ~0.13s |
 | Parakeet v2 | FluidAudio | CoreML / Neural Engine | ~450 MB | English only | ~0.13s |
 | **Cohere Transcribe 2B** | CoreML | FP16 encoder + INT8 decoder | ~3.8 GB | English | ~1s |
+| SenseVoice Small | FluidAudio | CoreML / Neural Engine | ~900 MB | 50+ languages | ~1s |
 | Qwen3 ASR | FluidAudio | CoreML / Neural Engine | ~1.3 GB | 52 languages | ~2-3s |
 | Whisper Small | WhisperKit | CoreML / Neural Engine | ~190 MB | English only | ~1-2s |
 | Whisper Medium | WhisperKit | CoreML / Neural Engine | ~1.5 GB | English only | ~2-3s |
@@ -250,7 +251,7 @@ Muesli needs these macOS permissions (guided during onboarding):
 | Component | Technology |
 |---|---|
 | App | Swift, AppKit, SwiftUI |
-| Primary ASR | [FluidAudio](https://github.com/FluidInference/FluidAudio) (Parakeet TDT + Qwen3 ASR on CoreML/ANE) |
+| Primary ASR | [FluidAudio](https://github.com/FluidInference/FluidAudio) (Parakeet TDT, SenseVoice Small, and Qwen3 ASR on CoreML/ANE) |
 | Cohere ASR | [Cohere Transcribe](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) (FP16 encoder + INT8 decoder on CoreML) |
 | Whisper ASR | [WhisperKit](https://github.com/argmaxinc/WhisperKit) (CoreML/ANE) |
 | Voice activity | Silero VAD via FluidAudio (streaming, event-driven) |

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -95,7 +95,7 @@ struct BackendOption: Equatable {
         backend: "sensevoice",
         model: "FluidInference/sensevoice-small-coreml",
         label: "SenseVoice Small",
-        sizeLabel: "~900 MB",
+        sizeLabel: "~1.6 GB",
         description: "FunASR SenseVoiceSmall via FluidAudio. CoreML/ANE, 50+ languages. Non-autoregressive with built-in punctuation.",
         recommended: false
     )

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -95,8 +95,8 @@ struct BackendOption: Equatable {
         backend: "sensevoice",
         model: "FluidInference/sensevoice-small-coreml",
         label: "SenseVoice Small",
-        sizeLabel: "~1.6 GB",
-        description: "FunASR SenseVoiceSmall via FluidAudio. CoreML/ANE, 50+ languages. Non-autoregressive with built-in punctuation.",
+        sizeLabel: SenseVoiceTranscriber.downloadedModelSizeLabel,
+        description: "FunASR SenseVoiceSmall via FluidAudio. INT8 CoreML/ANE, 50+ languages. Non-autoregressive with built-in punctuation.",
         recommended: false
     )
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -96,7 +96,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/sensevoice-small-coreml",
         label: "SenseVoice Small",
         sizeLabel: SenseVoiceTranscriber.downloadedModelSizeLabel,
-        description: "FunASR SenseVoiceSmall via FluidAudio. INT8 CoreML/ANE, 50+ languages. Non-autoregressive with built-in punctuation.",
+        description: "FunASR SenseVoiceSmall via FluidAudio. INT8 CoreML/ANE on macOS 14+, 50+ languages. Non-autoregressive with built-in punctuation.",
         recommended: false
     )
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -91,6 +91,15 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
+    static let senseVoiceSmall = BackendOption(
+        backend: "sensevoice",
+        model: "FluidInference/sensevoice-small-coreml",
+        label: "SenseVoice Small",
+        sizeLabel: "~900 MB",
+        description: "FunASR SenseVoiceSmall via FluidAudio. CoreML/ANE, 50+ languages. Non-autoregressive with built-in punctuation.",
+        recommended: false
+    )
+
     // Default alias
     static let whisper = parakeetMultilingual
 
@@ -112,7 +121,7 @@ struct BackendOption: Equatable {
     )
 
     static let experimental: [BackendOption] = [
-        .qwen3Asr, .canaryQwen, .nemotronStreaming,
+        .senseVoiceSmall, .qwen3Asr, .canaryQwen, .nemotronStreaming,
     ]
 
     /// Models available for download and use.
@@ -178,6 +187,8 @@ struct BackendOption: Equatable {
             return CanaryQwenModelStore.isAvailableLocally()
         case "cohere":
             return CohereTranscribeModelStore.isAvailableLocally()
+        case "sensevoice":
+            return SenseVoiceTranscriber.isModelDownloaded()
         default:
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -986,6 +986,8 @@ struct ModelsView: View {
             try? fm.removeItem(at: CanaryQwenModelStore.cacheDirectory())
         case "cohere":
             try? fm.removeItem(at: CohereTranscribeModelStore.cacheDirectory())
+        case "sensevoice":
+            SenseVoiceTranscriber.deleteModelFiles(fileManager: fm)
         case "fluidaudio":
             // FluidAudio models are in ~/Library/Application Support/FluidAudio/Models/
             let supportDir = fm.homeDirectoryForCurrentUser
@@ -1059,6 +1061,8 @@ struct ModelsView: View {
             return CanaryQwenModelStore.isAvailableLocally()
         case "cohere":
             return CohereTranscribeModelStore.isAvailableLocally()
+        case "sensevoice":
+            return SenseVoiceTranscriber.isModelDownloaded()
         default:
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -562,6 +562,7 @@ struct ModelsView: View {
         case "qwen": return "qwen-logo"
         case "nemotron": return "nvidia-logo"
         case "canary": return "qwen-logo"
+        case "sensevoice": return "qwen-logo"
         default: return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -153,7 +153,7 @@ struct ModelsView: View {
                                 .foregroundStyle(MuesliTheme.textSecondary)
                         }
 
-                        Text("Qwen and streaming backends. Hidden by default because these are still slower and less polished.")
+                        Text("SenseVoice, Qwen, and streaming backends. Hidden by default because these are still slower and less polished.")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(MuesliTheme.textPrimary)
                             .opacity(0.8)

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -914,15 +914,46 @@ struct ModelsView: View {
 
         let startTime = Date()
         let task = Task {
-            await controller.transcriptionCoordinator.preload(
-                backend: option,
-                includeMeetingHelpers: controller.config.resolvedOnboardingUseCase.includesMeetings
-            ) { progress, _ in
-                DispatchQueue.main.async {
-                    downloadProgress[option.model] = max(progress, 0.05)
+            do {
+                try await controller.transcriptionCoordinator.preloadRequired(
+                    backend: option,
+                    includeMeetingHelpers: controller.config.resolvedOnboardingUseCase.includesMeetings
+                ) { progress, _ in
+                    DispatchQueue.main.async {
+                        downloadProgress[option.model] = max(progress, 0.05)
+                    }
                 }
-            }
-            guard !Task.isCancelled else {
+                guard isModelDownloaded(option, fm: FileManager.default) else {
+                    throw NSError(
+                        domain: "MuesliModelDownload",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "\(option.label) was not downloaded successfully."]
+                    )
+                }
+                guard !Task.isCancelled else {
+                    await MainActor.run {
+                        withAnimation {
+                            downloadingModels.remove(option.model)
+                            downloadProgress.removeValue(forKey: option.model)
+                            downloadTasks.removeValue(forKey: option.model)
+                        }
+                    }
+                    return
+                }
+                // Ensure the downloading state is visible for at least 1.5s
+                let elapsed = Date().timeIntervalSince(startTime)
+                if elapsed < 1.5 {
+                    try? await Task.sleep(nanoseconds: UInt64((1.5 - elapsed) * 1_000_000_000))
+                }
+                await MainActor.run {
+                    withAnimation {
+                        downloadingModels.remove(option.model)
+                        downloadedModels.insert(option.model)
+                        downloadProgress.removeValue(forKey: option.model)
+                        downloadTasks.removeValue(forKey: option.model)
+                    }
+                }
+            } catch {
                 await MainActor.run {
                     withAnimation {
                         downloadingModels.remove(option.model)
@@ -930,19 +961,8 @@ struct ModelsView: View {
                         downloadTasks.removeValue(forKey: option.model)
                     }
                 }
-                return
-            }
-            // Ensure the downloading state is visible for at least 1.5s
-            let elapsed = Date().timeIntervalSince(startTime)
-            if elapsed < 1.5 {
-                try? await Task.sleep(nanoseconds: UInt64((1.5 - elapsed) * 1_000_000_000))
-            }
-            await MainActor.run {
-                withAnimation {
-                    downloadingModels.remove(option.model)
-                    downloadedModels.insert(option.model)
-                    downloadProgress.removeValue(forKey: option.model)
-                    downloadTasks.removeValue(forKey: option.model)
+                if !(error is CancellationError) {
+                    fputs("[muesli-native] model download failed for \(option.backend)/\(option.model): \(error)\n", stderr)
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -21,6 +21,8 @@ actor SenseVoiceTranscriber {
 
     /// Downloads models if needed and initializes the SenseVoice manager.
     func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+        // Actor isolation makes this check-and-set race-free. Waiters retry after
+        // a failed load so a transient download error does not poison the actor.
         while isLoading {
             try await Task.sleep(nanoseconds: 50_000_000)
             if manager != nil { return }
@@ -62,7 +64,7 @@ actor SenseVoiceTranscriber {
     }
 
     static func isModelDownloaded() -> Bool {
-        SenseVoiceModels.modelsExist(at: cacheDirectory(), precision: precision)
+        requiredModelsExist(at: cacheDirectory())
     }
 
     static func deleteModelFiles(fileManager: FileManager = .default) {
@@ -71,7 +73,7 @@ actor SenseVoiceTranscriber {
 
     private static func downloadRequiredModels(progress: ((Double, String?) -> Void)?) async throws -> URL {
         let directory = cacheDirectory()
-        if SenseVoiceModels.modelsExist(at: directory, precision: precision) {
+        if requiredModelsExist(at: directory) {
             return directory
         }
 
@@ -125,6 +127,7 @@ actor SenseVoiceTranscriber {
             return
         }
 
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         progress?(0.9, "Downloading SenseVoice vocabulary...")
         let remoteURL = try ModelRegistry.resolveModel(
             Repo.senseVoiceSmall.remotePath,
@@ -136,6 +139,12 @@ actor SenseVoiceTranscriber {
         )
         try data.write(to: vocabularyURL, options: .atomic)
         progress?(0.95, "SenseVoice vocabulary ready...")
+    }
+
+    private static func requiredModelsExist(at directory: URL, fileManager: FileManager = .default) -> Bool {
+        let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
+        return SenseVoiceModels.modelsExist(at: directory, precision: precision)
+            && fileManager.fileExists(atPath: vocabularyURL.path)
     }
 
     private func warmupIfNeeded(progress: ((Double, String?) -> Void)?) async {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -4,6 +4,7 @@ import Foundation
 /// Native Swift transcription backend for FunASR's SenseVoiceSmall via FluidAudio.
 actor SenseVoiceTranscriber {
     private var manager: SenseVoiceManager?
+    private static let precision: SenseVoiceEncoderPrecision = .int8
 
     enum TranscriberError: Error, LocalizedError {
         case notLoaded
@@ -21,17 +22,11 @@ actor SenseVoiceTranscriber {
         if manager != nil { return }
 
         fputs("[sensevoice] downloading/loading models...\n", stderr)
-        let loaded = try await SenseVoiceManager.load(precision: .fp16) { downloadProgress in
-            switch downloadProgress.phase {
-            case .listing:
-                progress?(downloadProgress.fractionCompleted, "Preparing SenseVoice download...")
-            case .downloading(_, _):
-                progress?(downloadProgress.fractionCompleted, "Downloading SenseVoice...")
-            case .compiling(_):
-                progress?(downloadProgress.fractionCompleted, "Compiling SenseVoice...")
-            }
-        }
-        self.manager = loaded
+        let modelDirectory = try await Self.downloadRequiredModels(progress: progress)
+        progress?(0.95, "Loading SenseVoice...")
+        let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
+        self.manager = SenseVoiceManager(models: models)
+        progress?(1.0, nil)
         fputs("[sensevoice] models ready\n", stderr)
     }
 
@@ -48,6 +43,7 @@ actor SenseVoiceTranscriber {
     }
 
     static let cacheRelativePath = "Library/Application Support/FluidAudio/Models/sensevoice-small-coreml"
+    static let downloadedModelSizeLabel = "~240 MB"
 
     static func cacheDirectory(fileManager: FileManager = .default) -> URL {
         fileManager.homeDirectoryForCurrentUser
@@ -55,10 +51,80 @@ actor SenseVoiceTranscriber {
     }
 
     static func isModelDownloaded() -> Bool {
-        SenseVoiceModels.modelsExist(at: cacheDirectory(), precision: .fp16)
+        SenseVoiceModels.modelsExist(at: cacheDirectory(), precision: precision)
     }
 
     static func deleteModelFiles(fileManager: FileManager = .default) {
         try? fileManager.removeItem(at: cacheDirectory(fileManager: fileManager))
+    }
+
+    private static func downloadRequiredModels(progress: ((Double, String?) -> Void)?) async throws -> URL {
+        let directory = cacheDirectory()
+        if SenseVoiceModels.modelsExist(at: directory, precision: precision) {
+            progress?(1.0, nil)
+            return directory
+        }
+
+        // FluidAudio 0.15.x downloads every SenseVoice encoder precision via SenseVoiceManager.load.
+        // Muesli only needs the INT8 ANE encoder, so fetch that subset and then use FluidAudio's loader.
+        let fm = FileManager.default
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        try await downloadSubdirectory(
+            ModelNames.SenseVoice.preprocessorFile,
+            to: directory,
+            progressRange: 0.0...0.2,
+            message: "Downloading SenseVoice preprocessor...",
+            progress: progress
+        )
+        try await downloadSubdirectory(
+            ModelNames.SenseVoice.encoderInt8File,
+            to: directory,
+            progressRange: 0.2...0.9,
+            message: "Downloading SenseVoice INT8 encoder...",
+            progress: progress
+        )
+        try await downloadVocabulary(to: directory, progress: progress)
+
+        return directory
+    }
+
+    private static func downloadSubdirectory(
+        _ subdirectory: String,
+        to directory: URL,
+        progressRange: ClosedRange<Double>,
+        message: String,
+        progress: ((Double, String?) -> Void)?
+    ) async throws {
+        try await DownloadUtils.downloadSubdirectory(
+            .senseVoiceSmall,
+            subdirectory: subdirectory,
+            to: directory,
+            progressHandler: { downloadProgress in
+                let span = progressRange.upperBound - progressRange.lowerBound
+                let fraction = progressRange.lowerBound + span * downloadProgress.fractionCompleted
+                progress?(min(max(fraction, 0.0), 1.0), message)
+            }
+        )
+    }
+
+    private static func downloadVocabulary(to directory: URL, progress: ((Double, String?) -> Void)?) async throws {
+        let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
+        if FileManager.default.fileExists(atPath: vocabularyURL.path) {
+            progress?(0.95, "SenseVoice vocabulary ready...")
+            return
+        }
+
+        progress?(0.9, "Downloading SenseVoice vocabulary...")
+        let remoteURL = try ModelRegistry.resolveModel(
+            Repo.senseVoiceSmall.remotePath,
+            ModelNames.SenseVoice.vocabularyFile
+        )
+        let data = try await DownloadUtils.fetchHuggingFaceFile(
+            from: remoteURL,
+            description: "SenseVoice vocabulary"
+        )
+        try data.write(to: vocabularyURL, options: .atomic)
+        progress?(0.95, "SenseVoice vocabulary ready...")
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -4,6 +4,8 @@ import Foundation
 /// Native Swift transcription backend for FunASR's SenseVoiceSmall via FluidAudio.
 actor SenseVoiceTranscriber {
     private var manager: SenseVoiceManager?
+    private var isLoading = false
+    private var hasCompletedWarmup = false
     private static let precision: SenseVoiceEncoderPrecision = .int8
 
     enum TranscriberError: Error, LocalizedError {
@@ -19,13 +21,21 @@ actor SenseVoiceTranscriber {
 
     /// Downloads models if needed and initializes the SenseVoice manager.
     func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+        while isLoading {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            if manager != nil { return }
+        }
         if manager != nil { return }
+
+        isLoading = true
+        defer { isLoading = false }
 
         fputs("[sensevoice] downloading/loading models...\n", stderr)
         let modelDirectory = try await Self.downloadRequiredModels(progress: progress)
         progress?(0.95, "Loading SenseVoice...")
         let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
         self.manager = SenseVoiceManager(models: models)
+        await warmupIfNeeded(progress: progress)
         progress?(1.0, nil)
         fputs("[sensevoice] models ready\n", stderr)
     }
@@ -40,6 +50,7 @@ actor SenseVoiceTranscriber {
 
     func shutdown() {
         manager = nil
+        hasCompletedWarmup = false
     }
 
     static let cacheRelativePath = "Library/Application Support/FluidAudio/Models/sensevoice-small-coreml"
@@ -61,7 +72,6 @@ actor SenseVoiceTranscriber {
     private static func downloadRequiredModels(progress: ((Double, String?) -> Void)?) async throws -> URL {
         let directory = cacheDirectory()
         if SenseVoiceModels.modelsExist(at: directory, precision: precision) {
-            progress?(1.0, nil)
             return directory
         }
 
@@ -126,5 +136,20 @@ actor SenseVoiceTranscriber {
         )
         try data.write(to: vocabularyURL, options: .atomic)
         progress?(0.95, "SenseVoice vocabulary ready...")
+    }
+
+    private func warmupIfNeeded(progress: ((Double, String?) -> Void)?) async {
+        guard !hasCompletedWarmup, let manager else { return }
+
+        progress?(0.98, "Warming up SenseVoice...")
+        fputs("[sensevoice] warmup: running silent audio for CoreML compilation...\n", stderr)
+        do {
+            let silence = [Float](repeating: 0, count: 16_000)
+            _ = try await manager.transcribe(audio: silence)
+            hasCompletedWarmup = true
+            fputs("[sensevoice] warmup complete\n", stderr)
+        } catch {
+            fputs("[sensevoice] warmup failed: \(error)\n", stderr)
+        }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -22,15 +22,13 @@ actor SenseVoiceTranscriber {
 
         fputs("[sensevoice] downloading/loading models...\n", stderr)
         let loaded = try await SenseVoiceManager.load(precision: .fp16) { downloadProgress in
-            DispatchQueue.main.async {
-                switch downloadProgress.phase {
-                case .listing:
-                    progress?(downloadProgress.fractionCompleted, "Preparing SenseVoice download...")
-                case .downloading(_, _):
-                    progress?(downloadProgress.fractionCompleted, "Downloading SenseVoice...")
-                case .compiling(_):
-                    progress?(downloadProgress.fractionCompleted, "Compiling SenseVoice...")
-                }
+            switch downloadProgress.phase {
+            case .listing:
+                progress?(downloadProgress.fractionCompleted, "Preparing SenseVoice download...")
+            case .downloading(_, _):
+                progress?(downloadProgress.fractionCompleted, "Downloading SenseVoice...")
+            case .compiling(_):
+                progress?(downloadProgress.fractionCompleted, "Compiling SenseVoice...")
             }
         }
         self.manager = loaded
@@ -49,9 +47,18 @@ actor SenseVoiceTranscriber {
         manager = nil
     }
 
+    static let cacheRelativePath = "Library/Application Support/FluidAudio/Models/sensevoice-small-coreml"
+
+    static func cacheDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(cacheRelativePath)
+    }
+
     static func isModelDownloaded() -> Bool {
-        let supportDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/FluidAudio/Models/sensevoice-small-coreml")
-        return SenseVoiceModels.modelsExist(at: supportDir, precision: .fp16)
+        SenseVoiceModels.modelsExist(at: cacheDirectory(), precision: .fp16)
+    }
+
+    static func deleteModelFiles(fileManager: FileManager = .default) {
+        try? fileManager.removeItem(at: cacheDirectory(fileManager: fileManager))
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -1,0 +1,57 @@
+import FluidAudio
+import Foundation
+
+/// Native Swift transcription backend for FunASR's SenseVoiceSmall via FluidAudio.
+actor SenseVoiceTranscriber {
+    private var manager: SenseVoiceManager?
+
+    enum TranscriberError: Error, LocalizedError {
+        case notLoaded
+
+        var errorDescription: String? {
+            switch self {
+            case .notLoaded:
+                return "SenseVoice models not loaded. Call loadModels() first."
+            }
+        }
+    }
+
+    /// Downloads models if needed and initializes the SenseVoice manager.
+    func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+        if manager != nil { return }
+
+        fputs("[sensevoice] downloading/loading models...\n", stderr)
+        let loaded = try await SenseVoiceManager.load(precision: .fp16) { downloadProgress in
+            DispatchQueue.main.async {
+                switch downloadProgress.phase {
+                case .listing:
+                    progress?(downloadProgress.fractionCompleted, "Preparing SenseVoice download...")
+                case .downloading(_, _):
+                    progress?(downloadProgress.fractionCompleted, "Downloading SenseVoice...")
+                case .compiling(_):
+                    progress?(downloadProgress.fractionCompleted, "Compiling SenseVoice...")
+                }
+            }
+        }
+        self.manager = loaded
+        fputs("[sensevoice] models ready\n", stderr)
+    }
+
+    func transcribe(wavURL: URL) async throws -> (text: String, processingTime: Double) {
+        guard let manager else { throw TranscriberError.notLoaded }
+        let start = CFAbsoluteTimeGetCurrent()
+        let text = try await manager.transcribe(audioURL: wavURL)
+        let processingTime = CFAbsoluteTimeGetCurrent() - start
+        return (text, processingTime)
+    }
+
+    func shutdown() {
+        manager = nil
+    }
+
+    static func isModelDownloaded() -> Bool {
+        let supportDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/FluidAudio/Models/sensevoice-small-coreml")
+        return SenseVoiceModels.modelsExist(at: supportDir, precision: .fp16)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -519,6 +519,7 @@ actor TranscriptionCoordinator {
         let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
         return SpeechTranscriptionResult(
             text: text,
+            // FluidAudio's SenseVoice API returns plain text only, so timestamped segments are not available here.
             segments: text.isEmpty ? [] : [SpeechSegment(start: 0, end: 0, text: text)]
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -21,6 +21,7 @@ actor TranscriptionCoordinator {
     private var _qwen3PostProcessor: Any?
     private var _canaryQwenTranscriber: Any?
     private var _cohereTranscriber: Any?
+    private let senseVoiceTranscriber = SenseVoiceTranscriber()
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
     private var activeBackend: String?
@@ -226,6 +227,8 @@ actor TranscriptionCoordinator {
                     NSLocalizedDescriptionKey: "Cohere Transcribe requires macOS 15 or later.",
                 ])
             }
+        case "sensevoice":
+            try await senseVoiceTranscriber.loadModels(progress: progress)
         default:
             throw NSError(domain: "MuesliTranscriptionRuntime", code: 5, userInfo: [
                 NSLocalizedDescriptionKey: "Unknown transcription backend: \(backend.backend)",
@@ -341,6 +344,7 @@ actor TranscriptionCoordinator {
     func shutdown() async {
         await fluidTranscriber.shutdown()
         await whisperTranscriber.shutdown()
+        await senseVoiceTranscriber.shutdown()
         if #available(macOS 15, *) {
             await nemotronTranscriber.shutdown()
             await qwen3Transcriber.shutdown()
@@ -451,6 +455,8 @@ actor TranscriptionCoordinator {
             return try await transcribeWithCanaryQwen(url: url)
         case "cohere":
             return try await transcribeWithCohere(url: url, language: cohereLanguage)
+        case "sensevoice":
+            return try await transcribeWithSenseVoice(url: url)
         default:
             return try await transcribeWithFluidAudio(url: url)
         }
@@ -502,6 +508,19 @@ actor TranscriptionCoordinator {
                 NSLocalizedDescriptionKey: "Qwen3 ASR requires macOS 15 or later.",
             ])
         }
+    }
+
+    // MARK: - SenseVoiceSmall (FunASR via FluidAudio/CoreML)
+
+    private func transcribeWithSenseVoice(url: URL) async throws -> SpeechTranscriptionResult {
+        fputs("[muesli-native] transcribing with SenseVoice: \(url.lastPathComponent)\n", stderr)
+        let result = try await senseVoiceTranscriber.transcribe(wavURL: url)
+        fputs("[muesli-native] SenseVoice result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return SpeechTranscriptionResult(
+            text: text,
+            segments: text.isEmpty ? [] : [SpeechSegment(start: 0, end: 0, text: text)]
+        )
     }
 
     private func transcribeWithCanaryQwen(url: URL) async throws -> SpeechTranscriptionResult {

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -67,6 +67,13 @@ struct SenseVoiceTranscriberTests {
         #expect(SenseVoiceTranscriber.cacheRelativePath == "Library/Application Support/FluidAudio/Models/sensevoice-small-coreml")
         #expect(SenseVoiceTranscriber.cacheDirectory().path.hasSuffix(SenseVoiceTranscriber.cacheRelativePath))
     }
+
+    @Test("sensevoice metadata reflects INT8 download footprint")
+    func senseVoiceInt8DownloadMetadata() {
+        #expect(SenseVoiceTranscriber.downloadedModelSizeLabel == "~240 MB")
+        #expect(BackendOption.senseVoiceSmall.sizeLabel == SenseVoiceTranscriber.downloadedModelSizeLabel)
+        #expect(BackendOption.senseVoiceSmall.description.contains("INT8"))
+    }
 }
 
 @Suite("NemotronStreamingTranscriber")

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -46,6 +46,23 @@ struct FluidAudioTranscriberTests {
     }
 }
 
+@Suite("SenseVoiceTranscriber")
+struct SenseVoiceTranscriberTests {
+
+    @Test("sensevoice model uses FluidAudio CoreML repo")
+    func senseVoiceModel() {
+        #expect(BackendOption.senseVoiceSmall.backend == "sensevoice")
+        #expect(BackendOption.senseVoiceSmall.model.contains("FluidInference"))
+        #expect(BackendOption.senseVoiceSmall.model.contains("sensevoice"))
+    }
+
+    @Test("sensevoice stays experimental")
+    func senseVoiceExperimental() {
+        #expect(BackendOption.experimental.contains(.senseVoiceSmall))
+        #expect(!BackendOption.onboarding.contains(.senseVoiceSmall))
+    }
+}
+
 @Suite("NemotronStreamingTranscriber")
 struct NemotronStreamingTranscriberTests {
 
@@ -71,6 +88,7 @@ struct BackendCoverageTests {
             .mapValues(\.count)
         #expect(backendCounts["fluidaudio"]! >= 2, "FluidAudio should have at least 2 models")
         #expect(backendCounts["whisper"]! >= 1, "Whisper should have at least 1 model")
+        #expect(backendCounts["sensevoice"]! >= 1, "SenseVoice should have at least 1 model")
         // Nemotron excluded from .all until RNNT decode is validated
         // #expect(backendCounts["nemotron"]! >= 1)
     }

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -61,6 +61,12 @@ struct SenseVoiceTranscriberTests {
         #expect(BackendOption.experimental.contains(.senseVoiceSmall))
         #expect(!BackendOption.onboarding.contains(.senseVoiceSmall))
     }
+
+    @Test("sensevoice cache path uses FluidAudio model store")
+    func senseVoiceCachePath() {
+        #expect(SenseVoiceTranscriber.cacheRelativePath == "Library/Application Support/FluidAudio/Models/sensevoice-small-coreml")
+        #expect(SenseVoiceTranscriber.cacheDirectory().path.hasSuffix(SenseVoiceTranscriber.cacheRelativePath))
+    }
 }
 
 @Suite("NemotronStreamingTranscriber")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -24,7 +24,7 @@ struct BackendOptionTests {
 
     @Test("backend field is one of the known backends")
     func knownBackends() {
-        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron", "canary", "cohere"]
+        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron", "canary", "cohere", "sensevoice"]
         for option in BackendOption.all {
             #expect(known.contains(option.backend), "Unknown backend: \(option.backend)")
         }
@@ -64,6 +64,7 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.qwen3Asr))
         #expect(BackendOption.all.contains(.canaryQwen))
         #expect(BackendOption.all.contains(.cohereTranscribe))
+        #expect(BackendOption.all.contains(.senseVoiceSmall))
         #expect(BackendOption.all.contains(.nemotronStreaming))
     }
 
@@ -71,6 +72,13 @@ struct BackendOptionTests {
     func cohereBackend() {
         #expect(BackendOption.cohereTranscribe.backend == "cohere")
         #expect(BackendOption.cohereTranscribe.model.contains("cohere"))
+    }
+
+    @Test("SenseVoice uses native FluidAudio CoreML model")
+    func senseVoiceBackend() {
+        #expect(BackendOption.senseVoiceSmall.backend == "sensevoice")
+        #expect(BackendOption.senseVoiceSmall.model == "FluidInference/sensevoice-small-coreml")
+        #expect(BackendOption.senseVoiceSmall.description.contains("FluidAudio"))
     }
 
     @Test("Cohere is not in experimental list")

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -92,7 +92,7 @@ struct TranscriptionCoordinatorTests {
     @Test("backend routing covers all known backends")
     func allBackendsCovered() {
         let backends = Set(BackendOption.all.map(\.backend))
-        let expected: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron", "canary", "cohere"]
+        let expected: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron", "canary", "cohere", "sensevoice"]
         #expect(backends == expected, "BackendOption.all backends should match expected set")
     }
 }


### PR DESCRIPTION
This pull request fixes #209 by adding FunASR/SenseVoice support through FluidAudio's native CoreML implementation instead of the generated Python sidecar.

What changed:

- Adds a native `SenseVoiceTranscriber` wrapper around FluidAudio's `SenseVoiceManager`.
- Exposes **SenseVoice Small** as an experimental transcription model in the Models tab.
- Routes dictation, meeting transcription, and meeting chunks through the existing `TranscriptionCoordinator` path.
- Uses FluidAudio's existing model download/cache flow for `FluidInference/sensevoice-small-coreml`.
- Removes the Python/FastAPI sidecar approach entirely: no Python dependencies, no subprocess, no HTTP server, no sidecar tests.

Validation:

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/pr220-sensevoice" --filter BackendOptionTests --filter BackendCoverageTests --filter SenseVoiceTranscriberTests`
- `env -u OPENAI_API_KEY -u OPENROUTER_API_KEY swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/pr220-sensevoice"`

The full Swift suite passes locally: 987 tests in 112 suites.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->