### PR TITLE
Harden release signing profile checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,20 @@ That installs `/Applications/MuesliDev.app` with bundle ID `com.muesli.dev`
 and stores data under `~/Library/Application Support/MuesliDev/`, so it does
 not touch your production Muesli install or data.
 
+By default, `scripts/dev-test.sh` uses CloudKit/iCloud entitlements only when a
+matching local provisioning profile exists. Maintainer machines keep those
+profiles outside this repository under a sibling `muesli-ios/secrets/`
+directory. If the profile is missing, the script falls back to local-only
+entitlements. External contributors should not need Apple Developer account
+access for ordinary local development.
+
 Useful dev commands:
 
 ```bash
-MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh          # Build and launch MuesliDev
-MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh --reset  # Re-run onboarding, keep data
-./scripts/dev-reset-permissions.sh                # Reset macOS privacy permissions for MuesliDev
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh                # Build and launch MuesliDev
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh --reset        # Re-run onboarding, keep data
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh --local-only   # Force local-only entitlements
+./scripts/dev-reset-permissions.sh                      # Reset macOS privacy permissions for MuesliDev
 ```
 
 If you do have your own signing certificate, you can override the identity:
@@ -37,6 +45,32 @@ If you do have your own signing certificate, you can override the identity:
 ```bash
 MUESLI_SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" ./scripts/dev-test.sh
 ```
+
+Cloud-entitled local builds require a provisioning profile whose App ID matches
+the selected bundle ID and whose certificate matches the signing identity:
+
+```bash
+MUESLI_PROVISIONING_PROFILE="/path/to/profile.provisionprofile" \
+MUESLI_SIGN_IDENTITY="Apple Development: Your Name (TEAMID)" \
+MUESLI_CODESIGN_TIMESTAMP=none \
+  ./scripts/dev-test.sh --cloud-entitlements
+```
+
+If `--cloud-entitlements` is passed explicitly and no matching profile is
+available, the script fails before building. That is expected; use
+`--local-only` for contributor builds that do not exercise iCloud sync.
+
+## Release Signing
+
+Official preprod and stable release scripts require maintainer-only Developer
+ID provisioning profiles:
+
+- `com.muesli.preprod` for `scripts/release-preprod.sh`
+- `com.muesli.app` for `scripts/release.sh`
+
+Those profiles are not committed to the repository. Maintainers pass them with
+`MUESLI_PROVISIONING_PROFILE`; contributors should not need to run these
+release scripts for normal PR validation.
 
 ## SwiftPM Build Cache
 
@@ -81,5 +115,7 @@ swift test --package-path native/MuesliNative \
 - Mention the test commands you ran in the PR description.
 - Use `MUESLI_SKIP_SIGN=1` for local app verification unless you have a valid
   signing identity.
+- Use `--local-only` unless your change specifically needs iCloud/CloudKit
+  entitlements.
 - Avoid committing generated build artifacts, app bundles, model files, or
   local application data.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,11 @@ That installs `/Applications/MuesliDev.app` with bundle ID `com.muesli.dev`
 and stores data under `~/Library/Application Support/MuesliDev/`, so it does
 not touch your production Muesli install or data.
 
-By default, `scripts/dev-test.sh` uses CloudKit/iCloud entitlements only when a
-matching local provisioning profile exists. Maintainer machines keep those
-profiles outside this repository under a sibling `muesli-ios/secrets/`
-directory. If the profile is missing, the script falls back to local-only
-entitlements. External contributors should not need Apple Developer account
-access for ordinary local development.
+By default, `scripts/dev-test.sh` uses local-only entitlements. Maintainer
+machines keep CloudKit profiles outside this repository under a sibling
+`muesli-ios/secrets/` directory, but those profiles are used only when
+`--cloud-entitlements` is passed. External contributors should not need Apple
+Developer account access for ordinary local development.
 
 Useful dev commands:
 
@@ -59,6 +58,10 @@ MUESLI_CODESIGN_TIMESTAMP=none \
 If `--cloud-entitlements` is passed explicitly and no matching profile is
 available, the script fails before building. That is expected; use
 `--local-only` for contributor builds that do not exercise iCloud sync.
