### PR TITLE
Track usage milestones in dashboard

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -106,6 +106,7 @@ final class AppState {
     var iCloudBridgeMessage: String?
     var iCloudLastSyncSummary: String?
     var iCloudLastSyncedAt: Date?
+    var contributionMilestonePrompt: ContributionMilestonePrompt?
     var modelPreparationTitle: String?
     var modelPreparationDetail: String?
     var modelPreparationProgress: Double?

--- a/native/MuesliNative/Sources/MuesliNativeApp/ContributionMilestonePrompt.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ContributionMilestonePrompt.swift
@@ -64,14 +64,18 @@ enum ContributionMilestonePolicy {
         nextMilestone(after: totalMeetings, interval: meetingInterval)
     }
 
+    static func nextMilestone(after total: Int, kind: ContributionMilestoneKind) -> Int {
+        switch kind {
+        case .dictationWords:
+            return nextMilestone(after: total)
+        case .meetings:
+            return nextMeetingMilestone(after: total)
+        }
+    }
+
     private static func nextMilestone(after total: Int, interval: Int) -> Int {
         let clampedTotal = max(total, 0)
         return ((clampedTotal / interval) + 1) * interval
-    }
-
-    private static func latestCrossedMilestone(at total: Int, interval: Int) -> Int {
-        let clampedTotal = max(total, 0)
-        return max(interval, (clampedTotal / interval) * interval)
     }
 
     static func resolvedNextMilestone(
@@ -93,11 +97,11 @@ enum ContributionMilestonePolicy {
 
         switch intervalKind {
         case .dictationWords:
-            guard total >= storedNextMilestone else { return storedNextMilestone }
-            return max(storedNextMilestone, latestCrossedMilestone(at: total, interval: dictationWordInterval))
+            guard total >= storedNextMilestone + dictationWordInterval else { return storedNextMilestone }
+            return nextMilestone(after: total)
         case .meetings:
-            guard total >= storedNextMilestone else { return storedNextMilestone }
-            return max(storedNextMilestone, latestCrossedMilestone(at: total, interval: meetingInterval))
+            guard total >= storedNextMilestone + meetingInterval else { return storedNextMilestone }
+            return nextMeetingMilestone(after: total)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ContributionMilestonePrompt.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ContributionMilestonePrompt.swift
@@ -69,6 +69,11 @@ enum ContributionMilestonePolicy {
         return ((clampedTotal / interval) + 1) * interval
     }
 
+    private static func latestCrossedMilestone(at total: Int, interval: Int) -> Int {
+        let clampedTotal = max(total, 0)
+        return max(interval, (clampedTotal / interval) * interval)
+    }
+
     static func resolvedNextMilestone(
         storedNextMilestone: Int?,
         total: Int,
@@ -77,11 +82,22 @@ enum ContributionMilestonePolicy {
         buyMeCoffeeClicked: Bool
     ) -> Int? {
         guard !githubStarClicked || !buyMeCoffeeClicked else { return nil }
+        guard let storedNextMilestone else {
+            switch intervalKind {
+            case .dictationWords:
+                return nextMilestone(after: total)
+            case .meetings:
+                return nextMeetingMilestone(after: total)
+            }
+        }
+
         switch intervalKind {
         case .dictationWords:
-            return storedNextMilestone ?? nextMilestone(after: total)
+            guard total >= storedNextMilestone else { return storedNextMilestone }
+            return max(storedNextMilestone, latestCrossedMilestone(at: total, interval: dictationWordInterval))
         case .meetings:
-            return storedNextMilestone ?? nextMeetingMilestone(after: total)
+            guard total >= storedNextMilestone else { return storedNextMilestone }
+            return max(storedNextMilestone, latestCrossedMilestone(at: total, interval: meetingInterval))
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/ContributionMilestonePrompt.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ContributionMilestonePrompt.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+enum ContributionMilestoneAction: String, CaseIterable {
+    case githubStar = "github_star"
+    case buyMeCoffee = "buy_me_coffee"
+
+    var url: URL {
+        switch self {
+        case .githubStar:
+            return URL(string: "https://github.com/Muesli-HQ/muesli")!
+        case .buyMeCoffee:
+            return URL(string: "https://buymeacoffee.com/phequals7")!
+        }
+    }
+}
+
+enum ContributionMilestoneKind: String {
+    case dictationWords = "dictation_words"
+    case meetings
+}
+
+struct ContributionMilestonePrompt: Equatable, Identifiable {
+    let kind: ContributionMilestoneKind
+    let count: Int
+    let showGitHubStar: Bool
+    let showBuyMeCoffee: Bool
+
+    var id: String { "\(kind.rawValue):\(count)" }
+
+    var title: String {
+        switch kind {
+        case .dictationWords:
+            return "You crossed \(Self.formatCount(count)) words!"
+        case .meetings:
+            return "You captured \(Self.formatCount(count)) meetings!"
+        }
+    }
+
+    var message: String {
+        switch kind {
+        case .dictationWords:
+            return "That is a serious pile of words. If Muesli has been saving your fingers and your flow, a GitHub star or a coffee helps keep it moving."
+        case .meetings:
+            return "That is a lot of conversations turned into something useful. If Muesli has been keeping your meetings in order, a GitHub star or a coffee helps keep it moving."
+        }
+    }
+
+    private static func formatCount(_ value: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+}
+
+enum ContributionMilestonePolicy {
+    static let dictationWordInterval = 1_000
+    static let meetingInterval = 25
+
+    static func nextMilestone(after totalWords: Int) -> Int {
+        nextMilestone(after: totalWords, interval: dictationWordInterval)
+    }
+
+    static func nextMeetingMilestone(after totalMeetings: Int) -> Int {
+        nextMilestone(after: totalMeetings, interval: meetingInterval)
+    }
+
+    private static func nextMilestone(after total: Int, interval: Int) -> Int {
+        let clampedTotal = max(total, 0)
+        return ((clampedTotal / interval) + 1) * interval
+    }
+
+    static func resolvedNextMilestone(
+        storedNextMilestone: Int?,
+        total: Int,
+        intervalKind: ContributionMilestoneKind,
+        githubStarClicked: Bool,
+        buyMeCoffeeClicked: Bool
+    ) -> Int? {
+        guard !githubStarClicked || !buyMeCoffeeClicked else { return nil }
+        switch intervalKind {
+        case .dictationWords:
+            return storedNextMilestone ?? nextMilestone(after: total)
+        case .meetings:
+            return storedNextMilestone ?? nextMeetingMilestone(after: total)
+        }
+    }
+
+    static func prompt(
+        kind: ContributionMilestoneKind,
+        total: Int,
+        nextMilestone: Int?,
+        githubStarClicked: Bool,
+        buyMeCoffeeClicked: Bool,
+        dismissedThisLaunch: Bool
+    ) -> ContributionMilestonePrompt? {
+        guard !dismissedThisLaunch,
+              let nextMilestone,
+              total >= nextMilestone,
+              !githubStarClicked || !buyMeCoffeeClicked else {
+            return nil
+        }
+
+        return ContributionMilestonePrompt(
+            kind: kind,
+            count: nextMilestone,
+            showGitHubStar: !githubStarClicked,
+            showBuyMeCoffee: !buyMeCoffeeClicked
+        )
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -17,6 +17,35 @@ struct DashboardRootView: View {
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 900, minHeight: 600)
         .preferredColorScheme(appState.config.darkMode ? .dark : .light)
+        .alert(
+            appState.contributionMilestonePrompt?.title ?? "Muesli milestone",
+            isPresented: Binding(
+                get: { appState.contributionMilestonePrompt != nil },
+                set: { if !$0 { controller.dismissContributionMilestonePrompt() } }
+            )
+        ) {
+            if appState.contributionMilestonePrompt?.showGitHubStar == true {
+                Button("Star on GitHub") {
+                    controller.openContributionMilestoneAction(.githubStar)
+                }
+            }
+            if appState.contributionMilestonePrompt?.showBuyMeCoffee == true {
+                Button("Buy Me a Coffee") {
+                    controller.openContributionMilestoneAction(.buyMeCoffee)
+                }
+            }
+            Button("Later", role: .cancel) {
+                controller.dismissContributionMilestonePrompt()
+            }
+        } message: {
+            Text(appState.contributionMilestonePrompt?.message ?? "")
+        }
+        .onAppear {
+            controller.recordContributionMilestonePromptSeen()
+        }
+        .onChange(of: appState.contributionMilestonePrompt?.id) { _, _ in
+            controller.recordContributionMilestonePromptSeen()
+        }
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -195,7 +195,7 @@ struct DictationsView: View {
                     controller.openContributionMilestoneAction(.buyMeCoffee)
                 }
             }
-            Button("Not Now", role: .cancel) {
+            Button("Later", role: .cancel) {
                 controller.dismissContributionMilestonePrompt()
             }
         } message: {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -178,35 +178,6 @@ struct DictationsView: View {
                 }
             }
         }
-        .alert(
-            appState.contributionMilestonePrompt?.title ?? "Muesli milestone",
-            isPresented: Binding(
-                get: { appState.contributionMilestonePrompt != nil },
-                set: { if !$0 { controller.dismissContributionMilestonePrompt() } }
-            )
-        ) {
-            if appState.contributionMilestonePrompt?.showGitHubStar == true {
-                Button("Star on GitHub") {
-                    controller.openContributionMilestoneAction(.githubStar)
-                }
-            }
-            if appState.contributionMilestonePrompt?.showBuyMeCoffee == true {
-                Button("Buy Me a Coffee") {
-                    controller.openContributionMilestoneAction(.buyMeCoffee)
-                }
-            }
-            Button("Later", role: .cancel) {
-                controller.dismissContributionMilestonePrompt()
-            }
-        } message: {
-            Text(appState.contributionMilestonePrompt?.message ?? "")
-        }
-        .onAppear {
-            controller.recordContributionMilestonePromptSeen()
-        }
-        .onChange(of: appState.contributionMilestonePrompt?.id) { _, _ in
-            controller.recordContributionMilestonePromptSeen()
-        }
     }
 
     private var bridgeState: ICloudBridgeState {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -178,6 +178,35 @@ struct DictationsView: View {
                 }
             }
         }
+        .alert(
+            appState.contributionMilestonePrompt?.title ?? "Muesli milestone",
+            isPresented: Binding(
+                get: { appState.contributionMilestonePrompt != nil },
+                set: { if !$0 { controller.dismissContributionMilestonePrompt() } }
+            )
+        ) {
+            if appState.contributionMilestonePrompt?.showGitHubStar == true {
+                Button("Star on GitHub") {
+                    controller.openContributionMilestoneAction(.githubStar)
+                }
+            }
+            if appState.contributionMilestonePrompt?.showBuyMeCoffee == true {
+                Button("Buy Me a Coffee") {
+                    controller.openContributionMilestoneAction(.buyMeCoffee)
+                }
+            }
+            Button("Not Now", role: .cancel) {
+                controller.dismissContributionMilestonePrompt()
+            }
+        } message: {
+            Text(appState.contributionMilestonePrompt?.message ?? "")
+        }
+        .onAppear {
+            controller.recordContributionMilestonePromptSeen()
+        }
+        .onChange(of: appState.contributionMilestonePrompt?.id) { _, _ in
+            controller.recordContributionMilestonePromptSeen()
+        }
     }
 
     private var bridgeState: ICloudBridgeState {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -788,6 +788,10 @@ struct AppConfig: Codable {
     var meetingHookTimeoutSeconds: Int = 30
     var iCloudSyncEnabled: Bool = false
     var showIOSCompanionPrompt: Bool = true
+    var contributionPromptNextWordCount: Int?
+    var contributionPromptNextMeetingCount: Int?
+    var contributionGitHubStarClicked: Bool = false
+    var contributionBuyMeCoffeeClicked: Bool = false
 
     enum CodingKeys: String, CodingKey {
         case dictationHotkey = "dictation_hotkey"
@@ -868,6 +872,10 @@ struct AppConfig: Codable {
         case meetingHookTimeoutSeconds = "meeting_hook_timeout_seconds"
         case iCloudSyncEnabled = "icloud_sync_enabled"
         case showIOSCompanionPrompt = "show_ios_companion_prompt"
+        case contributionPromptNextWordCount = "contribution_prompt_next_word_count"
+        case contributionPromptNextMeetingCount = "contribution_prompt_next_meeting_count"
+        case contributionGitHubStarClicked = "contribution_github_star_clicked"
+        case contributionBuyMeCoffeeClicked = "contribution_buy_me_coffee_clicked"
     }
 
     init() {}
@@ -980,6 +988,10 @@ struct AppConfig: Codable {
         meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled
         meetingHookPath = (try? c.decode(String.self, forKey: .meetingHookPath)) ?? defaults.meetingHookPath
         meetingHookTimeoutSeconds = (try? c.decode(Int.self, forKey: .meetingHookTimeoutSeconds)) ?? defaults.meetingHookTimeoutSeconds
+        contributionPromptNextWordCount = try? c.decode(Int.self, forKey: .contributionPromptNextWordCount)
+        contributionPromptNextMeetingCount = try? c.decode(Int.self, forKey: .contributionPromptNextMeetingCount)
+        contributionGitHubStarClicked = (try? c.decode(Bool.self, forKey: .contributionGitHubStarClicked)) ?? defaults.contributionGitHubStarClicked
+        contributionBuyMeCoffeeClicked = (try? c.decode(Bool.self, forKey: .contributionBuyMeCoffeeClicked)) ?? defaults.contributionBuyMeCoffeeClicked
     }
 
     var resolvedCohereLanguage: CohereTranscribeLanguage {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -998,6 +998,18 @@ final class MuesliController: NSObject {
         guard let prompt = appState.contributionMilestonePrompt else { return }
         contributionMilestonePromptDismissedThisLaunch = true
         appState.contributionMilestonePrompt = nil
+        let nextMilestone = ContributionMilestonePolicy.nextMilestone(
+            after: prompt.kind == .dictationWords ? appState.dictationStats.totalWords : appState.meetingStats.totalMeetings,
+            kind: prompt.kind
+        )
+        switch prompt.kind {
+        case .dictationWords:
+            config.contributionPromptNextWordCount = nextMilestone
+        case .meetings:
+            config.contributionPromptNextMeetingCount = nextMilestone
+        }
+        configStore.save(config)
+        appState.config = config
         TelemetryDeck.signal("contribution_prompt_dismissed", parameters: [
             "kind": prompt.kind.rawValue,
             "count": "\(prompt.count)",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1005,12 +1005,14 @@ final class MuesliController: NSObject {
     }
 
     func openContributionMilestoneAction(_ action: ContributionMilestoneAction) {
+        guard let prompt = appState.contributionMilestonePrompt else { return }
         NSWorkspace.shared.open(action.url)
+        // CTA clicks intentionally dismiss for this launch; any remaining CTA can reappear next launch.
         contributionMilestonePromptDismissedThisLaunch = true
         TelemetryDeck.signal("contribution_prompt_action_clicked", parameters: [
             "action": action.rawValue,
-            "kind": appState.contributionMilestonePrompt?.kind.rawValue ?? "",
-            "count": appState.contributionMilestonePrompt.map { "\($0.count)" } ?? "",
+            "kind": prompt.kind.rawValue,
+            "count": "\(prompt.count)",
         ])
 
         updateConfig { config in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -290,6 +290,8 @@ final class MuesliController: NSObject {
     private var isTerminatingAfterMeetingConfirmation = false
     private var backgroundMeetingProcessingCount = 0
     private var pendingMeetingCompletionNotification: PendingMeetingCompletionNotification?
+    private var contributionMilestonePromptDismissedThisLaunch = false
+    private var contributionMilestonePromptSeenIDsThisLaunch: Set<String> = []
     private var meetingStartTask: Task<Void, Never>?
     private var meetingStartMeetingID: Int64?
     private var importTask: Task<Void, Never>?
@@ -742,6 +744,10 @@ final class MuesliController: NSObject {
         }
         appState.dictationStats = dictationStats()
         appState.meetingStats = meetingStats()
+        refreshContributionMilestonePrompt(
+            totalWords: appState.dictationStats.totalWords,
+            totalMeetings: appState.meetingStats.totalMeetings
+        )
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
@@ -934,6 +940,95 @@ final class MuesliController: NSObject {
         } else if wasICloudSyncEnabled && !config.iCloudSyncEnabled {
             disableICloudSyncRuntimeState()
         }
+    }
+
+    private func refreshContributionMilestonePrompt(totalWords: Int, totalMeetings: Int) {
+        let resolvedNextWordMilestone = ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: config.contributionPromptNextWordCount,
+            total: totalWords,
+            intervalKind: .dictationWords,
+            githubStarClicked: config.contributionGitHubStarClicked,
+            buyMeCoffeeClicked: config.contributionBuyMeCoffeeClicked
+        )
+        let resolvedNextMeetingMilestone = ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: config.contributionPromptNextMeetingCount,
+            total: totalMeetings,
+            intervalKind: .meetings,
+            githubStarClicked: config.contributionGitHubStarClicked,
+            buyMeCoffeeClicked: config.contributionBuyMeCoffeeClicked
+        )
+
+        if config.contributionPromptNextWordCount != resolvedNextWordMilestone ||
+            config.contributionPromptNextMeetingCount != resolvedNextMeetingMilestone {
+            config.contributionPromptNextWordCount = resolvedNextWordMilestone
+            config.contributionPromptNextMeetingCount = resolvedNextMeetingMilestone
+            configStore.save(config)
+        }
+
+        appState.config = config
+        appState.contributionMilestonePrompt = ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: totalWords,
+            nextMilestone: resolvedNextWordMilestone,
+            githubStarClicked: config.contributionGitHubStarClicked,
+            buyMeCoffeeClicked: config.contributionBuyMeCoffeeClicked,
+            dismissedThisLaunch: contributionMilestonePromptDismissedThisLaunch
+        ) ?? ContributionMilestonePolicy.prompt(
+            kind: .meetings,
+            total: totalMeetings,
+            nextMilestone: resolvedNextMeetingMilestone,
+            githubStarClicked: config.contributionGitHubStarClicked,
+            buyMeCoffeeClicked: config.contributionBuyMeCoffeeClicked,
+            dismissedThisLaunch: contributionMilestonePromptDismissedThisLaunch
+        )
+    }
+
+    func recordContributionMilestonePromptSeen() {
+        guard let prompt = appState.contributionMilestonePrompt,
+              contributionMilestonePromptSeenIDsThisLaunch.insert(prompt.id).inserted else { return }
+        TelemetryDeck.signal("contribution_prompt_seen", parameters: [
+            "kind": prompt.kind.rawValue,
+            "count": "\(prompt.count)",
+            "github_star_clicked": "\(config.contributionGitHubStarClicked)",
+            "buy_me_coffee_clicked": "\(config.contributionBuyMeCoffeeClicked)",
+        ])
+    }
+
+    func dismissContributionMilestonePrompt() {
+        guard let prompt = appState.contributionMilestonePrompt else { return }
+        contributionMilestonePromptDismissedThisLaunch = true
+        appState.contributionMilestonePrompt = nil
+        TelemetryDeck.signal("contribution_prompt_dismissed", parameters: [
+            "kind": prompt.kind.rawValue,
+            "count": "\(prompt.count)",
+        ])
+    }
+
+    func openContributionMilestoneAction(_ action: ContributionMilestoneAction) {
+        NSWorkspace.shared.open(action.url)
+        contributionMilestonePromptDismissedThisLaunch = true
+        TelemetryDeck.signal("contribution_prompt_action_clicked", parameters: [
+            "action": action.rawValue,
+            "kind": appState.contributionMilestonePrompt?.kind.rawValue ?? "",
+            "count": appState.contributionMilestonePrompt.map { "\($0.count)" } ?? "",
+        ])
+
+        updateConfig { config in
+            switch action {
+            case .githubStar:
+                config.contributionGitHubStarClicked = true
+            case .buyMeCoffee:
+                config.contributionBuyMeCoffeeClicked = true
+            }
+            if config.contributionGitHubStarClicked && config.contributionBuyMeCoffeeClicked {
+                config.contributionPromptNextWordCount = nil
+                config.contributionPromptNextMeetingCount = nil
+            }
+        }
+        refreshContributionMilestonePrompt(
+            totalWords: appState.dictationStats.totalWords,
+            totalMeetings: appState.meetingStats.totalMeetings
+        )
     }
 
     func performICloudSync() {

--- a/native/MuesliNative/Tests/MuesliTests/ContributionMilestoneTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ContributionMilestoneTests.swift
@@ -10,10 +10,12 @@ struct ContributionMilestoneTests {
         #expect(ContributionMilestonePolicy.nextMilestone(after: 999) == 1_000)
         #expect(ContributionMilestonePolicy.nextMilestone(after: 1_000) == 2_000)
         #expect(ContributionMilestonePolicy.nextMilestone(after: 30_500) == 31_000)
+        #expect(ContributionMilestonePolicy.nextMilestone(after: 30_500, kind: .dictationWords) == 31_000)
         #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 0) == 25)
         #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 24) == 25)
         #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 25) == 50)
         #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 63) == 75)
+        #expect(ContributionMilestonePolicy.nextMilestone(after: 63, kind: .meetings) == 75)
     }
 
     @Test("stored milestone is initialized from current total")
@@ -31,7 +33,7 @@ struct ContributionMilestoneTests {
             intervalKind: .dictationWords,
             githubStarClicked: false,
             buyMeCoffeeClicked: false
-        ) == 30_000)
+        ) == 31_000)
         #expect(ContributionMilestonePolicy.resolvedNextMilestone(
             storedNextMilestone: nil,
             total: 63,
@@ -48,7 +50,7 @@ struct ContributionMilestoneTests {
         ) == nil)
     }
 
-    @Test("stale stored milestones advance to the latest crossed boundary")
+    @Test("stale stored milestones advance past current total")
     func staleStoredMilestonesAdvance() {
         #expect(ContributionMilestonePolicy.resolvedNextMilestone(
             storedNextMilestone: 31_000,
@@ -63,14 +65,14 @@ struct ContributionMilestoneTests {
             intervalKind: .dictationWords,
             githubStarClicked: false,
             buyMeCoffeeClicked: false
-        ) == 33_000)
+        ) == 34_000)
         #expect(ContributionMilestonePolicy.resolvedNextMilestone(
             storedNextMilestone: 25,
             total: 63,
             intervalKind: .meetings,
             githubStarClicked: false,
             buyMeCoffeeClicked: false
-        ) == 50)
+        ) == 75)
     }
 
     @Test("prompt is eligible only after crossing stored milestone")
