### PR TITLE
[codex] Add ChatGPT transcript cleanup backend

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -65,6 +65,7 @@ final class AppState {
     var selectedBackend: BackendOption = .whisper
     var selectedMeetingTranscriptionBackend: BackendOption = .whisper
     var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .chatGPT
+    var selectedPostProcessorBackend: TranscriptCleanupBackendOption = .local
     var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()
     var launchAtLoginRegistrationState: LaunchAtLoginRegistrationState = .disabled

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -67,20 +67,101 @@ enum ChatGPTResponsesClient {
                 let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else { continue }
 
-            if let outputText = json["output_text"] as? String, !outputText.isEmpty {
-                fullText = outputText
-            }
-
             if let type = json["type"] as? String,
                type == "response.output_text.delta",
                let delta = json["delta"] as? String {
                 fullText += delta
+                continue
+            }
+
+            if let outputText = extractOutputText(from: json), !outputText.isEmpty {
+                fullText = outputText
             }
         }
 
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         fputs("[\(logCategory)] ChatGPT WHAM: collected \(trimmed.count) chars\n", stderr)
         return trimmed
+    }
+
+    static func extractOutputText(from payload: [String: Any]) -> String? {
+        if let outputText = payload["output_text"] as? String, !outputText.isEmpty {
+            return outputText
+        }
+        if let response = payload["response"] as? [String: Any],
+           let responseText = extractOutputText(from: response) {
+            return responseText
+        }
+        if let outputText = extractText(fromOutput: payload["output"]) {
+            return outputText
+        }
+        if let contentText = extractText(fromContent: payload["content"]) {
+            return contentText
+        }
+        return nil
+    }
+
+    private static func extractText(fromOutput output: Any?) -> String? {
+        guard let output else { return nil }
+        if let outputText = output as? String, !outputText.isEmpty {
+            return outputText
+        }
+        if let item = output as? [String: Any] {
+            return extractText(fromContent: item["content"]) ?? (item["text"] as? String)
+        }
+        if let items = output as? [[String: Any]] {
+            let parts = items.compactMap { item -> String? in
+                if let text = extractText(fromContent: item["content"]) {
+                    return text
+                }
+                if let text = item["text"] as? String, !text.isEmpty {
+                    return text
+                }
+                return nil
+            }
+            let joined = parts.joined(separator: "")
+            return joined.isEmpty ? nil : joined
+        }
+        return nil
+    }
+
+    private static func extractText(fromContent content: Any?) -> String? {
+        guard let content else { return nil }
+        if let text = content as? String, !text.isEmpty {
+            return text
+        }
+        if let item = content as? [String: Any] {
+            if let text = item["text"] as? String, !text.isEmpty {
+                return text
+            }
+            if let text = item["content"] as? String, !text.isEmpty {
+                return text
+            }
+            if let nested = item["text"] as? [String: Any],
+               let value = nested["value"] as? String,
+               !value.isEmpty {
+                return value
+            }
+        }
+        if let items = content as? [[String: Any]] {
+            let parts = items.compactMap { item -> String? in
+                if let text = item["text"] as? String, !text.isEmpty {
+                    return text
+                }
+                if let text = item["content"] as? String, !text.isEmpty {
+                    return text
+                }
+                if let nested = item["text"] as? [String: Any],
+                   let value = nested["value"] as? String,
+                   !value.isEmpty {
+                    return value
+                }
+                return nil
+            }
+            let joined = parts.joined(separator: "")
+            return joined.isEmpty ? nil : joined
+        }
+        return nil
     }
 
     private static func extractErrorMessage(from data: Data) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+enum ChatGPTResponsesError: LocalizedError {
+    case backendFailed(statusCode: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .backendFailed(let statusCode, let message):
+            return "ChatGPT failed with status \(statusCode). \(message)"
+        }
+    }
+}
+
+enum ChatGPTResponsesClient {
+    private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
+
+    static func respond(
+        systemPrompt: String,
+        userPrompt: String,
+        model: String,
+        logCategory: String
+    ) async throws -> String {
+        let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
+        let body: [String: Any] = [
+            "model": model,
+            "store": false,
+            "stream": true,
+            "instructions": systemPrompt,
+            "input": [
+                [
+                    "role": "user",
+                    "content": [
+                        ["type": "input_text", "text": userPrompt],
+                    ],
+                ] as [String: Any],
+            ],
+        ]
+
+        var request = URLRequest(url: whamURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard httpStatus == 200 else {
+            var errorData = Data()
+            for try await byte in bytes { errorData.append(byte) }
+            let message = extractErrorMessage(from: errorData)
+                ?? String(data: errorData, encoding: .utf8)
+                ?? "(unknown)"
+            fputs("[\(logCategory)] ChatGPT WHAM: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
+            throw ChatGPTResponsesError.backendFailed(statusCode: httpStatus, message: message)
+        }
+
+        var fullText = ""
+        for try await line in bytes.lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let jsonString = String(line.dropFirst(6))
+            if jsonString == "[DONE]" { break }
+            guard
+                let data = jsonString.data(using: .utf8),
+                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { continue }
+
+            if let outputText = json["output_text"] as? String, !outputText.isEmpty {
+                fullText = outputText
+            }
+
+            if let type = json["type"] as? String,
+               type == "response.output_text.delta",
+               let delta = json["delta"] as? String {
+                fullText += delta
+            }
+        }
+
+        let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+        fputs("[\(logCategory)] ChatGPT WHAM: collected \(trimmed.count) chars\n", stderr)
+        return trimmed
+    }
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        if let error = json["error"] as? [String: Any] {
+            if let message = error["message"] as? String, !message.isEmpty {
+                return message
+            }
+            if let code = error["code"] as? String, !code.isEmpty {
+                return code
+            }
+            return String(describing: error)
+        }
+
+        if let message = json["message"] as? String, !message.isEmpty {
+            return message
+        }
+
+        if let detail = json["detail"] as? String, !detail.isEmpty {
+            return detail
+        }
+
+        return nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -24,7 +24,6 @@ enum MeetingSummaryClient {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingSummary")
     private static let openAIURL = URL(string: "https://api.openai.com/v1/responses")!
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
-    private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
     private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
@@ -423,7 +422,7 @@ enum MeetingSummaryClient {
     ) async throws -> String {
         do {
             let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
-            let text = try await callWHAM(
+            let text = try await ChatGPTResponsesClient.respond(
                 systemPrompt: instructions,
                 userPrompt: summaryUserPrompt(
                     transcript: transcript,
@@ -432,12 +431,13 @@ enum MeetingSummaryClient {
                     manualNotes: manualNotes,
                     visualContext: visualContext
                 ),
-                model: config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel
+                model: config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel,
+                logCategory: "summary"
             )
-            if let text, !text.isEmpty {
-                return text
+            guard !text.isEmpty else {
+                throw MeetingSummaryError.emptyResponse(backend: "ChatGPT")
             }
-            throw MeetingSummaryError.emptyResponse(backend: "ChatGPT")
+            return text
         } catch {
             fputs("[summary] ChatGPT summarization failed: \(error)\n", stderr)
             throw summaryRequestError(backend: "ChatGPT", error: error)
@@ -745,72 +745,6 @@ enum MeetingSummaryClient {
         }
     }
 
-    /// Call the WHAM streaming API and collect the full response text.
-    private static func callWHAM(systemPrompt: String, userPrompt: String, model: String) async throws -> String? {
-        let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
-
-        let body: [String: Any] = [
-            "model": model,
-            "store": false,
-            "stream": true,
-            "instructions": systemPrompt,
-            "input": [
-                [
-                    "role": "user",
-                    "content": [
-                        ["type": "input_text", "text": userPrompt],
-                    ],
-                ] as [String: Any],
-            ],
-        ]
-        // Note: WHAM does not support max_output_tokens
-
-        var request = URLRequest(url: whamURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        if !accountId.isEmpty {
-            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
-        }
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
-        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
-
-        guard httpStatus == 200 else {
-            // Collect error body
-            var errorData = Data()
-            for try await byte in bytes { errorData.append(byte) }
-            let message = extractErrorMessage(from: errorData) ?? String(data: errorData, encoding: .utf8) ?? "(unknown)"
-            fputs("[summary] ChatGPT WHAM: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
-            throw MeetingSummaryError.backendFailed(backend: "ChatGPT", statusCode: httpStatus, message: message)
-        }
-
-        // Parse SSE stream: collect text deltas from response.output_text.delta events
-        var fullText = ""
-        for try await line in bytes.lines {
-            guard line.hasPrefix("data: ") else { continue }
-            let jsonStr = String(line.dropFirst(6))
-            if jsonStr == "[DONE]" { break }
-            guard let data = jsonStr.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
-
-            // Check for output_text.done with full text
-            if let outputText = json["output_text"] as? String, !outputText.isEmpty {
-                fullText = outputText
-            }
-
-            // Check for streaming delta
-            if let type = json["type"] as? String, type == "response.output_text.delta",
-               let delta = json["delta"] as? String {
-                fullText += delta
-            }
-        }
-
-        fputs("[summary] ChatGPT WHAM: collected \(fullText.count) chars\n", stderr)
-        return fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private static func extractOpenAIText(from payload: [String: Any]) -> String? {
         if let outputText = payload["output_text"] as? String, !outputText.isEmpty {
             return outputText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -872,6 +806,12 @@ enum MeetingSummaryClient {
     private static func summaryRequestError(backend: String, error: Error) -> Error {
         if error is MeetingSummaryError {
             return error
+        }
+        if let error = error as? ChatGPTResponsesError {
+            switch error {
+            case .backendFailed(let statusCode, let message):
+                return MeetingSummaryError.backendFailed(backend: backend, statusCode: statusCode, message: message)
+            }
         }
         return MeetingSummaryError.requestFailed(backend: backend, underlying: error)
     }
@@ -1154,13 +1094,15 @@ enum MeetingSummaryClient {
     private static func generateTitleWithChatGPT(transcript: String, config: AppConfig) async -> String? {
         do {
             let model = config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel
-            let result = try await callWHAM(
+            let result = try await ChatGPTResponsesClient.respond(
                 systemPrompt: titleInstructions,
                 userPrompt: transcript,
-                model: model
+                model: model,
+                logCategory: "summary"
             )
-            let title = result?.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
-            fputs("[summary] ChatGPT generated title: \(title ?? "(nil)")\n", stderr)
+            let title = result.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+            guard !title.isEmpty else { return nil }
+            fputs("[summary] ChatGPT generated title: \(title)\n", stderr)
             return title
         } catch {
             fputs("[summary] ChatGPT title generation failed: \(error)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -484,7 +484,7 @@ struct PostProcessorOption: Identifiable, Equatable {
 
     You may: fix obvious misspellings, remove filler words (um, uh, like), apply 'scratch that' deletions, and format numbered or bullet lists when dictated.
 
-    Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.
+    Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in quotation marks, markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.
     """
 }
 
@@ -768,7 +768,9 @@ struct AppConfig: Codable {
     var hiddenCalendarEventIDs: [String] = []
     var disabledCalendarIDs: [String] = []
     var enablePostProcessor: Bool = false
+    var postProcessorBackend: String = TranscriptCleanupBackendOption.local.backend
     var activePostProcessorId: String = PostProcessorOption.defaultOption.id
+    var postProcessorChatGPTModel: String = ""
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     var enableScreenContext: Bool = false
     var useCoreAudioTap: Bool = true
@@ -846,7 +848,9 @@ struct AppConfig: Codable {
         case hiddenCalendarEventIDs = "hidden_calendar_event_ids"
         case disabledCalendarIDs = "disabled_calendar_ids"
         case enablePostProcessor = "enable_post_processor"
+        case postProcessorBackend = "post_processor_backend"
         case activePostProcessorId = "active_post_processor_id"
+        case postProcessorChatGPTModel = "post_processor_chatgpt_model"
         case postProcessorSystemPrompt = "post_processor_system_prompt"
         case enableScreenContext = "enable_screen_context"
         case useCoreAudioTap = "use_core_audio_tap"
@@ -956,7 +960,11 @@ struct AppConfig: Codable {
         hiddenCalendarEventIDs = (try? c.decode([String].self, forKey: .hiddenCalendarEventIDs)) ?? defaults.hiddenCalendarEventIDs
         disabledCalendarIDs = (try? c.decode([String].self, forKey: .disabledCalendarIDs)) ?? defaults.disabledCalendarIDs
         enablePostProcessor = (try? c.decode(Bool.self, forKey: .enablePostProcessor)) ?? defaults.enablePostProcessor
+        postProcessorBackend = TranscriptCleanupBackendOption
+            .resolved(try? c.decode(String.self, forKey: .postProcessorBackend))
+            .backend
         activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
+        postProcessorChatGPTModel = (try? c.decode(String.self, forKey: .postProcessorChatGPTModel)) ?? defaults.postProcessorChatGPTModel
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -214,6 +214,11 @@ struct ModelsView: View {
             .padding(.top, MuesliTheme.spacing8)
 
             VStack(spacing: MuesliTheme.spacing12) {
+                if appState.config.enablePostProcessor,
+                   appState.selectedPostProcessorBackend == .chatGPT {
+                    chatGPTPostProcCard
+                }
+
                 ForEach(PostProcessorOption.all) { option in
                     postProcModelCard(option)
                 }
@@ -223,9 +228,56 @@ struct ModelsView: View {
         }
     }
 
+    private var chatGPTPostProcCard: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                brandLogo("openai-logo")
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        Text("ChatGPT")
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+
+                        Text(resolvedChatGPTCleanupModelLabel)
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+
+                    Text("Uses your signed-in ChatGPT account for transcript cleanup.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+
+                Spacer()
+
+                Text("Active")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.success)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(MuesliTheme.success.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.accent.opacity(0.5), lineWidth: 1.5)
+        )
+    }
+
+    private var resolvedChatGPTCleanupModelLabel: String {
+        let model = TranscriptCleanupClient.resolvedChatGPTModel(appState.config.postProcessorChatGPTModel)
+        return SummaryModelPreset.chatGPTModels.first(where: { $0.id == model })?.label ?? model
+    }
+
     private func postProcModelCard(_ option: PostProcessorOption) -> some View {
         let isDownloaded = downloadedPostProcModels.contains(option.id)
-        let isActive = appState.activePostProcessor.id == option.id && isDownloaded
+        let isActive = appState.selectedPostProcessorBackend == .local
+            && appState.activePostProcessor.id == option.id
+            && isDownloaded
         let isDownloading = downloadingPostProcModels.contains(option.id)
         let progress = downloadProgressPostProc[option.id] ?? 0
 
@@ -774,7 +826,9 @@ struct ModelsView: View {
                         downloadProgressPostProc.removeValue(forKey: option.id)
                         downloadTasksPostProc.removeValue(forKey: option.id)
                     }
-                    if appState.config.enablePostProcessor && !appState.activePostProcessor.isDownloaded {
+                    if appState.config.enablePostProcessor,
+                       appState.selectedPostProcessorBackend == .local,
+                       !appState.activePostProcessor.isDownloaded {
                         controller.selectPostProcessor(option)
                         controller.preloadExperimentalTranscriptionFeatures()
                     }
@@ -884,7 +938,8 @@ struct ModelsView: View {
     }
 
     private func deletePostProcModel(_ option: PostProcessorOption) {
-        if appState.activePostProcessor.id == option.id {
+        if appState.selectedPostProcessorBackend == .local,
+           appState.activePostProcessor.id == option.id {
             let remainingDownloadedIDs = downloadedPostProcModels.subtracting([option.id])
             if let fallback = PostProcessorOption.firstDownloaded(excluding: option.id, downloadedIDs: remainingDownloadedIDs) {
                 controller.selectPostProcessor(fallback)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1071,6 +1071,8 @@ final class MuesliController: NSObject {
             $0.postProcessorBackend = TranscriptCleanupBackendOption.local.backend
             $0.activePostProcessorId = option.id
         }
+        selectedPostProcessorBackend = .local
+        appState.selectedPostProcessorBackend = .local
         appState.activePostProcessor = option
         guard config.enablePostProcessor else { return }
         Task { [weak self] in
@@ -1199,6 +1201,18 @@ final class MuesliController: NSObject {
         chatGPTAuth.signOut()
         if selectedMeetingSummaryBackend == .chatGPT {
             selectMeetingSummaryBackend(.openAI)
+        }
+        if selectedPostProcessorBackend == .chatGPT, config.enablePostProcessor {
+            if let localOption = PostProcessorOption.runtimeOption(id: config.activePostProcessorId) {
+                updateConfig {
+                    $0.postProcessorBackend = TranscriptCleanupBackendOption.local.backend
+                    $0.activePostProcessorId = localOption.id
+                }
+                appState.activePostProcessor = localOption
+            } else {
+                updateConfig { $0.enablePostProcessor = false }
+            }
+            preloadExperimentalTranscriptionFeatures()
         }
         syncAppState()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -236,6 +236,7 @@ final class MuesliController: NSObject {
     private(set) var selectedBackend: BackendOption
     private(set) var selectedMeetingTranscriptionBackend: BackendOption
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
+    private(set) var selectedPostProcessorBackend: TranscriptCleanupBackendOption
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
     private var activeMeetingAudioWarning: ActiveMeetingAudioWarning?
@@ -331,6 +332,7 @@ final class MuesliController: NSObject {
         self.selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == loadedConfig.meetingSummaryBackend
         }) ?? .chatGPT
+        self.selectedPostProcessorBackend = TranscriptCleanupBackendOption.resolved(loadedConfig.postProcessorBackend)
         self.indicator = FloatingIndicatorController(configStore: configStore)
         ComputerUseCursorOverlay.shared.attachIndicator(self.indicator)
         super.init()
@@ -542,17 +544,10 @@ final class MuesliController: NSObject {
                 guard let self else { return }
                 let includesMeetings = self.config.resolvedOnboardingUseCase.includesMeetings
                 let ppOption = self.runtimePostProcessorOption()
-                if #available(macOS 15, *) {
-                    if let ppOption {
-                        await self.transcriptionCoordinator.setActivePostProcessor(
-                            option: ppOption,
-                            systemPrompt: self.config.postProcessorSystemPrompt
-                        )
-                    }
-                }
+                await self.configureTranscriptCleanupForRuntime(option: ppOption)
                 await self.transcriptionCoordinator.preload(
                     backend: self.selectedBackend,
-                    enablePostProcessor: self.config.enablePostProcessor && ppOption != nil,
+                    enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
                     includeMeetingHelpers: includesMeetings
                 )
                 if includesMeetings, self.selectedMeetingTranscriptionBackend != self.selectedBackend {
@@ -718,6 +713,7 @@ final class MuesliController: NSObject {
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
+        appState.selectedPostProcessorBackend = selectedPostProcessorBackend
         appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
@@ -873,6 +869,7 @@ final class MuesliController: NSObject {
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == config.meetingSummaryBackend
         }) ?? .chatGPT
+        selectedPostProcessorBackend = TranscriptCleanupBackendOption.resolved(config.postProcessorBackend)
         statusBarController?.refresh()
         statusBarController?.refreshIcon()
         indicator.refreshIcon()
@@ -891,6 +888,7 @@ final class MuesliController: NSObject {
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
+        appState.selectedPostProcessorBackend = selectedPostProcessorBackend
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         syncCalendarMonitor()
@@ -956,17 +954,10 @@ final class MuesliController: NSObject {
                 }
             }
             let ppOption = self.runtimePostProcessorOption()
-            if #available(macOS 15, *) {
-                if let ppOption {
-                    await self.transcriptionCoordinator.setActivePostProcessor(
-                        option: ppOption,
-                        systemPrompt: self.config.postProcessorSystemPrompt
-                    )
-                }
-            }
+            await self.configureTranscriptCleanupForRuntime(option: ppOption)
             await self.transcriptionCoordinator.preload(
                 backend: option,
-                enablePostProcessor: self.config.enablePostProcessor && ppOption != nil,
+                enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
                 includeMeetingHelpers: self.config.resolvedOnboardingUseCase.includesMeetings
             )
             await MainActor.run {
@@ -1013,7 +1004,7 @@ final class MuesliController: NSObject {
     }
 
     var isPostProcessorReady: Bool {
-        config.enablePostProcessor && runtimePostProcessorOption() != nil
+        canRunTranscriptCleanup(option: runtimePostProcessorOption())
     }
 
     @discardableResult
@@ -1030,11 +1021,31 @@ final class MuesliController: NSObject {
     }
 
     private func runtimePostProcessorOption() -> PostProcessorOption? {
-        PostProcessorOption.runtimeOption(id: config.activePostProcessorId)
+        guard selectedPostProcessorBackend == .local else { return nil }
+        return PostProcessorOption.runtimeOption(id: config.activePostProcessorId)
+    }
+
+    private func canRunTranscriptCleanup(option: PostProcessorOption?) -> Bool {
+        guard config.enablePostProcessor else { return false }
+        switch selectedPostProcessorBackend {
+        case .chatGPT:
+            return chatGPTAuth.isAuthenticated
+        default:
+            return option != nil
+        }
+    }
+
+    private func configureTranscriptCleanupForRuntime(option: PostProcessorOption? = nil) async {
+        await transcriptionCoordinator.configurePostProcessor(
+            backend: selectedPostProcessorBackend,
+            option: option ?? runtimePostProcessorOption(),
+            systemPrompt: config.postProcessorSystemPrompt,
+            chatGPTModel: config.postProcessorChatGPTModel
+        )
     }
 
     func setPostProcessorEnabled(_ enabled: Bool) {
-        if enabled {
+        if enabled, selectedPostProcessorBackend == .local {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
                 appState.selectedTab = .models
@@ -1047,33 +1058,24 @@ final class MuesliController: NSObject {
 
     func preloadExperimentalTranscriptionFeatures() {
         let ppOption = runtimePostProcessorOption()
-        let enabled = config.enablePostProcessor && ppOption != nil
-        let ppPrompt = config.postProcessorSystemPrompt
+        let enabled = canRunTranscriptCleanup(option: ppOption)
         Task { [weak self] in
             guard let self else { return }
-            if let ppOption, #available(macOS 15, *) {
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: ppOption,
-                    systemPrompt: ppPrompt
-                )
-            }
+            await self.configureTranscriptCleanupForRuntime(option: ppOption)
             await self.transcriptionCoordinator.preloadPostProcessorIfNeeded(enabled: enabled)
         }
     }
 
     func selectPostProcessor(_ option: PostProcessorOption) {
-        updateConfig { $0.activePostProcessorId = option.id }
+        updateConfig {
+            $0.postProcessorBackend = TranscriptCleanupBackendOption.local.backend
+            $0.activePostProcessorId = option.id
+        }
         appState.activePostProcessor = option
         guard config.enablePostProcessor else { return }
-        let systemPrompt = config.postProcessorSystemPrompt
         Task { [weak self] in
             guard let self else { return }
-            if #available(macOS 15, *) {
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: option,
-                    systemPrompt: systemPrompt
-                )
-            }
+            await self.configureTranscriptCleanupForRuntime(option: option)
         }
     }
 
@@ -1083,13 +1085,26 @@ final class MuesliController: NSObject {
         guard config.enablePostProcessor else { return }
         Task { [weak self] in
             guard let self else { return }
-            if let ppOption, #available(macOS 15, *) {
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: ppOption,
-                    systemPrompt: prompt
-                )
+            await self.configureTranscriptCleanupForRuntime(option: ppOption)
+        }
+    }
+
+    func selectPostProcessorBackend(_ option: TranscriptCleanupBackendOption) {
+        updateConfig { $0.postProcessorBackend = option.backend }
+        if option == .local, config.enablePostProcessor {
+            guard normalizePostProcessorSelectionForAvailability() != nil else {
+                updateConfig { $0.enablePostProcessor = false }
+                appState.selectedTab = .models
+                return
             }
         }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
+    func updatePostProcessorChatGPTModel(_ model: String) {
+        updateConfig { $0.postProcessorChatGPTModel = model }
+        guard config.enablePostProcessor else { return }
+        preloadExperimentalTranscriptionFeatures()
     }
 
     func selectMeetingSummaryBackend(_ option: MeetingSummaryBackendOption) {
@@ -1165,11 +1180,14 @@ final class MuesliController: NSObject {
     }
 
     /// Returns nil on success, or an error message on failure.
-    func signInWithChatGPT() async -> String? {
+    func signInWithChatGPT(selectMeetingSummaryBackend shouldSelectMeetingSummaryBackend: Bool = true) async -> String? {
         do {
             try await chatGPTAuth.signIn()
-            selectMeetingSummaryBackend(.chatGPT)
+            if shouldSelectMeetingSummaryBackend {
+                selectMeetingSummaryBackend(.chatGPT)
+            }
             syncAppState()
+            preloadExperimentalTranscriptionFeatures()
             return nil
         } catch {
             fputs("[muesli-native] ChatGPT sign-in failed: \(error)\n", stderr)
@@ -5591,11 +5609,14 @@ final class MuesliController: NSObject {
             }
 
             do {
+                let ppOption = self.runtimePostProcessorOption()
+                await self.configureTranscriptCleanupForRuntime(option: ppOption)
+                let enableTranscriptCleanup = self.canRunTranscriptCleanup(option: ppOption)
                 let result = try await self.transcriptionCoordinator.transcribeDictation(
                     at: wavURL,
                     backend: transcriptionBackend,
                     cohereLanguage: transcriptionLanguage,
-                    enablePostProcessor: self.isPostProcessorReady,
+                    enablePostProcessor: enableTranscriptCleanup,
                     customWords: self.serializedCustomWords(),
                     appContext: promptContext
                 )

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -112,6 +112,10 @@ enum Qwen3PostProcessorOutputCleaner {
         guard !trimmed.isEmpty else { return true }
 
         let lower = trimmed.lowercased()
+        if isPlaceholderOutput(trimmed) {
+            return true
+        }
+
         let assistantMarkers = [
             "the user is asking",
             "**analysis:**",
@@ -138,6 +142,20 @@ enum Qwen3PostProcessorOutputCleaner {
         }
         return expansion > 2.0 && trimmed.count > 200
     }
+
+    private static func isPlaceholderOutput(_ text: String) -> Bool {
+        let normalized = text
+            .replacingOccurrences(of: "…", with: "...")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized == "..." || normalized == ". . ." {
+            return true
+        }
+
+        let punctuationOnly = normalized.allSatisfy { character in
+            character.isWhitespace || ".…-_,;:!?()[]{}".contains(character)
+        }
+        return punctuationOnly && normalized.count <= 8
+    }
 }
 
 enum Qwen3PostProcessorConfig {
@@ -145,7 +163,7 @@ enum Qwen3PostProcessorConfig {
     static let envOverride = "MUESLI_QWEN3_POSTPROC_GGUF"
     static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"
     // Dictation-only cleanup cap. Keep bounded to avoid slow local inference; long dictations may be truncated by LLM.swift.
-    static let maxContextTokens: Int32 = 1024
+    static let maxContextTokens: Int32 = 8192
 
     static func formatInput(_ text: String, appContext: String? = nil) -> String {
         var parts = ""

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -436,29 +436,56 @@ struct SettingsView: View {
                         controller.setPostProcessorEnabled(newValue)
                     }
                 }
-                if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
+                if appState.config.enablePostProcessor {
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cleanup model") {
-                        let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
-                            ? appState.activePostProcessor.label
-                            : (downloadedPostProcOptions.first?.label ?? "")
+                    settingsRow("Cleanup backend") {
                         settingsMenu(
-                            selection: selection,
-                            options: downloadedPostProcOptions.map(\.label)
+                            selection: appState.selectedPostProcessorBackend.label,
+                            options: TranscriptCleanupBackendOption.all.map(\.label)
                         ) { label in
-                            if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
-                                controller.selectPostProcessor(option)
+                            if let option = TranscriptCleanupBackendOption.all.first(where: { $0.label == label }) {
+                                controller.selectPostProcessorBackend(option)
                             }
                         }
                     }
-                } else if appState.config.enablePostProcessor {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cleanup model") {
-                        Text("Download a cleanup model in Models")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .multilineTextAlignment(.trailing)
-                            .frame(width: controlWidth, alignment: .trailing)
+                    if appState.selectedPostProcessorBackend == .chatGPT {
+                        Divider().background(MuesliTheme.surfaceBorder)
+                        settingsRow("Account") {
+                            chatGPTAccountControl(selectMeetingSummaryBackend: false)
+                        }
+                        Divider().background(MuesliTheme.surfaceBorder)
+                        settingsRow("Cleanup model") {
+                            settingsModelMenu(
+                                currentModel: appState.config.postProcessorChatGPTModel,
+                                presets: SummaryModelPreset.chatGPTModels
+                            ) { model in
+                                controller.updatePostProcessorChatGPTModel(model)
+                            }
+                        }
+                    } else if !downloadedPostProcOptions.isEmpty {
+                        Divider().background(MuesliTheme.surfaceBorder)
+                        settingsRow("Cleanup model") {
+                            let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
+                                ? appState.activePostProcessor.label
+                                : (downloadedPostProcOptions.first?.label ?? "")
+                            settingsMenu(
+                                selection: selection,
+                                options: downloadedPostProcOptions.map(\.label)
+                            ) { label in
+                                if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
+                                    controller.selectPostProcessor(option)
+                                }
+                            }
+                        }
+                    } else {
+                        Divider().background(MuesliTheme.surfaceBorder)
+                        settingsRow("Cleanup model") {
+                            Text("Download a cleanup model in Models")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: controlWidth, alignment: .trailing)
+                        }
                     }
                 }
             }
@@ -490,7 +517,7 @@ struct SettingsView: View {
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Account", controlWidth: meetingControlWidth) {
-                    chatGPTAccountControl
+                    chatGPTAccountControl()
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Planner model", controlWidth: meetingControlWidth) {
@@ -572,7 +599,7 @@ struct SettingsView: View {
 
                 if appState.selectedMeetingSummaryBackend == .chatGPT {
                     settingsRow("Account", controlWidth: meetingControlWidth) {
-                        chatGPTAccountControl
+                        chatGPTAccountControl()
                     }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Model", controlWidth: meetingControlWidth) {
@@ -954,7 +981,7 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private var chatGPTAccountControl: some View {
+    private func chatGPTAccountControl(selectMeetingSummaryBackend: Bool = true) -> some View {
         if appState.isChatGPTAuthenticated {
             Button {
                 controller.signOutChatGPT()
@@ -989,7 +1016,9 @@ struct SettingsView: View {
                     isSigningInChatGPT = true
                     chatGPTSignInError = nil
                     Task {
-                        let error = await controller.signInWithChatGPT()
+                        let error = await controller.signInWithChatGPT(
+                            selectMeetingSummaryBackend: selectMeetingSummaryBackend
+                        )
                         isSigningInChatGPT = false
                         chatGPTSignInError = error
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupBackendOption.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupBackendOption.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct TranscriptCleanupBackendOption: Equatable {
+    let backend: String
+    let label: String
+
+    static let local = TranscriptCleanupBackendOption(
+        backend: "local",
+        label: "Local Model"
+    )
+
+    static let chatGPT = TranscriptCleanupBackendOption(
+        backend: "chatgpt",
+        label: "ChatGPT"
+    )
+
+    static let all: [TranscriptCleanupBackendOption] = [.local, .chatGPT]
+
+    static func resolved(_ backend: String?) -> TranscriptCleanupBackendOption {
+        guard let backend, let option = all.first(where: { $0.backend == backend }) else {
+            return .local
+        }
+        return option
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+enum TranscriptCleanupError: LocalizedError {
+    case rejectedOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .rejectedOutput:
+            return "Transcript cleanup output was rejected by safety checks."
+        }
+    }
+}
+
+struct TranscriptCleanupResult {
+    let rawOutput: String
+    let cleanedOutput: String
+}
+
+enum TranscriptCleanupClient {
+    static let defaultChatGPTModel = "gpt-5.4-mini"
+
+    static func resolvedChatGPTModel(_ configuredModel: String) -> String {
+        let trimmed = configuredModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultChatGPTModel : trimmed
+    }
+
+    static func cleanWithChatGPT(
+        text: String,
+        systemPrompt: String,
+        appContext: String?,
+        model: String
+    ) async throws -> TranscriptCleanupResult {
+        let raw = try await ChatGPTResponsesClient.respond(
+            systemPrompt: systemPrompt,
+            userPrompt: Qwen3PostProcessorConfig.formatInput(text, appContext: appContext),
+            model: resolvedChatGPTModel(model),
+            logCategory: "postproc"
+        )
+        let cleaned = cleanChatGPTOutput(raw)
+        let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty, Qwen3DeletionCueDetector.containsDeletionCue(text) {
+            return TranscriptCleanupResult(rawOutput: raw, cleanedOutput: trimmed)
+        }
+        if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: trimmed, input: text) {
+            throw TranscriptCleanupError.rejectedOutput
+        }
+        return TranscriptCleanupResult(rawOutput: raw, cleanedOutput: trimmed)
+    }
+
+    static func cleanChatGPTOutput(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+
+        var result = text
+        result = result.replacingOccurrences(
+            of: #"<think>[\s\S]*?</think>"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?is)<think\b[^>]*>[\s\S]*$"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"<\|im_(?:start|end)\|>"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"```[A-Za-z0-9_-]*\s*"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"```"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"^`+|`+$"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\[end of text\]"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?im)^\s*(?:[#>*-]+\s*)?(?:\*\*|__)?(?:transcription|cleaned transcription|output|response)(?:\*\*|__)?\s*:\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\r\n?"#,
+            with: "\n",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"[ \t]+([,.;:!?])"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"[ \t]{2,}"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?m)[ \t]+$"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"[ \t]*\n[ \t]*"#,
+            with: "\n",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\n{3,}"#,
+            with: "\n\n",
+            options: .regularExpression
+        )
+        return stripBalancedWrappingQuotes(result)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func stripBalancedWrappingQuotes(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pairs = [
+            ("\"", "\""),
+            ("\u{201C}", "\u{201D}"),
+        ]
+
+        for (open, close) in pairs where trimmed.hasPrefix(open) && trimmed.hasSuffix(close) {
+            let start = trimmed.index(trimmed.startIndex, offsetBy: open.count)
+            let end = trimmed.index(trimmed.endIndex, offsetBy: -close.count)
+            guard start < end else { return trimmed }
+            let body = String(trimmed[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return body.isEmpty ? trimmed : body
+        }
+
+        return trimmed
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -87,11 +87,6 @@ enum TranscriptCleanupClient {
             options: .regularExpression
         )
         result = result.replacingOccurrences(
-            of: #"(?im)^\s*(?:[#>*-]+\s*)?(?:\*\*|__)?(?:transcription|cleaned transcription|output|response)(?:\*\*|__)?\s*:\s*"#,
-            with: "",
-            options: .regularExpression
-        )
-        result = result.replacingOccurrences(
             of: #"\r\n?"#,
             with: "\n",
             options: .regularExpression

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+enum TranscriptCleanupDebugLogger {
+    private static let logEnv = "MUESLI_LOG_TRANSCRIPT_CLEANUP_DEBUG"
+
+    struct Entry: Encodable {
+        let ts: String
+        let status: String
+        let cleanupBackend: String
+        let cleanupModel: String
+        let asrBackend: String
+        let rawASRText: String
+        let rawCleanupOutputText: String?
+        let cleanupOutputText: String?
+        let errorDescription: String?
+        let elapsedMs: Double?
+    }
+
+    static func append(
+        status: String,
+        cleanupBackend: TranscriptCleanupBackendOption,
+        cleanupModel: String,
+        asrBackend: String,
+        rawASRText: String,
+        rawCleanupOutputText: String? = nil,
+        cleanupOutputText: String? = nil,
+        errorDescription: String? = nil,
+        elapsedMs: Double? = nil
+    ) {
+        guard isEnabled else { return }
+
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let entry = Entry(
+            ts: iso8601.string(from: Date()),
+            status: status,
+            cleanupBackend: cleanupBackend.backend,
+            cleanupModel: cleanupModel,
+            asrBackend: asrBackend,
+            rawASRText: rawASRText,
+            rawCleanupOutputText: rawCleanupOutputText,
+            cleanupOutputText: cleanupOutputText,
+            errorDescription: errorDescription,
+            elapsedMs: elapsedMs
+        )
+        append(entry, to: AppIdentity.supportDirectoryURL.appendingPathComponent("transcript-cleanup-debug.jsonl"))
+    }
+
+    private static var isEnabled: Bool {
+        let raw = ProcessInfo.processInfo.environment[logEnv]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "yes" || Qwen3PostProcessorLogging.isPairLoggingEnabled
+    }
+
+    private static func append(_ entry: Entry, to logURL: URL) {
+        guard var data = try? JSONEncoder().encode(entry) else { return }
+        data.append(0x0A)
+        try? FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: logURL.path) {
+            if let fh = try? FileHandle(forWritingTo: logURL) {
+                defer { try? fh.close() }
+                fh.seekToEndOfFile()
+                fh.write(data)
+            }
+        } else {
+            try? data.write(to: logURL, options: .atomic)
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -58,6 +58,8 @@ actor TranscriptionCoordinator {
     private var postProcessorModelURL: URL = PostProcessorOption.defaultOption.modelURL
     private var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     private var postProcessorModelId: String = PostProcessorOption.defaultOption.id
+    private var postProcessorBackend: TranscriptCleanupBackendOption = .local
+    private var postProcessorChatGPTModel: String = TranscriptCleanupClient.defaultChatGPTModel
 
     @available(macOS 15, *)
     private var qwen3PostProcessor: Qwen3PostProcessor {
@@ -72,11 +74,32 @@ actor TranscriptionCoordinator {
 
     @available(macOS 15, *)
     func setActivePostProcessor(option: PostProcessorOption, systemPrompt: String) async {
-        postProcessorModelURL = option.modelURL
+        await configurePostProcessor(
+            backend: .local,
+            option: option,
+            systemPrompt: systemPrompt,
+            chatGPTModel: postProcessorChatGPTModel
+        )
+    }
+
+    func configurePostProcessor(
+        backend: TranscriptCleanupBackendOption,
+        option: PostProcessorOption?,
+        systemPrompt: String,
+        chatGPTModel: String
+    ) async {
+        postProcessorBackend = backend
         postProcessorSystemPrompt = systemPrompt
-        postProcessorModelId = option.id
-        if let existing = _qwen3PostProcessor as? Qwen3PostProcessor {
-            await existing.reconfigure(modelURL: option.modelURL, systemPrompt: systemPrompt)
+        postProcessorChatGPTModel = TranscriptCleanupClient.resolvedChatGPTModel(chatGPTModel)
+
+        if let option {
+            postProcessorModelURL = option.modelURL
+            postProcessorModelId = option.id
+            if #available(macOS 15, *), let existing = _qwen3PostProcessor as? Qwen3PostProcessor {
+                await existing.reconfigure(modelURL: option.modelURL, systemPrompt: systemPrompt)
+            }
+        } else if backend == .chatGPT {
+            postProcessorModelId = postProcessorChatGPTModel
         }
     }
 
@@ -236,7 +259,7 @@ actor TranscriptionCoordinator {
     }
 
     func preloadPostProcessorIfNeeded(enabled: Bool) async {
-        if enabled, #available(macOS 15, *) {
+        if enabled, postProcessorBackend == .local, #available(macOS 15, *) {
             do {
                 try await qwen3PostProcessor.prepare()
             } catch {
@@ -389,9 +412,18 @@ actor TranscriptionCoordinator {
             return nil
         }
         guard !result.text.isEmpty else {
-            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor skipped: empty transcript")
+            Qwen3PostProcessorLogging.logVerbose("Post-processor skipped: empty transcript")
             return nil
         }
+
+        if postProcessorBackend == .chatGPT {
+            return await postProcessDictationWithChatGPT(
+                result,
+                backend: backend,
+                appContext: appContext
+            )
+        }
+
         guard #available(macOS 15, *) else {
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor skipped: requires macOS 15+")
             return nil
@@ -407,11 +439,31 @@ actor TranscriptionCoordinator {
             let trimmed = processed.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
                 Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
+                TranscriptCleanupDebugLogger.append(
+                    status: "fallback_empty_output",
+                    cleanupBackend: postProcessorBackend,
+                    cleanupModel: postProcessorModelId,
+                    asrBackend: backend.backend,
+                    rawASRText: result.text,
+                    rawCleanupOutputText: processed,
+                    cleanupOutputText: trimmed,
+                    elapsedMs: elapsedMs
+                )
                 return nil
             }
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor final output: \(trimmed)")
             logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
+            TranscriptCleanupDebugLogger.append(
+                status: "applied",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                rawCleanupOutputText: processed,
+                cleanupOutputText: trimmed,
+                elapsedMs: elapsedMs
+            )
             return SpeechTranscriptionResult(
                 text: trimmed,
                 // Original ASR segments describe pre-cleanup text. Keep them only for debug diagnostics.
@@ -419,6 +471,74 @@ actor TranscriptionCoordinator {
             )
         } catch {
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor failed, falling back: \(error)")
+            TranscriptCleanupDebugLogger.append(
+                status: "fallback_error",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                errorDescription: String(describing: error)
+            )
+            return nil
+        }
+    }
+
+    private func postProcessDictationWithChatGPT(
+        _ result: SpeechTranscriptionResult,
+        backend: BackendOption,
+        appContext: String?
+    ) async -> SpeechTranscriptionResult? {
+        do {
+            let start = CFAbsoluteTimeGetCurrent()
+            let cleanup = try await TranscriptCleanupClient.cleanWithChatGPT(
+                text: result.text,
+                systemPrompt: postProcessorSystemPrompt,
+                appContext: appContext,
+                model: postProcessorChatGPTModel
+            )
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            let trimmed = cleanup.cleanedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
+                Qwen3PostProcessorLogging.logVerbose("ChatGPT post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
+                TranscriptCleanupDebugLogger.append(
+                    status: "fallback_empty_output",
+                    cleanupBackend: postProcessorBackend,
+                    cleanupModel: postProcessorModelId,
+                    asrBackend: backend.backend,
+                    rawASRText: result.text,
+                    rawCleanupOutputText: cleanup.rawOutput,
+                    cleanupOutputText: trimmed,
+                    elapsedMs: elapsedMs
+                )
+                return nil
+            }
+            Qwen3PostProcessorLogging.logVerbose("ChatGPT post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
+            Qwen3PostProcessorLogging.logVerbose("ChatGPT post-processor final output: \(trimmed)")
+            logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
+            TranscriptCleanupDebugLogger.append(
+                status: "applied",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                rawCleanupOutputText: cleanup.rawOutput,
+                cleanupOutputText: trimmed,
+                elapsedMs: elapsedMs
+            )
+            return SpeechTranscriptionResult(
+                text: trimmed,
+                segments: Qwen3PostProcessorLogging.isVerboseEnabled && !trimmed.isEmpty ? result.segments : []
+            )
+        } catch {
+            Qwen3PostProcessorLogging.logVerbose("ChatGPT post-processor failed, falling back: \(error)")
+            TranscriptCleanupDebugLogger.append(
+                status: "fallback_error",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                errorDescription: String(describing: error)
+            )
             return nil
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -68,18 +68,24 @@ struct FloatingIndicatorVisibilityTests {
     func postProcessorRoundTrip() throws {
         var config = AppConfig()
         config.enablePostProcessor = true
+        config.postProcessorBackend = TranscriptCleanupBackendOption.chatGPT.backend
+        config.postProcessorChatGPTModel = "gpt-5.4"
         config.activePostProcessorId = PostProcessorOption.finetunedV2.id
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.enablePostProcessor == true)
+        #expect(decoded.postProcessorBackend == TranscriptCleanupBackendOption.chatGPT.backend)
+        #expect(decoded.postProcessorChatGPTModel == "gpt-5.4")
         #expect(decoded.activePostProcessorId == PostProcessorOption.finetunedV2.id)
     }
 
     @Test("post processor decodes from snake_case JSON")
     func postProcessorSnakeCaseDecode() throws {
-        let json = #"{"enable_post_processor": true}"#
+        let json = #"{"enable_post_processor": true, "post_processor_backend": "chatgpt", "post_processor_chatgpt_model": "gpt-5.4"}"#
         let config = try JSONDecoder().decode(AppConfig.self, from: json.data(using: .utf8)!)
         #expect(config.enablePostProcessor == true)
+        #expect(config.postProcessorBackend == TranscriptCleanupBackendOption.chatGPT.backend)
+        #expect(config.postProcessorChatGPTModel == "gpt-5.4")
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -321,4 +321,38 @@ struct Qwen3PostProcessingOutputCleanerTests {
             input: "um yeah"
         ))
     }
+
+    @Test("rejects placeholder ellipsis output")
+    func rejectsPlaceholderEllipsisOutput() {
+        #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: "...",
+            input: "Please clean this real dictation."
+        ))
+        #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: ". . .",
+            input: "Please clean this real dictation."
+        ))
+    }
+}
+
+@Suite("ChatGPT transcript cleanup output cleanup")
+struct ChatGPTTranscriptCleanupOutputCleanerTests {
+
+    @Test("strips one balanced wrapping quote pair")
+    func stripsBalancedWrappingQuotes() {
+        let raw = "\"Okay, so I'm Ayush.\\n\\nThis is the second paragraph.\""
+        #expect(
+            TranscriptCleanupClient.cleanChatGPTOutput(raw) ==
+                "Okay, so I'm Ayush.\n\nThis is the second paragraph."
+        )
+    }
+
+    @Test("preserves paragraph breaks while normalizing spacing")
+    func preservesParagraphBreaks() {
+        let raw = "Cleaned transcription: First sentence.  \\n\\n  Second sentence."
+        #expect(
+            TranscriptCleanupClient.cleanChatGPTOutput(raw) ==
+                "First sentence.\n\nSecond sentence."
+        )
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -340,7 +340,7 @@ struct ChatGPTTranscriptCleanupOutputCleanerTests {
 
     @Test("strips one balanced wrapping quote pair")
     func stripsBalancedWrappingQuotes() {
-        let raw = "\"Okay, so I'm Ayush.\\n\\nThis is the second paragraph.\""
+        let raw = "\"Okay, so I'm Ayush.\n\nThis is the second paragraph.\""
         #expect(
             TranscriptCleanupClient.cleanChatGPTOutput(raw) ==
                 "Okay, so I'm Ayush.\n\nThis is the second paragraph."
@@ -349,10 +349,53 @@ struct ChatGPTTranscriptCleanupOutputCleanerTests {
 
     @Test("preserves paragraph breaks while normalizing spacing")
     func preservesParagraphBreaks() {
-        let raw = "Cleaned transcription: First sentence.  \\n\\n  Second sentence."
+        let raw = "First sentence.  \n\n  Second sentence."
         #expect(
             TranscriptCleanupClient.cleanChatGPTOutput(raw) ==
                 "First sentence.\n\nSecond sentence."
         )
+    }
+
+    @Test("preserves dictated labels")
+    func preservesDictatedLabels() {
+        #expect(
+            TranscriptCleanupClient.cleanChatGPTOutput("Output: increase the volume") ==
+                "Output: increase the volume"
+        )
+        #expect(
+            TranscriptCleanupClient.cleanChatGPTOutput("- Response: approved") ==
+                "- Response: approved"
+        )
+    }
+}
+
+@Suite("ChatGPT WHAM response parsing")
+struct ChatGPTResponsesClientParsingTests {
+
+    @Test("extracts nested final response output text")
+    func extractsNestedFinalResponseOutputText() {
+        let payload: [String: Any] = [
+            "type": "response.completed",
+            "response": [
+                "output": [
+                    [
+                        "type": "message",
+                        "content": [
+                            [
+                                "type": "output_text",
+                                "text": "Final nested text.",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        #expect(ChatGPTResponsesClient.extractOutputText(from: payload) == "Final nested text.")
+    }
+
+    @Test("extracts top-level output text")
+    func extractsTopLevelOutputText() {
+        #expect(ChatGPTResponsesClient.extractOutputText(from: ["output_text": "Final text."]) == "Final text.")
     }
 }


### PR DESCRIPTION
## Summary

Adds a ChatGPT-backed option for AI transcript cleanup while keeping the existing local Qwen cleanup path available.

- Adds a shared `ChatGPTResponsesClient` for ChatGPT WHAM response streaming and reuses it for meeting summaries.
- Adds cleanup backend/model settings so transcript cleanup can use either local Qwen or the signed-in ChatGPT account.
- Updates runtime wiring so the selected cleanup backend is applied immediately before dictation cleanup, avoiding stale local-model state.
- Increases the local Qwen cleanup context limit to 8192 tokens and treats placeholder ellipsis output as a failed cleanup so dictation falls back instead of inserting `...`.
- Adds developer-only transcript cleanup JSONL diagnostics, gated behind `MUESLI_LOG_TRANSCRIPT_CLEANUP_DEBUG=1` or the existing pair-logging env, to capture raw ASR/model output without exposing it in UI.

## Root Cause

The local Qwen cleanup prompt could exceed the old 1024-token context window, causing low-quality placeholder output such as `...`. The app also only had local post-processing runtime state, so choosing a ChatGPT cleanup model needed explicit backend selection and runtime configuration rather than only changing a model string in settings.

## Validation

- `swift build --package-path native/MuesliNative -c debug --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/muesli-3535265428/pr-build" --product MuesliNativeApp` passes.
- `git diff --check` passes.
- `swift test --package-path native/MuesliNative ...` is blocked in this local environment because the Swift toolchain cannot import the `Testing` module (`error: no such module 'Testing'`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784552898&installation_id=136549638&pr_number=230&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F230&signature=ad5fc95df8952c435f9e66b455e3a30a0c1052b76af0d1cd6d22b35e813e9120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->