+Maintainers switching an existing dev app from Developer ID/local-only signing
+to Apple Development/CloudKit signing may need to regrant macOS privacy
+permissions once because macOS tracks permissions against the app's signing
+requirement.
 
 ## Release Signing
 

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -17,12 +17,47 @@ This checklist is for **verification** after the script runs, and for manual rec
 - [ ] Version bumped in `scripts/build_native_app.sh` (CFBundleVersion + CFBundleShortVersionString)
 - [ ] No uncommitted changes (`git status` clean)
 
+## Signing Profiles
+
+Muesli's default entitlements include CloudKit (`iCloud.com.mueslihq.muesli`). Any cloud-entitled build must be signed with a provisioning profile whose app identifier matches the bundle ID and whose certificate matches the signing identity.
+
+- [ ] Dev lane `MuesliDev` / `com.muesli.dev`
+  - Use profile: `../muesli-ios/secrets/mueslimacosdevcloudkitcommueslidev.provisionprofile`
+  - Use identity: `Apple Development: Pranav Hari Guruvayurappan (59WTZW55XG)`
+  - Use `MUESLI_CODESIGN_TIMESTAMP=none`
+  - `scripts/dev-test.sh` auto-selects these values when that local profile exists
+
+- [ ] Named dev lanes `com.muesli.dev.a/b/c`
+  - Default to local-only entitlements and do not need a CloudKit profile
+  - If running with `--cloud-entitlements`, provide a lane-specific profile and matching Apple Development identity
+
+- [ ] Preprod `MuesliPreprod` / `com.muesli.preprod`
+  - Export `MUESLI_PROVISIONING_PROFILE=/path/to/com.muesli.preprod.profile`
+  - Maintainer local profile: `../muesli-ios/secrets/mueslimacospreproddeveloperidcloudkit.provisionprofile`
+  - Use the Developer ID release identity unless intentionally overriding `MUESLI_SIGN_IDENTITY`
+  - Verify the embedded profile carries `iCloud.com.mueslihq.muesli`
+
+- [ ] Stable `Muesli` / `com.muesli.app`
+  - Export `MUESLI_PROVISIONING_PROFILE=/path/to/com.muesli.app.profile`
+  - Maintainer local profile: `../muesli-ios/secrets/mueslimacosproductiondeveloperidcloudkit.provisionprofile`
+  - Use `Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)`
+  - Final app and DMG must be notarized, stapled, and accepted by Gatekeeper
+
+If launch fails with `No matching profile found`, the embedded profile, bundle ID, entitlements, or signing identity do not match.
+
 ## Build & Sign
 
 - [ ] `scripts/build_native_app.sh` completes without error
 - [ ] App installed to `/Applications/Muesli.app`
 - [ ] Verify signature: `codesign -dvvv /Applications/Muesli.app 2>&1 | grep "Authority"`
   - Must show `Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)`
+- [ ] Verify effective entitlements:
+  ```bash
+  codesign -d --entitlements :- /Applications/Muesli.app | plutil -p -
+  ```
+  - Must show CloudKit container `iCloud.com.mueslihq.muesli`
+  - Must show CloudKit environment `Production`
+  - Must show APNs environment `production` when using the production Developer ID CloudKit profile
 
 ## Notarize & Staple (CRITICAL ORDER)
 

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -25,7 +25,7 @@ Muesli's default entitlements include CloudKit (`iCloud.com.mueslihq.muesli`). A
   - Use profile: `../muesli-ios/secrets/mueslimacosdevcloudkitcommueslidev.provisionprofile`
   - Use identity: `Apple Development: Pranav Hari Guruvayurappan (59WTZW55XG)`
   - Use `MUESLI_CODESIGN_TIMESTAMP=none`
-  - `scripts/dev-test.sh` auto-selects these values when that local profile exists
+  - `scripts/dev-test.sh --cloud-entitlements` auto-selects these values when that local profile exists
 
 - [ ] Named dev lanes `com.muesli.dev.a/b/c`
   - Default to local-only entitlements and do not need a CloudKit profile

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -258,6 +258,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
     fi
     if [[ -n "$PROFILE_APP_IDENTIFIER" ]]; then
       PROFILE_BUNDLE_ID="${PROFILE_APP_IDENTIFIER#*.}"