@@ -122,7 +124,7 @@ struct ContributionMilestoneTests {
         #expect(prompt?.title == "You captured 25 meetings!")
     }
 
-    @Test("dismissal suppresses prompt only for current launch input")
+    @Test("dismissal suppresses current launch and advances next prompt")
     func dismissalSuppression() {
         #expect(ContributionMilestonePolicy.prompt(
             kind: .dictationWords,
@@ -140,6 +142,17 @@ struct ContributionMilestoneTests {
             buyMeCoffeeClicked: false,
             dismissedThisLaunch: false
         ) != nil)
+
+        let nextAfterDismissal = ContributionMilestonePolicy.nextMilestone(after: 31_500, kind: .dictationWords)
+        #expect(nextAfterDismissal == 32_000)
+        #expect(ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: 31_500,
+            nextMilestone: nextAfterDismissal,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        ) == nil)
     }
 
     @Test("completed actions control remaining prompt actions")

--- a/native/MuesliNative/Tests/MuesliTests/ContributionMilestoneTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ContributionMilestoneTests.swift
@@ -31,7 +31,7 @@ struct ContributionMilestoneTests {
             intervalKind: .dictationWords,
             githubStarClicked: false,
             buyMeCoffeeClicked: false
-        ) == 12_000)
+        ) == 30_000)
         #expect(ContributionMilestonePolicy.resolvedNextMilestone(
             storedNextMilestone: nil,
             total: 63,
