### PR TITLE
Fix CloudKit signing entitlement injection

### DIFF
--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -235,6 +235,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
   CODESIGN_ENTITLEMENTS="$ENTITLEMENTS"
   TEMP_ENTITLEMENTS=""
   APS_ENVIRONMENT="${MUESLI_APS_ENVIRONMENT:-}"
+  ICLOUD_CONTAINER_ENVIRONMENT="${MUESLI_ICLOUD_CONTAINER_ENVIRONMENT:-}"
   PROFILE_PLIST=""
   SIGN_TEMP_FILES=()
   cleanup_sign_temp_files() {
@@ -288,10 +289,27 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
         /usr/libexec/PlistBuddy -c "Add :$key string $value" "$TEMP_ENTITLEMENTS"
       fi
     }
+    copy_explicit_icloud_container_environment_entitlement() {
+      local key="$1"
+      local value
+      [[ -n "$PROFILE_PLIST" ]] || return 0
+      [[ -n "$ICLOUD_CONTAINER_ENVIRONMENT" ]] || return 0
+      /usr/libexec/PlistBuddy -c "Print :Entitlements:$key" "$PROFILE_PLIST" >/dev/null 2>&1 || return 0
+      value="$(printf '%s' "$ICLOUD_CONTAINER_ENVIRONMENT" | tr '[:upper:]' '[:lower:]')"
+      if [[ "$value" != "development" && "$value" != "production" ]]; then
+        echo "ERROR: unsupported iCloud container environment '$value'. Expected development or production." >&2
+        exit 1
+      fi
+      /usr/libexec/PlistBuddy -c "Delete :$key" "$TEMP_ENTITLEMENTS" >/dev/null 2>&1 || true
+      /usr/libexec/PlistBuddy -c "Add :$key string $value" "$TEMP_ENTITLEMENTS"
+      echo "Using iCloud entitlement: $key=$value"
+    }
     copy_profile_string_entitlement "com.apple.application-identifier"
     copy_profile_string_entitlement "application-identifier"
     copy_profile_string_entitlement "com.apple.developer.team-identifier"
-    copy_profile_string_entitlement "com.apple.developer.icloud-container-environment"
+    # Do not copy this profile entitlement by default: Apple profiles may store
+    # it as an array, while CloudKit expects a single lowercase runtime value.
+    copy_explicit_icloud_container_environment_entitlement "com.apple.developer.icloud-container-environment"
     if [[ -n "$APS_ENVIRONMENT" ]]; then
       if ! /usr/libexec/PlistBuddy -c "Set :com.apple.developer.aps-environment $APS_ENVIRONMENT" "$TEMP_ENTITLEMENTS" 2>/dev/null; then
         /usr/libexec/PlistBuddy -c "Add :com.apple.developer.aps-environment string $APS_ENVIRONMENT" "$TEMP_ENTITLEMENTS"


### PR DESCRIPTION
## Summary
- stop copying `com.apple.developer.icloud-container-environment` from provisioning profiles by default
- keep an explicit `MUESLI_ICLOUD_CONTAINER_ENVIRONMENT` override for release/debug cases that need to set the key manually
- preserve copying profile app/team/APNs entitlements for CloudKit-signed builds

## Why
Follow-up to #249. The merged script copied the iCloud container environment entitlement from the provisioning profile as a string. Dev profiles can expose that profile value as an array (`Production`, `Development`), which caused one of two failures depending on encoding:
- copied as profile array: app spawned but CloudKit crashed because it expects a single lowercase runtime value
- copied as lowercase string: `amfid`/`taskgated` rejected launch because the signed entitlement no longer matched the embedded profile

Omitting the entitlement by default while keeping the container/services entitlements lets the dev CloudKit build launch and sync correctly.

## Validation
- `bash -n scripts/build_native_app.sh scripts/dev-test.sh`
- `git diff --check`
- `./scripts/dev-test.sh --cloud-entitlements` using `/Volumes/MuesliBuildCache/muesli-spm/worktrees/muesli-1167756909/dev`
- verified `/Applications/MuesliDev.app` remains running
- verified signed entitlements include app identifier, APNs development, iCloud container identifiers/services, and do not include `com.apple.developer.icloud-container-environment` by default

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785051009&installation_id=136549638&pr_number=250&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F250&signature=86b59a44f6ffa95494b9b75a0f58d59f98d3e42c6696fe9fa760d19f45ef01a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now explicitly set the iCloud container environment used during app signing.
  * Supported values are limited to `development` or `production`, helping ensure the signed app uses the intended iCloud setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->