+      # shellcheck disable=SC2053 # Intentionally glob-match wildcard App IDs such as com.muesli.*.
       if [[ "$BUNDLE_ID" != $PROFILE_BUNDLE_ID ]]; then
         echo "ERROR: provisioning profile app identifier '$PROFILE_APP_IDENTIFIER' does not match bundle ID '$BUNDLE_ID'." >&2
         exit 1

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -247,12 +247,28 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
   if [[ -n "$PROVISIONING_PROFILE" ]]; then
     PROFILE_PLIST="$(mktemp "${TMPDIR:-/tmp}/muesli-profile.XXXXXX")"
     SIGN_TEMP_FILES+=("$PROFILE_PLIST")
-    if security cms -D -i "$PROVISIONING_PROFILE" > "$PROFILE_PLIST" 2>/dev/null; then
+    if ! security cms -D -i "$PROVISIONING_PROFILE" > "$PROFILE_PLIST" 2>/dev/null; then
+      echo "ERROR: could not decode provisioning profile: $PROVISIONING_PROFILE" >&2
+      exit 1
+    fi
+
+    PROFILE_APP_IDENTIFIER="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$PROFILE_PLIST" 2>/dev/null || true)"
+    if [[ -z "$PROFILE_APP_IDENTIFIER" ]]; then
+      PROFILE_APP_IDENTIFIER="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$PROFILE_PLIST" 2>/dev/null || true)"
+    fi
+    if [[ -n "$PROFILE_APP_IDENTIFIER" ]]; then
+      PROFILE_BUNDLE_ID="${PROFILE_APP_IDENTIFIER#*.}"
+      if [[ "$PROFILE_BUNDLE_ID" != "$BUNDLE_ID" && "$PROFILE_BUNDLE_ID" != *"*"* ]]; then
+        echo "ERROR: provisioning profile app identifier '$PROFILE_APP_IDENTIFIER' does not match bundle ID '$BUNDLE_ID'." >&2
+        exit 1
+      fi
+      echo "Using provisioning profile app identifier: $PROFILE_APP_IDENTIFIER"
+    fi
+
+    if [[ -z "$APS_ENVIRONMENT" ]]; then
+      APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.aps-environment' "$PROFILE_PLIST" 2>/dev/null || true)"
       if [[ -z "$APS_ENVIRONMENT" ]]; then
-        APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.aps-environment' "$PROFILE_PLIST" 2>/dev/null || true)"
-        if [[ -z "$APS_ENVIRONMENT" ]]; then
-          APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:aps-environment' "$PROFILE_PLIST" 2>/dev/null || true)"
-        fi
+        APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:aps-environment' "$PROFILE_PLIST" 2>/dev/null || true)"
       fi
     fi
   fi
@@ -274,6 +290,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
     copy_profile_string_entitlement "com.apple.application-identifier"
     copy_profile_string_entitlement "application-identifier"
     copy_profile_string_entitlement "com.apple.developer.team-identifier"
+    copy_profile_string_entitlement "com.apple.developer.icloud-container-environment"
     if [[ -n "$APS_ENVIRONMENT" ]]; then
       if ! /usr/libexec/PlistBuddy -c "Set :com.apple.developer.aps-environment $APS_ENVIRONMENT" "$TEMP_ENTITLEMENTS" 2>/dev/null; then
         /usr/libexec/PlistBuddy -c "Add :com.apple.developer.aps-environment string $APS_ENVIRONMENT" "$TEMP_ENTITLEMENTS"

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -258,7 +258,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
     fi
     if [[ -n "$PROFILE_APP_IDENTIFIER" ]]; then
       PROFILE_BUNDLE_ID="${PROFILE_APP_IDENTIFIER#*.}"
-      if [[ "$PROFILE_BUNDLE_ID" != "$BUNDLE_ID" && "$PROFILE_BUNDLE_ID" != *"*"* ]]; then
+      if [[ "$BUNDLE_ID" != $PROFILE_BUNDLE_ID ]]; then
         echo "ERROR: provisioning profile app identifier '$PROFILE_APP_IDENTIFIER' does not match bundle ID '$BUNDLE_ID'." >&2
         exit 1
       fi

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 # - Separate bundle ID (com.muesli.dev*) — won't interfere with production Muesli
 # - Separate data directory (~/Library/Application Support/MuesliDev*/)
 # - Preserves existing dev config and database by default