@@ -46,6 +46,31 @@ struct ContributionMilestoneTests {
             githubStarClicked: true,
             buyMeCoffeeClicked: true
         ) == nil)
+    }
+
+    @Test("stale stored milestones advance to the latest crossed boundary")
+    func staleStoredMilestonesAdvance() {
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: 31_000,
+            total: 31_500,
+            intervalKind: .dictationWords,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false
+        ) == 31_000)
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: 31_000,
+            total: 33_000,
+            intervalKind: .dictationWords,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false
+        ) == 33_000)
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: 25,
+            total: 63,
+            intervalKind: .meetings,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false
+        ) == 50)
     }
 
     @Test("prompt is eligible only after crossing stored milestone")

--- a/native/MuesliNative/Tests/MuesliTests/ContributionMilestoneTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ContributionMilestoneTests.swift
@@ -1,0 +1,142 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("ContributionMilestone")
+struct ContributionMilestoneTests {
+
+    @Test("next milestone is strict thousand boundary")
+    func nextMilestone() {
+        #expect(ContributionMilestonePolicy.nextMilestone(after: 0) == 1_000)
+        #expect(ContributionMilestonePolicy.nextMilestone(after: 999) == 1_000)
+        #expect(ContributionMilestonePolicy.nextMilestone(after: 1_000) == 2_000)
+        #expect(ContributionMilestonePolicy.nextMilestone(after: 30_500) == 31_000)
+        #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 0) == 25)
+        #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 24) == 25)
+        #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 25) == 50)
+        #expect(ContributionMilestonePolicy.nextMeetingMilestone(after: 63) == 75)
+    }
+
+    @Test("stored milestone is initialized from current total")
+    func resolvedNextMilestone() {
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: nil,
+            total: 30_500,
+            intervalKind: .dictationWords,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false
+        ) == 31_000)
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: 12_000,
+            total: 30_500,
+            intervalKind: .dictationWords,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false
+        ) == 12_000)
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: nil,
+            total: 63,
+            intervalKind: .meetings,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false
+        ) == 75)
+        #expect(ContributionMilestonePolicy.resolvedNextMilestone(
+            storedNextMilestone: 31_000,
+            total: 31_500,
+            intervalKind: .dictationWords,
+            githubStarClicked: true,
+            buyMeCoffeeClicked: true
+        ) == nil)
+    }
+
+    @Test("prompt is eligible only after crossing stored milestone")
+    func promptEligibility() {
+        #expect(ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: 30_999,
+            nextMilestone: 31_000,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        ) == nil)
+
+        let prompt = ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: 31_000,
+            nextMilestone: 31_000,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        )
+        #expect(prompt?.kind == .dictationWords)
+        #expect(prompt?.count == 31_000)
+        #expect(prompt?.showGitHubStar == true)
+        #expect(prompt?.showBuyMeCoffee == true)
+    }
+
+    @Test("meeting prompt is eligible after crossing stored meeting milestone")
+    func meetingPromptEligibility() {
+        #expect(ContributionMilestonePolicy.prompt(
+            kind: .meetings,
+            total: 24,
+            nextMilestone: 25,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        ) == nil)
+
+        let prompt = ContributionMilestonePolicy.prompt(
+            kind: .meetings,
+            total: 25,
+            nextMilestone: 25,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        )
+        #expect(prompt?.kind == .meetings)
+        #expect(prompt?.count == 25)
+        #expect(prompt?.title == "You captured 25 meetings!")
+    }
+
+    @Test("dismissal suppresses prompt only for current launch input")
+    func dismissalSuppression() {
+        #expect(ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: 31_000,
+            nextMilestone: 31_000,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: true
+        ) == nil)
+        #expect(ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: 31_000,
+            nextMilestone: 31_000,
+            githubStarClicked: false,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        ) != nil)
+    }
+
+    @Test("completed actions control remaining prompt actions")
+    func remainingActions() {
+        #expect(ContributionMilestonePolicy.prompt(
+            kind: .dictationWords,
+            total: 31_000,
+            nextMilestone: 31_000,
+            githubStarClicked: true,
+            buyMeCoffeeClicked: true,
+            dismissedThisLaunch: false
+        ) == nil)
+
+        let prompt = ContributionMilestonePolicy.prompt(
+            kind: .meetings,
+            total: 25,
+            nextMilestone: 25,
+            githubStarClicked: true,
+            buyMeCoffeeClicked: false,
+            dismissedThisLaunch: false
+        )
+        #expect(prompt?.showGitHubStar == false)
+        #expect(prompt?.showBuyMeCoffee == true)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -459,6 +459,10 @@ struct AppConfigTests {
         #expect(config.meetingHookEnabled == false)
         #expect(config.meetingHookPath.isEmpty)
         #expect(config.meetingHookTimeoutSeconds == 30)
