### PR TITLE
Fix dictation media pause follow-up

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MediaPlaybackController.swift
@@ -30,14 +30,22 @@ enum MediaPlaybackState: Equatable, CustomStringConvertible {
 protocol MediaPlaybackClient {
     /// Whether the current now-playing application is actually producing audio.
     /// `.unknown` is returned when the signal cannot be obtained.
-    func nowPlayingPlaybackState() -> MediaPlaybackState
+    func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void)
     func sendMediaPlayPauseToggle()
 }
 
 final class MediaPlaybackController: MediaPlaybackManaging {
+    private enum PauseState: Equatable {
+        case idle
+        case checkingBegin(Int)
+        case paused
+        case checkingRestore(Int)
+    }
+
     private let client: MediaPlaybackClient
     private let queue: DispatchQueue
-    private var pausedForSession = false
+    private var pauseState: PauseState = .idle
+    private var generation = 0
 
     init(
         client: MediaPlaybackClient = SystemMediaPlaybackClient(),
@@ -48,48 +56,86 @@ final class MediaPlaybackController: MediaPlaybackManaging {
     }
 
     func beginDictationMediaPause(enabled: Bool, routeKind: AudioOutputRouteKind) {
-        queue.sync { [self] in
+        queue.async { [self] in
             guard enabled else { return }
-            guard !pausedForSession else { return }
             guard routeKind == .speakerLike else { return }
-            // The media key is a blind global toggle: sending it to already-
-            // paused media would *start* playback. Only pause when we can
-            // positively confirm something is actually playing. IsRunningOutput
-            // cannot be used here because it stays true for paused media
-            // (browsers/video players keep their audio engine alive while
-            // paused), so an unknown state must also be a no-op.
-            guard client.nowPlayingPlaybackState() == .playing else { return }
-            client.sendMediaPlayPauseToggle()
-            pausedForSession = true
+            switch pauseState {
+            case .idle:
+                generation += 1
+                let token = generation
+                pauseState = .checkingBegin(token)
+                client.nowPlayingPlaybackState { [weak self] playbackState in
+                    self?.queue.async {
+                        self?.handleBeginPlaybackState(playbackState, token: token)
+                    }
+                }
+            case .checkingRestore:
+                // A new dictation began before the previous restore query
+                // completed. Keep the media paused and let this new session own
+                // the eventual restore instead of briefly resuming playback.
+                pauseState = .paused
+            case .checkingBegin, .paused:
+                return
+            }
         }
     }
 
     func restoreDictationMediaPause() {
         queue.async { [self] in
-            guard pausedForSession else { return }
-            pausedForSession = false
-            // We only paused media we confirmed was playing, so resume it. Do
-            // not gate on IsRunningOutput here: a paused video still reports
-            // its audio engine as running, which would block the resume and
-            // strand playback. Only skip the resume when something is actively
-            // playing again (the user resumed/started playback) so we do not
-            // pause it. When state is unknown, prefer restoring media we know
-            // Muesli paused over leaving playback stranded.
-            guard client.nowPlayingPlaybackState() != .playing else { return }
-            client.sendMediaPlayPauseToggle()
+            switch pauseState {
+            case .checkingBegin:
+                // The user released before we confirmed active playback. Cancel
+                // the pending pause so a late callback cannot start media.
+                pauseState = .idle
+            case .paused:
+                generation += 1
+                let token = generation
+                pauseState = .checkingRestore(token)
+                client.nowPlayingPlaybackState { [weak self] playbackState in
+                    self?.queue.async {
+                        self?.handleRestorePlaybackState(playbackState, token: token)
+                    }
+                }
+            case .idle, .checkingRestore:
+                return
+            }
         }
     }
 
     func waitForIdle() {
         queue.sync {}
+        queue.sync {}
+    }
+
+    private func handleBeginPlaybackState(_ playbackState: MediaPlaybackState, token: Int) {
+        guard pauseState == .checkingBegin(token) else { return }
+        // The media key is a blind global toggle: sending it to already-paused
+        // media would start playback. Only pause when we can positively confirm
+        // something is actually playing. Unknown is also a no-op.
+        guard playbackState == .playing else {
+            pauseState = .idle
+            return
+        }
+        client.sendMediaPlayPauseToggle()
+        pauseState = .paused
+    }
+
+    private func handleRestorePlaybackState(_ playbackState: MediaPlaybackState, token: Int) {
+        guard pauseState == .checkingRestore(token) else { return }
+        pauseState = .idle
+        // We only paused media we confirmed was playing, so resume it unless
+        // something is actively playing again. Unknown still restores to avoid
+        // leaving media stranded after Muesli paused it.
+        guard playbackState != .playing else { return }
+        client.sendMediaPlayPauseToggle()
     }
 }
 
 final class SystemMediaPlaybackClient: MediaPlaybackClient {
     private let nowPlaying = NowPlayingMediaRemoteClient()
 
-    func nowPlayingPlaybackState() -> MediaPlaybackState {
-        nowPlaying.playbackState()
+    func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void) {
+        nowPlaying.playbackState(completion: completion)
     }
 
     func sendMediaPlayPauseToggle() {
@@ -124,17 +170,16 @@ final class SystemMediaPlaybackClient: MediaPlaybackClient {
 /// playing — the signal that `kAudioProcessPropertyIsRunningOutput` cannot
 /// provide (an app's audio engine stays running while media is paused).
 ///
-/// The query is asynchronous (MediaRemote delivers the result on a dispatch
-/// queue), so it is turned into a synchronous call with a short timeout. The
-/// private symbols have been stable across macOS releases for many years; if
-/// the framework or symbol is unavailable we conservatively report `.unknown`
-/// and the caller treats that as "do not toggle".
+/// MediaRemote replies asynchronously. Results are delivered through
+/// `DispatchQueue.main` because the XPC-backed callback path is more reliable
+/// on a queue with a run loop, and timeout fallback is also asynchronous so
+/// dictation start is never blocked on media state detection.
 private final class NowPlayingMediaRemoteClient {
     private typealias MRNowPlayingIsPlayingHandler = @convention(block) (Bool) -> Void
     private typealias MRGetNowPlayingIsPlayingFn =
         @convention(c) (DispatchQueue, MRNowPlayingIsPlayingHandler) -> Void
 
-    private let callbackQueue = DispatchQueue(label: "com.muesli.media-playback.now-playing")
+    private let timeoutQueue = DispatchQueue(label: "com.muesli.media-playback.now-playing-timeout")
     private let queryTimeout: DispatchTimeInterval
     private let isPlayingFn: MRGetNowPlayingIsPlayingFn?
 
@@ -153,20 +198,29 @@ private final class NowPlayingMediaRemoteClient {
         self.isPlayingFn = unsafeBitCast(symbol, to: MRGetNowPlayingIsPlayingFn.self)
     }
 
-    func playbackState() -> MediaPlaybackState {
-        guard let isPlayingFn else { return .unknown }
-        let semaphore = DispatchSemaphore(value: 0)
-        var didCall = false
-        var isPlaying = false
+    func playbackState(completion: @escaping (MediaPlaybackState) -> Void) {
+        guard let isPlayingFn else {
+            completion(.unknown)
+            return
+        }
+        let lock = NSLock()
+        var completed = false
+        let finish: (MediaPlaybackState) -> Void = { state in
+            lock.lock()
+            guard !completed else {
+                lock.unlock()
+                return
+            }
+            completed = true
+            lock.unlock()
+            completion(state)
+        }
         let handler: MRNowPlayingIsPlayingHandler = { value in
-            isPlaying = value
-            didCall = true
-            semaphore.signal()
+            finish(value ? .playing : .notPlaying)
         }
-        isPlayingFn(callbackQueue, handler)
-        if semaphore.wait(timeout: .now() + queryTimeout) == .timedOut {
-            return .unknown
+        isPlayingFn(DispatchQueue.main, handler)
+        timeoutQueue.asyncAfter(deadline: .now() + queryTimeout) {
+            finish(.unknown)
         }
-        return didCall ? (isPlaying ? .playing : .notPlaying) : .unknown
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MediaPlaybackControllerTests.swift
@@ -76,6 +76,45 @@ struct MediaPlaybackControllerTests {
         #expect(client.toggleCalls == 2)
     }
 
+    @Test("begin does not block while playback state is pending")
+    func beginDoesNotBlockWhilePlaybackStateIsPending() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing, completesImmediately: false)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+
+        #expect(client.pendingQueryCount == 1)
+        #expect(client.toggleCalls == 0)
+
+        client.completeNext(with: .playing)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 1)
+    }
+
+    @Test("restore does not block while playback state is pending")
+    func restoreDoesNotBlockWhilePlaybackStateIsPending() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.toggleCalls == 1)
+
+        client.completesImmediately = false
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        #expect(client.pendingQueryCount == 1)
+        #expect(client.toggleCalls == 1)
+
+        client.completeNext(with: .notPlaying)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 2)
+    }
+
     @Test("restore does not toggle if user already resumed playback")
     func restoreDoesNotToggleResumedPlayback() {
         let client = FakeMediaPlaybackClient(playbackState: .playing)
@@ -105,6 +144,53 @@ struct MediaPlaybackControllerTests {
         #expect(client.toggleCalls == 2)
     }
 
+    @Test("release before playback query completes does not toggle")
+    func releaseBeforePlaybackQueryCompletesDoesNotToggle() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing, completesImmediately: false)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+
+        client.completeNext(with: .playing)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 0)
+    }
+
+    @Test("new begin during restore keeps media paused for next session")
+    func newBeginDuringRestoreKeepsMediaPausedForNextSession() {
+        let client = FakeMediaPlaybackClient(playbackState: .playing)
+        let controller = makeController(client: client)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+        #expect(client.toggleCalls == 1)
+
+        client.completesImmediately = false
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+        #expect(client.pendingQueryCount == 1)
+
+        controller.beginDictationMediaPause(enabled: true, routeKind: .speakerLike)
+        controller.waitForIdle()
+
+        client.completeNext(with: .notPlaying)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 1)
+
+        controller.restoreDictationMediaPause()
+        controller.waitForIdle()
+        #expect(client.pendingQueryCount == 1)
+
+        client.completeNext(with: .notPlaying)
+        controller.waitForIdle()
+
+        #expect(client.toggleCalls == 2)
+    }
+
     @Test("duplicate begin only pauses once")
     func duplicateBeginOnlyPausesOnce() {
         let client = FakeMediaPlaybackClient(playbackState: .playing)
@@ -127,17 +213,33 @@ struct MediaPlaybackControllerTests {
 
 private final class FakeMediaPlaybackClient: MediaPlaybackClient {
     var playbackState: MediaPlaybackState
+    var completesImmediately: Bool
     var toggleCalls = 0
+    private var pendingCompletions: [(MediaPlaybackState) -> Void] = []
 
-    init(playbackState: MediaPlaybackState) {
+    init(playbackState: MediaPlaybackState, completesImmediately: Bool = true) {
         self.playbackState = playbackState
+        self.completesImmediately = completesImmediately
     }
 
-    func nowPlayingPlaybackState() -> MediaPlaybackState {
-        playbackState
+    var pendingQueryCount: Int {
+        pendingCompletions.count
+    }
+
+    func nowPlayingPlaybackState(completion: @escaping (MediaPlaybackState) -> Void) {
+        guard completesImmediately else {
+            pendingCompletions.append(completion)
+            return
+        }
+        completion(playbackState)
     }
 
     func sendMediaPlayPauseToggle() {
         toggleCalls += 1
+    }
+
+    func completeNext(with playbackState: MediaPlaybackState) {
+        let completion = pendingCompletions.removeFirst()
+        completion(playbackState)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the accidentally merged #227 for #225.

This keeps the correct behavior from #227: the dictation media-pause feature only sends the blind play/pause media key when MediaRemote positively reports that now-playing media is `.playing`. Already-paused media (`.notPlaying`) and unknown state remain no-ops on press, so paused media is not started by dictation.

This PR addresses the review concerns that made #227 feel WIP:

- removes the synchronous semaphore wait around MediaRemote playback-state lookup
- makes `beginDictationMediaPause` and restore handling non-blocking for dictation startup and rapid re-dictation
- delivers MediaRemote callbacks through `DispatchQueue.main` instead of a plain serial queue
- replaces the old `pausedForSession` boolean with a generation-guarded state machine so late callbacks cannot toggle media after release or after a new dictation begins
- removes the dead `didCall` path by removing the sync bridge entirely

## PR state guidance

- #226 is a duplicate of the already-merged #227 patch and can be closed after this follow-up lands.
- #231 should not be merged as-is because it restores the CoreAudio `IsRunningOutput` behavior that caused #225.

Fixes #225.

## Tests

```bash
swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-media-pause-followup" --filter MediaPlaybackControllerTests
```

Passed: 12 tests.

```bash
swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-media-pause-followup" --filter 'MediaPlaybackControllerTests|DictationAudioSessionManagerTests|AudioDuckingControllerTests'
```

Passed: 58 tests across 3 suites.

Existing unrelated warnings appeared from files such as `GoogleCalendarAuthManager.swift` and `ScreenContextCapture.swift`; no errors from this change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784575201&installation_id=136549638&pr_number=232&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F232&signature=f201009cf8d63013d46b9497f7d30660a86a37d743291529766a24799a5d0dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->