### PR TITLE
Update release metadata for v0.7.1

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -6,6 +6,36 @@
         <language>en</language>
         <!-- Items are added by generate_appcast or the release script -->
         <item>
+            <title>0.7.1</title>
+            <pubDate>Fri, 26 Jun 2026 02:25:12 -0700</pubDate>
+            <description><![CDATA[
+<h2>Muesli 0.7.1</h2>
+<p>Muesli now learns from your corrections. When you fix a dictated word in the app you were typing into, Muesli can suggest adding that correction to your personal dictionary, so future dictations handle names, places, acronyms, and domain-specific terms more reliably.</p>
+<h3>What is new</h3>
+<ul>
+<li>Dictionary suggestions from corrected dictation: After a dictation, Muesli can detect when you corrected the text in-place and suggest adding that word or phrase to your dictionary. Suggestions are opt-in, require Accessibility permission, and can be accepted or ignored from a lightweight prompt or from the Dictionary view.</li>
+<li>Better dictionary management: Dictionary entries now support tuned matching thresholds, improved phrase handling, and a clearer review surface for pending suggestions.</li>
+<li>Nested meeting folders: Meetings can now be organized in a folder hierarchy, with recursive counts, stable ordering, and search/navigation improvements.</li>
+<li>iPhone sync onboarding: Added onboarding handoff for the iPhone sync path and CloudKit-backed device identity work.</li>
+<li>More transcription options: Added SenseVoice as an optional local transcription backend and updated FluidAudio to 0.15.1 for newer local ASR capabilities.</li>
+<li>More reliable meeting detection: Meeting prompts now require stronger full-duplex evidence, reducing false positives from unrelated browser or app audio.</li>
+<li>Media pause fix: Pause-media-during-dictation now preserves media that was already paused before dictation starts.</li>
+</ul>
+<h3>Release quality</h3>
+<ul>
+<li>Hardened production signing/profile checks for CloudKit/APNs builds.</li>
+<li>Validated the preprod Sparkle update path from 0.7.0-preprod.1 to 0.7.1-preprod.1.</li>
+<li>Expanded tests across dictionary suggestions, storage/search, meeting detection, media handling, release signing, and update-flow metadata.</li>
+<li>Signed, notarized, stapled, and verified by Apple.</li>
+</ul>
+]]></description>
+            <sparkle:version>0.7.1</sparkle:version>
+            <sparkle:shortVersionString>0.7.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.7.1/Muesli-0.7.1.dmg" length="70087020" type="application/octet-stream" sparkle:edSignature="du0g2qkGP0pib0PF6Nfp8nErOIt6F2nWNzQggsEOcDUx7ZKqhDTD0HbjEgKbdQBNyXTRnEbi0xEe9raRrdXtDg=="/>
+        </item>
+        <item>
             <title>0.7.0</title>
             <pubDate>Thu, 11 Jun 2026 23:46:47 -0700</pubDate>
             <description><![CDATA[

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -25,7 +25,7 @@ Muesli is a free, open-source macOS application that provides hold-to-talk dicta
 
 - Website: https://freedspeech.xyz
 - GitHub: https://github.com/Muesli-HQ/muesli
-- Download: https://github.com/Muesli-HQ/muesli/releases/download/v0.7.0/Muesli-0.7.0.dmg
+- Download: https://github.com/Muesli-HQ/muesli/releases/download/v0.7.1/Muesli-0.7.1.dmg
 - Support: https://buymeacoffee.com/phequals7
 - License: MIT
 


### PR DESCRIPTION
## Summary
- add the v0.7.1 production Sparkle appcast item
- update appcast release notes with the user-facing 0.7.1 highlights
- refresh llms.txt release metadata

## Verification
- ./scripts/verify_update_flow.sh --version 0.7.1 --dmg dist-release/Muesli-0.7.1.dmg --require-release-notes --require-notarized

## Release context
The v0.7.1 GitHub release is already published and its hosted DMG was verified by the release script before this metadata commit was created. Direct push to main was blocked by branch protection, so this PR carries the generated release metadata.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785058156&installation_id=136549638&pr_number=253&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F253&signature=96136fe29246337d3ef24b96aba716ce5eb5c9d7efd2fb4880c2e30066c5f593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release 0.7.1 to the app update feed, including release notes, version details, system requirements, and download information.
* **Documentation**
  * Updated the download link to point to the latest 0.7.1 release package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->