+        #expect(config.contributionPromptNextWordCount == nil)
+        #expect(config.contributionPromptNextMeetingCount == nil)
+        #expect(config.contributionGitHubStarClicked == false)
+        #expect(config.contributionBuyMeCoffeeClicked == false)
     }
 
     @Test("JSON encode/decode round-trip")
@@ -500,6 +504,10 @@ struct AppConfigTests {
         config.customLLMAPIKey = "custom-key"
         config.customLLMModel = "custom-model"
         config.customLLMFormat = "anthropic"
+        config.contributionPromptNextWordCount = 31_000
+        config.contributionPromptNextMeetingCount = 75
+        config.contributionGitHubStarClicked = true
+        config.contributionBuyMeCoffeeClicked = false
 
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
@@ -537,11 +545,17 @@ struct AppConfigTests {
         #expect(decoded.customLLMAPIKey == "custom-key")
         #expect(decoded.customLLMModel == "custom-model")
         #expect(decoded.customLLMFormat == "anthropic")
+        #expect(decoded.contributionPromptNextWordCount == 31_000)
+        #expect(decoded.contributionPromptNextMeetingCount == 75)
+        #expect(decoded.contributionGitHubStarClicked == true)
+        #expect(decoded.contributionBuyMeCoffeeClicked == false)
     }
 
     @Test("JSON coding keys use snake_case")
     func snakeCaseKeys() throws {
-        let config = AppConfig()
+        var config = AppConfig()
+        config.contributionPromptNextWordCount = 1_000
+        config.contributionPromptNextMeetingCount = 25
         let data = try JSONEncoder().encode(config)
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
 
@@ -572,6 +586,10 @@ struct AppConfigTests {
         #expect(json["meeting_hook_enabled"] != nil)
         #expect(json["meeting_hook_path"] != nil)
         #expect(json["meeting_hook_timeout_seconds"] != nil)
+        #expect(json["contribution_prompt_next_word_count"] != nil)
+        #expect(json["contribution_prompt_next_meeting_count"] != nil)
+        #expect(json["contribution_github_star_clicked"] != nil)
+        #expect(json["contribution_buy_me_coffee_clicked"] != nil)
         #expect(json["lmstudio_url"] != nil)
         #expect(json["lmstudio_model"] != nil)
         #expect(json["custom_llm_url"] != nil)


### PR DESCRIPTION
## Summary
- add one-time usage milestone prompts for dictated words and completed meetings
- persist independent CTA state and launch-only dismissals in AppConfig/AppState
- cover milestone math, CTA visibility, and config coding defaults

## Validation
- git diff --check
- swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/contribution-prompts" --filter 'AppConfigTests|ContributionMilestone'\n- MUESLI_SWIFTPM_SCRATCH_PATH="/Volumes/MuesliBuildCache/muesli-spm/worktrees/43e3/usage-milestone-prompts-dev" ./scripts/dev-test.sh built /Applications/MuesliDev.app using the eSSD scratch path\n\n## Notes\n- The first signed dev launch hit a local provisioning-profile rejection for com.muesli.dev; rebuilding with MUESLI_SKIP_SIGN=1 installed and invoked the dev app path, though the app process exited immediately after launch on this machine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784610767&installation_id=136549638&pr_number=234&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F234&signature=b7f4c252a9c9d97762636eb99f5d4bce5c304528bd21b0f6694c9ffaf240253c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->