### PR TITLE
Add iPhone sync onboarding handoff

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -106,6 +106,19 @@ final class AppState {
     var iCloudBridgeMessage: String?
     var iCloudBridgeRemoteDeviceName: String?
     var iCloudBridgeRemoteDevicePlatform: String?
+    var iCloudBridgeCompanionDeviceName: String? {
+        guard isICloudBridgeCompanionPlatform else { return nil }
+        return iCloudBridgeRemoteDeviceName
+    }
+    var isICloudBridgeCompanionPlatform: Bool {
+        guard let platform = iCloudBridgeRemoteDevicePlatform else { return false }
+        switch platform.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "ios", "ipados":
+            return true
+        default:
+            return false
+        }
+    }
     var iCloudLastSyncSummary: String?
     var iCloudLastSyncedAt: Date?
     var contributionMilestonePrompt: ContributionMilestonePrompt?

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -104,6 +104,9 @@ final class AppState {
     var isICloudBridgeActivationPending: Bool = false
     var iCloudBridgeState: ICloudBridgeState = .notConfigured
     var iCloudBridgeMessage: String?
+    var iCloudBridgeLocalDeviceName: String?
+    var iCloudBridgeRemoteDeviceName: String?
+    var iCloudBridgeRemoteDevicePlatform: String?
     var iCloudLastSyncSummary: String?
     var iCloudLastSyncedAt: Date?
     var modelPreparationTitle: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -104,7 +104,6 @@ final class AppState {
     var isICloudBridgeActivationPending: Bool = false
     var iCloudBridgeState: ICloudBridgeState = .notConfigured
     var iCloudBridgeMessage: String?
-    var iCloudBridgeLocalDeviceName: String?
     var iCloudBridgeRemoteDeviceName: String?
     var iCloudBridgeRemoteDevicePlatform: String?
     var iCloudLastSyncSummary: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -199,7 +199,6 @@ struct DictationsView: View {
                 isAnimating: bridgeSyncIconIsAnimating,
                 font: .system(size: 18, weight: .semibold)
             )
-                .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(bridgeIconColor)
                 .frame(width: 28)
 
@@ -285,7 +284,9 @@ struct DictationsView: View {
         switch bridgeState {
         case .notConfigured, .needsICloud, .error:
             return true
-        case .checkingICloud, .syncing, .active:
+        case .active:
+            return appState.iCloudBridgeRemoteDeviceName == nil
+        case .checkingICloud, .syncing:
             return false
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -180,6 +180,12 @@ struct DictationsView: View {
                 }
             }
         }
+        .sheet(isPresented: $isBridgeQRCodePresented) {
+            IPhoneBridgeQRCodeSheet(
+                deepLinkURL: IPhoneBridgeLinks.iOSSyncDeepLinkURL,
+                installURL: IPhoneBridgeLinks.installURL
+            )
+        }
     }
 
     private var bridgeState: ICloudBridgeState {
@@ -271,12 +277,6 @@ struct DictationsView: View {
             guard !bridgePromptSeen else { return }
             bridgePromptSeen = true
             TelemetryDeck.signal("bridge_prompt_seen", parameters: ["platform": "macos"])
-        }
-        .sheet(isPresented: $isBridgeQRCodePresented) {
-            IPhoneBridgeQRCodeSheet(
-                deepLinkURL: IPhoneBridgeLinks.iOSSyncDeepLinkURL,
-                installURL: IPhoneBridgeLinks.installURL
-            )
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -283,7 +283,7 @@ struct DictationsView: View {
         guard appState.config.iCloudSyncEnabled else { return false }
         switch bridgeState {
         case .needsICloud, .error:
-            return true
+            return false
         case .active:
             return appState.iCloudBridgeRemoteDeviceName == nil
         case .notConfigured, .checkingICloud, .syncing:

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -285,7 +285,7 @@ struct DictationsView: View {
         case .needsICloud, .error:
             return false
         case .active:
-            return appState.iCloudBridgeRemoteDeviceName == nil
+            return appState.iCloudBridgeCompanionDeviceName == nil
         case .notConfigured, .checkingICloud, .syncing:
             return false
         }
@@ -330,7 +330,7 @@ struct DictationsView: View {
     private var bridgeTitle: String {
         switch bridgeState {
         case .active:
-            guard let deviceName = appState.iCloudBridgeRemoteDeviceName else {
+            guard let deviceName = appState.iCloudBridgeCompanionDeviceName else {
                 if let lastSyncedAt = appState.iCloudLastSyncedAt {
                     return "iCloud sync active · \(relativeSyncTime(lastSyncedAt))"
                 }
@@ -354,7 +354,7 @@ struct DictationsView: View {
     private var bridgeSubtitle: String {
         switch bridgeState {
         case .active:
-            if let deviceName = appState.iCloudBridgeRemoteDeviceName {
+            if let deviceName = appState.iCloudBridgeCompanionDeviceName {
                 return "Private iCloud text sync is on with \(deviceName). Audio stays local."
             }
             return "Scan the QR code to connect your iPhone. Audio stays local."

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -345,7 +345,7 @@ struct DictationsView: View {
             if let deviceName = appState.iCloudBridgeRemoteDeviceName {
                 return "Private iCloud text sync is on with \(deviceName). Audio stays local."
             }
-            return "Private iCloud text sync is on. Scan the QR to finish setup on iPhone. Audio stays local."
+            return "Private iCloud text sync is on. Audio stays local."
         case .checkingICloud:
             return "Checking this Mac's iCloud account..."
         case .syncing:
@@ -608,6 +608,7 @@ private struct IPhoneBridgeQRCodeSheet: View {
     let deepLinkURL: URL
     let installURL: URL
     @Environment(\.dismiss) private var dismiss
+    @State private var didCopySetupLink = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
@@ -659,9 +660,13 @@ private struct IPhoneBridgeQRCodeSheet: View {
                 }
                 .buttonStyle(.bordered)
 
-                Button("Copy setup link") {
+                Button(didCopySetupLink ? "Copied!" : "Copy setup link") {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(deepLinkURL.absoluteString, forType: .string)
+                    didCopySetupLink = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        didCopySetupLink = false
+                    }
                 }
                 .buttonStyle(.bordered)
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -323,10 +323,11 @@ struct DictationsView: View {
     private var bridgeTitle: String {
         switch bridgeState {
         case .active:
+            let deviceName = appState.iCloudBridgeRemoteDeviceName ?? "iPhone"
             if let lastSyncedAt = appState.iCloudLastSyncedAt {
-                return "Synced with iPhone · \(relativeSyncTime(lastSyncedAt))"
+                return "Synced with \(deviceName) · \(relativeSyncTime(lastSyncedAt))"
             }
-            return "Synced with iPhone"
+            return "Synced with \(deviceName)"
         case .checkingICloud, .syncing:
             return "Setting up private iCloud sync"
         case .needsICloud:
@@ -341,6 +342,9 @@ struct DictationsView: View {
     private var bridgeSubtitle: String {
         switch bridgeState {
         case .active:
+            if let deviceName = appState.iCloudBridgeRemoteDeviceName {
+                return "Private iCloud text sync is on with \(deviceName). Audio stays local."
+            }
             return "Private iCloud text sync is on. Scan the QR to finish setup on iPhone. Audio stays local."
         case .checkingICloud:
             return "Checking this Mac's iCloud account..."

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -676,7 +676,8 @@ private struct IPhoneBridgeQRCodeSheet: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(deepLinkURL.absoluteString, forType: .string)
                     didCopySetupLink = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(1500))
                         didCopySetupLink = false
                     }
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -282,11 +282,11 @@ struct DictationsView: View {
     private var shouldShowBridgeHandoffButton: Bool {
         guard appState.config.iCloudSyncEnabled else { return false }
         switch bridgeState {
-        case .notConfigured, .needsICloud, .error:
+        case .needsICloud, .error:
             return true
         case .active:
             return appState.iCloudBridgeRemoteDeviceName == nil
-        case .checkingICloud, .syncing:
+        case .notConfigured, .checkingICloud, .syncing:
             return false
         }
     }
@@ -330,7 +330,12 @@ struct DictationsView: View {
     private var bridgeTitle: String {
         switch bridgeState {
         case .active:
-            let deviceName = appState.iCloudBridgeRemoteDeviceName ?? "iPhone"
+            guard let deviceName = appState.iCloudBridgeRemoteDeviceName else {
+                if let lastSyncedAt = appState.iCloudLastSyncedAt {
+                    return "iCloud sync active · \(relativeSyncTime(lastSyncedAt))"
+                }
+                return "iCloud sync active"
+            }
             if let lastSyncedAt = appState.iCloudLastSyncedAt {
                 return "Synced with \(deviceName) · \(relativeSyncTime(lastSyncedAt))"
             }
@@ -352,7 +357,7 @@ struct DictationsView: View {
             if let deviceName = appState.iCloudBridgeRemoteDeviceName {
                 return "Private iCloud text sync is on with \(deviceName). Audio stays local."
             }
-            return "Private iCloud text sync is on. Audio stays local."
+            return "Scan the QR code to connect your iPhone. Audio stays local."
         case .checkingICloud:
             return "Checking this Mac's iCloud account..."
         case .syncing:

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreImage.CIFilterBuiltins
 import SwiftUI
 import TelemetryDeck
 import MuesliCore
@@ -23,6 +24,7 @@ struct DictationsView: View {
     let controller: MuesliController
     @State private var selectedFilter: DictationFilter = .all
     @State private var bridgePromptSeen = false
+    @State private var isBridgeQRCodePresented = false
 
     private var groupedDictations: [(header: String, records: [DictationRecord])] {
         let calendar = Calendar.current
@@ -207,6 +209,22 @@ struct DictationsView: View {
 
             Spacer(minLength: MuesliTheme.spacing12)
 
+            if shouldShowBridgeHandoffButton {
+                Button {
+                    isBridgeQRCodePresented = true
+                    TelemetryDeck.signal("bridge_qr_shown", parameters: ["platform": "macos"])
+                } label: {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+                .help("Show iPhone setup QR")
+            }
+
             Button {
                 bridgePrimaryAction()
             } label: {
@@ -254,6 +272,16 @@ struct DictationsView: View {
             bridgePromptSeen = true
             TelemetryDeck.signal("bridge_prompt_seen", parameters: ["platform": "macos"])
         }
+        .sheet(isPresented: $isBridgeQRCodePresented) {
+            IPhoneBridgeQRCodeSheet(
+                deepLinkURL: IPhoneBridgeLinks.iOSSyncDeepLinkURL,
+                installURL: IPhoneBridgeLinks.installURL
+            )
+        }
+    }
+
+    private var shouldShowBridgeHandoffButton: Bool {
+        appState.config.iCloudSyncEnabled && bridgeState != .checkingICloud && bridgeState != .syncing
     }
 
     private var bridgeSyncIconIsAnimating: Bool {
@@ -295,6 +323,9 @@ struct DictationsView: View {
     private var bridgeTitle: String {
         switch bridgeState {
         case .active:
+            if let lastSyncedAt = appState.iCloudLastSyncedAt {
+                return "Synced with iPhone · \(relativeSyncTime(lastSyncedAt))"
+            }
             return "Synced with iPhone"
         case .checkingICloud, .syncing:
             return "Setting up private iCloud sync"
@@ -310,10 +341,7 @@ struct DictationsView: View {
     private var bridgeSubtitle: String {
         switch bridgeState {
         case .active:
-            if let lastSyncedAt = appState.iCloudLastSyncedAt {
-                return "Private text sync is on · \(relativeSyncTime(lastSyncedAt))"
-            }
-            return "Private iCloud text sync is on. Audio stays local."
+            return "Private iCloud text sync is on. Scan the QR to finish setup on iPhone. Audio stays local."
         case .checkingICloud:
             return "Checking this Mac's iCloud account..."
         case .syncing:
@@ -569,6 +597,109 @@ private struct BridgeSyncIcon: View {
         withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
             rotationDegrees = 360
         }
+    }
+}
+
+private struct IPhoneBridgeQRCodeSheet: View {
+    let deepLinkURL: URL
+    let installURL: URL
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text("Open Muesli on iPhone")
+                        .font(MuesliTheme.title3())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Scan this after installing the iPhone app. The QR only opens setup; private iCloud does the actual sync.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
+                QRCodeImage(payload: deepLinkURL.absoluteString)
+                    .frame(width: 148, height: 148)
+                    .padding(MuesliTheme.spacing8)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                    Label("Same iCloud account", systemImage: "icloud")
+                    Label("Text sync only", systemImage: "text.badge.checkmark")
+                    Label("Audio stays local", systemImage: "lock")
+                }
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            }
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                Button("Open iPhone app page") {
+                    NSWorkspace.shared.open(installURL)
+                }
+                .buttonStyle(.bordered)
+
+                Button("Copy setup link") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(deepLinkURL.absoluteString, forType: .string)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(MuesliTheme.spacing20)
+        .frame(width: 430)
+        .background(MuesliTheme.backgroundBase)
+    }
+}
+
+private struct QRCodeImage: View {
+    let payload: String
+
+    var body: some View {
+        Group {
+            if let image = makeQRCodeImage(payload: payload) {
+                Image(nsImage: image)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(systemName: "qrcode")
+                    .font(.system(size: 96, weight: .regular))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+        }
+        .accessibilityLabel("iPhone sync setup QR code")
+    }
+
+    private func makeQRCodeImage(payload: String) -> NSImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(payload.utf8)
+        filter.correctionLevel = "M"
+
+        guard let outputImage = filter.outputImage?.transformed(by: CGAffineTransform(scaleX: 8, y: 8)) else {
+            return nil
+        }
+
+        let representation = NSCIImageRep(ciImage: outputImage)
+        let image = NSImage(size: representation.size)
+        image.addRepresentation(representation)
+        return image
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -691,10 +691,11 @@ private struct IPhoneBridgeQRCodeSheet: View {
 
 private struct QRCodeImage: View {
     let payload: String
+    @State private var cachedImage: NSImage?
 
     var body: some View {
         Group {
-            if let image = makeQRCodeImage(payload: payload) {
+            if let image = cachedImage {
                 Image(nsImage: image)
                     .interpolation(.none)
                     .resizable()
@@ -706,6 +707,11 @@ private struct QRCodeImage: View {
             }
         }
         .accessibilityLabel("iPhone sync setup QR code")
+        .onAppear {
+            if cachedImage == nil {
+                cachedImage = makeQRCodeImage(payload: payload)
+            }
+        }
     }
 
     private func makeQRCodeImage(payload: String) -> NSImage? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -281,7 +281,13 @@ struct DictationsView: View {
     }
 
     private var shouldShowBridgeHandoffButton: Bool {
-        appState.config.iCloudSyncEnabled && bridgeState != .checkingICloud && bridgeState != .syncing
+        guard appState.config.iCloudSyncEnabled else { return false }
+        switch bridgeState {
+        case .notConfigured, .needsICloud, .error:
+            return true
+        case .checkingICloud, .syncing, .active:
+            return false
+        }
     }
 
     private var bridgeSyncIconIsAnimating: Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/IPhoneBridgeLinks.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/IPhoneBridgeLinks.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum IPhoneBridgeLinks {
+    static let iOSSyncDeepLinkURL = URL(string: "muesli://sync?source=mac_bridge")!
+    static let installURL = URL(string: "https://github.com/Muesli-HQ/muesli-ios")!
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -728,6 +728,11 @@ final class MuesliController: NSObject {
         syncAppState()
     }
 
+    private func refreshICloudBridgeDeviceState() {
+        appState.iCloudBridgeRemoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName
+        appState.iCloudBridgeRemoteDevicePlatform = MuesliBridgeDeviceIdentity.remoteDevicePlatform
+    }
+
     func syncAppState() {
         let rows = (try? dictationStore.recentDictations(
             limit: appState.dictationPageSize,
@@ -778,8 +783,7 @@ final class MuesliController: NSObject {
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
         appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
-        appState.iCloudBridgeRemoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName
-        appState.iCloudBridgeRemoteDevicePlatform = MuesliBridgeDeviceIdentity.remoteDevicePlatform
+        refreshICloudBridgeDeviceState()
         refreshICloudBridgeStateForConfig()
         // Keep appState in sync with persisted hidden event IDs
         let persisted = Set(config.hiddenCalendarEventIDs)
@@ -1298,6 +1302,7 @@ final class MuesliController: NSObject {
                     self.iCloudSyncTask = nil
                     self.appState.isICloudSyncInProgress = false
                     let summary = self.formatICloudSyncSummary(result)
+                    self.refreshICloudBridgeDeviceState()
                     let remoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName ?? "iPhone"
                     self.appState.iCloudSyncStatus = result.downloaded.total > 0
                         ? "Synced with \(remoteDeviceName)."

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1265,8 +1265,9 @@ final class MuesliController: NSObject {
                     self.iCloudSyncTask = nil
                     self.appState.isICloudSyncInProgress = false
                     let summary = self.formatICloudSyncSummary(result)
+                    let remoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName ?? "iPhone"
                     self.appState.iCloudSyncStatus = result.downloaded.total > 0
-                        ? "Synced with iPhone."
+                        ? "Synced with \(remoteDeviceName)."
                         : "All text is up to date."
                     self.appState.iCloudBridgeState = .active
                     self.appState.iCloudBridgeMessage = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -757,6 +757,9 @@ final class MuesliController: NSObject {
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
         appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
+        appState.iCloudBridgeLocalDeviceName = MuesliBridgeDeviceIdentity.localDeviceDisplayName
+        appState.iCloudBridgeRemoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName
+        appState.iCloudBridgeRemoteDevicePlatform = MuesliBridgeDeviceIdentity.remoteDevicePlatform
         refreshICloudBridgeStateForConfig()
         // Keep appState in sync with persisted hidden event IDs
         let persisted = Set(config.hiddenCalendarEventIDs)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1237,13 +1237,7 @@ final class MuesliController: NSObject {
         }
     }
 
-    private func startICloudSync(
-        userInitiated: Bool,
-        bridgeDiscoveryTriggered: Bool = false
-    ) {
-        if bridgeDiscoveryTriggered {
-            bridgeDiscoveryPending = true
-        }
+    private func startICloudSync(userInitiated: Bool) {
         guard config.iCloudSyncEnabled else {
             if userInitiated {
                 appState.iCloudSyncStatus = "Turn on iCloud sync first."

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -317,6 +317,7 @@ final class MuesliController: NSObject {
     private var hasEnsuredICloudSubscription = false
     private var bridgeActivationPending = false
     private var bridgeDiscoveryPending = false
+    private var bridgeDiscoveryFollowUpPending = false
     private var hasStarted = false
 
     init(
@@ -1255,7 +1256,7 @@ final class MuesliController: NSObject {
                 appState.iCloudSyncStatus = "Sync already in progress."
             }
             if bridgeDiscoveryPending {
-                scheduleICloudSync(delay: 1.0, userInitiated: false)
+                bridgeDiscoveryFollowUpPending = true
             }
             return
         }
@@ -1321,8 +1322,14 @@ final class MuesliController: NSObject {
                         self.ensureICloudSubscription()
                     }
                     self.refreshUI()
-                    if result.hasPendingUploads {
-                        self.scheduleICloudSync(delay: 0.2, userInitiated: false)
+                    let shouldRunBridgeDiscoveryFollowUp = self.bridgeDiscoveryFollowUpPending
+                    self.bridgeDiscoveryFollowUpPending = false
+                    if result.hasPendingUploads || shouldRunBridgeDiscoveryFollowUp {
+                        self.scheduleICloudSync(
+                            delay: 0.2,
+                            userInitiated: false,
+                            bridgeDiscoveryTriggered: shouldRunBridgeDiscoveryFollowUp
+                        )
                     }
                 }
             } catch is CancellationError {
@@ -1330,6 +1337,7 @@ final class MuesliController: NSObject {
                     guard let self, self.iCloudSyncGeneration == generation else { return }
                     self.iCloudSyncTask = nil
                     self.appState.isICloudSyncInProgress = false
+                    self.bridgeDiscoveryFollowUpPending = false
                     if self.bridgeActivationPending {
                         self.bridgeActivationPending = false
                         self.appState.isICloudBridgeActivationPending = false
@@ -1341,6 +1349,7 @@ final class MuesliController: NSObject {
                     guard let self, self.iCloudSyncGeneration == generation else { return }
                     self.iCloudSyncTask = nil
                     self.appState.isICloudSyncInProgress = false
+                    self.bridgeDiscoveryFollowUpPending = false
                     let message = error.localizedDescription
                     self.appState.iCloudSyncStatus = "Sync failed: \(message)"
                     if MuesliICloudSyncEngine.isICloudAccountAvailabilityError(error) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1254,6 +1254,9 @@ final class MuesliController: NSObject {
             if userInitiated {
                 appState.iCloudSyncStatus = "Sync already in progress."
             }
+            if bridgeDiscoveryPending {
+                scheduleICloudSync(delay: 1.0, userInitiated: false)
+            }
             return
         }
         if userInitiated {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1244,12 +1244,14 @@ final class MuesliController: NSObject {
         let store = dictationStore
         iCloudSyncGeneration += 1
         let generation = iCloudSyncGeneration
+        let bridgeActivationPendingAtStart = bridgeActivationPending
+        let hasKnownRemoteDeviceAtStart = MuesliBridgeDeviceIdentity.hasRemoteDevice()
         iCloudSyncTask = Task { [weak self] in
             do {
                 let forceBridgeDeviceRefresh = MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
                     userInitiated: userInitiated,
-                    bridgeActivationPending: self?.bridgeActivationPending == true,
-                    hasKnownRemoteDevice: MuesliBridgeDeviceIdentity.hasRemoteDevice()
+                    bridgeActivationPending: bridgeActivationPendingAtStart,
+                    hasKnownRemoteDevice: hasKnownRemoteDeviceAtStart
                 )
                 let result = try await MuesliICloudSyncEngine().sync(
                     store: store,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1376,10 +1376,7 @@ final class MuesliController: NSObject {
         iCloudSyncTask?.cancel()
         iCloudSyncTask = nil
         appState.isICloudSyncInProgress = false
-        if bridgeActivationPending {
-            bridgeActivationPending = false
-            appState.isICloudBridgeActivationPending = false
-        }
+        resetBridgeDiscoveryRuntimeState()
         refreshICloudBridgeStateForConfig()
     }
 
@@ -1390,11 +1387,17 @@ final class MuesliController: NSObject {
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
         resetICloudSubscriptionState()
-        bridgeActivationPending = false
-        appState.isICloudBridgeActivationPending = false
+        resetBridgeDiscoveryRuntimeState()
         appState.iCloudSyncStatus = "iCloud sync is off."
         appState.iCloudBridgeState = .notConfigured
         appState.iCloudBridgeMessage = nil
+    }
+
+    private func resetBridgeDiscoveryRuntimeState() {
+        bridgeActivationPending = false
+        bridgeDiscoveryPending = false
+        bridgeDiscoveryFollowUpPending = false
+        appState.isICloudBridgeActivationPending = false
     }
 
     private func resetICloudSubscriptionState() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -83,9 +83,12 @@ enum MuesliBridgeDeviceRefreshPolicy {
     static func shouldForceRefresh(
         userInitiated: Bool,
         bridgeActivationPending: Bool,
+        bridgeDiscoveryTriggered: Bool,
         hasKnownRemoteDevice: Bool
     ) -> Bool {
-        userInitiated || bridgeActivationPending || !hasKnownRemoteDevice
+        userInitiated
+            || bridgeActivationPending
+            || (bridgeDiscoveryTriggered && !hasKnownRemoteDevice)
     }
 }
 
@@ -1147,7 +1150,11 @@ final class MuesliController: NSObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.scheduleICloudSync(delay: 0.5, userInitiated: false)
+                self?.scheduleICloudSync(
+                    delay: 0.5,
+                    userInitiated: false,
+                    bridgeDiscoveryTriggered: true
+                )
             }
         }
         iCloudWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
@@ -1156,7 +1163,11 @@ final class MuesliController: NSObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.scheduleICloudSync(delay: 0.5, userInitiated: false)
+                self?.scheduleICloudSync(
+                    delay: 0.5,
+                    userInitiated: false,
+                    bridgeDiscoveryTriggered: true
+                )
             }
         }
     }
@@ -1197,7 +1208,11 @@ final class MuesliController: NSObject {
         scheduleICloudSync(delay: 2.0, userInitiated: false)
     }
 
-    private func scheduleICloudSync(delay: TimeInterval, userInitiated: Bool) {
+    private func scheduleICloudSync(
+        delay: TimeInterval,
+        userInitiated: Bool,
+        bridgeDiscoveryTriggered: Bool = false
+    ) {
         guard config.iCloudSyncEnabled else { return }
         enableICloudPersistentSync()
         iCloudSyncDebounceTask?.cancel()
@@ -1209,12 +1224,18 @@ final class MuesliController: NSObject {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 self?.iCloudSyncDebounceTask = nil
-                self?.startICloudSync(userInitiated: userInitiated)
+                self?.startICloudSync(
+                    userInitiated: userInitiated,
+                    bridgeDiscoveryTriggered: bridgeDiscoveryTriggered
+                )
             }
         }
     }
 
-    private func startICloudSync(userInitiated: Bool) {
+    private func startICloudSync(
+        userInitiated: Bool,
+        bridgeDiscoveryTriggered: Bool = false
+    ) {
         guard config.iCloudSyncEnabled else {
             if userInitiated {
                 appState.iCloudSyncStatus = "Turn on iCloud sync first."
@@ -1251,6 +1272,7 @@ final class MuesliController: NSObject {
                 let forceBridgeDeviceRefresh = MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
                     userInitiated: userInitiated,
                     bridgeActivationPending: bridgeActivationPendingAtStart,
+                    bridgeDiscoveryTriggered: bridgeDiscoveryTriggered,
                     hasKnownRemoteDevice: hasKnownRemoteDeviceAtStart
                 )
                 let result = try await MuesliICloudSyncEngine().sync(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -79,6 +79,16 @@ enum MeetingCompletionNotificationPolicy {
     }
 }
 
+enum MuesliBridgeDeviceRefreshPolicy {
+    static func shouldForceRefresh(
+        userInitiated: Bool,
+        bridgeActivationPending: Bool,
+        hasKnownRemoteDevice: Bool
+    ) -> Bool {
+        userInitiated || bridgeActivationPending || !hasKnownRemoteDevice
+    }
+}
+
 struct PendingMeetingCompletionNotification {
     let meetingID: Int64?
     let title: String
@@ -1127,7 +1137,11 @@ final class MuesliController: NSObject {
         let generation = iCloudSyncGeneration
         iCloudSyncTask = Task { [weak self] in
             do {
-                let forceBridgeDeviceRefresh = userInitiated || self?.bridgeActivationPending == true
+                let forceBridgeDeviceRefresh = MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+                    userInitiated: userInitiated,
+                    bridgeActivationPending: self?.bridgeActivationPending == true,
+                    hasKnownRemoteDevice: MuesliBridgeDeviceIdentity.hasRemoteDevice()
+                )
                 let result = try await MuesliICloudSyncEngine().sync(
                     store: store,
                     forceBridgeDeviceRefresh: forceBridgeDeviceRefresh

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -84,11 +84,11 @@ enum MuesliBridgeDeviceRefreshPolicy {
         userInitiated: Bool,
         bridgeActivationPending: Bool,
         bridgeDiscoveryTriggered: Bool,
-        hasKnownRemoteDevice: Bool
+        hasKnownCompanionDevice: Bool
     ) -> Bool {
         userInitiated
             || bridgeActivationPending
-            || (bridgeDiscoveryTriggered && !hasKnownRemoteDevice)
+            || (bridgeDiscoveryTriggered && !hasKnownCompanionDevice)
     }
 }
 
@@ -1275,14 +1275,14 @@ final class MuesliController: NSObject {
         let bridgeActivationPendingAtStart = bridgeActivationPending
         let bridgeDiscoveryTriggeredAtStart = bridgeDiscoveryPending
         bridgeDiscoveryPending = false
-        let hasKnownRemoteDeviceAtStart = MuesliBridgeDeviceIdentity.hasRemoteDevice()
+        let hasKnownCompanionDeviceAtStart = MuesliBridgeDeviceIdentity.hasCompanionRemoteDevice()
         iCloudSyncTask = Task { [weak self] in
             do {
                 let forceBridgeDeviceRefresh = MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
                     userInitiated: userInitiated,
                     bridgeActivationPending: bridgeActivationPendingAtStart,
                     bridgeDiscoveryTriggered: bridgeDiscoveryTriggeredAtStart,
-                    hasKnownRemoteDevice: hasKnownRemoteDeviceAtStart
+                    hasKnownCompanionDevice: hasKnownCompanionDeviceAtStart
                 )
                 let result = try await MuesliICloudSyncEngine().sync(
                     store: store,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -316,6 +316,7 @@ final class MuesliController: NSObject {
     private var iCloudSubscriptionTask: Task<Void, Never>?
     private var hasEnsuredICloudSubscription = false
     private var bridgeActivationPending = false
+    private var bridgeDiscoveryPending = false
     private var hasStarted = false
 
     init(
@@ -776,7 +777,6 @@ final class MuesliController: NSObject {
         appState.isGoogleCalendarAvailable = googleCalAuth.isAvailable
         appState.isGoogleCalendarVerified = googleCalAuth.isVerified
         appState.isGoogleCalendarAuthenticated = googleCalAuth.isAuthenticated
-        appState.iCloudBridgeLocalDeviceName = MuesliBridgeDeviceIdentity.localDeviceDisplayName
         appState.iCloudBridgeRemoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName
         appState.iCloudBridgeRemoteDevicePlatform = MuesliBridgeDeviceIdentity.remoteDevicePlatform
         refreshICloudBridgeStateForConfig()
@@ -1215,6 +1215,9 @@ final class MuesliController: NSObject {
     ) {
         guard config.iCloudSyncEnabled else { return }
         enableICloudPersistentSync()
+        if bridgeDiscoveryTriggered {
+            bridgeDiscoveryPending = true
+        }
         iCloudSyncDebounceTask?.cancel()
         let milliseconds = max(Int(delay * 1_000), 0)
         iCloudSyncDebounceTask = Task { [weak self] in
@@ -1224,10 +1227,7 @@ final class MuesliController: NSObject {
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 self?.iCloudSyncDebounceTask = nil
-                self?.startICloudSync(
-                    userInitiated: userInitiated,
-                    bridgeDiscoveryTriggered: bridgeDiscoveryTriggered
-                )
+                self?.startICloudSync(userInitiated: userInitiated)
             }
         }
     }
@@ -1236,6 +1236,9 @@ final class MuesliController: NSObject {
         userInitiated: Bool,
         bridgeDiscoveryTriggered: Bool = false
     ) {
+        if bridgeDiscoveryTriggered {
+            bridgeDiscoveryPending = true
+        }
         guard config.iCloudSyncEnabled else {
             if userInitiated {
                 appState.iCloudSyncStatus = "Turn on iCloud sync first."
@@ -1266,13 +1269,15 @@ final class MuesliController: NSObject {
         iCloudSyncGeneration += 1
         let generation = iCloudSyncGeneration
         let bridgeActivationPendingAtStart = bridgeActivationPending
+        let bridgeDiscoveryTriggeredAtStart = bridgeDiscoveryPending
+        bridgeDiscoveryPending = false
         let hasKnownRemoteDeviceAtStart = MuesliBridgeDeviceIdentity.hasRemoteDevice()
         iCloudSyncTask = Task { [weak self] in
             do {
                 let forceBridgeDeviceRefresh = MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
                     userInitiated: userInitiated,
                     bridgeActivationPending: bridgeActivationPendingAtStart,
-                    bridgeDiscoveryTriggered: bridgeDiscoveryTriggered,
+                    bridgeDiscoveryTriggered: bridgeDiscoveryTriggeredAtStart,
                     hasKnownRemoteDevice: hasKnownRemoteDeviceAtStart
                 )
                 let result = try await MuesliICloudSyncEngine().sync(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1127,7 +1127,11 @@ final class MuesliController: NSObject {
         let generation = iCloudSyncGeneration
         iCloudSyncTask = Task { [weak self] in
             do {
-                let result = try await MuesliICloudSyncEngine().sync(store: store)
+                let forceBridgeDeviceRefresh = userInitiated || self?.bridgeActivationPending == true
+                let result = try await MuesliICloudSyncEngine().sync(
+                    store: store,
+                    forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+                )
                 do {
                     _ = try store.purgeSoftDeletedTextRecords()
                 } catch {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -165,6 +165,10 @@ enum MuesliBridgeDeviceIdentity {
         defaults.set(latestRemote.lastSeenAt, forKey: remoteDeviceLastSeenAtKey)
     }
 
+    static func hasRemoteDevice(defaults: UserDefaults = .standard) -> Bool {
+        defaults.string(forKey: remoteDeviceIDKey) != nil
+    }
+
     static func snapshot(from record: CKRecord) -> MuesliBridgeDeviceSnapshot? {
         guard let deviceID = record["deviceID"] as? String,
               let platform = record["platform"] as? String,
@@ -346,7 +350,9 @@ final class MuesliICloudSyncEngine {
             try await upsertLocalBridgeDeviceRecord()
             let records = try await fetchBridgeDeviceRecords()
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
-            MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
+            if MuesliBridgeDeviceIdentity.hasRemoteDevice(defaults: defaults) {
+                MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
+            }
         } catch {
             fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -99,7 +99,8 @@ enum MuesliBridgeDeviceIdentity {
     private static let remoteDevicePlatformKey = "muesli.sync.bridge.remoteDevicePlatform.v1"
     private static let remoteDeviceLastSeenAtKey = "muesli.sync.bridge.remoteDeviceLastSeenAt.v1"
     private static let lastRefreshKey = "muesli.sync.bridge.lastRefreshed.v1"
-    private static let refreshInterval: TimeInterval = 60 * 60
+    private static let linkedRefreshInterval: TimeInterval = 60 * 60
+    private static let unlinkedRefreshInterval: TimeInterval = 60
 
     static func local(defaults: UserDefaults = .standard) -> MuesliBridgeDeviceSnapshot {
         let deviceID: String
@@ -137,7 +138,8 @@ enum MuesliBridgeDeviceIdentity {
         guard let lastRefresh = defaults.object(forKey: lastRefreshKey) as? Date else {
             return true
         }
-        return now.timeIntervalSince(lastRefresh) >= refreshInterval
+        let interval = hasRemoteDevice(defaults: defaults) ? linkedRefreshInterval : unlinkedRefreshInterval
+        return now.timeIntervalSince(lastRefresh) >= interval
     }
 
     static func markRefreshed(defaults: UserDefaults = .standard, at date: Date = Date()) {
@@ -350,9 +352,7 @@ final class MuesliICloudSyncEngine {
             try await upsertLocalBridgeDeviceRecord()
             let records = try await fetchBridgeDeviceRecords()
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
-            if MuesliBridgeDeviceIdentity.hasRemoteDevice(defaults: defaults) {
-                MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
-            }
+            MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
             fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
         }
@@ -666,6 +666,7 @@ final class MuesliICloudSyncEngine {
                 operation = CKQueryOperation(query: query)
                 operation.zoneID = Schema.syncZoneID
             }
+            operation.desiredKeys = Self.desiredBridgeDeviceKeys
             operation.resultsLimit = 100
 
             let lock = NSLock()
@@ -1111,6 +1112,16 @@ final class MuesliICloudSyncEngine {
             "wordCount",
             "isDeleted",
             "schemaVersion",
+        ]
+    }
+
+    private static var desiredBridgeDeviceKeys: [CKRecord.FieldKey] {
+        [
+            "deviceID",
+            "platform",
+            "deviceName",
+            "appVersion",
+            "lastSeenAt",
         ]
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -99,8 +99,10 @@ enum MuesliBridgeDeviceIdentity {
     private static let remoteDevicePlatformKey = "muesli.sync.bridge.remoteDevicePlatform.v1"
     private static let remoteDeviceLastSeenAtKey = "muesli.sync.bridge.remoteDeviceLastSeenAt.v1"
     private static let lastRefreshKey = "muesli.sync.bridge.lastRefreshed.v1"
+    private static let lastRefreshFailureKey = "muesli.sync.bridge.lastRefreshFailure.v1"
     private static let linkedRefreshInterval: TimeInterval = 60 * 60
     private static let unlinkedRefreshInterval: TimeInterval = 60
+    private static let failureRetryInterval: TimeInterval = 15
 
     static func local(defaults: UserDefaults = .standard) -> MuesliBridgeDeviceSnapshot {
         let deviceID: String
@@ -142,6 +144,12 @@ enum MuesliBridgeDeviceIdentity {
         if forceRefresh {
             return true
         }
+        if let lastFailure = defaults.object(forKey: lastRefreshFailureKey) as? Date {
+            let lastSuccess = defaults.object(forKey: lastRefreshKey) as? Date
+            if lastSuccess.map({ lastFailure > $0 }) ?? true {
+                return now.timeIntervalSince(lastFailure) >= failureRetryInterval
+            }
+        }
         guard let lastRefresh = defaults.object(forKey: lastRefreshKey) as? Date else {
             return true
         }
@@ -151,6 +159,11 @@ enum MuesliBridgeDeviceIdentity {
 
     static func markRefreshed(defaults: UserDefaults = .standard, at date: Date = Date()) {
         defaults.set(date, forKey: lastRefreshKey)
+        defaults.removeObject(forKey: lastRefreshFailureKey)
+    }
+
+    static func markRefreshFailed(defaults: UserDefaults = .standard, at date: Date = Date()) {
+        defaults.set(date, forKey: lastRefreshFailureKey)
     }
 
     static func updateRemoteDevices(from records: [CKRecord], defaults: UserDefaults = .standard) {
@@ -368,7 +381,7 @@ final class MuesliICloudSyncEngine {
             MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
             fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
-            MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
+            MuesliBridgeDeviceIdentity.markRefreshFailed(defaults: defaults)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -83,6 +83,108 @@ final class UserDefaultsICloudChangeTokenStore: ICloudChangeTokenStore {
     }
 }
 
+struct MuesliBridgeDeviceSnapshot: Equatable {
+    let deviceID: String
+    let platform: String
+    let deviceName: String
+    let appVersion: String
+    let lastSeenAt: Date
+}
+
+enum MuesliBridgeDeviceIdentity {
+    private static let localDeviceIDKey = "muesli.sync.bridge.localDeviceID.v1"
+    private static let localDeviceNameKey = "muesli.sync.bridge.localDeviceName.v1"
+    private static let remoteDeviceIDKey = "muesli.sync.bridge.remoteDeviceID.v1"
+    private static let remoteDeviceNameKey = "muesli.sync.bridge.remoteDeviceName.v1"
+    private static let remoteDevicePlatformKey = "muesli.sync.bridge.remoteDevicePlatform.v1"
+    private static let remoteDeviceLastSeenAtKey = "muesli.sync.bridge.remoteDeviceLastSeenAt.v1"
+
+    static func local(defaults: UserDefaults = .standard) -> MuesliBridgeDeviceSnapshot {
+        let deviceID: String
+        if let persisted = defaults.string(forKey: localDeviceIDKey), !persisted.isEmpty {
+            deviceID = persisted
+        } else {
+            deviceID = UUID().uuidString
+            defaults.set(deviceID, forKey: localDeviceIDKey)
+        }
+
+        let deviceName = currentDeviceName()
+        defaults.set(deviceName, forKey: localDeviceNameKey)
+        return MuesliBridgeDeviceSnapshot(
+            deviceID: deviceID,
+            platform: "macOS",
+            deviceName: deviceName,
+            appVersion: appVersion(),
+            lastSeenAt: Date()
+        )
+    }
+
+    static var localDeviceDisplayName: String {
+        UserDefaults.standard.string(forKey: localDeviceNameKey) ?? currentDeviceName()
+    }
+
+    static var remoteDeviceDisplayName: String? {
+        UserDefaults.standard.string(forKey: remoteDeviceNameKey)
+    }
+
+    static var remoteDevicePlatform: String? {
+        UserDefaults.standard.string(forKey: remoteDevicePlatformKey)
+    }
+
+    static func updateRemoteDevices(from records: [CKRecord], defaults: UserDefaults = .standard) {
+        let localID = local(defaults: defaults).deviceID
+        let latestRemote = records
+            .compactMap(Self.snapshot(from:))
+            .filter { $0.deviceID != localID }
+            .max { $0.lastSeenAt < $1.lastSeenAt }
+
+        guard let latestRemote else {
+            defaults.removeObject(forKey: remoteDeviceIDKey)
+            defaults.removeObject(forKey: remoteDeviceNameKey)
+            defaults.removeObject(forKey: remoteDevicePlatformKey)
+            defaults.removeObject(forKey: remoteDeviceLastSeenAtKey)
+            return
+        }
+
+        defaults.set(latestRemote.deviceID, forKey: remoteDeviceIDKey)
+        defaults.set(latestRemote.deviceName, forKey: remoteDeviceNameKey)
+        defaults.set(latestRemote.platform, forKey: remoteDevicePlatformKey)
+        defaults.set(latestRemote.lastSeenAt, forKey: remoteDeviceLastSeenAtKey)
+    }
+
+    static func snapshot(from record: CKRecord) -> MuesliBridgeDeviceSnapshot? {
+        guard let deviceID = record["deviceID"] as? String,
+              let platform = record["platform"] as? String,
+              let deviceName = record["deviceName"] as? String,
+              let lastSeenAt = record["lastSeenAt"] as? Date else {
+            return nil
+        }
+        return MuesliBridgeDeviceSnapshot(
+            deviceID: deviceID,
+            platform: platform,
+            deviceName: deviceName,
+            appVersion: record["appVersion"] as? String ?? "unknown",
+            lastSeenAt: lastSeenAt
+        )
+    }
+
+    private static func currentDeviceName() -> String {
+        let name = Host.current().localizedName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !name.isEmpty {
+            return name
+        }
+        let hostName = ProcessInfo.processInfo.hostName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return hostName.isEmpty ? "This Mac" : hostName
+    }
+
+    private static func appVersion() -> String {
+        let info = Bundle.main.infoDictionary
+        return (info?["CFBundleShortVersionString"] as? String)
+            ?? (info?["CFBundleVersion"] as? String)
+            ?? "unknown"
+    }
+}
+
 private enum ICloudSyncAccountError: LocalizedError {
     case noAccount
     case restricted
@@ -108,6 +210,7 @@ final class MuesliICloudSyncEngine {
         static let containerIdentifier = "iCloud.com.mueslihq.muesli"
         static let syncZoneName = "MuesliSyncZone"
         static let textRecordType = "MuesliTextRecord"
+        static let bridgeDeviceRecordType = "MuesliBridgeDevice"
         static let textSubscriptionID = "muesli-text-records-sync-zone-v1"
         static let migratedDefaultZoneKey = "muesli.icloud.textRecords.defaultToSyncZoneMigrated.v1"
 
@@ -137,6 +240,7 @@ final class MuesliICloudSyncEngine {
     func sync(store: DictationStore) async throws -> ICloudSyncResult {
         try await verifyAccountAvailable()
         let syncZoneWasRecreated = try await ensureSyncZone()
+        await refreshBridgeDeviceLink()
         try await migrateDefaultZoneIfNeeded(store: store)
 
         let remoteChanges = try await fetchChangedTextRecords()
@@ -221,6 +325,50 @@ final class MuesliICloudSyncEngine {
         @unknown default:
             throw ICloudSyncAccountError.couldNotDetermine
         }
+    }
+
+    private func refreshBridgeDeviceLink() async {
+        do {
+            try await upsertLocalBridgeDeviceRecord()
+            let records = try await fetchBridgeDeviceRecords()
+            MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
+        } catch {
+            fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
+        }
+    }
+
+    private func upsertLocalBridgeDeviceRecord() async throws {
+        let snapshot = MuesliBridgeDeviceIdentity.local(defaults: defaults)
+        let recordID = CKRecord.ID(
+            recordName: "bridge-device-\(snapshot.deviceID)",
+            zoneID: Schema.syncZoneID
+        )
+        let existingRecords = try await fetchExistingRecords(recordIDs: [recordID])
+        let record = existingRecords[recordID]
+            ?? CKRecord(recordType: Schema.bridgeDeviceRecordType, recordID: recordID)
+        if record["createdAt"] == nil {
+            record["createdAt"] = Date() as NSDate
+        }
+        record["deviceID"] = snapshot.deviceID as NSString
+        record["platform"] = snapshot.platform as NSString
+        record["deviceName"] = snapshot.deviceName as NSString
+        record["appVersion"] = snapshot.appVersion as NSString
+        record["lastSeenAt"] = snapshot.lastSeenAt as NSDate
+        _ = try await save(records: [record])
+    }
+
+    private func fetchBridgeDeviceRecords() async throws -> [CKRecord] {
+        let query = CKQuery(recordType: Schema.bridgeDeviceRecordType, predicate: NSPredicate(value: true))
+        var records: [CKRecord] = []
+        var cursor: CKQueryOperation.Cursor?
+
+        repeat {
+            let page = try await fetchBridgeDeviceRecordsPage(query: query, cursor: cursor)
+            records.append(contentsOf: page.records)
+            cursor = page.cursor
+        } while cursor != nil
+
+        return records
     }
 
     private func accountStatus() async throws -> CKAccountStatus {
@@ -465,6 +613,45 @@ final class MuesliICloudSyncEngine {
             var records: [CKRecord] = []
             operation.recordMatchedBlock = { _, result in
                 if case .success(let record) = result {
+                    lock.lock()
+                    records.append(record)
+                    lock.unlock()
+                }
+            }
+            operation.queryResultBlock = { result in
+                switch result {
+                case .success(let cursor):
+                    lock.lock()
+                    let pageRecords = records
+                    lock.unlock()
+                    continuation.resume(returning: ICloudQueryPage(records: pageRecords, cursor: cursor))
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            database.add(operation)
+        }
+    }
+
+    private func fetchBridgeDeviceRecordsPage(
+        query: CKQuery,
+        cursor: CKQueryOperation.Cursor?
+    ) async throws -> ICloudQueryPage {
+        try await withCheckedThrowingContinuation { continuation in
+            let operation: CKQueryOperation
+            if let cursor {
+                operation = CKQueryOperation(cursor: cursor)
+            } else {
+                operation = CKQueryOperation(query: query)
+                operation.zoneID = Schema.syncZoneID
+            }
+            operation.resultsLimit = 100
+
+            let lock = NSLock()
+            var records: [CKRecord] = []
+            operation.recordMatchedBlock = { _, result in
+                if case .success(let record) = result,
+                   record.recordType == Schema.bridgeDeviceRecordType {
                     lock.lock()
                     records.append(record)
                     lock.unlock()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -114,7 +114,9 @@ enum MuesliBridgeDeviceIdentity {
         }
 
         let deviceName = currentDeviceName()
-        defaults.set(deviceName, forKey: localDeviceNameKey)
+        if defaults.string(forKey: localDeviceNameKey) != deviceName {
+            defaults.set(deviceName, forKey: localDeviceNameKey)
+        }
         return MuesliBridgeDeviceSnapshot(
             deviceID: deviceID,
             platform: "macOS",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -134,9 +134,6 @@ enum MuesliBridgeDeviceIdentity {
     }
 
     static func shouldRefresh(defaults: UserDefaults = .standard, now: Date = Date()) -> Bool {
-        guard defaults.string(forKey: remoteDeviceIDKey) != nil else {
-            return true
-        }
         guard let lastRefresh = defaults.object(forKey: lastRefreshKey) as? Date else {
             return true
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -98,6 +98,8 @@ enum MuesliBridgeDeviceIdentity {
     private static let remoteDeviceNameKey = "muesli.sync.bridge.remoteDeviceName.v1"
     private static let remoteDevicePlatformKey = "muesli.sync.bridge.remoteDevicePlatform.v1"
     private static let remoteDeviceLastSeenAtKey = "muesli.sync.bridge.remoteDeviceLastSeenAt.v1"
+    private static let lastRefreshKey = "muesli.sync.bridge.lastRefreshed.v1"
+    private static let refreshInterval: TimeInterval = 60 * 60
 
     static func local(defaults: UserDefaults = .standard) -> MuesliBridgeDeviceSnapshot {
         let deviceID: String
@@ -131,8 +133,22 @@ enum MuesliBridgeDeviceIdentity {
         UserDefaults.standard.string(forKey: remoteDevicePlatformKey)
     }
 
+    static func shouldRefresh(defaults: UserDefaults = .standard, now: Date = Date()) -> Bool {
+        guard defaults.string(forKey: remoteDeviceIDKey) != nil else {
+            return true
+        }
+        guard let lastRefresh = defaults.object(forKey: lastRefreshKey) as? Date else {
+            return true
+        }
+        return now.timeIntervalSince(lastRefresh) >= refreshInterval
+    }
+
+    static func markRefreshed(defaults: UserDefaults = .standard, at date: Date = Date()) {
+        defaults.set(date, forKey: lastRefreshKey)
+    }
+
     static func updateRemoteDevices(from records: [CKRecord], defaults: UserDefaults = .standard) {
-        let localID = local(defaults: defaults).deviceID
+        let localID = defaults.string(forKey: localDeviceIDKey) ?? ""
         let latestRemote = records
             .compactMap(Self.snapshot(from:))
             .filter { $0.deviceID != localID }
@@ -328,10 +344,12 @@ final class MuesliICloudSyncEngine {
     }
 
     private func refreshBridgeDeviceLink() async {
+        guard MuesliBridgeDeviceIdentity.shouldRefresh(defaults: defaults) else { return }
         do {
             try await upsertLocalBridgeDeviceRecord()
             let records = try await fetchBridgeDeviceRecords()
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
+            MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
             fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -168,9 +168,12 @@ enum MuesliBridgeDeviceIdentity {
 
     static func updateRemoteDevices(from records: [CKRecord], defaults: UserDefaults = .standard) {
         let localID = defaults.string(forKey: localDeviceIDKey) ?? ""
-        let latestRemote = records
+        let remoteDevices = records
             .compactMap(Self.snapshot(from:))
             .filter { $0.deviceID != localID }
+
+        let candidateDevices = remoteDevices.filter { isCompanionPlatform($0.platform) }
+        let latestRemote = (candidateDevices.isEmpty ? remoteDevices : candidateDevices)
             .max { $0.lastSeenAt < $1.lastSeenAt }
 
         guard let latestRemote else {
@@ -189,6 +192,15 @@ enum MuesliBridgeDeviceIdentity {
 
     static func hasRemoteDevice(defaults: UserDefaults = .standard) -> Bool {
         defaults.string(forKey: remoteDeviceIDKey) != nil
+    }
+
+    private static func isCompanionPlatform(_ platform: String) -> Bool {
+        switch platform.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "ios", "ipados":
+            return true
+        default:
+            return false
+        }
     }
 
     static func snapshot(from record: CKRecord) -> MuesliBridgeDeviceSnapshot? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -155,7 +155,7 @@ enum MuesliBridgeDeviceIdentity {
         guard let lastRefresh = defaults.object(forKey: lastRefreshKey) as? Date else {
             return true
         }
-        let interval = hasRemoteDevice(defaults: defaults) ? linkedRefreshInterval : unlinkedRefreshInterval
+        let interval = hasCompanionRemoteDevice(defaults: defaults) ? linkedRefreshInterval : unlinkedRefreshInterval
         return now.timeIntervalSince(lastRefresh) >= interval
     }
 
@@ -192,8 +192,12 @@ enum MuesliBridgeDeviceIdentity {
         defaults.set(latestRemote.lastSeenAt, forKey: remoteDeviceLastSeenAtKey)
     }
 
-    static func hasRemoteDevice(defaults: UserDefaults = .standard) -> Bool {
-        defaults.string(forKey: remoteDeviceIDKey) != nil
+    static func hasCompanionRemoteDevice(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.string(forKey: remoteDeviceIDKey) != nil,
+              let platform = defaults.string(forKey: remoteDevicePlatformKey) else {
+            return false
+        }
+        return isCompanionPlatform(platform)
     }
 
     private static func isCompanionPlatform(_ platform: String) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -172,8 +172,8 @@ enum MuesliBridgeDeviceIdentity {
             .compactMap(Self.snapshot(from:))
             .filter { $0.deviceID != localID }
 
-        let candidateDevices = remoteDevices.filter { isCompanionPlatform($0.platform) }
-        let latestRemote = (candidateDevices.isEmpty ? remoteDevices : candidateDevices)
+        let latestRemote = remoteDevices
+            .filter { isCompanionPlatform($0.platform) }
             .max { $0.lastSeenAt < $1.lastSeenAt }
 
         guard let latestRemote else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -134,7 +134,14 @@ enum MuesliBridgeDeviceIdentity {
         UserDefaults.standard.string(forKey: remoteDevicePlatformKey)
     }
 
-    static func shouldRefresh(defaults: UserDefaults = .standard, now: Date = Date()) -> Bool {
+    static func shouldRefresh(
+        defaults: UserDefaults = .standard,
+        now: Date = Date(),
+        forceRefresh: Bool = false
+    ) -> Bool {
+        if forceRefresh {
+            return true
+        }
         guard let lastRefresh = defaults.object(forKey: lastRefreshKey) as? Date else {
             return true
         }
@@ -256,10 +263,13 @@ final class MuesliICloudSyncEngine {
         self.defaults = defaults
     }
 
-    func sync(store: DictationStore) async throws -> ICloudSyncResult {
+    func sync(
+        store: DictationStore,
+        forceBridgeDeviceRefresh: Bool = false
+    ) async throws -> ICloudSyncResult {
         try await verifyAccountAvailable()
         let syncZoneWasRecreated = try await ensureSyncZone()
-        await refreshBridgeDeviceLink()
+        await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
         try await migrateDefaultZoneIfNeeded(store: store)
 
         let remoteChanges = try await fetchChangedTextRecords()
@@ -346,8 +356,11 @@ final class MuesliICloudSyncEngine {
         }
     }
 
-    private func refreshBridgeDeviceLink() async {
-        guard MuesliBridgeDeviceIdentity.shouldRefresh(defaults: defaults) else { return }
+    private func refreshBridgeDeviceLink(forceRefresh: Bool = false) async {
+        guard MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            forceRefresh: forceRefresh
+        ) else { return }
         do {
             try await upsertLocalBridgeDeviceRecord()
             let records = try await fetchBridgeDeviceRecords()
@@ -355,6 +368,7 @@ final class MuesliICloudSyncEngine {
             MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
             fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
+            MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -477,6 +477,9 @@ struct SettingsView: View {
     private var syncLinkedDeviceText: String? {
         guard appState.config.iCloudSyncEnabled else { return nil }
         if let remoteDeviceName = appState.iCloudBridgeRemoteDeviceName {
+            if let platform = appState.iCloudBridgeRemoteDevicePlatform {
+                return "Linked \(platform) device: \(remoteDeviceName)"
+            }
             return "Linked device: \(remoteDeviceName)"
         }
         if let localDeviceName = appState.iCloudBridgeLocalDeviceName {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -482,10 +482,7 @@ struct SettingsView: View {
             }
             return "Linked device: \(remoteDeviceName)"
         }
-        if let localDeviceName = appState.iCloudBridgeLocalDeviceName {
-            return "This Mac: \(localDeviceName)"
-        }
-        return nil
+        return "No linked iPhone yet."
     }
 
     private var dictationSettingsPane: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -476,7 +476,7 @@ struct SettingsView: View {
 
     private var syncLinkedDeviceText: String? {
         guard appState.config.iCloudSyncEnabled else { return nil }
-        if let remoteDeviceName = appState.iCloudBridgeRemoteDeviceName {
+        if let remoteDeviceName = appState.iCloudBridgeCompanionDeviceName {
             if let platform = appState.iCloudBridgeRemoteDevicePlatform {
                 return "Linked \(syncDeviceLabel(for: platform)): \(remoteDeviceName)"
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -416,6 +416,12 @@ struct SettingsView: View {
                                 .font(MuesliTheme.caption())
                                 .foregroundStyle(MuesliTheme.textTertiary)
                         }
+                        if let linkedDeviceText = syncLinkedDeviceText {
+                            Text(linkedDeviceText)
+                                .font(MuesliTheme.caption())
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                     Spacer(minLength: MuesliTheme.spacing16)
                     actionButton("Sync now", systemImage: "arrow.triangle.2.circlepath") {
@@ -466,6 +472,17 @@ struct SettingsView: View {
     private var syncLastSyncedText: String? {
         guard let date = appState.iCloudLastSyncedAt else { return nil }
         return DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .short)
+    }
+
+    private var syncLinkedDeviceText: String? {
+        guard appState.config.iCloudSyncEnabled else { return nil }
+        if let remoteDeviceName = appState.iCloudBridgeRemoteDeviceName {
+            return "Linked device: \(remoteDeviceName)"
+        }
+        if let localDeviceName = appState.iCloudBridgeLocalDeviceName {
+            return "This Mac: \(localDeviceName)"
+        }
+        return nil
     }
 
     private var dictationSettingsPane: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -102,7 +102,7 @@ struct SettingsView: View {
     // Uniform width for all right-side controls
     private let controlWidth: CGFloat = 220
     private let meetingControlWidth: CGFloat = 275
-    private let iOSCompanionURL = URL(string: "https://github.com/Muesli-HQ/muesli-ios")!
+    private let iOSCompanionURL = IPhoneBridgeLinks.installURL
     private let screenContextGrantIntentTimeout: TimeInterval = 15 * 60
     private let meetingDetectionAppOptions: [MeetingDetectionAppOption] = [
         MeetingDetectionAppOption(bundleID: "com.google.Chrome", name: "Chrome", icon: "globe"),

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -478,11 +478,22 @@ struct SettingsView: View {
         guard appState.config.iCloudSyncEnabled else { return nil }
         if let remoteDeviceName = appState.iCloudBridgeRemoteDeviceName {
             if let platform = appState.iCloudBridgeRemoteDevicePlatform {
-                return "Linked \(platform) device: \(remoteDeviceName)"
+                return "Linked \(syncDeviceLabel(for: platform)): \(remoteDeviceName)"
             }
             return "Linked device: \(remoteDeviceName)"
         }
         return "No linked iPhone yet."
+    }
+
+    private func syncDeviceLabel(for platform: String) -> String {
+        switch platform.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "ios":
+            return "iPhone"
+        case "ipados":
+            return "iPad"
+        default:
+            return platform
+        }
     }
 
     private var dictationSettingsPane: some View {

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -1,0 +1,151 @@
+import CloudKit
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MuesliBridgeDeviceIdentity", .serialized)
+struct MuesliBridgeDeviceIdentityTests {
+    private enum DefaultsKey {
+        static let localDeviceID = "muesli.sync.bridge.localDeviceID.v1"
+        static let remoteDeviceID = "muesli.sync.bridge.remoteDeviceID.v1"
+        static let remoteDeviceName = "muesli.sync.bridge.remoteDeviceName.v1"
+        static let remoteDevicePlatform = "muesli.sync.bridge.remoteDevicePlatform.v1"
+        static let remoteDeviceLastSeenAt = "muesli.sync.bridge.remoteDeviceLastSeenAt.v1"
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "com.muesli.tests.bridge-device-identity.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+
+    private func bridgeRecord(
+        deviceID: String? = "device-1",
+        platform: String? = "iOS",
+        deviceName: String? = "iPhone",
+        appVersion: String? = "1.0",
+        lastSeenAt: Date? = Date(timeIntervalSince1970: 1_770_000_000)
+    ) -> CKRecord {
+        let record = CKRecord(recordType: "MuesliBridgeDevice")
+        if let deviceID {
+            record["deviceID"] = deviceID as NSString
+        }
+        if let platform {
+            record["platform"] = platform as NSString
+        }
+        if let deviceName {
+            record["deviceName"] = deviceName as NSString
+        }
+        if let appVersion {
+            record["appVersion"] = appVersion as NSString
+        }
+        if let lastSeenAt {
+            record["lastSeenAt"] = lastSeenAt as NSDate
+        }
+        return record
+    }
+
+    @Test("shouldRefresh returns true with no timestamp")
+    func shouldRefreshReturnsTrueWithNoTimestamp() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: Date(timeIntervalSince1970: 1_770_000_000)
+        ))
+    }
+
+    @Test("shouldRefresh returns false within one hour and true after one hour")
+    func shouldRefreshUsesOneHourInterval() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+
+        MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now)
+
+        #expect(!MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(60 * 59)
+        ))
+        #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(60 * 60)
+        ))
+    }
+
+    @Test("updateRemoteDevices with empty records clears remote keys")
+    func updateRemoteDevicesWithEmptyRecordsClearsRemoteKeys() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let previousLastSeenAt = Date(timeIntervalSince1970: 1_770_000_000)
+        defaults.set("remote-previous", forKey: DefaultsKey.remoteDeviceID)
+        defaults.set("Previous iPhone", forKey: DefaultsKey.remoteDeviceName)
+        defaults.set("iOS", forKey: DefaultsKey.remoteDevicePlatform)
+        defaults.set(previousLastSeenAt, forKey: DefaultsKey.remoteDeviceLastSeenAt)
+
+        MuesliBridgeDeviceIdentity.updateRemoteDevices(from: [], defaults: defaults)
+
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceID) == nil)
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceName) == nil)
+        #expect(defaults.object(forKey: DefaultsKey.remoteDevicePlatform) == nil)
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceLastSeenAt) == nil)
+    }
+
+    @Test("updateRemoteDevices picks the most recent non-local record")
+    func updateRemoteDevicesPicksMostRecentNonLocalRecord() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("local-mac", forKey: DefaultsKey.localDeviceID)
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+        let olderRemote = bridgeRecord(
+            deviceID: "remote-old",
+            deviceName: "Old iPhone",
+            lastSeenAt: now.addingTimeInterval(-60)
+        )
+        let latestRemote = bridgeRecord(
+            deviceID: "remote-new",
+            platform: "iPadOS",
+            deviceName: "iPad",
+            lastSeenAt: now
+        )
+        let localRecord = bridgeRecord(
+            deviceID: "local-mac",
+            platform: "macOS",
+            deviceName: "This Mac",
+            lastSeenAt: now.addingTimeInterval(60)
+        )
+
+        MuesliBridgeDeviceIdentity.updateRemoteDevices(
+            from: [olderRemote, latestRemote, localRecord],
+            defaults: defaults
+        )
+
+        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceID) == "remote-new")
+        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceName) == "iPad")
+        #expect(defaults.string(forKey: DefaultsKey.remoteDevicePlatform) == "iPadOS")
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceLastSeenAt) as? Date == now)
+    }
+
+    @Test("snapshot returns nil when required fields are missing")
+    func snapshotReturnsNilWhenRequiredFieldsAreMissing() {
+        #expect(MuesliBridgeDeviceIdentity.snapshot(from: bridgeRecord(deviceID: nil)) == nil)
+        #expect(MuesliBridgeDeviceIdentity.snapshot(from: bridgeRecord(platform: nil)) == nil)
+        #expect(MuesliBridgeDeviceIdentity.snapshot(from: bridgeRecord(deviceName: nil)) == nil)
+        #expect(MuesliBridgeDeviceIdentity.snapshot(from: bridgeRecord(lastSeenAt: nil)) == nil)
+    }
+
+    @Test("local persists UUID across calls for the same defaults suite")
+    func localPersistsUUIDAcrossCallsForSameDefaultsSuite() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let first = MuesliBridgeDeviceIdentity.local(defaults: defaults)
+        let second = MuesliBridgeDeviceIdentity.local(defaults: defaults)
+
+        #expect(first.deviceID == second.deviceID)
+        #expect(UUID(uuidString: first.deviceID) != nil)
+        #expect(defaults.string(forKey: DefaultsKey.localDeviceID) == first.deviceID)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -57,12 +57,31 @@ struct MuesliBridgeDeviceIdentityTests {
         ))
     }
 
-    @Test("shouldRefresh returns false within one hour and true after one hour")
-    func shouldRefreshUsesOneHourInterval() throws {
+    @Test("shouldRefresh uses a short interval before a remote device is known")
+    func shouldRefreshUsesShortIntervalBeforeRemoteDeviceIsKnown() throws {
         let (defaults, suiteName) = try makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let now = Date(timeIntervalSince1970: 1_770_000_000)
 
+        MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now)
+
+        #expect(!MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(59)
+        ))
+        #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(60)
+        ))
+    }
+
+    @Test("shouldRefresh returns false within one hour and true after one hour once linked")
+    func shouldRefreshUsesOneHourIntervalOnceLinked() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+
+        defaults.set("remote-iphone", forKey: DefaultsKey.remoteDeviceID)
         MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now)
 
         #expect(!MuesliBridgeDeviceIdentity.shouldRefresh(

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -90,6 +90,26 @@ struct MuesliBridgeDeviceIdentityTests {
         ))
     }
 
+    @Test("failed refresh uses short retry backoff instead of success throttle")
+    func failedRefreshUsesShortRetryBackoffInsteadOfSuccessThrottle() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+
+        defaults.set("remote-iphone", forKey: DefaultsKey.remoteDeviceID)
+        MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now.addingTimeInterval(-10))
+        MuesliBridgeDeviceIdentity.markRefreshFailed(defaults: defaults, at: now)
+
+        #expect(!MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(14)
+        ))
+        #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(15)
+        ))
+    }
+
     @Test("shouldRefresh returns false within one hour and true after one hour once linked")
     func shouldRefreshUsesOneHourIntervalOnceLinked() throws {
         let (defaults, suiteName) = try makeDefaults()

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -274,6 +274,7 @@ struct MuesliBridgeDeviceRefreshPolicyTests {
         #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: true,
             bridgeActivationPending: false,
+            bridgeDiscoveryTriggered: false,
             hasKnownRemoteDevice: true
         ))
     }
@@ -283,6 +284,7 @@ struct MuesliBridgeDeviceRefreshPolicyTests {
         #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: false,
             bridgeActivationPending: true,
+            bridgeDiscoveryTriggered: false,
             hasKnownRemoteDevice: true
         ))
     }
@@ -292,6 +294,17 @@ struct MuesliBridgeDeviceRefreshPolicyTests {
         #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: false,
             bridgeActivationPending: false,
+            bridgeDiscoveryTriggered: true,
+            hasKnownRemoteDevice: false
+        ))
+    }
+
+    @Test("background sync uses throttle before a remote device is known")
+    func backgroundSyncUsesThrottleBeforeRemoteDeviceIsKnown() {
+        #expect(!MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+            userInitiated: false,
+            bridgeActivationPending: false,
+            bridgeDiscoveryTriggered: false,
             hasKnownRemoteDevice: false
         ))
     }
@@ -301,6 +314,7 @@ struct MuesliBridgeDeviceRefreshPolicyTests {
         #expect(!MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: false,
             bridgeActivationPending: false,
+            bridgeDiscoveryTriggered: true,
             hasKnownRemoteDevice: true
         ))
     }

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -288,6 +288,27 @@ struct MuesliBridgeDeviceIdentityTests {
     }
 }
 
+@Suite("ICloudBridgeAppState")
+struct ICloudBridgeAppStateTests {
+    @MainActor
+    @Test("companion device name only returns iOS and iPadOS remotes")
+    func companionDeviceNameOnlyReturnsCompanionPlatforms() {
+        let state = AppState()
+
+        state.iCloudBridgeRemoteDeviceName = "Pranav MacBook"
+        state.iCloudBridgeRemoteDevicePlatform = "macOS"
+        #expect(state.iCloudBridgeCompanionDeviceName == nil)
+
+        state.iCloudBridgeRemoteDeviceName = "picophone"
+        state.iCloudBridgeRemoteDevicePlatform = "iOS"
+        #expect(state.iCloudBridgeCompanionDeviceName == "picophone")
+
+        state.iCloudBridgeRemoteDeviceName = "iPad"
+        state.iCloudBridgeRemoteDevicePlatform = " iPadOS "
+        #expect(state.iCloudBridgeCompanionDeviceName == "iPad")
+    }
+}
+
 @Suite("MuesliBridgeDeviceRefreshPolicy")
 struct MuesliBridgeDeviceRefreshPolicyTests {
     @Test("user initiated sync forces bridge device refresh")

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -182,6 +182,64 @@ struct MuesliBridgeDeviceIdentityTests {
         #expect(defaults.object(forKey: DefaultsKey.remoteDeviceLastSeenAt) as? Date == now)
     }
 
+    @Test("updateRemoteDevices prefers companion devices over newer remote Macs")
+    func updateRemoteDevicesPrefersCompanionDevicesOverNewerRemoteMacs() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("local-mac", forKey: DefaultsKey.localDeviceID)
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+        let iPhone = bridgeRecord(
+            deviceID: "remote-iphone",
+            platform: "iOS",
+            deviceName: "picophone",
+            lastSeenAt: now
+        )
+        let otherMac = bridgeRecord(
+            deviceID: "remote-mac",
+            platform: "macOS",
+            deviceName: "Other MacBook",
+            lastSeenAt: now.addingTimeInterval(60)
+        )
+
+        MuesliBridgeDeviceIdentity.updateRemoteDevices(
+            from: [iPhone, otherMac],
+            defaults: defaults
+        )
+
+        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceID) == "remote-iphone")
+        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceName) == "picophone")
+        #expect(defaults.string(forKey: DefaultsKey.remoteDevicePlatform) == "iOS")
+    }
+
+    @Test("updateRemoteDevices falls back to remote Mac when no companion exists")
+    func updateRemoteDevicesFallsBackToRemoteMacWhenNoCompanionExists() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set("local-mac", forKey: DefaultsKey.localDeviceID)
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+        let olderMac = bridgeRecord(
+            deviceID: "remote-mac-old",
+            platform: "macOS",
+            deviceName: "Old MacBook",
+            lastSeenAt: now
+        )
+        let newerMac = bridgeRecord(
+            deviceID: "remote-mac-new",
+            platform: "macOS",
+            deviceName: "New MacBook",
+            lastSeenAt: now.addingTimeInterval(60)
+        )
+
+        MuesliBridgeDeviceIdentity.updateRemoteDevices(
+            from: [olderMac, newerMac],
+            defaults: defaults
+        )
+
+        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceID) == "remote-mac-new")
+        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceName) == "New MacBook")
+        #expect(defaults.string(forKey: DefaultsKey.remoteDevicePlatform) == "macOS")
+    }
+
     @Test("snapshot returns nil when required fields are missing")
     func snapshotReturnsNilWhenRequiredFieldsAreMissing() {
         #expect(MuesliBridgeDeviceIdentity.snapshot(from: bridgeRecord(deviceID: nil)) == nil)

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -117,6 +117,7 @@ struct MuesliBridgeDeviceIdentityTests {
         let now = Date(timeIntervalSince1970: 1_770_000_000)
 
         defaults.set("remote-iphone", forKey: DefaultsKey.remoteDeviceID)
+        defaults.set("iOS", forKey: DefaultsKey.remoteDevicePlatform)
         MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now)
 
         #expect(!MuesliBridgeDeviceIdentity.shouldRefresh(
@@ -126,6 +127,26 @@ struct MuesliBridgeDeviceIdentityTests {
         #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
             defaults: defaults,
             now: now.addingTimeInterval(60 * 60)
+        ))
+    }
+
+    @Test("shouldRefresh treats stale non-companion remote cache as unlinked")
+    func shouldRefreshTreatsStaleNonCompanionRemoteCacheAsUnlinked() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+
+        defaults.set("remote-mac", forKey: DefaultsKey.remoteDeviceID)
+        defaults.set("macOS", forKey: DefaultsKey.remoteDevicePlatform)
+        MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now)
+
+        #expect(!MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(59)
+        ))
+        #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(60)
         ))
     }
 
@@ -275,7 +296,7 @@ struct MuesliBridgeDeviceRefreshPolicyTests {
             userInitiated: true,
             bridgeActivationPending: false,
             bridgeDiscoveryTriggered: false,
-            hasKnownRemoteDevice: true
+            hasKnownCompanionDevice: true
         ))
     }
 
@@ -285,37 +306,47 @@ struct MuesliBridgeDeviceRefreshPolicyTests {
             userInitiated: false,
             bridgeActivationPending: true,
             bridgeDiscoveryTriggered: false,
-            hasKnownRemoteDevice: true
+            hasKnownCompanionDevice: true
         ))
     }
 
-    @Test("app activation forces bridge device refresh until a remote device is known")
-    func appActivationForcesRefreshUntilRemoteDeviceIsKnown() {
+    @Test("app activation forces bridge device refresh until a companion device is known")
+    func appActivationForcesRefreshUntilCompanionDeviceIsKnown() {
         #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: false,
             bridgeActivationPending: false,
             bridgeDiscoveryTriggered: true,
-            hasKnownRemoteDevice: false
+            hasKnownCompanionDevice: false
         ))
     }
 
-    @Test("background sync uses throttle before a remote device is known")
-    func backgroundSyncUsesThrottleBeforeRemoteDeviceIsKnown() {
+    @Test("background sync uses throttle before a companion device is known")
+    func backgroundSyncUsesThrottleBeforeCompanionDeviceIsKnown() {
         #expect(!MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: false,
             bridgeActivationPending: false,
             bridgeDiscoveryTriggered: false,
-            hasKnownRemoteDevice: false
+            hasKnownCompanionDevice: false
         ))
     }
 
-    @Test("background sync uses throttle after remote device is known")
-    func backgroundSyncUsesThrottleAfterRemoteDeviceIsKnown() {
+    @Test("app activation uses throttle after companion device is known")
+    func appActivationUsesThrottleAfterCompanionDeviceIsKnown() {
         #expect(!MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
             userInitiated: false,
             bridgeActivationPending: false,
             bridgeDiscoveryTriggered: true,
-            hasKnownRemoteDevice: true
+            hasKnownCompanionDevice: true
+        ))
+    }
+
+    @Test("app activation refreshes when cached remote is not a companion")
+    func appActivationRefreshesWhenCachedRemoteIsNotACompanion() {
+        #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+            userInitiated: false,
+            bridgeActivationPending: false,
+            bridgeDiscoveryTriggered: true,
+            hasKnownCompanionDevice: false
         ))
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -203,3 +203,42 @@ struct MuesliBridgeDeviceIdentityTests {
         #expect(defaults.string(forKey: DefaultsKey.localDeviceID) == first.deviceID)
     }
 }
+
+@Suite("MuesliBridgeDeviceRefreshPolicy")
+struct MuesliBridgeDeviceRefreshPolicyTests {
+    @Test("user initiated sync forces bridge device refresh")
+    func userInitiatedSyncForcesBridgeDeviceRefresh() {
+        #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+            userInitiated: true,
+            bridgeActivationPending: false,
+            hasKnownRemoteDevice: true
+        ))
+    }
+
+    @Test("pending bridge activation forces bridge device refresh")
+    func pendingBridgeActivationForcesBridgeDeviceRefresh() {
+        #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+            userInitiated: false,
+            bridgeActivationPending: true,
+            hasKnownRemoteDevice: true
+        ))
+    }
+
+    @Test("app activation forces bridge device refresh until a remote device is known")
+    func appActivationForcesRefreshUntilRemoteDeviceIsKnown() {
+        #expect(MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+            userInitiated: false,
+            bridgeActivationPending: false,
+            hasKnownRemoteDevice: false
+        ))
+    }
+
+    @Test("background sync uses throttle after remote device is known")
+    func backgroundSyncUsesThrottleAfterRemoteDeviceIsKnown() {
+        #expect(!MuesliBridgeDeviceRefreshPolicy.shouldForceRefresh(
+            userInitiated: false,
+            bridgeActivationPending: false,
+            hasKnownRemoteDevice: true
+        ))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -211,11 +211,15 @@ struct MuesliBridgeDeviceIdentityTests {
         #expect(defaults.string(forKey: DefaultsKey.remoteDevicePlatform) == "iOS")
     }
 
-    @Test("updateRemoteDevices falls back to remote Mac when no companion exists")
-    func updateRemoteDevicesFallsBackToRemoteMacWhenNoCompanionExists() throws {
+    @Test("updateRemoteDevices clears remote bridge when no companion exists")
+    func updateRemoteDevicesClearsRemoteBridgeWhenNoCompanionExists() throws {
         let (defaults, suiteName) = try makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set("local-mac", forKey: DefaultsKey.localDeviceID)
+        defaults.set("previous-iphone", forKey: DefaultsKey.remoteDeviceID)
+        defaults.set("Previous iPhone", forKey: DefaultsKey.remoteDeviceName)
+        defaults.set("iOS", forKey: DefaultsKey.remoteDevicePlatform)
+        defaults.set(Date(timeIntervalSince1970: 1_769_999_000), forKey: DefaultsKey.remoteDeviceLastSeenAt)
         let now = Date(timeIntervalSince1970: 1_770_000_000)
         let olderMac = bridgeRecord(
             deviceID: "remote-mac-old",
@@ -235,9 +239,10 @@ struct MuesliBridgeDeviceIdentityTests {
             defaults: defaults
         )
 
-        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceID) == "remote-mac-new")
-        #expect(defaults.string(forKey: DefaultsKey.remoteDeviceName) == "New MacBook")
-        #expect(defaults.string(forKey: DefaultsKey.remoteDevicePlatform) == "macOS")
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceID) == nil)
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceName) == nil)
+        #expect(defaults.object(forKey: DefaultsKey.remoteDevicePlatform) == nil)
+        #expect(defaults.object(forKey: DefaultsKey.remoteDeviceLastSeenAt) == nil)
     }
 
     @Test("snapshot returns nil when required fields are missing")

--- a/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliBridgeDeviceIdentityTests.swift
@@ -75,6 +75,21 @@ struct MuesliBridgeDeviceIdentityTests {
         ))
     }
 
+    @Test("shouldRefresh can force refresh before the throttle expires")
+    func shouldRefreshCanForceRefreshBeforeThrottleExpires() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+
+        MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults, at: now)
+
+        #expect(MuesliBridgeDeviceIdentity.shouldRefresh(
+            defaults: defaults,
+            now: now.addingTimeInterval(1),
+            forceRefresh: true
+        ))
+    }
+
     @Test("shouldRefresh returns false within one hour and true after one hour once linked")
     func shouldRefreshUsesOneHourIntervalOnceLinked() throws {
         let (defaults, suiteName) = try makeDefaults()


### PR DESCRIPTION
## Summary
- replace the macOS timeline companion promo with a stateful iPhone bridge handoff
- add compact QR handoff UI that opens the iOS private iCloud sync setup deep link
- centralize the temporary iOS install/open URL for later TestFlight/App Store replacement

## Verification
- swift test --package-path native/MuesliNative --scratch-path /Volumes/MuesliBuildCache/muesli-spm/worktrees/sync-onboarding/test --filter DictationStoreTests
- rebuilt /Applications/MuesliPreprod.app with the existing MuesliPreprod app data/support directory and development iCloud/APNs profile

## Paired PR
- iOS: https://github.com/Muesli-HQ/muesli-ios/pull/5