-# - Plain MuesliDev uses the maintainer dev CloudKit provisioning profile when
-#   it is available locally; otherwise it falls back to local-only entitlements
-# - Named lanes default to local-only signing unless --cloud-entitlements is used
+# - Dev builds default to local-only entitlements to preserve existing TCC
+#   permissions and avoid requiring Apple Developer profiles
+# - CloudKit/APNs dev signing is opt-in with --cloud-entitlements
 # - External contributors can set MUESLI_SKIP_SIGN=1 to build without the
 #   maintainer signing certificate
 # - Uses a shared, worktree-isolated SwiftPM scratch path by default; set
@@ -41,16 +41,14 @@ Options:
 
 Default behavior without --lane is unchanged for the app identity: MuesliDev,
 com.muesli.dev, ~/Library/Application Support/MuesliDev, and
-/Applications/MuesliDev.app. It uses cloud entitlements only when a matching
-profile is available locally; otherwise it falls back to local-only entitlements.
-Named lanes default to --local-only unless --cloud-entitlements is provided.
+/Applications/MuesliDev.app. Dev builds use local-only entitlements unless
+--cloud-entitlements is provided.
 
 Cloud-entitled dev builds require a provisioning profile whose app identifier
 matches the selected bundle ID and a signing identity included by that profile.
 For the maintainer's plain MuesliDev lane, this script auto-selects the local
-com.muesli.dev CloudKit profile from ../muesli-ios/secrets when it exists.
-If --cloud-entitlements is passed explicitly, missing profile configuration is
-treated as an error.
+com.muesli.dev CloudKit profile from ../muesli-ios/secrets when
+--cloud-entitlements is provided and the profile exists.
 EOF
 }
 
@@ -119,11 +117,7 @@ case "$LANE" in
 esac
 
 if [[ -z "$ENTITLEMENTS_MODE" ]]; then
-  if [[ -n "$LANE" ]]; then
-    ENTITLEMENTS_MODE="local-only"
-  else
-    ENTITLEMENTS_MODE="cloud"
-  fi
+  ENTITLEMENTS_MODE="local-only"
 fi
 
 DEV_SUPPORT_DIR="$HOME/Library/Application Support/$DEV_APP_NAME"

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -145,16 +145,20 @@ if [[ -n "$LANE" ]]; then
   BUILD_ENV+=(MUESLI_EXECUTABLE_NAME="$DEV_APP_NAME")
 fi
 
+use_local_only_entitlements() {
+  RESOLVED_PROVISIONING_PROFILE=""
+  RESOLVED_SIGN_IDENTITY=""
+  RESOLVED_CODESIGN_TIMESTAMP=""
+  BUILD_ENV+=(
+    MUESLI_ENTITLEMENTS="$ROOT/scripts/MuesliLocalOnly.entitlements"
+    MUESLI_PROVISIONING_PROFILE=""
+    MUESLI_APS_ENVIRONMENT=""
+  )
+}
+
 case "$ENTITLEMENTS_MODE" in
   local-only)
-    RESOLVED_PROVISIONING_PROFILE=""
-    RESOLVED_SIGN_IDENTITY=""
-    RESOLVED_CODESIGN_TIMESTAMP=""
-    BUILD_ENV+=(
-      MUESLI_ENTITLEMENTS="$ROOT/scripts/MuesliLocalOnly.entitlements"
-      MUESLI_PROVISIONING_PROFILE=""
-      MUESLI_APS_ENVIRONMENT=""
-    )
+    use_local_only_entitlements
     ;;
   cloud)
     if [[ -z "$RESOLVED_PROVISIONING_PROFILE" && "$DEV_BUNDLE_ID" == "com.muesli.dev" && -f "$DEFAULT_DEV_CLOUD_PROFILE" ]]; then
@@ -175,14 +179,7 @@ case "$ENTITLEMENTS_MODE" in
       fi
       echo "No local CloudKit profile found for $DEV_BUNDLE_ID; building local-only dev app."
       ENTITLEMENTS_MODE="local-only"
