### PR TITLE
Feat/suggested words atomic

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -56,9 +56,25 @@ public final class DictationStore {
             source TEXT NOT NULL DEFAULT 'dictation',
             started_at TEXT,
             ended_at TEXT,
+            asr_backend TEXT,
             created_at TEXT DEFAULT (datetime('now'))
         );
         CREATE INDEX IF NOT EXISTS idx_dictations_timestamp ON dictations(timestamp DESC);
+
+        CREATE TABLE IF NOT EXISTS suggested_words (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            word TEXT NOT NULL,
+            replacement TEXT,
+            occurrence_count INTEGER NOT NULL DEFAULT 0,
+            phonetic_variants_json TEXT,
+            backends_json TEXT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            last_seen_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_suggested_words_word ON suggested_words(word);
+        CREATE INDEX IF NOT EXISTS idx_suggested_words_status ON suggested_words(status);
 
         CREATE TABLE IF NOT EXISTS computer_use_traces (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -152,6 +168,15 @@ public final class DictationStore {
         if sqlite3_exec(db, "ALTER TABLE dictations ADD COLUMN source TEXT NOT NULL DEFAULT 'dictation'", nil, nil, nil) != SQLITE_OK {
             // Column may already exist.
         }
+        // Upgrades pre-existing databases where dictations already exists.
+        // Nullable with no default, so ADD COLUMN does not rewrite the table.
+        if sqlite3_exec(db, "ALTER TABLE dictations ADD COLUMN asr_backend TEXT", nil, nil, nil) != SQLITE_OK {
+            // Column may already exist.
+        }
+        // Upgrades pre-existing suggested_words tables created before aging.
+        if sqlite3_exec(db, "ALTER TABLE suggested_words ADD COLUMN last_seen_at TEXT", nil, nil, nil) != SQLITE_OK {
+            // Column may already exist.
+        }
         let _ = sqlite3_exec(db, "CREATE INDEX IF NOT EXISTS idx_meetings_folder ON meetings(folder_id)", nil, nil, nil)
     }
 
@@ -162,15 +187,16 @@ public final class DictationStore {
         appContext: String = "",
         source: String = "dictation",
         startedAt: Date,
-        endedAt: Date
+        endedAt: Date,
+        asrBackend: String? = nil
     ) throws -> Int64 {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
         let sql = """
         INSERT INTO dictations
-        (timestamp, duration_seconds, raw_text, app_context, word_count, source, started_at, ended_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        (timestamp, duration_seconds, raw_text, app_context, word_count, source, started_at, ended_at, asr_backend)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
@@ -189,6 +215,11 @@ public final class DictationStore {
         sqlite3_bind_text(statement, 6, (source as NSString).utf8String, -1, nil)
         sqlite3_bind_text(statement, 7, (started as NSString).utf8String, -1, nil)
         sqlite3_bind_text(statement, 8, (ended as NSString).utf8String, -1, nil)
+        if let asrBackend {
+            sqlite3_bind_text(statement, 9, (asrBackend as NSString).utf8String, -1, nil)
+        } else {
+            sqlite3_bind_null(statement, 9)
+        }
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
@@ -822,6 +853,191 @@ public final class DictationStore {
             sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
             throw error
         }
+    }
+
+    // MARK: - Suggested Words
+
+    /// Raw dictation text + ASR backend for mining word suggestions, newest first.
+    public func dictationTextsForAnalysis(limit: Int = 2000) throws -> [(text: String, backend: String?)] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT raw_text, asr_backend
+        FROM dictations
+        WHERE source = 'dictation' AND raw_text IS NOT NULL
+        ORDER BY id DESC
+        LIMIT ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int(statement, 1, Int32(limit))
+
+        var rows: [(text: String, backend: String?)] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let text = stringColumn(statement, index: 0)
+            let backend: String? = sqlite3_column_type(statement, 1) == SQLITE_NULL ? nil : stringColumn(statement, index: 1)
+            rows.append((text: text, backend: backend))
+        }
+        return rows
+    }
+
+    /// Insert or update suggestions keyed by `word`. Re-upserting refreshes the
+    /// count/variants/backends but never resurrects a dismissed or accepted word
+    /// back to pending.
+    public func upsertSuggestedWords(_ suggestions: [SuggestedWordUpsert]) throws {
+        guard !suggestions.isEmpty else { return }
+
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+
+        do {
+            let sql = """
+            INSERT INTO suggested_words
+            (word, replacement, occurrence_count, phonetic_variants_json, backends_json, status, updated_at, last_seen_at)
+            VALUES (?, ?, ?, ?, ?, 'pending', datetime('now'), datetime('now'))
+            ON CONFLICT(word) DO UPDATE SET
+                replacement = excluded.replacement,
+                occurrence_count = excluded.occurrence_count,
+                phonetic_variants_json = excluded.phonetic_variants_json,
+                backends_json = excluded.backends_json,
+                updated_at = datetime('now'),
+                last_seen_at = datetime('now')
+            """
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            defer { sqlite3_finalize(statement) }
+
+            for suggestion in suggestions {
+                sqlite3_reset(statement)
+                sqlite3_clear_bindings(statement)
+                let variantsJSON = Self.encodeJSONArray(suggestion.phoneticVariants)
+                let backendsJSON = Self.encodeJSONArray(suggestion.backends)
+                sqlite3_bind_text(statement, 1, (suggestion.word as NSString).utf8String, -1, nil)
+                if let replacement = suggestion.replacement {
+                    sqlite3_bind_text(statement, 2, (replacement as NSString).utf8String, -1, nil)
+                } else {
+                    sqlite3_bind_null(statement, 2)
+                }
+                sqlite3_bind_int(statement, 3, Int32(suggestion.occurrenceCount))
+                sqlite3_bind_text(statement, 4, (variantsJSON as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, 5, (backendsJSON as NSString).utf8String, -1, nil)
+                guard sqlite3_step(statement) == SQLITE_DONE else {
+                    throw lastError(db)
+                }
+            }
+
+            guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+        } catch {
+            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    public func listSuggestedWords(status: SuggestedWordStatus) throws -> [SuggestedWordRecord] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT id, word, replacement, occurrence_count, phonetic_variants_json, backends_json, status, created_at, updated_at
+        FROM suggested_words
+        WHERE status = ?
+        ORDER BY occurrence_count DESC, word ASC
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (status.rawValue as NSString).utf8String, -1, nil)
+
+        var rows: [SuggestedWordRecord] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let replacement: String? = sqlite3_column_type(statement, 2) == SQLITE_NULL ? nil : stringColumn(statement, index: 2)
+            rows.append(SuggestedWordRecord(
+                id: sqlite3_column_int64(statement, 0),
+                word: stringColumn(statement, index: 1),
+                replacement: replacement,
+                occurrenceCount: Int(sqlite3_column_int(statement, 3)),
+                phoneticVariants: Self.decodeJSONArray(stringColumn(statement, index: 4)),
+                backends: Self.decodeJSONArray(stringColumn(statement, index: 5)),
+                status: SuggestedWordStatus(rawValue: stringColumn(statement, index: 6)) ?? .pending,
+                createdAt: stringColumn(statement, index: 7),
+                updatedAt: stringColumn(statement, index: 8)
+            ))
+        }
+        return rows
+    }
+
+    public func setSuggestedWordStatus(id: Int64, status: SuggestedWordStatus) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = "UPDATE suggested_words SET status = ?, updated_at = datetime('now') WHERE id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (status.rawValue as NSString).utf8String, -1, nil)
+        sqlite3_bind_int64(statement, 2, id)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    /// Delete pending suggestions not seen in the recent corpus for `days` days.
+    /// Only `pending` rows are aged out — accepted/dismissed rows are user
+    /// decisions and are kept regardless of age. Returns the number pruned.
+    @discardableResult
+    public func pruneStalePendingSuggestions(olderThanDays days: Int) throws -> Int {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        DELETE FROM suggested_words
+        WHERE status = 'pending'
+          AND last_seen_at IS NOT NULL
+          AND last_seen_at < datetime('now', ?)
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        let modifier = "-\(max(0, days)) days"
+        sqlite3_bind_text(statement, 1, (modifier as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+        return Int(sqlite3_changes(db))
+    }
+
+    private static func encodeJSONArray(_ values: [String]) -> String {
+        guard let data = try? JSONEncoder().encode(values),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
+
+    private static func decodeJSONArray(_ json: String) -> [String] {
+        guard !json.isEmpty,
+              let data = json.data(using: .utf8),
+              let values = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return values
     }
 
     public func liveTranscriptCheckpointText(meetingID: Int64) throws -> String? {

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -272,6 +272,74 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
     }
 }
 
+public enum SuggestedWordStatus: String, Codable, Sendable {
+    case pending
+    case accepted
+    case dismissed
+}
+
+/// A word mined from past dictations that is a candidate for the personal
+/// dictionary. `word` is the match side (what transcription produced);
+/// `replacement` is the proposed corrected spelling.
+public struct SuggestedWordRecord: Identifiable, Codable, Sendable {
+    public let id: Int64
+    public let word: String
+    public let replacement: String?
+    public let occurrenceCount: Int
+    /// Other near-duplicate spellings collapsed into this suggestion.
+    public let phoneticVariants: [String]
+    /// Distinct ASR backend identifiers ("backend:model") that produced this word.
+    public let backends: [String]
+    public let status: SuggestedWordStatus
+    public let createdAt: String
+    public let updatedAt: String
+
+    public init(
+        id: Int64,
+        word: String,
+        replacement: String?,
+        occurrenceCount: Int,
+        phoneticVariants: [String],
+        backends: [String],
+        status: SuggestedWordStatus,
+        createdAt: String,
+        updatedAt: String
+    ) {
+        self.id = id
+        self.word = word
+        self.replacement = replacement
+        self.occurrenceCount = occurrenceCount
+        self.phoneticVariants = phoneticVariants
+        self.backends = backends
+        self.status = status
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Write payload for upserting a mined suggestion. Keyed by `word`.
+public struct SuggestedWordUpsert: Sendable, Equatable {
+    public let word: String
+    public let replacement: String?
+    public let occurrenceCount: Int
+    public let phoneticVariants: [String]
+    public let backends: [String]
+
+    public init(
+        word: String,
+        replacement: String?,
+        occurrenceCount: Int,
+        phoneticVariants: [String],
+        backends: [String]
+    ) {
+        self.word = word
+        self.replacement = replacement
+        self.occurrenceCount = occurrenceCount
+        self.phoneticVariants = phoneticVariants
+        self.backends = backends
+    }
+}
+
 public struct MeetingFolder: Identifiable, Codable, Sendable {
     public let id: Int64
     public var name: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -61,6 +61,10 @@ final class AppState {
     )
     var meetingStats: MeetingStats = MeetingStats(totalWords: 0, totalMeetings: 0, averageWPM: 0)
 
+    // Suggested words (mined dictionary candidates)
+    var suggestedWords: [SuggestedWordRecord] = []
+    var isAnalyzingSuggestions: Bool = false
+
     // Config-driven state
     var selectedBackend: BackendOption = .whisper
     var selectedMeetingTranscriptionBackend: BackendOption = .whisper

--- a/native/MuesliNative/Sources/MuesliNativeApp/ClipboardCorrectionWatcher.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ClipboardCorrectionWatcher.swift
@@ -1,0 +1,113 @@
+import AppKit
+import Foundation
+import MuesliCore
+
+/// Opt-in watcher that learns dictionary corrections from the user's own edits.
+///
+/// After Muesli pastes a dictation, the user may fix a misspelled word, re-copy
+/// the corrected text, and paste it elsewhere. When that corrected text lands on
+/// the clipboard we diff it against what we pasted and extract word-level
+/// corrections as high-confidence suggestions.
+///
+/// This is **default-off** (`AppConfig.enableClipboardCorrectionTracking`):
+/// repeatedly reading `NSPasteboard` triggers a macOS "used the clipboard" notice
+/// and timer polling is unreliable under App Nap in an LSUIElement app. The
+/// watcher only samples for a bounded window immediately after our own paste, and
+/// it starts after `PasteController`'s clipboard-restore window so it never races
+/// or mis-reads the restore write as a user correction.
+@MainActor
+final class ClipboardCorrectionWatcher {
+    /// Begin sampling only after PasteController's 0.5s restore has happened.
+    private static let startDelay: TimeInterval = 0.8
+    private static let pollInterval: TimeInterval = 0.7
+    private static let maxPolls = 6
+    /// Corrected text must be this similar to the pasted text overall — a real
+    /// edit, not a different copy entirely.
+    nonisolated private static let minOverallSimilarity = 0.7
+
+    private let pasteboard: NSPasteboard
+    private var pollTask: Task<Void, Never>?
+
+    init(pasteboard: NSPasteboard = .general) {
+        self.pasteboard = pasteboard
+    }
+
+    /// Watch for an edited version of `pastedText` and report corrections.
+    func watch(pastedText: String, onCorrections: @escaping ([SuggestedWordUpsert]) -> Void) {
+        pollTask?.cancel()
+        let baselineChangeCount = pasteboard.changeCount
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(Self.startDelay * 1_000_000_000))
+            for _ in 0..<Self.maxPolls {
+                if Task.isCancelled { return }
+                if self.pasteboard.changeCount != baselineChangeCount,
+                   let current = self.pasteboard.string(forType: .string) {
+                    let corrections = Self.corrections(from: pastedText, to: current)
+                    if !corrections.isEmpty {
+                        onCorrections(corrections)
+                    }
+                    return
+                }
+                try? await Task.sleep(nanoseconds: UInt64(Self.pollInterval * 1_000_000_000))
+            }
+        }
+    }
+
+    func cancel() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    // MARK: - Pure diff (testable)
+
+    /// Diff pasted text against the (presumably edited) clipboard text and return
+    /// the words that changed in place as corrections. Returns empty if the two
+    /// texts are identical, too dissimilar to be an edit, or differ in length
+    /// (insertions/deletions are ignored — only same-position substitutions are
+    /// treated as corrections).
+    nonisolated static func corrections(from pasted: String, to edited: String) -> [SuggestedWordUpsert] {
+        let pastedTokens = tokenize(pasted)
+        let editedTokens = tokenize(edited)
+        guard !pastedTokens.isEmpty,
+              pastedTokens.count == editedTokens.count,
+              pastedTokens != editedTokens else {
+            return []
+        }
+
+        // Guard against unrelated clipboard copies: only a small minority of
+        // tokens may differ (always allowing at least one change, so a short
+        // sentence with a single fix still counts as an edit).
+        let differing = zip(pastedTokens, editedTokens).filter { $0 != $1 }.count
+        let maxDiffering = max(1, Int((1.0 - minOverallSimilarity) * Double(pastedTokens.count)))
+        guard differing <= maxDiffering else { return [] }
+
+        var corrections: [SuggestedWordUpsert] = []
+        for (original, corrected) in zip(pastedTokens, editedTokens) where original != corrected {
+            // Only treat single-word substitutions of similar words as
+            // corrections (filters out unrelated rewrites).
+            guard corrected.contains(where: { $0.isLetter }),
+                  CustomWordMatcher.jaroWinklerSimilarity(original.lowercased(), corrected.lowercased()) > 0.6 else {
+                continue
+            }
+            corrections.append(SuggestedWordUpsert(
+                word: original.lowercased(),
+                replacement: corrected,
+                occurrenceCount: WordSuggestionAnalyzer.minOccurrences,
+                phoneticVariants: [],
+                backends: []
+            ))
+        }
+        return corrections
+    }
+
+    nonisolated private static let boundaryPunctuation = CharacterSet(charactersIn: ".,!?;:\"'()[]{}")
+
+    nonisolated private static func tokenize(_ text: String) -> [String] {
+        text.components(separatedBy: .whitespacesAndNewlines)
+            .compactMap { raw in
+                let core = raw.trimmingCharacters(in: boundaryPunctuation)
+                return core.isEmpty ? nil : core
+            }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ClipboardCorrectionWatcher.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ClipboardCorrectionWatcher.swift
@@ -2,61 +2,62 @@ import AppKit
 import Foundation
 import MuesliCore
 
-/// Opt-in watcher that learns dictionary corrections from the user's own edits.
+/// Opt-in learner of dictionary corrections from the user's own edits.
 ///
-/// After Muesli pastes a dictation, the user may fix a misspelled word, re-copy
-/// the corrected text, and paste it elsewhere. When that corrected text lands on
-/// the clipboard we diff it against what we pasted and extract word-level
-/// corrections as high-confidence suggestions.
+/// After Muesli pastes a dictation, the user may fix a misspelled word and
+/// re-copy the corrected text. We diff that corrected text against what we pasted
+/// and extract word-level corrections as high-confidence suggestions.
 ///
-/// This is **default-off** (`AppConfig.enableClipboardCorrectionTracking`):
-/// repeatedly reading `NSPasteboard` triggers a macOS "used the clipboard" notice
-/// and timer polling is unreliable under App Nap in an LSUIElement app. The
-/// watcher only samples for a bounded window immediately after our own paste, and
-/// it starts after `PasteController`'s clipboard-restore window so it never races
-/// or mis-reads the restore write as a user correction.
+/// This is **default-off** (`AppConfig.enableClipboardCorrectionTracking`).
+/// Detection is **event-driven, not polling**: AppKit exposes no clipboard-change
+/// notification, so rather than sampling `NSPasteboard` on a timer (unreliable
+/// under App Nap in this LSUIElement app, and it trips a macOS "used the
+/// clipboard" notice on every read), we remember the last pasted text and inspect
+/// the clipboard exactly **once** at the next natural event — the start of the
+/// following dictation. If the user re-copied a corrected version in the
+/// meantime, the single diff captures it; otherwise the heavy guards in
+/// `corrections(from:to:)` reject whatever unrelated text is on the clipboard.
+///
+/// Trade-off vs. polling: a correction is only learned if the user re-copies it
+/// before their next dictation. That covers the intended "fix it, copy it, move
+/// on" flow without any background timer or clipboard surveillance.
 @MainActor
 final class ClipboardCorrectionWatcher {
-    /// Begin sampling only after PasteController's 0.5s restore has happened.
-    private static let startDelay: TimeInterval = 0.8
-    private static let pollInterval: TimeInterval = 0.7
-    private static let maxPolls = 6
     /// Corrected text must be this similar to the pasted text overall — a real
     /// edit, not a different copy entirely.
     nonisolated private static let minOverallSimilarity = 0.7
 
     private let pasteboard: NSPasteboard
-    private var pollTask: Task<Void, Never>?
+    /// The text Muesli most recently pasted, awaiting a one-shot correction check
+    /// at the next dictation start. Consumed (set to nil) once checked.
+    private var pendingPastedText: String?
 
     init(pasteboard: NSPasteboard = .general) {
         self.pasteboard = pasteboard
     }
 
-    /// Watch for an edited version of `pastedText` and report corrections.
-    func watch(pastedText: String, onCorrections: @escaping ([SuggestedWordUpsert]) -> Void) {
-        pollTask?.cancel()
-        let baselineChangeCount = pasteboard.changeCount
-        pollTask = Task { [weak self] in
-            guard let self else { return }
-            try? await Task.sleep(nanoseconds: UInt64(Self.startDelay * 1_000_000_000))
-            for _ in 0..<Self.maxPolls {
-                if Task.isCancelled { return }
-                if self.pasteboard.changeCount != baselineChangeCount,
-                   let current = self.pasteboard.string(forType: .string) {
-                    let corrections = Self.corrections(from: pastedText, to: current)
-                    if !corrections.isEmpty {
-                        onCorrections(corrections)
-                    }
-                    return
-                }
-                try? await Task.sleep(nanoseconds: UInt64(Self.pollInterval * 1_000_000_000))
-            }
+    /// Remember the text we just pasted so the next dictation start can check
+    /// whether the user re-copied a corrected version of it.
+    func recordPaste(_ pastedText: String) {
+        pendingPastedText = pastedText
+    }
+
+    /// Inspect the clipboard once for an edited version of the last pasted text
+    /// and report any word-level corrections. Call at a natural event (e.g. the
+    /// next dictation start) — never on a timer. The pending text is consumed
+    /// whether or not a correction is found, so each paste is checked at most once.
+    func checkForCorrections(onCorrections: ([SuggestedWordUpsert]) -> Void) {
+        guard let pastedText = pendingPastedText else { return }
+        pendingPastedText = nil
+        guard let current = pasteboard.string(forType: .string) else { return }
+        let corrections = Self.corrections(from: pastedText, to: current)
+        if !corrections.isEmpty {
+            onCorrections(corrections)
         }
     }
 
     func cancel() {
-        pollTask?.cancel()
-        pollTask = nil
+        pendingPastedText = nil
     }
 
     // MARK: - Pure diff (testable)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -21,12 +21,59 @@ struct DictionaryView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
                 header
+                if !appState.suggestedWords.isEmpty {
+                    suggestedWordsSection
+                }
                 wordList
             }
             .padding(MuesliTheme.spacing32)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
+    }
+
+    private var suggestedWordsSection: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack {
+                Text("Suggested Words (\(appState.suggestedWords.count))")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Spacer()
+                Button {
+                    Task { await controller.analyzeSuggestions() }
+                } label: {
+                    HStack(spacing: 4) {
+                        if appState.isAnalyzingSuggestions {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 11, weight: .bold))
+                        }
+                        Text("Refresh")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                }
+                .buttonStyle(.plain)
+                .disabled(appState.isAnalyzingSuggestions)
+            }
+            Text("Words that came up often in your dictations and aren't in your dictionary yet. Accept to add a correction rule, or dismiss to hide it.")
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textSecondary)
+
+            VStack(spacing: 0) {
+                ForEach(appState.suggestedWords) { suggestion in
+                    SuggestedWordRow(suggestion: suggestion, controller: controller)
+                    Divider().background(MuesliTheme.surfaceBorder)
+                }
+            }
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
     }
 
     private var header: some View {
@@ -243,6 +290,73 @@ private struct DictionaryWordEditorRow: View {
                 weight: .regular
             ) {
                 controller.removeCustomWord(id: word.id)
+            }
+        }
+        .padding(.horizontal, MuesliTheme.spacing16)
+        .padding(.vertical, MuesliTheme.spacing12)
+    }
+}
+
+private struct SuggestedWordRow: View {
+    let suggestion: SuggestedWordRecord
+    let controller: MuesliController
+
+    @State private var draftReplacement: String
+
+    init(suggestion: SuggestedWordRecord, controller: MuesliController) {
+        self.suggestion = suggestion
+        self.controller = controller
+        _draftReplacement = State(initialValue: suggestion.replacement ?? suggestion.word)
+    }
+
+    private var metadataText: String {
+        var parts = ["appeared \(suggestion.occurrenceCount) time\(suggestion.occurrenceCount == 1 ? "" : "s")"]
+        if !suggestion.backends.isEmpty {
+            parts.append("models: \(suggestion.backends.map(Self.modelLabel).joined(separator: ", "))")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// Turn a stored "backend:model" identifier into a short human label.
+    private static func modelLabel(_ identifier: String) -> String {
+        BackendOption.all.first { $0.identifier == identifier }?.label
+            ?? identifier.components(separatedBy: ":").first
+            ?? identifier
+    }
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(suggestion.word)
+                    .font(MuesliTheme.captionMedium())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(metadataText)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .frame(width: DictionaryRowMetrics.arrowWidth)
+            TextField("Replace with", text: $draftReplacement)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: .infinity)
+
+            DictionaryIconButton(
+                systemName: "checkmark",
+                label: "Accept suggestion",
+                tint: MuesliTheme.accent
+            ) {
+                controller.acceptSuggestion(suggestion, replacement: draftReplacement)
+            }
+            DictionaryIconButton(
+                systemName: "xmark",
+                label: "Dismiss suggestion",
+                tint: MuesliTheme.textTertiary
+            ) {
+                controller.dismissSuggestion(suggestion)
             }
         }
         .padding(.horizontal, MuesliTheme.spacing16)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -30,6 +30,14 @@ struct DictionaryView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
+        // App Nap can suspend the background analysis timer in this LSUIElement
+        // app, so refresh suggestions whenever the user actually opens the
+        // Dictionary tab or brings the app forward. scheduleSuggestionAnalysis
+        // coalesces these with any in-flight run, so repeated focus is cheap.
+        .onAppear { controller.scheduleSuggestionAnalysis() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            controller.scheduleSuggestionAnalysis()
+        }
     }
 
     private var suggestedWordsSection: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -776,6 +776,11 @@ struct AppConfig: Codable {
     var activePostProcessorId: String = PostProcessorOption.defaultOption.id
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     var enableScreenContext: Bool = false
+    /// Opt-in: watch the clipboard after a dictation paste to learn corrections
+    /// the user makes externally. Default OFF — repeatedly reading the clipboard
+    /// surfaces a macOS "used the clipboard" notice and polling is unreliable
+    /// under App Nap in this LSUIElement app.
+    var enableClipboardCorrectionTracking: Bool = false
     var useCoreAudioTap: Bool = true
     var meetingHookEnabled: Bool = false
     var meetingHookPath: String = ""
@@ -854,6 +859,7 @@ struct AppConfig: Codable {
         case activePostProcessorId = "active_post_processor_id"
         case postProcessorSystemPrompt = "post_processor_system_prompt"
         case enableScreenContext = "enable_screen_context"
+        case enableClipboardCorrectionTracking = "enable_clipboard_correction_tracking"
         case useCoreAudioTap = "use_core_audio_tap"
         case meetingHookEnabled = "meeting_hook_enabled"
         case meetingHookPath = "meeting_hook_path"
@@ -964,6 +970,7 @@ struct AppConfig: Codable {
         activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
+        enableClipboardCorrectionTracking = (try? c.decode(Bool.self, forKey: .enableClipboardCorrectionTracking)) ?? defaults.enableClipboardCorrectionTracking
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap
         meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled
         meetingHookPath = (try? c.decode(String.self, forKey: .meetingHookPath)) ?? defaults.meetingHookPath

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -10,6 +10,11 @@ struct BackendOption: Equatable {
     let description: String
     let recommended: Bool
 
+    /// Stable identifier persisted per dictation to track which ASR model produced it.
+    var identifier: String {
+        "\(backend):\(model)"
+    }
+
     static let parakeetMultilingual = BackendOption(
         backend: "fluidaudio",
         model: "FluidInference/parakeet-tdt-0.6b-v3-coreml",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -183,6 +183,8 @@ final class MuesliController: NSObject {
     private let runtime: RuntimePaths
     private let configStore = ConfigStore()
     private let dictationStore: DictationStore
+    private var suggestionAnalysisLaunchTask: Task<Void, Never>?
+    private var suggestionAnalysisDebounceTask: Task<Void, Never>?
     private let meetingHookDispatcher: MeetingHookDispatching
     private let launchAtLoginCoordinator: LaunchAtLoginCoordinator
     let transcriptionCoordinator = TranscriptionCoordinator()
@@ -582,6 +584,15 @@ final class MuesliController: NSObject {
 
         if canRunMainApp {
             PostInstallChecker.check()
+        }
+
+        // Surface any previously-mined suggestions immediately, then refresh in
+        // the background after model warmup has settled.
+        loadSuggestedWords()
+        suggestionAnalysisLaunchTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard !Task.isCancelled else { return }
+            await self?.analyzeSuggestions()
         }
     }
 
@@ -1538,6 +1549,123 @@ final class MuesliController: NSObject {
 
     func removeCustomWord(id: UUID) {
         updateConfig { $0.customWords.removeAll { $0.id == id } }
+    }
+
+    // MARK: - Suggested Words
+
+    /// Load persisted pending suggestions into AppState (off-main read).
+    func loadSuggestedWords() {
+        let store = dictationStore
+        Task { [weak self] in
+            let pending = (try? store.listSuggestedWords(status: .pending)) ?? []
+            await MainActor.run { self?.appState.suggestedWords = pending }
+        }
+    }
+
+    /// Coalesce frequent triggers (e.g. after each dictation) into one analysis
+    /// run, keeping the work off the dictation latency path.
+    func scheduleSuggestionAnalysis() {
+        suggestionAnalysisDebounceTask?.cancel()
+        suggestionAnalysisDebounceTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 30_000_000_000)
+            guard !Task.isCancelled else { return }
+            await self?.analyzeSuggestions()
+        }
+    }
+
+    /// Mine recent dictations for suggestions and persist them. The heavy
+    /// clustering runs off-main; the cheap `NSSpellChecker` pass runs on-main.
+    func analyzeSuggestions() async {
+        guard !appState.isAnalyzingSuggestions else { return }
+        appState.isAnalyzingSuggestions = true
+        defer { appState.isAnalyzingSuggestions = false }
+
+        let store = dictationStore
+        let customWords = config.customWords
+
+        // Words the user has already ruled on should never be re-suggested.
+        let resolved: Set<String> = await Task.detached {
+            let accepted = (try? store.listSuggestedWords(status: .accepted)) ?? []
+            let dismissed = (try? store.listSuggestedWords(status: .dismissed)) ?? []
+            return Set((accepted + dismissed).map { $0.word.lowercased() })
+        }.value
+
+        let dictations = await Task.detached {
+            (try? store.dictationTextsForAnalysis()) ?? []
+        }.value
+        guard !dictations.isEmpty else {
+            loadSuggestedWords()
+            return
+        }
+
+        // Pre-compute the candidate tokens off-main, then run the main-thread-only
+        // spell checker over just those tokens, then finish analysis off-main.
+        let candidates = await Task.detached {
+            WordSuggestionAnalyzer.candidateTokens(
+                dictations: dictations,
+                customWords: customWords,
+                dismissedOrAccepted: resolved
+            )
+        }.value
+
+        let spellCache = spellCheck(tokens: candidates)
+
+        let suggestions = await Task.detached {
+            WordSuggestionAnalyzer.analyze(
+                dictations: dictations,
+                customWords: customWords,
+                dismissedOrAccepted: resolved,
+                isSpelledCorrectly: { spellCache[$0]?.isCorrect ?? false },
+                suggestCorrection: { spellCache[$0]?.correction }
+            )
+        }.value
+
+        await Task.detached {
+            try? store.upsertSuggestedWords(suggestions)
+            // Words still present in the corpus just had last_seen_at refreshed;
+            // pending suggestions not seen for a while age out here.
+            try? store.pruneStalePendingSuggestions(olderThanDays: Self.staleSuggestionMaxAgeDays)
+        }.value
+        loadSuggestedWords()
+    }
+
+    /// Pending suggestions not seen in the recent corpus for this many days are
+    /// aged out on the next analysis run.
+    private static let staleSuggestionMaxAgeDays = 30
+
+    /// Run `NSSpellChecker` (main-thread-only) over the candidate tokens once.
+    private func spellCheck(tokens: [String]) -> [String: (isCorrect: Bool, correction: String?)] {
+        let checker = NSSpellChecker.shared
+        var result: [String: (isCorrect: Bool, correction: String?)] = [:]
+        for token in tokens {
+            let misspelledRange = checker.checkSpelling(of: token, startingAt: 0)
+            let isCorrect = misspelledRange.location == NSNotFound
+            var correction: String? = nil
+            if !isCorrect {
+                let range = NSRange(location: 0, length: (token as NSString).length)
+                correction = checker.correction(
+                    forWordRange: range,
+                    in: token,
+                    language: checker.language(),
+                    inSpellDocumentWithTag: 0
+                )
+            }
+            result[token] = (isCorrect, correction)
+        }
+        return result
+    }
+
+    func acceptSuggestion(_ suggestion: SuggestedWordRecord, replacement: String?) {
+        let target = (replacement?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 }
+            ?? suggestion.replacement
+        addCustomWord(CustomWord(word: suggestion.word, replacement: target))
+        try? dictationStore.setSuggestedWordStatus(id: suggestion.id, status: .accepted)
+        loadSuggestedWords()
+    }
+
+    func dismissSuggestion(_ suggestion: SuggestedWordRecord) {
+        try? dictationStore.setSuggestedWordStatus(id: suggestion.id, status: .dismissed)
+        loadSuggestedWords()
     }
 
     @discardableResult
@@ -5537,6 +5665,7 @@ final class MuesliController: NSObject {
                 endedAt: Date(),
                 asrBackend: BackendOption.nemotronStreaming.identifier
             )
+            scheduleSuggestionAnalysis()
         }
 
         statusBarController?.refresh()
@@ -5642,6 +5771,7 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                     self.historyWindowController?.reload()
                     self.syncAppState()
+                    self.scheduleSuggestionAnalysis()
                     if outputMode != .voiceNote {
                         PasteController.paste(text: text)
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -185,6 +185,7 @@ final class MuesliController: NSObject {
     private let dictationStore: DictationStore
     private var suggestionAnalysisLaunchTask: Task<Void, Never>?
     private var suggestionAnalysisDebounceTask: Task<Void, Never>?
+    private let clipboardCorrectionWatcher = ClipboardCorrectionWatcher()
     private let meetingHookDispatcher: MeetingHookDispatching
     private let launchAtLoginCoordinator: LaunchAtLoginCoordinator
     let transcriptionCoordinator = TranscriptionCoordinator()
@@ -1666,6 +1667,18 @@ final class MuesliController: NSObject {
     func dismissSuggestion(_ suggestion: SuggestedWordRecord) {
         try? dictationStore.setSuggestedWordStatus(id: suggestion.id, status: .dismissed)
         loadSuggestedWords()
+    }
+
+    /// Opt-in: after pasting, watch for an edited version of the text returning to
+    /// the clipboard and persist any word-level corrections as suggestions.
+    private func watchClipboardForCorrections(pastedText: String) {
+        guard config.enableClipboardCorrectionTracking else { return }
+        let store = dictationStore
+        clipboardCorrectionWatcher.watch(pastedText: pastedText) { [weak self] corrections in
+            guard !corrections.isEmpty else { return }
+            try? store.upsertSuggestedWords(corrections)
+            self?.loadSuggestedWords()
+        }
     }
 
     @discardableResult
@@ -5774,6 +5787,7 @@ final class MuesliController: NSObject {
                     self.scheduleSuggestionAnalysis()
                     if outputMode != .voiceNote {
                         PasteController.paste(text: text)
+                        self.watchClipboardForCorrections(pastedText: text)
                     }
                     self.resetDictationOutputMode()
                     self.setState(.idle)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4700,7 +4700,8 @@ final class MuesliController: NSObject {
                     durationSeconds: duration,
                     source: "cua",
                     startedAt: startedAt,
-                    endedAt: commandEndedAt
+                    endedAt: commandEndedAt,
+                    asrBackend: self.selectedBackend.identifier
                 )
                 await self.handleComputerUseCommand(transcript: text, dictationID: dictationID)
             } catch is CancellationError {
@@ -5533,7 +5534,8 @@ final class MuesliController: NSObject {
                 text: cleaned,
                 durationSeconds: duration,
                 startedAt: startedAt,
-                endedAt: Date()
+                endedAt: Date(),
+                asrBackend: BackendOption.nemotronStreaming.identifier
             )
         }
 
@@ -5632,7 +5634,8 @@ final class MuesliController: NSObject {
                     durationSeconds: duration,
                     appContext: storageContext,
                     startedAt: startedAt,
-                    endedAt: Date()
+                    endedAt: Date(),
+                    asrBackend: transcriptionBackend.identifier
                 )
                 await MainActor.run {
                     self.capturedDictationContext = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -184,7 +184,10 @@ final class MuesliController: NSObject {
     private let configStore = ConfigStore()
     private let dictationStore: DictationStore
     private var suggestionAnalysisLaunchTask: Task<Void, Never>?
-    private var suggestionAnalysisDebounceTask: Task<Void, Never>?
+    /// Timer-free serialiser for suggestion-analysis triggers (per-dictation,
+    /// tab-open/focus backstop, launch warmup, manual refresh). See the type doc
+    /// for why this coalesces instead of debouncing with `Task.sleep`.
+    private var suggestionAnalysisCoalescer = SuggestionAnalysisCoalescer()
     private let clipboardCorrectionWatcher = ClipboardCorrectionWatcher()
     private let meetingHookDispatcher: MeetingHookDispatching
     private let launchAtLoginCoordinator: LaunchAtLoginCoordinator
@@ -587,8 +590,11 @@ final class MuesliController: NSObject {
             PostInstallChecker.check()
         }
 
-        // Surface any previously-mined suggestions immediately, then refresh in
-        // the background after model warmup has settled.
+        // Surface any previously-mined suggestions immediately, then refresh once
+        // after model warmup has settled. The short delay only keeps launch-time
+        // work off the critical path — freshness no longer depends on it, since
+        // the Dictionary tab-open/focus backstop re-runs analysis on demand and
+        // App Nap can suspend this sleep in an LSUIElement app.
         loadSuggestedWords()
         suggestionAnalysisLaunchTask = Task { [weak self] in
             let activity = ProcessInfo.processInfo.beginActivity(
@@ -598,7 +604,7 @@ final class MuesliController: NSObject {
             defer { ProcessInfo.processInfo.endActivity(activity) }
             try? await Task.sleep(nanoseconds: 5_000_000_000)
             guard !Task.isCancelled else { return }
-            await self?.analyzeSuggestions()
+            self?.scheduleSuggestionAnalysis()
         }
     }
 
@@ -1568,22 +1574,22 @@ final class MuesliController: NSObject {
         }
     }
 
-    /// Coalesce frequent triggers (e.g. after each dictation) into one analysis
-    /// run, keeping the work off the dictation latency path.
+    /// Coalesce frequent triggers (e.g. after each dictation, plus the Dictionary
+    /// tab-open/focus backstop) into a serialised analysis run, keeping the work
+    /// off the dictation latency path.
+    ///
+    /// This is intentionally event-driven with no timer: in this LSUIElement app
+    /// App Nap can suspend `Task.sleep`, so a debounce sleep could leave Suggested
+    /// Words stale until a manual refresh. Instead each trigger either starts the
+    /// run or, if one is already in flight, requests a single rerun afterward so a
+    /// burst of dictations collapses into at most two passes over fresh data.
     func scheduleSuggestionAnalysis() {
-        suggestionAnalysisDebounceTask?.cancel()
-        suggestionAnalysisDebounceTask = Task { [weak self] in
-            // Hold an activity assertion across the debounce so App Nap doesn't
-            // suspend the sleep in this LSUIElement app and leave the Suggested
-            // Words section stale until the user manually refreshes.
-            let activity = ProcessInfo.processInfo.beginActivity(
-                options: .userInitiatedAllowingIdleSystemSleep,
-                reason: "Suggested words analysis"
-            )
-            defer { ProcessInfo.processInfo.endActivity(activity) }
-            try? await Task.sleep(nanoseconds: 30_000_000_000)
-            guard !Task.isCancelled else { return }
-            await self?.analyzeSuggestions()
+        guard suggestionAnalysisCoalescer.onTrigger() else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            repeat {
+                await self.analyzeSuggestions()
+            } while self.suggestionAnalysisCoalescer.onRunFinished()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -591,6 +591,11 @@ final class MuesliController: NSObject {
         // the background after model warmup has settled.
         loadSuggestedWords()
         suggestionAnalysisLaunchTask = Task { [weak self] in
+            let activity = ProcessInfo.processInfo.beginActivity(
+                options: .userInitiatedAllowingIdleSystemSleep,
+                reason: "Suggested words analysis"
+            )
+            defer { ProcessInfo.processInfo.endActivity(activity) }
             try? await Task.sleep(nanoseconds: 5_000_000_000)
             guard !Task.isCancelled else { return }
             await self?.analyzeSuggestions()
@@ -1568,6 +1573,14 @@ final class MuesliController: NSObject {
     func scheduleSuggestionAnalysis() {
         suggestionAnalysisDebounceTask?.cancel()
         suggestionAnalysisDebounceTask = Task { [weak self] in
+            // Hold an activity assertion across the debounce so App Nap doesn't
+            // suspend the sleep in this LSUIElement app and leave the Suggested
+            // Words section stale until the user manually refreshes.
+            let activity = ProcessInfo.processInfo.beginActivity(
+                options: .userInitiatedAllowingIdleSystemSleep,
+                reason: "Suggested words analysis"
+            )
+            defer { ProcessInfo.processInfo.endActivity(activity) }
             try? await Task.sleep(nanoseconds: 30_000_000_000)
             guard !Task.isCancelled else { return }
             await self?.analyzeSuggestions()
@@ -1669,13 +1682,19 @@ final class MuesliController: NSObject {
         loadSuggestedWords()
     }
 
-    /// Opt-in: after pasting, watch for an edited version of the text returning to
-    /// the clipboard and persist any word-level corrections as suggestions.
+    /// Opt-in: remember the just-pasted text so the next dictation start can check
+    /// (event-driven, no polling) whether the user re-copied a corrected version.
     private func watchClipboardForCorrections(pastedText: String) {
         guard config.enableClipboardCorrectionTracking else { return }
+        clipboardCorrectionWatcher.recordPaste(pastedText)
+    }
+
+    /// Opt-in: at the start of a dictation, inspect the clipboard once for an
+    /// edited version of the previously pasted text and persist any corrections.
+    private func checkClipboardForCorrections() {
+        guard config.enableClipboardCorrectionTracking else { return }
         let store = dictationStore
-        clipboardCorrectionWatcher.watch(pastedText: pastedText) { [weak self] corrections in
-            guard !corrections.isEmpty else { return }
+        clipboardCorrectionWatcher.checkForCorrections { [weak self] corrections in
             try? store.upsertSuggestedWords(corrections)
             self?.loadSuggestedWords()
         }
@@ -5146,6 +5165,9 @@ final class MuesliController: NSObject {
     private func beginDictationOutput(mode: DictationOutputMode? = nil) {
         currentDictationOutputMode = mode ?? defaultDictationOutputMode
         appState.isVoiceNoteRecording = currentDictationOutputMode == .voiceNote
+        // Event-driven correction learning: the prior paste left a clipboard
+        // snapshot to compare; this start is the natural moment to check it.
+        checkClipboardForCorrections()
     }
 
     private func resetDictationOutputMode() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -471,6 +471,12 @@ struct SettingsView: View {
                     }
                 }
                 screenContextRow("App context")
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Learn corrections from clipboard edits") {
+                    settingsSwitch(isOn: appState.config.enableClipboardCorrectionTracking) { newValue in
+                        controller.updateConfig { $0.enableClipboardCorrectionTracking = newValue }
+                    }
+                }
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SuggestionAnalysisCoalescer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SuggestionAnalysisCoalescer.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Serialises Suggested-Words analysis triggers **without a timer**.
+///
+/// In this LSUIElement app App Nap can suspend `Task.sleep`, so a debounce sleep
+/// could leave the section stale until a manual refresh. Instead of debouncing we
+/// coalesce: triggers arrive from several event sources (each completed dictation,
+/// the Dictionary tab-open/focus backstop, the launch warmup, manual refresh) and
+/// a burst collapses into at most two passes over fresh data — the pass already in
+/// flight, plus one rerun that picks up everything that arrived while it ran.
+///
+/// Pure state machine: the caller owns the actual async analysis. All access is
+/// expected to be serialised by the caller (the controller is `@MainActor`).
+struct SuggestionAnalysisCoalescer {
+    /// True while a run loop is active (between the first `onTrigger` that returns
+    /// `true` and the `onRunFinished` that returns `false`).
+    private(set) var isRunning = false
+
+    /// Set when a trigger arrives mid-run; consumed by the next `onRunFinished`.
+    private var rerunRequested = false
+
+    /// Record a trigger.
+    ///
+    /// - Returns: `true` if the caller should start the run loop now; `false` if a
+    ///   run is already active (a single rerun is queued instead, so any number of
+    ///   triggers during a run cause exactly one extra pass).
+    mutating func onTrigger() -> Bool {
+        guard !isRunning else {
+            rerunRequested = true
+            return false
+        }
+        isRunning = true
+        return true
+    }
+
+    /// Call after each analysis pass completes.
+    ///
+    /// - Returns: `true` if another pass should run immediately (a trigger arrived
+    ///   while the just-finished pass was running), `false` if the loop should stop.
+    mutating func onRunFinished() -> Bool {
+        if rerunRequested {
+            rerunRequested = false
+            return true
+        }
+        isRunning = false
+        return false
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/WordSuggestionAnalyzer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WordSuggestionAnalyzer.swift
@@ -1,0 +1,203 @@
+import Foundation
+import MuesliCore
+
+/// Mines historical dictation text for words that are candidates for the
+/// personal dictionary — frequently transcribed terms that aren't already known
+/// and that a standard lexicon doesn't recognize.
+///
+/// This type is deliberately **pure**: it takes the corpus and two predicates as
+/// inputs and returns suggestions, with no I/O and no `NSSpellChecker` dependency
+/// (which is main-thread-only). The caller injects `isSpelledCorrectly` and
+/// `suggestCorrection`, runs the heavy clustering off the main thread, and runs
+/// the cheap spell pass on the main thread.
+enum WordSuggestionAnalyzer {
+
+    /// Minimum number of occurrences (summed across a phonetic cluster) before a
+    /// word is surfaced as a suggestion.
+    static let minOccurrences = 3
+
+    /// Jaro-Winkler similarity above which two candidate words are treated as
+    /// spellings of the same word and merged into one cluster.
+    static let clusterSimilarityThreshold = 0.85
+
+    /// Cap on the number of unique candidate tokens fed into the O(k²) clustering
+    /// step, keeping analysis bounded on large corpora.
+    static let maxUniqueTokens = 1000
+
+    /// Analyze a corpus of dictations and return suggestions to persist.
+    ///
+    /// - Parameters:
+    ///   - dictations: raw text + the ASR backend identifier that produced it.
+    ///   - customWords: the user's existing dictionary; matching tokens are skipped.
+    ///   - dismissedOrAccepted: lowercased words the user has already ruled on.
+    ///   - isSpelledCorrectly: returns true if a standard lexicon knows the word
+    ///     (such words are dropped — they aren't misspellings worth suggesting).
+    ///   - suggestCorrection: returns a confident corrected spelling for a word,
+    ///     or nil when none is available (e.g. an unknown proper noun).
+    /// The unique candidate tokens that survive filtering — a superset of the
+    /// canonicals `analyze` will produce. Exposed so the caller can run the
+    /// main-thread-only spell checker over just these tokens once.
+    static func candidateTokens(
+        dictations: [(text: String, backend: String?)],
+        customWords: [CustomWord],
+        dismissedOrAccepted: Set<String>
+    ) -> [String] {
+        let (counts, _) = tally(
+            dictations: dictations,
+            customWords: customWords,
+            dismissedOrAccepted: dismissedOrAccepted
+        )
+        return Array(counts.keys)
+    }
+
+    /// Words already in the dictionary or ruled on, plus per-word counts and the
+    /// set of backends that produced each.
+    private static func tally(
+        dictations: [(text: String, backend: String?)],
+        customWords: [CustomWord],
+        dismissedOrAccepted: Set<String>
+    ) -> (counts: [String: Int], backends: [String: Set<String>]) {
+        var known = dismissedOrAccepted
+        for custom in customWords {
+            known.insert(custom.word.lowercased())
+            known.insert(custom.targetWord.lowercased())
+        }
+
+        var counts: [String: Int] = [:]
+        var backends: [String: Set<String>] = [:]
+        for dictation in dictations {
+            let backend = dictation.backend
+            for token in tokenize(dictation.text) {
+                guard isCandidateToken(token), !known.contains(token) else { continue }
+                counts[token, default: 0] += 1
+                if let backend {
+                    backends[token, default: []].insert(backend)
+                }
+            }
+        }
+        return (counts, backends)
+    }
+
+    static func analyze(
+        dictations: [(text: String, backend: String?)],
+        customWords: [CustomWord],
+        dismissedOrAccepted: Set<String>,
+        isSpelledCorrectly: (String) -> Bool,
+        suggestCorrection: (String) -> String?
+    ) -> [SuggestedWordUpsert] {
+        let (counts, backends) = tally(
+            dictations: dictations,
+            customWords: customWords,
+            dismissedOrAccepted: dismissedOrAccepted
+        )
+
+        guard !counts.isEmpty else { return [] }
+
+        // Keep the most frequent unique tokens before the O(k²) clustering pass.
+        let cappedTokens = counts.sorted { lhs, rhs in
+            lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
+        }
+        .prefix(maxUniqueTokens)
+        .map { $0.key }
+
+        let clusters = cluster(tokens: cappedTokens, counts: counts)
+
+        var suggestions: [SuggestedWordUpsert] = []
+        for cluster in clusters {
+            let totalCount = cluster.reduce(0) { $0 + (counts[$1] ?? 0) }
+            guard totalCount >= minOccurrences else { continue }
+
+            // Canonical = highest-count variant; ties broken alphabetically.
+            let canonical = cluster.sorted { lhs, rhs in
+                let lc = counts[lhs] ?? 0
+                let rc = counts[rhs] ?? 0
+                return lc != rc ? lc > rc : lhs < rhs
+            }.first!
+
+            // A correctly-spelled canonical isn't a misspelling — skip the cluster.
+            guard !isSpelledCorrectly(canonical) else { continue }
+
+            // Smart canonical: prefer a confident spell-checker correction that
+            // actually differs from the word; otherwise the replacement is the
+            // most-frequent variant itself (a no-op rule the user can edit).
+            // Compare case-sensitively so a capitalization-only fix (e.g.
+            // "graphql" -> "GraphQL") is kept, while a truly identical string
+            // falls through to the no-op.
+            let correction = suggestCorrection(canonical)
+            let replacement: String?
+            if let correction, !correction.isEmpty, correction != canonical {
+                replacement = correction
+            } else {
+                replacement = canonical
+            }
+
+            let variants = cluster.filter { $0 != canonical }.sorted()
+            let clusterBackends = cluster
+                .flatMap { backends[$0] ?? [] }
+                .reduce(into: Set<String>()) { $0.insert($1) }
+                .sorted()
+
+            suggestions.append(SuggestedWordUpsert(
+                word: canonical,
+                replacement: replacement,
+                occurrenceCount: totalCount,
+                phoneticVariants: variants,
+                backends: clusterBackends
+            ))
+        }
+
+        // Rank: cross-model (seen under 2+ backends) first, then by count.
+        return suggestions.sorted { lhs, rhs in
+            let lhsCross = lhs.backends.count >= 2
+            let rhsCross = rhs.backends.count >= 2
+            if lhsCross != rhsCross { return lhsCross }
+            if lhs.occurrenceCount != rhs.occurrenceCount { return lhs.occurrenceCount > rhs.occurrenceCount }
+            return lhs.word < rhs.word
+        }
+    }
+
+    // MARK: - Tokenization
+
+    private static let boundaryPunctuation = CharacterSet(charactersIn: ".,!?;:\"'()[]{}")
+
+    /// Split text into lowercased word cores, stripping boundary punctuation.
+    static func tokenize(_ text: String) -> [String] {
+        text.components(separatedBy: .whitespacesAndNewlines)
+            .compactMap { raw in
+                let core = raw.trimmingCharacters(in: boundaryPunctuation).lowercased()
+                return core.isEmpty ? nil : core
+            }
+    }
+
+    /// A candidate must be at least 2 chars and contain a letter (drops pure
+    /// numbers and stray punctuation tokens).
+    private static func isCandidateToken(_ token: String) -> Bool {
+        guard token.count >= 2 else { return false }
+        return token.contains { $0.isLetter }
+    }
+
+    // MARK: - Clustering
+
+    /// Greedily group tokens whose Jaro-Winkler similarity exceeds the threshold.
+    /// Each returned array is one cluster of near-duplicate spellings.
+    private static func cluster(tokens: [String], counts: [String: Int]) -> [[String]] {
+        // Process highest-count tokens first so they seed clusters.
+        let ordered = tokens.sorted { (counts[$0] ?? 0) > (counts[$1] ?? 0) }
+        var clusters: [[String]] = []
+        var assigned = Set<String>()
+
+        for token in ordered {
+            guard !assigned.contains(token) else { continue }
+            var group = [token]
+            assigned.insert(token)
+            for other in ordered where !assigned.contains(other) {
+                if CustomWordMatcher.jaroWinklerSimilarity(token, other) > clusterSimilarityThreshold {
+                    group.append(other)
+                    assigned.insert(other)
+                }
+            }
+            clusters.append(group)
+        }
+        return clusters
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ClipboardCorrectionWatcherTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ClipboardCorrectionWatcherTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Clipboard Correction Watcher")
+struct ClipboardCorrectionWatcherTests {
+
+    @Test("identical text yields no corrections")
+    func identical() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "deploy to kubernetes", to: "deploy to kubernetes")
+        #expect(result.isEmpty)
+    }
+
+    @Test("a single in-place word fix is captured")
+    func singleFix() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "deploy to kubernetez now", to: "deploy to kubernetes now")
+        #expect(result.count == 1)
+        #expect(result.first?.word == "kubernetez")
+        #expect(result.first?.replacement == "kubernetes")
+    }
+
+    @Test("unrelated text (too dissimilar) yields no corrections")
+    func unrelated() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "deploy to kubernetes", to: "buy milk and eggs")
+        #expect(result.isEmpty)
+    }
+
+    @Test("length changes (insert/delete) are ignored")
+    func lengthChange() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "deploy kubernetes", to: "deploy to kubernetes")
+        #expect(result.isEmpty)
+    }
+
+    @Test("a substitution of an unrelated word is not treated as a correction")
+    func dissimilarSubstitution() {
+        // Same length, mostly matching, but the changed word is nothing like the original.
+        let result = ClipboardCorrectionWatcher.corrections(from: "send the report today", to: "send the banana today")
+        #expect(result.isEmpty)
+    }
+
+    @Test("punctuation around the corrected word is tolerated")
+    func punctuationTolerated() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "I love muesli.", to: "I love müsli.")
+        #expect(result.first?.word == "muesli")
+        #expect(result.first?.replacement == "müsli")
+    }
+
+    @Test("empty inputs yield no corrections")
+    func emptyInputs() {
+        #expect(ClipboardCorrectionWatcher.corrections(from: "", to: "").isEmpty)
+        #expect(ClipboardCorrectionWatcher.corrections(from: "", to: "hello").isEmpty)
+        #expect(ClipboardCorrectionWatcher.corrections(from: "hello", to: "").isEmpty)
+    }
+
+    @Test("a capitalization-only fix is captured with the cased replacement")
+    func capitalizationFix() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "ship to github today", to: "ship to GitHub today")
+        #expect(result.count == 1)
+        #expect(result.first?.word == "github")   // match side lowercased
+        #expect(result.first?.replacement == "GitHub")
+    }
+
+    @Test("multiple in-place fixes are all captured when within the change budget")
+    func multipleFixes() {
+        // 2 of 8 tokens changed -> within 30% budget; both are near-matches.
+        let result = ClipboardCorrectionWatcher.corrections(
+            from: "deploy kubernetez and run kubecti on the cluster",
+            to:   "deploy kubernetes and run kubectl on the cluster"
+        )
+        let words = Set(result.map(\.word))
+        #expect(words == ["kubernetez", "kubecti"])
+    }
+
+    @Test("too many changed tokens is treated as an unrelated copy")
+    func tooManyChanges() {
+        // 3 of 4 differ -> exceeds the change budget -> rejected wholesale.
+        let result = ClipboardCorrectionWatcher.corrections(from: "alpha beta gamma delta", to: "alpha one two three")
+        #expect(result.isEmpty)
+    }
+
+    @Test("a changed token that is purely punctuation is skipped")
+    func punctuationOnlyChangeSkipped() {
+        // "end." vs "end!" -> cores are identical after stripping, so not a diff;
+        // "go" vs "--" -> the replacement has no letter, so it's skipped.
+        let result = ClipboardCorrectionWatcher.corrections(from: "go now", to: "-- now")
+        #expect(result.isEmpty)
+    }
+
+    @Test("whitespace differences alone are not corrections")
+    func whitespaceOnly() {
+        let result = ClipboardCorrectionWatcher.corrections(from: "hello   world", to: "hello world")
+        #expect(result.isEmpty)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ClipboardCorrectionWatcherTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ClipboardCorrectionWatcherTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AppKit
 import MuesliCore
 @testable import MuesliNativeApp
 
@@ -91,5 +92,81 @@ struct ClipboardCorrectionWatcherTests {
     func whitespaceOnly() {
         let result = ClipboardCorrectionWatcher.corrections(from: "hello   world", to: "hello world")
         #expect(result.isEmpty)
+    }
+
+    // MARK: - Event-driven instance flow
+
+    /// Use a uniquely-named pasteboard so tests never touch the real clipboard.
+    @MainActor
+    private func makeIsolated() -> (ClipboardCorrectionWatcher, NSPasteboard) {
+        let pb = NSPasteboard(name: NSPasteboard.Name("muesli.test.\(UUID().uuidString)"))
+        pb.clearContents()
+        return (ClipboardCorrectionWatcher(pasteboard: pb), pb)
+    }
+
+    @Test("check before any paste reports nothing")
+    @MainActor
+    func checkWithoutPaste() {
+        let (watcher, _) = makeIsolated()
+        var calls = 0
+        watcher.checkForCorrections { _ in calls += 1 }
+        #expect(calls == 0)
+    }
+
+    @Test("a corrected re-copy is captured at the next check")
+    @MainActor
+    func correctedRecopyCaptured() {
+        let (watcher, pb) = makeIsolated()
+        watcher.recordPaste("deploy to kubernetez now")
+        // User fixes the word and re-copies it.
+        pb.clearContents()
+        pb.setString("deploy to kubernetes now", forType: .string)
+
+        var captured: [SuggestedWordUpsert] = []
+        watcher.checkForCorrections { captured = $0 }
+        #expect(captured.count == 1)
+        #expect(captured.first?.word == "kubernetez")
+        #expect(captured.first?.replacement == "kubernetes")
+    }
+
+    @Test("an unchanged clipboard yields no corrections")
+    @MainActor
+    func unchangedClipboard() {
+        let (watcher, pb) = makeIsolated()
+        watcher.recordPaste("deploy to kubernetes now")
+        pb.clearContents()
+        pb.setString("deploy to kubernetes now", forType: .string)
+
+        var calls = 0
+        watcher.checkForCorrections { _ in calls += 1 }
+        #expect(calls == 0)
+    }
+
+    @Test("each paste is checked at most once")
+    @MainActor
+    func pendingConsumedAfterCheck() {
+        let (watcher, pb) = makeIsolated()
+        watcher.recordPaste("deploy to kubernetez now")
+        pb.clearContents()
+        pb.setString("deploy to kubernetes now", forType: .string)
+
+        var calls = 0
+        watcher.checkForCorrections { _ in calls += 1 }
+        watcher.checkForCorrections { _ in calls += 1 }   // nothing pending now
+        #expect(calls == 1)
+    }
+
+    @Test("cancel clears the pending paste so no correction is reported")
+    @MainActor
+    func cancelClearsPending() {
+        let (watcher, pb) = makeIsolated()
+        watcher.recordPaste("deploy to kubernetez now")
+        pb.clearContents()
+        pb.setString("deploy to kubernetes now", forType: .string)
+
+        watcher.cancel()
+        var calls = 0
+        watcher.checkForCorrections { _ in calls += 1 }
+        #expect(calls == 0)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/SuggestedWordStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SuggestedWordStoreTests.swift
@@ -1,0 +1,199 @@
+import Testing
+import Foundation
+import MuesliCore
+import SQLite3
+@testable import MuesliNativeApp
+
+@Suite("Suggested Word Store", .serialized)
+struct SuggestedWordStoreTests {
+
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-sugg-test-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    /// A dictations table without the asr_backend column, to exercise the ALTER migration.
+    private func makeLegacyDictationStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-legacy-dict-\(UUID().uuidString).db")
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let sql = """
+        CREATE TABLE dictations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            duration_seconds REAL,
+            raw_text TEXT,
+            app_context TEXT,
+            word_count INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'dictation',
+            started_at TEXT,
+            ended_at TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+        #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+        return DictationStore(databaseURL: url)
+    }
+
+    private func upsert(_ word: String, count: Int = 3, replacement: String? = nil, variants: [String] = [], backends: [String] = []) -> SuggestedWordUpsert {
+        SuggestedWordUpsert(
+            word: word,
+            replacement: replacement,
+            occurrenceCount: count,
+            phoneticVariants: variants,
+            backends: backends
+        )
+    }
+
+    @Test("migration is idempotent and creates suggested_words")
+    func migrationIdempotent() throws {
+        let store = try makeStore()
+        try store.migrateIfNeeded()
+        #expect(try store.listSuggestedWords(status: .pending).isEmpty)
+    }
+
+    @Test("migration upgrades a legacy dictations table with asr_backend")
+    func legacyDictationUpgrade() throws {
+        let store = try makeLegacyDictationStore()
+        try store.migrateIfNeeded()
+        let now = Date()
+        let id = try store.insertDictation(
+            text: "hello kubectl",
+            durationSeconds: 1.0,
+            startedAt: now,
+            endedAt: now,
+            asrBackend: "whisper:small"
+        )
+        #expect(id > 0)
+        let rows = try store.dictationTextsForAnalysis()
+        #expect(rows.first?.backend == "whisper:small")
+    }
+
+    @Test("insertDictation round-trips asr_backend")
+    func asrBackendRoundTrip() throws {
+        let store = try makeStore()
+        let now = Date()
+        _ = try store.insertDictation(text: "with backend", durationSeconds: 1, startedAt: now, endedAt: now, asrBackend: "fluidaudio:parakeet")
+        _ = try store.insertDictation(text: "no backend", durationSeconds: 1, startedAt: now, endedAt: now)
+        let rows = try store.dictationTextsForAnalysis()
+        #expect(rows.count == 2)
+        #expect(rows.contains { $0.backend == "fluidaudio:parakeet" })
+        #expect(rows.contains { $0.backend == nil })
+    }
+
+    @Test("upsert inserts then updates count by word")
+    func upsertUpdatesCount() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("kubectl", count: 3)])
+        try store.upsertSuggestedWords([upsert("kubectl", count: 7, backends: ["whisper:small"])])
+        let pending = try store.listSuggestedWords(status: .pending)
+        #expect(pending.count == 1)
+        #expect(pending.first?.occurrenceCount == 7)
+        #expect(pending.first?.backends == ["whisper:small"])
+    }
+
+    @Test("upsert does not resurrect a dismissed word to pending")
+    func upsertDoesNotResurrectDismissed() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("graphql")])
+        let id = try #require(try store.listSuggestedWords(status: .pending).first?.id)
+        try store.setSuggestedWordStatus(id: id, status: .dismissed)
+
+        // Re-mined later — must stay dismissed.
+        try store.upsertSuggestedWords([upsert("graphql", count: 9)])
+        #expect(try store.listSuggestedWords(status: .pending).isEmpty)
+        let dismissed = try store.listSuggestedWords(status: .dismissed)
+        #expect(dismissed.count == 1)
+        #expect(dismissed.first?.occurrenceCount == 9) // count still refreshed
+    }
+
+    @Test("listSuggestedWords filters by status and orders by count")
+    func listFilteringAndOrdering() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([
+            upsert("low", count: 3),
+            upsert("high", count: 10),
+        ])
+        let pending = try store.listSuggestedWords(status: .pending)
+        #expect(pending.map(\.word) == ["high", "low"])
+        #expect(try store.listSuggestedWords(status: .accepted).isEmpty)
+    }
+
+    /// Force a row's last_seen_at into the past so aging can be tested.
+    private func backdateLastSeen(_ store: DictationStore, word: String, days: Int) throws {
+        var db: OpaquePointer?
+        #expect(sqlite3_open(store.resolvedDatabaseURL.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let sql = "UPDATE suggested_words SET last_seen_at = datetime('now', '-\(days) days') WHERE word = '\(word)'"
+        #expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+    }
+
+    @Test("prune removes pending suggestions not seen recently")
+    func pruneStalePending() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("stale"), upsert("fresh")])
+        try backdateLastSeen(store, word: "stale", days: 45)
+
+        let pruned = try store.pruneStalePendingSuggestions(olderThanDays: 30)
+        #expect(pruned == 1)
+        let pending = try store.listSuggestedWords(status: .pending)
+        #expect(pending.map(\.word) == ["fresh"])
+    }
+
+    @Test("prune leaves recently-seen pending suggestions")
+    func pruneKeepsFresh() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("recent")])
+        try backdateLastSeen(store, word: "recent", days: 10)
+        let pruned = try store.pruneStalePendingSuggestions(olderThanDays: 30)
+        #expect(pruned == 0)
+        #expect(try store.listSuggestedWords(status: .pending).count == 1)
+    }
+
+    @Test("prune never ages out accepted or dismissed suggestions")
+    func pruneSparesDecidedWords() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("accepted"), upsert("dismissed")])
+        let words = try store.listSuggestedWords(status: .pending)
+        let acceptedID = try #require(words.first { $0.word == "accepted" }?.id)
+        let dismissedID = try #require(words.first { $0.word == "dismissed" }?.id)
+        try store.setSuggestedWordStatus(id: acceptedID, status: .accepted)
+        try store.setSuggestedWordStatus(id: dismissedID, status: .dismissed)
+        try backdateLastSeen(store, word: "accepted", days: 365)
+        try backdateLastSeen(store, word: "dismissed", days: 365)
+
+        let pruned = try store.pruneStalePendingSuggestions(olderThanDays: 30)
+        #expect(pruned == 0)
+        #expect(try store.listSuggestedWords(status: .accepted).count == 1)
+        #expect(try store.listSuggestedWords(status: .dismissed).count == 1)
+    }
+
+    @Test("re-upserting a stale word refreshes last_seen and saves it from pruning")
+    func upsertRefreshesLastSeen() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("revived")])
+        try backdateLastSeen(store, word: "revived", days: 60)
+        // Seen again in a new analysis run -> last_seen_at bumped to now.
+        try store.upsertSuggestedWords([upsert("revived", count: 5)])
+        let pruned = try store.pruneStalePendingSuggestions(olderThanDays: 30)
+        #expect(pruned == 0)
+        #expect(try store.listSuggestedWords(status: .pending).first?.occurrenceCount == 5)
+    }
+
+    @Test("setSuggestedWordStatus moves a word between buckets")
+    func setStatus() throws {
+        let store = try makeStore()
+        try store.upsertSuggestedWords([upsert("muesli", replacement: "muesli", variants: ["museli"])])
+        let id = try #require(try store.listSuggestedWords(status: .pending).first?.id)
+        try store.setSuggestedWordStatus(id: id, status: .accepted)
+        #expect(try store.listSuggestedWords(status: .pending).isEmpty)
+        let accepted = try store.listSuggestedWords(status: .accepted)
+        #expect(accepted.first?.phoneticVariants == ["museli"])
+        #expect(accepted.first?.replacement == "muesli")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SuggestionAnalysisCoalescerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SuggestionAnalysisCoalescerTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("SuggestionAnalysisCoalescer")
+struct SuggestionAnalysisCoalescerTests {
+
+    /// Drive the coalescer the way the controller does: start a run when a trigger
+    /// says to, then loop while `onRunFinished` asks for another pass. Returns the
+    /// number of analysis passes that would actually run.
+    private func runLoop(_ coalescer: inout SuggestionAnalysisCoalescer,
+                         triggersDuringEachPass: [Int]) -> Int {
+        guard coalescer.onTrigger() else { return 0 }
+        var passes = 0
+        var remaining = triggersDuringEachPass
+        repeat {
+            passes += 1
+            // Simulate triggers that arrive while this pass is running.
+            if !remaining.isEmpty {
+                for _ in 0..<remaining.removeFirst() {
+                    _ = coalescer.onTrigger()
+                }
+            }
+        } while coalescer.onRunFinished()
+        return passes
+    }
+
+    @Test("a single trigger runs exactly one pass")
+    func singleTrigger() {
+        var coalescer = SuggestionAnalysisCoalescer()
+        let passes = runLoop(&coalescer, triggersDuringEachPass: [0])
+        #expect(passes == 1)
+        #expect(coalescer.isRunning == false)
+    }
+
+    @Test("the first trigger starts a run; it is the only one that returns true")
+    func firstTriggerStartsRun() {
+        var coalescer = SuggestionAnalysisCoalescer()
+        #expect(coalescer.onTrigger() == true)
+        #expect(coalescer.isRunning == true)
+        // Further triggers while running do not start a second loop.
+        #expect(coalescer.onTrigger() == false)
+        #expect(coalescer.onTrigger() == false)
+    }
+
+    @Test("a burst of triggers during one pass collapses into exactly one rerun")
+    func burstCollapsesToOneRerun() {
+        var coalescer = SuggestionAnalysisCoalescer()
+        // Five triggers arrive while the first pass runs -> one rerun, two passes.
+        let passes = runLoop(&coalescer, triggersDuringEachPass: [5])
+        #expect(passes == 2)
+        #expect(coalescer.isRunning == false)
+    }
+
+    @Test("triggers arriving during the rerun queue one more pass")
+    func triggersDuringRerunChain() {
+        var coalescer = SuggestionAnalysisCoalescer()
+        // Pass 1 gets 3 triggers -> rerun. Pass 2 (the rerun) gets 2 more -> another
+        // rerun. Pass 3 gets none -> stop. Three passes total.
+        let passes = runLoop(&coalescer, triggersDuringEachPass: [3, 2, 0])
+        #expect(passes == 3)
+        #expect(coalescer.isRunning == false)
+    }
+
+    @Test("after a run finishes, a fresh trigger starts a new run")
+    func newRunAfterCompletion() {
+        var coalescer = SuggestionAnalysisCoalescer()
+        let first = runLoop(&coalescer, triggersDuringEachPass: [0])
+        #expect(first == 1)
+        #expect(coalescer.isRunning == false)
+        // A later, independent trigger must be able to start again.
+        let second = runLoop(&coalescer, triggersDuringEachPass: [1])
+        #expect(second == 2)
+        #expect(coalescer.isRunning == false)
+    }
+
+    @Test("a rerun request does not survive past the run that consumed it")
+    func rerunRequestDoesNotLeak() {
+        var coalescer = SuggestionAnalysisCoalescer()
+        // One trigger during pass 1 schedules the rerun (pass 2). No triggers during
+        // pass 2, so the loop must stop at two passes, not spin forever.
+        let passes = runLoop(&coalescer, triggersDuringEachPass: [1, 0])
+        #expect(passes == 2)
+        #expect(coalescer.isRunning == false)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/WordSuggestionAnalyzerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/WordSuggestionAnalyzerTests.swift
@@ -1,0 +1,275 @@
+import Testing
+import Foundation
+import MuesliCore
+@testable import MuesliNativeApp
+
+@Suite("Word Suggestion Analyzer")
+struct WordSuggestionAnalyzerTests {
+
+    /// Convenience: everything spelled correctly = false (treat all as unknown),
+    /// no corrections offered. Lets tests focus on frequency/clustering.
+    private func analyze(
+        _ dictations: [(text: String, backend: String?)],
+        customWords: [CustomWord] = [],
+        dismissedOrAccepted: Set<String> = [],
+        isSpelledCorrectly: @escaping (String) -> Bool = { _ in false },
+        suggestCorrection: @escaping (String) -> String? = { _ in nil }
+    ) -> [SuggestedWordUpsert] {
+        WordSuggestionAnalyzer.analyze(
+            dictations: dictations,
+            customWords: customWords,
+            dismissedOrAccepted: dismissedOrAccepted,
+            isSpelledCorrectly: isSpelledCorrectly,
+            suggestCorrection: suggestCorrection
+        )
+    }
+
+    private func dictations(_ texts: [String], backend: String? = "whisper:small") -> [(text: String, backend: String?)] {
+        texts.map { (text: $0, backend: backend) }
+    }
+
+    @Test("requires the minimum number of occurrences")
+    func frequencyThreshold() {
+        let twice = analyze(dictations(["kubectl deploy", "kubectl logs"]))
+        #expect(!twice.contains { $0.word == "kubectl" })
+
+        let thrice = analyze(dictations(["kubectl deploy", "kubectl logs", "run kubectl"]))
+        #expect(thrice.contains { $0.word == "kubectl" })
+    }
+
+    @Test("filters numeric and very short tokens")
+    func filtersNoise() {
+        let result = analyze(dictations([
+            "go go go", "42 42 42", "a a a", "go to 42"
+        ]))
+        #expect(!result.contains { $0.word == "42" })
+        #expect(!result.contains { $0.word == "a" })
+        // "go" is 2 chars and alphabetic -> allowed
+        #expect(result.contains { $0.word == "go" })
+    }
+
+    @Test("excludes words already in the dictionary")
+    func excludesCustomWords() {
+        let custom = [CustomWord(word: "kubectl", replacement: nil)]
+        let result = analyze(
+            dictations(["kubectl one", "kubectl two", "kubectl three"]),
+            customWords: custom
+        )
+        #expect(!result.contains { $0.word == "kubectl" })
+    }
+
+    @Test("excludes words matching a custom replacement")
+    func excludesCustomReplacement() {
+        let custom = [CustomWord(word: "k8s", replacement: "kubernetes")]
+        let result = analyze(
+            dictations(["kubernetes one", "kubernetes two", "kubernetes three"]),
+            customWords: custom
+        )
+        #expect(!result.contains { $0.word == "kubernetes" })
+    }
+
+    @Test("excludes dismissed or accepted words")
+    func excludesDismissed() {
+        let result = analyze(
+            dictations(["graphql a", "graphql b", "graphql c"]),
+            dismissedOrAccepted: ["graphql"]
+        )
+        #expect(!result.contains { $0.word == "graphql" })
+    }
+
+    @Test("drops correctly spelled words")
+    func dropsCorrectlySpelled() {
+        let result = analyze(
+            dictations(["hello there", "hello world", "hello again"]),
+            isSpelledCorrectly: { $0 == "hello" }
+        )
+        #expect(!result.contains { $0.word == "hello" })
+    }
+
+    @Test("clusters phonetic variants under the most frequent canonical")
+    func clustersVariants() {
+        // muesli x3, museli x2, musli x1 -> one cluster, canonical "muesli"
+        let result = analyze(dictations([
+            "muesli bowl", "muesli oats", "fresh muesli",
+            "museli bowl", "museli oats",
+            "musli please"
+        ]))
+        let muesli = result.first { $0.word == "muesli" }
+        #expect(muesli != nil)
+        #expect(muesli?.occurrenceCount == 6)
+        #expect(muesli?.phoneticVariants.contains("museli") == true)
+        #expect(muesli?.phoneticVariants.contains("musli") == true)
+        // Variants should not appear as their own suggestions.
+        #expect(!result.contains { $0.word == "museli" })
+    }
+
+    @Test("smart canonical uses spell-checker correction when offered")
+    func smartCanonicalUsesCorrection() {
+        let result = analyze(
+            dictations(["kubernetez a", "kubernetez b", "kubernetez c"]),
+            suggestCorrection: { $0 == "kubernetez" ? "kubernetes" : nil }
+        )
+        let suggestion = result.first { $0.word == "kubernetez" }
+        #expect(suggestion?.replacement == "kubernetes")
+    }
+
+    @Test("smart canonical falls back to the most frequent variant when no correction")
+    func smartCanonicalFallsBack() {
+        let result = analyze(dictations([
+            "caivex a", "caivex b", "caivex c", "caveex d"
+        ]))
+        let suggestion = result.first { $0.word == "caivex" }
+        // No correction offered -> replacement is the canonical itself.
+        #expect(suggestion?.replacement == "caivex")
+    }
+
+    @Test("cross-model words rank ahead of single-model words")
+    func crossModelBoost() {
+        // "alpha" appears under two backends; "betaword" under one but more often.
+        let mixed: [(text: String, backend: String?)] = [
+            ("alpha one", "whisper:small"),
+            ("alpha two", "fluidaudio:parakeet"),
+            ("alpha three", "whisper:small"),
+            ("betaword x", "whisper:small"),
+            ("betaword y", "whisper:small"),
+            ("betaword z", "whisper:small"),
+            ("betaword w", "whisper:small"),
+        ]
+        let result = analyze(mixed)
+        #expect(result.first?.word == "alpha")
+        let alpha = result.first { $0.word == "alpha" }
+        #expect(alpha?.backends.count == 2)
+    }
+
+    @Test("empty corpus yields no suggestions and no crash")
+    func emptyCorpus() {
+        #expect(analyze([]).isEmpty)
+        #expect(WordSuggestionAnalyzer.candidateTokens(dictations: [], customWords: [], dismissedOrAccepted: []).isEmpty)
+    }
+
+    @Test("blank and whitespace-only text is ignored")
+    func blankText() {
+        let result = analyze(dictations(["", "   ", "\n\t", "kubectl", "kubectl", "kubectl"]))
+        #expect(result.count == 1)
+        #expect(result.first?.word == "kubectl")
+    }
+
+    @Test("occurrences are counted case-insensitively")
+    func caseInsensitiveCounting() {
+        // KUBECTL + Kubectl + kubectl == 3 occurrences of one token.
+        let result = analyze(dictations(["KUBECTL run", "Kubectl run", "kubectl run"]))
+        let kubectl = result.first { $0.word == "kubectl" }
+        #expect(kubectl != nil)
+        #expect(kubectl?.occurrenceCount == 3)
+    }
+
+    @Test("custom word exclusion is case-insensitive")
+    func caseInsensitiveCustomExclusion() {
+        let custom = [CustomWord(word: "Kubectl", replacement: nil)]
+        let result = analyze(
+            dictations(["kubectl a", "kubectl b", "kubectl c"]),
+            customWords: custom
+        )
+        #expect(!result.contains { $0.word == "kubectl" })
+    }
+
+    @Test("spell-checker capitalization-only fix is preserved as the replacement")
+    func capitalizationOnlyCorrection() {
+        // Regression: a correction differing only in case must not be discarded.
+        let result = analyze(
+            dictations(["graphql a", "graphql b", "graphql c"]),
+            suggestCorrection: { $0 == "graphql" ? "GraphQL" : nil }
+        )
+        let suggestion = result.first { $0.word == "graphql" }
+        #expect(suggestion?.replacement == "GraphQL")
+    }
+
+    @Test("an empty-string correction falls back to the canonical")
+    func emptyCorrectionFallsBack() {
+        let result = analyze(
+            dictations(["zoiks a", "zoiks b", "zoiks c"]),
+            suggestCorrection: { _ in "" }
+        )
+        #expect(result.first { $0.word == "zoiks" }?.replacement == "zoiks")
+    }
+
+    @Test("a correction identical to the canonical falls back to the no-op rule")
+    func identicalCorrectionFallsBack() {
+        let result = analyze(
+            dictations(["zoiks a", "zoiks b", "zoiks c"]),
+            suggestCorrection: { $0 }
+        )
+        #expect(result.first { $0.word == "zoiks" }?.replacement == "zoiks")
+    }
+
+    @Test("a correctly-spelled canonical suppresses the whole cluster")
+    func correctCanonicalSuppressesCluster() {
+        // muesli (correct) is canonical with the highest count; the misspelled
+        // variant must not leak out as its own suggestion.
+        let result = analyze(
+            dictations(["muesli a", "muesli b", "muesli c", "museli d"]),
+            isSpelledCorrectly: { $0 == "muesli" }
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test("threshold is met by summing counts across a cluster")
+    func thresholdViaClusterSum() {
+        // Each variant appears twice (< 3 alone) but the cluster sums to 4.
+        let result = analyze(dictations([
+            "musli a", "musli b", "museli c", "museli d"
+        ]))
+        let suggestion = result.first { $0.word == "musli" || $0.word == "museli" }
+        #expect(suggestion != nil)
+        #expect(suggestion?.occurrenceCount == 4)
+    }
+
+    @Test("ties in count are broken alphabetically for the canonical")
+    func tieBreakAlphabetical() {
+        // "musli" and "museli" each appear 3x and cluster together; the
+        // alphabetically-first ("museli") wins the canonical.
+        let result = analyze(dictations([
+            "musli a", "musli b", "musli c",
+            "museli d", "museli e", "museli f"
+        ]))
+        let suggestion = result.first { $0.phoneticVariants.contains("musli") || $0.phoneticVariants.contains("museli") }
+        #expect(suggestion?.word == "museli")
+        #expect(suggestion?.phoneticVariants == ["musli"])
+    }
+
+    @Test("backends are de-duplicated and sorted across a cluster")
+    func backendsDedupedAndSorted() {
+        let mixed: [(text: String, backend: String?)] = [
+            ("musli x", "whisper:small"),
+            ("musli y", "whisper:small"),
+            ("museli z", "fluidaudio:parakeet"),
+        ]
+        let result = WordSuggestionAnalyzer.analyze(
+            dictations: mixed,
+            customWords: [],
+            dismissedOrAccepted: [],
+            isSpelledCorrectly: { _ in false },
+            suggestCorrection: { _ in nil }
+        )
+        let suggestion = result.first
+        #expect(suggestion?.backends == ["fluidaudio:parakeet", "whisper:small"])
+    }
+
+    @Test("nil backends do not produce phantom cross-model boosts")
+    func nilBackendsNoBoost() {
+        let result = analyze(dictations(["ztoken a", "ztoken b", "ztoken c"], backend: nil))
+        #expect(result.first?.backends.isEmpty == true)
+    }
+
+    @Test("analysis does not depend on NSSpellChecker")
+    func noSpellCheckerDependency() {
+        // Both predicates stubbed; a result is still produced purely from inputs.
+        var spellCalls = 0
+        let result = analyze(
+            dictations(["zzqx a", "zzqx b", "zzqx c"]),
+            isSpelledCorrectly: { _ in spellCalls += 1; return false }
+        )
+        #expect(result.contains { $0.word == "zzqx" })
+        #expect(spellCalls > 0) // the injected closure is what's consulted
+    }
+}


### PR DESCRIPTION
Suggested Words: auto-detect misspelled words for the dictionary

Problem

Different ASR models consistently misspell certain words — proper nouns, technical terms, company
names, domain jargon. Users currently have to manually add each correction to the personal dictionary
after noticing the error.

What this does

Mines historical dictations for frequently-transcribed words that aren't already in the dictionary,
and surfaces them in a new Suggested Words section of the Dictionary tab. Each suggestion shows the
word, how many times it appeared, and which model(s) produced it. One click to Accept (adds a
CustomWord rule, with an editable replacement) or Dismiss (hidden permanently).

Detection methods

1. Frequency — words appearing ≥3× (summed across phonetic clusters) that aren't in the dictionary or
recognized by NSSpellChecker.
2. Cross-model comparison — a word produced under 2+ ASR backends ranks higher (stronger proper-noun
signal).
3. Phonetic clustering — near-duplicate spellings (e.g. muesli/museli/musli) collapse into one
suggestion with a smart canonical: a confident NSSpellChecker correction when available (case
included), otherwise the most-frequent variant — always editable before accepting.
4. Clipboard-diff correction tracking — opt-in, default OFF. After a paste, watches for an edited
version returning to the clipboard and diffs it into corrections.

Stale-suggestion aging

Pending suggestions carry a last_seen_at that's refreshed whenever the word reappears in the corpus;
analysis prunes pending suggestions not seen in 30 days. Accepted/dismissed rows are never aged out.

Implementation notes

- SQLite storage: new suggested_words table + asr_backend/last_seen_at columns. Upsert is
conflict-safe and never resurrects a dismissed/accepted word to pending.
- WordSuggestionAnalyzer is pure and fully unit-tested. NSSpellChecker is main-thread-only, so it's
injected as closures — heavy clustering runs off-main, the cheap spell pass runs on MainActor.
- Analysis is debounced (30s coalescing) after each dictation plus a delayed launch run, so it never
touches the dictation latency path.
- Clipboard-diff is default-off because repeatedly reading NSPasteboard surfaces a macOS "used the
clipboard" notice and timer polling is unreliable under App Nap in this LSUIElement app. The watcher
only samples after our own paste, starts after PasteController's restore window, and requires a high
near-match before treating a diff as a correction.

Commits (atomic, build independently)

1. Add suggested_words storage layer to DictationStore
2. Record the ASR backend that produced each dictation
3. Add WordSuggestionAnalyzer for mining dictionary candidates
4. Wire suggestion analysis into the controller
5. Add Suggested Words section to the Dictionary tab
6. Add opt-in clipboard-diff correction tracking

Open questions (resolved)

- Min occurrences: 3.
- Retroactive vs forward: both — scans existing dictations on launch, then updates incrementally.
- Correctly-spelled domain terms (kubectl, GraphQL): suggested once; accepting stores them permanently
so they're never re-suggested.

Testing

46 new tests (analyzer, store/migration/aging, clipboard diff). Full suite: 1030 tests across 114
suites, all green. Unit tests cover the pure logic and store layer; controller orchestration and the
SwiftUI view were verified manually (consistent with the rest of the suite).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784524943&installation_id=136549638&pr_number=229&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F229&signature=4224d979b25f74eb1bc3d8b14b6844bc5267b64102a4b3f90a41affb92b849af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->