### PR TITLE
feat(meetings): transcript timestamps and subtitle export

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -182,37 +182,82 @@ enum AudioFileImportController {
         try Task.checkCancellation()
 
         progress("Transcribing audio...")
-        let transcription = try await transcriptionCoordinator.transcribeMeeting(
-            at: wavURL,
-            backend: backend,
-            cohereLanguage: config.resolvedCohereLanguage
-        )
-        let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !rawTranscript.isEmpty else {
+        // Obtain VAD-timed segments so timestamps work for ALL backends, not just Parakeet.
+        var timedSegments: [SpeechSegment] = []
+        // Reused for diarization below to avoid a second full-file decode on the common path.
+        var resampledSamples: [Float]?
+        if let vadManager = await transcriptionCoordinator.getVadManager() {
+            do {
+                let samples = try AudioConverter().resampleAudioFile(wavURL)
+                resampledSamples = samples
+                timedSegments = try await VadTimedTranscriber.timedSegments(
+                    samples: samples,
+                    vadManager: vadManager
+                ) { sliceURL in
+                    try await transcriptionCoordinator.transcribeMeeting(
+                        at: sliceURL,
+                        backend: backend,
+                        cohereLanguage: config.resolvedCohereLanguage
+                    )
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // Best-effort timestamps: any failure in the VAD-timed pass falls
+                // back to the full-file (complete, untimed) path below. Drop any
+                // partial resample so diarization re-decodes cleanly.
+                fputs("[import] VAD-timed transcription failed, falling back to full-file: \(error)\n", stderr)
+                timedSegments = []
+                resampledSamples = nil
+            }
+        }
+
+        // Fallback: if VAD unavailable, single full-file transcription (untimed) as before.
+        let transcription: SpeechTranscriptionResult
+        let fallbackText: String
+        if timedSegments.isEmpty {
+            let whole = try await transcriptionCoordinator.transcribeMeeting(
+                at: wavURL,
+                backend: backend,
+                cohereLanguage: config.resolvedCohereLanguage
+            )
+            fallbackText = whole.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            transcription = whole
+        } else {
+            fallbackText = timedSegments.map(\.text).joined(separator: " ")
+            transcription = SpeechTranscriptionResult(text: fallbackText, segments: timedSegments)
+        }
+        guard !fallbackText.isEmpty else {
             throw ImportError.readError("No speech was transcribed from the selected audio file.")
         }
 
         try Task.checkCancellation()
 
         // Run speaker diarization if available
-        var diarizedTranscript = rawTranscript
+        var diarizedTranscript = InlineTranscriptFormatter.transcriptForStorage(
+            segments: timedSegments, multiSpeakerText: nil, fallbackText: fallbackText)
         if let diarizerManager = await transcriptionCoordinator.getDiarizerManager(),
            diarizerManager.isAvailable {
             progress("Identifying speakers...")
             do {
-                let converter = AudioConverter()
-                let samples = try converter.resampleAudioFile(wavURL)
+                // Reuse the VAD-path resample when present; only re-decode in the
+                // VAD-unavailable fallback (keeps behavior identical, one decode).
+                let samples = try resampledSamples ?? AudioConverter().resampleAudioFile(wavURL)
                 try Task.checkCancellation()
                 let diarizationResult = try diarizerManager.performCompleteDiarization(
                     samples,
                     sampleRate: 16000
                 )
                 if !diarizationResult.segments.isEmpty {
-                    diarizedTranscript = formatTranscriptWithSpeakers(
-                        transcription: transcription,
-                        diarizationSegments: diarizationResult.segments,
-                        meetingStart: importedTranscriptTimelineStart()
-                    )
+                    let speakerCount = Set(diarizationResult.segments.map(\.speakerId)).count
+                    if speakerCount > 1 {
+                        diarizedTranscript = formatTranscriptWithSpeakers(
+                            transcription: transcription,
+                            diarizationSegments: diarizationResult.segments,
+                            meetingStart: importedTranscriptTimelineStart()
+                        )
+                    }
+                    // single speaker: keep the inline-timestamped diarizedTranscript built above
                 }
             } catch is CancellationError {
                 throw CancellationError()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import MuesliCore
 
 private enum MeetingDocumentMode: Hashable {
@@ -55,6 +56,7 @@ struct MeetingDetailView: View {
     @State private var pendingTemplateID: String
     @State private var documentMode: MeetingDocumentMode
     @State private var recordingMode: RecordingContentMode = .notes
+    @State private var showTimestamps: Bool = true
     @State private var titleSaveTask: DispatchWorkItem?
     @State private var notesSaveTask: DispatchWorkItem?
     @State private var transcriptSaveTask: DispatchWorkItem?
@@ -358,7 +360,7 @@ struct MeetingDetailView: View {
                         .allowsHitTesting(documentMode == .notes)
                         .accessibilityHidden(documentMode != .notes)
 
-                    MeetingTranscriptView(transcript: meeting.rawTranscript)
+                    MeetingTranscriptView(transcript: meeting.rawTranscript, showTimestamps: showTimestamps)
                         .opacity(documentMode == .transcript ? 1 : 0)
                         .allowsHitTesting(documentMode == .transcript)
                         .accessibilityHidden(documentMode != .transcript)
@@ -552,6 +554,53 @@ struct MeetingDetailView: View {
         }
     }
 
+    /// Export subtitles directly when the transcript already carries inline timestamps;
+    /// otherwise offer to Re-transcribe (which generates them) and auto-export on success.
+    private func exportSubtitlesOrOfferRetranscribe(for meeting: MeetingRecord) {
+        guard !isRetranscribing else { return }
+
+        if MeetingExporter.transcriptHasTimestamps(meeting.rawTranscript) {
+            MeetingExporter.exportSubtitles(meeting: meeting)
+            return
+        }
+
+        // Re-transcribe can only regenerate timestamps when a saved recording exists
+        // (controller.retranscribe early-returns otherwise). Don't offer a dead button.
+        let hasRecording = (meeting.savedRecordingPath?.isEmpty == false)
+        guard hasRecording else {
+            let alert = NSAlert()
+            alert.messageText = "No Timestamps"
+            alert.informativeText = "This transcript has no timestamps and no saved recording to regenerate them from."
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "No Timestamps Yet"
+        alert.informativeText = "This transcript doesn't have timestamps yet, which subtitles require. Re-transcribe to generate them, then export subtitles automatically."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Re-transcribe")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        guard !isRetranscribing else { return }
+        isRetranscribing = true
+        controller.retranscribe(meeting: meeting) { [meeting] result in
+            isRetranscribing = false
+            switch result {
+            case .success:
+                if let updated = controller.meeting(id: meeting.id) {
+                    syncLocalState(with: updated)
+                    MeetingExporter.exportSubtitles(meeting: updated)
+                }
+            case .failure(let error):
+                retranscriptionErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
     @ViewBuilder
     private func templateMenu(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
         Menu {
@@ -630,6 +679,17 @@ struct MeetingDetailView: View {
             Spacer()
 
             retranscribeAction(for: meeting)
+
+            if documentMode == .transcript,
+               MeetingExporter.transcriptHasTimestamps(meeting.rawTranscript) {
+                Button {
+                    showTimestamps.toggle()
+                } label: {
+                    Label(showTimestamps ? "Hide Timestamps" : "Show Timestamps",
+                          systemImage: showTimestamps ? "clock.fill" : "clock")
+                }
+                .help(showTimestamps ? "Hide timestamps" : "Show timestamps")
+            }
 
             Button(action: {
                 controller.copyToClipboard(activeCopyText(for: meeting))
@@ -797,6 +857,12 @@ struct MeetingDetailView: View {
                 MeetingExporter.export(meeting: meeting, content: .fullMeeting)
             } label: {
                 Label("Export Full Meeting", systemImage: "doc.on.doc")
+            }
+            Divider()
+            Button {
+                exportSubtitlesOrOfferRetranscribe(for: meeting)
+            } label: {
+                Label("Export Subtitles…", systemImage: "captions.bubble")
             }
         } label: {
             HStack(spacing: 6) {
@@ -1461,35 +1527,39 @@ private struct MarqueeTitleTextField: View {
     private let titleFont = Font.system(size: 30, weight: .bold)
 
     var body: some View {
-        ZStack(alignment: .leading) {
-            TextField("Meeting Title", text: $text)
-                .font(titleFont)
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .textFieldStyle(.plain)
-                .lineLimit(1)
-                .opacity(shouldShowMarquee ? 0 : 1)
-                .focused($isTitleFocused)
-                .onSubmit(onSubmit)
-                .onChange(of: text) { _, _ in
-                    onTextChange()
-                    restartMarqueeIfNeeded()
-                }
-                .onChange(of: isTitleFocused) { _, _ in
-                    restartMarqueeIfNeeded()
-                }
-
-            Text(text.isEmpty ? "Meeting Title" : text)
-                .font(titleFont)
-                .fontWeight(.bold)
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                .offset(x: marqueeOffset)
-                .opacity(shouldShowMarquee ? 1 : 0)
-                .allowsHitTesting(false)
-        }
-        .frame(maxWidth: .infinity, minHeight: 38, alignment: .leading)
-        .clipped()
+        TextField("Meeting Title", text: $text)
+            .font(titleFont)
+            .foregroundStyle(MuesliTheme.textPrimary)
+            .textFieldStyle(.plain)
+            .lineLimit(1)
+            .opacity(shouldShowMarquee ? 0 : 1)
+            .focused($isTitleFocused)
+            .onSubmit(onSubmit)
+            .onChange(of: text) { _, _ in
+                onTextChange()
+                restartMarqueeIfNeeded()
+            }
+            .onChange(of: isTitleFocused) { _, _ in
+                restartMarqueeIfNeeded()
+            }
+            .frame(maxWidth: .infinity, minHeight: 38, alignment: .leading)
+            // The scrolling marquee text is an overlay, not a ZStack sibling, so its
+            // `fixedSize` width does NOT drive the field's own layout width. As a
+            // sibling it forced the title to its full intrinsic width, overflowing the
+            // header and pushing the action toolbar off-screen for long titles.
+            // `.clipped()` keeps the overflowing marquee text within the field bounds.
+            .overlay(alignment: .leading) {
+                Text(text.isEmpty ? "Meeting Title" : text)
+                    .font(titleFont)
+                    .fontWeight(.bold)
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .offset(x: marqueeOffset)
+                    .opacity(shouldShowMarquee ? 1 : 0)
+                    .allowsHitTesting(false)
+            }
+            .clipped()
         .contentShape(Rectangle())
         .background(
             GeometryReader { proxy in
@@ -1660,10 +1730,12 @@ struct TranscriptChatMessage: Identifiable, Equatable {
 
 private struct MeetingTranscriptView: View {
     let transcript: String
+    let showTimestamps: Bool
     @State private var messages: [TranscriptChatMessage]
 
-    init(transcript: String) {
+    init(transcript: String, showTimestamps: Bool) {
         self.transcript = transcript
+        self.showTimestamps = showTimestamps
         _messages = State(initialValue: TranscriptChatMessage.messages(from: transcript))
     }
 
@@ -1678,7 +1750,7 @@ private struct MeetingTranscriptView: View {
                         .padding(MuesliTheme.spacing24)
                 } else {
                     ForEach(messages) { message in
-                        TranscriptChatBubble(message: message)
+                        TranscriptChatBubble(message: message, showTimestamps: showTimestamps)
                     }
                 }
             }
@@ -1695,6 +1767,7 @@ private struct MeetingTranscriptView: View {
 
 struct TranscriptChatBubble: View {
     let message: TranscriptChatMessage
+    var showTimestamps: Bool = true
 
     var body: some View {
         HStack(alignment: .bottom, spacing: MuesliTheme.spacing8) {
@@ -1733,13 +1806,14 @@ struct TranscriptChatBubble: View {
     }
 
     private var metadata: String? {
-        switch (message.speaker, message.timestamp) {
-        case let (speaker?, timestamp?):
-            return "\(speaker) \(timestamp)"
+        let timestamp = showTimestamps ? message.timestamp : nil
+        switch (message.speaker, timestamp) {
+        case let (speaker?, ts?):
+            return "\(speaker) \(ts)"
         case let (speaker?, nil):
             return speaker
-        case let (nil, timestamp?):
-            return timestamp
+        case let (nil, ts?):
+            return ts
         case (nil, nil):
             return nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingExporter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingExporter.swift
@@ -12,6 +12,10 @@ struct MeetingExporter {
 
     static let mdType = UTType(filenameExtension: "md") ?? .plainText
     static let pdfType = UTType.pdf
+    static let srtType = UTType(filenameExtension: "srt") ?? .plainText
+    static let vttType = UTType(filenameExtension: "vtt") ?? .plainText
+
+    enum SubtitleFormat { case srt, vtt }
 
     static func export(meeting: MeetingRecord, content: MeetingExportContent) {
         DispatchQueue.main.async {
@@ -34,6 +38,87 @@ struct MeetingExporter {
                 }
             }
         }
+    }
+
+    // MARK: - Subtitle export
+
+    /// True when the transcript contains at least one inline [HH:MM:SS] / [MM:SS] line.
+    static func transcriptHasTimestamps(_ transcript: String) -> Bool {
+        !TranscriptTimestampParser.parse(transcript).isEmpty
+    }
+
+    /// Pure string builder — returns nil when the transcript carries no inline timestamps.
+    /// `isWallClock` is true for live recordings (markers are time-of-day and must
+    /// be rebased to media time 0) and false for imports (markers are already
+    /// elapsed media time and must be left untouched).
+    /// `wallClockOrigin` is the live meeting's start time-of-day in seconds — the
+    /// rebase anchor that preserves leading silence; nil falls back to the first marker.
+    static func subtitleString(transcript: String, totalDuration: Double, isWallClock: Bool, wallClockOrigin: Double? = nil, format: SubtitleFormat) -> String? {
+        let lines = TranscriptTimestampParser.parse(transcript)
+        guard !lines.isEmpty else { return nil }
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: totalDuration, isWallClock: isWallClock, wallClockOrigin: wallClockOrigin)
+        switch format {
+        case .srt: return SubtitleBuilder.srt(cues: cues)
+        case .vtt: return SubtitleBuilder.vtt(cues: cues)
+        }
+    }
+
+    static func exportSubtitles(meeting: MeetingRecord) {
+        // Imports store elapsed media time; live recordings store wall-clock.
+        let isWallClock = meeting.source != .audioImport
+        // Rebase live cues against the meeting's START time-of-day so leading
+        // silence is preserved (first spoken marker is not the recording start).
+        let wallClockOrigin: Double? = isWallClock
+            ? MeetingBrowserLogic.parseDate(meeting.startTime).map {
+                $0.timeIntervalSince(Calendar.current.startOfDay(for: $0))
+            }
+            : nil
+        DispatchQueue.main.async {
+            // Default to SRT; the accessory popup lets the user switch to VTT.
+            guard subtitleString(transcript: meeting.rawTranscript,
+                                 totalDuration: meeting.durationSeconds,
+                                 isWallClock: isWallClock,
+                                 wallClockOrigin: wallClockOrigin, format: .srt) != nil else {
+                showError("No Timestamps",
+                          "This transcript has no timestamps yet. Use Re-transcribe to generate them, then export subtitles.")
+                return
+            }
+            let panel = NSSavePanel()
+            // Bare stem (no extension): `allowedContentTypes` supplies the extension.
+            // Putting ".srt" here too makes NSSavePanel append a second one (".srt.srt").
+            panel.nameFieldStringValue = suggestedSubtitleStem(meeting: meeting)
+            panel.allowedContentTypes = [srtType]
+            panel.canCreateDirectories = true
+
+            let picker = SubtitleFormatAccessory(panel: panel)
+            panel.accessoryView = picker.view
+
+            presentSavePanel(panel) { url in
+                let format: SubtitleFormat = picker.selectedFormat
+                guard let text = subtitleString(transcript: meeting.rawTranscript,
+                                                totalDuration: meeting.durationSeconds,
+                                                isWallClock: isWallClock,
+                                                wallClockOrigin: wallClockOrigin, format: format) else {
+                    showError("Export Failed", "Could not build subtitles.")
+                    return
+                }
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        try text.write(to: url, atomically: true, encoding: .utf8)
+                        DispatchQueue.main.async { NSWorkspace.shared.open(url) }
+                    } catch {
+                        DispatchQueue.main.async { showError("Export Failed", error.localizedDescription) }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Base filename WITHOUT extension. The NSSavePanel's `allowedContentTypes`
+    /// appends the chosen subtitle extension, so this must not include one.
+    static func suggestedSubtitleStem(meeting: MeetingRecord) -> String {
+        let base = (suggestedFilename(meeting: meeting, content: .transcript) as NSString).deletingPathExtension
+        return base.hasSuffix("-transcript") ? String(base.dropLast("-transcript".count)) : base
     }
 
     // MARK: - Markdown composition
@@ -409,5 +494,51 @@ private class ExportFormatAccessory: NSObject {
             panel.allowedContentTypes = [MeetingExporter.mdType]
             panel.nameFieldStringValue = "\(stem).md"
         }
+    }
+}
+
+// MARK: - Subtitle format picker accessory
+
+private class SubtitleFormatAccessory: NSObject {
+    let view: NSView
+    private let popup: NSPopUpButton
+    private weak var panel: NSSavePanel?
+
+    var selectedFormat: MeetingExporter.SubtitleFormat {
+        popup.indexOfSelectedItem == 0 ? .srt : .vtt
+    }
+
+    init(panel: NSSavePanel) {
+        self.panel = panel
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 260, height: 32))
+
+        let label = NSTextField(labelWithString: "Format:")
+        label.font = .systemFont(ofSize: 13)
+        label.frame = NSRect(x: 0, y: 6, width: 55, height: 20)
+
+        let button = NSPopUpButton(frame: NSRect(x: 60, y: 2, width: 190, height: 28), pullsDown: false)
+        button.addItems(withTitles: ["SRT", "WebVTT"])
+        button.selectItem(at: 0)
+
+        container.addSubview(label)
+        container.addSubview(button)
+
+        self.popup = button
+        self.view = container
+
+        super.init()
+
+        button.target = self
+        button.action = #selector(formatChanged)
+    }
+
+    @objc private func formatChanged() {
+        guard let panel else { return }
+        // Keep the name field as a bare stem; `allowedContentTypes` supplies the
+        // extension. Re-adding ".srt"/".vtt" here would double it (".srt.srt").
+        let stem = (panel.nameFieldStringValue as NSString).deletingPathExtension
+        panel.allowedContentTypes = [selectedFormat == .srt ? MeetingExporter.srtType : MeetingExporter.vttType]
+        panel.nameFieldStringValue = stem
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2,6 +2,7 @@ import AppKit
 import AVFoundation
 import CloudKit
 import CoreAudio
+import FluidAudio
 import Foundation
 import Sparkle
 import TelemetryDeck
@@ -2884,15 +2885,59 @@ final class MuesliController: NSObject {
                     enablePostProcessor: false,
                     includeMeetingHelpers: true
                 )
-                let transcription = try await self.transcriptionCoordinator.transcribeMeeting(
-                    at: recordingURL,
-                    backend: backend,
-                    cohereLanguage: self.config.resolvedCohereLanguage
-                )
-                let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !rawTranscript.isEmpty else {
+                // Obtain VAD-timed segments so timestamps work for ALL backends, not just Parakeet.
+                var timedSegments: [SpeechSegment] = []
+                if let vadManager = await self.transcriptionCoordinator.getVadManager() {
+                    do {
+                        let samples = try AudioConverter().resampleAudioFile(recordingURL)
+                        timedSegments = try await VadTimedTranscriber.timedSegments(
+                            samples: samples,
+                            vadManager: vadManager
+                        ) { sliceURL in
+                            try await self.transcriptionCoordinator.transcribeMeeting(
+                                at: sliceURL,
+                                backend: backend,
+                                cohereLanguage: self.config.resolvedCohereLanguage
+                            )
+                        }
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        // Best-effort timestamps: fall back to the full-file
+                        // (complete, untimed) path below on any VAD-timed failure.
+                        fputs("[retranscribe] VAD-timed transcription failed, falling back to full-file: \(error)\n", stderr)
+                        timedSegments = []
+                    }
+                }
+
+                // Fallback: if VAD unavailable, single full-file transcription (untimed) as before.
+                let flatText: String
+                if timedSegments.isEmpty {
+                    let whole = try await self.transcriptionCoordinator.transcribeMeeting(
+                        at: recordingURL,
+                        backend: backend,
+                        cohereLanguage: self.config.resolvedCohereLanguage
+                    )
+                    flatText = whole.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                } else {
+                    flatText = timedSegments.map(\.text).joined(separator: " ")
+                }
+                guard !flatText.isEmpty else {
                     throw MeetingRetranscriptionError.emptyTranscript
                 }
+                // Live recordings store WALL-CLOCK markers (TranscriptFormatter.merge
+                // anchors at the real meeting start). Re-transcription must match so
+                // subtitle export — which rebases by meeting source — stays correct;
+                // otherwise a live meeting whose first speech starts minutes in would
+                // get its cues shifted to 0. Imports keep elapsed markers (offset 0).
+                let liveClockOffset: Double = {
+                    guard meeting.source != .audioImport,
+                          let start = MeetingBrowserLogic.parseDate(meeting.startTime) else { return 0 }
+                    return start.timeIntervalSince(Calendar.current.startOfDay(for: start))
+                }()
+                let rawTranscript = InlineTranscriptFormatter.transcriptForStorage(
+                    segments: timedSegments, multiSpeakerText: nil, fallbackText: flatText,
+                    startOffsetSeconds: liveClockOffset)
 
                 let templateSnapshot = MeetingTemplates.snapshot(
                     for: meeting,

--- a/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/InlineTranscriptFormatter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/InlineTranscriptFormatter.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Builds a readable transcript string with inline `[HH:MM:SS]` markers from
+/// single-speaker ASR segments. Lines break at sentence boundaries (., ?, !)
+/// or when a line grows past `maxLineWords`, so the transcript view renders
+/// readable bubbles rather than one wall of text.
+enum InlineTranscriptFormatter {
+    private static let maxLineWords = 40
+
+    /// - `startOffsetSeconds`: added to every label so the markers read as
+    ///   wall-clock time-of-day. Live recordings pass the meeting's start
+    ///   time-of-day (matching `TranscriptFormatter.merge`); imports pass 0 so
+    ///   their markers stay elapsed media time. Subtitle export keys its rebase
+    ///   off the meeting source, so the two conventions must stay aligned.
+    static func timestampedTranscript(from segments: [SpeechSegment],
+                                      startOffsetSeconds: Double = 0) -> String {
+        let usable = segments
+            .map { SpeechSegment(start: $0.start, end: $0.end,
+                                 text: $0.text.trimmingCharacters(in: .whitespacesAndNewlines)) }
+            .filter { !$0.text.isEmpty }
+        guard !usable.isEmpty else { return "" }
+
+        var lines: [String] = []
+        var lineStart: Double = usable[0].start
+        var lineWords: [String] = []
+
+        func flush() {
+            guard !lineWords.isEmpty else { return }
+            let label = SubtitleTimecode.inlineLabel(seconds: lineStart + startOffsetSeconds)
+            lines.append("[\(label)] \(lineWords.joined(separator: " "))")
+            lineWords.removeAll(keepingCapacity: true)
+        }
+
+        for segment in usable {
+            if lineWords.isEmpty { lineStart = segment.start }
+            let words = segment.text.split(whereSeparator: { $0 == " " }).map(String.init)
+            lineWords.append(contentsOf: words)
+
+            let endsSentence = segment.text.last.map { ".?!".contains($0) } ?? false
+            if endsSentence || lineWords.count >= maxLineWords {
+                flush()
+            }
+        }
+        flush()
+        return lines.joined(separator: "\n")
+    }
+
+    /// Decides what text to persist as `rawTranscript`.
+    /// - `multiSpeakerText`: non-nil when diarization produced multi-speaker,
+    ///   already-timestamped text — use it verbatim.
+    /// - else build timestamped lines from VAD-timed `segments`.
+    /// - else fall back to `fallbackText` (e.g. joined region text).
+    /// NOTE: in production both call sites pass `multiSpeakerText: nil`; the
+    /// multi-speaker result is applied downstream by reassigning
+    /// `diarizedTranscript` after diarization runs. The parameter exists so this
+    /// selection policy stays unit-testable in one place.
+    static func transcriptForStorage(
+        segments: [SpeechSegment],
+        multiSpeakerText: String?,
+        fallbackText: String,
+        startOffsetSeconds: Double = 0
+    ) -> String {
+        if let multiSpeakerText, !multiSpeakerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return multiSpeakerText
+        }
+        let timestamped = timestampedTranscript(from: segments, startOffsetSeconds: startOffsetSeconds)
+        return timestamped.isEmpty ? fallbackText : timestamped
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/SubtitleBuilder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/SubtitleBuilder.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum SubtitleBuilder {
+    static func srt(cues: [SubtitleCue]) -> String {
+        guard !cues.isEmpty else { return "" }
+        let body = cues.map { cue in
+            let start = SubtitleTimecode.string(seconds: cue.start, style: .srt)
+            let end = SubtitleTimecode.string(seconds: cue.end, style: .srt)
+            return "\(cue.index)\n\(start) --> \(end)\n\(cue.text)"
+        }.joined(separator: "\n\n")
+        // SRT convention: terminate the final cue with a blank line so strict
+        // parsers don't drop it.
+        return body + "\n"
+    }
+
+    static func vtt(cues: [SubtitleCue]) -> String {
+        var blocks = ["WEBVTT"]
+        for cue in cues {
+            let start = SubtitleTimecode.string(seconds: cue.start, style: .vtt)
+            let end = SubtitleTimecode.string(seconds: cue.end, style: .vtt)
+            blocks.append("\(start) --> \(end)\n\(cue.text)")
+        }
+        return blocks.joined(separator: "\n\n")
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/SubtitleModels.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/SubtitleModels.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// One subtitle cue with absolute start/end (seconds from media start) and text.
+struct SubtitleCue: Equatable {
+    var index: Int
+    var start: Double
+    var end: Double
+    var text: String
+}
+
+enum SubtitleTimecode {
+    enum Style { case srt, vtt }
+
+    /// Cue timecode, e.g. "00:01:23,500" (srt) or "00:01:23.500" (vtt).
+    static func string(seconds: Double, style: Style) -> String {
+        let clamped = max(0, seconds)
+        let totalMillis = Int((clamped * 1000).rounded())
+        let ms = totalMillis % 1000
+        let totalSeconds = totalMillis / 1000
+        let s = totalSeconds % 60
+        let m = (totalSeconds / 60) % 60
+        let h = totalSeconds / 3600
+        let fractionSeparator = style == .srt ? "," : "."
+        return String(format: "%02d:%02d:%02d%@%03d", h, m, s, fractionSeparator, ms)
+    }
+
+    /// Inline transcript label, e.g. "00:01:23" (no fraction).
+    static func inlineLabel(seconds: Double) -> String {
+        let clamped = max(0, seconds)
+        let totalSeconds = Int(clamped.rounded(.down))
+        let s = totalSeconds % 60
+        let m = (totalSeconds / 60) % 60
+        let h = totalSeconds / 3600
+        return String(format: "%02d:%02d:%02d", h, m, s)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/SubtitleSegmenter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/SubtitleSegmenter.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Re-groups timestamped transcript lines into short subtitle cues.
+/// Subtitle convention: a cue should be quick to read — we cap each cue at
+/// `maxWords` and split longer lines, interpolating time linearly across the
+/// line's [start, nextStart) span.
+enum SubtitleSegmenter {
+    private static let secondsPerDay: Double = 86_400
+
+    static func cues(
+        from lines: [ParsedTranscriptLine],
+        totalDuration: Double,
+        isWallClock: Bool,
+        wallClockOrigin: Double? = nil,
+        maxWords: Int = 7,
+        minCueDuration: Double = 0.4,
+        tailSeconds: Double = 2.0
+    ) -> [SubtitleCue] {
+        guard !lines.isEmpty else { return [] }
+
+        // Live recordings (MeetingSource.meeting / .iOS) store WALL-CLOCK
+        // time-of-day markers (e.g. 14:30:05, or 00:01:04 for a meeting started
+        // just after midnight) rather than elapsed media time.
+        //
+        // Imported media (.audioImport) is the opposite: its markers are already
+        // elapsed media time (single-speaker uses elapsed-from-zero; multi-speaker
+        // diarization anchors at startOfDay, i.e. midnight, which is also elapsed).
+        // Its speech may legitimately start at a large offset (a 1h recording
+        // silent until 30:00), so it must NEVER be rebased — the offset is real.
+        //
+        // The two are numerically indistinguishable (a live meeting at 00:30 and
+        // an import with first speech at 30:00 both read [00:30:00]). Speaker
+        // labels don't separate them either — diarized imports also carry
+        // Speaker N: labels. Only the meeting's source reliably tells them apart,
+        // so the caller passes it in as `isWallClock`.
+        //
+        // For live recordings the rebase origin is the meeting's START time-of-day
+        // (`wallClockOrigin`), NOT the first spoken marker. Anchoring on first
+        // speech would drop any leading silence (meeting starts 14:30, first words
+        // 14:35 -> [14:35:00] must map to media 300s, not 0). The markers are
+        // formatted through DateFormatter "HH:mm:ss", so a meeting crossing
+        // midnight produces a decreasing run ([23:59:58] then [00:00:02]). It can
+        // also start before midnight while its FIRST spoken marker is already past
+        // midnight (origin 23:55, first speech 00:05 -> 300s) with no earlier line
+        // to reveal the wrap. `unwrapMidnight` handles both by lifting any marker
+        // more than half a day below a running reference (seeded with the origin)
+        // onto the next day, then we subtract the origin. When the origin is
+        // unknown (unparseable start), fall back to the smallest marker so cues at
+        // least begin near zero.
+        var working = lines
+        if isWallClock {
+            working = unwrapMidnight(lines, origin: wallClockOrigin)
+            let origin = wallClockOrigin ?? (working.map(\.startSeconds).min() ?? 0)
+            if origin != 0 {
+                working = working.map {
+                    ParsedTranscriptLine(startSeconds: $0.startSeconds - origin, text: $0.text)
+                }
+            }
+        }
+        let lines = working
+
+        var cues: [SubtitleCue] = []
+        var index = 1
+        // Whole-second rounding can make consecutive lines share a start time.
+        // Track the previous cue's end as a cursor so emitted cues never overlap
+        // and their starts are non-decreasing, across both whole-line cues and
+        // the split sub-cues of a long line.
+        var cursor = 0.0
+
+        for (i, line) in lines.enumerated() {
+            let lineStart = line.startSeconds
+            let nextStart = (i + 1 < lines.count)
+                ? lines[i + 1].startSeconds
+                : (totalDuration > lineStart ? totalDuration : lineStart + tailSeconds)
+            let lineEnd = max(nextStart, lineStart + minCueDuration)
+
+            let words = line.text.split(whereSeparator: { $0 == " " }).map(String.init)
+            guard !words.isEmpty else { continue }
+
+            let groups = stride(from: 0, to: words.count, by: maxWords).map { start -> [String] in
+                Array(words[start..<min(start + maxWords, words.count)])
+            }
+            let span = lineEnd - lineStart
+            let totalWords = Double(words.count)
+            var consumed = 0
+            for group in groups {
+                let startFraction = Double(consumed) / totalWords
+                consumed += group.count
+                let endFraction = Double(consumed) / totalWords
+                let start = max(lineStart + span * startFraction, cursor)
+                let end = max(lineStart + span * endFraction, start + minCueDuration)
+                cues.append(SubtitleCue(
+                    index: index,
+                    start: start,
+                    end: end,
+                    text: group.joined(separator: " ")
+                ))
+                cursor = end
+                index += 1
+            }
+        }
+        return cues
+    }
+
+    /// Live wall-clock markers are formatted HH:mm:ss, so a meeting crossing
+    /// midnight wraps to a decreasing run. Restore monotonic time by lifting a
+    /// marker onto the next day whenever it sits more than half a day below a
+    /// running reference. The reference is seeded with the meeting's start
+    /// `origin`, so a first spoken marker already past midnight is caught even
+    /// though no earlier line exposes the wrap; thereafter it tracks the running
+    /// max so later wrapped lines stay ordered. The half-day tolerance is the key
+    /// invariant: a genuine midnight wrap is a ~24h backward step, while clock
+    /// skew is at most seconds — only the former crosses the tolerance, so skew is
+    /// left to clamp near zero instead of being misread as a 24h jump. When the
+    /// origin is unknown the first marker seeds the reference (no lift on it).
+    private static func unwrapMidnight(_ lines: [ParsedTranscriptLine],
+                                       origin: Double?) -> [ParsedTranscriptLine] {
+        let tolerance = secondsPerDay / 2
+        var dayOffset: Double = 0
+        var reference: Double = origin ?? -.greatestFiniteMagnitude
+        return lines.map { line in
+            var seconds = line.startSeconds + dayOffset
+            if seconds < reference - tolerance {
+                dayOffset += secondsPerDay
+                seconds += secondsPerDay
+            }
+            reference = max(reference, seconds)
+            return ParsedTranscriptLine(startSeconds: seconds, text: line.text)
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/TranscriptTimestampParser.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/TranscriptTimestampParser.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+struct ParsedTranscriptLine: Equatable {
+    var startSeconds: Double
+    var text: String
+}
+
+/// Parses a stored transcript whose lines may begin with `[HH:MM:SS]` or
+/// `[MM:SS]`, optionally followed by a `You:` / `Others:` / `Speaker N:` label.
+/// Lines without a leading timestamp are skipped (they carry no timing).
+enum TranscriptTimestampParser {
+    static func parse(_ transcript: String) -> [ParsedTranscriptLine] {
+        var result: [ParsedTranscriptLine] = []
+        for rawLine in transcript.replacingOccurrences(of: "\r\n", with: "\n").split(separator: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard line.hasPrefix("["), let close = line.firstIndex(of: "]") else { continue }
+            let inside = String(line[line.index(after: line.startIndex)..<close])
+            guard let seconds = seconds(fromTimecode: inside) else { continue }
+            var body = line[line.index(after: close)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            body = stripSpeakerLabel(body)
+            guard !body.isEmpty else { continue }
+            result.append(ParsedTranscriptLine(startSeconds: seconds, text: body))
+        }
+        return result
+    }
+
+    /// Accepts "HH:MM:SS" or "MM:SS".
+    static func seconds(fromTimecode raw: String) -> Double? {
+        let parts = raw.split(separator: ":").map(String.init)
+        guard parts.count == 2 || parts.count == 3 else { return nil }
+        let ints = parts.compactMap { Int($0) }
+        guard ints.count == parts.count else { return nil }
+        if ints.count == 3 { return Double(ints[0] * 3600 + ints[1] * 60 + ints[2]) }
+        return Double(ints[0] * 60 + ints[1])
+    }
+
+    private static func stripSpeakerLabel(_ text: String) -> String {
+        guard let colon = text.firstIndex(of: ":") else { return text }
+        let candidate = text[..<colon].trimmingCharacters(in: .whitespacesAndNewlines)
+        let isLabel = candidate.localizedCaseInsensitiveCompare("You") == .orderedSame
+            || candidate.localizedCaseInsensitiveCompare("Others") == .orderedSame
+            || candidate.range(of: #"^Speaker\s+\d+$"#, options: [.regularExpression, .caseInsensitive]) != nil
+        guard isLabel else { return text }
+        return text[text.index(after: colon)...].trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/VadTimedTranscriber.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Subtitles/VadTimedTranscriber.swift
@@ -1,0 +1,70 @@
+import Foundation
+import FluidAudio
+
+/// A speech region with absolute time bounds (seconds), backend-agnostic.
+struct VadTimedRegion: Equatable {
+    var startTime: Double
+    var endTime: Double
+}
+
+/// Builds timed `SpeechSegment`s by transcribing each VAD speech region
+/// independently, so timing works for every ASR backend (not just Parakeet).
+enum VadTimedTranscriber {
+    /// PURE SEAM: given regions and a per-region transcribe function, build
+    /// timed segments. Blank transcriptions are dropped. Order is preserved.
+    static func assemble(
+        regions: [VadTimedRegion],
+        transcribe: (VadTimedRegion) async throws -> String
+    ) async rethrows -> [SpeechSegment] {
+        var out: [SpeechSegment] = []
+        for region in regions {
+            let text = try await transcribe(region).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            out.append(SpeechSegment(start: region.startTime, end: region.endTime, text: text))
+        }
+        return out
+    }
+
+    /// IO DRIVER (not unit-tested — exercised manually): run VAD on `samples`,
+    /// transcribe each region via `transcribeWAV`, return timed segments.
+    /// Delegates to `assemble` so production and tests share one drop/tag path.
+    /// Mirrors the existing pattern at MeetingSession.swift:904-949.
+    static func timedSegments(
+        samples: [Float],
+        vadManager: VadManager,
+        maxSpeechDuration: Double = 10.0,
+        transcribeWAV: (URL) async throws -> SpeechTranscriptionResult
+    ) async throws -> [SpeechSegment] {
+        let speechSegments = try await vadManager.segmentSpeech(
+            samples,
+            config: VadSegmentationConfig(maxSpeechDuration: maxSpeechDuration, speechPadding: 0.15)
+        )
+        // `VadSegment.startTime`/`.endTime` are `TimeInterval` (Double) already.
+        let regions = speechSegments.map {
+            VadTimedRegion(startTime: $0.startTime, endTime: $0.endTime)
+        }
+        let sampleRate = VadManager.sampleRate
+        return try await assemble(regions: regions) { region in
+            // Stay cancellable mid-run on long files (many regions, slow cloud ASR).
+            try Task.checkCancellation()
+            // Sample bounds mirror VadSegment.startSample/endSample: Int(time * rate).
+            let startSample = max(0, Int(region.startTime * Double(sampleRate)))
+            let endSample = min(samples.count, Int(region.endTime * Double(sampleRate)))
+            // Degenerate slice → empty text; `assemble` drops it (single drop path).
+            guard endSample > startSample else { return "" }
+            let sliceURL = try MeetingMicRepairPlanner.writeTemporaryWAV(
+                samples: Array(samples[startSample..<endSample])
+            )
+            defer { try? FileManager.default.removeItem(at: sliceURL) }
+            do {
+                return try await transcribeWAV(sliceURL).text
+            } catch is CancellationError {
+                // Real cancellation must abort the whole job — propagate.
+                throw CancellationError()
+            }
+            // A real transcription error PROPAGATES (assemble rethrows), so the
+            // caller can fall back to a full-file, untimed transcription rather
+            // than silently dropping this region's speech.
+        }
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/InlineTranscriptFormatterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InlineTranscriptFormatterTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Inline Transcript Formatter")
+struct InlineTranscriptFormatterTests {
+    @Test("prefixes each grouped line with its start timecode")
+    func prefixesTimecode() {
+        let segments = [
+            SpeechSegment(start: 0, end: 2.0, text: "Hello there."),
+            SpeechSegment(start: 2.0, end: 4.0, text: "This is a test."),
+        ]
+        let out = InlineTranscriptFormatter.timestampedTranscript(from: segments)
+        let lines = out.split(separator: "\n").map(String.init)
+        #expect(lines.first == "[00:00:00] Hello there.")
+        #expect(lines.contains("[00:00:02] This is a test."))
+    }
+
+    @Test("groups tiny fragments up to the sentence boundary")
+    func groupsFragments() {
+        let segments = [
+            SpeechSegment(start: 0, end: 0.4, text: "Hello"),
+            SpeechSegment(start: 0.4, end: 0.9, text: "there"),
+            SpeechSegment(start: 0.9, end: 1.4, text: "world."),
+        ]
+        let out = InlineTranscriptFormatter.timestampedTranscript(from: segments)
+        // One sentence => one line, timestamped at the first fragment's start.
+        #expect(out == "[00:00:00] Hello there world.")
+    }
+
+    @Test("empty segments produce empty string")
+    func empty() {
+        #expect(InlineTranscriptFormatter.timestampedTranscript(from: []) == "")
+    }
+
+    @Test("falls back to flat text when no usable segments but text exists")
+    func fallback() {
+        // A single huge no-punctuation segment still yields one timestamped line.
+        let segments = [SpeechSegment(start: 0, end: 5, text: "one two three four five")]
+        let out = InlineTranscriptFormatter.timestampedTranscript(from: segments)
+        #expect(out == "[00:00:00] one two three four five")
+    }
+
+    @Test("uses timestamped lines for single-speaker, passes through multi-speaker text")
+    func selectionPolicy() {
+        let segments = [SpeechSegment(start: 0, end: 2, text: "Hello there.")]
+        let single = InlineTranscriptFormatter.transcriptForStorage(
+            segments: segments, multiSpeakerText: nil, fallbackText: "Hello there.")
+        #expect(single == "[00:00:00] Hello there.")
+
+        let multi = InlineTranscriptFormatter.transcriptForStorage(
+            segments: segments,
+            multiSpeakerText: "[00:00:00] Speaker 1: Hello there.",
+            fallbackText: "Hello there.")
+        #expect(multi == "[00:00:00] Speaker 1: Hello there.")
+
+        let none = InlineTranscriptFormatter.transcriptForStorage(
+            segments: [], multiSpeakerText: nil, fallbackText: "raw flat text")
+        #expect(none == "raw flat text")
+    }
+
+    @Test("startOffsetSeconds shifts labels to wall-clock time-of-day")
+    func wallClockOffset() {
+        // A live meeting started at 14:30:00 (52200s). Elapsed segments at 0s/5s
+        // must read as wall-clock [14:30:00] / [14:30:05] so subtitle export's
+        // source-based rebase recovers media time.
+        let segments = [
+            SpeechSegment(start: 0, end: 2, text: "Hello there."),
+            SpeechSegment(start: 5, end: 7, text: "Second sentence."),
+        ]
+        let out = InlineTranscriptFormatter.timestampedTranscript(from: segments, startOffsetSeconds: 52200)
+        let lines = out.split(separator: "\n").map(String.init)
+        #expect(lines.first == "[14:30:00] Hello there.")
+        #expect(lines.contains("[14:30:05] Second sentence."))
+    }
+
+    @Test("splits a long unpunctuated run at the word cap into multiple lines")
+    func splitsAtWordCap() {
+        // 50 single-word segments with no sentence punctuation: the running word
+        // count crosses maxLineWords (40) and flushes mid-stream, so the output
+        // breaks into more than one line.
+        let segments = (1...50).map {
+            SpeechSegment(start: Double($0), end: Double($0) + 0.5, text: "w\($0)")
+        }
+        let out = InlineTranscriptFormatter.timestampedTranscript(from: segments)
+        let lines = out.split(separator: "\n")
+        #expect(lines.count > 1)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingExporterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingExporterTests.swift
@@ -29,6 +29,18 @@ struct MeetingExporterTests {
         )
     }
 
+    // MARK: - Timestamp detection
+
+    @Test("transcriptHasTimestamps is true for an inline-timestamped transcript")
+    func transcriptHasTimestampsTrue() {
+        #expect(MeetingExporter.transcriptHasTimestamps("[00:00:00] hi"))
+    }
+
+    @Test("transcriptHasTimestamps is false for plain text")
+    func transcriptHasTimestampsFalse() {
+        #expect(!MeetingExporter.transcriptHasTimestamps("just some plain words with no timestamps"))
+    }
+
     // MARK: - Markdown composition
 
     @Test("Notes export includes metadata header and formatted notes")
@@ -241,5 +253,21 @@ struct MeetingExporterTests {
 
         let stem = name.replacingOccurrences(of: ".pdf", with: "")
         #expect(stem.count <= 50)
+    }
+
+    // MARK: - Subtitle export
+
+    @Test("builds SRT from a timestamped transcript")
+    func subtitleStringSRT() {
+        let raw = "[00:00:00] Hello there.\n[00:00:04] Goodbye now."
+        let out = MeetingExporter.subtitleString(transcript: raw, totalDuration: 6, isWallClock: false, format: .srt)
+        #expect(out?.contains("00:00:00,000 --> 00:00:04,000") == true)
+        #expect(out?.contains("Hello there.") == true)
+        #expect(out?.contains("00:00:04,000 --> 00:00:06,000") == true)
+    }
+
+    @Test("returns nil when transcript has no timestamps")
+    func subtitleStringNoTimestamps() {
+        #expect(MeetingExporter.subtitleString(transcript: "no markers here", totalDuration: 6, isWallClock: false, format: .srt) == nil)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/SubtitleBuilderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SubtitleBuilderTests.swift
@@ -1,0 +1,46 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Subtitle Builder")
+struct SubtitleBuilderTests {
+    private let cues = [
+        SubtitleCue(index: 1, start: 0, end: 3.5, text: "Hello there."),
+        SubtitleCue(index: 2, start: 3.5, end: 6, text: "General Kenobi."),
+    ]
+
+    @Test("builds valid SRT")
+    func srt() {
+        let out = SubtitleBuilder.srt(cues: cues)
+        let expected = """
+        1
+        00:00:00,000 --> 00:00:03,500
+        Hello there.
+
+        2
+        00:00:03,500 --> 00:00:06,000
+        General Kenobi.
+        """
+        #expect(out.trimmingCharacters(in: .whitespacesAndNewlines)
+                == expected.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    @Test("non-empty SRT ends with a trailing blank line")
+    func srtTrailingNewline() {
+        let out = SubtitleBuilder.srt(cues: cues)
+        #expect(out.hasSuffix("\n"))
+    }
+
+    @Test("builds valid VTT with header and dot separator")
+    func vtt() {
+        let out = SubtitleBuilder.vtt(cues: cues)
+        #expect(out.hasPrefix("WEBVTT"))
+        #expect(out.contains("00:00:00.000 --> 00:00:03.500"))
+    }
+
+    @Test("empty cues still produce a WEBVTT header / empty srt")
+    func empty() {
+        #expect(SubtitleBuilder.srt(cues: []) == "")
+        #expect(SubtitleBuilder.vtt(cues: []).hasPrefix("WEBVTT"))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SubtitleSegmenterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SubtitleSegmenterTests.swift
@@ -1,0 +1,221 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Subtitle Segmenter")
+struct SubtitleSegmenterTests {
+    @Test("one short line becomes one cue spanning to the next line")
+    func basicSpacing() {
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 0, text: "Hello there."),
+            ParsedTranscriptLine(startSeconds: 4, text: "Goodbye."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 6, isWallClock: false)
+        #expect(cues.count == 2)
+        #expect(cues[0].index == 1)
+        #expect(cues[0].start == 0)
+        #expect(cues[0].end == 4)
+        #expect(cues[1].start == 4)
+        #expect(cues[1].end == 6)            // tail clamped to totalDuration
+    }
+
+    @Test("a long line splits into multiple short cues with interpolated times")
+    func splitsLongLine() {
+        // 14 words over 0..7s, maxWords 7 => two cues of 7 words, ~3.5s each.
+        let text = (1...14).map { "w\($0)" }.joined(separator: " ")
+        let lines = [ParsedTranscriptLine(startSeconds: 0, text: text)]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 7, isWallClock: false, maxWords: 7)
+        #expect(cues.count == 2)
+        #expect(cues[0].start == 0)
+        #expect(abs(cues[0].end - 3.5) < 0.01)
+        #expect(abs(cues[1].start - 3.5) < 0.01)
+        #expect(cues[1].end == 7)
+        #expect(cues[0].text == "w1 w2 w3 w4 w5 w6 w7")
+        #expect(cues[1].text == "w8 w9 w10 w11 w12 w13 w14")
+        #expect(cues[1].index == 2)          // indices are sequential across splits
+    }
+
+    @Test("rebases live wall-clock timestamps to media time zero")
+    func rebasesWallClock() {
+        // 14:30:00 and 14:30:04 as wall-clock -> 52200s, 52204s; media is 6s long.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 52200, text: "Hello there."),
+            ParsedTranscriptLine(startSeconds: 52204, text: "Goodbye."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 6, isWallClock: true)
+        #expect(cues.first?.start == 0)
+        #expect(cues.first?.end == 4)
+        #expect(cues.last?.end == 6)
+    }
+
+    @Test("does NOT rebase imported elapsed times with a leading offset")
+    func keepsLeadingOffset() {
+        let lines = [ParsedTranscriptLine(startSeconds: 30, text: "Late start.")]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 300, isWallClock: false)
+        #expect(cues.first?.start == 30)   // preserved, not rebased to 0
+    }
+
+    @Test("rebases live wall-clock timestamps even when duration is unknown")
+    func rebasesWallClockWithoutDuration() {
+        // Older/synced live meetings carry wall-clock markers but no known
+        // duration (totalDuration 0). The huge leading offset must still rebase.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 52200, text: "Hello there."),
+            ParsedTranscriptLine(startSeconds: 52204, text: "Goodbye."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 0, isWallClock: true)
+        #expect(cues.first?.start == 0)         // rebased to start at zero
+        #expect(cues.first?.end == 4)           // content span preserved
+        #expect(cues.last!.end < 10)            // far below the 52204s wall-clock
+    }
+
+    @Test("rebases a near-midnight live meeting that stays within duration")
+    func rebasesMidnightWallClockWithinDuration() {
+        // A live meeting started at 00:01:00 stores wall-clock markers
+        // [00:01:00] / [00:01:04] (60s, 64s) — numerically below a 600s duration.
+        // Because the source is live (isWallClock), they still rebase to media 0.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 60, text: "Hello there."),
+            ParsedTranscriptLine(startSeconds: 64, text: "Goodbye."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 600, isWallClock: true)
+        #expect(cues.first?.start == 0)   // rebased, not 60s late
+        #expect(cues.first?.end == 4)
+    }
+
+    @Test("does NOT rebase imported elapsed times even when sparse")
+    func keepsSparseElapsedWithKnownDuration() {
+        // A 1h import silent until 30:00: minStart (1800) dwarfs the speech span,
+        // but these are real elapsed media times. An import (isWallClock false)
+        // must keep them — the subtitles belong at 30:00, not 0.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 1800, text: "Speech starts late."),
+            ParsedTranscriptLine(startSeconds: 1804, text: "And continues."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 3600, isWallClock: false)
+        #expect(cues.first?.start == 1800)      // NOT rebased to 0
+    }
+
+    @Test("does not overlap cues whose lines share a start time")
+    func nonOverlappingDuplicateStarts() {
+        // Whole-second rounding makes both lines round to start 5; cues must
+        // stay non-overlapping with non-decreasing starts.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 5, text: "First line here."),
+            ParsedTranscriptLine(startSeconds: 5, text: "Second line here."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 12, isWallClock: false)
+        #expect(cues.count == 2)
+        #expect(cues[1].start >= cues[0].end)   // no overlap
+        #expect(cues[0].start <= cues[1].start)  // non-decreasing starts
+    }
+
+    @Test("clamps zero-gap cues to a minimum positive duration")
+    func clampsMinCueDuration() {
+        // Two lines sharing a start time leave no gap; minCueDuration must keep
+        // the first cue from collapsing to zero length.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 0, text: "First."),
+            ParsedTranscriptLine(startSeconds: 0, text: "Second."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 10, isWallClock: false)
+        #expect(cues.first!.end > cues.first!.start)
+    }
+
+    @Test("preserves leading silence using the meeting start origin")
+    func preservesLeadingSilence() {
+        // Meeting starts 14:30:00 (origin 52200s); first speech at 14:35:00
+        // (52500s). Rebasing against the START — not the first marker — keeps the
+        // 300s of leading silence so the first cue lands at 300, not 0.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 52500, text: "Hello there."),
+            ParsedTranscriptLine(startSeconds: 52504, text: "Goodbye."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 600,
+                                          isWallClock: true, wallClockOrigin: 52200)
+        #expect(cues.first?.start == 300)   // 52500 - 52200, silence preserved
+        #expect(cues.first?.end == 304)
+    }
+
+    @Test("falls back to first marker when no origin is supplied")
+    func wallClockFallsBackToFirstMarker() {
+        // Unparseable start time => nil origin => rebase on the smallest marker so
+        // cues still begin near zero rather than 14h into the media.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 52500, text: "Hello there."),
+            ParsedTranscriptLine(startSeconds: 52504, text: "Goodbye."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 600,
+                                          isWallClock: true, wallClockOrigin: nil)
+        #expect(cues.first?.start == 0)
+        #expect(cues.first?.end == 4)
+    }
+
+    @Test("unwraps a live meeting crossing midnight before rebasing")
+    func unwrapsMidnightCrossing() {
+        // Meeting starts 23:55:00 (origin 86100s). Markers cross midnight:
+        // 23:59:58 (86398s) then 00:00:02 wraps to 2s in HH:mm:ss. Unwrapping adds
+        // a day to the post-midnight marker so it stays after, not 24h before.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 86398, text: "Before midnight."),
+            ParsedTranscriptLine(startSeconds: 2, text: "After midnight."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 600,
+                                          isWallClock: true, wallClockOrigin: 86100)
+        #expect(cues.count == 2)
+        #expect(cues[0].start == 298)            // 86398 - 86100
+        #expect(cues[1].start == 302)            // (2 + 86400) - 86100, not negative
+        #expect(cues[1].start >= cues[0].end)    // monotonic, no 24h blowup
+    }
+
+    @Test("lifts a first marker already past midnight using the origin")
+    func liftsPostMidnightFirstMarker() {
+        // Meeting starts 23:55:00 (origin 86100s). The first — and only — spoken
+        // marker is 00:05:00, which parses as 300s. No earlier line exposes the
+        // wrap, so the origin floor must push it to the next day: 300 + 86400 -
+        // 86100 = 600s of leading silence, not a negative time clamped to 0.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 300, text: "Hello after midnight."),
+            ParsedTranscriptLine(startSeconds: 320, text: "Still going."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 1200,
+                                          isWallClock: true, wallClockOrigin: 86100)
+        #expect(cues.first?.start == 600)        // 300 + 86400 - 86100
+        #expect(cues.last?.start == 620)
+    }
+
+    @Test("does not lift a marker only seconds before the origin")
+    func keepsMinorClockSkew() {
+        // A marker 1s before the origin is clock skew, not a midnight wrap. The
+        // half-day tolerance must leave it alone so it clamps near zero rather
+        // than jumping ~24h into the media.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 52199, text: "Tiny skew."),
+            ParsedTranscriptLine(startSeconds: 52260, text: "One minute in."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 600,
+                                          isWallClock: true, wallClockOrigin: 52200)
+        #expect(cues.first!.start < 1)           // ~ -1 clamped, not 86399
+        #expect(cues.last!.start < 70)           // 52260 - 52200 = 60
+    }
+
+    @Test("a small backward step is skew, not a midnight wrap")
+    func backwardSkewIsNotMidnight() {
+        // Markers normally rise monotonically; a 1s backward step is clock skew,
+        // never a real wrap. The half-day tolerance must keep the dipped marker
+        // near its neighbours instead of flinging it ~24h into the media.
+        let lines = [
+            ParsedTranscriptLine(startSeconds: 52260, text: "One minute in."),
+            ParsedTranscriptLine(startSeconds: 52259, text: "Tiny dip."),
+            ParsedTranscriptLine(startSeconds: 52300, text: "Back on track."),
+        ]
+        let cues = SubtitleSegmenter.cues(from: lines, totalDuration: 600,
+                                          isWallClock: true, wallClockOrigin: 52200)
+        #expect(cues.allSatisfy { $0.start < 200 })   // ~60..100s, never 86400+
+    }
+
+    @Test("empty input yields no cues")
+    func empty() {
+        #expect(SubtitleSegmenter.cues(from: [], totalDuration: 10, isWallClock: false).isEmpty)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/SubtitleTimecodeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/SubtitleTimecodeTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Subtitle Timecode")
+struct SubtitleTimecodeTests {
+    @Test("formats SRT timecode with comma and milliseconds")
+    func srtTimecode() {
+        #expect(SubtitleTimecode.string(seconds: 0, style: .srt) == "00:00:00,000")
+        #expect(SubtitleTimecode.string(seconds: 83.5, style: .srt) == "00:01:23,500")
+        #expect(SubtitleTimecode.string(seconds: 3661.25, style: .srt) == "01:01:01,250")
+    }
+
+    @Test("formats VTT timecode with dot")
+    func vttTimecode() {
+        #expect(SubtitleTimecode.string(seconds: 83.5, style: .vtt) == "00:01:23.500")
+    }
+
+    @Test("formats inline label HH:MM:SS without fraction")
+    func inlineLabel() {
+        #expect(SubtitleTimecode.inlineLabel(seconds: 83) == "00:01:23")
+        #expect(SubtitleTimecode.inlineLabel(seconds: 3661) == "01:01:01")
+    }
+
+    @Test("clamps negatives to zero")
+    func clampsNegative() {
+        #expect(SubtitleTimecode.string(seconds: -5, style: .srt) == "00:00:00,000")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptTimestampParserTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptTimestampParserTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("Transcript Timestamp Parser")
+struct TranscriptTimestampParserTests {
+    @Test("parses HH:MM:SS lines without speaker")
+    func parsesPlain() {
+        let raw = "[00:00:00] Hello there.\n[00:00:02] Second line."
+        let lines = TranscriptTimestampParser.parse(raw)
+        #expect(lines.count == 2)
+        #expect(lines[0].startSeconds == 0)
+        #expect(lines[0].text == "Hello there.")
+        #expect(lines[1].startSeconds == 2)
+    }
+
+    @Test("parses HH:MM:SS lines with speaker prefix, dropping the label")
+    func parsesSpeaker() {
+        let raw = "[00:01:05] Speaker 1: How are you?"
+        let lines = TranscriptTimestampParser.parse(raw)
+        #expect(lines.count == 1)
+        #expect(lines[0].startSeconds == 65)
+        #expect(lines[0].text == "How are you?")
+    }
+
+    @Test("accepts MM:SS as well as HH:MM:SS")
+    func parsesShortForm() {
+        let raw = "[01:05] Hi."
+        let lines = TranscriptTimestampParser.parse(raw)
+        #expect(lines[0].startSeconds == 65)
+    }
+
+    @Test("ignores lines without a leading timestamp")
+    func ignoresUntimed() {
+        let raw = "No timestamp here.\n[00:00:03] Timed."
+        let lines = TranscriptTimestampParser.parse(raw)
+        #expect(lines.count == 1)
+        #expect(lines[0].startSeconds == 3)
+    }
+
+    @Test("returns empty for transcript with no timestamps")
+    func noTimestamps() {
+        #expect(TranscriptTimestampParser.parse("Just plain text, no markers.").isEmpty)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/VadTimedTranscriberTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/VadTimedTranscriberTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import MuesliNativeApp
+
+@Suite("VAD Timed Transcriber")
+struct VadTimedTranscriberTests {
+    @Test("assembles one timed SpeechSegment per non-empty region, in order")
+    func assembles() async throws {
+        let regions = [
+            VadTimedRegion(startTime: 0, endTime: 2),
+            VadTimedRegion(startTime: 2.5, endTime: 4),
+            VadTimedRegion(startTime: 5, endTime: 6),
+        ]
+        let segments = try await VadTimedTranscriber.assemble(regions: regions) { region in
+            // Fake transcriber: region 2.5–4 returns blank (silence/no speech).
+            region.startTime == 2.5 ? "   " : "text@\(Int(region.startTime))"
+        }
+        #expect(segments.count == 2)                       // blank region dropped
+        #expect(segments[0].start == 0 && segments[0].end == 2)
+        #expect(segments[0].text == "text@0")
+        #expect(segments[1].start == 5 && segments[1].text == "text@5")
+    }
+
+    @Test("empty region list yields no segments")
+    func empty() async throws {
+        let segments = try await VadTimedTranscriber.assemble(regions: []) { _ in "x" }
+        #expect(segments.isEmpty)
+    }
+
+    @Test("assemble rethrows an error thrown by the transcribe closure")
+    func `rethrows`() async {
+        struct Boom: Error {}
+        await #expect(throws: Boom.self) {
+            try await VadTimedTranscriber.assemble(regions: [VadTimedRegion(startTime: 0, endTime: 1)]) { _ in
+                throw Boom()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Meeting transcripts now carry inline `[HH:MM:SS]` timestamps, with a show/hide toggle in the Transcript view and a new "Export Subtitles…" action that writes `.srt` / `.vtt` files with short, readable cues.

<img width="1103" height="876" alt="image" src="https://github.com/user-attachments/assets/8898b350-e38d-4252-98f0-4410ad4b1ac9" />

## How / why

  - **Timing from VAD, not ASR segments.** Only the Parakeet backend emits per-segment timing; the other six return one untimed blob. So timing is derived from VAD speech regions (`VadTimedTranscriber`) — each region is transcribed with the user's selected backend and tagged with its VAD `[start,end]`. Timestamps now work for **all** backends.
  - **No schema change.** Markers live inside the existing `rawTranscript` TEXT column — the same format the transcript view already parses.
  - **Short cues.** `SubtitleSegmenter` regroups into ≤7-word cues and rebases wall-clock timestamps (live meetings) to media-relative time.
  - **UX:** the toggle hides when a transcript has no timestamps; exporting subtitles from a timestamp-less transcript offers Re-transcribe, then auto-exports.

Save subtitles either in `.srt` or `.webvtt`

<img width="393" height="261" alt="image" src="https://github.com/user-attachments/assets/a7b1e44a-9f44-491c-aae8-77e1e530e82f" />

 ## Fixes
 
 Long meeting titles no longer push the header toolbar off-screen.

 This is what was happening. Longer titles were pushing the buttons to the edge even in full screen. Now the title is cut to accommodate the buttons. 
 
<img width="1714" height="1081" alt="image" src="https://github.com/user-attachments/assets/9007ac6e-fe60-4078-95bc-88026eb1297c" />

## Testing

  Ran:
  ```bash
  swift test --package-path native/MuesliNative   # 1081 passing, 122 suites
  MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh        # manual verification
  ```
  
  - 7 new unit suites (timecode, formatter, parser, segmenter, builder, VAD seam) + extended exporter tests.
  - Manually verified import + export across Parakeet, Whisper, and Qwen3.
  
  ## Notes / limitations

  - Meetings transcribed before this change get timestamps after one Re-transcribe (no backfill, since no schema change).
  - VAD-segmented transcription = N transcribe calls per file (more API calls for cloud backends like Cohere); falls back to a single untimed pass if VAD is unavailable.
  
  ### Note on scope

  This PR also includes one small, unrelated UI fix: long meeting titles were pushing the header toolbar (Export / Re-summarize) off-screen. I hit it while testing subtitle export on imports with long filenames, so it's bundled here. Happy to split it into a separate PR if you'd prefer to keep this one strictly to the timestamps/subtitle feature.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784718376&installation_id=136549638&pr_number=237&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F237&signature=43031503edd9e6a3c1177f4b4fa7f40efddc59114f56a1cecae7e270758614a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->