-      RESOLVED_PROVISIONING_PROFILE=""
-      RESOLVED_SIGN_IDENTITY=""
-      RESOLVED_CODESIGN_TIMESTAMP=""
-      BUILD_ENV+=(
-        MUESLI_ENTITLEMENTS="$ROOT/scripts/MuesliLocalOnly.entitlements"
-        MUESLI_PROVISIONING_PROFILE=""
-        MUESLI_APS_ENVIRONMENT=""
-      )
+      use_local_only_entitlements
     else
       if [[ -z "$RESOLVED_SIGN_IDENTITY" ]]; then
         echo "Error: cloud-entitled dev builds require MUESLI_SIGN_IDENTITY." >&2

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 # - Separate bundle ID (com.muesli.dev*) — won't interfere with production Muesli
 # - Separate data directory (~/Library/Application Support/MuesliDev*/)
 # - Preserves existing dev config and database by default
-# - Signed with Developer ID by default (Accessibility permission persists across rebuilds)
+# - Plain MuesliDev uses the maintainer dev CloudKit provisioning profile when
+#   it is available locally; otherwise it falls back to local-only entitlements
+# - Named lanes default to local-only signing unless --cloud-entitlements is used
 # - External contributors can set MUESLI_SKIP_SIGN=1 to build without the
 #   maintainer signing certificate
 # - Uses a shared, worktree-isolated SwiftPM scratch path by default; set
@@ -18,6 +20,9 @@ set -euo pipefail
 #   ./scripts/dev-test.sh --lane A                # Build and launch MuesliDevA
 #   ./scripts/dev-test.sh --lane A --local-only   # Omit iCloud/APNs entitlements
 #   ./scripts/dev-test.sh --reset                 # Reset onboarding only (keeps data)
+#   MUESLI_PROVISIONING_PROFILE=/path/to/profile.provisionprofile \
+#   MUESLI_SIGN_IDENTITY="Apple Development: Name (TEAMID)" \
+#   MUESLI_CODESIGN_TIMESTAMP=none ./scripts/dev-test.sh --cloud-entitlements
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -34,9 +39,18 @@ Options:
   --reset                 Reset onboarding only for the selected lane.
   --help                  Show this help text.
 
-Default behavior without --lane is unchanged: MuesliDev, com.muesli.dev,
-~/Library/Application Support/MuesliDev, and /Applications/MuesliDev.app.
+Default behavior without --lane is unchanged for the app identity: MuesliDev,
+com.muesli.dev, ~/Library/Application Support/MuesliDev, and
+/Applications/MuesliDev.app. It uses cloud entitlements only when a matching
+profile is available locally; otherwise it falls back to local-only entitlements.
 Named lanes default to --local-only unless --cloud-entitlements is provided.
+
+Cloud-entitled dev builds require a provisioning profile whose app identifier
+matches the selected bundle ID and a signing identity included by that profile.
+For the maintainer's plain MuesliDev lane, this script auto-selects the local
+com.muesli.dev CloudKit profile from ../muesli-ios/secrets when it exists.
+If --cloud-entitlements is passed explicitly, missing profile configuration is
+treated as an error.
 EOF
 }
 
@@ -44,6 +58,7 @@ EOF
 RESET=0
 LANE=""
 ENTITLEMENTS_MODE=""
+ENTITLEMENTS_MODE_EXPLICIT=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --clean)
@@ -66,10 +81,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --local-only|--without-cloud-entitlements)
       ENTITLEMENTS_MODE="local-only"
+      ENTITLEMENTS_MODE_EXPLICIT=1
       shift
       ;;
     --cloud-entitlements|--with-cloud-entitlements)
       ENTITLEMENTS_MODE="cloud"
+      ENTITLEMENTS_MODE_EXPLICIT=1
       shift
       ;;
     --help|-h)
@@ -112,6 +129,11 @@ fi
 DEV_SUPPORT_DIR="$HOME/Library/Application Support/$DEV_APP_NAME"
 DEV_APP="/Applications/$DEV_APP_NAME.app"
 ONBOARDING_PROGRESS_FILE="$DEV_SUPPORT_DIR/onboarding-progress.json"
