### PR TITLE
Suggest dictionary additions from corrected dictation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -24,6 +24,11 @@ struct DictionaryCorrectionDetector {
     private static let minimumCorrectionSimilarity = 0.64
     private static let maxObservedTokensPerDictionaryWord = 2
 
+    private struct CorrectionCandidate {
+        let observed: String
+        let replacement: String
+    }
+
     static func suggestion(
         originalText: String,
         editedText: String,
@@ -75,48 +80,89 @@ struct DictionaryCorrectionDetector {
         appContext: String = "",
         maxSuggestions: Int = Int.max
     ) -> [DictionarySuggestion] {
-        guard maxSuggestions > 0 else { return [] }
-        guard !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
-        guard baselineText != currentText else { return [] }
-        guard hasSufficientSharedContext(originalText: originalText, editedText: currentText) else { return [] }
+        guard isDetectionRequestValid(
+            originalText: originalText,
+            baselineText: baselineText,
+            currentText: currentText,
+            maxSuggestions: maxSuggestions
+        ) else { return [] }
 
         var results: [DictionarySuggestion] = []
         var seenKeys = Set<String>()
 
-        func append(_ suggestion: DictionarySuggestion?) {
-            guard results.count < maxSuggestions, let suggestion else { return }
+        func append(_ candidate: CorrectionCandidate) {
+            guard results.count < maxSuggestions else { return }
+            let suggestion = DictionarySuggestion(
+                observed: candidate.observed,
+                replacement: candidate.replacement,
+                appContext: appContext
+            )
             guard !seenKeys.contains(suggestion.key) else { return }
             seenKeys.insert(suggestion.key)
             results.append(suggestion)
         }
 
-        append(fragmentSuggestion(
+        for candidate in extractCandidateCorrections(
             originalText: originalText,
             baselineText: baselineText,
             currentText: currentText,
-            appContext: appContext
-        ))
-
-        if results.count < maxSuggestions {
-            for suggestion in tokenAlignedSuggestions(
-                originalText: originalText,
-                editedText: currentText,
-                appContext: appContext,
-                maxSuggestions: maxSuggestions - results.count
-            ) {
-                append(suggestion)
-            }
+            maxCandidates: maxSuggestions
+        ) {
+            append(candidate)
         }
 
         return results
     }
 
-    private static func fragmentSuggestion(
+    private static func isDetectionRequestValid(
         originalText: String,
         baselineText: String,
         currentText: String,
-        appContext: String
-    ) -> DictionarySuggestion? {
+        maxSuggestions: Int
+    ) -> Bool {
+        guard maxSuggestions > 0 else { return false }
+        guard !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard baselineText != currentText else { return false }
+        return hasSufficientSharedContext(originalText: originalText, editedText: currentText)
+    }
+
+    private static func extractCandidateCorrections(
+        originalText: String,
+        baselineText: String,
+        currentText: String,
+        maxCandidates: Int
+    ) -> [CorrectionCandidate] {
+        var candidates: [CorrectionCandidate] = []
+
+        func append(_ candidate: CorrectionCandidate?) {
+            guard candidates.count < maxCandidates, let candidate else { return }
+            candidates.append(candidate)
+        }
+
+        append(fragmentCandidate(
+            originalText: originalText,
+            baselineText: baselineText,
+            currentText: currentText
+        ))
+
+        if candidates.count < maxCandidates {
+            for candidate in tokenAlignedCandidates(
+                originalText: originalText,
+                editedText: currentText,
+                maxCandidates: maxCandidates - candidates.count
+            ) {
+                append(candidate)
+            }
+        }
+
+        return candidates
+    }
+
+    private static func fragmentCandidate(
+        originalText: String,
+        baselineText: String,
+        currentText: String
+    ) -> CorrectionCandidate? {
         let diff = changedFragments(from: baselineText, to: currentText)
         guard let observed = normalizedCandidate(diff.removed),
               let replacement = normalizedCandidate(diff.inserted)
@@ -130,10 +176,9 @@ struct DictionaryCorrectionDetector {
         }
         guard isLikelyDictionaryCorrection(observed: observed, replacement: replacement) else { return nil }
 
-        return DictionarySuggestion(
+        return CorrectionCandidate(
             observed: observed,
-            replacement: replacement,
-            appContext: appContext
+            replacement: replacement
         )
     }
 
@@ -142,41 +187,40 @@ struct DictionaryCorrectionDetector {
         let normalized: String
     }
 
-    private static func tokenAlignedSuggestions(
+    private static func tokenAlignedCandidates(
         originalText: String,
         editedText: String,
-        appContext: String,
-        maxSuggestions: Int
-    ) -> [DictionarySuggestion] {
-        guard maxSuggestions > 0 else { return [] }
+        maxCandidates: Int
+    ) -> [CorrectionCandidate] {
+        guard maxCandidates > 0 else { return [] }
         let originalTokens = wordTokens(in: originalText)
         let editedTokens = wordTokens(in: editedText)
         guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return [] }
         guard originalTokens.count <= 160, editedTokens.count <= 220 else { return [] }
 
         let operations = alignmentOperations(from: originalTokens, to: editedTokens)
-        var suggestions: [DictionarySuggestion] = []
+        var candidates: [CorrectionCandidate] = []
         var seenKeys = Set<String>()
 
-        func append(_ suggestion: DictionarySuggestion) {
-            guard suggestions.count < maxSuggestions else { return }
-            guard !seenKeys.contains(suggestion.key) else { return }
-            seenKeys.insert(suggestion.key)
-            suggestions.append(suggestion)
+        func append(_ candidate: CorrectionCandidate) {
+            guard candidates.count < maxCandidates else { return }
+            let key = DictionarySuggestion.key(observed: candidate.observed, replacement: candidate.replacement)
+            guard !seenKeys.contains(key) else { return }
+            seenKeys.insert(key)
+            candidates.append(candidate)
         }
 
         for run in tokenChangeRuns(in: operations) {
-            for suggestion in suggestionsFromTokenRun(
+            for candidate in candidatesFromTokenRun(
                 fromTokenRun: run,
                 originalText: originalText,
-                appContext: appContext,
-                maxSuggestions: maxSuggestions - suggestions.count
+                maxCandidates: maxCandidates - candidates.count
             ) {
-                append(suggestion)
+                append(candidate)
             }
-            if suggestions.count >= maxSuggestions { break }
+            if candidates.count >= maxCandidates { break }
         }
-        return suggestions
+        return candidates
     }
 
     private struct TokenChangeRun {
@@ -217,23 +261,22 @@ struct DictionaryCorrectionDetector {
         return runs
     }
 
-    private static func suggestionsFromTokenRun(
+    private static func candidatesFromTokenRun(
         fromTokenRun run: TokenChangeRun,
         originalText: String,
-        appContext: String,
-        maxSuggestions: Int
-    ) -> [DictionarySuggestion] {
-        guard maxSuggestions > 0 else { return [] }
+        maxCandidates: Int
+    ) -> [CorrectionCandidate] {
+        guard maxCandidates > 0 else { return [] }
         guard run.observedTokens.count <= run.replacementTokens.count * maxObservedTokensPerDictionaryWord else {
             return []
         }
-        var results: [DictionarySuggestion] = []
+        var results: [CorrectionCandidate] = []
         var observedIndex = 0
 
         for replacementToken in run.replacementTokens {
-            guard results.count < maxSuggestions, observedIndex < run.observedTokens.count else { break }
+            guard results.count < maxCandidates, observedIndex < run.observedTokens.count else { break }
 
-            var bestSuggestion: DictionarySuggestion?
+            var bestCandidate: CorrectionCandidate?
             var bestObservedLength = 0
             var bestSimilarity = 0.0
             let maxObservedLength = min(maxObservedTokensPerDictionaryWord, run.observedTokens.count - observedIndex)
@@ -254,18 +297,17 @@ struct DictionaryCorrectionDetector {
                     replacementCandidate.lowercased()
                 )
                 if similarity > bestSimilarity {
-                    bestSuggestion = DictionarySuggestion(
+                    bestCandidate = CorrectionCandidate(
                         observed: observedCandidate,
-                        replacement: replacementCandidate,
-                        appContext: appContext
+                        replacement: replacementCandidate
                     )
                     bestObservedLength = observedLength
                     bestSimilarity = similarity
                 }
             }
 
-            if let bestSuggestion {
-                results.append(bestSuggestion)
+            if let bestCandidate {
+                results.append(bestCandidate)
                 observedIndex += bestObservedLength
             } else {
                 observedIndex += 1

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -803,7 +803,7 @@ final class DictationCorrectionMonitor {
                         Self.log("stableSnapshot rejected suggestions=0")
                     }
                     for suggestion in suggestions where !emittedSuggestionKeys.contains(suggestion.key) {
-                        let shouldPresentPrompt = emittedSuggestionCount == 0
+                        let shouldPresentPrompt = true
                         emittedSuggestionKeys.insert(suggestion.key)
                         emittedSuggestionCount += 1
                         Self.log("emit presentPrompt=\(shouldPresentPrompt) \(Self.suggestionLogMetadata(suggestion))")

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -881,8 +881,7 @@ struct DictationCorrectionSnapshotStabilizer {
     }
 }
 
-@MainActor
-private final class EnglishWordRecognizer {
+private actor EnglishWordRecognizer {
     private let maxEntries: Int
     private let spellChecker = NSSpellChecker()
     private var cache: [String: Bool] = [:]
@@ -892,6 +891,9 @@ private final class EnglishWordRecognizer {
         self.maxEntries = maxEntries
     }
 
+    // NSSpellChecker.checkSpelling is synchronous and can do noticeable first-run
+    // work on cache misses. Keep it off the MainActor, but serialize access here
+    // so the checker instance and LRU cache are not touched concurrently.
     func recognizedWords(from candidates: Set<String>) -> Set<String> {
         guard !candidates.isEmpty else { return [] }
 
@@ -947,7 +949,7 @@ final class DictationCorrectionMonitor {
     nonisolated private static let maxCandidateCharacters = 2_000
     nonisolated private static let maxEnglishWordRecognitionCandidates = 128
     nonisolated private static let maxEnglishWordRecognitionCacheEntries = 5_000
-    private static let englishWordRecognizer = EnglishWordRecognizer(maxEntries: maxEnglishWordRecognitionCacheEntries)
+    nonisolated private static let englishWordRecognizer = EnglishWordRecognizer(maxEntries: maxEnglishWordRecognitionCacheEntries)
 
     private var task: Task<Void, Never>?
 
@@ -1003,7 +1005,7 @@ final class DictationCorrectionMonitor {
                     Self.log("poll=\(pollCount) stableSnapshots=\(stableSnapshots.count)")
                 }
                 for stableSnapshot in stableSnapshots {
-                    let recognizedEnglishWords = Self.englishWordRecognizer.recognizedWords(
+                    let recognizedEnglishWords = await Self.englishWordRecognizer.recognizedWords(
                         from: Self.englishWordCandidates(originalText: originalText, editedText: stableSnapshot)
                     )
                     if Task.isCancelled { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -292,12 +292,8 @@ struct DictionaryCorrectionDetector {
 
         let normalizedReplacement = replacement.lowercased()
         let normalizedObserved = observed.lowercased()
-        let hasSpecialDictionarySignal = hasInternalCapital(replacement)
-            || replacement.contains(where: \.isNumber)
+        let hasFormattingDictionarySignal = hasStrongDictionarySignal(replacement)
             || replacement.contains("-")
-            || replacement.contains("_")
-            || replacement.contains("/")
-            || isAcronymLike(replacement)
 
         let similarity = CustomWordMatcher.jaroWinklerSimilarity(
             normalizedObserved,
@@ -312,29 +308,87 @@ struct DictionaryCorrectionDetector {
                 compactObserved,
                 compactReplacement
             )
-            return compactSimilarity >= 0.82
+            return compactSimilarity >= 0.82 || isLikelyStrongDictionaryCorrection(
+                observed: observed,
+                replacement: replacement,
+                observedTokens: observedTokens,
+                similarity: compactSimilarity
+            )
         }
 
         if commonWords.contains(normalizedObserved) {
             if observed.lowercased() == replacement.lowercased() {
-                return hasSpecialDictionarySignal || replacement.contains(where: \.isUppercase)
+                return hasFormattingDictionarySignal || replacement.contains(where: \.isUppercase)
             }
-            return similarity >= 0.82 && hasSpecialDictionarySignal
+            return similarity >= 0.82 && hasFormattingDictionarySignal
         }
 
-        if commonWords.contains(normalizedReplacement), !hasSpecialDictionarySignal {
+        if commonWords.contains(normalizedReplacement), !hasFormattingDictionarySignal {
             return false
         }
 
         if observed.lowercased() == replacement.lowercased() {
-            return hasSpecialDictionarySignal || replacement.contains(where: \.isUppercase)
+            return hasFormattingDictionarySignal || replacement.contains(where: \.isUppercase)
         }
 
         guard !isCommonWordTruncation(observed: normalizedObserved, replacement: normalizedReplacement) else {
             return false
         }
 
-        return similarity >= minimumCorrectionSimilarity
+        return similarity >= minimumCorrectionSimilarity || isLikelyStrongDictionaryCorrection(
+            observed: observed,
+            replacement: replacement,
+            observedTokens: observedTokens,
+            similarity: similarity
+        )
+    }
+
+    private static func hasStrongDictionarySignal(_ value: String) -> Bool {
+        hasInternalCapital(value)
+            || value.contains(where: \.isNumber)
+            || value.contains("_")
+            || value.contains("/")
+            || isAcronymLike(value)
+    }
+
+    private static func isLikelyStrongDictionaryCorrection(
+        observed: String,
+        replacement: String,
+        observedTokens: [String],
+        similarity: Double
+    ) -> Bool {
+        guard hasStrongDictionarySignal(replacement) else { return false }
+        if isNumericShorthand(observed: observed, replacement: replacement) {
+            return true
+        }
+        if isAcronymLike(replacement), isAcronymCorrection(observedTokens: observedTokens, replacement: replacement) {
+            return true
+        }
+        if replacement.contains("_") || replacement.contains("/") || hasInternalCapital(replacement) {
+            return similarity >= 0.55
+        }
+        return false
+    }
+
+    private static func isNumericShorthand(observed: String, replacement: String) -> Bool {
+        let observedLetters = observed.lowercased().filter(\.isLetter)
+        let replacementCharacters = Array(replacement.lowercased())
+        guard observedLetters.count >= 4,
+              replacementCharacters.contains(where: \.isNumber),
+              let firstObserved = observedLetters.first,
+              let lastObserved = observedLetters.last,
+              replacementCharacters.first == firstObserved,
+              replacementCharacters.last == lastObserved
+        else { return false }
+        return true
+    }
+
+    private static func isAcronymCorrection(observedTokens: [String], replacement: String) -> Bool {
+        guard observedTokens.count > 1 else { return false }
+        let initials = observedTokens.compactMap { $0.first?.lowercased() }.joined()
+        let replacementLetters = replacement.lowercased().filter(\.isLetter)
+        guard !initials.isEmpty, !replacementLetters.isEmpty else { return false }
+        return replacementLetters.hasPrefix(initials)
     }
 
     private static func isCommonWordTruncation(observed: String, replacement: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -121,7 +121,7 @@ struct DictionaryCorrectionDetector {
               let replacement = normalizedCandidate(diff.inserted)
         else { return nil }
 
-        guard isSingleTokenCandidate(observed), isSingleTokenCandidate(replacement) else {
+        guard isWordScopedSuggestion(observed: observed, replacement: replacement) else {
             return nil
         }
         guard originalText.range(of: observed, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
@@ -156,45 +156,118 @@ struct DictionaryCorrectionDetector {
         let operations = alignmentOperations(from: originalTokens, to: editedTokens)
         var suggestions: [DictionarySuggestion] = []
         var seenKeys = Set<String>()
-        for (index, operation) in operations.enumerated() {
-            guard case .substitution(let observed, let replacement) = operation else { continue }
-            guard !isAdjacentToTokenCountChange(index: index, operations: operations) else {
-                continue
-            }
-            guard let observedCandidate = normalizedCandidate(observed.text),
-                  let replacementCandidate = normalizedCandidate(replacement.text)
-            else { continue }
-            guard originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
-                continue
-            }
-            guard isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate) else {
-                continue
-            }
-            let suggestion = DictionarySuggestion(
-                observed: observedCandidate,
-                replacement: replacementCandidate,
-                appContext: appContext
-            )
-            guard !seenKeys.contains(suggestion.key) else { continue }
+
+        func append(_ suggestion: DictionarySuggestion) {
+            guard suggestions.count < maxSuggestions else { return }
+            guard !seenKeys.contains(suggestion.key) else { return }
             seenKeys.insert(suggestion.key)
             suggestions.append(suggestion)
-            if suggestions.count >= maxSuggestions {
-                break
+        }
+
+        for run in tokenChangeRuns(in: operations) {
+            for suggestion in suggestionsFromTokenRun(
+                fromTokenRun: run,
+                originalText: originalText,
+                appContext: appContext,
+                maxSuggestions: maxSuggestions - suggestions.count
+            ) {
+                append(suggestion)
             }
+            if suggestions.count >= maxSuggestions { break }
         }
         return suggestions
     }
 
-    private static func isAdjacentToTokenCountChange(index: Int, operations: [AlignmentOperation]) -> Bool {
-        for adjacentIndex in [index - 1, index + 1] where operations.indices.contains(adjacentIndex) {
-            switch operations[adjacentIndex] {
-            case .insertion, .deletion:
-                return true
-            case .match, .substitution:
-                continue
+    private struct TokenChangeRun {
+        let observedTokens: [WordToken]
+        let replacementTokens: [WordToken]
+    }
+
+    private static func tokenChangeRuns(in operations: [AlignmentOperation]) -> [TokenChangeRun] {
+        var runs: [TokenChangeRun] = []
+        var observedTokens: [WordToken] = []
+        var replacementTokens: [WordToken] = []
+
+        func flush() {
+            guard !observedTokens.isEmpty, !replacementTokens.isEmpty else {
+                observedTokens.removeAll()
+                replacementTokens.removeAll()
+                return
+            }
+            runs.append(TokenChangeRun(observedTokens: observedTokens, replacementTokens: replacementTokens))
+            observedTokens.removeAll()
+            replacementTokens.removeAll()
+        }
+
+        for operation in operations {
+            switch operation {
+            case .match:
+                flush()
+            case .deletion(let token):
+                observedTokens.append(token)
+            case .insertion(let token):
+                replacementTokens.append(token)
+            case .substitution(let observed, let replacement):
+                observedTokens.append(observed)
+                replacementTokens.append(replacement)
             }
         }
-        return false
+        flush()
+        return runs
+    }
+
+    private static func suggestionsFromTokenRun(
+        fromTokenRun run: TokenChangeRun,
+        originalText: String,
+        appContext: String,
+        maxSuggestions: Int
+    ) -> [DictionarySuggestion] {
+        guard maxSuggestions > 0 else { return [] }
+        var results: [DictionarySuggestion] = []
+        var observedIndex = 0
+
+        for replacementToken in run.replacementTokens {
+            guard results.count < maxSuggestions, observedIndex < run.observedTokens.count else { break }
+
+            var bestSuggestion: DictionarySuggestion?
+            var bestObservedLength = 0
+            var bestSimilarity = 0.0
+            let maxObservedLength = min(3, run.observedTokens.count - observedIndex)
+
+            for observedLength in 1...maxObservedLength {
+                let observedText = run.observedTokens[observedIndex..<(observedIndex + observedLength)]
+                    .map(\.text)
+                    .joined(separator: " ")
+                guard let observedCandidate = normalizedCandidate(observedText),
+                      let replacementCandidate = normalizedCandidate(replacementToken.text),
+                      isWordScopedSuggestion(observed: observedCandidate, replacement: replacementCandidate),
+                      originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil,
+                      isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate)
+                else { continue }
+
+                let similarity = CustomWordMatcher.jaroWinklerSimilarity(
+                    observedCandidate.replacingOccurrences(of: " ", with: "").lowercased(),
+                    replacementCandidate.lowercased()
+                )
+                if similarity > bestSimilarity {
+                    bestSuggestion = DictionarySuggestion(
+                        observed: observedCandidate,
+                        replacement: replacementCandidate,
+                        appContext: appContext
+                    )
+                    bestObservedLength = observedLength
+                    bestSimilarity = similarity
+                }
+            }
+
+            if let bestSuggestion {
+                results.append(bestSuggestion)
+                observedIndex += bestObservedLength
+            } else {
+                observedIndex += 1
+            }
+        }
+        return results
     }
 
     static func hasSufficientSharedContext(originalText: String, editedText: String) -> Bool {
@@ -356,8 +429,34 @@ struct DictionaryCorrectionDetector {
         return tokens.joined(separator: " ")
     }
 
-    private static func isSingleTokenCandidate(_ value: String) -> Bool {
-        value.split(whereSeparator: \.isWhitespace).count == 1
+    private static func isWordScopedSuggestion(observed: String, replacement: String) -> Bool {
+        let observedTokens = observed.split(whereSeparator: \.isWhitespace)
+        let replacementTokens = replacement.split(whereSeparator: \.isWhitespace)
+        guard replacementTokens.count == 1, (1...3).contains(observedTokens.count) else {
+            return false
+        }
+        if observedTokens.count == 1 {
+            if isAcronymLike(replacement), observed.lowercased() != replacement.lowercased() {
+                return false
+            }
+            if replacement.contains("-"), !observed.contains("-") {
+                return CustomWordMatcher.jaroWinklerSimilarity(
+                    observed.lowercased(),
+                    replacement.lowercased()
+                ) >= 0.82
+            }
+            return true
+        }
+
+        guard !replacement.contains("-"),
+              !replacement.contains("_"),
+              !replacement.contains("/"),
+              !isAcronymLike(replacement)
+        else { return false }
+
+        let compactObserved = observedTokens.joined().lowercased()
+        let compactReplacement = replacement.lowercased()
+        return CustomWordMatcher.jaroWinklerSimilarity(compactObserved, compactReplacement) >= minimumCorrectionSimilarity
     }
 
     private static func isLikelyDictionaryCorrection(observed: String, replacement: String) -> Bool {
@@ -385,7 +484,13 @@ struct DictionaryCorrectionDetector {
                 compactObserved,
                 compactReplacement
             )
-            return compactSimilarity >= 0.82 || isLikelyStrongDictionaryCorrection(
+            return compactSimilarity >= 0.82
+                || isLikelySingleWordSplitCorrection(
+                    replacement: replacement,
+                    replacementTokens: replacementTokens,
+                    similarity: compactSimilarity
+                )
+                || isLikelyStrongDictionaryCorrection(
                 observed: observed,
                 replacement: replacement,
                 observedTokens: observedTokens,
@@ -445,6 +550,23 @@ struct DictionaryCorrectionDetector {
             return similarity >= 0.55
         }
         return false
+    }
+
+    private static func isLikelySingleWordSplitCorrection(
+        replacement: String,
+        replacementTokens: [String],
+        similarity: Double
+    ) -> Bool {
+        guard replacementTokens.count == 1,
+              !replacement.contains("-"),
+              !replacement.contains("_"),
+              !replacement.contains("/"),
+              !isAcronymLike(replacement),
+              !commonWords.contains(replacement.lowercased()),
+              similarity >= minimumCorrectionSimilarity
+        else { return false }
+        return replacement.contains(where: \.isUppercase)
+            || !isRecognizedEnglishWord(replacement.lowercased())
     }
 
     private static func isNumericShorthand(observed: String, replacement: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -330,51 +330,38 @@ struct DictionaryCorrectionDetector {
             return hasSpecialDictionarySignal || replacement.contains(where: \.isUppercase)
         }
 
-        guard !isPlainSingleCharacterEdit(observed: normalizedObserved, replacement: normalizedReplacement) else {
+        guard !isCommonWordTruncation(observed: normalizedObserved, replacement: normalizedReplacement) else {
             return false
         }
 
         return similarity >= minimumCorrectionSimilarity || hasSpecialDictionarySignal
     }
 
-    private static func isPlainSingleCharacterEdit(observed: String, replacement: String) -> Bool {
+    private static func isCommonWordTruncation(observed: String, replacement: String) -> Bool {
         guard observed.split(whereSeparator: \.isWhitespace).count == 1,
               replacement.split(whereSeparator: \.isWhitespace).count == 1,
-              observed.allSatisfy({ $0.isLowercase || $0.isNumber }),
-              replacement.allSatisfy({ $0.isLowercase || $0.isNumber })
+              observed.allSatisfy(\.isLowercase),
+              replacement.allSatisfy(\.isLowercase),
+              observed != replacement,
+              (observed.hasPrefix(replacement) || replacement.hasPrefix(observed)),
+              isRecognizedEnglishWord(observed),
+              isRecognizedEnglishWord(replacement)
         else { return false }
-
-        return boundedEditDistance(observed, replacement, limit: 1) <= 1
+        return true
     }
 
-    private static func boundedEditDistance(_ lhs: String, _ rhs: String, limit: Int) -> Int {
-        let lhsChars = Array(lhs)
-        let rhsChars = Array(rhs)
-        guard abs(lhsChars.count - rhsChars.count) <= limit else {
-            return limit + 1
-        }
-        guard !lhsChars.isEmpty else { return rhsChars.count }
-        guard !rhsChars.isEmpty else { return lhsChars.count }
-
-        var previous = Array(0...rhsChars.count)
-        for row in 1...lhsChars.count {
-            var current = [row] + Array(repeating: 0, count: rhsChars.count)
-            var rowMinimum = current[0]
-            for column in 1...rhsChars.count {
-                let substitutionCost = lhsChars[row - 1] == rhsChars[column - 1] ? 0 : 1
-                current[column] = min(
-                    previous[column] + 1,
-                    current[column - 1] + 1,
-                    previous[column - 1] + substitutionCost
-                )
-                rowMinimum = min(rowMinimum, current[column])
-            }
-            if rowMinimum > limit {
-                return limit + 1
-            }
-            previous = current
-        }
-        return previous[rhsChars.count]
+    private static func isRecognizedEnglishWord(_ value: String) -> Bool {
+        spellCheckerLock.lock()
+        defer { spellCheckerLock.unlock() }
+        let range = NSSpellChecker.shared.checkSpelling(
+            of: value,
+            startingAt: 0,
+            language: "en",
+            wrap: false,
+            inSpellDocumentWithTag: 0,
+            wordCount: nil
+        )
+        return range.location == NSNotFound
     }
 
     private static func hasInternalCapital(_ value: String) -> Bool {
@@ -398,6 +385,30 @@ struct DictionaryCorrectionDetector {
         "them", "then", "there", "they", "this", "to", "up", "us", "was", "we", "were",
         "what", "when", "where", "which", "who", "will", "with", "would", "you", "your",
     ]
+
+    private static let spellCheckerLock = NSLock()
+}
+
+struct DictationCorrectionSnapshotStabilizer {
+    private var currentSnapshot: String?
+    private var currentSnapshotChangedAt: Date?
+    private var lastEvaluatedSnapshot: String?
+
+    mutating func observe(snapshot: String?, now: Date, quietWindow: TimeInterval) -> String? {
+        guard let snapshot else { return nil }
+        guard currentSnapshot == snapshot else {
+            currentSnapshot = snapshot
+            currentSnapshotChangedAt = now
+            return nil
+        }
+        guard lastEvaluatedSnapshot != snapshot,
+              let currentSnapshotChangedAt,
+              now.timeIntervalSince(currentSnapshotChangedAt) >= quietWindow
+        else { return nil }
+
+        lastEvaluatedSnapshot = snapshot
+        return snapshot
+    }
 }
 
 @MainActor
@@ -407,6 +418,7 @@ final class DictationCorrectionMonitor {
     private static let steadyPollIntervalNanoseconds: UInt64 = 1_000_000_000
     private static let fastPollingWindowSeconds: TimeInterval = 10
     private static let monitoringWindowSeconds: TimeInterval = 45
+    private static let snapshotQuietWindowSeconds: TimeInterval = 1.5
     nonisolated private static let maxAccessibilityNodes = 140
     nonisolated private static let maxCandidateCharacters = 2_000
 
@@ -424,21 +436,36 @@ final class DictationCorrectionMonitor {
         task = Task {
             let fastPollingDeadline = Date().addingTimeInterval(Self.fastPollingWindowSeconds)
             let deadline = Date().addingTimeInterval(Self.monitoringWindowSeconds)
+            var stabilizer = DictationCorrectionSnapshotStabilizer()
             try? await Task.sleep(nanoseconds: Self.initialPollDelayNanoseconds)
             while !Task.isCancelled, Date() < deadline {
-                let suggestion = await Task.detached(priority: .utility) {
-                    Self.detectSuggestion(
+                let snapshot = await Task.detached(priority: .utility) {
+                    Self.detectEditedSnapshot(
                         originalText: originalText,
-                        appContext: appContext,
                         targetApp: targetApp
                     )
                 }.value
                 if Task.isCancelled { return }
-                if let suggestion {
-                    await MainActor.run {
-                        onSuggestion(suggestion)
+                if let stableSnapshot = stabilizer.observe(
+                    snapshot: snapshot,
+                    now: Date(),
+                    quietWindow: Self.snapshotQuietWindowSeconds
+                ) {
+                    let suggestion = await Task.detached(priority: .utility) {
+                        Self.suggestion(
+                            originalText: originalText,
+                            editedSnapshot: stableSnapshot,
+                            appContext: appContext,
+                            targetApp: targetApp
+                        )
+                    }.value
+                    if Task.isCancelled { return }
+                    if let suggestion {
+                        await MainActor.run {
+                            onSuggestion(suggestion)
+                        }
+                        return
                     }
-                    return
                 }
                 let interval = Date() < fastPollingDeadline
                     ? Self.fastPollIntervalNanoseconds
@@ -453,36 +480,48 @@ final class DictationCorrectionMonitor {
         task = nil
     }
 
-    nonisolated private static func detectSuggestion(
+    nonisolated private static func suggestion(
         originalText: String,
+        editedSnapshot: String,
         appContext: String,
         targetApp: DictationCorrectionTargetApp?
     ) -> DictionarySuggestion? {
         let resolvedAppContext = appContext.isEmpty ? (targetApp?.appContext ?? "") : appContext
+        return DictionaryCorrectionDetector.suggestion(
+            originalText: originalText,
+            editedText: editedSnapshot,
+            appContext: resolvedAppContext
+        )
+    }
+
+    nonisolated private static func detectEditedSnapshot(
+        originalText: String,
+        targetApp: DictationCorrectionTargetApp?
+    ) -> String? {
         var seen = Set<String>()
 
-        func suggestion(from value: String?) -> DictionarySuggestion? {
+        func snapshot(from value: String?) -> String? {
             guard let snapshot = normalizedSnapshot(value, originalText: originalText),
-                  !seen.contains(snapshot)
+                  !seen.contains(snapshot),
+                  DictionaryCorrectionDetector.hasSufficientSharedContext(
+                      originalText: originalText,
+                      editedText: snapshot
+                  )
             else { return nil }
             seen.insert(snapshot)
-            return DictionaryCorrectionDetector.suggestion(
-                originalText: originalText,
-                editedText: snapshot,
-                appContext: resolvedAppContext
-            )
+            return snapshot
         }
 
         var focusedProcessID: pid_t?
-        if let focusedSuggestion = systemFocusedTextSnapshot(
+        if let focusedSnapshot = systemFocusedTextSnapshot(
             maxCharacters: maxCandidateCharacters,
             processID: &focusedProcessID
-        ).flatMap(suggestion(from:)) {
-            return focusedSuggestion
+        ).flatMap(snapshot(from:)) {
+            return focusedSnapshot
         }
 
         if let targetApp, targetApp.processID != focusedProcessID {
-            return collectTextSnapshots(fromProcessID: targetApp.processID, evaluate: suggestion(from:))
+            return collectTextSnapshots(fromProcessID: targetApp.processID, evaluate: snapshot(from:))
         }
         return nil
     }
@@ -506,8 +545,8 @@ final class DictationCorrectionMonitor {
 
     nonisolated private static func collectTextSnapshots(
         fromProcessID processID: pid_t,
-        evaluate: (String?) -> DictionarySuggestion?
-    ) -> DictionarySuggestion? {
+        evaluate: (String?) -> String?
+    ) -> String? {
         let axApp = AXUIElementCreateApplication(processID)
         var roots: [AXUIElement] = []
 
@@ -544,8 +583,8 @@ final class DictationCorrectionMonitor {
         depth: Int,
         remainingNodes: inout Int,
         visited: inout Set<String>,
-        evaluate: (String?) -> DictionarySuggestion?
-    ) -> DictionarySuggestion? {
+        evaluate: (String?) -> String?
+    ) -> String? {
         guard depth <= 8, remainingNodes > 0 else { return nil }
         let visitKey = elementVisitKey(element)
         guard !visited.contains(visitKey) else { return nil }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -24,8 +24,10 @@ struct DictionaryCorrectionDetector {
     private static let minimumCorrectionSimilarity = 0.64
     private static let maxObservedTokensPerDictionaryWord = 2
     private static let alignmentContextTokenCount = 4
+    private static let alignmentAnchorTokenCount = 4
     private static let maxAlignmentWindowTokens = 96
     private static let maxAlignmentCellCount = 12_000
+    private static let maxAlignmentSegmentationDepth = 12
     private static let spellChecker = NSSpellChecker()
 
     private struct CorrectionCandidate {
@@ -200,9 +202,7 @@ struct DictionaryCorrectionDetector {
         let originalTokens = wordTokens(in: originalText)
         let editedTokens = wordTokens(in: editedText)
         guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return [] }
-        guard let tokenWindow = alignmentTokenWindow(from: originalTokens, to: editedTokens) else { return [] }
 
-        let operations = alignmentOperations(from: tokenWindow.original, to: tokenWindow.edited)
         var candidates: [CorrectionCandidate] = []
         var seenKeys = Set<String>()
 
@@ -214,57 +214,240 @@ struct DictionaryCorrectionDetector {
             candidates.append(candidate)
         }
 
-        for run in tokenChangeRuns(in: operations) {
-            for candidate in candidatesFromTokenRun(
-                fromTokenRun: run,
-                originalText: originalText,
-                maxCandidates: maxCandidates - candidates.count
-            ) {
-                append(candidate)
+        for tokenWindow in alignmentTokenWindows(from: originalTokens, to: editedTokens) {
+            let operations = alignmentOperations(from: tokenWindow.original, to: tokenWindow.edited)
+            for run in tokenChangeRuns(in: operations) {
+                for candidate in candidatesFromTokenRun(
+                    fromTokenRun: run,
+                    originalText: originalText,
+                    maxCandidates: maxCandidates - candidates.count
+                ) {
+                    append(candidate)
+                }
+                if candidates.count >= maxCandidates { break }
             }
             if candidates.count >= maxCandidates { break }
         }
         return candidates
     }
 
-    private static func alignmentTokenWindow(
+    private struct AlignmentTokenWindow {
+        let original: [WordToken]
+        let edited: [WordToken]
+    }
+
+    private struct TokenChangeRange {
+        let originalStart: Int
+        let originalEnd: Int
+        let editedStart: Int
+        let editedEnd: Int
+    }
+
+    private struct TokenAnchor {
+        let originalStart: Int
+        let editedStart: Int
+        let length: Int
+    }
+
+    private static func alignmentTokenWindows(
         from originalTokens: [WordToken],
         to editedTokens: [WordToken]
-    ) -> (original: [WordToken], edited: [WordToken])? {
-        var prefix = 0
-        while prefix < originalTokens.count,
-              prefix < editedTokens.count,
-              originalTokens[prefix].normalized == editedTokens[prefix].normalized {
-            prefix += 1
-        }
-
-        var originalSuffix = originalTokens.count
-        var editedSuffix = editedTokens.count
-        while originalSuffix > prefix,
-              editedSuffix > prefix,
-              originalTokens[originalSuffix - 1].normalized == editedTokens[editedSuffix - 1].normalized {
-            originalSuffix -= 1
-            editedSuffix -= 1
-        }
-
-        let originalStart = max(0, prefix - alignmentContextTokenCount)
-        let editedStart = max(0, prefix - alignmentContextTokenCount)
-        let originalEnd = min(originalTokens.count, originalSuffix + alignmentContextTokenCount)
-        let editedEnd = min(editedTokens.count, editedSuffix + alignmentContextTokenCount)
-        let originalWindowCount = originalEnd - originalStart
-        let editedWindowCount = editedEnd - editedStart
-
-        guard originalWindowCount > 0,
-              editedWindowCount > 0,
-              originalWindowCount <= maxAlignmentWindowTokens,
-              editedWindowCount <= maxAlignmentWindowTokens,
-              (originalWindowCount + 1) * (editedWindowCount + 1) <= maxAlignmentCellCount
-        else { return nil }
-
-        return (
-            Array(originalTokens[originalStart..<originalEnd]),
-            Array(editedTokens[editedStart..<editedEnd])
+    ) -> [AlignmentTokenWindow] {
+        let ranges = changedTokenRanges(
+            originalTokens: originalTokens,
+            editedTokens: editedTokens,
+            originalStart: 0,
+            originalEnd: originalTokens.count,
+            editedStart: 0,
+            editedEnd: editedTokens.count,
+            depth: 0
         )
+
+        return ranges.compactMap { range in
+            let originalStart = max(0, range.originalStart - alignmentContextTokenCount)
+            let editedStart = max(0, range.editedStart - alignmentContextTokenCount)
+            let originalEnd = min(originalTokens.count, range.originalEnd + alignmentContextTokenCount)
+            let editedEnd = min(editedTokens.count, range.editedEnd + alignmentContextTokenCount)
+            guard isAlignmentWindowWithinBounds(
+                originalCount: originalEnd - originalStart,
+                editedCount: editedEnd - editedStart
+            ) else { return nil }
+            return AlignmentTokenWindow(
+                original: Array(originalTokens[originalStart..<originalEnd]),
+                edited: Array(editedTokens[editedStart..<editedEnd])
+            )
+        }
+    }
+
+    // Split large AX snapshots into local edit islands so distant edits do not suppress each other.
+    private static func changedTokenRanges(
+        originalTokens: [WordToken],
+        editedTokens: [WordToken],
+        originalStart: Int,
+        originalEnd: Int,
+        editedStart: Int,
+        editedEnd: Int,
+        depth: Int
+    ) -> [TokenChangeRange] {
+        var originalStart = originalStart
+        var editedStart = editedStart
+        var originalEnd = originalEnd
+        var editedEnd = editedEnd
+
+        while originalStart < originalEnd,
+              editedStart < editedEnd,
+              originalTokens[originalStart].text == editedTokens[editedStart].text {
+            originalStart += 1
+            editedStart += 1
+        }
+
+        while originalEnd > originalStart,
+              editedEnd > editedStart,
+              originalTokens[originalEnd - 1].text == editedTokens[editedEnd - 1].text {
+            originalEnd -= 1
+            editedEnd -= 1
+        }
+
+        guard originalStart < originalEnd || editedStart < editedEnd else { return [] }
+
+        if isAlignmentWindowWithinBounds(
+            originalCount: originalEnd - originalStart + alignmentContextTokenCount * 2,
+            editedCount: editedEnd - editedStart + alignmentContextTokenCount * 2
+        ) {
+            return [
+                TokenChangeRange(
+                    originalStart: originalStart,
+                    originalEnd: originalEnd,
+                    editedStart: editedStart,
+                    editedEnd: editedEnd
+                ),
+            ]
+        }
+
+        guard depth < maxAlignmentSegmentationDepth,
+              let anchor = bestCommonTokenAnchor(
+                originalTokens: originalTokens,
+                editedTokens: editedTokens,
+                originalStart: originalStart,
+                originalEnd: originalEnd,
+                editedStart: editedStart,
+                editedEnd: editedEnd
+              )
+        else { return [] }
+
+        let left = changedTokenRanges(
+            originalTokens: originalTokens,
+            editedTokens: editedTokens,
+            originalStart: originalStart,
+            originalEnd: anchor.originalStart,
+            editedStart: editedStart,
+            editedEnd: anchor.editedStart,
+            depth: depth + 1
+        )
+        let right = changedTokenRanges(
+            originalTokens: originalTokens,
+            editedTokens: editedTokens,
+            originalStart: anchor.originalStart + anchor.length,
+            originalEnd: originalEnd,
+            editedStart: anchor.editedStart + anchor.length,
+            editedEnd: editedEnd,
+            depth: depth + 1
+        )
+        return left + right
+    }
+
+    private static func isAlignmentWindowWithinBounds(originalCount: Int, editedCount: Int) -> Bool {
+        guard originalCount > 0,
+              editedCount > 0,
+              originalCount <= maxAlignmentWindowTokens,
+              editedCount <= maxAlignmentWindowTokens
+        else { return false }
+        return (originalCount + 1) * (editedCount + 1) <= maxAlignmentCellCount
+    }
+
+    private static func bestCommonTokenAnchor(
+        originalTokens: [WordToken],
+        editedTokens: [WordToken],
+        originalStart: Int,
+        originalEnd: Int,
+        editedStart: Int,
+        editedEnd: Int
+    ) -> TokenAnchor? {
+        let maxLength = min(alignmentAnchorTokenCount, originalEnd - originalStart, editedEnd - editedStart)
+        guard maxLength >= 2 else { return nil }
+
+        for length in stride(from: maxLength, through: 2, by: -1) {
+            var originalPositionsByKey: [String: [Int]] = [:]
+            var editedPositionsByKey: [String: [Int]] = [:]
+
+            if originalEnd - originalStart >= length {
+                for index in originalStart...(originalEnd - length) {
+                    originalPositionsByKey[tokenWindowKey(originalTokens, start: index, length: length), default: []].append(index)
+                }
+            }
+            if editedEnd - editedStart >= length {
+                for index in editedStart...(editedEnd - length) {
+                    editedPositionsByKey[tokenWindowKey(editedTokens, start: index, length: length), default: []].append(index)
+                }
+            }
+
+            var bestAnchor: TokenAnchor?
+            var bestScore = Int.max
+            let originalMidpoint = (originalStart + originalEnd) / 2
+            let editedMidpoint = (editedStart + editedEnd) / 2
+
+            for key in originalPositionsByKey.keys.sorted() {
+                guard let originalPositions = originalPositionsByKey[key] else { continue }
+                guard originalPositions.count == 1,
+                      let editedPositions = editedPositionsByKey[key],
+                      editedPositions.count == 1,
+                      let originalPosition = originalPositions.first,
+                      let editedPosition = editedPositions.first
+                else { continue }
+
+                let anchor = TokenAnchor(
+                    originalStart: originalPosition,
+                    editedStart: editedPosition,
+                    length: length
+                )
+                guard splitsChangedRange(
+                    anchor: anchor,
+                    originalStart: originalStart,
+                    originalEnd: originalEnd,
+                    editedStart: editedStart,
+                    editedEnd: editedEnd
+                ) else { continue }
+
+                let originalCenter = originalPosition + length / 2
+                let editedCenter = editedPosition + length / 2
+                let score = abs(originalCenter - originalMidpoint) + abs(editedCenter - editedMidpoint)
+                if score < bestScore {
+                    bestScore = score
+                    bestAnchor = anchor
+                }
+            }
+
+            if let bestAnchor {
+                return bestAnchor
+            }
+        }
+        return nil
+    }
+
+    private static func splitsChangedRange(
+        anchor: TokenAnchor,
+        originalStart: Int,
+        originalEnd: Int,
+        editedStart: Int,
+        editedEnd: Int
+    ) -> Bool {
+        let hasLeftSide = anchor.originalStart > originalStart || anchor.editedStart > editedStart
+        let hasRightSide = anchor.originalStart + anchor.length < originalEnd || anchor.editedStart + anchor.length < editedEnd
+        return hasLeftSide && hasRightSide
+    }
+
+    private static func tokenWindowKey(_ tokens: [WordToken], start: Int, length: Int) -> String {
+        tokens[start..<(start + length)].map(\.text).joined(separator: "\u{1f}")
     }
 
     private struct TokenChangeRun {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -390,24 +390,27 @@ struct DictionaryCorrectionDetector {
 }
 
 struct DictationCorrectionSnapshotStabilizer {
-    private var currentSnapshot: String?
-    private var currentSnapshotChangedAt: Date?
-    private var lastEvaluatedSnapshot: String?
+    private var snapshotChangedAt: [String: Date] = [:]
+    private var evaluatedSnapshots = Set<String>()
 
-    mutating func observe(snapshot: String?, now: Date, quietWindow: TimeInterval) -> String? {
-        guard let snapshot else { return nil }
-        guard currentSnapshot == snapshot else {
-            currentSnapshot = snapshot
-            currentSnapshotChangedAt = now
-            return nil
+    mutating func observe(snapshots: [String], now: Date, quietWindow: TimeInterval) -> [String] {
+        let currentSnapshots = Set(snapshots)
+        snapshotChangedAt = snapshotChangedAt.filter { currentSnapshots.contains($0.key) }
+
+        for snapshot in snapshots where snapshotChangedAt[snapshot] == nil {
+            snapshotChangedAt[snapshot] = now
         }
-        guard lastEvaluatedSnapshot != snapshot,
-              let currentSnapshotChangedAt,
-              now.timeIntervalSince(currentSnapshotChangedAt) >= quietWindow
-        else { return nil }
 
-        lastEvaluatedSnapshot = snapshot
-        return snapshot
+        var stableSnapshots: [String] = []
+        for snapshot in snapshots {
+            guard !evaluatedSnapshots.contains(snapshot),
+                  let changedAt = snapshotChangedAt[snapshot],
+                  now.timeIntervalSince(changedAt) >= quietWindow
+            else { continue }
+            evaluatedSnapshots.insert(snapshot)
+            stableSnapshots.append(snapshot)
+        }
+        return stableSnapshots
     }
 }
 
@@ -439,18 +442,19 @@ final class DictationCorrectionMonitor {
             var stabilizer = DictationCorrectionSnapshotStabilizer()
             try? await Task.sleep(nanoseconds: Self.initialPollDelayNanoseconds)
             while !Task.isCancelled, Date() < deadline {
-                let snapshot = await Task.detached(priority: .utility) {
-                    Self.detectEditedSnapshot(
+                let snapshots = await Task.detached(priority: .utility) {
+                    Self.detectEditedSnapshots(
                         originalText: originalText,
                         targetApp: targetApp
                     )
                 }.value
                 if Task.isCancelled { return }
-                if let stableSnapshot = stabilizer.observe(
-                    snapshot: snapshot,
+                let stableSnapshots = stabilizer.observe(
+                    snapshots: snapshots,
                     now: Date(),
                     quietWindow: Self.snapshotQuietWindowSeconds
-                ) {
+                )
+                for stableSnapshot in stableSnapshots {
                     let suggestion = await Task.detached(priority: .utility) {
                         Self.suggestion(
                             originalText: originalText,
@@ -494,36 +498,35 @@ final class DictationCorrectionMonitor {
         )
     }
 
-    nonisolated private static func detectEditedSnapshot(
+    nonisolated private static func detectEditedSnapshots(
         originalText: String,
         targetApp: DictationCorrectionTargetApp?
-    ) -> String? {
+    ) -> [String] {
         var seen = Set<String>()
+        var snapshots: [String] = []
 
-        func snapshot(from value: String?) -> String? {
+        func addSnapshot(from value: String?) {
             guard let snapshot = normalizedSnapshot(value, originalText: originalText),
                   !seen.contains(snapshot),
                   DictionaryCorrectionDetector.hasSufficientSharedContext(
                       originalText: originalText,
                       editedText: snapshot
                   )
-            else { return nil }
+            else { return }
             seen.insert(snapshot)
-            return snapshot
+            snapshots.append(snapshot)
         }
 
         var focusedProcessID: pid_t?
-        if let focusedSnapshot = systemFocusedTextSnapshot(
+        addSnapshot(from: systemFocusedTextSnapshot(
             maxCharacters: maxCandidateCharacters,
             processID: &focusedProcessID
-        ).flatMap(snapshot(from:)) {
-            return focusedSnapshot
-        }
+        ))
 
-        if let targetApp, targetApp.processID != focusedProcessID {
-            return collectTextSnapshots(fromProcessID: targetApp.processID, evaluate: snapshot(from:))
+        if let targetApp {
+            collectTextSnapshots(fromProcessID: targetApp.processID, add: addSnapshot(from:))
         }
-        return nil
+        return snapshots
     }
 
     nonisolated private static func normalizedSnapshot(_ value: String?, originalText: String) -> String? {
@@ -545,8 +548,8 @@ final class DictationCorrectionMonitor {
 
     nonisolated private static func collectTextSnapshots(
         fromProcessID processID: pid_t,
-        evaluate: (String?) -> String?
-    ) -> String? {
+        add: (String?) -> Void
+    ) {
         let axApp = AXUIElementCreateApplication(processID)
         var roots: [AXUIElement] = []
 
@@ -564,18 +567,15 @@ final class DictationCorrectionMonitor {
         var remainingNodes = maxAccessibilityNodes
         var visited = Set<String>()
         for root in roots {
-            if let suggestion = collectTextSnapshots(
+            collectTextSnapshots(
                 from: root,
                 depth: 0,
                 remainingNodes: &remainingNodes,
                 visited: &visited,
-                evaluate: evaluate
-            ) {
-                return suggestion
-            }
-            if remainingNodes <= 0 { return nil }
+                add: add
+            )
+            if remainingNodes <= 0 { return }
         }
-        return nil
     }
 
     nonisolated private static func collectTextSnapshots(
@@ -583,18 +583,17 @@ final class DictationCorrectionMonitor {
         depth: Int,
         remainingNodes: inout Int,
         visited: inout Set<String>,
-        evaluate: (String?) -> String?
-    ) -> String? {
-        guard depth <= 8, remainingNodes > 0 else { return nil }
+        add: (String?) -> Void
+    ) {
+        guard depth <= 8, remainingNodes > 0 else { return }
         let visitKey = elementVisitKey(element)
-        guard !visited.contains(visitKey) else { return nil }
+        guard !visited.contains(visitKey) else { return }
         visited.insert(visitKey)
         remainingNodes -= 1
 
         var valueRef: CFTypeRef?
-        if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success,
-           let suggestion = evaluate(valueRef as? String) {
-            return suggestion
+        if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success {
+            add(valueRef as? String)
         }
 
         for childAttribute in [
@@ -603,19 +602,16 @@ final class DictationCorrectionMonitor {
             kAXContentsAttribute,
         ] {
             for child in axElementArrayAttribute(childAttribute, from: element) {
-                if let suggestion = collectTextSnapshots(
+                collectTextSnapshots(
                     from: child,
                     depth: depth + 1,
                     remainingNodes: &remainingNodes,
                     visited: &visited,
-                    evaluate: evaluate
-                ) {
-                    return suggestion
-                }
-                if remainingNodes <= 0 { return nil }
+                    add: add
+                )
+                if remainingNodes <= 0 { return }
             }
         }
-        return nil
     }
 
     nonisolated private static func systemFocusedTextSnapshot(

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -121,6 +121,9 @@ struct DictionaryCorrectionDetector {
               let replacement = normalizedCandidate(diff.inserted)
         else { return nil }
 
+        guard isSingleTokenCandidate(observed), isSingleTokenCandidate(replacement) else {
+            return nil
+        }
         guard originalText.range(of: observed, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
             return nil
         }
@@ -153,8 +156,11 @@ struct DictionaryCorrectionDetector {
         let operations = alignmentOperations(from: originalTokens, to: editedTokens)
         var suggestions: [DictionarySuggestion] = []
         var seenKeys = Set<String>()
-        for operation in operations {
+        for (index, operation) in operations.enumerated() {
             guard case .substitution(let observed, let replacement) = operation else { continue }
+            guard !isAdjacentToTokenCountChange(index: index, operations: operations) else {
+                continue
+            }
             guard let observedCandidate = normalizedCandidate(observed.text),
                   let replacementCandidate = normalizedCandidate(replacement.text)
             else { continue }
@@ -177,6 +183,18 @@ struct DictionaryCorrectionDetector {
             }
         }
         return suggestions
+    }
+
+    private static func isAdjacentToTokenCountChange(index: Int, operations: [AlignmentOperation]) -> Bool {
+        for adjacentIndex in [index - 1, index + 1] where operations.indices.contains(adjacentIndex) {
+            switch operations[adjacentIndex] {
+            case .insertion, .deletion:
+                return true
+            case .match, .substitution:
+                continue
+            }
+        }
+        return false
     }
 
     static func hasSufficientSharedContext(originalText: String, editedText: String) -> Bool {
@@ -336,6 +354,10 @@ struct DictionaryCorrectionDetector {
         }) else { return nil }
 
         return tokens.joined(separator: " ")
+    }
+
+    private static func isSingleTokenCandidate(_ value: String) -> Bool {
+        value.split(whereSeparator: \.isWhitespace).count == 1
     }
 
     private static func isLikelyDictionaryCorrection(observed: String, replacement: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -819,6 +819,8 @@ struct DictationCorrectionSnapshotStabilizer {
                   let changedAt = snapshotChangedAt[snapshot],
                   now.timeIntervalSince(changedAt) >= quietWindow
             else { continue }
+            // Content-addressed stabilization intentionally evaluates each exact
+            // snapshot once; later edits must produce a different snapshot to run.
             evaluatedSnapshots.insert(snapshot)
             stableSnapshots.append(snapshot)
         }
@@ -839,8 +841,12 @@ final class DictationCorrectionMonitor {
     nonisolated private static let maxSuggestionsPerSession = 3
     nonisolated private static let maxAccessibilityNodes = 140
     nonisolated private static let maxCandidateCharacters = 2_000
+    nonisolated private static let maxEnglishWordRecognitionCacheEntries = 5_000
 
+    // MainActor-isolated by the enclosing type; NSSpellChecker is only touched
+    // while filling this cache before detached detector work starts.
     private static var englishWordRecognitionCache: [String: Bool] = [:]
+    private static var englishWordRecognitionCacheOrder: [String] = []
 
     private var task: Task<Void, Never>?
 
@@ -976,13 +982,25 @@ final class DictationCorrectionMonitor {
                     wordCount: nil
                 )
                 isRecognized = range.location == NSNotFound
-                englishWordRecognitionCache[candidate] = isRecognized
+                cacheEnglishWordRecognition(candidate, isRecognized: isRecognized)
             }
             if isRecognized {
                 recognizedWords.insert(candidate)
             }
         }
         return recognizedWords
+    }
+
+    private static func cacheEnglishWordRecognition(_ candidate: String, isRecognized: Bool) {
+        if englishWordRecognitionCache[candidate] == nil {
+            englishWordRecognitionCacheOrder.append(candidate)
+        }
+        englishWordRecognitionCache[candidate] = isRecognized
+
+        while englishWordRecognitionCacheOrder.count > maxEnglishWordRecognitionCacheEntries {
+            let evicted = englishWordRecognitionCacheOrder.removeFirst()
+            englishWordRecognitionCache.removeValue(forKey: evicted)
+        }
     }
 
     private static func englishWordCandidates(in texts: [String]) -> Set<String> {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -23,6 +23,10 @@ struct DictationCorrectionTargetApp: Sendable {
 struct DictionaryCorrectionDetector {
     private static let minimumCorrectionSimilarity = 0.64
     private static let maxObservedTokensPerDictionaryWord = 2
+    private static let alignmentContextTokenCount = 4
+    private static let maxAlignmentWindowTokens = 96
+    private static let maxAlignmentCellCount = 12_000
+    private static let spellChecker = NSSpellChecker()
 
     private struct CorrectionCandidate {
         let observed: String
@@ -196,9 +200,9 @@ struct DictionaryCorrectionDetector {
         let originalTokens = wordTokens(in: originalText)
         let editedTokens = wordTokens(in: editedText)
         guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return [] }
-        guard originalTokens.count <= 160, editedTokens.count <= 220 else { return [] }
+        guard let tokenWindow = alignmentTokenWindow(from: originalTokens, to: editedTokens) else { return [] }
 
-        let operations = alignmentOperations(from: originalTokens, to: editedTokens)
+        let operations = alignmentOperations(from: tokenWindow.original, to: tokenWindow.edited)
         var candidates: [CorrectionCandidate] = []
         var seenKeys = Set<String>()
 
@@ -221,6 +225,46 @@ struct DictionaryCorrectionDetector {
             if candidates.count >= maxCandidates { break }
         }
         return candidates
+    }
+
+    private static func alignmentTokenWindow(
+        from originalTokens: [WordToken],
+        to editedTokens: [WordToken]
+    ) -> (original: [WordToken], edited: [WordToken])? {
+        var prefix = 0
+        while prefix < originalTokens.count,
+              prefix < editedTokens.count,
+              originalTokens[prefix].normalized == editedTokens[prefix].normalized {
+            prefix += 1
+        }
+
+        var originalSuffix = originalTokens.count
+        var editedSuffix = editedTokens.count
+        while originalSuffix > prefix,
+              editedSuffix > prefix,
+              originalTokens[originalSuffix - 1].normalized == editedTokens[editedSuffix - 1].normalized {
+            originalSuffix -= 1
+            editedSuffix -= 1
+        }
+
+        let originalStart = max(0, prefix - alignmentContextTokenCount)
+        let editedStart = max(0, prefix - alignmentContextTokenCount)
+        let originalEnd = min(originalTokens.count, originalSuffix + alignmentContextTokenCount)
+        let editedEnd = min(editedTokens.count, editedSuffix + alignmentContextTokenCount)
+        let originalWindowCount = originalEnd - originalStart
+        let editedWindowCount = editedEnd - editedStart
+
+        guard originalWindowCount > 0,
+              editedWindowCount > 0,
+              originalWindowCount <= maxAlignmentWindowTokens,
+              editedWindowCount <= maxAlignmentWindowTokens,
+              (originalWindowCount + 1) * (editedWindowCount + 1) <= maxAlignmentCellCount
+        else { return nil }
+
+        return (
+            Array(originalTokens[originalStart..<originalEnd]),
+            Array(editedTokens[editedStart..<editedEnd])
+        )
     }
 
     private struct TokenChangeRun {
@@ -695,7 +739,7 @@ struct DictionaryCorrectionDetector {
         let initials = observedTokens.compactMap { $0.first?.lowercased() }.joined()
         let replacementLetters = replacement.lowercased().filter(\.isLetter)
         guard !initials.isEmpty, !replacementLetters.isEmpty else { return false }
-        return replacementLetters.hasPrefix(initials)
+        return replacementLetters == initials
     }
 
     private static func isCommonWordTruncation(observed: String, replacement: String) -> Bool {
@@ -714,7 +758,7 @@ struct DictionaryCorrectionDetector {
     private static func isRecognizedEnglishWord(_ value: String) -> Bool {
         spellCheckerLock.lock()
         defer { spellCheckerLock.unlock() }
-        let range = NSSpellChecker().checkSpelling(
+        let range = spellChecker.checkSpelling(
             of: value,
             startingAt: 0,
             language: "en",

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -1128,11 +1128,7 @@ final class DictationCorrectionMonitor {
             snapshots.append(snapshot)
         }
 
-        var focusedProcessID: pid_t?
-        addSnapshot(from: systemFocusedTextSnapshot(
-            maxCharacters: maxCandidateCharacters,
-            processID: &focusedProcessID
-        ))
+        addSnapshot(from: systemFocusedTextSnapshot(maxCharacters: maxCandidateCharacters))
 
         if let targetApp {
             collectTextSnapshots(fromProcessID: targetApp.processID, add: addSnapshot(from:))
@@ -1229,8 +1225,7 @@ final class DictationCorrectionMonitor {
     }
 
     nonisolated private static func systemFocusedTextSnapshot(
-        maxCharacters: Int = 20_000,
-        processID focusedProcessID: inout pid_t?
+        maxCharacters: Int = 20_000
     ) -> String? {
         let system = AXUIElementCreateSystemWide()
         var focusedRef: CFTypeRef?
@@ -1240,10 +1235,6 @@ final class DictationCorrectionMonitor {
         else { return nil }
 
         let element = focused as! AXUIElement
-        var pid: pid_t = 0
-        if AXUIElementGetPid(element, &pid) == .success {
-            focusedProcessID = pid
-        }
         return textSnapshot(from: element, maxCharacters: maxCharacters)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -434,7 +434,17 @@ struct DictionaryCorrectionDetector {
         guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return false }
 
         if originalTokens.count <= 3 {
-            return true
+            let editedTokenSet = Set(editedTokens)
+            let anchorTokens = originalTokens.filter { token in
+                token.count >= 3 && !commonWords.contains(token)
+            }
+            if anchorTokens.contains(where: editedTokenSet.contains) {
+                return true
+            }
+
+            let compactOriginal = originalTokens.joined()
+            let compactEdited = editedTokens.joined()
+            return CustomWordMatcher.jaroWinklerSimilarity(compactOriginal, compactEdited) >= minimumCorrectionSimilarity
         }
 
         let anchorLength = originalTokens.count == 4 ? 2 : min(4, originalTokens.count - 2)
@@ -463,6 +473,9 @@ struct DictionaryCorrectionDetector {
             current = ""
         }
 
+        // Keep dictionary-significant separators inside tokens; boundary
+        // normalization later trims surrounding punctuation without discarding
+        // product/domain forms like sc-domain, API_v2, or foo/bar.
         for character in text {
             if character.isLetter || character.isNumber || character == "-" || character == "_" || character == "/" || character == "+" {
                 current.append(character)
@@ -835,6 +848,56 @@ struct DictationCorrectionSnapshotStabilizer {
     }
 }
 
+private actor EnglishWordRecognizer {
+    private let maxEntries: Int
+    private let spellChecker = NSSpellChecker()
+    private var cache: [String: Bool] = [:]
+    private var cacheOrder: [String] = []
+
+    init(maxEntries: Int) {
+        self.maxEntries = maxEntries
+    }
+
+    func recognizedWords(from candidates: Set<String>) -> Set<String> {
+        guard !candidates.isEmpty else { return [] }
+
+        var recognizedWords = Set<String>()
+        for candidate in candidates.sorted() {
+            let isRecognized: Bool
+            if let cached = cache[candidate] {
+                isRecognized = cached
+            } else {
+                let range = spellChecker.checkSpelling(
+                    of: candidate,
+                    startingAt: 0,
+                    language: "en",
+                    wrap: false,
+                    inSpellDocumentWithTag: 0,
+                    wordCount: nil
+                )
+                isRecognized = range.location == NSNotFound
+                store(candidate, isRecognized: isRecognized)
+            }
+            if isRecognized {
+                recognizedWords.insert(candidate)
+            }
+        }
+        return recognizedWords
+    }
+
+    private func store(_ candidate: String, isRecognized: Bool) {
+        if cache[candidate] == nil {
+            cacheOrder.append(candidate)
+        }
+        cache[candidate] = isRecognized
+
+        while cacheOrder.count > maxEntries {
+            let evicted = cacheOrder.removeFirst()
+            cache.removeValue(forKey: evicted)
+        }
+    }
+}
+
 @MainActor
 final class DictationCorrectionMonitor {
     nonisolated private static let logger = Logger(subsystem: "com.muesli.native", category: "DictionaryCorrection")
@@ -849,11 +912,7 @@ final class DictationCorrectionMonitor {
     nonisolated private static let maxAccessibilityNodes = 140
     nonisolated private static let maxCandidateCharacters = 2_000
     nonisolated private static let maxEnglishWordRecognitionCacheEntries = 5_000
-
-    // MainActor-isolated by the enclosing type; NSSpellChecker is only touched
-    // while filling this cache before detached detector work starts.
-    private static var englishWordRecognitionCache: [String: Bool] = [:]
-    private static var englishWordRecognitionCacheOrder: [String] = []
+    private static let englishWordRecognizer = EnglishWordRecognizer(maxEntries: maxEnglishWordRecognitionCacheEntries)
 
     private var task: Task<Void, Never>?
 
@@ -909,7 +968,10 @@ final class DictationCorrectionMonitor {
                     Self.log("poll=\(pollCount) stableSnapshots=\(stableSnapshots.count)")
                 }
                 for stableSnapshot in stableSnapshots {
-                    let recognizedEnglishWords = Self.recognizedEnglishWords(in: [originalText, stableSnapshot])
+                    let recognizedEnglishWords = await Self.englishWordRecognizer.recognizedWords(
+                        from: Self.englishWordCandidates(in: [originalText, stableSnapshot])
+                    )
+                    if Task.isCancelled { return }
                     let suggestions = await Task.detached(priority: .utility) {
                         Self.suggestions(
                             originalText: originalText,
@@ -969,48 +1031,7 @@ final class DictationCorrectionMonitor {
         )
     }
 
-    private static func recognizedEnglishWords(in texts: [String]) -> Set<String> {
-        let candidates = englishWordCandidates(in: texts)
-        guard !candidates.isEmpty else { return [] }
-
-        var recognizedWords = Set<String>()
-        let spellChecker = NSSpellChecker.shared
-        for candidate in candidates {
-            let isRecognized: Bool
-            if let cached = englishWordRecognitionCache[candidate] {
-                isRecognized = cached
-            } else {
-                let range = spellChecker.checkSpelling(
-                    of: candidate,
-                    startingAt: 0,
-                    language: "en",
-                    wrap: false,
-                    inSpellDocumentWithTag: 0,
-                    wordCount: nil
-                )
-                isRecognized = range.location == NSNotFound
-                cacheEnglishWordRecognition(candidate, isRecognized: isRecognized)
-            }
-            if isRecognized {
-                recognizedWords.insert(candidate)
-            }
-        }
-        return recognizedWords
-    }
-
-    private static func cacheEnglishWordRecognition(_ candidate: String, isRecognized: Bool) {
-        if englishWordRecognitionCache[candidate] == nil {
-            englishWordRecognitionCacheOrder.append(candidate)
-        }
-        englishWordRecognitionCache[candidate] = isRecognized
-
-        while englishWordRecognitionCacheOrder.count > maxEnglishWordRecognitionCacheEntries {
-            let evicted = englishWordRecognitionCacheOrder.removeFirst()
-            englishWordRecognitionCache.removeValue(forKey: evicted)
-        }
-    }
-
-    private static func englishWordCandidates(in texts: [String]) -> Set<String> {
+    nonisolated private static func englishWordCandidates(in texts: [String]) -> Set<String> {
         var candidates = Set<String>()
         for text in texts {
             for token in text.lowercased().split(whereSeparator: { !$0.isLetter }) {
@@ -1128,12 +1149,16 @@ final class DictationCorrectionMonitor {
             add(valueRef as? String)
         }
 
-        for childAttribute in [
-            kAXVisibleChildrenAttribute,
-            kAXChildrenAttribute,
-            kAXContentsAttribute,
-        ] {
-            for child in axElementArrayAttribute(childAttribute, from: element) {
+        let visibleChildren = axElementArrayAttribute(kAXVisibleChildrenAttribute, from: element)
+        let fallbackAttributes = visibleChildren.isEmpty
+            ? [kAXChildrenAttribute, kAXContentsAttribute]
+            : []
+        let childGroups = [visibleChildren] + fallbackAttributes.map {
+            axElementArrayAttribute($0, from: element)
+        }
+
+        for childGroup in childGroups {
+            for child in childGroup {
                 collectTextSnapshots(
                     from: child,
                     depth: depth + 1,

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -330,7 +330,51 @@ struct DictionaryCorrectionDetector {
             return hasSpecialDictionarySignal || replacement.contains(where: \.isUppercase)
         }
 
+        guard !isPlainSingleCharacterEdit(observed: normalizedObserved, replacement: normalizedReplacement) else {
+            return false
+        }
+
         return similarity >= minimumCorrectionSimilarity || hasSpecialDictionarySignal
+    }
+
+    private static func isPlainSingleCharacterEdit(observed: String, replacement: String) -> Bool {
+        guard observed.split(whereSeparator: \.isWhitespace).count == 1,
+              replacement.split(whereSeparator: \.isWhitespace).count == 1,
+              observed.allSatisfy({ $0.isLowercase || $0.isNumber }),
+              replacement.allSatisfy({ $0.isLowercase || $0.isNumber })
+        else { return false }
+
+        return boundedEditDistance(observed, replacement, limit: 1) <= 1
+    }
+
+    private static func boundedEditDistance(_ lhs: String, _ rhs: String, limit: Int) -> Int {
+        let lhsChars = Array(lhs)
+        let rhsChars = Array(rhs)
+        guard abs(lhsChars.count - rhsChars.count) <= limit else {
+            return limit + 1
+        }
+        guard !lhsChars.isEmpty else { return rhsChars.count }
+        guard !rhsChars.isEmpty else { return lhsChars.count }
+
+        var previous = Array(0...rhsChars.count)
+        for row in 1...lhsChars.count {
+            var current = [row] + Array(repeating: 0, count: rhsChars.count)
+            var rowMinimum = current[0]
+            for column in 1...rhsChars.count {
+                let substitutionCost = lhsChars[row - 1] == rhsChars[column - 1] ? 0 : 1
+                current[column] = min(
+                    previous[column] + 1,
+                    current[column - 1] + 1,
+                    previous[column - 1] + substitutionCost
+                )
+                rowMinimum = min(rowMinimum, current[column])
+            }
+            if rowMinimum > limit {
+                return limit + 1
+            }
+            previous = current
+        }
+        return previous[rhsChars.count]
     }
 
     private static func hasInternalCapital(_ value: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -23,11 +23,8 @@ struct DictationCorrectionTargetApp: Sendable {
 struct DictionaryCorrectionDetector {
     private static let minimumCorrectionSimilarity = 0.64
     private static let maxObservedTokensPerDictionaryWord = 2
-    private static let alignmentContextTokenCount = 4
-    private static let alignmentAnchorTokenCount = 4
-    private static let maxAlignmentWindowTokens = 96
-    private static let maxAlignmentCellCount = 12_000
-    private static let maxAlignmentSegmentationDepth = 12
+    private static let maxAlignmentTokens = 320
+    private static let maxAlignmentCellCount = 120_000
     private static let spellChecker = NSSpellChecker()
 
     private struct CorrectionCandidate {
@@ -202,6 +199,10 @@ struct DictionaryCorrectionDetector {
         let originalTokens = wordTokens(in: originalText)
         let editedTokens = wordTokens(in: editedText)
         guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return [] }
+        guard isAlignmentInputWithinBounds(
+            originalCount: originalTokens.count,
+            editedCount: editedTokens.count
+        ) else { return [] }
 
         var candidates: [CorrectionCandidate] = []
         var seenKeys = Set<String>()
@@ -214,240 +215,27 @@ struct DictionaryCorrectionDetector {
             candidates.append(candidate)
         }
 
-        for tokenWindow in alignmentTokenWindows(from: originalTokens, to: editedTokens) {
-            let operations = alignmentOperations(from: tokenWindow.original, to: tokenWindow.edited)
-            for run in tokenChangeRuns(in: operations) {
-                for candidate in candidatesFromTokenRun(
-                    fromTokenRun: run,
-                    originalText: originalText,
-                    maxCandidates: maxCandidates - candidates.count
-                ) {
-                    append(candidate)
-                }
-                if candidates.count >= maxCandidates { break }
+        let operations = alignmentOperations(from: originalTokens, to: editedTokens)
+        for run in tokenChangeRuns(in: operations) {
+            for candidate in candidatesFromTokenRun(
+                fromTokenRun: run,
+                originalText: originalText,
+                maxCandidates: maxCandidates - candidates.count
+            ) {
+                append(candidate)
             }
             if candidates.count >= maxCandidates { break }
         }
         return candidates
     }
 
-    private struct AlignmentTokenWindow {
-        let original: [WordToken]
-        let edited: [WordToken]
-    }
-
-    private struct TokenChangeRange {
-        let originalStart: Int
-        let originalEnd: Int
-        let editedStart: Int
-        let editedEnd: Int
-    }
-
-    private struct TokenAnchor {
-        let originalStart: Int
-        let editedStart: Int
-        let length: Int
-    }
-
-    private static func alignmentTokenWindows(
-        from originalTokens: [WordToken],
-        to editedTokens: [WordToken]
-    ) -> [AlignmentTokenWindow] {
-        let ranges = changedTokenRanges(
-            originalTokens: originalTokens,
-            editedTokens: editedTokens,
-            originalStart: 0,
-            originalEnd: originalTokens.count,
-            editedStart: 0,
-            editedEnd: editedTokens.count,
-            depth: 0
-        )
-
-        return ranges.compactMap { range in
-            let originalStart = max(0, range.originalStart - alignmentContextTokenCount)
-            let editedStart = max(0, range.editedStart - alignmentContextTokenCount)
-            let originalEnd = min(originalTokens.count, range.originalEnd + alignmentContextTokenCount)
-            let editedEnd = min(editedTokens.count, range.editedEnd + alignmentContextTokenCount)
-            guard isAlignmentWindowWithinBounds(
-                originalCount: originalEnd - originalStart,
-                editedCount: editedEnd - editedStart
-            ) else { return nil }
-            return AlignmentTokenWindow(
-                original: Array(originalTokens[originalStart..<originalEnd]),
-                edited: Array(editedTokens[editedStart..<editedEnd])
-            )
-        }
-    }
-
-    // Split large AX snapshots into local edit islands so distant edits do not suppress each other.
-    private static func changedTokenRanges(
-        originalTokens: [WordToken],
-        editedTokens: [WordToken],
-        originalStart: Int,
-        originalEnd: Int,
-        editedStart: Int,
-        editedEnd: Int,
-        depth: Int
-    ) -> [TokenChangeRange] {
-        var originalStart = originalStart
-        var editedStart = editedStart
-        var originalEnd = originalEnd
-        var editedEnd = editedEnd
-
-        while originalStart < originalEnd,
-              editedStart < editedEnd,
-              originalTokens[originalStart].text == editedTokens[editedStart].text {
-            originalStart += 1
-            editedStart += 1
-        }
-
-        while originalEnd > originalStart,
-              editedEnd > editedStart,
-              originalTokens[originalEnd - 1].text == editedTokens[editedEnd - 1].text {
-            originalEnd -= 1
-            editedEnd -= 1
-        }
-
-        guard originalStart < originalEnd || editedStart < editedEnd else { return [] }
-
-        if isAlignmentWindowWithinBounds(
-            originalCount: originalEnd - originalStart + alignmentContextTokenCount * 2,
-            editedCount: editedEnd - editedStart + alignmentContextTokenCount * 2
-        ) {
-            return [
-                TokenChangeRange(
-                    originalStart: originalStart,
-                    originalEnd: originalEnd,
-                    editedStart: editedStart,
-                    editedEnd: editedEnd
-                ),
-            ]
-        }
-
-        guard depth < maxAlignmentSegmentationDepth,
-              let anchor = bestCommonTokenAnchor(
-                originalTokens: originalTokens,
-                editedTokens: editedTokens,
-                originalStart: originalStart,
-                originalEnd: originalEnd,
-                editedStart: editedStart,
-                editedEnd: editedEnd
-              )
-        else { return [] }
-
-        let left = changedTokenRanges(
-            originalTokens: originalTokens,
-            editedTokens: editedTokens,
-            originalStart: originalStart,
-            originalEnd: anchor.originalStart,
-            editedStart: editedStart,
-            editedEnd: anchor.editedStart,
-            depth: depth + 1
-        )
-        let right = changedTokenRanges(
-            originalTokens: originalTokens,
-            editedTokens: editedTokens,
-            originalStart: anchor.originalStart + anchor.length,
-            originalEnd: originalEnd,
-            editedStart: anchor.editedStart + anchor.length,
-            editedEnd: editedEnd,
-            depth: depth + 1
-        )
-        return left + right
-    }
-
-    private static func isAlignmentWindowWithinBounds(originalCount: Int, editedCount: Int) -> Bool {
+    private static func isAlignmentInputWithinBounds(originalCount: Int, editedCount: Int) -> Bool {
         guard originalCount > 0,
               editedCount > 0,
-              originalCount <= maxAlignmentWindowTokens,
-              editedCount <= maxAlignmentWindowTokens
+              originalCount <= maxAlignmentTokens,
+              editedCount <= maxAlignmentTokens
         else { return false }
         return (originalCount + 1) * (editedCount + 1) <= maxAlignmentCellCount
-    }
-
-    private static func bestCommonTokenAnchor(
-        originalTokens: [WordToken],
-        editedTokens: [WordToken],
-        originalStart: Int,
-        originalEnd: Int,
-        editedStart: Int,
-        editedEnd: Int
-    ) -> TokenAnchor? {
-        let maxLength = min(alignmentAnchorTokenCount, originalEnd - originalStart, editedEnd - editedStart)
-        guard maxLength >= 2 else { return nil }
-
-        for length in stride(from: maxLength, through: 2, by: -1) {
-            var originalPositionsByKey: [String: [Int]] = [:]
-            var editedPositionsByKey: [String: [Int]] = [:]
-
-            if originalEnd - originalStart >= length {
-                for index in originalStart...(originalEnd - length) {
-                    originalPositionsByKey[tokenWindowKey(originalTokens, start: index, length: length), default: []].append(index)
-                }
-            }
-            if editedEnd - editedStart >= length {
-                for index in editedStart...(editedEnd - length) {
-                    editedPositionsByKey[tokenWindowKey(editedTokens, start: index, length: length), default: []].append(index)
-                }
-            }
-
-            var bestAnchor: TokenAnchor?
-            var bestScore = Int.max
-            let originalMidpoint = (originalStart + originalEnd) / 2
-            let editedMidpoint = (editedStart + editedEnd) / 2
-
-            for key in originalPositionsByKey.keys.sorted() {
-                guard let originalPositions = originalPositionsByKey[key] else { continue }
-                guard originalPositions.count == 1,
-                      let editedPositions = editedPositionsByKey[key],
-                      editedPositions.count == 1,
-                      let originalPosition = originalPositions.first,
-                      let editedPosition = editedPositions.first
-                else { continue }
-
-                let anchor = TokenAnchor(
-                    originalStart: originalPosition,
-                    editedStart: editedPosition,
-                    length: length
-                )
-                guard splitsChangedRange(
-                    anchor: anchor,
-                    originalStart: originalStart,
-                    originalEnd: originalEnd,
-                    editedStart: editedStart,
-                    editedEnd: editedEnd
-                ) else { continue }
-
-                let originalCenter = originalPosition + length / 2
-                let editedCenter = editedPosition + length / 2
-                let score = abs(originalCenter - originalMidpoint) + abs(editedCenter - editedMidpoint)
-                if score < bestScore {
-                    bestScore = score
-                    bestAnchor = anchor
-                }
-            }
-
-            if let bestAnchor {
-                return bestAnchor
-            }
-        }
-        return nil
-    }
-
-    private static func splitsChangedRange(
-        anchor: TokenAnchor,
-        originalStart: Int,
-        originalEnd: Int,
-        editedStart: Int,
-        editedEnd: Int
-    ) -> Bool {
-        let hasLeftSide = anchor.originalStart > originalStart || anchor.editedStart > editedStart
-        let hasRightSide = anchor.originalStart + anchor.length < originalEnd || anchor.editedStart + anchor.length < editedEnd
-        return hasLeftSide && hasRightSide
-    }
-
-    private static func tokenWindowKey(_ tokens: [WordToken], start: Int, length: Int) -> String {
-        tokens[start..<(start + length)].map(\.text).joined(separator: "\u{1f}")
     }
 
     private struct TokenChangeRun {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -23,8 +23,8 @@ struct DictationCorrectionTargetApp: Sendable {
 struct DictionaryCorrectionDetector {
     private static let minimumCorrectionSimilarity = 0.64
     private static let maxObservedTokensPerDictionaryWord = 2
-    private static let maxAlignmentTokens = 320
-    private static let maxAlignmentCellCount = 120_000
+    private static let maxAlignmentTokens = 512
+    private static let maxAlignmentCellCount = 300_000
     private static let spellChecker = NSSpellChecker()
 
     private struct CorrectionCandidate {
@@ -553,8 +553,8 @@ struct DictionaryCorrectionDetector {
             return false
         }
         if observedTokens.count == 1 {
-            if isAcronymLike(replacement), observed.lowercased() != replacement.lowercased() {
-                return false
+            if isAcronymLike(replacement) {
+                return observed.lowercased() == replacement.lowercased()
             }
             if replacement.contains("-"), !observed.contains("-") {
                 return CustomWordMatcher.jaroWinklerSimilarity(

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -744,6 +744,7 @@ struct DictionaryCorrectionDetector {
         let replacementCharacters = Array(replacement.lowercased())
         guard observedLetters.count >= 4,
               replacementCharacters.count >= 3,
+              replacementCharacters.count < observedLetters.count / 2,
               let firstObserved = observedLetters.first,
               let lastObserved = observedLetters.last,
               replacementCharacters.first == firstObserved,

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -25,7 +25,18 @@ struct DictionaryCorrectionDetector {
     private static let maxObservedTokensPerDictionaryWord = 2
     private static let maxAlignmentTokens = 512
     private static let maxAlignmentCellCount = 300_000
-    private static let spellChecker = NSSpellChecker()
+
+    private struct EnglishWordLookup: Sendable {
+        private let recognizedWords: Set<String>
+
+        init(recognizedWords: Set<String>) {
+            self.recognizedWords = Set(recognizedWords.map { $0.lowercased() })
+        }
+
+        func isRecognized(_ value: String) -> Bool {
+            recognizedWords.contains(value.lowercased())
+        }
+    }
 
     private struct CorrectionCandidate {
         let observed: String
@@ -35,14 +46,16 @@ struct DictionaryCorrectionDetector {
     static func suggestion(
         originalText: String,
         editedText: String,
-        appContext: String = ""
+        appContext: String = "",
+        recognizedEnglishWords: Set<String> = []
     ) -> DictionarySuggestion? {
         suggestions(
             originalText: originalText,
             baselineText: originalText,
             currentText: editedText,
             appContext: appContext,
-            maxSuggestions: 1
+            maxSuggestions: 1,
+            recognizedEnglishWords: recognizedEnglishWords
         ).first
     }
 
@@ -50,14 +63,16 @@ struct DictionaryCorrectionDetector {
         originalText: String,
         editedText: String,
         appContext: String = "",
-        maxSuggestions: Int = Int.max
+        maxSuggestions: Int = Int.max,
+        recognizedEnglishWords: Set<String> = []
     ) -> [DictionarySuggestion] {
         suggestions(
             originalText: originalText,
             baselineText: originalText,
             currentText: editedText,
             appContext: appContext,
-            maxSuggestions: maxSuggestions
+            maxSuggestions: maxSuggestions,
+            recognizedEnglishWords: recognizedEnglishWords
         )
     }
 
@@ -65,14 +80,16 @@ struct DictionaryCorrectionDetector {
         originalText: String,
         baselineText: String,
         currentText: String,
-        appContext: String = ""
+        appContext: String = "",
+        recognizedEnglishWords: Set<String> = []
     ) -> DictionarySuggestion? {
         suggestions(
             originalText: originalText,
             baselineText: baselineText,
             currentText: currentText,
             appContext: appContext,
-            maxSuggestions: 1
+            maxSuggestions: 1,
+            recognizedEnglishWords: recognizedEnglishWords
         ).first
     }
 
@@ -81,7 +98,8 @@ struct DictionaryCorrectionDetector {
         baselineText: String,
         currentText: String,
         appContext: String = "",
-        maxSuggestions: Int = Int.max
+        maxSuggestions: Int = Int.max,
+        recognizedEnglishWords: Set<String> = []
     ) -> [DictionarySuggestion] {
         guard isDetectionRequestValid(
             originalText: originalText,
@@ -90,6 +108,7 @@ struct DictionaryCorrectionDetector {
             maxSuggestions: maxSuggestions
         ) else { return [] }
 
+        let englishWordLookup = EnglishWordLookup(recognizedWords: recognizedEnglishWords)
         var results: [DictionarySuggestion] = []
         var seenKeys = Set<String>()
 
@@ -109,7 +128,8 @@ struct DictionaryCorrectionDetector {
             originalText: originalText,
             baselineText: baselineText,
             currentText: currentText,
-            maxCandidates: maxSuggestions
+            maxCandidates: maxSuggestions,
+            englishWordLookup: englishWordLookup
         ) {
             append(candidate)
         }
@@ -133,7 +153,8 @@ struct DictionaryCorrectionDetector {
         originalText: String,
         baselineText: String,
         currentText: String,
-        maxCandidates: Int
+        maxCandidates: Int,
+        englishWordLookup: EnglishWordLookup
     ) -> [CorrectionCandidate] {
         var candidates: [CorrectionCandidate] = []
 
@@ -145,14 +166,16 @@ struct DictionaryCorrectionDetector {
         append(fragmentCandidate(
             originalText: originalText,
             baselineText: baselineText,
-            currentText: currentText
+            currentText: currentText,
+            englishWordLookup: englishWordLookup
         ))
 
         if candidates.count < maxCandidates {
             for candidate in tokenAlignedCandidates(
                 originalText: originalText,
                 editedText: currentText,
-                maxCandidates: maxCandidates - candidates.count
+                maxCandidates: maxCandidates - candidates.count,
+                englishWordLookup: englishWordLookup
             ) {
                 append(candidate)
             }
@@ -164,7 +187,8 @@ struct DictionaryCorrectionDetector {
     private static func fragmentCandidate(
         originalText: String,
         baselineText: String,
-        currentText: String
+        currentText: String,
+        englishWordLookup: EnglishWordLookup
     ) -> CorrectionCandidate? {
         let diff = changedFragments(from: baselineText, to: currentText)
         guard let observed = normalizedCandidate(diff.removed),
@@ -177,7 +201,11 @@ struct DictionaryCorrectionDetector {
         guard originalText.range(of: observed, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
             return nil
         }
-        guard isLikelyDictionaryCorrection(observed: observed, replacement: replacement) else { return nil }
+        guard isLikelyDictionaryCorrection(
+            observed: observed,
+            replacement: replacement,
+            englishWordLookup: englishWordLookup
+        ) else { return nil }
 
         return CorrectionCandidate(
             observed: observed,
@@ -193,7 +221,8 @@ struct DictionaryCorrectionDetector {
     private static func tokenAlignedCandidates(
         originalText: String,
         editedText: String,
-        maxCandidates: Int
+        maxCandidates: Int,
+        englishWordLookup: EnglishWordLookup
     ) -> [CorrectionCandidate] {
         guard maxCandidates > 0 else { return [] }
         let originalTokens = wordTokens(in: originalText)
@@ -220,7 +249,8 @@ struct DictionaryCorrectionDetector {
             for candidate in candidatesFromTokenRun(
                 fromTokenRun: run,
                 originalText: originalText,
-                maxCandidates: maxCandidates - candidates.count
+                maxCandidates: maxCandidates - candidates.count,
+                englishWordLookup: englishWordLookup
             ) {
                 append(candidate)
             }
@@ -279,7 +309,8 @@ struct DictionaryCorrectionDetector {
     private static func candidatesFromTokenRun(
         fromTokenRun run: TokenChangeRun,
         originalText: String,
-        maxCandidates: Int
+        maxCandidates: Int,
+        englishWordLookup: EnglishWordLookup
     ) -> [CorrectionCandidate] {
         guard maxCandidates > 0 else { return [] }
         var results: [CorrectionCandidate] = []
@@ -299,7 +330,8 @@ struct DictionaryCorrectionDetector {
                 observedTokens: run.observedTokens,
                 observedIndex: observedIndex,
                 replacementToken: replacementToken,
-                originalText: originalText
+                originalText: originalText,
+                englishWordLookup: englishWordLookup
             ) {
                 results.append(bestCandidate)
                 observedIndex += observedLength
@@ -312,7 +344,8 @@ struct DictionaryCorrectionDetector {
         observedTokens: [WordToken],
         observedIndex: Int,
         replacementToken: WordToken,
-        originalText: String
+        originalText: String,
+        englishWordLookup: EnglishWordLookup
     ) -> (CorrectionCandidate, Int)? {
         var bestCandidate: CorrectionCandidate?
         var bestObservedLength = 0
@@ -327,7 +360,11 @@ struct DictionaryCorrectionDetector {
                   let replacementCandidate = normalizedCandidate(replacementToken.text),
                   isWordScopedSuggestion(observed: observedCandidate, replacement: replacementCandidate),
                   originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil,
-                  isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate)
+                  isLikelyDictionaryCorrection(
+                      observed: observedCandidate,
+                      replacement: replacementCandidate,
+                      englishWordLookup: englishWordLookup
+                  )
             else { continue }
 
             let similarity = CustomWordMatcher.jaroWinklerSimilarity(
@@ -576,7 +613,11 @@ struct DictionaryCorrectionDetector {
         return CustomWordMatcher.jaroWinklerSimilarity(compactObserved, compactReplacement) >= minimumCorrectionSimilarity
     }
 
-    private static func isLikelyDictionaryCorrection(observed: String, replacement: String) -> Bool {
+    private static func isLikelyDictionaryCorrection(
+        observed: String,
+        replacement: String,
+        englishWordLookup: EnglishWordLookup
+    ) -> Bool {
         guard observed != replacement else { return false }
         guard observed.count >= 2, replacement.count >= 2 else { return false }
 
@@ -605,14 +646,15 @@ struct DictionaryCorrectionDetector {
                 || isLikelySingleWordSplitCorrection(
                     replacement: replacement,
                     replacementTokens: replacementTokens,
-                    similarity: compactSimilarity
+                    similarity: compactSimilarity,
+                    englishWordLookup: englishWordLookup
                 )
                 || isLikelyStrongDictionaryCorrection(
-                observed: observed,
-                replacement: replacement,
-                observedTokens: observedTokens,
-                similarity: compactSimilarity
-            )
+                    observed: observed,
+                    replacement: replacement,
+                    observedTokens: observedTokens,
+                    similarity: compactSimilarity
+                )
         }
 
         if commonWords.contains(normalizedObserved) {
@@ -630,7 +672,11 @@ struct DictionaryCorrectionDetector {
             return hasFormattingDictionarySignal || replacement.contains(where: \.isUppercase)
         }
 
-        guard !isCommonWordTruncation(observed: normalizedObserved, replacement: normalizedReplacement) else {
+        guard !isCommonWordTruncation(
+            observed: normalizedObserved,
+            replacement: normalizedReplacement,
+            englishWordLookup: englishWordLookup
+        ) else {
             return false
         }
 
@@ -672,7 +718,8 @@ struct DictionaryCorrectionDetector {
     private static func isLikelySingleWordSplitCorrection(
         replacement: String,
         replacementTokens: [String],
-        similarity: Double
+        similarity: Double,
+        englishWordLookup: EnglishWordLookup
     ) -> Bool {
         guard replacementTokens.count == 1,
               !replacement.contains("-"),
@@ -683,7 +730,7 @@ struct DictionaryCorrectionDetector {
               similarity >= minimumCorrectionSimilarity
         else { return false }
         return replacement.contains(where: \.isUppercase)
-            || !isRecognizedEnglishWord(replacement.lowercased())
+            || !englishWordLookup.isRecognized(replacement.lowercased())
     }
 
     private static func isNumericShorthand(observed: String, replacement: String) -> Bool {
@@ -713,31 +760,21 @@ struct DictionaryCorrectionDetector {
         return replacementLetters == initials
     }
 
-    private static func isCommonWordTruncation(observed: String, replacement: String) -> Bool {
+    private static func isCommonWordTruncation(
+        observed: String,
+        replacement: String,
+        englishWordLookup: EnglishWordLookup
+    ) -> Bool {
         guard observed.split(whereSeparator: \.isWhitespace).count == 1,
               replacement.split(whereSeparator: \.isWhitespace).count == 1,
               observed.allSatisfy(\.isLowercase),
               replacement.allSatisfy(\.isLowercase),
               observed != replacement,
               (observed.hasPrefix(replacement) || replacement.hasPrefix(observed)),
-              isRecognizedEnglishWord(observed),
-              isRecognizedEnglishWord(replacement)
+              englishWordLookup.isRecognized(observed),
+              englishWordLookup.isRecognized(replacement)
         else { return false }
         return true
-    }
-
-    private static func isRecognizedEnglishWord(_ value: String) -> Bool {
-        spellCheckerLock.lock()
-        defer { spellCheckerLock.unlock() }
-        let range = spellChecker.checkSpelling(
-            of: value,
-            startingAt: 0,
-            language: "en",
-            wrap: false,
-            inSpellDocumentWithTag: 0,
-            wordCount: nil
-        )
-        return range.location == NSNotFound
     }
 
     private static func hasInternalCapital(_ value: String) -> Bool {
@@ -762,7 +799,6 @@ struct DictionaryCorrectionDetector {
         "what", "when", "where", "which", "who", "will", "with", "would", "you", "your",
     ]
 
-    private static let spellCheckerLock = NSLock()
 }
 
 struct DictationCorrectionSnapshotStabilizer {
@@ -803,6 +839,8 @@ final class DictationCorrectionMonitor {
     nonisolated private static let maxSuggestionsPerSession = 3
     nonisolated private static let maxAccessibilityNodes = 140
     nonisolated private static let maxCandidateCharacters = 2_000
+
+    private static var englishWordRecognitionCache: [String: Bool] = [:]
 
     private var task: Task<Void, Never>?
 
@@ -858,13 +896,15 @@ final class DictationCorrectionMonitor {
                     Self.log("poll=\(pollCount) stableSnapshots=\(stableSnapshots.count)")
                 }
                 for stableSnapshot in stableSnapshots {
+                    let recognizedEnglishWords = Self.recognizedEnglishWords(in: [originalText, stableSnapshot])
                     let suggestions = await Task.detached(priority: .utility) {
                         Self.suggestions(
                             originalText: originalText,
                             editedSnapshot: stableSnapshot,
                             appContext: appContext,
                             targetApp: targetApp,
-                            maxSuggestions: Self.maxSuggestionsPerSession
+                            maxSuggestions: Self.maxSuggestionsPerSession,
+                            recognizedEnglishWords: recognizedEnglishWords
                         )
                     }.value
                     if Task.isCancelled { return }
@@ -903,15 +943,57 @@ final class DictationCorrectionMonitor {
         editedSnapshot: String,
         appContext: String,
         targetApp: DictationCorrectionTargetApp?,
-        maxSuggestions: Int
+        maxSuggestions: Int,
+        recognizedEnglishWords: Set<String>
     ) -> [DictionarySuggestion] {
         let resolvedAppContext = appContext.isEmpty ? (targetApp?.appContext ?? "") : appContext
         return DictionaryCorrectionDetector.suggestions(
             originalText: originalText,
             editedText: editedSnapshot,
             appContext: resolvedAppContext,
-            maxSuggestions: maxSuggestions
+            maxSuggestions: maxSuggestions,
+            recognizedEnglishWords: recognizedEnglishWords
         )
+    }
+
+    private static func recognizedEnglishWords(in texts: [String]) -> Set<String> {
+        let candidates = englishWordCandidates(in: texts)
+        guard !candidates.isEmpty else { return [] }
+
+        var recognizedWords = Set<String>()
+        let spellChecker = NSSpellChecker.shared
+        for candidate in candidates {
+            let isRecognized: Bool
+            if let cached = englishWordRecognitionCache[candidate] {
+                isRecognized = cached
+            } else {
+                let range = spellChecker.checkSpelling(
+                    of: candidate,
+                    startingAt: 0,
+                    language: "en",
+                    wrap: false,
+                    inSpellDocumentWithTag: 0,
+                    wordCount: nil
+                )
+                isRecognized = range.location == NSNotFound
+                englishWordRecognitionCache[candidate] = isRecognized
+            }
+            if isRecognized {
+                recognizedWords.insert(candidate)
+            }
+        }
+        return recognizedWords
+    }
+
+    private static func englishWordCandidates(in texts: [String]) -> Set<String> {
+        var candidates = Set<String>()
+        for text in texts {
+            for token in text.lowercased().split(whereSeparator: { !$0.isLetter }) {
+                guard token.count >= 2 else { continue }
+                candidates.insert(String(token))
+            }
+        }
+        return candidates
     }
 
     nonisolated private static func log(_ message: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -22,6 +22,7 @@ struct DictationCorrectionTargetApp: Sendable {
 
 struct DictionaryCorrectionDetector {
     private static let minimumCorrectionSimilarity = 0.64
+    private static let maxObservedTokensPerDictionaryWord = 2
 
     static func suggestion(
         originalText: String,
@@ -223,6 +224,9 @@ struct DictionaryCorrectionDetector {
         maxSuggestions: Int
     ) -> [DictionarySuggestion] {
         guard maxSuggestions > 0 else { return [] }
+        guard run.observedTokens.count <= run.replacementTokens.count * maxObservedTokensPerDictionaryWord else {
+            return []
+        }
         var results: [DictionarySuggestion] = []
         var observedIndex = 0
 
@@ -232,7 +236,7 @@ struct DictionaryCorrectionDetector {
             var bestSuggestion: DictionarySuggestion?
             var bestObservedLength = 0
             var bestSimilarity = 0.0
-            let maxObservedLength = min(3, run.observedTokens.count - observedIndex)
+            let maxObservedLength = min(maxObservedTokensPerDictionaryWord, run.observedTokens.count - observedIndex)
 
             for observedLength in 1...maxObservedLength {
                 let observedText = run.observedTokens[observedIndex..<(observedIndex + observedLength)]
@@ -432,7 +436,9 @@ struct DictionaryCorrectionDetector {
     private static func isWordScopedSuggestion(observed: String, replacement: String) -> Bool {
         let observedTokens = observed.split(whereSeparator: \.isWhitespace)
         let replacementTokens = replacement.split(whereSeparator: \.isWhitespace)
-        guard replacementTokens.count == 1, (1...3).contains(observedTokens.count) else {
+        guard replacementTokens.count == 1,
+              (1...maxObservedTokensPerDictionaryWord).contains(observedTokens.count)
+        else {
             return false
         }
         if observedTokens.count == 1 {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import Foundation
+import os
 
 struct DictationCorrectionTargetApp: Sendable {
     let processID: pid_t
@@ -27,11 +28,27 @@ struct DictionaryCorrectionDetector {
         editedText: String,
         appContext: String = ""
     ) -> DictionarySuggestion? {
-        suggestion(
+        suggestions(
             originalText: originalText,
             baselineText: originalText,
             currentText: editedText,
-            appContext: appContext
+            appContext: appContext,
+            maxSuggestions: 1
+        ).first
+    }
+
+    static func suggestions(
+        originalText: String,
+        editedText: String,
+        appContext: String = "",
+        maxSuggestions: Int = Int.max
+    ) -> [DictionarySuggestion] {
+        suggestions(
+            originalText: originalText,
+            baselineText: originalText,
+            currentText: editedText,
+            appContext: appContext,
+            maxSuggestions: maxSuggestions
         )
     }
 
@@ -41,28 +58,56 @@ struct DictionaryCorrectionDetector {
         currentText: String,
         appContext: String = ""
     ) -> DictionarySuggestion? {
-        guard !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-        guard baselineText != currentText else { return nil }
-        guard hasSufficientSharedContext(originalText: originalText, editedText: currentText) else { return nil }
+        suggestions(
+            originalText: originalText,
+            baselineText: baselineText,
+            currentText: currentText,
+            appContext: appContext,
+            maxSuggestions: 1
+        ).first
+    }
 
-        if let suggestion = fragmentSuggestion(
+    static func suggestions(
+        originalText: String,
+        baselineText: String,
+        currentText: String,
+        appContext: String = "",
+        maxSuggestions: Int = Int.max
+    ) -> [DictionarySuggestion] {
+        guard maxSuggestions > 0 else { return [] }
+        guard !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        guard baselineText != currentText else { return [] }
+        guard hasSufficientSharedContext(originalText: originalText, editedText: currentText) else { return [] }
+
+        var results: [DictionarySuggestion] = []
+        var seenKeys = Set<String>()
+
+        func append(_ suggestion: DictionarySuggestion?) {
+            guard results.count < maxSuggestions, let suggestion else { return }
+            guard !seenKeys.contains(suggestion.key) else { return }
+            seenKeys.insert(suggestion.key)
+            results.append(suggestion)
+        }
+
+        append(fragmentSuggestion(
             originalText: originalText,
             baselineText: baselineText,
             currentText: currentText,
             appContext: appContext
-        ) {
-            return suggestion
+        ))
+
+        if results.count < maxSuggestions {
+            for suggestion in tokenAlignedSuggestions(
+                originalText: originalText,
+                editedText: currentText,
+                appContext: appContext,
+                maxSuggestions: maxSuggestions - results.count
+            ) {
+                append(suggestion)
+            }
         }
 
-        if let suggestion = tokenAlignedSuggestion(
-            originalText: originalText,
-            editedText: currentText,
-            appContext: appContext
-        ) {
-            return suggestion
-        }
-
-        return nil
+        return results
     }
 
     private static func fragmentSuggestion(
@@ -93,17 +138,21 @@ struct DictionaryCorrectionDetector {
         let normalized: String
     }
 
-    private static func tokenAlignedSuggestion(
+    private static func tokenAlignedSuggestions(
         originalText: String,
         editedText: String,
-        appContext: String
-    ) -> DictionarySuggestion? {
+        appContext: String,
+        maxSuggestions: Int
+    ) -> [DictionarySuggestion] {
+        guard maxSuggestions > 0 else { return [] }
         let originalTokens = wordTokens(in: originalText)
         let editedTokens = wordTokens(in: editedText)
-        guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return nil }
-        guard originalTokens.count <= 160, editedTokens.count <= 220 else { return nil }
+        guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return [] }
+        guard originalTokens.count <= 160, editedTokens.count <= 220 else { return [] }
 
         let operations = alignmentOperations(from: originalTokens, to: editedTokens)
+        var suggestions: [DictionarySuggestion] = []
+        var seenKeys = Set<String>()
         for operation in operations {
             guard case .substitution(let observed, let replacement) = operation else { continue }
             guard let observedCandidate = normalizedCandidate(observed.text),
@@ -115,13 +164,19 @@ struct DictionaryCorrectionDetector {
             guard isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate) else {
                 continue
             }
-            return DictionarySuggestion(
+            let suggestion = DictionarySuggestion(
                 observed: observedCandidate,
                 replacement: replacementCandidate,
                 appContext: appContext
             )
+            guard !seenKeys.contains(suggestion.key) else { continue }
+            seenKeys.insert(suggestion.key)
+            suggestions.append(suggestion)
+            if suggestions.count >= maxSuggestions {
+                break
+            }
         }
-        return nil
+        return suggestions
     }
 
     static func hasSufficientSharedContext(originalText: String, editedText: String) -> Bool {
@@ -476,12 +531,15 @@ struct DictationCorrectionSnapshotStabilizer {
 
 @MainActor
 final class DictationCorrectionMonitor {
+    nonisolated private static let logger = Logger(subsystem: "com.muesli.native", category: "DictionaryCorrection")
+
     private static let initialPollDelayNanoseconds: UInt64 = 100_000_000
     private static let fastPollIntervalNanoseconds: UInt64 = 150_000_000
     private static let steadyPollIntervalNanoseconds: UInt64 = 1_000_000_000
     private static let fastPollingWindowSeconds: TimeInterval = 10
     private static let monitoringWindowSeconds: TimeInterval = 45
     private static let snapshotQuietWindowSeconds: TimeInterval = 1.5
+    nonisolated private static let maxSuggestionsPerSession = 3
     nonisolated private static let maxAccessibilityNodes = 140
     nonisolated private static let maxCandidateCharacters = 2_000
 
@@ -491,17 +549,28 @@ final class DictationCorrectionMonitor {
         originalText: String,
         appContext: String,
         targetApp: DictationCorrectionTargetApp?,
-        onSuggestion: @escaping @MainActor (DictionarySuggestion) -> Void
+        onSuggestion: @escaping @MainActor (DictionarySuggestion, Bool) -> Void
     ) {
         cancel()
-        guard AXIsProcessTrusted() else { return }
+        Self.log("start originalCharacters=\(originalText.count) target=\(targetApp?.appContext ?? appContext)")
+        guard AXIsProcessTrusted() else {
+            Self.log("not-started axTrusted=false")
+            return
+        }
 
         task = Task {
             let fastPollingDeadline = Date().addingTimeInterval(Self.fastPollingWindowSeconds)
             let deadline = Date().addingTimeInterval(Self.monitoringWindowSeconds)
             var stabilizer = DictationCorrectionSnapshotStabilizer()
+            var pollCount = 0
+            var observedSnapshotCount = 0
+            var stableSnapshotCount = 0
+            var emittedSuggestionCount = 0
+            var emittedSuggestionKeys = Set<String>()
+            var lastLoggedSnapshotCount: Int?
             try? await Task.sleep(nanoseconds: Self.initialPollDelayNanoseconds)
             while !Task.isCancelled, Date() < deadline {
+                pollCount += 1
                 let snapshots = await Task.detached(priority: .utility) {
                     Self.detectEditedSnapshots(
                         originalText: originalText,
@@ -509,26 +578,50 @@ final class DictationCorrectionMonitor {
                     )
                 }.value
                 if Task.isCancelled { return }
+                if !snapshots.isEmpty {
+                    observedSnapshotCount += snapshots.count
+                    if lastLoggedSnapshotCount != snapshots.count {
+                        Self.log("poll=\(pollCount) snapshots=\(snapshots.count)")
+                        lastLoggedSnapshotCount = snapshots.count
+                    }
+                } else {
+                    lastLoggedSnapshotCount = nil
+                }
                 let stableSnapshots = stabilizer.observe(
                     snapshots: snapshots,
                     now: Date(),
                     quietWindow: Self.snapshotQuietWindowSeconds
                 )
+                if !stableSnapshots.isEmpty {
+                    stableSnapshotCount += stableSnapshots.count
+                    Self.log("poll=\(pollCount) stableSnapshots=\(stableSnapshots.count)")
+                }
                 for stableSnapshot in stableSnapshots {
-                    let suggestion = await Task.detached(priority: .utility) {
-                        Self.suggestion(
+                    let suggestions = await Task.detached(priority: .utility) {
+                        Self.suggestions(
                             originalText: originalText,
                             editedSnapshot: stableSnapshot,
                             appContext: appContext,
-                            targetApp: targetApp
+                            targetApp: targetApp,
+                            maxSuggestions: Self.maxSuggestionsPerSession
                         )
                     }.value
                     if Task.isCancelled { return }
-                    if let suggestion {
+                    if suggestions.isEmpty {
+                        Self.log("stableSnapshot rejected suggestions=0")
+                    }
+                    for suggestion in suggestions where !emittedSuggestionKeys.contains(suggestion.key) {
+                        let shouldPresentPrompt = emittedSuggestionCount == 0
+                        emittedSuggestionKeys.insert(suggestion.key)
+                        emittedSuggestionCount += 1
+                        Self.log("emit suggestion=\(suggestion.key) presentPrompt=\(shouldPresentPrompt)")
                         await MainActor.run {
-                            onSuggestion(suggestion)
+                            onSuggestion(suggestion, shouldPresentPrompt)
                         }
-                        return
+                        if emittedSuggestionCount >= Self.maxSuggestionsPerSession {
+                            Self.log("complete reason=maxSuggestions count=\(emittedSuggestionCount)")
+                            return
+                        }
                     }
                 }
                 let interval = Date() < fastPollingDeadline
@@ -536,6 +629,7 @@ final class DictationCorrectionMonitor {
                     : Self.steadyPollIntervalNanoseconds
                 try? await Task.sleep(nanoseconds: interval)
             }
+            Self.log("complete reason=timeout polls=\(pollCount) snapshots=\(observedSnapshotCount) stableSnapshots=\(stableSnapshotCount) suggestions=\(emittedSuggestionCount)")
         }
     }
 
@@ -544,18 +638,25 @@ final class DictationCorrectionMonitor {
         task = nil
     }
 
-    nonisolated private static func suggestion(
+    nonisolated private static func suggestions(
         originalText: String,
         editedSnapshot: String,
         appContext: String,
-        targetApp: DictationCorrectionTargetApp?
-    ) -> DictionarySuggestion? {
+        targetApp: DictationCorrectionTargetApp?,
+        maxSuggestions: Int
+    ) -> [DictionarySuggestion] {
         let resolvedAppContext = appContext.isEmpty ? (targetApp?.appContext ?? "") : appContext
-        return DictionaryCorrectionDetector.suggestion(
+        return DictionaryCorrectionDetector.suggestions(
             originalText: originalText,
             editedText: editedSnapshot,
-            appContext: resolvedAppContext
+            appContext: resolvedAppContext,
+            maxSuggestions: maxSuggestions
         )
+    }
+
+    nonisolated private static func log(_ message: String) {
+        logger.debug("\(message, privacy: .public)")
+        fputs("[dictionary-monitor] \(message)\n", stderr)
     }
 
     nonisolated private static func detectEditedSnapshots(

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -2,7 +2,7 @@ import AppKit
 import ApplicationServices
 import Foundation
 
-struct DictationCorrectionTargetApp {
+struct DictationCorrectionTargetApp: Sendable {
     let processID: pid_t
     let appName: String
     let bundleID: String
@@ -363,8 +363,8 @@ final class DictationCorrectionMonitor {
     private static let steadyPollIntervalNanoseconds: UInt64 = 1_000_000_000
     private static let fastPollingWindowSeconds: TimeInterval = 10
     private static let monitoringWindowSeconds: TimeInterval = 45
-    private static let maxAccessibilityNodes = 500
-    private static let maxCandidateCharacters = 2_000
+    nonisolated private static let maxAccessibilityNodes = 140
+    nonisolated private static let maxCandidateCharacters = 2_000
 
     private var task: Task<Void, Never>?
 
@@ -377,17 +377,23 @@ final class DictationCorrectionMonitor {
         cancel()
         guard AXIsProcessTrusted() else { return }
 
-        task = Task { @MainActor in
+        task = Task {
             let fastPollingDeadline = Date().addingTimeInterval(Self.fastPollingWindowSeconds)
             let deadline = Date().addingTimeInterval(Self.monitoringWindowSeconds)
             try? await Task.sleep(nanoseconds: Self.initialPollDelayNanoseconds)
             while !Task.isCancelled, Date() < deadline {
-                if let suggestion = Self.detectSuggestion(
-                    originalText: originalText,
-                    appContext: appContext,
-                    targetApp: targetApp
-                ) {
-                    onSuggestion(suggestion)
+                let suggestion = await Task.detached(priority: .utility) {
+                    Self.detectSuggestion(
+                        originalText: originalText,
+                        appContext: appContext,
+                        targetApp: targetApp
+                    )
+                }.value
+                if Task.isCancelled { return }
+                if let suggestion {
+                    await MainActor.run {
+                        onSuggestion(suggestion)
+                    }
                     return
                 }
                 let interval = Date() < fastPollingDeadline
@@ -403,49 +409,41 @@ final class DictationCorrectionMonitor {
         task = nil
     }
 
-    private static func detectSuggestion(
+    nonisolated private static func detectSuggestion(
         originalText: String,
         appContext: String,
         targetApp: DictationCorrectionTargetApp?
     ) -> DictionarySuggestion? {
         let resolvedAppContext = appContext.isEmpty ? (targetApp?.appContext ?? "") : appContext
-        for snapshot in textSnapshots(near: originalText, appContext: resolvedAppContext, targetApp: targetApp) {
-            if let suggestion = DictionaryCorrectionDetector.suggestion(
+        var seen = Set<String>()
+
+        func suggestion(from value: String?) -> DictionarySuggestion? {
+            guard let snapshot = normalizedSnapshot(value, originalText: originalText),
+                  !seen.contains(snapshot)
+            else { return nil }
+            seen.insert(snapshot)
+            return DictionaryCorrectionDetector.suggestion(
                 originalText: originalText,
                 editedText: snapshot,
                 appContext: resolvedAppContext
-            ) {
-                return suggestion
-            }
+            )
+        }
+
+        var focusedProcessID: pid_t?
+        if let focusedSuggestion = systemFocusedTextSnapshot(
+            maxCharacters: maxCandidateCharacters,
+            processID: &focusedProcessID
+        ).flatMap(suggestion(from:)) {
+            return focusedSuggestion
+        }
+
+        if let targetApp, targetApp.processID != focusedProcessID {
+            return collectTextSnapshots(fromProcessID: targetApp.processID, evaluate: suggestion(from:))
         }
         return nil
     }
 
-    private static func textSnapshots(
-        near originalText: String,
-        appContext: String,
-        targetApp: DictationCorrectionTargetApp?
-    ) -> [String] {
-        var seen = Set<String>()
-        var candidates: [String] = []
-
-        func add(_ value: String?) {
-            guard let normalized = normalizedSnapshot(value, originalText: originalText),
-                  !seen.contains(normalized)
-            else { return }
-            seen.insert(normalized)
-            candidates.append(normalized)
-        }
-
-        let focusedProcessID = addSystemFocusedTextSnapshot(maxCharacters: maxCandidateCharacters, add: add)
-
-        for app in targetApplications(focusedProcessID: focusedProcessID, appContext: appContext, targetApp: targetApp) {
-            collectTextSnapshots(from: app, add: add)
-        }
-        return candidates
-    }
-
-    private static func normalizedSnapshot(_ value: String?, originalText: String) -> String? {
+    nonisolated private static func normalizedSnapshot(_ value: String?, originalText: String) -> String? {
         guard let value else { return nil }
         let normalized = value
             .replacingOccurrences(of: "\u{00a0}", with: " ")
@@ -462,44 +460,11 @@ final class DictationCorrectionMonitor {
         return normalized
     }
 
-    private static func targetApplications(
-        focusedProcessID: pid_t?,
-        appContext: String,
-        targetApp: DictationCorrectionTargetApp?
-    ) -> [NSRunningApplication] {
-        var apps: [NSRunningApplication] = []
-        var seen = Set<pid_t>()
-
-        func add(_ app: NSRunningApplication?) {
-            guard let app, !seen.contains(app.processIdentifier) else { return }
-            seen.insert(app.processIdentifier)
-            apps.append(app)
-        }
-
-        if let targetApp {
-            add(NSWorkspace.shared.runningApplications.first { $0.processIdentifier == targetApp.processID })
-        }
-        if let focusedProcessID {
-            add(NSWorkspace.shared.runningApplications.first { $0.processIdentifier == focusedProcessID })
-        }
-        add(NSWorkspace.shared.frontmostApplication)
-        add(runningApplication(from: appContext))
-        return apps
-    }
-
-    private static func runningApplication(from appContext: String) -> NSRunningApplication? {
-        let parts = appContext.split(separator: "|", omittingEmptySubsequences: false)
-        guard parts.count >= 2 else { return nil }
-        let bundleID = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !bundleID.isEmpty else { return nil }
-        return NSWorkspace.shared.runningApplications.first { $0.bundleIdentifier == bundleID }
-    }
-
-    private static func collectTextSnapshots(
-        from app: NSRunningApplication,
-        add: (String?) -> Void
-    ) {
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+    nonisolated private static func collectTextSnapshots(
+        fromProcessID processID: pid_t,
+        evaluate: (String?) -> DictionarySuggestion?
+    ) -> DictionarySuggestion? {
+        let axApp = AXUIElementCreateApplication(processID)
         var roots: [AXUIElement] = []
 
         for attribute in [
@@ -514,67 +479,66 @@ final class DictationCorrectionMonitor {
         roots.append(axApp)
 
         var remainingNodes = maxAccessibilityNodes
-        var visited = Set<AXUIElement>()
+        var visited = Set<String>()
         for root in roots {
-            collectTextSnapshots(
+            if let suggestion = collectTextSnapshots(
                 from: root,
                 depth: 0,
                 remainingNodes: &remainingNodes,
                 visited: &visited,
-                add: add
-            )
-            if remainingNodes <= 0 { return }
+                evaluate: evaluate
+            ) {
+                return suggestion
+            }
+            if remainingNodes <= 0 { return nil }
         }
+        return nil
     }
 
-    private static func collectTextSnapshots(
+    nonisolated private static func collectTextSnapshots(
         from element: AXUIElement,
         depth: Int,
         remainingNodes: inout Int,
-        visited: inout Set<AXUIElement>,
-        add: (String?) -> Void
-    ) {
-        guard depth <= 10, remainingNodes > 0, !visited.contains(element) else { return }
-        visited.insert(element)
+        visited: inout Set<String>,
+        evaluate: (String?) -> DictionarySuggestion?
+    ) -> DictionarySuggestion? {
+        guard depth <= 8, remainingNodes > 0 else { return nil }
+        let visitKey = elementVisitKey(element)
+        guard !visited.contains(visitKey) else { return nil }
+        visited.insert(visitKey)
         remainingNodes -= 1
 
-        for attribute in [
-            kAXValueAttribute,
-            kAXTitleAttribute,
-            kAXDescriptionAttribute,
-            kAXHelpAttribute,
-        ] {
-            var valueRef: CFTypeRef?
-            if AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success {
-                add(valueRef as? String)
-            }
+        var valueRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success,
+           let suggestion = evaluate(valueRef as? String) {
+            return suggestion
         }
 
         for childAttribute in [
             kAXVisibleChildrenAttribute,
             kAXChildrenAttribute,
             kAXContentsAttribute,
-            kAXRowsAttribute,
-            kAXColumnsAttribute,
         ] {
             for child in axElementArrayAttribute(childAttribute, from: element) {
-                collectTextSnapshots(
+                if let suggestion = collectTextSnapshots(
                     from: child,
                     depth: depth + 1,
                     remainingNodes: &remainingNodes,
                     visited: &visited,
-                    add: add
-                )
-                if remainingNodes <= 0 { return }
+                    evaluate: evaluate
+                ) {
+                    return suggestion
+                }
+                if remainingNodes <= 0 { return nil }
             }
         }
+        return nil
     }
 
-    @discardableResult
-    private static func addSystemFocusedTextSnapshot(
+    nonisolated private static func systemFocusedTextSnapshot(
         maxCharacters: Int = 20_000,
-        add: (String?) -> Void
-    ) -> pid_t? {
+        processID focusedProcessID: inout pid_t?
+    ) -> String? {
         let system = AXUIElementCreateSystemWide()
         var focusedRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
@@ -583,14 +547,14 @@ final class DictationCorrectionMonitor {
         else { return nil }
 
         let element = focused as! AXUIElement
-        add(textSnapshot(from: element, maxCharacters: maxCharacters))
-
-        var processID: pid_t = 0
-        guard AXUIElementGetPid(element, &processID) == .success else { return nil }
-        return processID
+        var pid: pid_t = 0
+        if AXUIElementGetPid(element, &pid) == .success {
+            focusedProcessID = pid
+        }
+        return textSnapshot(from: element, maxCharacters: maxCharacters)
     }
 
-    private static func textSnapshot(from element: AXUIElement, maxCharacters: Int) -> String? {
+    nonisolated private static func textSnapshot(from element: AXUIElement, maxCharacters: Int) -> String? {
         var charCountRef: CFTypeRef?
         if AXUIElementCopyAttributeValue(element, kAXNumberOfCharactersAttribute as CFString, &charCountRef) == .success,
            let count = charCountRef as? Int,
@@ -606,7 +570,21 @@ final class DictationCorrectionMonitor {
         return value
     }
 
-    private static func axElementAttribute(_ attribute: String, from element: AXUIElement) -> AXUIElement? {
+    nonisolated private static func elementVisitKey(_ element: AXUIElement) -> String {
+        var pid: pid_t = 0
+        _ = AXUIElementGetPid(element, &pid)
+
+        let role = axStringAttribute(kAXRoleAttribute, from: element)
+        let position = cgPointAttribute(kAXPositionAttribute, from: element)
+        let size = cgSizeAttribute(kAXSizeAttribute, from: element)
+
+        if let position, let size {
+            return "\(pid)|\(role)|\(Int(position.x))|\(Int(position.y))|\(Int(size.width))|\(Int(size.height))"
+        }
+        return "\(pid)|\(role)|\(CFHash(element))"
+    }
+
+    nonisolated private static func axElementAttribute(_ attribute: String, from element: AXUIElement) -> AXUIElement? {
         var valueRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success,
               let value = valueRef,
@@ -615,7 +593,7 @@ final class DictationCorrectionMonitor {
         return (value as! AXUIElement)
     }
 
-    private static func axElementArrayAttribute(_ attribute: String, from element: AXUIElement) -> [AXUIElement] {
+    nonisolated private static func axElementArrayAttribute(_ attribute: String, from element: AXUIElement) -> [AXUIElement] {
         var valueRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success,
               let value = valueRef
@@ -625,5 +603,39 @@ final class DictationCorrectionMonitor {
             return [value as! AXUIElement]
         }
         return (value as? [AXUIElement]) ?? []
+    }
+
+    nonisolated private static func axStringAttribute(_ attribute: String, from element: AXUIElement) -> String {
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success else {
+            return ""
+        }
+        return (valueRef as? String) ?? ""
+    }
+
+    nonisolated private static func cgPointAttribute(_ attribute: String, from element: AXUIElement) -> CGPoint? {
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success,
+              let valueRef,
+              CFGetTypeID(valueRef) == AXValueGetTypeID()
+        else { return nil }
+        let value = valueRef as! AXValue
+        guard AXValueGetType(value) == .cgPoint else { return nil }
+        var point = CGPoint.zero
+        guard AXValueGetValue(value, .cgPoint, &point) else { return nil }
+        return point
+    }
+
+    nonisolated private static func cgSizeAttribute(_ attribute: String, from element: AXUIElement) -> CGSize? {
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success,
+              let valueRef,
+              CFGetTypeID(valueRef) == AXValueGetTypeID()
+        else { return nil }
+        let value = valueRef as! AXValue
+        guard AXValueGetType(value) == .cgSize else { return nil }
+        var size = CGSize.zero
+        guard AXValueGetValue(value, .cgSize, &size) else { return nil }
+        return size
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -1,0 +1,629 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+struct DictationCorrectionTargetApp {
+    let processID: pid_t
+    let appName: String
+    let bundleID: String
+
+    var appContext: String {
+        "\(appName)|\(bundleID)"
+    }
+
+    init?(app: NSRunningApplication?) {
+        guard let app else { return nil }
+        self.processID = app.processIdentifier
+        self.appName = app.localizedName ?? "Unknown"
+        self.bundleID = app.bundleIdentifier ?? ""
+    }
+}
+
+struct DictionaryCorrectionDetector {
+    private static let minimumCorrectionSimilarity = 0.64
+
+    static func suggestion(
+        originalText: String,
+        editedText: String,
+        appContext: String = ""
+    ) -> DictionarySuggestion? {
+        suggestion(
+            originalText: originalText,
+            baselineText: originalText,
+            currentText: editedText,
+            appContext: appContext
+        )
+    }
+
+    static func suggestion(
+        originalText: String,
+        baselineText: String,
+        currentText: String,
+        appContext: String = ""
+    ) -> DictionarySuggestion? {
+        guard !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        guard baselineText != currentText else { return nil }
+        guard hasSufficientSharedContext(originalText: originalText, editedText: currentText) else { return nil }
+
+        if let suggestion = fragmentSuggestion(
+            originalText: originalText,
+            baselineText: baselineText,
+            currentText: currentText,
+            appContext: appContext
+        ) {
+            return suggestion
+        }
+
+        if let suggestion = tokenAlignedSuggestion(
+            originalText: originalText,
+            editedText: currentText,
+            appContext: appContext
+        ) {
+            return suggestion
+        }
+
+        return nil
+    }
+
+    private static func fragmentSuggestion(
+        originalText: String,
+        baselineText: String,
+        currentText: String,
+        appContext: String
+    ) -> DictionarySuggestion? {
+        let diff = changedFragments(from: baselineText, to: currentText)
+        guard let observed = normalizedCandidate(diff.removed),
+              let replacement = normalizedCandidate(diff.inserted)
+        else { return nil }
+
+        guard originalText.range(of: observed, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
+            return nil
+        }
+        guard isLikelyDictionaryCorrection(observed: observed, replacement: replacement) else { return nil }
+
+        return DictionarySuggestion(
+            observed: observed,
+            replacement: replacement,
+            appContext: appContext
+        )
+    }
+
+    private struct WordToken: Equatable {
+        let text: String
+        let normalized: String
+    }
+
+    private static func tokenAlignedSuggestion(
+        originalText: String,
+        editedText: String,
+        appContext: String
+    ) -> DictionarySuggestion? {
+        let originalTokens = wordTokens(in: originalText)
+        let editedTokens = wordTokens(in: editedText)
+        guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return nil }
+        guard originalTokens.count <= 160, editedTokens.count <= 220 else { return nil }
+
+        let operations = alignmentOperations(from: originalTokens, to: editedTokens)
+        for operation in operations {
+            guard case .substitution(let observed, let replacement) = operation else { continue }
+            guard let observedCandidate = normalizedCandidate(observed.text),
+                  let replacementCandidate = normalizedCandidate(replacement.text)
+            else { continue }
+            guard originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil else {
+                continue
+            }
+            guard isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate) else {
+                continue
+            }
+            return DictionarySuggestion(
+                observed: observedCandidate,
+                replacement: replacementCandidate,
+                appContext: appContext
+            )
+        }
+        return nil
+    }
+
+    static func hasSufficientSharedContext(originalText: String, editedText: String) -> Bool {
+        let originalTokens = wordTokens(in: originalText).map(\.normalized)
+        let editedTokens = wordTokens(in: editedText).map(\.normalized)
+        guard !originalTokens.isEmpty, !editedTokens.isEmpty else { return false }
+
+        if originalTokens.count <= 3 {
+            return true
+        }
+
+        let anchorLength = originalTokens.count == 4 ? 2 : min(4, originalTokens.count - 2)
+        guard anchorLength > 0, editedTokens.count >= anchorLength else { return false }
+
+        let editedWindows = Set(windows(in: editedTokens, length: anchorLength))
+        return windows(in: originalTokens, length: anchorLength).contains { editedWindows.contains($0) }
+    }
+
+    private static func windows(in tokens: [String], length: Int) -> [String] {
+        guard length > 0, tokens.count >= length else { return [] }
+        return (0...(tokens.count - length)).map { index in
+            tokens[index..<(index + length)].joined(separator: "\u{1f}")
+        }
+    }
+
+    private static func wordTokens(in text: String) -> [WordToken] {
+        var tokens: [WordToken] = []
+        var current = ""
+
+        func flush() {
+            let candidate = current.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !candidate.isEmpty {
+                tokens.append(WordToken(text: candidate, normalized: candidate.lowercased()))
+            }
+            current = ""
+        }
+
+        for character in text {
+            if character.isLetter || character.isNumber || character == "-" || character == "_" || character == "/" || character == "+" {
+                current.append(character)
+            } else {
+                flush()
+            }
+        }
+        flush()
+        return tokens
+    }
+
+    private enum AlignmentOperation {
+        case match
+        case insertion(WordToken)
+        case deletion(WordToken)
+        case substitution(observed: WordToken, replacement: WordToken)
+    }
+
+    private static func alignmentOperations(from old: [WordToken], to new: [WordToken]) -> [AlignmentOperation] {
+        let rows = old.count + 1
+        let columns = new.count + 1
+        var costs = Array(repeating: Array(repeating: 0, count: columns), count: rows)
+
+        for row in 0..<rows { costs[row][0] = row }
+        for column in 0..<columns { costs[0][column] = column }
+
+        for row in 1..<rows {
+            for column in 1..<columns {
+                let substitutionCost = old[row - 1].text == new[column - 1].text ? 0 : 1
+                costs[row][column] = min(
+                    costs[row - 1][column] + 1,
+                    costs[row][column - 1] + 1,
+                    costs[row - 1][column - 1] + substitutionCost
+                )
+            }
+        }
+
+        var row = old.count
+        var column = new.count
+        var operations: [AlignmentOperation] = []
+
+        while row > 0 || column > 0 {
+            if row > 0, column > 0 {
+                let substitutionCost = old[row - 1].text == new[column - 1].text ? 0 : 1
+                if costs[row][column] == costs[row - 1][column - 1] + substitutionCost {
+                    if substitutionCost == 0 {
+                        operations.append(.match)
+                    } else {
+                        operations.append(.substitution(observed: old[row - 1], replacement: new[column - 1]))
+                    }
+                    row -= 1
+                    column -= 1
+                    continue
+                }
+            }
+            if row > 0, costs[row][column] == costs[row - 1][column] + 1 {
+                operations.append(.deletion(old[row - 1]))
+                row -= 1
+                continue
+            }
+            if column > 0 {
+                operations.append(.insertion(new[column - 1]))
+                column -= 1
+            }
+        }
+
+        return operations.reversed()
+    }
+
+    private static func changedFragments(from oldText: String, to newText: String) -> (removed: String, inserted: String) {
+        let old = Array(oldText)
+        let new = Array(newText)
+
+        var prefix = 0
+        while prefix < old.count, prefix < new.count, old[prefix] == new[prefix] {
+            prefix += 1
+        }
+
+        var oldSuffix = old.count
+        var newSuffix = new.count
+        while oldSuffix > prefix, newSuffix > prefix, old[oldSuffix - 1] == new[newSuffix - 1] {
+            oldSuffix -= 1
+            newSuffix -= 1
+        }
+
+        while prefix > 0, !isBoundary(old[prefix - 1]), !isBoundary(new[prefix - 1]) {
+            prefix -= 1
+        }
+        while oldSuffix < old.count, !isBoundary(old[oldSuffix]) {
+            oldSuffix += 1
+        }
+        while newSuffix < new.count, !isBoundary(new[newSuffix]) {
+            newSuffix += 1
+        }
+
+        return (
+            String(old[prefix..<oldSuffix]),
+            String(new[prefix..<newSuffix])
+        )
+    }
+
+    private static func isBoundary(_ character: Character) -> Bool {
+        character.isWhitespace || character.isPunctuation && character != "-" && character != "_" && character != "/" && character != "+"
+    }
+
+    private static func normalizedCandidate(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains("\n") else { return nil }
+
+        let boundaryPunctuation = CharacterSet.whitespacesAndNewlines
+            .union(.punctuationCharacters)
+            .subtracting(CharacterSet(charactersIn: "_-+/"))
+        let cleaned = trimmed.trimmingCharacters(in: boundaryPunctuation)
+        guard !cleaned.isEmpty, cleaned.count <= 60 else { return nil }
+
+        let tokens = cleaned.split(whereSeparator: \.isWhitespace)
+        guard (1...3).contains(tokens.count) else { return nil }
+        guard tokens.allSatisfy({ token in
+            token.contains { $0.isLetter || $0.isNumber }
+        }) else { return nil }
+
+        return tokens.joined(separator: " ")
+    }
+
+    private static func isLikelyDictionaryCorrection(observed: String, replacement: String) -> Bool {
+        guard observed != replacement else { return false }
+        guard observed.count >= 2, replacement.count >= 2 else { return false }
+
+        let observedTokens = observed.split(whereSeparator: \.isWhitespace).map(String.init)
+        let replacementTokens = replacement.split(whereSeparator: \.isWhitespace).map(String.init)
+
+        let normalizedReplacement = replacement.lowercased()
+        let normalizedObserved = observed.lowercased()
+        let hasSpecialDictionarySignal = hasInternalCapital(replacement)
+            || replacement.contains(where: \.isNumber)
+            || replacement.contains("-")
+            || replacement.contains("_")
+            || replacement.contains("/")
+            || isAcronymLike(replacement)
+
+        let similarity = CustomWordMatcher.jaroWinklerSimilarity(
+            normalizedObserved,
+            normalizedReplacement
+        )
+
+        if observedTokens.count != replacementTokens.count {
+            guard !observedTokens.contains(where: { commonWords.contains($0.lowercased()) }) else { return false }
+            let compactObserved = observedTokens.joined().lowercased()
+            let compactReplacement = replacementTokens.joined().lowercased()
+            let compactSimilarity = CustomWordMatcher.jaroWinklerSimilarity(
+                compactObserved,
+                compactReplacement
+            )
+            return compactSimilarity >= 0.82 || hasSpecialDictionarySignal
+        }
+
+        if commonWords.contains(normalizedObserved) {
+            if observed.lowercased() == replacement.lowercased() {
+                return hasSpecialDictionarySignal || replacement.contains(where: \.isUppercase)
+            }
+            return similarity >= 0.82 && hasSpecialDictionarySignal
+        }
+
+        if commonWords.contains(normalizedReplacement), !hasSpecialDictionarySignal {
+            return false
+        }
+
+        if observed.lowercased() == replacement.lowercased() {
+            return hasSpecialDictionarySignal || replacement.contains(where: \.isUppercase)
+        }
+
+        return similarity >= minimumCorrectionSimilarity || hasSpecialDictionarySignal
+    }
+
+    private static func hasInternalCapital(_ value: String) -> Bool {
+        let scalars = Array(value)
+        guard scalars.count > 1 else { return false }
+        return scalars.dropFirst().contains(where: \.isUppercase)
+    }
+
+    private static func isAcronymLike(_ value: String) -> Bool {
+        let letters = value.filter(\.isLetter)
+        guard letters.count >= 2 else { return false }
+        return letters.allSatisfy(\.isUppercase)
+    }
+
+    private static let commonWords: Set<String> = [
+        "a", "about", "after", "all", "also", "am", "an", "and", "are", "as", "at",
+        "be", "because", "but", "by", "can", "could", "did", "do", "does", "for",
+        "from", "get", "go", "had", "has", "have", "he", "her", "here", "him", "his",
+        "how", "i", "if", "in", "is", "it", "its", "just", "like", "me", "my", "not",
+        "now", "of", "on", "or", "our", "out", "she", "so", "that", "the", "their",
+        "them", "then", "there", "they", "this", "to", "up", "us", "was", "we", "were",
+        "what", "when", "where", "which", "who", "will", "with", "would", "you", "your",
+    ]
+}
+
+@MainActor
+final class DictationCorrectionMonitor {
+    private static let initialPollDelayNanoseconds: UInt64 = 100_000_000
+    private static let fastPollIntervalNanoseconds: UInt64 = 150_000_000
+    private static let steadyPollIntervalNanoseconds: UInt64 = 1_000_000_000
+    private static let fastPollingWindowSeconds: TimeInterval = 10
+    private static let monitoringWindowSeconds: TimeInterval = 45
+    private static let maxAccessibilityNodes = 500
+    private static let maxCandidateCharacters = 2_000
+
+    private var task: Task<Void, Never>?
+
+    func start(
+        originalText: String,
+        appContext: String,
+        targetApp: DictationCorrectionTargetApp?,
+        onSuggestion: @escaping @MainActor (DictionarySuggestion) -> Void
+    ) {
+        cancel()
+        guard AXIsProcessTrusted() else { return }
+
+        task = Task { @MainActor in
+            let fastPollingDeadline = Date().addingTimeInterval(Self.fastPollingWindowSeconds)
+            let deadline = Date().addingTimeInterval(Self.monitoringWindowSeconds)
+            try? await Task.sleep(nanoseconds: Self.initialPollDelayNanoseconds)
+            while !Task.isCancelled, Date() < deadline {
+                if let suggestion = Self.detectSuggestion(
+                    originalText: originalText,
+                    appContext: appContext,
+                    targetApp: targetApp
+                ) {
+                    onSuggestion(suggestion)
+                    return
+                }
+                let interval = Date() < fastPollingDeadline
+                    ? Self.fastPollIntervalNanoseconds
+                    : Self.steadyPollIntervalNanoseconds
+                try? await Task.sleep(nanoseconds: interval)
+            }
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+
+    private static func detectSuggestion(
+        originalText: String,
+        appContext: String,
+        targetApp: DictationCorrectionTargetApp?
+    ) -> DictionarySuggestion? {
+        let resolvedAppContext = appContext.isEmpty ? (targetApp?.appContext ?? "") : appContext
+        for snapshot in textSnapshots(near: originalText, appContext: resolvedAppContext, targetApp: targetApp) {
+            if let suggestion = DictionaryCorrectionDetector.suggestion(
+                originalText: originalText,
+                editedText: snapshot,
+                appContext: resolvedAppContext
+            ) {
+                return suggestion
+            }
+        }
+        return nil
+    }
+
+    private static func textSnapshots(
+        near originalText: String,
+        appContext: String,
+        targetApp: DictationCorrectionTargetApp?
+    ) -> [String] {
+        var seen = Set<String>()
+        var candidates: [String] = []
+
+        func add(_ value: String?) {
+            guard let normalized = normalizedSnapshot(value, originalText: originalText),
+                  !seen.contains(normalized)
+            else { return }
+            seen.insert(normalized)
+            candidates.append(normalized)
+        }
+
+        let focusedProcessID = addSystemFocusedTextSnapshot(maxCharacters: maxCandidateCharacters, add: add)
+
+        for app in targetApplications(focusedProcessID: focusedProcessID, appContext: appContext, targetApp: targetApp) {
+            collectTextSnapshots(from: app, add: add)
+        }
+        return candidates
+    }
+
+    private static func normalizedSnapshot(_ value: String?, originalText: String) -> String? {
+        guard let value else { return nil }
+        let normalized = value
+            .replacingOccurrences(of: "\u{00a0}", with: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, normalized.count <= maxCandidateCharacters else { return nil }
+        guard normalized != originalText else { return nil }
+
+        let originalLength = originalText.count
+        let lengthDelta = abs(normalized.count - originalLength)
+        let allowedDelta = max(240, originalLength * 2)
+        guard normalized.count >= max(2, originalLength / 2), lengthDelta <= allowedDelta else { return nil }
+        return normalized
+    }
+
+    private static func targetApplications(
+        focusedProcessID: pid_t?,
+        appContext: String,
+        targetApp: DictationCorrectionTargetApp?
+    ) -> [NSRunningApplication] {
+        var apps: [NSRunningApplication] = []
+        var seen = Set<pid_t>()
+
+        func add(_ app: NSRunningApplication?) {
+            guard let app, !seen.contains(app.processIdentifier) else { return }
+            seen.insert(app.processIdentifier)
+            apps.append(app)
+        }
+
+        if let targetApp {
+            add(NSWorkspace.shared.runningApplications.first { $0.processIdentifier == targetApp.processID })
+        }
+        if let focusedProcessID {
+            add(NSWorkspace.shared.runningApplications.first { $0.processIdentifier == focusedProcessID })
+        }
+        add(NSWorkspace.shared.frontmostApplication)
+        add(runningApplication(from: appContext))
+        return apps
+    }
+
+    private static func runningApplication(from appContext: String) -> NSRunningApplication? {
+        let parts = appContext.split(separator: "|", omittingEmptySubsequences: false)
+        guard parts.count >= 2 else { return nil }
+        let bundleID = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !bundleID.isEmpty else { return nil }
+        return NSWorkspace.shared.runningApplications.first { $0.bundleIdentifier == bundleID }
+    }
+
+    private static func collectTextSnapshots(
+        from app: NSRunningApplication,
+        add: (String?) -> Void
+    ) {
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var roots: [AXUIElement] = []
+
+        for attribute in [
+            kAXFocusedUIElementAttribute,
+            kAXFocusedWindowAttribute,
+            kAXMainWindowAttribute,
+        ] {
+            if let element = axElementAttribute(attribute, from: axApp) {
+                roots.append(element)
+            }
+        }
+        roots.append(axApp)
+
+        var remainingNodes = maxAccessibilityNodes
+        var visited = Set<AXUIElement>()
+        for root in roots {
+            collectTextSnapshots(
+                from: root,
+                depth: 0,
+                remainingNodes: &remainingNodes,
+                visited: &visited,
+                add: add
+            )
+            if remainingNodes <= 0 { return }
+        }
+    }
+
+    private static func collectTextSnapshots(
+        from element: AXUIElement,
+        depth: Int,
+        remainingNodes: inout Int,
+        visited: inout Set<AXUIElement>,
+        add: (String?) -> Void
+    ) {
+        guard depth <= 10, remainingNodes > 0, !visited.contains(element) else { return }
+        visited.insert(element)
+        remainingNodes -= 1
+
+        for attribute in [
+            kAXValueAttribute,
+            kAXTitleAttribute,
+            kAXDescriptionAttribute,
+            kAXHelpAttribute,
+        ] {
+            var valueRef: CFTypeRef?
+            if AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success {
+                add(valueRef as? String)
+            }
+        }
+
+        for childAttribute in [
+            kAXVisibleChildrenAttribute,
+            kAXChildrenAttribute,
+            kAXContentsAttribute,
+            kAXRowsAttribute,
+            kAXColumnsAttribute,
+        ] {
+            for child in axElementArrayAttribute(childAttribute, from: element) {
+                collectTextSnapshots(
+                    from: child,
+                    depth: depth + 1,
+                    remainingNodes: &remainingNodes,
+                    visited: &visited,
+                    add: add
+                )
+                if remainingNodes <= 0 { return }
+            }
+        }
+    }
+
+    @discardableResult
+    private static func addSystemFocusedTextSnapshot(
+        maxCharacters: Int = 20_000,
+        add: (String?) -> Void
+    ) -> pid_t? {
+        let system = AXUIElementCreateSystemWide()
+        var focusedRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
+              let focused = focusedRef,
+              CFGetTypeID(focused) == AXUIElementGetTypeID()
+        else { return nil }
+
+        let element = focused as! AXUIElement
+        add(textSnapshot(from: element, maxCharacters: maxCharacters))
+
+        var processID: pid_t = 0
+        guard AXUIElementGetPid(element, &processID) == .success else { return nil }
+        return processID
+    }
+
+    private static func textSnapshot(from element: AXUIElement, maxCharacters: Int) -> String? {
+        var charCountRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXNumberOfCharactersAttribute as CFString, &charCountRef) == .success,
+           let count = charCountRef as? Int,
+           count > maxCharacters {
+            return nil
+        }
+
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success,
+              let value = valueRef as? String,
+              value.count <= maxCharacters
+        else { return nil }
+        return value
+    }
+
+    private static func axElementAttribute(_ attribute: String, from element: AXUIElement) -> AXUIElement? {
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success,
+              let value = valueRef,
+              CFGetTypeID(value) == AXUIElementGetTypeID()
+        else { return nil }
+        return (value as! AXUIElement)
+    }
+
+    private static func axElementArrayAttribute(_ attribute: String, from element: AXUIElement) -> [AXUIElement] {
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &valueRef) == .success,
+              let value = valueRef
+        else { return [] }
+
+        if CFGetTypeID(value) == AXUIElementGetTypeID() {
+            return [value as! AXUIElement]
+        }
+        return (value as? [AXUIElement]) ?? []
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -848,7 +848,8 @@ struct DictationCorrectionSnapshotStabilizer {
     }
 }
 
-private actor EnglishWordRecognizer {
+@MainActor
+private final class EnglishWordRecognizer {
     private let maxEntries: Int
     private let spellChecker = NSSpellChecker()
     private var cache: [String: Bool] = [:]
@@ -911,6 +912,7 @@ final class DictationCorrectionMonitor {
     nonisolated private static let maxSuggestionsPerSession = 3
     nonisolated private static let maxAccessibilityNodes = 140
     nonisolated private static let maxCandidateCharacters = 2_000
+    nonisolated private static let maxEnglishWordRecognitionCandidates = 128
     nonisolated private static let maxEnglishWordRecognitionCacheEntries = 5_000
     private static let englishWordRecognizer = EnglishWordRecognizer(maxEntries: maxEnglishWordRecognitionCacheEntries)
 
@@ -968,7 +970,7 @@ final class DictationCorrectionMonitor {
                     Self.log("poll=\(pollCount) stableSnapshots=\(stableSnapshots.count)")
                 }
                 for stableSnapshot in stableSnapshots {
-                    let recognizedEnglishWords = await Self.englishWordRecognizer.recognizedWords(
+                    let recognizedEnglishWords = Self.englishWordRecognizer.recognizedWords(
                         from: Self.englishWordCandidates(in: [originalText, stableSnapshot])
                     )
                     if Task.isCancelled { return }
@@ -1038,6 +1040,14 @@ final class DictationCorrectionMonitor {
                 guard token.count >= 2 else { continue }
                 candidates.insert(String(token))
             }
+        }
+        if candidates.count > maxEnglishWordRecognitionCandidates {
+            return Set(candidates.sorted {
+                if $0.count != $1.count {
+                    return $0.count < $1.count
+                }
+                return $0 < $1
+            }.prefix(maxEnglishWordRecognitionCandidates))
         }
         return candidates
     }
@@ -1149,16 +1159,15 @@ final class DictationCorrectionMonitor {
             add(valueRef as? String)
         }
 
-        let visibleChildren = axElementArrayAttribute(kAXVisibleChildrenAttribute, from: element)
-        let fallbackAttributes = visibleChildren.isEmpty
-            ? [kAXChildrenAttribute, kAXContentsAttribute]
-            : []
-        let childGroups = [visibleChildren] + fallbackAttributes.map {
-            axElementArrayAttribute($0, from: element)
-        }
-
-        for childGroup in childGroups {
-            for child in childGroup {
+        // AX trees are not guaranteed to put editable text under visible
+        // children. Walk all known child containers; visited + node budget
+        // handle duplicate chrome/text nodes without skipping AXContents.
+        for childAttribute in [
+            kAXVisibleChildrenAttribute,
+            kAXChildrenAttribute,
+            kAXContentsAttribute,
+        ] {
+            for child in axElementArrayAttribute(childAttribute, from: element) {
                 collectTextSnapshots(
                     from: child,
                     depth: depth + 1,

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -806,7 +806,7 @@ final class DictationCorrectionMonitor {
                         let shouldPresentPrompt = emittedSuggestionCount == 0
                         emittedSuggestionKeys.insert(suggestion.key)
                         emittedSuggestionCount += 1
-                        Self.log("emit suggestion=\(suggestion.key) presentPrompt=\(shouldPresentPrompt)")
+                        Self.log("emit presentPrompt=\(shouldPresentPrompt) \(Self.suggestionLogMetadata(suggestion))")
                         await MainActor.run {
                             onSuggestion(suggestion, shouldPresentPrompt)
                         }
@@ -849,6 +849,10 @@ final class DictationCorrectionMonitor {
     nonisolated private static func log(_ message: String) {
         logger.debug("\(message, privacy: .public)")
         fputs("[dictionary-monitor] \(message)\n", stderr)
+    }
+
+    nonisolated private static func suggestionLogMetadata(_ suggestion: DictionarySuggestion) -> String {
+        "observedChars=\(suggestion.observed.count) replacementChars=\(suggestion.replacement.count)"
     }
 
     nonisolated private static func detectEditedSnapshots(

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -803,6 +803,39 @@ struct DictionaryCorrectionDetector {
         return scalars.dropFirst().contains(where: \.isUppercase)
     }
 
+    static func requiredEnglishWordCandidates(originalText: String, editedText: String) -> Set<String> {
+        var candidates = Set<String>()
+
+        func addWords(from value: String) {
+            for token in wordTokens(in: value) where token.normalized.count >= 2 {
+                guard token.normalized.allSatisfy(\.isLetter) else { continue }
+                candidates.insert(token.normalized)
+            }
+        }
+
+        let diff = changedFragments(from: originalText, to: editedText)
+        addWords(from: diff.removed)
+        addWords(from: diff.inserted)
+
+        let originalTokens = wordTokens(in: originalText)
+        let editedTokens = wordTokens(in: editedText)
+        guard isAlignmentInputWithinBounds(
+            originalCount: originalTokens.count,
+            editedCount: editedTokens.count
+        ) else { return candidates }
+
+        let operations = alignmentOperations(from: originalTokens, to: editedTokens)
+        for run in tokenChangeRuns(in: operations) {
+            for token in run.observedTokens + run.replacementTokens {
+                guard token.normalized.count >= 2,
+                      token.normalized.allSatisfy(\.isLetter)
+                else { continue }
+                candidates.insert(token.normalized)
+            }
+        }
+        return candidates
+    }
+
     private static func isAcronymLike(_ value: String) -> Bool {
         let letters = value.filter(\.isLetter)
         guard letters.count >= 2 else { return false }
@@ -971,7 +1004,7 @@ final class DictationCorrectionMonitor {
                 }
                 for stableSnapshot in stableSnapshots {
                     let recognizedEnglishWords = Self.englishWordRecognizer.recognizedWords(
-                        from: Self.englishWordCandidates(in: [originalText, stableSnapshot])
+                        from: Self.englishWordCandidates(originalText: originalText, editedText: stableSnapshot)
                     )
                     if Task.isCancelled { return }
                     let suggestions = await Task.detached(priority: .utility) {
@@ -1033,6 +1066,20 @@ final class DictationCorrectionMonitor {
         )
     }
 
+    nonisolated private static func englishWordCandidates(originalText: String, editedText: String) -> Set<String> {
+        let requiredCandidates = DictionaryCorrectionDetector.requiredEnglishWordCandidates(
+            originalText: originalText,
+            editedText: editedText
+        )
+        let extraCandidates = englishWordCandidates(in: [originalText, editedText])
+            .subtracting(requiredCandidates)
+        let extraBudget = max(0, maxEnglishWordRecognitionCandidates - requiredCandidates.count)
+        guard extraCandidates.count > extraBudget else {
+            return requiredCandidates.union(extraCandidates)
+        }
+        return requiredCandidates.union(sortedEnglishWordCandidates(extraCandidates).prefix(extraBudget))
+    }
+
     nonisolated private static func englishWordCandidates(in texts: [String]) -> Set<String> {
         var candidates = Set<String>()
         for text in texts {
@@ -1041,15 +1088,16 @@ final class DictationCorrectionMonitor {
                 candidates.insert(String(token))
             }
         }
-        if candidates.count > maxEnglishWordRecognitionCandidates {
-            return Set(candidates.sorted {
-                if $0.count != $1.count {
-                    return $0.count < $1.count
-                }
-                return $0 < $1
-            }.prefix(maxEnglishWordRecognitionCandidates))
-        }
         return candidates
+    }
+
+    nonisolated private static func sortedEnglishWordCandidates(_ candidates: Set<String>) -> [String] {
+        candidates.sorted {
+            if $0.count != $1.count {
+                return $0.count < $1.count
+            }
+            return $0 < $1
+        }
     }
 
     nonisolated private static func log(_ message: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -25,6 +25,7 @@ struct DictionaryCorrectionDetector {
     private static let maxObservedTokensPerDictionaryWord = 2
     private static let maxAlignmentTokens = 512
     private static let maxAlignmentCellCount = 300_000
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "DictionaryCorrection")
 
     private struct EnglishWordLookup: Sendable {
         private let recognizedWords: Set<String>
@@ -260,12 +261,17 @@ struct DictionaryCorrectionDetector {
     }
 
     private static func isAlignmentInputWithinBounds(originalCount: Int, editedCount: Int) -> Bool {
-        guard originalCount > 0,
-              editedCount > 0,
-              originalCount <= maxAlignmentTokens,
-              editedCount <= maxAlignmentTokens
-        else { return false }
-        return (originalCount + 1) * (editedCount + 1) <= maxAlignmentCellCount
+        let cellCount = (originalCount + 1) * (editedCount + 1)
+        guard originalCount > 0, editedCount > 0 else { return false }
+        guard originalCount <= maxAlignmentTokens, editedCount <= maxAlignmentTokens else {
+            logger.debug("alignmentSkipped reason=tokenLimit originalTokens=\(originalCount, privacy: .public) editedTokens=\(editedCount, privacy: .public) maxTokens=\(maxAlignmentTokens, privacy: .public)")
+            return false
+        }
+        guard cellCount <= maxAlignmentCellCount else {
+            logger.debug("alignmentSkipped reason=cellLimit originalTokens=\(originalCount, privacy: .public) editedTokens=\(editedCount, privacy: .public) cells=\(cellCount, privacy: .public) maxCells=\(maxAlignmentCellCount, privacy: .public)")
+            return false
+        }
+        return true
     }
 
     private struct TokenChangeRun {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -374,13 +374,19 @@ struct DictionaryCorrectionDetector {
         let observedLetters = observed.lowercased().filter(\.isLetter)
         let replacementCharacters = Array(replacement.lowercased())
         guard observedLetters.count >= 4,
-              replacementCharacters.contains(where: \.isNumber),
+              replacementCharacters.count >= 3,
               let firstObserved = observedLetters.first,
               let lastObserved = observedLetters.last,
               replacementCharacters.first == firstObserved,
               replacementCharacters.last == lastObserved
         else { return false }
-        return true
+
+        let middleCharacters = replacementCharacters.dropFirst().dropLast()
+        guard !middleCharacters.isEmpty,
+              middleCharacters.allSatisfy(\.isNumber),
+              let omittedCount = Int(String(middleCharacters))
+        else { return false }
+        return omittedCount == observedLetters.count - 2
     }
 
     private static func isAcronymCorrection(observedTokens: [String], replacement: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -267,53 +267,107 @@ struct DictionaryCorrectionDetector {
         maxCandidates: Int
     ) -> [CorrectionCandidate] {
         guard maxCandidates > 0 else { return [] }
-        guard run.observedTokens.count <= run.replacementTokens.count * maxObservedTokensPerDictionaryWord else {
-            return []
-        }
         var results: [CorrectionCandidate] = []
         var observedIndex = 0
 
         for replacementToken in run.replacementTokens {
             guard results.count < maxCandidates, observedIndex < run.observedTokens.count else { break }
 
-            var bestCandidate: CorrectionCandidate?
-            var bestObservedLength = 0
-            var bestSimilarity = 0.0
-            let maxObservedLength = min(maxObservedTokensPerDictionaryWord, run.observedTokens.count - observedIndex)
-
-            for observedLength in 1...maxObservedLength {
-                let observedText = run.observedTokens[observedIndex..<(observedIndex + observedLength)]
-                    .map(\.text)
-                    .joined(separator: " ")
-                guard let observedCandidate = normalizedCandidate(observedText),
-                      let replacementCandidate = normalizedCandidate(replacementToken.text),
-                      isWordScopedSuggestion(observed: observedCandidate, replacement: replacementCandidate),
-                      originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil,
-                      isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate)
-                else { continue }
-
-                let similarity = CustomWordMatcher.jaroWinklerSimilarity(
-                    observedCandidate.replacingOccurrences(of: " ", with: "").lowercased(),
-                    replacementCandidate.lowercased()
-                )
-                if similarity > bestSimilarity {
-                    bestCandidate = CorrectionCandidate(
-                        observed: observedCandidate,
-                        replacement: replacementCandidate
-                    )
-                    bestObservedLength = observedLength
-                    bestSimilarity = similarity
-                }
-            }
-
-            if let bestCandidate {
+            if let overlongLength = overlongCorrectionLength(
+                observedTokens: run.observedTokens,
+                observedIndex: observedIndex,
+                replacementToken: replacementToken,
+                originalText: originalText
+            ) {
+                observedIndex += overlongLength
+            } else if let (bestCandidate, observedLength) = bestTokenCandidate(
+                observedTokens: run.observedTokens,
+                observedIndex: observedIndex,
+                replacementToken: replacementToken,
+                originalText: originalText
+            ) {
                 results.append(bestCandidate)
-                observedIndex += bestObservedLength
-            } else {
-                observedIndex += 1
+                observedIndex += observedLength
             }
         }
         return results
+    }
+
+    private static func bestTokenCandidate(
+        observedTokens: [WordToken],
+        observedIndex: Int,
+        replacementToken: WordToken,
+        originalText: String
+    ) -> (CorrectionCandidate, Int)? {
+        var bestCandidate: CorrectionCandidate?
+        var bestObservedLength = 0
+        var bestSimilarity = 0.0
+        let maxObservedLength = min(maxObservedTokensPerDictionaryWord, observedTokens.count - observedIndex)
+
+        for observedLength in 1...maxObservedLength {
+            let observedText = observedTokens[observedIndex..<(observedIndex + observedLength)]
+                .map(\.text)
+                .joined(separator: " ")
+            guard let observedCandidate = normalizedCandidate(observedText),
+                  let replacementCandidate = normalizedCandidate(replacementToken.text),
+                  isWordScopedSuggestion(observed: observedCandidate, replacement: replacementCandidate),
+                  originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil,
+                  isLikelyDictionaryCorrection(observed: observedCandidate, replacement: replacementCandidate)
+            else { continue }
+
+            let similarity = CustomWordMatcher.jaroWinklerSimilarity(
+                observedCandidate.replacingOccurrences(of: " ", with: "").lowercased(),
+                replacementCandidate.lowercased()
+            )
+            if similarity > bestSimilarity {
+                bestCandidate = CorrectionCandidate(
+                    observed: observedCandidate,
+                    replacement: replacementCandidate
+                )
+                bestObservedLength = observedLength
+                bestSimilarity = similarity
+            }
+        }
+
+        guard let bestCandidate else { return nil }
+        return (bestCandidate, bestObservedLength)
+    }
+
+    private static func overlongCorrectionLength(
+        observedTokens: [WordToken],
+        observedIndex: Int,
+        replacementToken: WordToken,
+        originalText: String
+    ) -> Int? {
+        let maxOverlongLength = min(3, observedTokens.count - observedIndex)
+        guard maxOverlongLength > maxObservedTokensPerDictionaryWord else { return nil }
+        for observedLength in stride(from: maxOverlongLength, through: maxObservedTokensPerDictionaryWord + 1, by: -1) {
+            let observedText = observedTokens[observedIndex..<(observedIndex + observedLength)]
+                .map(\.text)
+                .joined(separator: " ")
+            guard let observedCandidate = normalizedCandidate(observedText),
+                  let replacementCandidate = normalizedCandidate(replacementToken.text),
+                  originalText.range(of: observedCandidate, options: [.caseInsensitive, .diacriticInsensitive]) != nil,
+                  isLikelyOverlongSplitCorrection(observed: observedCandidate, replacement: replacementCandidate)
+            else { continue }
+            return observedLength
+        }
+        return nil
+    }
+
+    private static func isLikelyOverlongSplitCorrection(observed: String, replacement: String) -> Bool {
+        let observedTokens = observed.split(whereSeparator: \.isWhitespace)
+        guard observedTokens.count > maxObservedTokensPerDictionaryWord,
+              !replacement.contains("-"),
+              !replacement.contains("_"),
+              !replacement.contains("/"),
+              !isAcronymLike(replacement),
+              !commonWords.contains(replacement.lowercased())
+        else { return false }
+
+        let compactObserved = observedTokens.joined().lowercased()
+        let compactReplacement = replacement.lowercased()
+        return CustomWordMatcher.jaroWinklerSimilarity(compactObserved, compactReplacement) >= minimumCorrectionSimilarity
     }
 
     static func hasSufficientSharedContext(originalText: String, editedText: String) -> Bool {
@@ -660,7 +714,7 @@ struct DictionaryCorrectionDetector {
     private static func isRecognizedEnglishWord(_ value: String) -> Bool {
         spellCheckerLock.lock()
         defer { spellCheckerLock.unlock() }
-        let range = NSSpellChecker.shared.checkSpelling(
+        let range = NSSpellChecker().checkSpelling(
             of: value,
             startingAt: 0,
             language: "en",
@@ -741,7 +795,7 @@ final class DictationCorrectionMonitor {
         originalText: String,
         appContext: String,
         targetApp: DictationCorrectionTargetApp?,
-        onSuggestion: @escaping @MainActor (DictionarySuggestion, Bool) -> Void
+        onSuggestion: @escaping @MainActor (DictionarySuggestion) -> Void
     ) {
         cancel()
         Self.log("start originalCharacters=\(originalText.count) target=\(targetApp?.appContext ?? appContext)")
@@ -803,12 +857,11 @@ final class DictationCorrectionMonitor {
                         Self.log("stableSnapshot rejected suggestions=0")
                     }
                     for suggestion in suggestions where !emittedSuggestionKeys.contains(suggestion.key) {
-                        let shouldPresentPrompt = true
                         emittedSuggestionKeys.insert(suggestion.key)
                         emittedSuggestionCount += 1
-                        Self.log("emit presentPrompt=\(shouldPresentPrompt) \(Self.suggestionLogMetadata(suggestion))")
+                        Self.log("emit \(Self.suggestionLogMetadata(suggestion))")
                         await MainActor.run {
-                            onSuggestion(suggestion, shouldPresentPrompt)
+                            onSuggestion(suggestion)
                         }
                         if emittedSuggestionCount >= Self.maxSuggestionsPerSession {
                             Self.log("complete reason=maxSuggestions count=\(emittedSuggestionCount)")

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -312,7 +312,7 @@ struct DictionaryCorrectionDetector {
                 compactObserved,
                 compactReplacement
             )
-            return compactSimilarity >= 0.82 || hasSpecialDictionarySignal
+            return compactSimilarity >= 0.82
         }
 
         if commonWords.contains(normalizedObserved) {
@@ -334,7 +334,7 @@ struct DictionaryCorrectionDetector {
             return false
         }
 
-        return similarity >= minimumCorrectionSimilarity || hasSpecialDictionarySignal
+        return similarity >= minimumCorrectionSimilarity
     }
 
     private static func isCommonWordTruncation(observed: String, replacement: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -17,6 +17,10 @@ final class DictionarySuggestionPromptController: NSObject {
         super.init()
     }
 
+    var isShowing: Bool {
+        panel != nil
+    }
+
     func show(
         suggestion: DictionarySuggestion,
         anchorFrame: NSRect?,
@@ -119,8 +123,10 @@ final class DictionarySuggestionPromptController: NSObject {
         progressLayer?.timeOffset = 0
         progressLayer?.beginTime = 0
         progressLayer = nil
-        panel?.orderOut(nil)
+        let previousPanel = panel
         panel = nil
+        previousPanel?.orderOut(nil)
+        previousPanel?.close()
         if notify {
             dismissHandler?()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -17,8 +17,8 @@ final class DictionarySuggestionPromptController: NSObject {
         super.init()
     }
 
-    static func firesAutoDismissCallbackAfterFade(wasDismissPaused: Bool) -> Bool {
-        !wasDismissPaused
+    static func shouldAutoDismissFromTimer(isPausedWhenTimerFires: Bool) -> Bool {
+        !isPausedWhenTimerFires
     }
 
     var isShowing: Bool {
@@ -162,12 +162,9 @@ final class DictionarySuggestionPromptController: NSObject {
     }
 
     private func autoDismissNow() {
-        guard !isDismissPaused else { return }
+        guard Self.shouldAutoDismissFromTimer(isPausedWhenTimerFires: isDismissPaused) else { return }
         animateOut { [weak self] in
-            guard let self else { return }
-            let wasPaused = self.isDismissPaused
-            let shouldNotify = Self.firesAutoDismissCallbackAfterFade(wasDismissPaused: wasPaused)
-            self.dismiss(notify: shouldNotify)
+            self?.dismiss(notify: true)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -25,6 +25,10 @@ final class DictionarySuggestionPromptController: NSObject {
         !isPausedAtCompletion
     }
 
+    static func resumedAutoDismissDurationAfterPausedFade(totalDuration: TimeInterval) -> TimeInterval {
+        max(0.1, totalDuration / 3)
+    }
+
     var isShowing: Bool {
         panel != nil
     }
@@ -227,6 +231,7 @@ final class DictionarySuggestionPromptController: NSObject {
     private func restoreAfterPausedAutoDismissFade() {
         guard let panel else { return }
         panel.alphaValue = 1
+        startDismissCountdown(duration: Self.resumedAutoDismissDurationAfterPausedFade(totalDuration: Self.dismissDuration))
     }
 
     private static func frame(for size: NSSize, anchorFrame: NSRect?) -> NSRect {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -21,8 +21,8 @@ final class DictionarySuggestionPromptController {
     ) {
         dismiss()
 
-        let cardWidth: CGFloat = 384
-        let cardHeight: CGFloat = 74
+        let cardWidth: CGFloat = 420
+        let cardHeight: CGFloat = 126
         let closeButtonSize: CGFloat = 22
         let cardX = closeButtonSize / 2 + 1
         let topGutter: CGFloat = closeButtonSize / 2 + 1
@@ -278,36 +278,38 @@ private final class DictionarySuggestionPromptView: NSView {
         cardView.layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
         addSubview(cardView)
 
-        let iconSize: CGFloat = 26
+        let iconSize: CGFloat = 28
         let iconView = NSImageView()
         iconView.image = NSImage(systemSymbolName: "text.book.closed", accessibilityDescription: "Dictionary")
             ?? NSImage(systemSymbolName: "text.quote", accessibilityDescription: "Dictionary")
         iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 15, weight: .semibold)
         iconView.contentTintColor = NSColor.white.withAlphaComponent(0.86)
         iconView.imageScaling = .scaleProportionallyUpOrDown
-        iconView.frame = NSRect(x: 14, y: (cardFrame.height - iconSize) / 2 + 1, width: iconSize, height: iconSize)
+        iconView.frame = NSRect(x: 16, y: cardFrame.height - 46, width: iconSize, height: iconSize)
         cardView.addSubview(iconView)
 
-        let textX: CGFloat = 49
-        let buttonWidth: CGFloat = 68
+        let textX: CGFloat = 56
+        let buttonWidth: CGFloat = 86
         let buttonGap: CGFloat = 8
-        let buttonY: CGFloat = 22
+        let buttonY: CGFloat = 18
         let buttonHeight: CGFloat = 30
-        let ignoreX = cardFrame.width - 12 - buttonWidth
+        let ignoreX = cardFrame.width - 16 - buttonWidth
         let laterX = ignoreX - buttonGap - buttonWidth
         let addX = laterX - buttonGap - buttonWidth
-        let textMaxX = addX - 12
+        let textWidth = cardFrame.width - textX - 18
 
         let title = label("Add correction?", font: .systemFont(ofSize: 13, weight: .semibold), color: .white)
-        title.frame = NSRect(x: textX, y: 41, width: max(40, textMaxX - textX), height: 18)
+        title.frame = NSRect(x: textX, y: 92, width: textWidth, height: 18)
         cardView.addSubview(title)
 
         let detail = label(
-            "\"\(truncate(suggestion.observed, limit: 22))\" -> \"\(truncate(suggestion.replacement, limit: 22))\"",
-            font: .systemFont(ofSize: 11),
-            color: NSColor.white.withAlphaComponent(0.58)
+            "\"\(suggestion.observed)\" -> \"\(suggestion.replacement)\"",
+            font: .systemFont(ofSize: 13),
+            color: NSColor.white.withAlphaComponent(0.72),
+            lineBreakMode: .byTruncatingMiddle
         )
-        detail.frame = NSRect(x: textX, y: 22, width: max(40, textMaxX - textX), height: 16)
+        detail.toolTip = "\"\(suggestion.observed)\" -> \"\(suggestion.replacement)\""
+        detail.frame = NSRect(x: textX, y: 66, width: textWidth, height: 18)
         cardView.addSubview(detail)
 
         let add = button(title: "Add", action: #selector(addTapped), isPrimary: true)
@@ -323,11 +325,16 @@ private final class DictionarySuggestionPromptView: NSView {
         cardView.addSubview(ignore)
     }
 
-    private func label(_ text: String, font: NSFont, color: NSColor) -> NSTextField {
+    private func label(
+        _ text: String,
+        font: NSFont,
+        color: NSColor,
+        lineBreakMode: NSLineBreakMode = .byTruncatingTail
+    ) -> NSTextField {
         let label = NSTextField(labelWithString: text)
         label.font = font
         label.textColor = color
-        label.lineBreakMode = .byTruncatingTail
+        label.lineBreakMode = lineBreakMode
         return label
     }
 
@@ -343,11 +350,6 @@ private final class DictionarySuggestionPromptView: NSView {
         button.focusRingType = .none
         button.contentTintColor = .white
         return button
-    }
-
-    private func truncate(_ value: String, limit: Int) -> String {
-        guard value.count > limit else { return value }
-        return String(value.prefix(limit - 1)) + "..."
     }
 
     @objc private func addTapped() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -16,7 +16,6 @@ final class DictionarySuggestionPromptController {
         suggestion: DictionarySuggestion,
         anchorFrame: NSRect?,
         onAdd: @escaping () -> Void,
-        onLater: @escaping () -> Void,
         onIgnore: @escaping () -> Void
     ) {
         dismiss()
@@ -54,10 +53,6 @@ final class DictionarySuggestionPromptController {
             onAdd: { [weak self] in
                 self?.dismiss()
                 onAdd()
-            },
-            onLater: { [weak self] in
-                self?.dismiss()
-                onLater()
             },
             onIgnore: { [weak self] in
                 self?.dismiss()
@@ -243,7 +238,6 @@ private final class DictionarySuggestionPromptView: NSView {
     private let cardFrame: NSRect
     private let suggestion: DictionarySuggestion
     private let onAdd: () -> Void
-    private let onLater: () -> Void
     private let onIgnore: () -> Void
 
     init(
@@ -251,13 +245,11 @@ private final class DictionarySuggestionPromptView: NSView {
         cardFrame: NSRect,
         suggestion: DictionarySuggestion,
         onAdd: @escaping () -> Void,
-        onLater: @escaping () -> Void,
         onIgnore: @escaping () -> Void
     ) {
         self.cardFrame = cardFrame
         self.suggestion = suggestion
         self.onAdd = onAdd
-        self.onLater = onLater
         self.onIgnore = onIgnore
         super.init(frame: frame)
         wantsLayer = true
@@ -289,13 +281,12 @@ private final class DictionarySuggestionPromptView: NSView {
         cardView.addSubview(iconView)
 
         let textX: CGFloat = 56
-        let buttonWidth: CGFloat = 86
+        let buttonWidth: CGFloat = 82
         let buttonGap: CGFloat = 8
         let buttonY: CGFloat = 18
         let buttonHeight: CGFloat = 30
         let ignoreX = cardFrame.width - 16 - buttonWidth
-        let laterX = ignoreX - buttonGap - buttonWidth
-        let addX = laterX - buttonGap - buttonWidth
+        let addX = ignoreX - buttonGap - buttonWidth
         let textWidth = cardFrame.width - textX - 18
 
         let title = label("Add correction?", font: .systemFont(ofSize: 13, weight: .semibold), color: .white)
@@ -315,10 +306,6 @@ private final class DictionarySuggestionPromptView: NSView {
         let add = button(title: "Add", action: #selector(addTapped), isPrimary: true)
         add.frame = NSRect(x: addX, y: buttonY, width: buttonWidth, height: buttonHeight)
         cardView.addSubview(add)
-
-        let later = button(title: "Later", action: #selector(laterTapped), isPrimary: false)
-        later.frame = NSRect(x: laterX, y: buttonY, width: buttonWidth, height: buttonHeight)
-        cardView.addSubview(later)
 
         let ignore = button(title: "Ignore", action: #selector(ignoreTapped), isPrimary: false)
         ignore.frame = NSRect(x: ignoreX, y: buttonY, width: buttonWidth, height: buttonHeight)
@@ -354,10 +341,6 @@ private final class DictionarySuggestionPromptView: NSView {
 
     @objc private func addTapped() {
         onAdd()
-    }
-
-    @objc private func laterTapped() {
-        onLater()
     }
 
     @objc private func ignoreTapped() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -17,6 +17,10 @@ final class DictionarySuggestionPromptController: NSObject {
         super.init()
     }
 
+    static func firesAutoDismissCallbackAfterFade(wasDismissPaused: Bool) -> Bool {
+        !wasDismissPaused
+    }
+
     var isShowing: Bool {
         panel != nil
     }
@@ -156,8 +160,18 @@ final class DictionarySuggestionPromptController: NSObject {
         dismissDeadline = Date().addingTimeInterval(duration)
         dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
             Task { @MainActor in
-                self?.dismiss()
+                self?.autoDismissNow()
             }
+        }
+    }
+
+    private func autoDismissNow() {
+        guard !isDismissPaused else { return }
+        animateOut { [weak self] in
+            guard let self else { return }
+            let wasPaused = self.isDismissPaused
+            let shouldNotify = Self.firesAutoDismissCallbackAfterFade(wasDismissPaused: wasPaused)
+            self.dismiss(notify: shouldNotify)
         }
     }
 
@@ -191,7 +205,21 @@ final class DictionarySuggestionPromptController: NSObject {
     }
 
     @objc private func handleDismiss() {
-        dismiss()
+        animateOut { [weak self] in
+            self?.dismiss()
+        }
+    }
+
+    private func animateOut(completion: @escaping @MainActor @Sendable () -> Void) {
+        guard let panel else { completion(); return }
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.2
+            panel.animator().alphaValue = 0
+        }, completionHandler: {
+            Task { @MainActor in
+                completion()
+            }
+        })
     }
 
     private static func frame(for size: NSSize, anchorFrame: NSRect?) -> NSRect {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -11,7 +11,6 @@ final class DictionarySuggestionPromptController {
     private var dismissDeadline: Date?
     private var remainingDismissDuration: TimeInterval = 0
     private var isDismissPaused = false
-    private var onAutoDismiss: (() -> Void)?
 
     func show(
         suggestion: DictionarySuggestion,
@@ -139,7 +138,7 @@ final class DictionarySuggestionPromptController {
         dismissTimer?.invalidate()
         dismissDeadline = Date().addingTimeInterval(duration)
         dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self?.dismiss()
             }
         }
@@ -205,7 +204,7 @@ final class DictionarySuggestionPromptController {
 
 @MainActor
 private final class DictionarySuggestionPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
+    override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -114,6 +114,10 @@ final class DictionarySuggestionPromptController: NSObject {
         dismiss(notify: true)
     }
 
+    func dismissWithoutNotification() {
+        dismiss(notify: false)
+    }
+
     private func dismiss(notify: Bool) {
         let dismissHandler = onDismiss
         onDismiss = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -25,10 +25,6 @@ final class DictionarySuggestionPromptController: NSObject {
         !isPausedAtCompletion
     }
 
-    static func resumedAutoDismissDurationAfterPausedFade(totalDuration: TimeInterval) -> TimeInterval {
-        max(0.1, totalDuration / 3)
-    }
-
     var isShowing: Bool {
         panel != nil
     }
@@ -231,7 +227,6 @@ final class DictionarySuggestionPromptController: NSObject {
     private func restoreAfterPausedAutoDismissFade() {
         guard let panel else { return }
         panel.alphaValue = 1
-        startDismissCountdown(duration: Self.resumedAutoDismissDurationAfterPausedFade(totalDuration: Self.dismissDuration))
     }
 
     private static func frame(for size: NSSize, anchorFrame: NSRect?) -> NSRect {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -34,8 +34,8 @@ final class DictionarySuggestionPromptController: NSObject {
     ) {
         dismiss(notify: false)
 
-        let cardWidth: CGFloat = 420
-        let cardHeight: CGFloat = 126
+        let cardWidth: CGFloat = 356
+        let cardHeight: CGFloat = 96
         let closeButtonSize: CGFloat = 22
         let cardX = closeButtonSize / 2 + 1
         let topGutter: CGFloat = closeButtonSize / 2 + 1
@@ -64,6 +64,9 @@ final class DictionarySuggestionPromptController: NSObject {
             frame: NSRect(origin: .zero, size: size),
             cardFrame: NSRect(x: cardX, y: 0, width: cardWidth, height: cardHeight),
             suggestion: suggestion,
+            onProgressLayerReady: { [weak self] layer in
+                self?.progressLayer = layer
+            },
             onAdd: { [weak self] in
                 self?.dismiss(notify: false)
                 onAdd()
@@ -95,13 +98,6 @@ final class DictionarySuggestionPromptController: NSObject {
         dismissButton.toolTip = "Dismiss"
         contentView.addSubview(dismissButton)
 
-        let progressBar = CALayer()
-        progressBar.frame = CGRect(x: 0, y: 0, width: cardWidth, height: 3)
-        progressBar.backgroundColor = NSColor(red: 0.3, green: 0.6, blue: 1.0, alpha: 0.8).cgColor
-        progressBar.anchorPoint = CGPoint(x: 0, y: 0.5)
-        progressBar.position = CGPoint(x: cardX, y: 1.5)
-        contentView.layer?.addSublayer(progressBar)
-        progressLayer = progressBar
         panel.contentView = contentView
 
         self.panel = panel
@@ -287,6 +283,7 @@ private final class DictionarySuggestionHoverView: NSView {
 private final class DictionarySuggestionPromptView: NSView {
     private let cardFrame: NSRect
     private let suggestion: DictionarySuggestion
+    private let onProgressLayerReady: (CALayer) -> Void
     private let onAdd: () -> Void
     private let onIgnore: () -> Void
 
@@ -294,11 +291,13 @@ private final class DictionarySuggestionPromptView: NSView {
         frame: NSRect,
         cardFrame: NSRect,
         suggestion: DictionarySuggestion,
+        onProgressLayerReady: @escaping (CALayer) -> Void,
         onAdd: @escaping () -> Void,
         onIgnore: @escaping () -> Void
     ) {
         self.cardFrame = cardFrame
         self.suggestion = suggestion
+        self.onProgressLayerReady = onProgressLayerReady
         self.onAdd = onAdd
         self.onIgnore = onIgnore
         super.init(frame: frame)
@@ -320,27 +319,40 @@ private final class DictionarySuggestionPromptView: NSView {
         cardView.layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
         addSubview(cardView)
 
-        let iconSize: CGFloat = 28
+        let countdownTrack = CALayer()
+        countdownTrack.frame = CGRect(x: 0, y: 0, width: cardFrame.width, height: 5)
+        countdownTrack.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        cardView.layer?.addSublayer(countdownTrack)
+
+        let progressBar = CALayer()
+        progressBar.frame = countdownTrack.bounds
+        progressBar.backgroundColor = NSColor(red: 0.24, green: 0.56, blue: 1.0, alpha: 1.0).cgColor
+        progressBar.anchorPoint = CGPoint(x: 0, y: 0.5)
+        progressBar.position = CGPoint(x: 0, y: countdownTrack.bounds.midY)
+        countdownTrack.addSublayer(progressBar)
+        onProgressLayerReady(progressBar)
+
+        let iconSize: CGFloat = 24
         let iconView = NSImageView()
         iconView.image = NSImage(systemSymbolName: "text.book.closed", accessibilityDescription: "Dictionary")
             ?? NSImage(systemSymbolName: "text.quote", accessibilityDescription: "Dictionary")
         iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 15, weight: .semibold)
         iconView.contentTintColor = NSColor.white.withAlphaComponent(0.86)
         iconView.imageScaling = .scaleProportionallyUpOrDown
-        iconView.frame = NSRect(x: 16, y: cardFrame.height - 46, width: iconSize, height: iconSize)
+        iconView.frame = NSRect(x: 14, y: cardFrame.height - 42, width: iconSize, height: iconSize)
         cardView.addSubview(iconView)
 
-        let textX: CGFloat = 56
-        let buttonWidth: CGFloat = 82
+        let textX: CGFloat = 50
+        let buttonWidth: CGFloat = 76
         let buttonGap: CGFloat = 8
-        let buttonY: CGFloat = 18
-        let buttonHeight: CGFloat = 30
-        let ignoreX = cardFrame.width - 16 - buttonWidth
+        let buttonY: CGFloat = 13
+        let buttonHeight: CGFloat = 28
+        let ignoreX = cardFrame.width - 14 - buttonWidth
         let addX = ignoreX - buttonGap - buttonWidth
-        let textWidth = cardFrame.width - textX - 18
+        let textWidth = cardFrame.width - textX - 14
 
         let title = label("Add correction?", font: .systemFont(ofSize: 13, weight: .semibold), color: .white)
-        title.frame = NSRect(x: textX, y: 92, width: textWidth, height: 18)
+        title.frame = NSRect(x: textX, y: 66, width: textWidth, height: 18)
         cardView.addSubview(title)
 
         let detail = label(
@@ -350,7 +362,7 @@ private final class DictionarySuggestionPromptView: NSView {
             lineBreakMode: .byTruncatingMiddle
         )
         detail.toolTip = "\"\(suggestion.observed)\" -> \"\(suggestion.replacement)\""
-        detail.frame = NSRect(x: textX, y: 66, width: textWidth, height: 18)
+        detail.frame = NSRect(x: textX, y: 43, width: textWidth, height: 18)
         cardView.addSubview(detail)
 
         let add = button(title: "Add", action: #selector(addTapped), isPrimary: true)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -1,0 +1,365 @@
+import AppKit
+import QuartzCore
+
+@MainActor
+final class DictionarySuggestionPromptController {
+    private static let dismissDuration: TimeInterval = 15
+
+    private var panel: NSPanel?
+    private var dismissTimer: Timer?
+    private var progressLayer: CALayer?
+    private var dismissDeadline: Date?
+    private var remainingDismissDuration: TimeInterval = 0
+    private var isDismissPaused = false
+    private var onAutoDismiss: (() -> Void)?
+
+    func show(
+        suggestion: DictionarySuggestion,
+        anchorFrame: NSRect?,
+        onAdd: @escaping () -> Void,
+        onLater: @escaping () -> Void,
+        onIgnore: @escaping () -> Void
+    ) {
+        dismiss()
+
+        let cardWidth: CGFloat = 384
+        let cardHeight: CGFloat = 74
+        let closeButtonSize: CGFloat = 22
+        let cardX = closeButtonSize / 2 + 1
+        let topGutter: CGFloat = closeButtonSize / 2 + 1
+        let size = NSSize(width: cardWidth + cardX, height: cardHeight + topGutter)
+        let frame = Self.frame(for: size, anchorFrame: anchorFrame)
+        let panel = DictionarySuggestionPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.becomesKeyOnlyIfNeeded = true
+
+        let contentView = DictionarySuggestionHoverView(frame: NSRect(origin: .zero, size: size))
+        contentView.onMouseEntered = { [weak self] in self?.pauseDismissCountdown() }
+        contentView.onMouseExited = { [weak self] in self?.resumeDismissCountdown() }
+        contentView.wantsLayer = true
+
+        let cardView = DictionarySuggestionPromptView(
+            frame: NSRect(origin: .zero, size: size),
+            cardFrame: NSRect(x: cardX, y: 0, width: cardWidth, height: cardHeight),
+            suggestion: suggestion,
+            onAdd: { [weak self] in
+                self?.dismiss()
+                onAdd()
+            },
+            onLater: { [weak self] in
+                self?.dismiss()
+                onLater()
+            },
+            onIgnore: { [weak self] in
+                self?.dismiss()
+                onIgnore()
+            }
+        )
+        contentView.addSubview(cardView)
+
+        let dismissButton = NSButton(title: "×", target: self, action: #selector(handleDismiss))
+        dismissButton.font = .systemFont(ofSize: 15, weight: .medium)
+        dismissButton.frame = NSRect(
+            x: cardX - closeButtonSize / 2,
+            y: cardHeight + topGutter - closeButtonSize,
+            width: closeButtonSize,
+            height: closeButtonSize
+        )
+        dismissButton.wantsLayer = true
+        dismissButton.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.70).cgColor
+        dismissButton.layer?.borderWidth = 1
+        dismissButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.55).cgColor
+        dismissButton.layer?.cornerRadius = closeButtonSize / 2
+        dismissButton.alignment = .center
+        dismissButton.focusRingType = .none
+        dismissButton.isBordered = false
+        dismissButton.contentTintColor = NSColor.white.withAlphaComponent(0.86)
+        dismissButton.toolTip = "Dismiss"
+        contentView.addSubview(dismissButton)
+
+        let progressBar = CALayer()
+        progressBar.frame = CGRect(x: 0, y: 0, width: cardWidth, height: 3)
+        progressBar.backgroundColor = NSColor(red: 0.3, green: 0.6, blue: 1.0, alpha: 0.8).cgColor
+        progressBar.anchorPoint = CGPoint(x: 0, y: 0.5)
+        progressBar.position = CGPoint(x: cardX, y: 1.5)
+        contentView.layer?.addSublayer(progressBar)
+        progressLayer = progressBar
+        panel.contentView = contentView
+
+        self.panel = panel
+        panel.orderFrontRegardless()
+        startDismissCountdown(duration: Self.dismissDuration)
+    }
+
+    func dismiss() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+        dismissDeadline = nil
+        remainingDismissDuration = 0
+        isDismissPaused = false
+        progressLayer?.removeAllAnimations()
+        progressLayer?.speed = 1
+        progressLayer?.timeOffset = 0
+        progressLayer?.beginTime = 0
+        progressLayer = nil
+        panel?.orderOut(nil)
+        panel = nil
+    }
+
+    private func startDismissCountdown(duration: TimeInterval) {
+        remainingDismissDuration = duration
+        isDismissPaused = false
+        startProgressAnimation(duration: duration)
+        scheduleDismissTimer(after: duration)
+    }
+
+    private func startProgressAnimation(duration: TimeInterval) {
+        guard let progressLayer else { return }
+        let shrink = CABasicAnimation(keyPath: "bounds.size.width")
+        shrink.fromValue = progressLayer.bounds.width
+        shrink.toValue = 0
+        shrink.duration = duration
+        shrink.timingFunction = CAMediaTimingFunction(name: .linear)
+        shrink.fillMode = .forwards
+        shrink.isRemovedOnCompletion = false
+        progressLayer.add(shrink, forKey: "countdown")
+    }
+
+    private func scheduleDismissTimer(after duration: TimeInterval) {
+        dismissTimer?.invalidate()
+        dismissDeadline = Date().addingTimeInterval(duration)
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.dismiss()
+            }
+        }
+    }
+
+    private func pauseDismissCountdown() {
+        guard !isDismissPaused else { return }
+        isDismissPaused = true
+        if let dismissDeadline {
+            remainingDismissDuration = max(0.1, dismissDeadline.timeIntervalSinceNow)
+        }
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+        dismissDeadline = nil
+
+        guard let progressLayer else { return }
+        let pausedTime = progressLayer.convertTime(CACurrentMediaTime(), from: nil)
+        progressLayer.speed = 0
+        progressLayer.timeOffset = pausedTime
+    }
+
+    private func resumeDismissCountdown() {
+        guard isDismissPaused else { return }
+        isDismissPaused = false
+        scheduleDismissTimer(after: remainingDismissDuration)
+
+        guard let progressLayer else { return }
+        let pausedTime = progressLayer.timeOffset
+        let resumeHostTime = CACurrentMediaTime()
+        progressLayer.speed = 1
+        progressLayer.timeOffset = 0
+        progressLayer.beginTime = resumeHostTime - pausedTime
+    }
+
+    @objc private func handleDismiss() {
+        dismiss()
+    }
+
+    private static func frame(for size: NSSize, anchorFrame: NSRect?) -> NSRect {
+        let screenFrame = (anchorFrame.flatMap { anchor in
+            NSScreen.screens.first { screen in
+                screen.visibleFrame.intersects(anchor)
+            }
+        } ?? NSScreen.main)?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1200, height: 800)
+
+        let anchor = anchorFrame ?? NSRect(
+            x: screenFrame.midX - 22,
+            y: screenFrame.minY + 24,
+            width: 44,
+            height: 28
+        )
+
+        var x = anchor.midX - size.width / 2
+        var y = anchor.maxY + 10
+        if y + size.height > screenFrame.maxY {
+            y = anchor.minY - size.height - 10
+        }
+        x = min(max(x, screenFrame.minX + 12), screenFrame.maxX - size.width - 12)
+        y = min(max(y, screenFrame.minY + 12), screenFrame.maxY - size.height - 12)
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+}
+
+@MainActor
+private final class DictionarySuggestionPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+private final class DictionarySuggestionHoverView: NSView {
+    var onMouseEntered: (() -> Void)?
+    var onMouseExited: (() -> Void)?
+    private var trackingAreaRef: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaRef {
+            removeTrackingArea(trackingAreaRef)
+        }
+        let tracking = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(tracking)
+        trackingAreaRef = tracking
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onMouseEntered?()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onMouseExited?()
+    }
+}
+
+@MainActor
+private final class DictionarySuggestionPromptView: NSView {
+    private let cardFrame: NSRect
+    private let suggestion: DictionarySuggestion
+    private let onAdd: () -> Void
+    private let onLater: () -> Void
+    private let onIgnore: () -> Void
+
+    init(
+        frame: NSRect,
+        cardFrame: NSRect,
+        suggestion: DictionarySuggestion,
+        onAdd: @escaping () -> Void,
+        onLater: @escaping () -> Void,
+        onIgnore: @escaping () -> Void
+    ) {
+        self.cardFrame = cardFrame
+        self.suggestion = suggestion
+        self.onAdd = onAdd
+        self.onLater = onLater
+        self.onIgnore = onIgnore
+        super.init(frame: frame)
+        wantsLayer = true
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        let cardView = NSView(frame: cardFrame)
+        cardView.wantsLayer = true
+        cardView.layer?.cornerRadius = 10
+        cardView.layer?.masksToBounds = true
+        cardView.layer?.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.12, alpha: 0.97).cgColor
+        cardView.layer?.borderWidth = 1
+        cardView.layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        addSubview(cardView)
+
+        let iconSize: CGFloat = 26
+        let iconView = NSImageView()
+        iconView.image = NSImage(systemSymbolName: "text.book.closed", accessibilityDescription: "Dictionary")
+            ?? NSImage(systemSymbolName: "text.quote", accessibilityDescription: "Dictionary")
+        iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 15, weight: .semibold)
+        iconView.contentTintColor = NSColor.white.withAlphaComponent(0.86)
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        iconView.frame = NSRect(x: 14, y: (cardFrame.height - iconSize) / 2 + 1, width: iconSize, height: iconSize)
+        cardView.addSubview(iconView)
+
+        let textX: CGFloat = 49
+        let buttonWidth: CGFloat = 68
+        let buttonGap: CGFloat = 8
+        let buttonY: CGFloat = 22
+        let buttonHeight: CGFloat = 30
+        let ignoreX = cardFrame.width - 12 - buttonWidth
+        let laterX = ignoreX - buttonGap - buttonWidth
+        let addX = laterX - buttonGap - buttonWidth
+        let textMaxX = addX - 12
+
+        let title = label("Add correction?", font: .systemFont(ofSize: 13, weight: .semibold), color: .white)
+        title.frame = NSRect(x: textX, y: 41, width: max(40, textMaxX - textX), height: 18)
+        cardView.addSubview(title)
+
+        let detail = label(
+            "\"\(truncate(suggestion.observed, limit: 22))\" -> \"\(truncate(suggestion.replacement, limit: 22))\"",
+            font: .systemFont(ofSize: 11),
+            color: NSColor.white.withAlphaComponent(0.58)
+        )
+        detail.frame = NSRect(x: textX, y: 22, width: max(40, textMaxX - textX), height: 16)
+        cardView.addSubview(detail)
+
+        let add = button(title: "Add", action: #selector(addTapped), isPrimary: true)
+        add.frame = NSRect(x: addX, y: buttonY, width: buttonWidth, height: buttonHeight)
+        cardView.addSubview(add)
+
+        let later = button(title: "Later", action: #selector(laterTapped), isPrimary: false)
+        later.frame = NSRect(x: laterX, y: buttonY, width: buttonWidth, height: buttonHeight)
+        cardView.addSubview(later)
+
+        let ignore = button(title: "Ignore", action: #selector(ignoreTapped), isPrimary: false)
+        ignore.frame = NSRect(x: ignoreX, y: buttonY, width: buttonWidth, height: buttonHeight)
+        cardView.addSubview(ignore)
+    }
+
+    private func label(_ text: String, font: NSFont, color: NSColor) -> NSTextField {
+        let label = NSTextField(labelWithString: text)
+        label.font = font
+        label.textColor = color
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }
+
+    private func button(title: String, action: Selector, isPrimary: Bool) -> NSButton {
+        let button = NSButton(title: title, target: self, action: action)
+        button.font = .systemFont(ofSize: 12, weight: .medium)
+        button.wantsLayer = true
+        button.layer?.backgroundColor = isPrimary
+            ? NSColor(red: 0.2, green: 0.5, blue: 1.0, alpha: 1.0).cgColor
+            : NSColor.white.withAlphaComponent(0.12).cgColor
+        button.layer?.cornerRadius = 6
+        button.isBordered = false
+        button.focusRingType = .none
+        button.contentTintColor = .white
+        return button
+    }
+
+    private func truncate(_ value: String, limit: Int) -> String {
+        guard value.count > limit else { return value }
+        return String(value.prefix(limit - 1)) + "..."
+    }
+
+    @objc private func addTapped() {
+        onAdd()
+    }
+
+    @objc private func laterTapped() {
+        onLater()
+    }
+
+    @objc private func ignoreTapped() {
+        onIgnore()
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -2,7 +2,7 @@ import AppKit
 import QuartzCore
 
 @MainActor
-final class DictionarySuggestionPromptController {
+final class DictionarySuggestionPromptController: NSObject {
     private static let dismissDuration: TimeInterval = 15
 
     private var panel: NSPanel?
@@ -11,6 +11,10 @@ final class DictionarySuggestionPromptController {
     private var dismissDeadline: Date?
     private var remainingDismissDuration: TimeInterval = 0
     private var isDismissPaused = false
+
+    override init() {
+        super.init()
+    }
 
     func show(
         suggestion: DictionarySuggestion,

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -21,6 +21,10 @@ final class DictionarySuggestionPromptController: NSObject {
         !isPausedWhenTimerFires
     }
 
+    static func shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: Bool) -> Bool {
+        !isPausedAtCompletion
+    }
+
     var isShowing: Bool {
         panel != nil
     }
@@ -164,7 +168,12 @@ final class DictionarySuggestionPromptController: NSObject {
     private func autoDismissNow() {
         guard Self.shouldAutoDismissFromTimer(isPausedWhenTimerFires: isDismissPaused) else { return }
         animateOut { [weak self] in
-            self?.dismiss(notify: true)
+            guard let self else { return }
+            guard Self.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: self.isDismissPaused) else {
+                self.restoreAfterPausedAutoDismissFade()
+                return
+            }
+            self.dismiss(notify: true)
         }
     }
 
@@ -213,6 +222,11 @@ final class DictionarySuggestionPromptController: NSObject {
                 completion()
             }
         })
+    }
+
+    private func restoreAfterPausedAutoDismissFade() {
+        guard let panel else { return }
+        panel.alphaValue = 1
     }
 
     private static func frame(for size: NSSize, anchorFrame: NSRect?) -> NSRect {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -11,6 +11,7 @@ final class DictionarySuggestionPromptController: NSObject {
     private var dismissDeadline: Date?
     private var remainingDismissDuration: TimeInterval = 0
     private var isDismissPaused = false
+    private var onDismiss: (() -> Void)?
 
     override init() {
         super.init()
@@ -20,9 +21,10 @@ final class DictionarySuggestionPromptController: NSObject {
         suggestion: DictionarySuggestion,
         anchorFrame: NSRect?,
         onAdd: @escaping () -> Void,
-        onIgnore: @escaping () -> Void
+        onIgnore: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
     ) {
-        dismiss()
+        dismiss(notify: false)
 
         let cardWidth: CGFloat = 420
         let cardHeight: CGFloat = 126
@@ -55,11 +57,11 @@ final class DictionarySuggestionPromptController: NSObject {
             cardFrame: NSRect(x: cardX, y: 0, width: cardWidth, height: cardHeight),
             suggestion: suggestion,
             onAdd: { [weak self] in
-                self?.dismiss()
+                self?.dismiss(notify: false)
                 onAdd()
             },
             onIgnore: { [weak self] in
-                self?.dismiss()
+                self?.dismiss(notify: false)
                 onIgnore()
             }
         )
@@ -95,11 +97,18 @@ final class DictionarySuggestionPromptController: NSObject {
         panel.contentView = contentView
 
         self.panel = panel
+        self.onDismiss = onDismiss
         panel.orderFrontRegardless()
         startDismissCountdown(duration: Self.dismissDuration)
     }
 
     func dismiss() {
+        dismiss(notify: true)
+    }
+
+    private func dismiss(notify: Bool) {
+        let dismissHandler = onDismiss
+        onDismiss = nil
         dismissTimer?.invalidate()
         dismissTimer = nil
         dismissDeadline = nil
@@ -112,6 +121,9 @@ final class DictionarySuggestionPromptController: NSObject {
         progressLayer = nil
         panel?.orderOut(nil)
         panel = nil
+        if notify {
+            dismissHandler?()
+        }
     }
 
     private func startDismissCountdown(duration: TimeInterval) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionarySuggestionPromptController.swift
@@ -181,7 +181,7 @@ final class DictionarySuggestionPromptController: NSObject {
         guard !isDismissPaused else { return }
         isDismissPaused = true
         if let dismissDeadline {
-            remainingDismissDuration = max(0.1, dismissDeadline.timeIntervalSinceNow)
+            remainingDismissDuration = max(2.0, dismissDeadline.timeIntervalSinceNow)
         }
         dismissTimer?.invalidate()
         dismissTimer = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -37,8 +37,9 @@ struct DictionaryView: View {
         .alert("Enable Accessibility?", isPresented: $isShowingAccessibilityPrompt) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                let granted = controller.requestDictionaryCorrectionAccessibilityEnable()
-                controller.setDictionaryCorrectionPromptsEnabled(granted)
+                if controller.requestDictionaryCorrectionAccessibilityEnable() {
+                    controller.setDictionaryCorrectionPromptsEnabled(true)
+                }
             }
         } message: {
             Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -40,7 +40,7 @@ struct DictionaryView: View {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
-            Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")
+            Text("Dictionary suggestions need Accessibility to detect text edits after dictation. Grant access, restart Muesli, then turn suggestions on.")
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -34,8 +34,8 @@ struct DictionaryView: View {
         .alert("Enable Screen Context?", isPresented: $isShowingScreenContextPrompt) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                controller.setDictionaryCorrectionPromptsEnabled(true)
-                controller.requestScreenContextEnable()
+                let granted = controller.requestScreenContextEnable()
+                controller.setDictionaryCorrectionPromptsEnabled(granted)
             }
         } message: {
             Text("Dictionary suggestions need Screen Context to detect text edits after dictation.")

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -97,7 +97,7 @@ struct DictionaryView: View {
     }
 
     private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {
-        if controller.setDictionaryCorrectionPromptsFromToggle(enabled) {
+        if controller.setDictionaryCorrectionPromptsFromToggle(enabled) == .needsAccessibilityPermission {
             isShowingAccessibilityPrompt = true
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -49,6 +49,8 @@ struct DictionaryView: View {
                 .toggleStyle(.switch)
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textSecondary)
+                .disabled(!appState.config.enableScreenContext)
+                .help(appState.config.enableScreenContext ? "Suggest corrections after dictation edits." : "Enable Screen Context first.")
                 Button {
                     isAdding = true
                     newWord = ""
@@ -269,8 +271,8 @@ private struct DictionarySuggestionRow: View {
 
     private var detailText: String {
         var parts = ["Seen \(suggestion.occurrenceCount)x"]
-        if !suggestion.appContext.isEmpty {
-            parts.append(suggestion.appContext)
+        if !suggestion.appDisplayName.isEmpty {
+            parts.append(suggestion.appDisplayName)
         }
         return parts.joined(separator: " | ")
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -6,6 +6,7 @@ private enum DictionaryRowMetrics {
     static let thresholdWidth: CGFloat = 76
     static let actionButtonSize: CGFloat = 24
     static let actionsWidth: CGFloat = actionButtonSize * 2 + MuesliTheme.spacing8
+    static let suggestionPageSize = 10
 }
 
 struct DictionaryView: View {
@@ -17,6 +18,7 @@ struct DictionaryView: View {
     @State private var newReplacement = ""
     @State private var newThreshold = 0.85
     @State private var isShowingScreenContextPrompt = false
+    @State private var suggestionPage = 0
 
     var body: some View {
         ScrollView {
@@ -120,9 +122,13 @@ struct DictionaryView: View {
 
             Divider().background(MuesliTheme.surfaceBorder)
 
-            ForEach(appState.config.dictionarySuggestions) { suggestion in
+            ForEach(visibleDictionarySuggestions) { suggestion in
                 DictionarySuggestionRow(suggestion: suggestion, controller: controller)
                 Divider().background(MuesliTheme.surfaceBorder)
+            }
+
+            if suggestionPageCount > 1 {
+                suggestionPaginationControls
             }
         }
         .background(MuesliTheme.backgroundRaised)
@@ -131,6 +137,62 @@ struct DictionaryView: View {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+    }
+
+    private var visibleDictionarySuggestions: [DictionarySuggestion] {
+        let suggestions = appState.config.dictionarySuggestions
+        guard !suggestions.isEmpty else { return [] }
+        let startIndex = boundedSuggestionPage * DictionaryRowMetrics.suggestionPageSize
+        let endIndex = min(startIndex + DictionaryRowMetrics.suggestionPageSize, suggestions.count)
+        return Array(suggestions[startIndex..<endIndex])
+    }
+
+    private var suggestionPageCount: Int {
+        let count = appState.config.dictionarySuggestions.count
+        guard count > 0 else { return 0 }
+        return (count + DictionaryRowMetrics.suggestionPageSize - 1) / DictionaryRowMetrics.suggestionPageSize
+    }
+
+    private var boundedSuggestionPage: Int {
+        min(max(suggestionPage, 0), max(suggestionPageCount - 1, 0))
+    }
+
+    private var suggestionRangeText: String {
+        let count = appState.config.dictionarySuggestions.count
+        guard count > 0 else { return "" }
+        let start = boundedSuggestionPage * DictionaryRowMetrics.suggestionPageSize + 1
+        let end = min(start + DictionaryRowMetrics.suggestionPageSize - 1, count)
+        return "\(start)-\(end) of \(count)"
+    }
+
+    private var suggestionPaginationControls: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Text(suggestionRangeText)
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+
+            Spacer()
+
+            DictionaryIconButton(
+                systemName: "chevron.left",
+                label: "Previous suggestions",
+                tint: MuesliTheme.textSecondary,
+                isDisabled: boundedSuggestionPage == 0
+            ) {
+                suggestionPage = max(boundedSuggestionPage - 1, 0)
+            }
+
+            DictionaryIconButton(
+                systemName: "chevron.right",
+                label: "Next suggestions",
+                tint: MuesliTheme.textSecondary,
+                isDisabled: boundedSuggestionPage >= suggestionPageCount - 1
+            ) {
+                suggestionPage = min(boundedSuggestionPage + 1, max(suggestionPageCount - 1, 0))
+            }
+        }
+        .padding(.horizontal, MuesliTheme.spacing16)
+        .padding(.vertical, MuesliTheme.spacing8)
     }
 
     private var wordList: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -38,7 +38,9 @@ struct DictionaryView: View {
             controller.reconcilePendingDictionaryCorrectionAccessibilityEnable()
         }
         .alert("Enable Accessibility?", isPresented: $isShowingAccessibilityPrompt) {
-            Button("Cancel", role: .cancel) {}
+            Button("Cancel", role: .cancel) {
+                controller.cancelDictionaryCorrectionAccessibilityEnableRequest()
+            }
             Button("Enable") {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -34,12 +34,13 @@ struct DictionaryView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
+        .onAppear {
+            controller.reconcilePendingDictionaryCorrectionPromptsEnable()
+        }
         .alert("Enable Accessibility?", isPresented: $isShowingAccessibilityPrompt) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                if controller.requestDictionaryCorrectionAccessibilityEnable() {
-                    controller.setDictionaryCorrectionPromptsEnabled(true)
-                }
+                controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
             Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import SwiftUI
 import MuesliCore
 
@@ -17,7 +18,7 @@ struct DictionaryView: View {
     @State private var newWord = ""
     @State private var newReplacement = ""
     @State private var newThreshold = 0.85
-    @State private var isShowingScreenContextPrompt = false
+    @State private var isShowingAccessibilityPrompt = false
     @State private var suggestionPage = 0
 
     var body: some View {
@@ -33,14 +34,14 @@ struct DictionaryView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
-        .alert("Enable Screen Context?", isPresented: $isShowingScreenContextPrompt) {
+        .alert("Enable Accessibility?", isPresented: $isShowingAccessibilityPrompt) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                let granted = controller.requestScreenContextEnable()
+                let granted = controller.requestDictionaryCorrectionAccessibilityEnable()
                 controller.setDictionaryCorrectionPromptsEnabled(granted)
             }
         } message: {
-            Text("Dictionary suggestions need Screen Context to detect text edits after dictation.")
+            Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")
         }
     }
 
@@ -97,8 +98,8 @@ struct DictionaryView: View {
             controller.setDictionaryCorrectionPromptsEnabled(false)
             return
         }
-        guard appState.config.enableScreenContext else {
-            isShowingScreenContextPrompt = true
+        guard AXIsProcessTrusted() else {
+            isShowingAccessibilityPrompt = true
             return
         }
         controller.setDictionaryCorrectionPromptsEnabled(true)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -34,13 +34,16 @@ struct DictionaryView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
+        .onAppear {
+            controller.reconcilePendingDictionaryCorrectionAccessibilityEnable()
+        }
         .alert("Enable Accessibility?", isPresented: $isShowingAccessibilityPrompt) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
-            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, restart Muesli, then turn suggestions on.")
+            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, then relaunch Muesli to turn suggestions on.")
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -40,7 +40,7 @@ struct DictionaryView: View {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
-            Text("Dictionary suggestions need Accessibility to detect text edits after dictation. Grant access, restart Muesli, then turn suggestions on.")
+            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, restart Muesli, then turn suggestions on.")
         }
     }
 
@@ -61,7 +61,7 @@ struct DictionaryView: View {
                 .toggleStyle(.switch)
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textSecondary)
-                .help("Suggest corrections after dictation edits.")
+                .help("Briefly reads focused app text after dictation to detect corrections.")
                 Button {
                     isAdding = true
                     newWord = ""
@@ -111,7 +111,7 @@ struct DictionaryView: View {
                     Text("Suggested Corrections")
                         .font(MuesliTheme.headline())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("Corrections Muesli noticed after recent dictations.")
+                    Text("Corrections Muesli noticed by briefly reading focused app text after dictation.")
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -34,9 +34,6 @@ struct DictionaryView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
-        .onAppear {
-            controller.reconcilePendingDictionaryCorrectionPromptsEnable()
-        }
         .alert("Enable Accessibility?", isPresented: $isShowingAccessibilityPrompt) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -21,6 +21,9 @@ struct DictionaryView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
                 header
+                if !appState.config.dictionarySuggestions.isEmpty {
+                    suggestionList
+                }
                 wordList
             }
             .padding(MuesliTheme.spacing32)
@@ -36,6 +39,16 @@ struct DictionaryView: View {
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
                 Spacer()
+                Toggle(
+                    "Dictionary suggestions",
+                    isOn: Binding(
+                        get: { appState.config.enableDictionaryCorrectionPrompts },
+                        set: { controller.setDictionaryCorrectionPromptsEnabled($0) }
+                    )
+                )
+                .toggleStyle(.switch)
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
                 Button {
                     isAdding = true
                     newWord = ""
@@ -64,6 +77,37 @@ struct DictionaryView: View {
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
+    }
+
+    private var suggestionList: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Suggested Corrections")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Corrections Muesli noticed after recent dictations.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, MuesliTheme.spacing16)
+            .padding(.vertical, MuesliTheme.spacing12)
+
+            Divider().background(MuesliTheme.surfaceBorder)
+
+            ForEach(appState.config.dictionarySuggestions) { suggestion in
+                DictionarySuggestionRow(suggestion: suggestion, controller: controller)
+                Divider().background(MuesliTheme.surfaceBorder)
+            }
+        }
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
     }
 
     private var wordList: some View {
@@ -175,6 +219,60 @@ struct DictionaryView: View {
         }
         .padding(.horizontal, MuesliTheme.spacing16)
         .padding(.vertical, MuesliTheme.spacing12)
+    }
+}
+
+private struct DictionarySuggestionRow: View {
+    let suggestion: DictionarySuggestion
+    let controller: MuesliController
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    Text(suggestion.observed)
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                    Text(suggestion.replacement)
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+                }
+                Text(detailText)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            DictionaryIconButton(
+                systemName: "checkmark",
+                label: "Add correction",
+                tint: MuesliTheme.accent
+            ) {
+                controller.acceptDictionarySuggestion(id: suggestion.id)
+            }
+            DictionaryIconButton(
+                systemName: "xmark",
+                label: "Dismiss correction",
+                tint: MuesliTheme.textTertiary
+            ) {
+                controller.dismissDictionarySuggestion(id: suggestion.id)
+            }
+        }
+        .padding(.horizontal, MuesliTheme.spacing16)
+        .padding(.vertical, MuesliTheme.spacing12)
+    }
+
+    private var detailText: String {
+        var parts = ["Seen \(suggestion.occurrenceCount)x"]
+        if !suggestion.appContext.isEmpty {
+            parts.append(suggestion.appContext)
+        }
+        return parts.joined(separator: " | ")
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -1,4 +1,3 @@
-import ApplicationServices
 import SwiftUI
 import MuesliCore
 
@@ -98,15 +97,9 @@ struct DictionaryView: View {
     }
 
     private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {
-        guard enabled else {
-            controller.setDictionaryCorrectionPromptsEnabled(false)
-            return
-        }
-        guard AXIsProcessTrusted() else {
+        if controller.setDictionaryCorrectionPromptsFromToggle(enabled) {
             isShowingAccessibilityPrompt = true
-            return
         }
-        controller.setDictionaryCorrectionPromptsEnabled(true)
     }
 
     private var suggestionList: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -16,6 +16,7 @@ struct DictionaryView: View {
     @State private var newWord = ""
     @State private var newReplacement = ""
     @State private var newThreshold = 0.85
+    @State private var isShowingScreenContextPrompt = false
 
     var body: some View {
         ScrollView {
@@ -30,6 +31,15 @@ struct DictionaryView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
+        .alert("Enable Screen Context?", isPresented: $isShowingScreenContextPrompt) {
+            Button("Cancel", role: .cancel) {}
+            Button("Enable") {
+                controller.setDictionaryCorrectionPromptsEnabled(true)
+                controller.requestScreenContextEnable()
+            }
+        } message: {
+            Text("Dictionary suggestions need Screen Context to detect text edits after dictation.")
+        }
     }
 
     private var header: some View {
@@ -43,14 +53,13 @@ struct DictionaryView: View {
                     "Dictionary suggestions",
                     isOn: Binding(
                         get: { appState.config.enableDictionaryCorrectionPrompts },
-                        set: { controller.setDictionaryCorrectionPromptsEnabled($0) }
+                        set: { handleDictionaryCorrectionPromptsToggle($0) }
                     )
                 )
                 .toggleStyle(.switch)
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textSecondary)
-                .disabled(!appState.config.enableScreenContext)
-                .help(appState.config.enableScreenContext ? "Suggest corrections after dictation edits." : "Enable Screen Context first.")
+                .help("Suggest corrections after dictation edits.")
                 Button {
                     isAdding = true
                     newWord = ""
@@ -79,6 +88,18 @@ struct DictionaryView: View {
                 .font(MuesliTheme.body())
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
+    }
+
+    private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {
+        guard enabled else {
+            controller.setDictionaryCorrectionPromptsEnabled(false)
+            return
+        }
+        guard appState.config.enableScreenContext else {
+            isShowingScreenContextPrompt = true
+            return
+        }
+        controller.setDictionaryCorrectionPromptsEnabled(true)
     }
 
     private var suggestionList: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -121,6 +121,10 @@ final class FloatingIndicatorController: NSObject {
 
     var onStopToggleDictation: (() -> Void)?
 
+    var currentFrame: NSRect? {
+        panel?.frame
+    }
+
     func handleClick(atX x: CGFloat? = nil) {
         if state == .recording, let x {
             if x < 30 {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -533,7 +533,7 @@ struct CustomWord: Codable, Equatable, Identifiable {
 }
 
 struct DictionarySuggestion: Codable, Equatable, Identifiable, Sendable {
-    var id = UUID()
+    let id: UUID
     var observed: String
     var replacement: String
     var appContext: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -532,14 +532,14 @@ struct CustomWord: Codable, Equatable, Identifiable {
     }
 }
 
-struct DictionarySuggestion: Codable, Equatable, Identifiable {
+struct DictionarySuggestion: Codable, Equatable, Identifiable, Sendable {
     var id = UUID()
     var observed: String
     var replacement: String
     var appContext: String
     var occurrenceCount: Int = 1
-    var createdAt: String = ISO8601DateFormatter().string(from: Date())
-    var lastSeenAt: String = ISO8601DateFormatter().string(from: Date())
+    var createdAt: String = DictionarySuggestion.timestamp()
+    var lastSeenAt: String = DictionarySuggestion.timestamp()
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -557,8 +557,8 @@ struct DictionarySuggestion: Codable, Equatable, Identifiable {
         replacement: String,
         appContext: String = "",
         occurrenceCount: Int = 1,
-        createdAt: String = ISO8601DateFormatter().string(from: Date()),
-        lastSeenAt: String = ISO8601DateFormatter().string(from: Date())
+        createdAt: String = DictionarySuggestion.timestamp(),
+        lastSeenAt: String = DictionarySuggestion.timestamp()
     ) {
         self.id = id
         self.observed = observed
@@ -577,9 +577,27 @@ struct DictionarySuggestion: Codable, Equatable, Identifiable {
         CustomWord(word: observed, replacement: replacement, matchingThreshold: 0.92)
     }
 
+    var appDisplayName: String {
+        let name = appContext
+            .split(separator: "|", omittingEmptySubsequences: false)
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return name.isEmpty ? appContext : name
+    }
+
     static func key(observed: String, replacement: String) -> String {
         "\(normalize(observed))->\(normalize(replacement))"
     }
+
+    static func timestamp() -> String {
+        iso8601Lock.lock()
+        defer { iso8601Lock.unlock() }
+        return iso8601.string(from: Date())
+    }
+
+    private static let iso8601 = ISO8601DateFormatter()
+    private static let iso8601Lock = NSLock()
 
     private static func normalize(_ value: String) -> String {
         value
@@ -815,7 +833,7 @@ struct AppConfig: Codable {
     ]
     var dictionarySuggestions: [DictionarySuggestion] = []
     var dismissedDictionarySuggestionKeys: [String] = []
-    var enableDictionaryCorrectionPrompts: Bool = true
+    var enableDictionaryCorrectionPrompts: Bool = false
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
     var pauseMediaDuringDictation: Bool = false

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -585,7 +585,9 @@ struct DictionarySuggestion: Codable, Equatable, Identifiable, Sendable {
     }
 
     var customWord: CustomWord {
-        CustomWord(word: observed, replacement: replacement)
+        // Auto-learned corrections come from one observed edit pair, so keep
+        // them stricter than manually configured words to avoid broad rewrites.
+        CustomWord(word: observed, replacement: replacement, matchingThreshold: 0.92)
     }
 
     var appDisplayName: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -532,6 +532,64 @@ struct CustomWord: Codable, Equatable, Identifiable {
     }
 }
 
+struct DictionarySuggestion: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var observed: String
+    var replacement: String
+    var appContext: String
+    var occurrenceCount: Int = 1
+    var createdAt: String = ISO8601DateFormatter().string(from: Date())
+    var lastSeenAt: String = ISO8601DateFormatter().string(from: Date())
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case observed
+        case replacement
+        case appContext = "app_context"
+        case occurrenceCount = "occurrence_count"
+        case createdAt = "created_at"
+        case lastSeenAt = "last_seen_at"
+    }
+
+    init(
+        id: UUID = UUID(),
+        observed: String,
+        replacement: String,
+        appContext: String = "",
+        occurrenceCount: Int = 1,
+        createdAt: String = ISO8601DateFormatter().string(from: Date()),
+        lastSeenAt: String = ISO8601DateFormatter().string(from: Date())
+    ) {
+        self.id = id
+        self.observed = observed
+        self.replacement = replacement
+        self.appContext = appContext
+        self.occurrenceCount = max(occurrenceCount, 1)
+        self.createdAt = createdAt
+        self.lastSeenAt = lastSeenAt
+    }
+
+    var key: String {
+        Self.key(observed: observed, replacement: replacement)
+    }
+
+    var customWord: CustomWord {
+        CustomWord(word: observed, replacement: replacement, matchingThreshold: 0.92)
+    }
+
+    static func key(observed: String, replacement: String) -> String {
+        "\(normalize(observed))->\(normalize(replacement))"
+    }
+
+    private static func normalize(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .lowercased()
+    }
+}
+
 enum IndicatorAnchor: String, Codable, CaseIterable {
     case topLeading = "top_leading"
     case topCenter = "top_center"
@@ -755,6 +813,9 @@ struct AppConfig: Codable {
     var customWords: [CustomWord] = [
         CustomWord(word: "muesli", replacement: "muesli"),
     ]
+    var dictionarySuggestions: [DictionarySuggestion] = []
+    var dismissedDictionarySuggestionKeys: [String] = []
+    var enableDictionaryCorrectionPrompts: Bool = true
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
     var pauseMediaDuringDictation: Bool = false
@@ -833,6 +894,9 @@ struct AppConfig: Codable {
         case userName = "user_name"
         case customMeetingTemplates = "custom_meeting_templates"
         case customWords = "custom_words"
+        case dictionarySuggestions = "dictionary_suggestions"
+        case dismissedDictionarySuggestionKeys = "dismissed_dictionary_suggestion_keys"
+        case enableDictionaryCorrectionPrompts = "enable_dictionary_correction_prompts"
         case folderOrder = "folder_order"
         case soundEnabled = "sound_enabled"
         case pauseMediaDuringDictation = "pause_media_during_dictation"
@@ -943,6 +1007,9 @@ struct AppConfig: Codable {
         userName = (try? c.decode(String.self, forKey: .userName)) ?? defaults.userName
         customMeetingTemplates = (try? c.decode([CustomMeetingTemplate].self, forKey: .customMeetingTemplates)) ?? defaults.customMeetingTemplates
         customWords = (try? c.decode([CustomWord].self, forKey: .customWords)) ?? defaults.customWords
+        dictionarySuggestions = (try? c.decode([DictionarySuggestion].self, forKey: .dictionarySuggestions)) ?? defaults.dictionarySuggestions
+        dismissedDictionarySuggestionKeys = (try? c.decode([String].self, forKey: .dismissedDictionarySuggestionKeys)) ?? defaults.dismissedDictionarySuggestionKeys
+        enableDictionaryCorrectionPrompts = (try? c.decode(Bool.self, forKey: .enableDictionaryCorrectionPrompts)) ?? defaults.enableDictionaryCorrectionPrompts
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
         pauseMediaDuringDictation = (try? c.decode(Bool.self, forKey: .pauseMediaDuringDictation)) ?? defaults.pauseMediaDuringDictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -585,7 +585,7 @@ struct DictionarySuggestion: Codable, Equatable, Identifiable, Sendable {
     }
 
     var customWord: CustomWord {
-        CustomWord(word: observed, replacement: replacement, matchingThreshold: 0.92)
+        CustomWord(word: observed, replacement: replacement)
     }
 
     var appDisplayName: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -580,6 +580,17 @@ struct DictionarySuggestion: Codable, Equatable, Identifiable, Sendable {
         self.lastSeenAt = lastSeenAt
     }
 
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = (try? c.decode(UUID.self, forKey: .id)) ?? UUID()
+        observed = try c.decode(String.self, forKey: .observed)
+        replacement = try c.decode(String.self, forKey: .replacement)
+        appContext = (try? c.decode(String.self, forKey: .appContext)) ?? ""
+        occurrenceCount = max((try? c.decode(Int.self, forKey: .occurrenceCount)) ?? 1, 1)
+        createdAt = (try? c.decode(String.self, forKey: .createdAt)) ?? DictionarySuggestion.timestamp()
+        lastSeenAt = (try? c.decode(String.self, forKey: .lastSeenAt)) ?? DictionarySuggestion.timestamp()
+    }
+
     var key: String {
         Self.key(observed: observed, replacement: replacement)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2081,6 +2081,8 @@ final class MuesliController: NSObject {
     private func presentNextDictionarySuggestionPromptIfPossible() {
         guard config.enableDictionaryCorrectionPrompts else { return }
         guard activeDictionarySuggestionPromptKey == nil else { return }
+        // While the advance task is sleeping, it owns the next drain attempt.
+        // Newly queued suggestions remain in queuedDictionarySuggestionPromptKeys.
         guard dictionarySuggestionPromptAdvanceTask == nil else { return }
         guard !dictionarySuggestionPrompt.isShowing else {
             scheduleNextDictionarySuggestionPrompt()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -183,9 +183,6 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
 final class MuesliController: NSObject {
     private static let maxDismissedDictionarySuggestionKeys = 200
     private static let maxDictionarySuggestions = 50
-    private static let pendingDictionaryCorrectionPromptsEnableKey = "settings.pendingDictionaryCorrectionPromptsEnable"
-    private static let pendingDictionaryCorrectionPromptsRequestedAtKey = "settings.pendingDictionaryCorrectionPromptsRequestedAt"
-    private static let pendingDictionaryCorrectionPromptsEnableTimeout: TimeInterval = 3 * 60
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -383,7 +380,6 @@ final class MuesliController: NSObject {
         CoreAudioSystemRecorder.cleanupStaleDevices()
 
         syncLaunchAtLoginConfigWithSystem()
-        reconcilePendingDictionaryCorrectionPromptsEnable()
 
         // Clean up leftover audio temp files from previous sessions.
         cleanupTemporaryDirectory(
@@ -2024,18 +2020,15 @@ final class MuesliController: NSObject {
 
     func setDictionaryCorrectionPromptsEnabled(_ enabled: Bool) {
         if !enabled {
-            clearPendingDictionaryCorrectionPromptsEnable()
             dictationCorrectionMonitor.cancel()
             updateConfig { $0.enableDictionaryCorrectionPrompts = false }
             return
         }
         guard AXIsProcessTrusted() else {
-            recordPendingDictionaryCorrectionPromptsEnable()
             dictationCorrectionMonitor.cancel()
             updateConfig { $0.enableDictionaryCorrectionPrompts = false }
             return
         }
-        clearPendingDictionaryCorrectionPromptsEnable()
         updateConfig { $0.enableDictionaryCorrectionPrompts = true }
     }
 
@@ -2047,35 +2040,11 @@ final class MuesliController: NSObject {
         }
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
-        recordPendingDictionaryCorrectionPromptsEnable()
-        return false
-    }
-
-    func reconcilePendingDictionaryCorrectionPromptsEnable() {
-        guard UserDefaults.standard.bool(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey) else { return }
-        if isPendingDictionaryCorrectionPromptsEnableExpired {
-            clearPendingDictionaryCorrectionPromptsEnable()
-            return
+        if AXIsProcessTrusted() {
+            setDictionaryCorrectionPromptsEnabled(true)
+            return true
         }
-        guard AXIsProcessTrusted() else { return }
-        clearPendingDictionaryCorrectionPromptsEnable()
-        updateConfig { $0.enableDictionaryCorrectionPrompts = true }
-    }
-
-    private func recordPendingDictionaryCorrectionPromptsEnable() {
-        UserDefaults.standard.set(true, forKey: Self.pendingDictionaryCorrectionPromptsEnableKey)
-        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
-    }
-
-    private func clearPendingDictionaryCorrectionPromptsEnable() {
-        UserDefaults.standard.removeObject(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey)
-        UserDefaults.standard.removeObject(forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
-    }
-
-    private var isPendingDictionaryCorrectionPromptsEnableExpired: Bool {
-        let requestedAt = UserDefaults.standard.double(forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
-        guard requestedAt > 0 else { return true }
-        return Date().timeIntervalSince1970 - requestedAt > Self.pendingDictionaryCorrectionPromptsEnableTimeout
+        return false
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -202,6 +202,7 @@ final class MuesliController: NSObject {
     private var activeDictionarySuggestionPromptKey: String?
     private var queuedDictionarySuggestionPromptKeys: [String] = []
     private var promptedDictionarySuggestionPromptKeys = Set<String>()
+    private var dictionarySuggestionPromptAdvanceTask: Task<Void, Never>?
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
     private lazy var dictationAudioSessionManager = DictationAudioSessionManager(
@@ -904,6 +905,8 @@ final class MuesliController: NSObject {
             dictationCorrectionMonitor.cancel()
             queuedDictionarySuggestionPromptKeys.removeAll()
             promptedDictionarySuggestionPromptKeys.removeAll()
+            dictionarySuggestionPromptAdvanceTask?.cancel()
+            dictionarySuggestionPromptAdvanceTask = nil
             activeDictionarySuggestionPromptKey = nil
             dictionarySuggestionPrompt.dismiss()
         }
@@ -2057,12 +2060,27 @@ final class MuesliController: NSObject {
         guard activeDictionarySuggestionPromptKey == key else { return }
         activeDictionarySuggestionPromptKey = nil
         logDictionarySuggestion("complete action=\(action) queued=\(queuedDictionarySuggestionPromptKeys.count)")
-        presentNextDictionarySuggestionPromptIfPossible()
+        scheduleNextDictionarySuggestionPrompt()
+    }
+
+    private func scheduleNextDictionarySuggestionPrompt() {
+        dictionarySuggestionPromptAdvanceTask?.cancel()
+        dictionarySuggestionPromptAdvanceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
+            self?.dictionarySuggestionPromptAdvanceTask = nil
+            self?.presentNextDictionarySuggestionPromptIfPossible()
+        }
     }
 
     private func presentNextDictionarySuggestionPromptIfPossible() {
         guard config.enableDictionaryCorrectionPrompts else { return }
         guard activeDictionarySuggestionPromptKey == nil else { return }
+        guard dictionarySuggestionPromptAdvanceTask == nil else { return }
+        guard !dictionarySuggestionPrompt.isShowing else {
+            scheduleNextDictionarySuggestionPrompt()
+            return
+        }
 
         while !queuedDictionarySuggestionPromptKeys.isEmpty {
             let key = queuedDictionarySuggestionPromptKeys.removeFirst()
@@ -2076,6 +2094,10 @@ final class MuesliController: NSObject {
             presentDictionarySuggestionPrompt(suggestion)
             return
         }
+    }
+
+    private func presentNextDictionarySuggestionPromptIfPossibleBeforeQueueHandoff() {
+        presentNextDictionarySuggestionPromptIfPossible()
     }
 
     private func dictionarySuggestionLogMetadata(_ suggestion: DictionarySuggestion) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -210,7 +210,6 @@ final class MuesliController: NSObject {
     private let dictionarySuggestionPrompt = DictionarySuggestionPromptController()
     private var activeDictionarySuggestionPromptKey: String?
     private var queuedDictionarySuggestionPromptKeys: [String] = []
-    private var promptedDictionarySuggestionPromptKeys = Set<String>()
     private var dictionarySuggestionPromptAdvanceTask: Task<Void, Never>?
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
@@ -914,7 +913,6 @@ final class MuesliController: NSObject {
         if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {
             dictationCorrectionMonitor.cancel()
             queuedDictionarySuggestionPromptKeys.removeAll()
-            promptedDictionarySuggestionPromptKeys.removeAll()
             dictionarySuggestionPromptAdvanceTask?.cancel()
             dictionarySuggestionPromptAdvanceTask = nil
             activeDictionarySuggestionPromptKey = nil
@@ -2034,7 +2032,6 @@ final class MuesliController: NSObject {
     private func presentDictionarySuggestionPrompt(_ suggestion: DictionarySuggestion) {
         let key = suggestion.key
         activeDictionarySuggestionPromptKey = key
-        promptedDictionarySuggestionPromptKeys.insert(key)
         logDictionarySuggestion("present \(dictionarySuggestionLogMetadata(suggestion))")
         dictionarySuggestionPrompt.show(
             suggestion: suggestion,
@@ -2059,10 +2056,9 @@ final class MuesliController: NSObject {
         let key = suggestion.key
         guard config.enableDictionaryCorrectionPrompts else { return }
         guard activeDictionarySuggestionPromptKey != key else { return }
-        guard !promptedDictionarySuggestionPromptKeys.contains(key) else { return }
         guard !queuedDictionarySuggestionPromptKeys.contains(key) else { return }
-        // The monitor caps each dictation edit window at a small suggestion set.
-        // Queue all of them here so add/ignore/dismiss reveals the next correction.
+        // Showing or timing out a prompt is not a final answer. Only Add or
+        // Ignore suppresses future prompts for this correction pair.
         queuedDictionarySuggestionPromptKeys.append(key)
         logDictionarySuggestion("queue depth=\(queuedDictionarySuggestionPromptKeys.count) \(dictionarySuggestionLogMetadata(suggestion))")
         presentNextDictionarySuggestionPromptIfPossible()
@@ -2098,7 +2094,6 @@ final class MuesliController: NSObject {
 
         while !queuedDictionarySuggestionPromptKeys.isEmpty {
             let key = queuedDictionarySuggestionPromptKeys.removeFirst()
-            guard !promptedDictionarySuggestionPromptKeys.contains(key) else { continue }
             guard !config.dismissedDictionarySuggestionKeys.contains(key) else { continue }
             guard let suggestion = config.dictionarySuggestions.first(where: { $0.key == key }) else { continue }
             let hasCustomWord = config.customWords.contains {
@@ -6417,6 +6412,10 @@ final class MuesliController: NSObject {
                     if outputMode != .voiceNote {
                         PasteController.paste(text: text)
                         if self.config.enableDictionaryCorrectionPrompts {
+                            // Dictionary correction prompts are an explicit opt-in
+                            // screen-context feature: they briefly read focused app
+                            // text via Accessibility after dictation, then stop when
+                            // the bounded edit monitor session ends.
                             self.dictationCorrectionMonitor.start(
                                 originalText: text,
                                 appContext: storageContext,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -893,8 +893,12 @@ final class MuesliController: NSObject {
         let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
+        let previousEnableScreenContext = config.enableScreenContext
         let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         mutate(&config)
+        if previousEnableScreenContext, !config.enableScreenContext {
+            dictationCorrectionMonitor.cancel()
+        }
         if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {
             dictationCorrectionMonitor.cancel()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -894,9 +894,13 @@ final class MuesliController: NSObject {
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
         let previousEnableScreenContext = config.enableScreenContext
+        let previousEnablePostProcessor = config.enablePostProcessor
         let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         mutate(&config)
         if previousEnableScreenContext, !config.enableScreenContext {
+            dictationCorrectionMonitor.cancel()
+        }
+        if previousEnablePostProcessor, !config.enablePostProcessor {
             dictationCorrectionMonitor.cancel()
         }
         if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2030,7 +2030,8 @@ final class MuesliController: NSObject {
         guard !AXIsProcessTrusted() else { return true }
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
-        return AXIsProcessTrusted()
+        // macOS may require an app restart before AX trust is visible here.
+        return true
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -181,6 +181,7 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
 @MainActor
 final class MuesliController: NSObject {
     private static let maxDismissedDictionarySuggestionKeys = 200
+    private static let maxDictionarySuggestions = 50
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -1561,7 +1562,8 @@ final class MuesliController: NSObject {
                 if existing.appContext.isEmpty {
                     existing.appContext = suggestion.appContext
                 }
-                config.dictionarySuggestions[index] = existing
+                config.dictionarySuggestions.remove(at: index)
+                config.dictionarySuggestions.insert(existing, at: 0)
                 promptSuggestion = existing
             } else {
                 promptSuggestion = DictionarySuggestion(
@@ -1570,6 +1572,9 @@ final class MuesliController: NSObject {
                     appContext: suggestion.appContext
                 )
                 config.dictionarySuggestions.insert(promptSuggestion, at: 0)
+            }
+            if config.dictionarySuggestions.count > Self.maxDictionarySuggestions {
+                config.dictionarySuggestions = Array(config.dictionarySuggestions.prefix(Self.maxDictionarySuggestions))
             }
         }
 
@@ -5255,7 +5260,7 @@ final class MuesliController: NSObject {
             pendingDictationStopSessionID = nil
             pendingDictationStopStartedAt = nil
             pendingReleaseSoundSessionID = nil
-            capturedDictationContext = nil
+            clearCapturedDictationSessionContext()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
             meetingMonitor.refreshState()
@@ -5348,6 +5353,19 @@ final class MuesliController: NSObject {
         }
     }
 
+    private func clearCapturedDictationSessionContext() {
+        capturedDictationContext = nil
+        capturedDictationCorrectionTargetApp = nil
+    }
+
+    private func captureDictationCorrectionTargetApp() {
+        capturedDictationCorrectionTargetApp = DictationCorrectionTargetApp(
+            app: NSWorkspace.shared.frontmostApplication == NSRunningApplication.current
+                ? lastExternalApp
+                : NSWorkspace.shared.frontmostApplication
+        )
+    }
+
     private func handleStart() {
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
@@ -5368,12 +5386,8 @@ final class MuesliController: NSObject {
         meetingMonitor.suppressWhileActive()
         beginDictationOutput()
         dictationStartedAt = nil
-        capturedDictationContext = nil
-        capturedDictationCorrectionTargetApp = DictationCorrectionTargetApp(
-            app: NSWorkspace.shared.frontmostApplication == NSRunningApplication.current
-                ? lastExternalApp
-                : NSWorkspace.shared.frontmostApplication
-        )
+        clearCapturedDictationSessionContext()
+        captureDictationCorrectionTargetApp()
         setState(.preparing)
         dictationAudioSessionManager.beginRecording(
             mode: "hold-start",
@@ -5438,6 +5452,7 @@ final class MuesliController: NSObject {
         nemotronStreamingSessionID = nil
         previousStreamText = ""
         dictationStartedAt = nil
+        clearCapturedDictationSessionContext()
         dictationAudioSessionManager.endExternalSession(reason: "nemotron-start-failed")
         indicator.setToggleDictation(false, config: config)
         resetDictationOutputMode()
@@ -5457,6 +5472,7 @@ final class MuesliController: NSObject {
         nemotronStreamingSessionID = nil
         previousStreamText = ""
         dictationStartedAt = nil
+        clearCapturedDictationSessionContext()
         dictationAudioSessionManager.endExternalSession(reason: "nemotron-runtime-failed")
         indicator.setToggleDictation(false, config: config)
         resetDictationOutputMode()
@@ -5483,7 +5499,7 @@ final class MuesliController: NSObject {
         }
 
         dictationAudioSessionManager.cancel(reason: "user-cancel")
-        capturedDictationContext = nil
+        clearCapturedDictationSessionContext()
         dictationStartedAt = nil
         pendingDictationStopSessionID = nil
         pendingDictationStopStartedAt = nil
@@ -5506,6 +5522,8 @@ final class MuesliController: NSObject {
         meetingMonitor.suppressWhileActive()
         beginDictationOutput(mode: outputMode)
         dictationStartedAt = nil
+        clearCapturedDictationSessionContext()
+        captureDictationCorrectionTargetApp()
         setState(.preparing)
 
         // Nemotron streaming: live text at cursor in handsfree mode too
@@ -5618,7 +5636,7 @@ final class MuesliController: NSObject {
         }
 
         dictationStartedAt = nil
-        capturedDictationContext = nil
+        clearCapturedDictationSessionContext()
         pendingDictationStopSessionID = nil
         pendingDictationStopStartedAt = nil
         pendingReleaseSoundSessionID = nil
@@ -5666,6 +5684,7 @@ final class MuesliController: NSObject {
         statusBarController?.refresh()
         historyWindowController?.reload()
         syncAppState()
+        clearCapturedDictationSessionContext()
         resetDictationOutputMode()
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
@@ -5678,6 +5697,7 @@ final class MuesliController: NSObject {
         markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
             fputs("[muesli-native] stop without wav\n", stderr)
+            clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -5692,6 +5712,7 @@ final class MuesliController: NSObject {
             if isDictationTestMode {
                 dictationTestCallback?("")
             }
+            clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
@@ -5736,6 +5757,7 @@ final class MuesliController: NSObject {
                 if isTestMode {
                     await MainActor.run {
                         self.dictationTestCallback?(text)
+                        self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
@@ -5749,6 +5771,7 @@ final class MuesliController: NSObject {
                 }
                 guard !text.isEmpty else {
                     await MainActor.run {
+                        self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
@@ -5764,8 +5787,7 @@ final class MuesliController: NSObject {
                     endedAt: Date()
                 )
                 await MainActor.run {
-                    self.capturedDictationContext = nil
-                    self.capturedDictationCorrectionTargetApp = nil
+                    self.clearCapturedDictationSessionContext()
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()
@@ -5793,6 +5815,7 @@ final class MuesliController: NSObject {
             } catch is CancellationError {
                 fputs("[muesli-native] test dictation cancelled\n", stderr)
                 await MainActor.run {
+                    self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
@@ -5804,6 +5827,7 @@ final class MuesliController: NSObject {
                     if self.isDictationTestMode {
                         self.dictationTestFailureCallback?(self.userFacingDictationTestError(error))
                     }
+                    self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2230,14 +2230,11 @@ final class MuesliController: NSObject {
 
     @discardableResult
     func requestScreenContextEnable() -> Bool {
-        guard CGPreflightScreenCaptureAccess() else {
+        guard AXIsProcessTrusted() else {
             updateConfig { $0.enableScreenContext = false }
-            let granted = CGRequestScreenCaptureAccess()
-            let hasAccess = granted || CGPreflightScreenCaptureAccess()
-            if hasAccess {
-                updateConfig { $0.enableScreenContext = true }
-            }
-            return hasAccess
+            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+            AXIsProcessTrustedWithOptions(options)
+            return false
         }
 
         updateConfig { $0.enableScreenContext = true }
@@ -5959,7 +5956,7 @@ final class MuesliController: NSObject {
         let traceID = dictationLatencyTraceID
         markDictationLatency("context_capture_enqueue")
         DispatchQueue.global(qos: .utility).async { [weak self, traceID] in
-            guard CGPreflightScreenCaptureAccess() else { return }
+            guard AXIsProcessTrusted() else { return }
             let context = DictationContextCapture.capture()
             DispatchQueue.main.async { [weak self, traceID] in
                 guard let self,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -187,6 +187,7 @@ final class MuesliController: NSObject {
     private static let dictionarySuggestionLogger = Logger(subsystem: "com.muesli.native", category: "DictionarySuggestion")
     private static let pendingDictionaryCorrectionAccessibilityEnableKey = "dictionaryCorrectionPrompts.pendingAccessibilityEnable"
     private static let pendingDictionaryCorrectionAccessibilityRequestedAtKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestedAt"
+    private static let pendingDictionaryCorrectionAccessibilityRequestProcessIDKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestProcessID"
     private static let dictionaryCorrectionAccessibilityIntentTimeout: TimeInterval = 24 * 60 * 60
 
     private let runtime: RuntimePaths
@@ -2157,6 +2158,10 @@ final class MuesliController: NSObject {
         return false
     }
 
+    func cancelDictionaryCorrectionAccessibilityEnableRequest() {
+        clearPendingDictionaryCorrectionAccessibilityEnable()
+    }
+
     @discardableResult
     func reconcilePendingDictionaryCorrectionAccessibilityEnable(now: Date = Date()) -> Bool {
         guard isPendingDictionaryCorrectionAccessibilityEnable else { return false }
@@ -2164,6 +2169,11 @@ final class MuesliController: NSObject {
             clearPendingDictionaryCorrectionAccessibilityEnable()
             return false
         }
+        guard let isPendingFromPreviousProcess = isPendingDictionaryCorrectionAccessibilityEnableFromPreviousProcess else {
+            clearPendingDictionaryCorrectionAccessibilityEnable()
+            return false
+        }
+        guard isPendingFromPreviousProcess else { return false }
         guard AXIsProcessTrusted() else { return false }
         clearPendingDictionaryCorrectionAccessibilityEnable()
         setDictionaryCorrectionPromptsEnabled(true)
@@ -2178,18 +2188,32 @@ final class MuesliController: NSObject {
         let defaults = UserDefaults.standard
         defaults.set(true, forKey: Self.pendingDictionaryCorrectionAccessibilityEnableKey)
         defaults.set(now.timeIntervalSince1970, forKey: Self.pendingDictionaryCorrectionAccessibilityRequestedAtKey)
+        defaults.set(
+            Int(ProcessInfo.processInfo.processIdentifier),
+            forKey: Self.pendingDictionaryCorrectionAccessibilityRequestProcessIDKey
+        )
     }
 
     private func clearPendingDictionaryCorrectionAccessibilityEnable() {
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: Self.pendingDictionaryCorrectionAccessibilityEnableKey)
         defaults.removeObject(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestedAtKey)
+        defaults.removeObject(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestProcessIDKey)
     }
 
     private func isPendingDictionaryCorrectionAccessibilityEnableExpired(now: Date) -> Bool {
         let requestedAt = UserDefaults.standard.double(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestedAtKey)
         guard requestedAt > 0 else { return true }
         return now.timeIntervalSince1970 - requestedAt > Self.dictionaryCorrectionAccessibilityIntentTimeout
+    }
+
+    private var isPendingDictionaryCorrectionAccessibilityEnableFromPreviousProcess: Bool? {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestProcessIDKey) != nil else {
+            return nil
+        }
+        return defaults.integer(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestProcessIDKey)
+            != Int(ProcessInfo.processInfo.processIdentifier)
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -189,6 +189,7 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
 final class MuesliController: NSObject {
     private static let maxDismissedDictionarySuggestionKeys = 200
     private static let maxDictionarySuggestions = 50
+    private static let maxDictionarySuggestionPromptQueue = 10
     private static let dictionarySuggestionLogger = Logger(subsystem: "com.muesli.native", category: "DictionarySuggestion")
     private static let pendingDictionaryCorrectionAccessibilityEnableKey = "dictionaryCorrectionPrompts.pendingAccessibilityEnable"
     private static let pendingDictionaryCorrectionAccessibilityRequestedAtKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestedAt"
@@ -2060,6 +2061,9 @@ final class MuesliController: NSObject {
         // Showing or timing out a prompt is not a final answer. Only Add or
         // Ignore suppresses future prompts for this correction pair.
         queuedDictionarySuggestionPromptKeys.append(key)
+        if queuedDictionarySuggestionPromptKeys.count > Self.maxDictionarySuggestionPromptQueue {
+            queuedDictionarySuggestionPromptKeys.removeFirst(queuedDictionarySuggestionPromptKeys.count - Self.maxDictionarySuggestionPromptQueue)
+        }
         logDictionarySuggestion("queue depth=\(queuedDictionarySuggestionPromptKeys.count) \(dictionarySuggestionLogMetadata(suggestion))")
         presentNextDictionarySuggestionPromptIfPossible()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -185,6 +185,9 @@ final class MuesliController: NSObject {
     private static let maxDismissedDictionarySuggestionKeys = 200
     private static let maxDictionarySuggestions = 50
     private static let dictionarySuggestionLogger = Logger(subsystem: "com.muesli.native", category: "DictionarySuggestion")
+    private static let pendingDictionaryCorrectionAccessibilityEnableKey = "dictionaryCorrectionPrompts.pendingAccessibilityEnable"
+    private static let pendingDictionaryCorrectionAccessibilityRequestedAtKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestedAt"
+    private static let dictionaryCorrectionAccessibilityIntentTimeout: TimeInterval = 24 * 60 * 60
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -386,6 +389,7 @@ final class MuesliController: NSObject {
         CoreAudioSystemRecorder.cleanupStaleDevices()
 
         syncLaunchAtLoginConfigWithSystem()
+        reconcilePendingDictionaryCorrectionAccessibilityEnable()
 
         // Clean up leftover audio temp files from previous sessions.
         cleanupTemporaryDirectory(
@@ -2122,6 +2126,7 @@ final class MuesliController: NSObject {
 
     func setDictionaryCorrectionPromptsEnabled(_ enabled: Bool) {
         if !enabled {
+            clearPendingDictionaryCorrectionAccessibilityEnable()
             dictationCorrectionMonitor.cancel()
             updateConfig { $0.enableDictionaryCorrectionPrompts = false }
             return
@@ -2137,16 +2142,54 @@ final class MuesliController: NSObject {
     @discardableResult
     func requestDictionaryCorrectionAccessibilityEnable() -> Bool {
         guard !AXIsProcessTrusted() else {
+            clearPendingDictionaryCorrectionAccessibilityEnable()
             setDictionaryCorrectionPromptsEnabled(true)
             return true
         }
+        markPendingDictionaryCorrectionAccessibilityEnable()
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
         if AXIsProcessTrusted() {
+            clearPendingDictionaryCorrectionAccessibilityEnable()
             setDictionaryCorrectionPromptsEnabled(true)
             return true
         }
         return false
+    }
+
+    @discardableResult
+    func reconcilePendingDictionaryCorrectionAccessibilityEnable(now: Date = Date()) -> Bool {
+        guard isPendingDictionaryCorrectionAccessibilityEnable else { return false }
+        guard !isPendingDictionaryCorrectionAccessibilityEnableExpired(now: now) else {
+            clearPendingDictionaryCorrectionAccessibilityEnable()
+            return false
+        }
+        guard AXIsProcessTrusted() else { return false }
+        clearPendingDictionaryCorrectionAccessibilityEnable()
+        setDictionaryCorrectionPromptsEnabled(true)
+        return true
+    }
+
+    private var isPendingDictionaryCorrectionAccessibilityEnable: Bool {
+        UserDefaults.standard.bool(forKey: Self.pendingDictionaryCorrectionAccessibilityEnableKey)
+    }
+
+    private func markPendingDictionaryCorrectionAccessibilityEnable(now: Date = Date()) {
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: Self.pendingDictionaryCorrectionAccessibilityEnableKey)
+        defaults.set(now.timeIntervalSince1970, forKey: Self.pendingDictionaryCorrectionAccessibilityRequestedAtKey)
+    }
+
+    private func clearPendingDictionaryCorrectionAccessibilityEnable() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: Self.pendingDictionaryCorrectionAccessibilityEnableKey)
+        defaults.removeObject(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestedAtKey)
+    }
+
+    private func isPendingDictionaryCorrectionAccessibilityEnableExpired(now: Date) -> Bool {
+        let requestedAt = UserDefaults.standard.double(forKey: Self.pendingDictionaryCorrectionAccessibilityRequestedAtKey)
+        guard requestedAt > 0 else { return true }
+        return now.timeIntervalSince1970 - requestedAt > Self.dictionaryCorrectionAccessibilityIntentTimeout
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2152,11 +2152,6 @@ final class MuesliController: NSObject {
         markPendingDictionaryCorrectionAccessibilityEnable()
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
-        if AXIsProcessTrusted() {
-            clearPendingDictionaryCorrectionAccessibilityEnable()
-            setDictionaryCorrectionPromptsEnabled(true)
-            return true
-        }
         return false
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -183,6 +183,8 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
 final class MuesliController: NSObject {
     private static let maxDismissedDictionarySuggestionKeys = 200
     private static let maxDictionarySuggestions = 50
+    private static let pendingDictionaryCorrectionPromptsEnableKey = "settings.pendingDictionaryCorrectionPromptsEnable"
+    private static let pendingDictionaryCorrectionPromptsRequestedAtKey = "settings.pendingDictionaryCorrectionPromptsRequestedAt"
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -380,6 +382,7 @@ final class MuesliController: NSObject {
         CoreAudioSystemRecorder.cleanupStaleDevices()
 
         syncLaunchAtLoginConfigWithSystem()
+        reconcilePendingDictionaryCorrectionPromptsEnable()
 
         // Clean up leftover audio temp files from previous sessions.
         cleanupTemporaryDirectory(
@@ -2020,18 +2023,48 @@ final class MuesliController: NSObject {
 
     func setDictionaryCorrectionPromptsEnabled(_ enabled: Bool) {
         if !enabled {
+            clearPendingDictionaryCorrectionPromptsEnable()
             dictationCorrectionMonitor.cancel()
+            updateConfig { $0.enableDictionaryCorrectionPrompts = false }
+            return
         }
-        updateConfig { $0.enableDictionaryCorrectionPrompts = enabled }
+        guard AXIsProcessTrusted() else {
+            recordPendingDictionaryCorrectionPromptsEnable()
+            dictationCorrectionMonitor.cancel()
+            updateConfig { $0.enableDictionaryCorrectionPrompts = false }
+            return
+        }
+        clearPendingDictionaryCorrectionPromptsEnable()
+        updateConfig { $0.enableDictionaryCorrectionPrompts = true }
     }
 
     @discardableResult
     func requestDictionaryCorrectionAccessibilityEnable() -> Bool {
-        guard !AXIsProcessTrusted() else { return true }
+        guard !AXIsProcessTrusted() else {
+            setDictionaryCorrectionPromptsEnabled(true)
+            return true
+        }
+        recordPendingDictionaryCorrectionPromptsEnable()
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
-        // macOS may require an app restart before AX trust is visible here.
-        return true
+        return false
+    }
+
+    func reconcilePendingDictionaryCorrectionPromptsEnable() {
+        guard UserDefaults.standard.bool(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey) else { return }
+        guard AXIsProcessTrusted() else { return }
+        clearPendingDictionaryCorrectionPromptsEnable()
+        updateConfig { $0.enableDictionaryCorrectionPrompts = true }
+    }
+
+    private func recordPendingDictionaryCorrectionPromptsEnable() {
+        UserDefaults.standard.set(true, forKey: Self.pendingDictionaryCorrectionPromptsEnableKey)
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
+    }
+
+    private func clearPendingDictionaryCorrectionPromptsEnable() {
+        UserDefaults.standard.removeObject(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey)
+        UserDefaults.standard.removeObject(forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -893,12 +893,8 @@ final class MuesliController: NSObject {
         let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
-        let previousEnableScreenContext = config.enableScreenContext
         let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         mutate(&config)
-        if previousEnableScreenContext, !config.enableScreenContext {
-            dictationCorrectionMonitor.cancel()
-        }
         if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {
             dictationCorrectionMonitor.cancel()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -185,7 +185,7 @@ final class MuesliController: NSObject {
     private static let maxDictionarySuggestions = 50
     private static let pendingDictionaryCorrectionPromptsEnableKey = "settings.pendingDictionaryCorrectionPromptsEnable"
     private static let pendingDictionaryCorrectionPromptsRequestedAtKey = "settings.pendingDictionaryCorrectionPromptsRequestedAt"
-    private static let pendingDictionaryCorrectionPromptsEnableTimeout: TimeInterval = 15 * 60
+    private static let pendingDictionaryCorrectionPromptsEnableTimeout: TimeInterval = 3 * 60
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -2045,22 +2045,21 @@ final class MuesliController: NSObject {
             setDictionaryCorrectionPromptsEnabled(true)
             return true
         }
-        recordPendingDictionaryCorrectionPromptsEnable()
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
+        recordPendingDictionaryCorrectionPromptsEnable()
         return false
     }
 
     func reconcilePendingDictionaryCorrectionPromptsEnable() {
         guard UserDefaults.standard.bool(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey) else { return }
-        if AXIsProcessTrusted() {
-            clearPendingDictionaryCorrectionPromptsEnable()
-            updateConfig { $0.enableDictionaryCorrectionPrompts = true }
-            return
-        }
         if isPendingDictionaryCorrectionPromptsEnableExpired {
             clearPendingDictionaryCorrectionPromptsEnable()
+            return
         }
+        guard AXIsProcessTrusted() else { return }
+        clearPendingDictionaryCorrectionPromptsEnable()
+        updateConfig { $0.enableDictionaryCorrectionPrompts = true }
     }
 
     private func recordPendingDictionaryCorrectionPromptsEnable() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -6,6 +6,7 @@ import Foundation
 import Sparkle
 import TelemetryDeck
 import MuesliCore
+import os
 
 private enum DictationOutputMode {
     case paste
@@ -183,6 +184,7 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
 final class MuesliController: NSObject {
     private static let maxDismissedDictionarySuggestionKeys = 200
     private static let maxDictionarySuggestions = 50
+    private static let dictionarySuggestionLogger = Logger(subsystem: "com.muesli.native", category: "DictionarySuggestion")
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -1920,19 +1922,35 @@ final class MuesliController: NSObject {
     }
 
     func addDictionarySuggestion(_ suggestion: DictionarySuggestion, presentPrompt: Bool = false) {
-        guard config.enableDictionaryCorrectionPrompts else { return }
+        guard config.enableDictionaryCorrectionPrompts else {
+            logDictionarySuggestion("skip reason=disabled key=\(suggestion.key)")
+            return
+        }
         let trimmedObserved = suggestion.observed.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedReplacement = suggestion.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedObserved.isEmpty, !trimmedReplacement.isEmpty else { return }
-        guard trimmedObserved != trimmedReplacement else { return }
+        guard !trimmedObserved.isEmpty, !trimmedReplacement.isEmpty else {
+            logDictionarySuggestion("skip reason=empty")
+            return
+        }
+        guard trimmedObserved != trimmedReplacement else {
+            logDictionarySuggestion("skip reason=sameText")
+            return
+        }
 
         let key = DictionarySuggestion.key(observed: trimmedObserved, replacement: trimmedReplacement)
-        guard !config.dismissedDictionarySuggestionKeys.contains(key) else { return }
+        guard !config.dismissedDictionarySuggestionKeys.contains(key) else {
+            logDictionarySuggestion("skip reason=dismissed key=\(key)")
+            return
+        }
         guard !config.customWords.contains(where: {
             DictionarySuggestion.key(observed: $0.word, replacement: $0.targetWord) == key
-        }) else { return }
+        }) else {
+            logDictionarySuggestion("skip reason=customWordExists key=\(key)")
+            return
+        }
 
         var promptSuggestion = suggestion
+        var persistenceAction = "insert"
         updateConfig { config in
             if let index = config.dictionarySuggestions.firstIndex(where: { $0.key == key }) {
                 var existing = config.dictionarySuggestions[index]
@@ -1944,6 +1962,7 @@ final class MuesliController: NSObject {
                 config.dictionarySuggestions.remove(at: index)
                 config.dictionarySuggestions.insert(existing, at: 0)
                 promptSuggestion = existing
+                persistenceAction = "update"
             } else {
                 promptSuggestion = DictionarySuggestion(
                     observed: trimmedObserved,
@@ -1957,6 +1976,7 @@ final class MuesliController: NSObject {
             }
         }
 
+        logDictionarySuggestion("persist action=\(persistenceAction) key=\(key) presentPrompt=\(presentPrompt)")
         if presentPrompt {
             presentDictionarySuggestionPrompt(promptSuggestion)
         }
@@ -1983,6 +2003,7 @@ final class MuesliController: NSObject {
             config.dictionarySuggestions.removeAll { $0.key == key }
             config.dismissedDictionarySuggestionKeys.removeAll { $0 == key }
         }
+        logDictionarySuggestion("accept key=\(key)")
     }
 
     private func dismissDictionarySuggestion(_ suggestion: DictionarySuggestion) {
@@ -1996,9 +2017,11 @@ final class MuesliController: NSObject {
                 config.dismissedDictionarySuggestionKeys = Array(config.dismissedDictionarySuggestionKeys.suffix(Self.maxDismissedDictionarySuggestionKeys))
             }
         }
+        logDictionarySuggestion("ignore key=\(key)")
     }
 
     private func presentDictionarySuggestionPrompt(_ suggestion: DictionarySuggestion) {
+        logDictionarySuggestion("present key=\(suggestion.key)")
         dictionarySuggestionPrompt.show(
             suggestion: suggestion,
             anchorFrame: indicator.currentFrame,
@@ -2009,6 +2032,11 @@ final class MuesliController: NSObject {
                 self?.dismissDictionarySuggestion(suggestion)
             }
         )
+    }
+
+    private func logDictionarySuggestion(_ message: String) {
+        Self.dictionarySuggestionLogger.debug("\(message, privacy: .public)")
+        fputs("[dictionary-suggestion] \(message)\n", stderr)
     }
 
     func updateCustomWord(_ word: CustomWord) {
@@ -6242,8 +6270,8 @@ final class MuesliController: NSObject {
                                 originalText: text,
                                 appContext: storageContext,
                                 targetApp: correctionTargetApp
-                            ) { [weak self] suggestion in
-                                self?.addDictionarySuggestion(suggestion, presentPrompt: true)
+                            ) { [weak self] suggestion, shouldPresentPrompt in
+                                self?.addDictionarySuggestion(suggestion, presentPrompt: shouldPresentPrompt)
                             }
                         }
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2053,13 +2053,14 @@ final class MuesliController: NSObject {
 
     func reconcilePendingDictionaryCorrectionPromptsEnable() {
         guard UserDefaults.standard.bool(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey) else { return }
-        if isPendingDictionaryCorrectionPromptsEnableExpired {
+        if AXIsProcessTrusted() {
             clearPendingDictionaryCorrectionPromptsEnable()
+            updateConfig { $0.enableDictionaryCorrectionPrompts = true }
             return
         }
-        guard AXIsProcessTrusted() else { return }
-        clearPendingDictionaryCorrectionPromptsEnable()
-        updateConfig { $0.enableDictionaryCorrectionPrompts = true }
+        if isPendingDictionaryCorrectionPromptsEnableExpired {
+            clearPendingDictionaryCorrectionPromptsEnable()
+        }
     }
 
     private func recordPendingDictionaryCorrectionPromptsEnable() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1621,7 +1621,6 @@ final class MuesliController: NSObject {
             onAdd: { [weak self] in
                 self?.acceptDictionarySuggestion(suggestion)
             },
-            onLater: {},
             onIgnore: { [weak self] in
                 self?.dismissDictionarySuggestion(suggestion)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -22,6 +22,11 @@ private enum DictationOutputMode {
     }
 }
 
+enum DictionaryCorrectionPromptsToggleResult {
+    case updated
+    case needsAccessibilityPermission
+}
+
 private enum DictationAudioRouteTiming {
     static let stabilizationDelay: TimeInterval = 1.0
 }
@@ -2130,16 +2135,16 @@ final class MuesliController: NSObject {
     }
 
     @discardableResult
-    func setDictionaryCorrectionPromptsFromToggle(_ enabled: Bool) -> Bool {
+    func setDictionaryCorrectionPromptsFromToggle(_ enabled: Bool) -> DictionaryCorrectionPromptsToggleResult {
         guard enabled else {
             setDictionaryCorrectionPromptsEnabled(false)
-            return false
+            return .updated
         }
         guard AXIsProcessTrusted() else {
-            return true
+            return .needsAccessibilityPermission
         }
         setDictionaryCorrectionPromptsEnabled(true)
-        return false
+        return .updated
     }
 
     func setDictionaryCorrectionPromptsEnabled(_ enabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -917,7 +917,7 @@ final class MuesliController: NSObject {
             dictionarySuggestionPromptAdvanceTask?.cancel()
             dictionarySuggestionPromptAdvanceTask = nil
             activeDictionarySuggestionPromptKey = nil
-            dictionarySuggestionPrompt.dismiss()
+            dictionarySuggestionPrompt.dismissWithoutNotification()
         }
         config.hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.hotkeyTriggerThresholdMS)
         config.computerUseHotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.computerUseHotkeyTriggerThresholdMS)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -894,8 +894,12 @@ final class MuesliController: NSObject {
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
         let previousEnableScreenContext = config.enableScreenContext
+        let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         mutate(&config)
         if previousEnableScreenContext, !config.enableScreenContext {
+            dictationCorrectionMonitor.cancel()
+        }
+        if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {
             dictationCorrectionMonitor.cancel()
         }
         config.hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.hotkeyTriggerThresholdMS)
@@ -2019,6 +2023,14 @@ final class MuesliController: NSObject {
             dictationCorrectionMonitor.cancel()
         }
         updateConfig { $0.enableDictionaryCorrectionPrompts = enabled }
+    }
+
+    @discardableResult
+    func requestDictionaryCorrectionAccessibilityEnable() -> Bool {
+        guard !AXIsProcessTrusted() else { return true }
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        AXIsProcessTrustedWithOptions(options)
+        return AXIsProcessTrusted()
     }
 
     @discardableResult
@@ -6207,7 +6219,7 @@ final class MuesliController: NSObject {
                     self.syncAppState()
                     if outputMode != .voiceNote {
                         PasteController.paste(text: text)
-                        if self.config.enableDictionaryCorrectionPrompts && self.config.enableScreenContext {
+                        if self.config.enableDictionaryCorrectionPrompts {
                             self.dictationCorrectionMonitor.start(
                                 originalText: text,
                                 appContext: storageContext,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -180,6 +180,8 @@ private final class DictationLatencyLogWriter: @unchecked Sendable {
 
 @MainActor
 final class MuesliController: NSObject {
+    private static let maxDismissedDictionarySuggestionKeys = 200
+
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
     private let dictationStore: DictationStore
@@ -859,7 +861,11 @@ final class MuesliController: NSObject {
         let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
+        let previousEnableScreenContext = config.enableScreenContext
         mutate(&config)
+        if previousEnableScreenContext, !config.enableScreenContext {
+            dictationCorrectionMonitor.cancel()
+        }
         config.hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.hotkeyTriggerThresholdMS)
         config.computerUseHotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.computerUseHotkeyTriggerThresholdMS)
         config.meetingRecordingHotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.meetingRecordingHotkeyTriggerThresholdMS)
@@ -1551,7 +1557,7 @@ final class MuesliController: NSObject {
             if let index = config.dictionarySuggestions.firstIndex(where: { $0.key == key }) {
                 var existing = config.dictionarySuggestions[index]
                 existing.occurrenceCount += 1
-                existing.lastSeenAt = ISO8601DateFormatter().string(from: Date())
+                existing.lastSeenAt = DictionarySuggestion.timestamp()
                 if existing.appContext.isEmpty {
                     existing.appContext = suggestion.appContext
                 }
@@ -1567,7 +1573,7 @@ final class MuesliController: NSObject {
             }
         }
 
-        if presentPrompt, config.enableDictionaryCorrectionPrompts {
+        if presentPrompt {
             presentDictionarySuggestionPrompt(promptSuggestion)
         }
     }
@@ -1601,6 +1607,9 @@ final class MuesliController: NSObject {
             config.dictionarySuggestions.removeAll { $0.key == key }
             if !config.dismissedDictionarySuggestionKeys.contains(key) {
                 config.dismissedDictionarySuggestionKeys.append(key)
+            }
+            if config.dismissedDictionarySuggestionKeys.count > Self.maxDismissedDictionarySuggestionKeys {
+                config.dismissedDictionarySuggestionKeys = Array(config.dismissedDictionarySuggestionKeys.suffix(Self.maxDismissedDictionarySuggestionKeys))
             }
         }
     }
@@ -5747,7 +5756,7 @@ final class MuesliController: NSObject {
                     self.syncAppState()
                     if outputMode != .voiceNote {
                         PasteController.paste(text: text)
-                        if self.config.enableDictionaryCorrectionPrompts {
+                        if self.config.enableDictionaryCorrectionPrompts && self.config.enableScreenContext {
                             self.dictationCorrectionMonitor.start(
                                 originalText: text,
                                 appContext: storageContext,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2056,6 +2056,8 @@ final class MuesliController: NSObject {
         guard activeDictionarySuggestionPromptKey != key else { return }
         guard !promptedDictionarySuggestionPromptKeys.contains(key) else { return }
         guard !queuedDictionarySuggestionPromptKeys.contains(key) else { return }
+        // The monitor caps each dictation edit window at a small suggestion set.
+        // Queue all of them here so add/ignore/dismiss reveals the next correction.
         queuedDictionarySuggestionPromptKeys.append(key)
         logDictionarySuggestion("queue depth=\(queuedDictionarySuggestionPromptKeys.count) \(dictionarySuggestionLogMetadata(suggestion))")
         presentNextDictionarySuggestionPromptIfPossible()
@@ -2125,6 +2127,19 @@ final class MuesliController: NSObject {
 
     func removeCustomWord(id: UUID) {
         updateConfig { $0.customWords.removeAll { $0.id == id } }
+    }
+
+    @discardableResult
+    func setDictionaryCorrectionPromptsFromToggle(_ enabled: Bool) -> Bool {
+        guard enabled else {
+            setDictionaryCorrectionPromptsEnabled(false)
+            return false
+        }
+        guard AXIsProcessTrusted() else {
+            return true
+        }
+        setDictionaryCorrectionPromptsEnabled(true)
+        return false
     }
 
     func setDictionaryCorrectionPromptsEnabled(_ enabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -199,6 +199,9 @@ final class MuesliController: NSObject {
     private let dictationRecorder = RouteAwareDictationRecorder()
     private let dictationCorrectionMonitor = DictationCorrectionMonitor()
     private let dictionarySuggestionPrompt = DictionarySuggestionPromptController()
+    private var activeDictionarySuggestionPromptKey: String?
+    private var queuedDictionarySuggestionPromptKeys: [String] = []
+    private var promptedDictionarySuggestionPromptKeys = Set<String>()
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
     private lazy var dictationAudioSessionManager = DictationAudioSessionManager(
@@ -899,6 +902,10 @@ final class MuesliController: NSObject {
         mutate(&config)
         if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {
             dictationCorrectionMonitor.cancel()
+            queuedDictionarySuggestionPromptKeys.removeAll()
+            promptedDictionarySuggestionPromptKeys.removeAll()
+            activeDictionarySuggestionPromptKey = nil
+            dictionarySuggestionPrompt.dismiss()
         }
         config.hotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.hotkeyTriggerThresholdMS)
         config.computerUseHotkeyTriggerThresholdMS = HotkeyTriggerTiming.clampedMilliseconds(config.computerUseHotkeyTriggerThresholdMS)
@@ -1970,9 +1977,7 @@ final class MuesliController: NSObject {
         }
 
         logDictionarySuggestion("persist action=\(persistenceAction) presentPrompt=\(presentPrompt) \(metadata)")
-        if presentPrompt {
-            presentDictionarySuggestionPrompt(promptSuggestion)
-        }
+        enqueueDictionarySuggestionPrompt(promptSuggestion)
     }
 
     func acceptDictionarySuggestion(id: UUID) {
@@ -2014,17 +2019,63 @@ final class MuesliController: NSObject {
     }
 
     private func presentDictionarySuggestionPrompt(_ suggestion: DictionarySuggestion) {
+        let key = suggestion.key
+        activeDictionarySuggestionPromptKey = key
+        promptedDictionarySuggestionPromptKeys.insert(key)
         logDictionarySuggestion("present \(dictionarySuggestionLogMetadata(suggestion))")
         dictionarySuggestionPrompt.show(
             suggestion: suggestion,
             anchorFrame: indicator.currentFrame,
             onAdd: { [weak self] in
-                self?.acceptDictionarySuggestion(suggestion)
+                guard let self else { return }
+                self.acceptDictionarySuggestion(suggestion)
+                self.completeDictionarySuggestionPrompt(key: key, action: "add")
             },
             onIgnore: { [weak self] in
-                self?.dismissDictionarySuggestion(suggestion)
+                guard let self else { return }
+                self.dismissDictionarySuggestion(suggestion)
+                self.completeDictionarySuggestionPrompt(key: key, action: "ignore")
+            },
+            onDismiss: { [weak self] in
+                self?.completeDictionarySuggestionPrompt(key: key, action: "dismiss")
             }
         )
+    }
+
+    private func enqueueDictionarySuggestionPrompt(_ suggestion: DictionarySuggestion) {
+        let key = suggestion.key
+        guard config.enableDictionaryCorrectionPrompts else { return }
+        guard activeDictionarySuggestionPromptKey != key else { return }
+        guard !promptedDictionarySuggestionPromptKeys.contains(key) else { return }
+        guard !queuedDictionarySuggestionPromptKeys.contains(key) else { return }
+        queuedDictionarySuggestionPromptKeys.append(key)
+        logDictionarySuggestion("queue depth=\(queuedDictionarySuggestionPromptKeys.count) \(dictionarySuggestionLogMetadata(suggestion))")
+        presentNextDictionarySuggestionPromptIfPossible()
+    }
+
+    private func completeDictionarySuggestionPrompt(key: String, action: String) {
+        guard activeDictionarySuggestionPromptKey == key else { return }
+        activeDictionarySuggestionPromptKey = nil
+        logDictionarySuggestion("complete action=\(action) queued=\(queuedDictionarySuggestionPromptKeys.count)")
+        presentNextDictionarySuggestionPromptIfPossible()
+    }
+
+    private func presentNextDictionarySuggestionPromptIfPossible() {
+        guard config.enableDictionaryCorrectionPrompts else { return }
+        guard activeDictionarySuggestionPromptKey == nil else { return }
+
+        while !queuedDictionarySuggestionPromptKeys.isEmpty {
+            let key = queuedDictionarySuggestionPromptKeys.removeFirst()
+            guard !promptedDictionarySuggestionPromptKeys.contains(key) else { continue }
+            guard !config.dismissedDictionarySuggestionKeys.contains(key) else { continue }
+            guard let suggestion = config.dictionarySuggestions.first(where: { $0.key == key }) else { continue }
+            let hasCustomWord = config.customWords.contains {
+                DictionarySuggestion.key(observed: $0.word, replacement: $0.targetWord) == key
+            }
+            guard !hasCustomWord else { continue }
+            presentDictionarySuggestionPrompt(suggestion)
+            return
+        }
     }
 
     private func dictionarySuggestionLogMetadata(_ suggestion: DictionarySuggestion) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1980,7 +1980,9 @@ final class MuesliController: NSObject {
         }
 
         logDictionarySuggestion("persist action=\(persistenceAction) presentPrompt=\(presentPrompt) \(metadata)")
-        enqueueDictionarySuggestionPrompt(promptSuggestion)
+        if presentPrompt {
+            enqueueDictionarySuggestionPrompt(promptSuggestion)
+        }
     }
 
     func acceptDictionarySuggestion(id: UUID) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -191,6 +191,8 @@ final class MuesliController: NSObject {
     private let meetingRecordingHotkeyMonitor = HotkeyMonitor()
     private let computerUseRecorder = MicrophoneRecorder()
     private let dictationRecorder = RouteAwareDictationRecorder()
+    private let dictationCorrectionMonitor = DictationCorrectionMonitor()
+    private let dictionarySuggestionPrompt = DictionarySuggestionPromptController()
     private let audioDuckingController: AudioDuckingManaging
     private let dictationAudioRoutingController: DictationAudioRouting
     private lazy var dictationAudioSessionManager = DictationAudioSessionManager(
@@ -269,6 +271,7 @@ final class MuesliController: NSObject {
     private var openWindowCount = 0
     private var lastExternalApp: NSRunningApplication?
     private var capturedDictationContext: DictationContext?
+    private var capturedDictationCorrectionTargetApp: DictationCorrectionTargetApp?
     private var workspaceObserver: NSObjectProtocol?
     private var dataDidChangeObserver: NSObjectProtocol?
     private var isStartingMeetingRecording = false
@@ -613,6 +616,7 @@ final class MuesliController: NSObject {
         meetingDetectionMonitorStarted = false
         dismissPresentedMeetingDetection()
         meetingNotification.close()
+        dictationCorrectionMonitor.cancel()
         activeMeetingSession?.discard()
         activeMeetingSession = nil
         if let activeMeetingID {
@@ -1529,6 +1533,92 @@ final class MuesliController: NSObject {
         updateConfig { $0.customWords.append(word) }
     }
 
+    func addDictionarySuggestion(_ suggestion: DictionarySuggestion, presentPrompt: Bool = false) {
+        guard config.enableDictionaryCorrectionPrompts else { return }
+        let trimmedObserved = suggestion.observed.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedReplacement = suggestion.replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedObserved.isEmpty, !trimmedReplacement.isEmpty else { return }
+        guard trimmedObserved != trimmedReplacement else { return }
+
+        let key = DictionarySuggestion.key(observed: trimmedObserved, replacement: trimmedReplacement)
+        guard !config.dismissedDictionarySuggestionKeys.contains(key) else { return }
+        guard !config.customWords.contains(where: {
+            DictionarySuggestion.key(observed: $0.word, replacement: $0.targetWord) == key
+        }) else { return }
+
+        var promptSuggestion = suggestion
+        updateConfig { config in
+            if let index = config.dictionarySuggestions.firstIndex(where: { $0.key == key }) {
+                var existing = config.dictionarySuggestions[index]
+                existing.occurrenceCount += 1
+                existing.lastSeenAt = ISO8601DateFormatter().string(from: Date())
+                if existing.appContext.isEmpty {
+                    existing.appContext = suggestion.appContext
+                }
+                config.dictionarySuggestions[index] = existing
+                promptSuggestion = existing
+            } else {
+                promptSuggestion = DictionarySuggestion(
+                    observed: trimmedObserved,
+                    replacement: trimmedReplacement,
+                    appContext: suggestion.appContext
+                )
+                config.dictionarySuggestions.insert(promptSuggestion, at: 0)
+            }
+        }
+
+        if presentPrompt, config.enableDictionaryCorrectionPrompts {
+            presentDictionarySuggestionPrompt(promptSuggestion)
+        }
+    }
+
+    func acceptDictionarySuggestion(id: UUID) {
+        guard let suggestion = config.dictionarySuggestions.first(where: { $0.id == id }) else { return }
+        acceptDictionarySuggestion(suggestion)
+    }
+
+    func dismissDictionarySuggestion(id: UUID) {
+        guard let suggestion = config.dictionarySuggestions.first(where: { $0.id == id }) else { return }
+        dismissDictionarySuggestion(suggestion)
+    }
+
+    private func acceptDictionarySuggestion(_ suggestion: DictionarySuggestion) {
+        let key = suggestion.key
+        updateConfig { config in
+            if !config.customWords.contains(where: {
+                DictionarySuggestion.key(observed: $0.word, replacement: $0.targetWord) == key
+            }) {
+                config.customWords.append(suggestion.customWord)
+            }
+            config.dictionarySuggestions.removeAll { $0.key == key }
+            config.dismissedDictionarySuggestionKeys.removeAll { $0 == key }
+        }
+    }
+
+    private func dismissDictionarySuggestion(_ suggestion: DictionarySuggestion) {
+        let key = suggestion.key
+        updateConfig { config in
+            config.dictionarySuggestions.removeAll { $0.key == key }
+            if !config.dismissedDictionarySuggestionKeys.contains(key) {
+                config.dismissedDictionarySuggestionKeys.append(key)
+            }
+        }
+    }
+
+    private func presentDictionarySuggestionPrompt(_ suggestion: DictionarySuggestion) {
+        dictionarySuggestionPrompt.show(
+            suggestion: suggestion,
+            anchorFrame: indicator.currentFrame,
+            onAdd: { [weak self] in
+                self?.acceptDictionarySuggestion(suggestion)
+            },
+            onLater: {},
+            onIgnore: { [weak self] in
+                self?.dismissDictionarySuggestion(suggestion)
+            }
+        )
+    }
+
     func updateCustomWord(_ word: CustomWord) {
         updateConfig { config in
             guard let index = config.customWords.firstIndex(where: { $0.id == word.id }) else { return }
@@ -1538,6 +1628,13 @@ final class MuesliController: NSObject {
 
     func removeCustomWord(id: UUID) {
         updateConfig { $0.customWords.removeAll { $0.id == id } }
+    }
+
+    func setDictionaryCorrectionPromptsEnabled(_ enabled: Bool) {
+        if !enabled {
+            dictationCorrectionMonitor.cancel()
+        }
+        updateConfig { $0.enableDictionaryCorrectionPrompts = enabled }
     }
 
     @discardableResult
@@ -5248,6 +5345,11 @@ final class MuesliController: NSObject {
         beginDictationOutput()
         dictationStartedAt = nil
         capturedDictationContext = nil
+        capturedDictationCorrectionTargetApp = DictationCorrectionTargetApp(
+            app: NSWorkspace.shared.frontmostApplication == NSRunningApplication.current
+                ? lastExternalApp
+                : NSWorkspace.shared.frontmostApplication
+        )
         setState(.preparing)
         dictationAudioSessionManager.beginRecording(
             mode: "hold-start",
@@ -5583,7 +5685,10 @@ final class MuesliController: NSObject {
         let transcriptionLanguage = isTestMode ? (dictationTestCohereLanguage ?? config.resolvedCohereLanguage) : config.resolvedCohereLanguage
         let capturedContext = capturedDictationContext
         let promptContext = capturedContext.map { DictationContextCapture.formatForPrompt($0) }
-        let storageContext = capturedContext.map { DictationContextCapture.formatForStorage($0) } ?? ""
+        let correctionTargetApp = capturedDictationCorrectionTargetApp
+        let storageContext = capturedContext.map { DictationContextCapture.formatForStorage($0) }
+            ?? correctionTargetApp?.appContext
+            ?? ""
         let task = Task { [weak self] in
             guard let self else { return }
             defer {
@@ -5636,11 +5741,21 @@ final class MuesliController: NSObject {
                 )
                 await MainActor.run {
                     self.capturedDictationContext = nil
+                    self.capturedDictationCorrectionTargetApp = nil
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()
                     if outputMode != .voiceNote {
                         PasteController.paste(text: text)
+                        if self.config.enableDictionaryCorrectionPrompts {
+                            self.dictationCorrectionMonitor.start(
+                                originalText: text,
+                                appContext: storageContext,
+                                targetApp: correctionTargetApp
+                            ) { [weak self] suggestion in
+                                self?.addDictionarySuggestion(suggestion, presentPrompt: true)
+                            }
+                        }
                     }
                     self.resetDictationOutputMode()
                     self.setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -895,16 +895,8 @@ final class MuesliController: NSObject {
         let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
         let previousMeetingRecordingHotkeyTriggerThresholdMS = config.meetingRecordingHotkeyTriggerThresholdMS
-        let previousEnableScreenContext = config.enableScreenContext
-        let previousEnablePostProcessor = config.enablePostProcessor
         let previousEnableDictionaryCorrectionPrompts = config.enableDictionaryCorrectionPrompts
         mutate(&config)
-        if previousEnableScreenContext, !config.enableScreenContext {
-            dictationCorrectionMonitor.cancel()
-        }
-        if previousEnablePostProcessor, !config.enablePostProcessor {
-            dictationCorrectionMonitor.cancel()
-        }
         if previousEnableDictionaryCorrectionPrompts, !config.enableDictionaryCorrectionPrompts {
             dictationCorrectionMonitor.cancel()
         }
@@ -1923,7 +1915,7 @@ final class MuesliController: NSObject {
 
     func addDictionarySuggestion(_ suggestion: DictionarySuggestion, presentPrompt: Bool = false) {
         guard config.enableDictionaryCorrectionPrompts else {
-            logDictionarySuggestion("skip reason=disabled key=\(suggestion.key)")
+            logDictionarySuggestion("skip reason=disabled \(dictionarySuggestionLogMetadata(suggestion))")
             return
         }
         let trimmedObserved = suggestion.observed.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1938,14 +1930,15 @@ final class MuesliController: NSObject {
         }
 
         let key = DictionarySuggestion.key(observed: trimmedObserved, replacement: trimmedReplacement)
+        let metadata = dictionarySuggestionLogMetadata(observed: trimmedObserved, replacement: trimmedReplacement)
         guard !config.dismissedDictionarySuggestionKeys.contains(key) else {
-            logDictionarySuggestion("skip reason=dismissed key=\(key)")
+            logDictionarySuggestion("skip reason=dismissed \(metadata)")
             return
         }
         guard !config.customWords.contains(where: {
             DictionarySuggestion.key(observed: $0.word, replacement: $0.targetWord) == key
         }) else {
-            logDictionarySuggestion("skip reason=customWordExists key=\(key)")
+            logDictionarySuggestion("skip reason=customWordExists \(metadata)")
             return
         }
 
@@ -1976,7 +1969,7 @@ final class MuesliController: NSObject {
             }
         }
 
-        logDictionarySuggestion("persist action=\(persistenceAction) key=\(key) presentPrompt=\(presentPrompt)")
+        logDictionarySuggestion("persist action=\(persistenceAction) presentPrompt=\(presentPrompt) \(metadata)")
         if presentPrompt {
             presentDictionarySuggestionPrompt(promptSuggestion)
         }
@@ -2003,7 +1996,7 @@ final class MuesliController: NSObject {
             config.dictionarySuggestions.removeAll { $0.key == key }
             config.dismissedDictionarySuggestionKeys.removeAll { $0 == key }
         }
-        logDictionarySuggestion("accept key=\(key)")
+        logDictionarySuggestion("accept \(dictionarySuggestionLogMetadata(suggestion))")
     }
 
     private func dismissDictionarySuggestion(_ suggestion: DictionarySuggestion) {
@@ -2017,11 +2010,11 @@ final class MuesliController: NSObject {
                 config.dismissedDictionarySuggestionKeys = Array(config.dismissedDictionarySuggestionKeys.suffix(Self.maxDismissedDictionarySuggestionKeys))
             }
         }
-        logDictionarySuggestion("ignore key=\(key)")
+        logDictionarySuggestion("ignore \(dictionarySuggestionLogMetadata(suggestion))")
     }
 
     private func presentDictionarySuggestionPrompt(_ suggestion: DictionarySuggestion) {
-        logDictionarySuggestion("present key=\(suggestion.key)")
+        logDictionarySuggestion("present \(dictionarySuggestionLogMetadata(suggestion))")
         dictionarySuggestionPrompt.show(
             suggestion: suggestion,
             anchorFrame: indicator.currentFrame,
@@ -2032,6 +2025,14 @@ final class MuesliController: NSObject {
                 self?.dismissDictionarySuggestion(suggestion)
             }
         )
+    }
+
+    private func dictionarySuggestionLogMetadata(_ suggestion: DictionarySuggestion) -> String {
+        dictionarySuggestionLogMetadata(observed: suggestion.observed, replacement: suggestion.replacement)
+    }
+
+    private func dictionarySuggestionLogMetadata(observed: String, replacement: String) -> String {
+        "observedChars=\(observed.count) replacementChars=\(replacement.count)"
     }
 
     private func logDictionarySuggestion(_ message: String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1923,7 +1923,7 @@ final class MuesliController: NSObject {
         updateConfig { $0.customWords.append(word) }
     }
 
-    func addDictionarySuggestion(_ suggestion: DictionarySuggestion, presentPrompt: Bool = false) {
+    func addDictionarySuggestion(_ suggestion: DictionarySuggestion) {
         guard config.enableDictionaryCorrectionPrompts else {
             logDictionarySuggestion("skip reason=disabled \(dictionarySuggestionLogMetadata(suggestion))")
             return
@@ -1979,10 +1979,8 @@ final class MuesliController: NSObject {
             }
         }
 
-        logDictionarySuggestion("persist action=\(persistenceAction) presentPrompt=\(presentPrompt) \(metadata)")
-        if presentPrompt {
-            enqueueDictionarySuggestionPrompt(promptSuggestion)
-        }
+        logDictionarySuggestion("persist action=\(persistenceAction) \(metadata)")
+        enqueueDictionarySuggestionPrompt(promptSuggestion)
     }
 
     func acceptDictionarySuggestion(id: UUID) {
@@ -2096,10 +2094,6 @@ final class MuesliController: NSObject {
             presentDictionarySuggestionPrompt(suggestion)
             return
         }
-    }
-
-    private func presentNextDictionarySuggestionPromptIfPossibleBeforeQueueHandoff() {
-        presentNextDictionarySuggestionPromptIfPossible()
     }
 
     private func dictionarySuggestionLogMetadata(_ suggestion: DictionarySuggestion) -> String {
@@ -6346,8 +6340,8 @@ final class MuesliController: NSObject {
                                 originalText: text,
                                 appContext: storageContext,
                                 targetApp: correctionTargetApp
-                            ) { [weak self] suggestion, shouldPresentPrompt in
-                                self?.addDictionarySuggestion(suggestion, presentPrompt: shouldPresentPrompt)
+                            ) { [weak self] suggestion in
+                                self?.addDictionarySuggestion(suggestion)
                             }
                         }
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1647,6 +1647,22 @@ final class MuesliController: NSObject {
     }
 
     @discardableResult
+    func requestScreenContextEnable() -> Bool {
+        guard CGPreflightScreenCaptureAccess() else {
+            updateConfig { $0.enableScreenContext = false }
+            let granted = CGRequestScreenCaptureAccess()
+            let hasAccess = granted || CGPreflightScreenCaptureAccess()
+            if hasAccess {
+                updateConfig { $0.enableScreenContext = true }
+            }
+            return hasAccess
+        }
+
+        updateConfig { $0.enableScreenContext = true }
+        return true
+    }
+
+    @discardableResult
     func updateDictationHotkey(_ hotkey: HotkeyConfig) -> ShortcutHotkeyUpdateResult {
         let result = ShortcutHotkeyPolicy.validateDictationHotkey(
             hotkey,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -185,6 +185,7 @@ final class MuesliController: NSObject {
     private static let maxDictionarySuggestions = 50
     private static let pendingDictionaryCorrectionPromptsEnableKey = "settings.pendingDictionaryCorrectionPromptsEnable"
     private static let pendingDictionaryCorrectionPromptsRequestedAtKey = "settings.pendingDictionaryCorrectionPromptsRequestedAt"
+    private static let pendingDictionaryCorrectionPromptsEnableTimeout: TimeInterval = 15 * 60
 
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
@@ -2052,6 +2053,10 @@ final class MuesliController: NSObject {
 
     func reconcilePendingDictionaryCorrectionPromptsEnable() {
         guard UserDefaults.standard.bool(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey) else { return }
+        if isPendingDictionaryCorrectionPromptsEnableExpired {
+            clearPendingDictionaryCorrectionPromptsEnable()
+            return
+        }
         guard AXIsProcessTrusted() else { return }
         clearPendingDictionaryCorrectionPromptsEnable()
         updateConfig { $0.enableDictionaryCorrectionPrompts = true }
@@ -2065,6 +2070,12 @@ final class MuesliController: NSObject {
     private func clearPendingDictionaryCorrectionPromptsEnable() {
         UserDefaults.standard.removeObject(forKey: Self.pendingDictionaryCorrectionPromptsEnableKey)
         UserDefaults.standard.removeObject(forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
+    }
+
+    private var isPendingDictionaryCorrectionPromptsEnableExpired: Bool {
+        let requestedAt = UserDefaults.standard.double(forKey: Self.pendingDictionaryCorrectionPromptsRequestedAtKey)
+        guard requestedAt > 0 else { return true }
+        return Date().timeIntervalSince1970 - requestedAt > Self.pendingDictionaryCorrectionPromptsEnableTimeout
     }
 
     @discardableResult

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -270,10 +270,13 @@ struct SettingsView: View {
     ]
 
     private var screenContextDescription: String {
-        if screenRecordingGranted {
-            return "Adds nearby app text and meeting OCR context. Processed on-device."
+        if !accessibilityGranted {
+            return "Requires Accessibility. Adds nearby app text for post-processing."
         }
-        return "Requires Screen Recording. Adds nearby app text and meeting OCR context."
+        if !screenRecordingGranted {
+            return "Adds nearby app text for post-processing. Screen Recording enables OCR context."
+        }
+        return "Adds nearby app text and OCR context. Processed on-device."
     }
 
     @ViewBuilder
@@ -1432,7 +1435,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func screenContextControl(width: CGFloat? = nil) -> some View {
-        if screenRecordingGranted {
+        if accessibilityGranted {
             settingsSwitch(isOn: appState.config.enableScreenContext) { newValue in
                 handleScreenContextToggle(newValue)
             }
@@ -1461,18 +1464,17 @@ struct SettingsView: View {
             return false
         }
 
-        guard CGPreflightScreenCaptureAccess() else {
+        guard accessibilityGranted else {
             pendingScreenContextEnable = true
             pendingScreenContextRequestedAt = Date().timeIntervalSince1970
             let granted = controller.requestScreenContextEnable()
-            screenRecordingGranted = CGPreflightScreenCaptureAccess()
-            if granted || screenRecordingGranted {
+            accessibilityGranted = AXIsProcessTrusted()
+            if granted || accessibilityGranted {
                 clearPendingScreenContextEnable()
             }
-            return granted || screenRecordingGranted
+            return granted || accessibilityGranted
         }
 
-        screenRecordingGranted = true
         clearPendingScreenContextEnable()
         return controller.requestScreenContextEnable()
     }
@@ -1507,14 +1509,14 @@ struct SettingsView: View {
         if refreshLaunchAtLogin {
             controller.refreshLaunchAtLoginState()
         }
-        if screenRecordingGranted && pendingScreenContextEnable {
+        if accessibilityGranted && pendingScreenContextEnable {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = true }
         }
-        if !screenRecordingGranted && isPendingScreenContextGrantExpired {
+        if !accessibilityGranted && isPendingScreenContextGrantExpired {
             clearPendingScreenContextEnable()
         }
-        if !screenRecordingGranted && appState.config.enableScreenContext {
+        if !accessibilityGranted && appState.config.enableScreenContext {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = false }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -229,8 +229,11 @@ struct SettingsView: View {
         ) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                controller.setDictionaryCorrectionPromptsEnabled(true)
-                handleScreenContextToggle(true)
+                if handleScreenContextToggle(true) {
+                    controller.setDictionaryCorrectionPromptsEnabled(true)
+                } else {
+                    controller.setDictionaryCorrectionPromptsEnabled(false)
+                }
             }
         } message: {
             Text("Dictionary suggestions need Screen Context to detect text edits after dictation.")
@@ -1372,11 +1375,12 @@ struct SettingsView: View {
         }
     }
 
-    private func handleScreenContextToggle(_ enabled: Bool) {
+    @discardableResult
+    private func handleScreenContextToggle(_ enabled: Bool) -> Bool {
         guard enabled else {
             clearPendingScreenContextEnable()
             controller.updateConfig { $0.enableScreenContext = false }
-            return
+            return false
         }
 
         guard CGPreflightScreenCaptureAccess() else {
@@ -1387,12 +1391,12 @@ struct SettingsView: View {
             if granted || screenRecordingGranted {
                 clearPendingScreenContextEnable()
             }
-            return
+            return granted || screenRecordingGranted
         }
 
         screenRecordingGranted = true
         clearPendingScreenContextEnable()
-        controller.requestScreenContextEnable()
+        return controller.requestScreenContextEnable()
     }
 
     private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -270,9 +270,9 @@ struct SettingsView: View {
 
     private var screenContextDescription: String {
         if screenRecordingGranted {
-            return "Adds nearby app text and meeting OCR context. Processed on-device."
+            return "Adds nearby app text, meeting OCR, and post-dictation edit detection. Processed on-device."
         }
-        return "Requires Screen Recording. Adds nearby app text and meeting OCR context."
+        return "Requires Screen Recording for nearby app text, meeting OCR, and post-dictation edit detection."
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -235,7 +235,7 @@ struct SettingsView: View {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
-            Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")
+            Text("Dictionary suggestions need Accessibility to detect text edits after dictation. Grant access, restart Muesli, then turn suggestions on.")
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -234,8 +234,6 @@ struct SettingsView: View {
             Button("Enable") {
                 if controller.requestDictionaryCorrectionAccessibilityEnable() {
                     controller.setDictionaryCorrectionPromptsEnabled(true)
-                } else {
-                    controller.setDictionaryCorrectionPromptsEnabled(false)
                 }
             }
         } message: {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -235,7 +235,7 @@ struct SettingsView: View {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
-            Text("Dictionary suggestions need Accessibility to detect text edits after dictation. Grant access, restart Muesli, then turn suggestions on.")
+            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, restart Muesli, then turn suggestions on.")
         }
     }
 
@@ -531,12 +531,12 @@ struct SettingsView: View {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(
                     "Dictionary suggestions",
-                    description: "Suggest adding words when you correct dictation output. Requires Accessibility."
+                    description: "Suggest words after corrections by briefly reading focused app text via Accessibility."
                 ) {
                     settingsSwitch(isOn: appState.config.enableDictionaryCorrectionPrompts) { newValue in
                         handleDictionaryCorrectionPromptsToggle(newValue)
                     }
-                    .help("Suggest corrections after dictation edits.")
+                    .help("Briefly reads focused app text after dictation to detect corrections.")
                 }
                 if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
                     Divider().background(MuesliTheme.surfaceBorder)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -232,9 +232,7 @@ struct SettingsView: View {
         ) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                if controller.requestDictionaryCorrectionAccessibilityEnable() {
-                    controller.setDictionaryCorrectionPromptsEnabled(true)
-                }
+                controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
             Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")
@@ -1509,6 +1507,7 @@ struct SettingsView: View {
         accessibilityGranted = AXIsProcessTrusted()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
+        controller.reconcilePendingDictionaryCorrectionPromptsEnable()
         if refreshLaunchAtLogin {
             controller.refreshLaunchAtLoginState()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1480,7 +1480,7 @@ struct SettingsView: View {
     }
 
     private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {
-        if controller.setDictionaryCorrectionPromptsFromToggle(enabled) {
+        if controller.setDictionaryCorrectionPromptsFromToggle(enabled) == .needsAccessibilityPermission {
             isShowingDictionaryAccessibilityPrompt = true
         }
     }
@@ -1510,7 +1510,9 @@ struct SettingsView: View {
             controller.refreshLaunchAtLoginState()
         }
         if accessibilityGranted && pendingScreenContextEnable {
-            clearPendingScreenContextEnable()
+            if controller.requestScreenContextEnable() {
+                clearPendingScreenContextEnable()
+            }
         }
         if !accessibilityGranted && isPendingScreenContextGrantExpired {
             clearPendingScreenContextEnable()

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -439,11 +439,13 @@ struct SettingsView: View {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(
                     "Dictionary suggestions",
-                    description: "Suggest adding words when you correct dictation output."
+                    description: "Suggest adding words when you correct dictation output. Requires Screen Context."
                 ) {
                     settingsSwitch(isOn: appState.config.enableDictionaryCorrectionPrompts) { newValue in
                         controller.setDictionaryCorrectionPromptsEnabled(newValue)
                     }
+                    .disabled(!appState.config.enableScreenContext)
+                    .help(appState.config.enableScreenContext ? "Suggest corrections after dictation edits." : "Enable Screen Context first.")
                 }
                 if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
                     Divider().background(MuesliTheme.surfaceBorder)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -81,7 +81,7 @@ struct SettingsView: View {
     @State private var googleCalSignInError: String?
     @State private var isSigningInGoogleCal = false
     @State private var pendingDataDestruction: PendingDataDestruction?
-    @State private var isShowingDictionaryScreenContextPrompt = false
+    @State private var isShowingDictionaryAccessibilityPrompt = false
     @State private var isPreviewingClip = false
     @State private var selectedPane: SettingsPane = .general
     @State private var downloadedBackendOptions: [BackendOption] = []
@@ -227,19 +227,19 @@ struct SettingsView: View {
             Text(pendingDataDestruction?.message ?? "")
         }
         .alert(
-            "Enable Screen Context?",
-            isPresented: $isShowingDictionaryScreenContextPrompt
+            "Enable Accessibility?",
+            isPresented: $isShowingDictionaryAccessibilityPrompt
         ) {
             Button("Cancel", role: .cancel) {}
             Button("Enable") {
-                if handleScreenContextToggle(true) {
+                if controller.requestDictionaryCorrectionAccessibilityEnable() {
                     controller.setDictionaryCorrectionPromptsEnabled(true)
                 } else {
                     controller.setDictionaryCorrectionPromptsEnabled(false)
                 }
             }
         } message: {
-            Text("Dictionary suggestions need Screen Context to detect text edits after dictation.")
+            Text("Dictionary suggestions need Accessibility to detect text edits after dictation.")
         }
     }
 
@@ -273,9 +273,9 @@ struct SettingsView: View {
 
     private var screenContextDescription: String {
         if screenRecordingGranted {
-            return "Adds nearby app text, meeting OCR, and post-dictation edit detection. Processed on-device."
+            return "Adds nearby app text and meeting OCR context. Processed on-device."
         }
-        return "Requires Screen Recording for nearby app text, meeting OCR, and post-dictation edit detection."
+        return "Requires Screen Recording. Adds nearby app text and meeting OCR context."
     }
 
     @ViewBuilder
@@ -535,7 +535,7 @@ struct SettingsView: View {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(
                     "Dictionary suggestions",
-                    description: "Suggest adding words when you correct dictation output. Requires Screen Context."
+                    description: "Suggest adding words when you correct dictation output. Requires Accessibility."
                 ) {
                     settingsSwitch(isOn: appState.config.enableDictionaryCorrectionPrompts) { newValue in
                         handleDictionaryCorrectionPromptsToggle(newValue)
@@ -1484,8 +1484,8 @@ struct SettingsView: View {
             controller.setDictionaryCorrectionPromptsEnabled(false)
             return
         }
-        guard appState.config.enableScreenContext else {
-            isShowingDictionaryScreenContextPrompt = true
+        guard AXIsProcessTrusted() else {
+            isShowingDictionaryAccessibilityPrompt = true
             return
         }
         controller.setDictionaryCorrectionPromptsEnabled(true)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -230,7 +230,9 @@ struct SettingsView: View {
             "Enable Accessibility?",
             isPresented: $isShowingDictionaryAccessibilityPrompt
         ) {
-            Button("Cancel", role: .cancel) {}
+            Button("Cancel", role: .cancel) {
+                controller.cancelDictionaryCorrectionAccessibilityEnableRequest()
+            }
             Button("Enable") {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -235,7 +235,7 @@ struct SettingsView: View {
                 controller.requestDictionaryCorrectionAccessibilityEnable()
             }
         } message: {
-            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, restart Muesli, then turn suggestions on.")
+            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, then relaunch Muesli to turn suggestions on.")
         }
     }
 
@@ -1505,6 +1505,7 @@ struct SettingsView: View {
     private func refreshPermissionStatuses(refreshLaunchAtLogin: Bool = false) {
         micGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         accessibilityGranted = AXIsProcessTrusted()
+        controller.reconcilePendingDictionaryCorrectionAccessibilityEnable()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
         if refreshLaunchAtLogin {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -271,7 +271,7 @@ struct SettingsView: View {
 
     private var screenContextDescription: String {
         if !accessibilityGranted {
-            return "Requires Accessibility. Adds nearby app text for post-processing."
+            return "Grant Accessibility, then toggle again if needed."
         }
         if !screenRecordingGranted {
             return "Adds nearby app text for post-processing. Screen Recording enables OCR context."
@@ -1511,7 +1511,6 @@ struct SettingsView: View {
         }
         if accessibilityGranted && pendingScreenContextEnable {
             clearPendingScreenContextEnable()
-            controller.updateConfig { $0.enableScreenContext = true }
         }
         if !accessibilityGranted && isPendingScreenContextGrantExpired {
             clearPendingScreenContextEnable()

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1478,15 +1478,9 @@ struct SettingsView: View {
     }
 
     private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {
-        guard enabled else {
-            controller.setDictionaryCorrectionPromptsEnabled(false)
-            return
-        }
-        guard AXIsProcessTrusted() else {
+        if controller.setDictionaryCorrectionPromptsFromToggle(enabled) {
             isShowingDictionaryAccessibilityPrompt = true
-            return
         }
-        controller.setDictionaryCorrectionPromptsEnabled(true)
     }
 
     private func startPermissionPolling() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1507,7 +1507,6 @@ struct SettingsView: View {
         accessibilityGranted = AXIsProcessTrusted()
         inputMonitoringGranted = CGPreflightListenEventAccess()
         screenRecordingGranted = CGPreflightScreenCaptureAccess()
-        controller.reconcilePendingDictionaryCorrectionPromptsEnable()
         if refreshLaunchAtLogin {
             controller.refreshLaunchAtLoginState()
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -436,6 +436,15 @@ struct SettingsView: View {
                         controller.setPostProcessorEnabled(newValue)
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow(
+                    "Dictionary suggestions",
+                    description: "Suggest adding words when you correct dictation output."
+                ) {
+                    settingsSwitch(isOn: appState.config.enableDictionaryCorrectionPrompts) { newValue in
+                        controller.setDictionaryCorrectionPromptsEnabled(newValue)
+                    }
+                }
                 if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Cleanup model") {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -79,6 +79,7 @@ struct SettingsView: View {
     @State private var googleCalSignInError: String?
     @State private var isSigningInGoogleCal = false
     @State private var pendingDataDestruction: PendingDataDestruction?
+    @State private var isShowingDictionaryScreenContextPrompt = false
     @State private var isPreviewingClip = false
     @State private var selectedPane: SettingsPane = .general
     @State private var downloadedBackendOptions: [BackendOption] = []
@@ -221,6 +222,18 @@ struct SettingsView: View {
             }
         } message: {
             Text(pendingDataDestruction?.message ?? "")
+        }
+        .alert(
+            "Enable Screen Context?",
+            isPresented: $isShowingDictionaryScreenContextPrompt
+        ) {
+            Button("Cancel", role: .cancel) {}
+            Button("Enable") {
+                controller.setDictionaryCorrectionPromptsEnabled(true)
+                handleScreenContextToggle(true)
+            }
+        } message: {
+            Text("Dictionary suggestions need Screen Context to detect text edits after dictation.")
         }
     }
 
@@ -442,10 +455,9 @@ struct SettingsView: View {
                     description: "Suggest adding words when you correct dictation output. Requires Screen Context."
                 ) {
                     settingsSwitch(isOn: appState.config.enableDictionaryCorrectionPrompts) { newValue in
-                        controller.setDictionaryCorrectionPromptsEnabled(newValue)
+                        handleDictionaryCorrectionPromptsToggle(newValue)
                     }
-                    .disabled(!appState.config.enableScreenContext)
-                    .help(appState.config.enableScreenContext ? "Suggest corrections after dictation edits." : "Enable Screen Context first.")
+                    .help("Suggest corrections after dictation edits.")
                 }
                 if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
                     Divider().background(MuesliTheme.surfaceBorder)
@@ -1368,21 +1380,31 @@ struct SettingsView: View {
         }
 
         guard CGPreflightScreenCaptureAccess() else {
-            controller.updateConfig { $0.enableScreenContext = false }
             pendingScreenContextEnable = true
             pendingScreenContextRequestedAt = Date().timeIntervalSince1970
-            let granted = CGRequestScreenCaptureAccess()
+            let granted = controller.requestScreenContextEnable()
             screenRecordingGranted = CGPreflightScreenCaptureAccess()
             if granted || screenRecordingGranted {
                 clearPendingScreenContextEnable()
-                controller.updateConfig { $0.enableScreenContext = true }
             }
             return
         }
 
         screenRecordingGranted = true
         clearPendingScreenContextEnable()
-        controller.updateConfig { $0.enableScreenContext = true }
+        controller.requestScreenContextEnable()
+    }
+
+    private func handleDictionaryCorrectionPromptsToggle(_ enabled: Bool) {
+        guard enabled else {
+            controller.setDictionaryCorrectionPromptsEnabled(false)
+            return
+        }
+        guard appState.config.enableScreenContext else {
+            isShowingDictionaryScreenContextPrompt = true
+            return
+        }
+        controller.setDictionaryCorrectionPromptsEnabled(true)
     }
 
     private func startPermissionPolling() {

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -30,37 +30,34 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "muesli")
     }
 
-    @Test("detects proper noun split merge corrections")
-    func detectsProperNounSplitMergeCorrection() {
+    @Test("does not suggest split merge phrase corrections")
+    func skipsSplitMergePhraseCorrection() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "often I try to say Alvar Pet in dictation",
             editedText: "often I try to say Alwarpet in dictation"
         )
 
-        #expect(suggestion?.observed == "Alvar Pet")
-        #expect(suggestion?.replacement == "Alwarpet")
+        #expect(suggestion == nil)
     }
 
-    @Test("detects close hyphenated split merge corrections")
-    func detectsCloseHyphenatedSplitMergeCorrection() {
+    @Test("does not suggest hyphenated phrase corrections")
+    func skipsHyphenatedPhraseCorrection() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "please route this to sc domain",
             editedText: "please route this to sc-domain"
         )
 
-        #expect(suggestion?.observed == "sc domain")
-        #expect(suggestion?.replacement == "sc-domain")
+        #expect(suggestion == nil)
     }
 
-    @Test("detects acronym replacement corrections")
-    func detectsAcronymReplacementCorrection() {
+    @Test("does not suggest acronym phrase replacements")
+    func skipsAcronymPhraseReplacement() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "I moved to New York last year and I like it",
             editedText: "I moved to NYC last year and I like it"
         )
 
-        #expect(suggestion?.observed == "New York")
-        #expect(suggestion?.replacement == "NYC")
+        #expect(suggestion == nil)
     }
 
     @Test("detects numeric shorthand corrections")
@@ -129,6 +126,22 @@ struct DictionaryCorrectionDetectorTests {
 
         #expect(suggestions.map(\.observed) == ["Mailapur", "Trivanmir", "Teenagar"])
         #expect(suggestions.map(\.replacement) == ["Mylapore", "Thiruvanmiyur", "TNagar"])
+    }
+
+    @Test("does not emit phrase suggestions when adjacent words are edited")
+    func skipsPhraseSuggestionsForAdjacentWordEdits() {
+        let original = "Chennai area names called Mylapore, Mandavali, Dirvaniur."
+        let edited = "Chennai area names called Mylapore, Mandaiveli, Thiruvanmiyur."
+
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: original,
+            editedText: edited,
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["Mandavali", "Dirvaniur"])
+        #expect(suggestions.map(\.replacement) == ["Mandaiveli", "Thiruvanmiyur"])
+        #expect(suggestions.allSatisfy { !$0.observed.contains(" ") && !$0.replacement.contains(" ") })
     }
 
     @Test("detects word correction when extra text is appended afterwards")

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -4,6 +4,38 @@ import Testing
 
 @Suite("Dictionary correction detector")
 struct DictionaryCorrectionDetectorTests {
+    @Test("contract surfaces one-word and two-token-to-one-word corrections only")
+    func contractSurfacesSupportedCorrectionShapesOnly() {
+        let singleWordSuggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "for the dictionary test please write musley in this sentence today",
+            editedText: "for the dictionary test please write muesli in this sentence today"
+        )
+        #expect(singleWordSuggestion?.observed == "musley")
+        #expect(singleWordSuggestion?.replacement == "muesli")
+
+        let splitWordSuggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "for the dictionary test please write Thoray Pakam in this sentence today",
+            editedText: "for the dictionary test please write Thoraipakkam in this sentence today"
+        )
+        #expect(splitWordSuggestion?.observed == "Thoray Pakam")
+        #expect(splitWordSuggestion?.replacement == "Thoraipakkam")
+
+        let adjacentWordSuggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: "for the dictionary test please write Mandavali Dirvaniur in this sentence today",
+            editedText: "for the dictionary test please write Mandaiveli Thiruvanmiyur in this sentence today",
+            maxSuggestions: 3
+        )
+        #expect(adjacentWordSuggestions.map(\.observed) == ["Mandavali", "Dirvaniur"])
+        #expect(adjacentWordSuggestions.map(\.replacement) == ["Mandaiveli", "Thiruvanmiyur"])
+        #expect(adjacentWordSuggestions.allSatisfy { !$0.observed.contains(" ") && !$0.replacement.contains(" ") })
+
+        let threeTokenSuggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "for the dictionary test please write Thoray I Pakam in this sentence today",
+            editedText: "for the dictionary test please write Thoraipakkam in this sentence today"
+        )
+        #expect(threeTokenSuggestion == nil)
+    }
+
     @Test("detects a corrected misspelling inside pasted text")
     func detectsCorrectedMisspelling() {
         let suggestion = DictionaryCorrectionDetector.suggestion(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -187,9 +187,9 @@ struct DictionaryCorrectionSnapshotStabilizerTests {
         let start = Date(timeIntervalSince1970: 1_000)
         let snapshot = "I usually use this prompt"
 
-        #expect(stabilizer.observe(snapshot: snapshot, now: start, quietWindow: 1.5) == nil)
-        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(1.0), quietWindow: 1.5) == nil)
-        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(1.6), quietWindow: 1.5) == snapshot)
+        #expect(stabilizer.observe(snapshots: [snapshot], now: start, quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: [snapshot], now: start.addingTimeInterval(1.0), quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: [snapshot], now: start.addingTimeInterval(1.6), quietWindow: 1.5) == [snapshot])
     }
 
     @Test("resets the quiet window when the snapshot changes")
@@ -197,10 +197,10 @@ struct DictionaryCorrectionSnapshotStabilizerTests {
         var stabilizer = DictationCorrectionSnapshotStabilizer()
         let start = Date(timeIntervalSince1970: 2_000)
 
-        #expect(stabilizer.observe(snapshot: "I usually", now: start, quietWindow: 1.5) == nil)
-        #expect(stabilizer.observe(snapshot: "I usual", now: start.addingTimeInterval(1.0), quietWindow: 1.5) == nil)
-        #expect(stabilizer.observe(snapshot: "I usual", now: start.addingTimeInterval(2.4), quietWindow: 1.5) == nil)
-        #expect(stabilizer.observe(snapshot: "I usual", now: start.addingTimeInterval(2.6), quietWindow: 1.5) == "I usual")
+        #expect(stabilizer.observe(snapshots: ["I usually"], now: start, quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: ["I usual"], now: start.addingTimeInterval(1.0), quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: ["I usual"], now: start.addingTimeInterval(2.4), quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: ["I usual"], now: start.addingTimeInterval(2.6), quietWindow: 1.5) == ["I usual"])
     }
 
     @Test("does not evaluate the same stable snapshot repeatedly")
@@ -209,9 +209,22 @@ struct DictionaryCorrectionSnapshotStabilizerTests {
         let start = Date(timeIntervalSince1970: 3_000)
         let snapshot = "muwsly"
 
-        #expect(stabilizer.observe(snapshot: snapshot, now: start, quietWindow: 1.5) == nil)
-        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(2.0), quietWindow: 1.5) == snapshot)
-        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(3.0), quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshots: [snapshot], now: start, quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: [snapshot], now: start.addingTimeInterval(2.0), quietWindow: 1.5) == [snapshot])
+        #expect(stabilizer.observe(snapshots: [snapshot], now: start.addingTimeInterval(3.0), quietWindow: 1.5).isEmpty)
+    }
+
+    @Test("evaluates later stable snapshots after an earlier snapshot was already evaluated")
+    func evaluatesLaterStableSnapshotAfterEarlierCandidate() {
+        var stabilizer = DictationCorrectionSnapshotStabilizer()
+        let start = Date(timeIntervalSince1970: 4_000)
+        let earlier = "I changed punctuation only."
+        let later = "I changed museli to muesli."
+
+        #expect(stabilizer.observe(snapshots: [earlier], now: start, quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: [earlier], now: start.addingTimeInterval(1.6), quietWindow: 1.5) == [earlier])
+        #expect(stabilizer.observe(snapshots: [earlier, later], now: start.addingTimeInterval(1.7), quietWindow: 1.5).isEmpty)
+        #expect(stabilizer.observe(snapshots: [earlier, later], now: start.addingTimeInterval(3.3), quietWindow: 1.5) == [later])
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -146,12 +146,12 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion == nil)
     }
 
-    @Test("does not suggest plain one character lowercase edits")
-    func skipsPlainOneCharacterLowercaseEdits() {
+    @Test("does not suggest common word truncations")
+    func skipsCommonWordTruncations() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "I usually use this prompt",
             baselineText: "I usually use this prompt",
-            currentText: "I usualy use this prompt"
+            currentText: "I usual use this prompt"
         )
 
         #expect(suggestion == nil)
@@ -176,6 +176,42 @@ struct DictionaryCorrectionDetectorTests {
         )
 
         #expect(suggestion == nil)
+    }
+}
+
+@Suite("Dictionary correction snapshot stabilizer")
+struct DictionaryCorrectionSnapshotStabilizerTests {
+    @Test("waits for a quiet window before evaluating a changed snapshot")
+    func waitsForQuietWindow() {
+        var stabilizer = DictationCorrectionSnapshotStabilizer()
+        let start = Date(timeIntervalSince1970: 1_000)
+        let snapshot = "I usually use this prompt"
+
+        #expect(stabilizer.observe(snapshot: snapshot, now: start, quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(1.0), quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(1.6), quietWindow: 1.5) == snapshot)
+    }
+
+    @Test("resets the quiet window when the snapshot changes")
+    func resetsQuietWindowOnChange() {
+        var stabilizer = DictationCorrectionSnapshotStabilizer()
+        let start = Date(timeIntervalSince1970: 2_000)
+
+        #expect(stabilizer.observe(snapshot: "I usually", now: start, quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshot: "I usual", now: start.addingTimeInterval(1.0), quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshot: "I usual", now: start.addingTimeInterval(2.4), quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshot: "I usual", now: start.addingTimeInterval(2.6), quietWindow: 1.5) == "I usual")
+    }
+
+    @Test("does not evaluate the same stable snapshot repeatedly")
+    func evaluatesStableSnapshotOnce() {
+        var stabilizer = DictationCorrectionSnapshotStabilizer()
+        let start = Date(timeIntervalSince1970: 3_000)
+        let snapshot = "muwsly"
+
+        #expect(stabilizer.observe(snapshot: snapshot, now: start, quietWindow: 1.5) == nil)
+        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(2.0), quietWindow: 1.5) == snapshot)
+        #expect(stabilizer.observe(snapshot: snapshot, now: start.addingTimeInterval(3.0), quietWindow: 1.5) == nil)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -247,6 +247,24 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "muesli")
     }
 
+    @Test("detects far-apart corrections inside a large focused text snapshot")
+    func detectsFarApartCorrectionsInsideLargeFocusedTextSnapshot() {
+        let prefix = (0..<40).map { "prefix\($0)" }.joined(separator: " ")
+        let middle = (0..<140).map { "middle\($0)" }.joined(separator: " ")
+        let suffix = (0..<40).map { "suffix\($0)" }.joined(separator: " ")
+        let original = "\(prefix) I like museli today \(middle) I mentioned newsly again \(suffix)"
+        let edited = "\(prefix) I like muesli today \(middle) I mentioned muesli again \(suffix)"
+
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: original,
+            editedText: edited,
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["museli", "newsly"])
+        #expect(suggestions.map(\.replacement) == ["muesli", "muesli"])
+    }
+
     @Test("detects a word correction next to an inserted word")
     func detectsCorrectionNextToInsertedWord() {
         let suggestions = DictionaryCorrectionDetector.suggestions(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -52,6 +52,28 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "sc-domain")
     }
 
+    @Test("detects acronym replacement corrections")
+    func detectsAcronymReplacementCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "I moved to New York last year and I like it",
+            editedText: "I moved to NYC last year and I like it"
+        )
+
+        #expect(suggestion?.observed == "New York")
+        #expect(suggestion?.replacement == "NYC")
+    }
+
+    @Test("detects numeric shorthand corrections")
+    func detectsNumericShorthandCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "we run kubernetes in production for backend services today",
+            editedText: "we run k8s in production for backend services today"
+        )
+
+        #expect(suggestion?.observed == "kubernetes")
+        #expect(suggestion?.replacement == "k8s")
+    }
+
     @Test("detects muesli corrections from latest failure shape")
     func detectsMuesliCorrectionFromLatestFailureShape() {
         let original = "No, typically I think the word muzzle is the worst toughest one for it to transcribe because it usually transcribes to the one starting with the w letter N instead of just muzzli."
@@ -183,6 +205,16 @@ struct DictionaryCorrectionDetectorTests {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "Please review the Vitruvian design note",
             editedText: "Please review the follow-up design note"
+        )
+
+        #expect(suggestion == nil)
+    }
+
+    @Test("does not let numeric shorthand signal alone replace unrelated words")
+    func skipsUnrelatedNumericShorthandReplacement() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "Please review the Vitruvian design note",
+            editedText: "Please review the k8s design note"
         )
 
         #expect(suggestion == nil)

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -30,14 +30,15 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "muesli")
     }
 
-    @Test("does not suggest split merge phrase corrections")
-    func skipsSplitMergePhraseCorrection() {
+    @Test("detects split ASR for a single proper noun")
+    func detectsSplitASRForSingleProperNoun() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "often I try to say Alvar Pet in dictation",
             editedText: "often I try to say Alwarpet in dictation"
         )
 
-        #expect(suggestion == nil)
+        #expect(suggestion?.observed == "Alvar Pet")
+        #expect(suggestion?.replacement == "Alwarpet")
     }
 
     @Test("does not suggest hyphenated phrase corrections")
@@ -142,6 +143,21 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestions.map(\.observed) == ["Mandavali", "Dirvaniur"])
         #expect(suggestions.map(\.replacement) == ["Mandaiveli", "Thiruvanmiyur"])
         #expect(suggestions.allSatisfy { !$0.observed.contains(" ") && !$0.replacement.contains(" ") })
+    }
+
+    @Test("detects multiple split ASR proper nouns from one edited snapshot")
+    func detectsMultipleSplitASRProperNouns() {
+        let original = "Okay, I am only interested in just like proper noun related corrections, so I don't want any phrasal related changes that is not part of my concern for the dictionary prompts. So let us check. can it transcribe Thoray Pakam, Kara Pakam, Nongam Bakam properly?"
+        let edited = "Okay, I am only interested in just like proper noun related corrections, so I don't want any phrasal related changes that is not part of my concern for the dictionary prompts. So let us check. can it transcribe Thoraipakkam, Karapakkam, Nungambakkam properly?"
+
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: original,
+            editedText: edited,
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["Thoray Pakam", "Kara Pakam", "Nongam Bakam"])
+        #expect(suggestions.map(\.replacement) == ["Thoraipakkam", "Karapakkam", "Nungambakkam"])
     }
 
     @Test("detects word correction when extra text is appended afterwards")

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -160,6 +160,19 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestions.map(\.replacement) == ["Thoraipakkam", "Karapakkam", "Nungambakkam"])
     }
 
+    @Test("does not suggest three token collapse corrections")
+    func skipsThreeTokenCollapseCorrections() {
+        let original = "can it transcribe Thoray I Pakam properly in this sentence"
+        let edited = "can it transcribe Thoraipakkam properly in this sentence"
+
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: original,
+            editedText: edited
+        )
+
+        #expect(suggestion == nil)
+    }
+
     @Test("detects word correction when extra text is appended afterwards")
     func detectsCorrectionWithAdditionalTyping() {
         let original = "So this time if I say Newsly has not transcribed Newsly properly, would you be able to add it to dictionary immediately?"

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -373,7 +373,8 @@ struct DictionaryCorrectionDetectorTests {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "I usually use this prompt",
             baselineText: "I usually use this prompt",
-            currentText: "I usual use this prompt"
+            currentText: "I usual use this prompt",
+            recognizedEnglishWords: ["usually", "usual"]
         )
 
         #expect(suggestion == nil)

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -85,6 +85,9 @@ struct DictionaryCorrectionDetectorTests {
 
     @Test("does not suggest acronym phrase replacements")
     func skipsAcronymPhraseReplacement() {
+        // Phrase-to-acronym learning is intentionally outside prompt scope.
+        // `New York` initials are `ny`, so it is not an exact acronym correction
+        // for `NYC`.
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "I moved to New York last year and I like it",
             editedText: "I moved to NYC last year and I like it"
@@ -331,6 +334,16 @@ struct DictionaryCorrectionDetectorTests {
         #expect(!DictionaryCorrectionDetector.hasSufficientSharedContext(
             originalText: "please look up spelling correction",
             editedText: "please look file_00000000f4ac61f4841155122554864c-sanitized spelling correction"
+        ))
+
+        #expect(!DictionaryCorrectionDetector.hasSufficientSharedContext(
+            originalText: "hello muesli today",
+            editedText: "unrelated editor content"
+        ))
+
+        #expect(DictionaryCorrectionDetector.hasSufficientSharedContext(
+            originalText: "Alvar Pet",
+            editedText: "Alwarpet"
         ))
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -93,6 +93,18 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion == nil)
     }
 
+    @Test("detects single-token acronym casing corrections")
+    func detectsSingleTokenAcronymCasingCorrection() {
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: "we use api and hsr routing today",
+            editedText: "we use API and HSR routing today",
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["api", "hsr"])
+        #expect(suggestions.map(\.replacement) == ["API", "HSR"])
+    }
+
     @Test("does not accept prefix-only acronym corrections")
     func skipsPrefixOnlyAcronymCorrection() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
@@ -268,6 +280,22 @@ struct DictionaryCorrectionDetectorTests {
     @Test("detects far-apart corrections across repeated separator text")
     func detectsFarApartCorrectionsAcrossRepeatedSeparatorText() {
         let middle = Array(repeating: "and then", count: 100).joined(separator: " ")
+        let original = "I like museli today \(middle) I mentioned newsly again"
+        let edited = "I like muesli today \(middle) I mentioned muesli again"
+
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: original,
+            editedText: edited,
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["museli", "newsly"])
+        #expect(suggestions.map(\.replacement) == ["muesli", "muesli"])
+    }
+
+    @Test("detects repeated-separator corrections beyond the old token cap")
+    func detectsRepeatedSeparatorCorrectionsBeyondOldTokenCap() {
+        let middle = Array(repeating: "and then", count: 160).joined(separator: " ")
         let original = "I like museli today \(middle) I mentioned newsly again"
         let edited = "I like muesli today \(middle) I mentioned muesli again"
 

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -116,6 +116,21 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "muesli")
     }
 
+    @Test("detects multiple proper noun corrections from one edited snapshot")
+    func detectsMultipleProperNounCorrectionsFromOneSnapshot() {
+        let original = "Okay, testing the dictionary prompt once again. So let us see if it can transcribe Mailapur, Mandavali, Trivanmir, Teenagar, Alvarped."
+        let edited = "Okay, testing the dictionary prompt once again. So let us see if it can transcribe Mylapore, Mandavali, Thiruvanmiyur, TNagar, Alwarpet."
+
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: original,
+            editedText: edited,
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["Mailapur", "Trivanmir", "Teenagar"])
+        #expect(suggestions.map(\.replacement) == ["Mylapore", "Thiruvanmiyur", "TNagar"])
+    }
+
     @Test("detects word correction when extra text is appended afterwards")
     func detectsCorrectionWithAdditionalTyping() {
         let original = "So this time if I say Newsly has not transcribed Newsly properly, would you be able to add it to dictionary immediately?"

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -265,6 +265,22 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestions.map(\.replacement) == ["muesli", "muesli"])
     }
 
+    @Test("detects far-apart corrections across repeated separator text")
+    func detectsFarApartCorrectionsAcrossRepeatedSeparatorText() {
+        let middle = Array(repeating: "and then", count: 100).joined(separator: " ")
+        let original = "I like museli today \(middle) I mentioned newsly again"
+        let edited = "I like muesli today \(middle) I mentioned muesli again"
+
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: original,
+            editedText: edited,
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["museli", "newsly"])
+        #expect(suggestions.map(\.replacement) == ["muesli", "muesli"])
+    }
+
     @Test("detects a word correction next to an inserted word")
     func detectsCorrectionNextToInsertedWord() {
         let suggestions = DictionaryCorrectionDetector.suggestions(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -93,6 +93,16 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion == nil)
     }
 
+    @Test("does not accept prefix-only acronym corrections")
+    func skipsPrefixOnlyAcronymCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "we discussed north american expansion today",
+            editedText: "we discussed NASA expansion today"
+        )
+
+        #expect(suggestion == nil)
+    }
+
     @Test("detects numeric shorthand corrections")
     func detectsNumericShorthandCorrection() {
         let suggestion = DictionaryCorrectionDetector.suggestion(
@@ -219,6 +229,22 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.observed == "Newsly")
         #expect(suggestion?.replacement == "muesli")
         #expect(suggestion?.appContext == "Codex|com.openai.chat")
+    }
+
+    @Test("detects a correction inside a large focused text snapshot")
+    func detectsCorrectionInsideLargeFocusedTextSnapshot() {
+        let prefix = (0..<140).map { "prefix\($0)" }.joined(separator: " ")
+        let suffix = (0..<140).map { "suffix\($0)" }.joined(separator: " ")
+        let original = "\(prefix) I like museli today \(suffix)"
+        let edited = "\(prefix) I like muesli today \(suffix)"
+
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: original,
+            editedText: edited
+        )
+
+        #expect(suggestion?.observed == "museli")
+        #expect(suggestion?.replacement == "muesli")
     }
 
     @Test("detects a word correction next to an inserted word")

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -156,12 +156,12 @@ struct DictionaryCorrectionDetectorTests {
 
 @Suite("Dictionary suggestion config")
 struct DictionarySuggestionConfigTests {
-    @Test("old configs decode with correction prompts enabled")
+    @Test("old configs decode with correction prompts disabled")
     func oldConfigDefaults() throws {
         let data = Data(#"{"custom_words":[]}"#.utf8)
         let config = try JSONDecoder().decode(AppConfig.self, from: data)
 
-        #expect(config.enableDictionaryCorrectionPrompts)
+        #expect(!config.enableDictionaryCorrectionPrompts)
         #expect(config.dictionarySuggestions.isEmpty)
         #expect(config.dismissedDictionarySuggestionKeys.isEmpty)
     }
@@ -172,5 +172,16 @@ struct DictionarySuggestionConfigTests {
             DictionarySuggestion.key(observed: " Museli ", replacement: "Muesli")
                 == DictionarySuggestion.key(observed: "museli", replacement: " muesli ")
         )
+    }
+
+    @Test("suggestion app display name hides bundle identifier")
+    func suggestionAppDisplayName() {
+        let suggestion = DictionarySuggestion(
+            observed: "museli",
+            replacement: "muesli",
+            appContext: "Codex|com.openai.codex"
+        )
+
+        #expect(suggestion.appDisplayName == "Codex")
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -69,6 +69,20 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "muesli")
     }
 
+    @Test("detects muesli corrections from latest muwsly failure")
+    func detectsMuesliCorrectionFromLatestMuwslyFailure() {
+        let original = "See, I typically find the word muesli to be wrongly transcribed almost every time, so I'm just repeating muwsly twice."
+        let edited = "See, I typically find the word muesli to be wrongly transcribed almost every time, so I'm just repeating muesli twice."
+
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: original,
+            editedText: edited
+        )
+
+        #expect(suggestion?.observed == "muwsly")
+        #expect(suggestion?.replacement == "muesli")
+    }
+
     @Test("detects word correction when extra text is appended afterwards")
     func detectsCorrectionWithAdditionalTyping() {
         let original = "So this time if I say Newsly has not transcribed Newsly properly, would you be able to add it to dictionary immediately?"
@@ -127,6 +141,17 @@ struct DictionaryCorrectionDetectorTests {
             originalText: "ship teh update",
             baselineText: "ship teh update",
             currentText: "ship the update"
+        )
+
+        #expect(suggestion == nil)
+    }
+
+    @Test("does not suggest plain one character lowercase edits")
+    func skipsPlainOneCharacterLowercaseEdits() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "I usually use this prompt",
+            baselineText: "I usually use this prompt",
+            currentText: "I usualy use this prompt"
         )
 
         #expect(suggestion == nil)

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -420,6 +420,16 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion == nil)
     }
 
+    @Test("does not suggest short same-endpoint numeric shorthand edits")
+    func skipsShortSameEndpointNumericShorthand() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "Please review the token design note today",
+            editedText: "Please review the t3n design note today"
+        )
+
+        #expect(suggestion == nil)
+    }
+
     @Test("ignores edits outside the pasted dictation")
     func ignoresOutsideEdits() {
         let suggestion = DictionaryCorrectionDetector.suggestion(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -531,6 +531,41 @@ struct DictionarySuggestionConfigTests {
         #expect(config.dismissedDictionarySuggestionKeys.isEmpty)
     }
 
+    @Test("suggestions decode despite missing or corrupt ids")
+    func suggestionDecodeToleratesBadIDs() throws {
+        let data = Data(
+            #"""
+            {
+              "dictionary_suggestions": [
+                {
+                  "id": "not-a-uuid",
+                  "observed": "museli",
+                  "replacement": "muesli",
+                  "app_context": "Codex|com.openai.codex",
+                  "occurrence_count": 0,
+                  "created_at": "2026-06-24T00:00:00Z",
+                  "last_seen_at": "2026-06-24T00:00:01Z"
+                },
+                {
+                  "observed": "mylapor",
+                  "replacement": "Mylapore"
+                }
+              ]
+            }
+            """#.utf8
+        )
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(config.dictionarySuggestions.count == 2)
+        #expect(config.dictionarySuggestions[0].observed == "museli")
+        #expect(config.dictionarySuggestions[0].replacement == "muesli")
+        #expect(config.dictionarySuggestions[0].occurrenceCount == 1)
+        #expect(config.dictionarySuggestions[1].observed == "mylapor")
+        #expect(config.dictionarySuggestions[1].replacement == "Mylapore")
+        #expect(config.dictionarySuggestions[1].appContext == "")
+    }
+
     @Test("suggestion key is stable across whitespace and case")
     func stableSuggestionKey() {
         #expect(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -347,6 +347,21 @@ struct DictionaryCorrectionDetectorTests {
         ))
     }
 
+    @Test("keeps changed English words in recognition candidates")
+    func keepsChangedEnglishWordsInRecognitionCandidates() {
+        let filler = (0..<180).map { "a\($0)" }.joined(separator: " ")
+        let original = "\(filler) internationalization"
+        let edited = "\(filler) international"
+
+        let candidates = DictionaryCorrectionDetector.requiredEnglishWordCandidates(
+            originalText: original,
+            editedText: edited
+        )
+
+        #expect(candidates.contains("internationalization"))
+        #expect(candidates.contains("international"))
+    }
+
     @Test("detects corrections from a final edited transcript snapshot")
     func detectsFinalEditedTranscriptSnapshot() {
         let suggestion = DictionaryCorrectionDetector.suggestion(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -41,6 +41,17 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.replacement == "Alwarpet")
     }
 
+    @Test("detects close hyphenated split merge corrections")
+    func detectsCloseHyphenatedSplitMergeCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "please route this to sc domain",
+            editedText: "please route this to sc-domain"
+        )
+
+        #expect(suggestion?.observed == "sc domain")
+        #expect(suggestion?.replacement == "sc-domain")
+    }
+
     @Test("detects muesli corrections from latest failure shape")
     func detectsMuesliCorrectionFromLatestFailureShape() {
         let original = "No, typically I think the word muzzle is the worst toughest one for it to transcribe because it usually transcribes to the one starting with the w letter N instead of just muzzli."
@@ -162,6 +173,16 @@ struct DictionaryCorrectionDetectorTests {
         let suggestion = DictionaryCorrectionDetector.suggestion(
             originalText: "please look up spelling correction",
             editedText: "please look file_00000000f4ac61f4841155122554864c-sanitized spelling correction"
+        )
+
+        #expect(suggestion == nil)
+    }
+
+    @Test("does not let punctuation alone make unrelated words suggestions")
+    func skipsUnrelatedHyphenatedReplacement() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "Please review the Vitruvian design note",
+            editedText: "Please review the follow-up design note"
         )
 
         #expect(suggestion == nil)

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Dictionary correction detector")
+struct DictionaryCorrectionDetectorTests {
+    @Test("detects a corrected misspelling inside pasted text")
+    func detectsCorrectedMisspelling() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "I love museli",
+            baselineText: "I love museli",
+            currentText: "I love muesli",
+            appContext: "Notes|com.apple.Notes"
+        )
+
+        #expect(suggestion?.observed == "museli")
+        #expect(suggestion?.replacement == "muesli")
+        #expect(suggestion?.appContext == "Notes|com.apple.Notes")
+    }
+
+    @Test("detects less similar uncommon product-name corrections")
+    func detectsLessSimilarProductNameCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "the word newsly is hard to transcribe",
+            baselineText: "the word newsly is hard to transcribe",
+            currentText: "the word muesli is hard to transcribe"
+        )
+
+        #expect(suggestion?.observed == "newsly")
+        #expect(suggestion?.replacement == "muesli")
+    }
+
+    @Test("detects proper noun split merge corrections")
+    func detectsProperNounSplitMergeCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "often I try to say Alvar Pet in dictation",
+            editedText: "often I try to say Alwarpet in dictation"
+        )
+
+        #expect(suggestion?.observed == "Alvar Pet")
+        #expect(suggestion?.replacement == "Alwarpet")
+    }
+
+    @Test("detects muesli corrections from latest failure shape")
+    func detectsMuesliCorrectionFromLatestFailureShape() {
+        let original = "No, typically I think the word muzzle is the worst toughest one for it to transcribe because it usually transcribes to the one starting with the w letter N instead of just muzzli."
+        let edited = "No, typically I think the word muesli is the worst toughest one for it to transcribe because it usually transcribes to the one starting with the w letter N instead of just muesli."
+
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: original,
+            editedText: edited
+        )
+
+        #expect(suggestion?.observed == "muzzle")
+        #expect(suggestion?.replacement == "muesli")
+    }
+
+    @Test("detects muesli corrections from latest musley failure")
+    func detectsMuesliCorrectionFromLatestMusleyFailure() {
+        let original = "Okay, it is able to transcribe the word musley if I say it very explicitly and enunciate the words, but I think as such if I say musley fast it's not able to."
+        let edited = "Okay, it is able to transcribe the word muesli if I say it very explicitly and enunciate the words, but I think as such if I say muesli fast it's not able to."
+
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: original,
+            editedText: edited
+        )
+
+        #expect(suggestion?.observed == "musley")
+        #expect(suggestion?.replacement == "muesli")
+    }
+
+    @Test("detects word correction when extra text is appended afterwards")
+    func detectsCorrectionWithAdditionalTyping() {
+        let original = "So this time if I say Newsly has not transcribed Newsly properly, would you be able to add it to dictionary immediately?"
+        let edited = "So this time if I say muesli has not transcribed muesli properly, would you be able to add it to dictionary immediately? (still did not trigger the prompt unfortunately)"
+
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: original,
+            editedText: edited,
+            appContext: "Codex|com.openai.chat"
+        )
+
+        #expect(suggestion?.observed == "Newsly")
+        #expect(suggestion?.replacement == "muesli")
+        #expect(suggestion?.appContext == "Codex|com.openai.chat")
+    }
+
+    @Test("requires shared dictation context before diffing AX snapshots")
+    func requiresSharedDictationContext() {
+        #expect(DictionaryCorrectionDetector.hasSufficientSharedContext(
+            originalText: "So this time if I say Newsly has not transcribed Newsly properly",
+            editedText: "So this time if I say muesli has not transcribed muesli properly and then I kept typing"
+        ))
+
+        #expect(!DictionaryCorrectionDetector.hasSufficientSharedContext(
+            originalText: "please look up spelling correction",
+            editedText: "please look file_00000000f4ac61f4841155122554864c-sanitized spelling correction"
+        ))
+    }
+
+    @Test("detects corrections from a final edited transcript snapshot")
+    func detectsFinalEditedTranscriptSnapshot() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "Hey Musley, can you see if you're transcribing the word correctly?",
+            editedText: "Hey Muesli, can you see if you're transcribing the word correctly?"
+        )
+
+        #expect(suggestion?.observed == "Musley")
+        #expect(suggestion?.replacement == "Muesli")
+    }
+
+    @Test("detects capitalization corrections for names")
+    func detectsCapitalizationCorrection() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "talk to pranav today",
+            baselineText: "talk to pranav today",
+            currentText: "talk to Pranav today"
+        )
+
+        #expect(suggestion?.observed == "pranav")
+        #expect(suggestion?.replacement == "Pranav")
+    }
+
+    @Test("does not suggest common everyday typo corrections")
+    func skipsCommonWords() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "ship teh update",
+            baselineText: "ship teh update",
+            currentText: "ship the update"
+        )
+
+        #expect(suggestion == nil)
+    }
+
+    @Test("does not suggest common word to generated artifact corrections")
+    func skipsCommonWordToGeneratedArtifact() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "please look up spelling correction",
+            editedText: "please look file_00000000f4ac61f4841155122554864c-sanitized spelling correction"
+        )
+
+        #expect(suggestion == nil)
+    }
+
+    @Test("ignores edits outside the pasted dictation")
+    func ignoresOutsideEdits() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "hello muesli",
+            baselineText: "before hello muesli",
+            currentText: "before hello muesli!"
+        )
+
+        #expect(suggestion == nil)
+    }
+}
+
+@Suite("Dictionary suggestion config")
+struct DictionarySuggestionConfigTests {
+    @Test("old configs decode with correction prompts enabled")
+    func oldConfigDefaults() throws {
+        let data = Data(#"{"custom_words":[]}"#.utf8)
+        let config = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(config.enableDictionaryCorrectionPrompts)
+        #expect(config.dictionarySuggestions.isEmpty)
+        #expect(config.dismissedDictionarySuggestionKeys.isEmpty)
+    }
+
+    @Test("suggestion key is stable across whitespace and case")
+    func stableSuggestionKey() {
+        #expect(
+            DictionarySuggestion.key(observed: " Museli ", replacement: "Muesli")
+                == DictionarySuggestion.key(observed: "museli", replacement: " muesli ")
+        )
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -220,6 +220,16 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion == nil)
     }
 
+    @Test("does not suggest same-endpoint numeric shorthand with wrong omitted count")
+    func skipsSameEndpointNumericShorthandWithWrongOmittedCount() {
+        let suggestion = DictionaryCorrectionDetector.suggestion(
+            originalText: "Please review the validation design note today",
+            editedText: "Please review the v2n design note today"
+        )
+
+        #expect(suggestion == nil)
+    }
+
     @Test("ignores edits outside the pasted dictation")
     func ignoresOutsideEdits() {
         let suggestion = DictionaryCorrectionDetector.suggestion(

--- a/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionaryCorrectionDetectorTests.swift
@@ -221,6 +221,18 @@ struct DictionaryCorrectionDetectorTests {
         #expect(suggestion?.appContext == "Codex|com.openai.chat")
     }
 
+    @Test("detects a word correction next to an inserted word")
+    func detectsCorrectionNextToInsertedWord() {
+        let suggestions = DictionaryCorrectionDetector.suggestions(
+            originalText: "I like museli today",
+            editedText: "I like fresh muesli today",
+            maxSuggestions: 3
+        )
+
+        #expect(suggestions.map(\.observed) == ["museli"])
+        #expect(suggestions.map(\.replacement) == ["muesli"])
+    }
+
     @Test("requires shared dictation context before diffing AX snapshots")
     func requiresSharedDictationContext() {
         #expect(DictionaryCorrectionDetector.hasSufficientSharedContext(

--- a/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
@@ -3,10 +3,10 @@ import Testing
 
 @Suite("DictionarySuggestionPromptController")
 struct DictionarySuggestionPromptControllerTests {
-    @Test("Auto-dismiss callback is skipped when hover pauses during fade-out")
+    @Test("Auto-dismiss decision is made when timer fires")
     @MainActor
-    func autoDismissCallbackSkippedWhenPausedDuringFadeOut() {
-        #expect(DictionarySuggestionPromptController.firesAutoDismissCallbackAfterFade(wasDismissPaused: false))
-        #expect(!DictionarySuggestionPromptController.firesAutoDismissCallbackAfterFade(wasDismissPaused: true))
+    func autoDismissDecisionIsMadeWhenTimerFires() {
+        #expect(DictionarySuggestionPromptController.shouldAutoDismissFromTimer(isPausedWhenTimerFires: false))
+        #expect(!DictionarySuggestionPromptController.shouldAutoDismissFromTimer(isPausedWhenTimerFires: true))
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
@@ -16,4 +16,11 @@ struct DictionarySuggestionPromptControllerTests {
         #expect(DictionarySuggestionPromptController.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: false))
         #expect(!DictionarySuggestionPromptController.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: true))
     }
+
+    @Test("Paused fade recovery restarts a bounded countdown")
+    @MainActor
+    func pausedFadeRecoveryRestartsBoundedCountdown() {
+        #expect(DictionarySuggestionPromptController.resumedAutoDismissDurationAfterPausedFade(totalDuration: 15) == 5)
+        #expect(DictionarySuggestionPromptController.resumedAutoDismissDurationAfterPausedFade(totalDuration: 0.15) == 0.1)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("DictionarySuggestionPromptController")
+struct DictionarySuggestionPromptControllerTests {
+    @Test("Auto-dismiss callback is skipped when hover pauses during fade-out")
+    @MainActor
+    func autoDismissCallbackSkippedWhenPausedDuringFadeOut() {
+        #expect(DictionarySuggestionPromptController.firesAutoDismissCallbackAfterFade(wasDismissPaused: false))
+        #expect(!DictionarySuggestionPromptController.firesAutoDismissCallbackAfterFade(wasDismissPaused: true))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
@@ -9,4 +9,11 @@ struct DictionarySuggestionPromptControllerTests {
         #expect(DictionarySuggestionPromptController.shouldAutoDismissFromTimer(isPausedWhenTimerFires: false))
         #expect(!DictionarySuggestionPromptController.shouldAutoDismissFromTimer(isPausedWhenTimerFires: true))
     }
+
+    @Test("Auto-dismiss completion re-checks pause state after fade")
+    @MainActor
+    func autoDismissCompletionRechecksPauseStateAfterFade() {
+        #expect(DictionarySuggestionPromptController.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: false))
+        #expect(!DictionarySuggestionPromptController.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: true))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictionarySuggestionPromptControllerTests.swift
@@ -16,11 +16,4 @@ struct DictionarySuggestionPromptControllerTests {
         #expect(DictionarySuggestionPromptController.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: false))
         #expect(!DictionarySuggestionPromptController.shouldCompleteAutoDismissAfterFade(isPausedAtCompletion: true))
     }
-
-    @Test("Paused fade recovery restarts a bounded countdown")
-    @MainActor
-    func pausedFadeRecoveryRestartsBoundedCountdown() {
-        #expect(DictionarySuggestionPromptController.resumedAutoDismissDurationAfterPausedFade(totalDuration: 15) == 5)
-        #expect(DictionarySuggestionPromptController.resumedAutoDismissDurationAfterPausedFade(totalDuration: 0.15) == 0.1)
-    }
 }

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -245,7 +245,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
   }
   trap cleanup_sign_temp_files EXIT
   if [[ -n "$PROVISIONING_PROFILE" ]]; then
-    PROFILE_PLIST="$(mktemp "${TMPDIR:-/tmp}/muesli-profile.XXXXXX.plist")"
+    PROFILE_PLIST="$(mktemp "${TMPDIR:-/tmp}/muesli-profile.XXXXXX")"
     SIGN_TEMP_FILES+=("$PROFILE_PLIST")
     if security cms -D -i "$PROVISIONING_PROFILE" > "$PROFILE_PLIST" 2>/dev/null; then
       if [[ -z "$APS_ENVIRONMENT" ]]; then
@@ -258,7 +258,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
   fi
 
   if [[ -n "$APS_ENVIRONMENT" || -n "$PROFILE_PLIST" ]]; then
-    TEMP_ENTITLEMENTS="$(mktemp "${TMPDIR:-/tmp}/muesli-entitlements.XXXXXX.plist")"
+    TEMP_ENTITLEMENTS="$(mktemp "${TMPDIR:-/tmp}/muesli-entitlements.XXXXXX")"
     SIGN_TEMP_FILES+=("$TEMP_ENTITLEMENTS")
     cp "$ENTITLEMENTS" "$TEMP_ENTITLEMENTS"
     copy_profile_string_entitlement() {


### PR DESCRIPTION
## Summary
- add a post-dictation correction monitor that compares pasted dictation text with the edited text exposed through Accessibility
- add dictionary correction suggestions, pending/dismissed suggestion state, and Add/Later/Ignore prompt UI
- add a Dictation settings toggle for dictionary suggestions so users can disable the feature
- surface pending suggestions in the Dictionary screen and add focused detector/config tests

## Context
Refs #11. This is the current implementation attempt for auto-suggesting custom dictionary entries when a user corrects a word after dictation. It is intentionally opened as a draft because the UX and detection strategy still need review in real apps like Codex/Claude Code.

## Notes for review
- The monitor is gated by the new Dictionary suggestions toggle. Turning it off cancels active monitoring and prevents new suggestions.
- The prompt uses a compact non-activating panel rather than a blocking alert.
- The current detector uses token/fragment alignment plus Jaro-Winkler-style correction filtering and explicit false-positive guards.
- Known open direction: the AX polling monitor likely needs to become more event-backed/focused-editor-driven before this should be considered production-ready.

## Validation
- `git diff --check`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/662c/dictionary-corrections" --filter DictionaryCorrection`

## Follow-ups likely needed
- Validate prompt placement in Codex/Claude Code and decide whether to anchor near caret/editor instead of the floating icon.
- Reduce empirical detector thresholds or replace the correction detection core with a more structural diff/event model.
- Audit the Accessibility monitor for broad-app performance before marking this ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784179768&installation_id=136549638&pr_number=222&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F222&signature=bccdaf2b9b73ec10feb942352d5e2b3b741a5cb02fea03d3ef2a0ea2359b8e2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->