### PR TITLE
Fix Settings permission polling UI stalls

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import AVFoundation
 import SwiftUI
 import MuesliCore
@@ -181,6 +182,10 @@ struct SettingsView: View {
                 refreshDictationInputDevices()
                 refreshPermissionStatuses(refreshLaunchAtLogin: true)
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            guard appState.selectedTab == .settings else { return }
+            refreshPermissionStatuses(refreshLaunchAtLogin: true)
         }
         .onChange(of: appState.selectedBackend) { _, _ in
             refreshDownloadedModelOptions()

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -179,7 +179,7 @@ struct SettingsView: View {
             if tab == .settings {
                 refreshDownloadedModelOptions()
                 refreshDictationInputDevices()
-                refreshPermissionStatuses()
+                refreshPermissionStatuses(refreshLaunchAtLogin: true)
             }
         }
         .onChange(of: appState.selectedBackend) { _, _ in
@@ -1370,7 +1370,7 @@ struct SettingsView: View {
     }
 
     private func startPermissionPolling() {
-        refreshPermissionStatuses()
+        refreshPermissionStatuses(refreshLaunchAtLogin: true)
         permissionPollTimer?.invalidate()
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             refreshPermissionStatuses()
@@ -1384,12 +1384,14 @@ struct SettingsView: View {
         permissionPollTimer = nil
     }
 
-    private func refreshPermissionStatuses() {
+    private func refreshPermissionStatuses(refreshLaunchAtLogin: Bool = false) {
         micGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         accessibilityGranted = AXIsProcessTrusted()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
-        controller.refreshLaunchAtLoginState()
+        if refreshLaunchAtLogin {
+            controller.refreshLaunchAtLoginState()
+        }
         if screenRecordingGranted && pendingScreenContextEnable {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = true }


### PR DESCRIPTION
## Summary
- stop polling Launch-at-Login state from the 1-second Settings permission timer
- refresh Launch-at-Login state only when Settings appears or the Settings tab is re-entered
- keep the lightweight permission checks on the existing timer

## Root cause
A local sample captured `SettingsView.startPermissionPolling()` calling `refreshPermissionStatuses()` every second, which in turn called `controller.refreshLaunchAtLoginState()`. That path reaches `SMAppService.mainApp.status`, which can synchronously block on ServiceManagement/XPC on the main thread. In the captured sample it blocked for roughly a second and made Settings scrolling feel laggy.

## Validation
- `git diff --check`
- `swift build --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-settings-permission-polling" --product MuesliNativeApp`

Note: the Swift build completes with existing unrelated warnings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784176732&installation_id=136549638&pr_number=221&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F221&signature=8e2b6b4431b22a66fe5333249774772af169884ae4c9f22010e8cbe8c6bb7ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->