+DEFAULT_DEV_CLOUD_PROFILE="$ROOT/../muesli-ios/secrets/mueslimacosdevcloudkitcommueslidev.provisionprofile"
+DEFAULT_DEV_CLOUD_SIGN_IDENTITY="Apple Development: Pranav Hari Guruvayurappan (59WTZW55XG)"
+RESOLVED_PROVISIONING_PROFILE="${MUESLI_PROVISIONING_PROFILE:-}"
+RESOLVED_SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-}"
+RESOLVED_CODESIGN_TIMESTAMP="${MUESLI_CODESIGN_TIMESTAMP:-}"
 BUILD_ENV=(
   MUESLI_APP_NAME="$DEV_APP_NAME"
   MUESLI_BUNDLE_ID="$DEV_BUNDLE_ID"
@@ -125,6 +147,9 @@ fi
 
 case "$ENTITLEMENTS_MODE" in
   local-only)
+    RESOLVED_PROVISIONING_PROFILE=""
+    RESOLVED_SIGN_IDENTITY=""
+    RESOLVED_CODESIGN_TIMESTAMP=""
     BUILD_ENV+=(
       MUESLI_ENTITLEMENTS="$ROOT/scripts/MuesliLocalOnly.entitlements"
       MUESLI_PROVISIONING_PROFILE=""
@@ -132,6 +157,46 @@ case "$ENTITLEMENTS_MODE" in
     )
     ;;
   cloud)
+    if [[ -z "$RESOLVED_PROVISIONING_PROFILE" && "$DEV_BUNDLE_ID" == "com.muesli.dev" && -f "$DEFAULT_DEV_CLOUD_PROFILE" ]]; then
+      RESOLVED_PROVISIONING_PROFILE="$DEFAULT_DEV_CLOUD_PROFILE"
+      if [[ -z "$RESOLVED_SIGN_IDENTITY" ]]; then
+        RESOLVED_SIGN_IDENTITY="$DEFAULT_DEV_CLOUD_SIGN_IDENTITY"
+      fi
+      if [[ -z "$RESOLVED_CODESIGN_TIMESTAMP" ]]; then
+        RESOLVED_CODESIGN_TIMESTAMP="none"
+      fi
+    fi
+    if [[ -z "$RESOLVED_PROVISIONING_PROFILE" ]]; then
+      if [[ "$ENTITLEMENTS_MODE_EXPLICIT" -eq 1 ]]; then
+        echo "Error: cloud-entitled dev builds require MUESLI_PROVISIONING_PROFILE." >&2
+        echo "The profile must match bundle ID '$DEV_BUNDLE_ID' and include the signing identity." >&2
+        echo "Use --local-only for a dev build that does not need iCloud/APNs entitlements." >&2
+        exit 2
+      fi
+      echo "No local CloudKit profile found for $DEV_BUNDLE_ID; building local-only dev app."
+      ENTITLEMENTS_MODE="local-only"
+      RESOLVED_PROVISIONING_PROFILE=""
+      RESOLVED_SIGN_IDENTITY=""
+      RESOLVED_CODESIGN_TIMESTAMP=""
+      BUILD_ENV+=(
+        MUESLI_ENTITLEMENTS="$ROOT/scripts/MuesliLocalOnly.entitlements"
+        MUESLI_PROVISIONING_PROFILE=""
+        MUESLI_APS_ENVIRONMENT=""
+      )
+    else
+      if [[ -z "$RESOLVED_SIGN_IDENTITY" ]]; then
+        echo "Error: cloud-entitled dev builds require MUESLI_SIGN_IDENTITY." >&2
+        echo "Use the Apple Development identity included by the selected provisioning profile." >&2
+        exit 2
+      fi
+      BUILD_ENV+=(
+        MUESLI_PROVISIONING_PROFILE="$RESOLVED_PROVISIONING_PROFILE"
+        MUESLI_SIGN_IDENTITY="$RESOLVED_SIGN_IDENTITY"
+      )
+      if [[ -n "$RESOLVED_CODESIGN_TIMESTAMP" ]]; then
+        BUILD_ENV+=(MUESLI_CODESIGN_TIMESTAMP="$RESOLVED_CODESIGN_TIMESTAMP")
+      fi
+    fi
     ;;
   *)
     echo "Error: internal unsupported entitlements mode '$ENTITLEMENTS_MODE'." >&2
