### PR TITLE
Update preprod appcast for v0.7.1-preprod.1

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,6 +6,32 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
+            <title>0.7.1-preprod.1</title>
+            <pubDate>Fri, 26 Jun 2026 01:24:05 -0700</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.7.1-preprod.1</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.7.1-preprod.1.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>7001001</sparkle:version>
+            <sparkle:shortVersionString>0.7.1-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.7.1-preprod.1/MuesliPreprod-0.7.1-preprod.1.dmg" length="70083841" type="application/octet-stream" sparkle:edSignature="GAgPwgF8sUXhKczie0Ph0iZd4lKqCxSky+7buvLsrR98mSewVyRnnUOlBHzegMu3rK5k8H05/8YwP0ghqwLXBA=="/>
+        </item>
+        <item>
             <title>0.7.0-preprod.1</title>
             <pubDate>Thu, 11 Jun 2026 11:27:00 -0700</pubDate>
             <description><![CDATA[


### PR DESCRIPTION
## Summary
- Add the v0.7.1-preprod.1 entry to docs/appcast-preprod.xml.
- Point the enclosure at the published GitHub prerelease DMG.
- Preserve the stable appcast, website, and Homebrew paths untouched.

## Validation
- Ran ./scripts/release-preprod.sh 0.7.1-preprod.1 with MUESLI_SWIFTPM_SCRATCH_PATH=/Volumes/MuesliBuildCache/muesli-spm/preprod.
- Swift test passed: 1128 tests in 120 suites.
- App notarization accepted and stapled.
- DMG notarization accepted and stapled.
- Hosted DMG SHA256 matched local: f0fe4691f8af58a555b97d70b22789e35ceb3afa46d0247ea522f57b7927741c.
- verify_update_flow.sh passed for Sparkle build 7001001 with release notes and notarization required.

## Note
The release pipeline published tag v0.7.1-preprod.1 and the GitHub prerelease successfully, but direct push of the appcast commit to main was blocked by branch protection requiring ci-gate. This PR carries only that generated appcast update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785054441&installation_id=136549638&pr_number=251&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F251&signature=e2d393ee6527d838f8d0a83c94e0d56d956c7ac5d1aae16030d29676e0613379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pre-release app update entry to the appcast feed.
  * Included release details, system requirements, download information, and install notes for the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->