### PR TITLE
Fix issue #225: Pause media during dictation: already-paused media gets un-paused on press and re-paused on release

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -1,5 +1,5 @@
 import AppKit
-import CoreAudio
+import Darwin
 import Foundation
 
 protocol MediaPlaybackManaging: AnyObject {
@@ -7,8 +7,30 @@ protocol MediaPlaybackManaging: AnyObject {
     func restoreDictationMediaPause()
 }
 
+/// Actual playback state of the system now-playing application, as opposed to
+/// `AudioOutputActivityStatus`, which only reflects whether an app's audio
+/// output pipeline is running. Browsers and most video players keep their
+/// audio engine/IO alive while a video is *paused*, so `IsRunningOutput` (and
+/// therefore `AudioOutputActivityStatus`) reports "active" for paused media
+/// and cannot be used to decide whether to send a play/pause toggle.
+enum MediaPlaybackState: Equatable, CustomStringConvertible {
+    case playing
+    case notPlaying
+    case unknown
+
+    var description: String {
+        switch self {
+        case .playing: return "playing"
+        case .notPlaying: return "not-playing"
+        case .unknown: return "unknown"
+        }
+    }
+}
+
 protocol MediaPlaybackClient {
-    func outputActivityStatus() -> AudioOutputActivityStatus
+    /// Whether the current now-playing application is actually producing audio.
+    /// `.unknown` is returned when the signal cannot be obtained.
+    func nowPlayingPlaybackState() -> MediaPlaybackState
     func sendMediaPlayPauseToggle()
 }
 
@@ -30,7 +52,13 @@ final class MediaPlaybackController: MediaPlaybackManaging {
             guard enabled else { return }
             guard !pausedForSession else { return }
             guard routeKind == .speakerLike else { return }
-            guard client.outputActivityStatus() == .active else { return }
+            // The media key is a blind global toggle: sending it to already-
+            // paused media would *start* playback. Only pause when we can
+            // positively confirm something is actually playing. IsRunningOutput
+            // cannot be used here because it stays true for paused media
+            // (browsers/video players keep their audio engine alive while
+            // paused), so an unknown state must also be a no-op.
+            guard client.nowPlayingPlaybackState() == .playing else { return }
             client.sendMediaPlayPauseToggle()
             pausedForSession = true
         }
@@ -40,12 +68,14 @@ final class MediaPlaybackController: MediaPlaybackManaging {
         queue.async { [self] in
             guard pausedForSession else { return }
             pausedForSession = false
-            // macOS exposes a reliable public media key toggle, not a global
-            // "resume only what I paused" API. Resume only when output still
-            // does not look active so we do not pause user-started playback.
-            // If activity is unknown, prefer restoring media we know Muesli
-            // paused over leaving playback stranded.
-            guard client.outputActivityStatus() != .active else { return }
+            // We only paused media we confirmed was playing, so resume it. Do
+            // not gate on IsRunningOutput here: a paused video still reports
+            // its audio engine as running, which would block the resume and
+            // strand playback. Only skip the resume when something is actively
+            // playing again (the user resumed/started playback) so we do not
+            // pause it. When state is unknown, prefer restoring media we know
+            // Muesli paused over leaving playback stranded.
+            guard client.nowPlayingPlaybackState() != .playing else { return }
             client.sendMediaPlayPauseToggle()
         }
     }
@@ -56,18 +86,10 @@ final class MediaPlaybackController: MediaPlaybackManaging {
 }
 
 final class SystemMediaPlaybackClient: MediaPlaybackClient {
-    private let currentProcessID = ProcessInfo.processInfo.processIdentifier
+    private let nowPlaying = NowPlayingMediaRemoteClient()
 
-    func outputActivityStatus() -> AudioOutputActivityStatus {
-        guard let processIDs = processObjectIDs() else { return .unknown }
-        for processObjectID in processIDs {
-            guard boolProperty(kAudioProcessPropertyIsRunningOutput, objectID: processObjectID),
-                  let pid = pidProperty(objectID: processObjectID),
-                  pid > 0,
-                  pid != currentProcessID else { continue }
-            return .active
-        }
-        return .inactive
+    func nowPlayingPlaybackState() -> MediaPlaybackState {
+        nowPlaying.playbackState()
     }
 
     func sendMediaPlayPauseToggle() {
@@ -94,89 +116,57 @@ final class SystemMediaPlaybackClient: MediaPlaybackClient {
         )?.cgEvent else { return }
         event.post(tap: .cghidEventTap)
     }
+}
 
-    private func processObjectIDs() -> [AudioObjectID]? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyProcessObjectList,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var dataSize: UInt32 = 0
-        guard AudioObjectGetPropertyDataSize(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address,
-            0,
-            nil,
-            &dataSize
-        ) == noErr else {
-            return nil
-        }
-        guard dataSize > 0 else { return [] }
+/// Reads the system now-playing playback state through the private MediaRemote
+/// framework, loaded lazily via `dlsym`. MediaRemote tracks the application
+/// that owns the current "now playing" info and exposes whether it is actually
+/// playing — the signal that `kAudioProcessPropertyIsRunningOutput` cannot
+/// provide (an app's audio engine stays running while media is paused).
+///
+/// The query is asynchronous (MediaRemote delivers the result on a dispatch
+/// queue), so it is turned into a synchronous call with a short timeout. The
+/// private symbols have been stable across macOS releases for many years; if
+/// the framework or symbol is unavailable we conservatively report `.unknown`
+/// and the caller treats that as "do not toggle".
+private final class NowPlayingMediaRemoteClient {
+    private typealias MRNowPlayingIsPlayingHandler = @convention(block) (Bool) -> Void
+    private typealias MRGetNowPlayingIsPlayingFn =
+        @convention(c) (DispatchQueue, MRNowPlayingIsPlayingHandler) -> Void
 
-        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
-        var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
-        guard AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address,
-            0,
-            nil,
-            &dataSize,
-            &ids
-        ) == noErr else {
-            return nil
+    private let callbackQueue = DispatchQueue(label: "com.muesli.media-playback.now-playing")
+    private let queryTimeout: DispatchTimeInterval
+    private let isPlayingFn: MRGetNowPlayingIsPlayingFn?
+
+    init(queryTimeout: DispatchTimeInterval = .milliseconds(250)) {
+        self.queryTimeout = queryTimeout
+        // dlopen is globally refcounted by dyld, so the framework stays loaded
+        // for the process lifetime; the handle does not need to be retained.
+        guard let handle = dlopen(
+            "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote",
+            RTLD_NOW | RTLD_LOCAL
+        ),
+            let symbol = dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying") else {
+            self.isPlayingFn = nil
+            return
         }
-        return ids.filter { $0 != AudioObjectID(kAudioObjectUnknown) }
+        self.isPlayingFn = unsafeBitCast(symbol, to: MRGetNowPlayingIsPlayingFn.self)
     }
 
-    private func pidProperty(objectID: AudioObjectID) -> pid_t? {
-        var pid = pid_t(0)
-        guard getPid(kAudioProcessPropertyPID, objectID: objectID, value: &pid) else {
-            return nil
+    func playbackState() -> MediaPlaybackState {
+        guard let isPlayingFn else { return .unknown }
+        let semaphore = DispatchSemaphore(value: 0)
+        var didCall = false
+        var isPlaying = false
+        let handler: MRNowPlayingIsPlayingHandler = { value in
+            isPlaying = value
+            didCall = true
+            semaphore.signal()
         }
-        return pid
-    }
-
-    private func boolProperty(_ selector: AudioObjectPropertySelector, objectID: AudioObjectID) -> Bool {
-        var value: UInt32 = 0
-        guard getUInt32(
-            selector,
-            objectID: objectID,
-            scope: kAudioObjectPropertyScopeGlobal,
-            element: kAudioObjectPropertyElementMain,
-            value: &value
-        ) else {
-            return false
+        isPlayingFn(callbackQueue, handler)
+        if semaphore.wait(timeout: .now() + queryTimeout) == .timedOut {
+            return .unknown
         }
-        return value != 0
-    }
-
-    private func getPid(
-        _ selector: AudioObjectPropertySelector,
-        objectID: AudioObjectID,
-        value: inout pid_t
-    ) -> Bool {
-        var address = AudioObjectPropertyAddress(
-            mSelector: selector,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var dataSize = UInt32(MemoryLayout<pid_t>.size)
-        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
-    }
-
-    private func getUInt32(
-        _ selector: AudioObjectPropertySelector,
-        objectID: AudioObjectID,
-        scope: AudioObjectPropertyScope,
-        element: AudioObjectPropertyElement,
-        value: inout UInt32
-    ) -> Bool {
-        var address = AudioObjectPropertyAddress(
-            mSelector: selector,
-            mScope: scope,
-            mElement: element
-        )
-        var dataSize = UInt32(MemoryLayout<UInt32>.size)
-        return AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, &value) == noErr
+        return didCall ? (isPlaying ? .playing : .notPlaying) : .unknown
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct MediaPlaybackControllerTests {
     @Test("disabled setting is a no-op")
     func disabledSettingIsNoOp() {
-        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: false, routeKind: .speakerLike)
@@ -16,12 +16,33 @@ struct MediaPlaybackControllerTests {
         #expect(client.toggleCalls == 0)
     }
 
-    @Test("inactive output is skipped")
-    func inactiveOutputIsSkipped() {
-        let client = FakeMediaPlaybackClient(activityStatus: .inactive)
+    @Test("already-paused media is left alone throughout")
+    func alreadyPausedMediaIsLeftAlone() {
+        // Paused video reports "not playing" via now-playing state, even though
+        // IsRunningOutput would (incorrectly) read active. The press must be a
+        // no-op so the blind play/pause key does not start the paused media,
+        // and the release must not toggle either.
+        let client = FakeMediaPlaybackClient(playbackState: .notPlaying)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 0)
+    }
+
+    @Test("unknown playback state is a no-op on press")
+    func unknownPlaybackStateIsNoOpOnPress() {
+        // If we cannot positively confirm audio is playing, do not risk
+        // un-pausing already-paused media.
+        let client = FakeMediaPlaybackClient(playbackState: .unknown)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
         #expect(client.toggleCalls == 0)
@@ -29,7 +50,7 @@ struct MediaPlaybackControllerTests {
 
     @Test("headphone output is skipped")
     func headphoneOutputIsSkipped() {
-        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .headphoneLike)
@@ -38,43 +59,46 @@ struct MediaPlaybackControllerTests {
         #expect(client.toggleCalls == 0)
     }
 
-    @Test("speaker active output pauses and restores")
-    func speakerActiveOutputPausesAndRestores() {
-        let client = FakeMediaPlaybackClient(activityStatus: .active)
+    @Test("playing media pauses and restores")
+    func playingMediaPausesAndRestores() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
         controller.waitForIdle()
         #expect(client.toggleCalls == 1)
 
-        client.activityStatus = .inactive
+        // After pausing, now-playing reports not playing; the resume toggle fires.
+        client.playbackState = .notPlaying
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
         #expect(client.toggleCalls == 2)
     }
 
-    @Test("restore does not toggle if user already started playback")
-    func restoreDoesNotToggleActivePlayback() {
-        let client = FakeMediaPlaybackClient(activityStatus: .active)
+    @Test("restore does not toggle if user already resumed playback")
+    func restoreDoesNotToggleResumedPlayback() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
         controller.waitForIdle()
+        // The user resumed/started playback during the session; resuming again
+        // would instead pause it, so the restore must be skipped.
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
         #expect(client.toggleCalls == 1)
     }
 
-    @Test("restore resumes when output activity is unknown")
-    func restoreResumesWhenActivityIsUnknown() {
-        let client = FakeMediaPlaybackClient(activityStatus: .active)
+    @Test("restore resumes when playback state is unknown")
+    func restoreResumesWhenPlaybackStateIsUnknown() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
         controller.waitForIdle()
-        client.activityStatus = .unknown
+        client.playbackState = .unknown
         controller.restoreDictationMediaPause()
         controller.waitForIdle()
 
@@ -83,7 +107,7 @@ struct MediaPlaybackControllerTests {
 
     @Test("duplicate begin only pauses once")
     func duplicateBeginOnlyPausesOnce() {
-        let client = FakeMediaPlaybackClient(activityStatus: .active)
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
         let controller = makeController(client: client)
 
         controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
@@ -102,15 +126,15 @@ struct MediaPlaybackControllerTests {
 }
 
 private final class FakeMediaPlaybackClient: MediaPlaybackClient {
-    var activityStatus: AudioOutputActivityStatus
+    var playbackState: MediaPlaybackState
     var toggleCalls = 0
 
-    init(activityStatus: AudioOutputActivityStatus) {
-        self.activityStatus = activityStatus
+    init(playbackState: MediaPlaybackState) {
+        self.playbackState = playbackState
     }
 
-    func outputActivityStatus() -> AudioOutputActivityStatus {
-        activityStatus
+    func nowPlayingPlaybackState() -> MediaPlaybackState {
+        playbackState
     }
 
     func sendMediaPlayPauseToggle() {


### PR DESCRIPTION
This pull request fixes #225.

The PR correctly resolves the issue by replacing the flawed `kAudioProcessPropertyIsRunningOutput` check (which reports "audio pipeline running" and stays true for paused media) with the actual system now-playing playback state via MediaRemote's `MRMediaRemoteGetNowPlayingApplicationIsPlaying`.

**Concrete changes and their impact:**

1. **New `MediaPlaybackState` enum** (`playing` / `notPlaying` / `unknown`) replaces `AudioOutputActivityStatus`, representing actual playback state rather than audio engine state.

2. **`beginDictationMediaPause` guard changed** from `outputActivityStatus() == .active` to `nowPlayingPlaybackState() == .playing`. This means:
   - Media actively playing → toggle (pause) ✅
   - Media paused (`.notPlaying`) → no-op, does NOT send the blind toggle that would start playback ✅ (this is the core bug fix)
   - State unknown → no-op (conservative, as the issue explicitly requested: "if it cannot positively confirm audio is playing, it should not toggle")

3. **`restoreDictationMediaPause` guard changed** from `outputActivityStatus() != .active` to `nowPlayingPlaybackState() != .playing`. This means:
   - Not playing → resume (toggle) ✅
   - Unknown → resume (restore what Muesli paused, matching the prior trade-off) ✅
   - Actively playing → skip (user resumed/started playback; toggling would pause it) ✅

4. **`NowPlayingMediaRemoteClient`** implements the new signal by loading MediaRemote via `dlopen`/`dlsym` and calling `MRMediaRemoteGetNowPlayingApplicationIsPlaying`, converting the async callback to a synchronous call with a 250ms timeout. If the framework/symbol is unavailable or times out, it returns `.unknown`, which the caller treats as a no-op on press.

5. **Tests updated and expanded**: Two new regression tests directly cover the bug — "already-paused media is left alone throughout" (verifies 0 toggles for `.notPlaying` on both press and release) and "unknown playback state is a no-op on press". Existing tests were remapped to the new semantics and all hand-trace correctly.

The fix directly addresses the root cause described in the issue: it uses a playback-state signal that reflects whether audio is actually playing (MediaRemote now-playing state) rather than whether the audio engine is running (`IsRunningOutput`). The conservative no-op-on-unknown behavior matches the issue's suggested fix. The already-paused media scenario — the exact reproduction case — will now be a no-op throughout the hold, as intended.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784422696&installation_id=136549638&pr_number=227&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F227&signature=936b1bb641e6e860162c89fcdd544a106c4be660597927c2196203e82823b0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->