@@ -167,6 +232,12 @@ echo "Building $DEV_APP_NAME (debug, signed)..."
 echo "  Bundle ID:    $DEV_BUNDLE_ID"
 echo "  Data:         $DEV_SUPPORT_DIR"
 echo "  Entitlements: $ENTITLEMENTS_MODE"
+if [[ -n "$RESOLVED_PROVISIONING_PROFILE" ]]; then
+  echo "  Profile:      $RESOLVED_PROVISIONING_PROFILE"
+fi
+if [[ -n "$RESOLVED_SIGN_IDENTITY" ]]; then
+  echo "  Sign identity: $RESOLVED_SIGN_IDENTITY"
+fi
 env "${BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" debug
 
 echo ""

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 #   - Support dir: ~/Library/Application Support/MuesliPreprod
 #   - Sparkle feed: https://muesli-hq.github.io/muesli/appcast-preprod.xml
 #
+# Required signing environment:
+#   MUESLI_PROVISIONING_PROFILE=/path/to/com.muesli.preprod.profile
+#   MUESLI_SIGN_IDENTITY="Developer ID Application: ... (TEAMID)"
+#
 # Usage: ./scripts/release-preprod.sh [version]
 #   e.g. ./scripts/release-preprod.sh 0.6.3-preprod.1
 #   If no version is given, auto-increments from the next stable patch base.
@@ -37,6 +41,7 @@ else
 fi
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
+PROVISIONING_PROFILE="${MUESLI_PROVISIONING_PROFILE:-}"
 APP_NAME="MuesliPreprod"
 BUNDLE_ID="com.muesli.preprod"
 SUPPORT_DIR_NAME="MuesliPreprod"
@@ -105,6 +110,17 @@ if [[ ! -f "$UPDATE_APPCAST_RELEASE_NOTES" ]]; then
   exit 1
 fi
 
+if [[ -z "$PROVISIONING_PROFILE" ]]; then
+  echo "ERROR: preprod release builds require MUESLI_PROVISIONING_PROFILE." >&2
+  echo "Use the provisioning profile for bundle ID $BUNDLE_ID with CloudKit container iCloud.com.mueslihq.muesli." >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROVISIONING_PROFILE" ]]; then
+  echo "ERROR: provisioning profile not found: $PROVISIONING_PROFILE" >&2
+  exit 1
+fi
+
 TAG="v${VERSION}"
 DMG_PATH="$OUTPUT_DIR/${APP_NAME}-${VERSION}.dmg"
 RELEASE_TITLE="${APP_NAME} ${VERSION}"
@@ -166,7 +182,11 @@ PREPROD_BUILD_ENV=(
   MUESLI_SUPPORT_DIR_NAME="$SUPPORT_DIR_NAME"
   MUESLI_SPARKLE_FEED_URL="$PREPROD_FEED_URL"
   MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY"
+  MUESLI_PROVISIONING_PROFILE="$PROVISIONING_PROFILE"
 )
+echo "  Bundle ID: $BUNDLE_ID"
+echo "  Profile:   $PROVISIONING_PROFILE"
+echo "  Identity:  $SIGN_IDENTITY"
 env "${PREPROD_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
 if [[ ! -x "$GENERATE_APPCAST" ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -198,7 +198,7 @@ RELEASE_BUILD_ENV=(
 echo "  Bundle ID: com.muesli.app"
 echo "  Profile:   $PROVISIONING_PROFILE"
 echo "  Identity:  $SIGN_IDENTITY"
-echo "y" | env "${RELEASE_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
+echo "y" | env "${RELEASE_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null
 echo "  Installed to $APP_DIR"
 if [[ ! -x "$GENERATE_APPCAST" ]]; then
   echo "ERROR: generate_appcast not found at $GENERATE_APPCAST" >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 #
 # Prerequisites:
 #   - Developer ID cert in keychain
+#   - Production provisioning profile for com.muesli.app when CloudKit
+#     entitlements are enabled:
+#       MUESLI_PROVISIONING_PROFILE=/path/to/profile.provisionprofile
 #   - Notary profile stored: xcrun notarytool store-credentials MuesliNotary
 #   - gh CLI authenticated
 #
@@ -47,6 +50,7 @@ else
 fi
 PROFILE_NAME="${MUESLI_NOTARY_PROFILE:-MuesliNotary}"
 SIGN_IDENTITY="${MUESLI_SIGN_IDENTITY:-Developer ID Application: Pranav Hari Guruvayurappan (58W55QJ567)}"
+PROVISIONING_PROFILE="${MUESLI_PROVISIONING_PROFILE:-}"
 OUTPUT_DIR="$ROOT/dist-release"
 INSTALL_DIR="${MUESLI_RELEASE_INSTALL_DIR:-$OUTPUT_DIR/install-root}"
 APP_DIR="${MUESLI_RELEASE_APP_DIR:-$INSTALL_DIR/Muesli.app}"
@@ -103,6 +107,17 @@ fi
 
 if [[ ! -f "$UPDATE_APPCAST_RELEASE_NOTES" ]]; then
   echo "ERROR: update_appcast_release_notes.py not found at $UPDATE_APPCAST_RELEASE_NOTES" >&2
+  exit 1
+fi
+
+if [[ -z "$PROVISIONING_PROFILE" ]]; then
+  echo "ERROR: stable release builds require MUESLI_PROVISIONING_PROFILE." >&2
+  echo "Use the production provisioning profile for bundle ID com.muesli.app with CloudKit container iCloud.com.mueslihq.muesli." >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROVISIONING_PROFILE" ]]; then
+  echo "ERROR: provisioning profile not found: $PROVISIONING_PROFILE" >&2
   exit 1
 fi
 
@@ -176,8 +191,13 @@ rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 RELEASE_BUILD_ENV=(
   MUESLI_INSTALL_DIR="$INSTALL_DIR"
+  MUESLI_PROVISIONING_PROFILE="$PROVISIONING_PROFILE"
+  MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY"
   "${BUILD_ENV[@]}"
 )
+echo "  Bundle ID: com.muesli.app"
+echo "  Profile:   $PROVISIONING_PROFILE"
+echo "  Identity:  $SIGN_IDENTITY"
 echo "y" | env "${RELEASE_BUILD_ENV[@]}" "$ROOT/scripts/build_native_app.sh" > /dev/null 2>&1
 echo "  Installed to $APP_DIR"
 if [[ ! -x "$GENERATE_APPCAST" ]]; then


### PR DESCRIPTION
## Summary
- require explicit provisioning profiles for preprod and stable release scripts
- validate provisioning profile bundle IDs during signing and copy APNs/CloudKit environment entitlements from the profile
- keep contributor dev builds safe by falling back to local-only entitlements unless cloud entitlements are explicitly requested
- document contributor signing expectations and maintainer release profile conventions

## Validation
- `bash -n scripts/build_native_app.sh scripts/dev-test.sh scripts/release.sh scripts/release-preprod.sh`
- `./scripts/dev-test.sh --help`
- `./scripts/release.sh 0.7.1` without `MUESLI_PROVISIONING_PROFILE` fails early as expected
- `./scripts/release-preprod.sh 0.7.1-preprod.99` without `MUESLI_PROVISIONING_PROFILE` fails early as expected
- `./scripts/dev-test.sh --lane A --cloud-entitlements` without profile fails early as expected
- `git diff --check`

## Notes
- provisioning profile files remain outside this repo
- ordinary contributors can continue using `MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh` and local-only entitlements

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785045600&installation_id=136549638&pr_number=249&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F249&signature=3e24f91f54cb5197d2e8ce7d907c08c5559bae033fca75e97b5640631e0541ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor and release-signing guidance with lane-specific signing profiles, clearer `local-only` vs CloudKit/iCloud expectations, and updated development command examples.
  * Enhanced release checklist verification with an “effective entitlements” check, including required CloudKit/iCloud values and production APNs environment validation.
* **Bug Fixes**
  * Improved signing reliability: clearer failures for missing/unreadable profiles, stricter bundle ID matching, and more robust entitlements extraction/templating.
  * Dev builds now default to `local-only` and require explicit opt-in for CloudKit; stable/preprod builds now validate required provisioning profiles up front and surface build/signing errors more directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->