### PR TITLE
[codex] Fix manual meeting recording auto-stop

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -1,5 +1,39 @@
 import Foundation
 
+enum MeetingRecordingStartOrigin: Equatable {
+    case manual
+    case detectedPrompt
+    case calendarAutoRecord
+    case scheduledMeetingPrompt
+    case joinAndRecord
+
+    var enablesMeetingAutoStop: Bool {
+        switch self {
+        case .manual:
+            return false
+        case .detectedPrompt, .calendarAutoRecord, .scheduledMeetingPrompt, .joinAndRecord:
+            return true
+        }
+    }
+
+    var signalLossResponse: MeetingSignalLossResponse {
+        enablesMeetingAutoStop ? .autoStopAfterWarning : .warnOnly
+    }
+
+    func signalLossSource(
+        explicitSource: MeetingAutoStopSource?,
+        recentSource: @autoclosure () -> MeetingAutoStopSource?
+    ) -> MeetingAutoStopSource? {
+        return explicitSource ?? recentSource()
+    }
+}
+
+enum MeetingSignalLossResponse: Equatable {
+    case none
+    case warnOnly
+    case autoStopAfterWarning
+}
+
 struct MeetingAutoStopSource: Equatable {
     let candidateID: String?
     let suppressionID: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -17,14 +17,19 @@ enum MeetingRecordingStartOrigin: Equatable {
     }
 
     var signalLossResponse: MeetingSignalLossResponse {
-        enablesMeetingAutoStop ? .autoStopAfterWarning : .warnOnly
+        enablesMeetingAutoStop ? .autoStopAfterWarning : .none
     }
 
     func signalLossSource(
         explicitSource: MeetingAutoStopSource?,
         recentSource: @autoclosure () -> MeetingAutoStopSource?
     ) -> MeetingAutoStopSource? {
-        return explicitSource ?? recentSource()
+        switch self {
+        case .manual:
+            return nil
+        case .detectedPrompt, .calendarAutoRecord, .scheduledMeetingPrompt, .joinAndRecord:
+            return explicitSource ?? recentSource()
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -39,6 +39,37 @@ enum MeetingSignalLossResponse: Equatable {
     case autoStopAfterWarning
 }
 
+struct MeetingSignalLossPromptState: Equatable {
+    private(set) var isPromptSuppressed = false
+    private(set) var isDismissedForRecording = false
+
+    var canPresentPrompt: Bool {
+        !isPromptSuppressed && !isDismissedForRecording
+    }
+
+    mutating func resetForRecording() {
+        isPromptSuppressed = false
+        isDismissedForRecording = false
+    }
+
+    mutating func markPromptPresented() {
+        isPromptSuppressed = true
+    }
+
+    mutating func markSourceRecovered() {
+        isPromptSuppressed = false
+    }
+
+    mutating func markDismissedByUser() {
+        isPromptSuppressed = true
+        isDismissedForRecording = true
+    }
+
+    mutating func markAutoDismissed() {
+        isPromptSuppressed = true
+    }
+}
+
 struct MeetingAutoStopSource: Equatable {
     let candidateID: String?
     let suppressionID: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNotificationController.swift
@@ -25,6 +25,29 @@ final class MeetingNotificationController {
 
     private static let dismissDuration: TimeInterval = 15
 
+    static func singleActionTextWidth(
+        cardWidth: CGFloat,
+        textX: CGFloat,
+        buttonWidth: CGFloat = 110,
+        trailingInset: CGFloat = 12,
+        spacing: CGFloat = 8
+    ) -> CGFloat {
+        max(0, cardWidth - trailingInset - buttonWidth - spacing - textX)
+    }
+
+    static func singleActionCardWidth(
+        requiredTextWidth: CGFloat,
+        textX: CGFloat,
+        buttonWidth: CGFloat = 110,
+        trailingInset: CGFloat = 12,
+        spacing: CGFloat = 8,
+        minimumWidth: CGFloat = 344,
+        maximumWidth: CGFloat = 420
+    ) -> CGFloat {
+        let requiredWidth = ceil(textX + requiredTextWidth + spacing + buttonWidth + trailingInset)
+        return min(maximumWidth, max(minimumWidth, requiredWidth))
+    }
+
     @discardableResult
     func show(
         promptID: String? = nil,
@@ -56,8 +79,25 @@ final class MeetingNotificationController {
 
         let hasJoinButton = meetingURL != nil && onJoinAndRecord != nil
         let platform = explicitPlatform ?? meetingURL.flatMap { MeetingPlatform.detect(from: $0) }
+        let platformIcon = platform?.loadIcon()
+        let iconSize: CGFloat = 26
+        let textX: CGFloat = platformIcon == nil ? 14 : 14 + iconSize + 9
+        let titleFont = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        let subtitleFont = NSFont.systemFont(ofSize: 11)
 
-        let cardWidth: CGFloat = 344
+        let minimumCardWidth: CGFloat = 344
+        let cardWidth: CGFloat
+        if hasJoinButton {
+            cardWidth = minimumCardWidth
+        } else {
+            let titleWidth = (title as NSString).size(withAttributes: [.font: titleFont]).width
+            let subtitleWidth = (subtitle as NSString).size(withAttributes: [.font: subtitleFont]).width
+            cardWidth = Self.singleActionCardWidth(
+                requiredTextWidth: max(titleWidth, subtitleWidth),
+                textX: textX,
+                minimumWidth: minimumCardWidth
+            )
+        }
         let cardHeight: CGFloat = 60
         let closeButtonSize: CGFloat = 22
         let cardX = closeButtonSize / 2 + 1
@@ -137,28 +177,23 @@ final class MeetingNotificationController {
         contentView.hoverFrames = [cardView.frame, dismissButton.frame]
 
         // Platform icon + text layout
-        let textX: CGFloat
-        if let platform, let icon = platform.loadIcon() {
-            let iconSize: CGFloat = 26
+        if let icon = platformIcon {
             let iconView = NSImageView(image: icon)
             iconView.imageScaling = .scaleProportionallyUpOrDown
             iconView.frame = NSRect(x: 14, y: (cardHeight - iconSize) / 2 + 1, width: iconSize, height: iconSize)
             cardView.addSubview(iconView)
-            textX = 14 + iconSize + 9
-        } else {
-            textX = 14
         }
 
         // Title label
         let titleLabel = NSTextField(labelWithString: title)
-        titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        titleLabel.font = titleFont
         titleLabel.textColor = .white
         titleLabel.frame = NSRect(x: textX, y: 32, width: 144, height: 18)
         cardView.addSubview(titleLabel)
 
         // Subtitle label
         let subtitleLabel = NSTextField(labelWithString: subtitle)
-        subtitleLabel.font = .systemFont(ofSize: 11)
+        subtitleLabel.font = subtitleFont
         subtitleLabel.textColor = NSColor.white.withAlphaComponent(0.55)
         subtitleLabel.frame = NSRect(x: textX, y: 14, width: 144, height: 16)
         cardView.addSubview(subtitleLabel)
@@ -202,9 +237,15 @@ final class MeetingNotificationController {
             cardView.addSubview(chevronButton)
         } else {
             // Single "Start Recording" button
+            let buttonWidth: CGFloat = 110
+            let buttonX = cardWidth - buttonWidth - 12
+            let textWidth = Self.singleActionTextWidth(cardWidth: cardWidth, textX: textX, buttonWidth: buttonWidth)
+            titleLabel.frame.size.width = textWidth
+            subtitleLabel.frame.size.width = textWidth
+
             let startButton = NSButton(title: actionLabel, target: self, action: #selector(handleStartRecording))
             startButton.font = .systemFont(ofSize: 12, weight: .medium)
-            startButton.frame = NSRect(x: cardWidth - 122, y: 15, width: 110, height: 30)
+            startButton.frame = NSRect(x: buttonX, y: 15, width: buttonWidth, height: 30)
             startButton.wantsLayer = true
             startButton.layer?.backgroundColor = NSColor(red: 0.2, green: 0.5, blue: 1.0, alpha: 1.0).cgColor
             startButton.layer?.cornerRadius = 6

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5868,6 +5868,8 @@ final class MuesliController: NSObject {
             subtitle: "Still recording. Stop if the meeting ended.",
             actionLabel: "Stop Recording",
             dismissAfter: 30,
+            // MeetingNotificationController uses onStartRecording as its generic
+            // primary-action slot; here the primary action is stopping recording.
             onStartRecording: { [weak self] in
                 self?.stopMeetingRecording()
             },

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -317,6 +317,8 @@ final class MuesliController: NSObject {
     private var latestMeetingActivityCandidate: MeetingCandidate?
     private var latestMeetingActivityCandidateObservedAt: Date?
     private var activeMeetingAutoStop = MeetingAutoStopTracker()
+    private var activeMeetingSignalLossResponse: MeetingSignalLossResponse = .none
+    private var isMeetingSignalLossPromptSuppressed = false
     private let meetingAutoStopGracePeriod: TimeInterval = 20
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
@@ -2138,7 +2140,8 @@ final class MuesliController: NSObject {
                     calendarEventID: event.id,
                     openDocument: true,
                     endDate: event.endDate,
-                    autoStopSource: event.meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
+                    autoStopSource: event.meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) },
+                    startOrigin: .calendarAutoRecord
                 )
                 return
             }
@@ -2220,7 +2223,8 @@ final class MuesliController: NSObject {
                     title: title,
                     calendarEventID: calendarEventID,
                     endDate: endDate,
-                    autoStopSource: autoStopSource
+                    autoStopSource: autoStopSource,
+                    startOrigin: .scheduledMeetingPrompt
                 )
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
@@ -4037,7 +4041,8 @@ final class MuesliController: NSObject {
                 title: payload.title,
                 calendarEventID: payload.calendarEventID,
                 endDate: payload.endDate,
-                autoStopSource: payload.autoStopSource
+                autoStopSource: payload.autoStopSource,
+                startOrigin: .scheduledMeetingPrompt
             )
             return
         }
@@ -4051,7 +4056,8 @@ final class MuesliController: NSObject {
         title: String = "Meeting",
         calendarEventID: String? = nil,
         endDate: Date? = nil,
-        autoStopSource: MeetingAutoStopSource? = nil
+        autoStopSource: MeetingAutoStopSource? = nil,
+        startOrigin: MeetingRecordingStartOrigin = .manual
     ) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
         if isMeetingRecording() {
@@ -4064,7 +4070,8 @@ final class MuesliController: NSObject {
             calendarEventID: calendarEventID,
             openDocument: true,
             endDate: endDate,
-            autoStopSource: autoStopSource
+            autoStopSource: autoStopSource,
+            startOrigin: startOrigin
         )
         guard didStart else { return false }
         presentHistoryWindow(tab: .meetings)
@@ -4077,7 +4084,8 @@ final class MuesliController: NSObject {
         calendarEventID: String? = nil,
         openDocument: Bool = false,
         endDate: Date? = nil,
-        autoStopSource: MeetingAutoStopSource? = nil
+        autoStopSource: MeetingAutoStopSource? = nil,
+        startOrigin: MeetingRecordingStartOrigin = .manual
     ) -> Bool {
         guard !isMeetingRecording(), !isStartingMeetingRecording else { return false }
         guard let meetingBackend = normalizeMeetingTranscriptionSelectionForAvailability() else {
@@ -4110,7 +4118,13 @@ final class MuesliController: NSObject {
             presentErrorAlert(title: "Meeting failed to start", message: error.localizedDescription)
             return false
         }
-        armMeetingAutoStop(source: autoStopSource ?? recentMeetingAutoStopSource())
+        armMeetingAutoStop(
+            source: startOrigin.signalLossSource(
+                explicitSource: autoStopSource,
+                recentSource: recentMeetingAutoStopSource()
+            ),
+            response: startOrigin.signalLossResponse
+        )
         isStartingMeetingRecording = true
         // Keep this after backend normalization and live-meeting creation so
         // a failed meeting start does not silently cancel an active dictation.
@@ -4210,7 +4224,13 @@ final class MuesliController: NSObject {
         activeMeetingAudioWarning = nil
         syncAppState()
 
-        armMeetingAutoStop(source: recentMeetingAutoStopSource())
+        armMeetingAutoStop(
+            source: MeetingRecordingStartOrigin.manual.signalLossSource(
+                explicitSource: nil,
+                recentSource: recentMeetingAutoStopSource()
+            ),
+            response: MeetingRecordingStartOrigin.manual.signalLossResponse
+        )
         isStartingMeetingRecording = true
         cancelDictationAudioSessionForMeetingRecordingIfNeeded()
         syncDictationRecorderWarmup(intent: .idlePrewarm(.meetingStateChanged))
@@ -4658,7 +4678,8 @@ final class MuesliController: NSObject {
             title: title,
             calendarEventID: calendarEventID,
             endDate: endDate,
-            autoStopSource: MeetingAutoStopSource(meetingURL: meetingURL)
+            autoStopSource: MeetingAutoStopSource(meetingURL: meetingURL),
+            startOrigin: .joinAndRecord
         )
     }
 
@@ -5739,8 +5760,13 @@ final class MuesliController: NSObject {
         )
     }
 
-    private func armMeetingAutoStop(source: MeetingAutoStopSource?) {
+    private func armMeetingAutoStop(
+        source: MeetingAutoStopSource?,
+        response: MeetingSignalLossResponse = .autoStopAfterWarning
+    ) {
         activeMeetingAutoStop.arm(source: source)
+        activeMeetingSignalLossResponse = source == nil ? .none : response
+        isMeetingSignalLossPromptSuppressed = false
         syncMeetingDetectionMonitor()
     }
 
@@ -5769,6 +5795,8 @@ final class MuesliController: NSObject {
 
     private func disarmMeetingAutoStop() {
         activeMeetingAutoStop.disarm()
+        activeMeetingSignalLossResponse = .none
+        isMeetingSignalLossPromptSuppressed = false
         latestMeetingActivityCandidate = nil
         latestMeetingActivityCandidateObservedAt = nil
         syncMeetingDetectionMonitor()
@@ -5805,12 +5833,58 @@ final class MuesliController: NSObject {
         }
 
         let now = Date()
+        let matchedSource = candidate.flatMap { candidate in
+            activeMeetingAutoStop.source.map { source in
+                MeetingAutoStopPolicy.matches(candidate: candidate, source: source)
+            }
+        } ?? false
+        if matchedSource {
+            isMeetingSignalLossPromptSuppressed = false
+        }
         if activeMeetingAutoStop.observe(
             candidate: candidate,
             now: now,
             gracePeriod: meetingAutoStopGracePeriod
         ) {
-            fputs("[meeting] auto-stopping recording after meeting source disappeared\n", stderr)
+            presentMeetingSignalLossPromptIfNeeded()
+        }
+    }
+
+    private func presentMeetingSignalLossPromptIfNeeded() {
+        guard activeMeetingSignalLossResponse != .none,
+              !isMeetingSignalLossPromptSuppressed,
+              activeMeetingSession?.isRecording == true,
+              !isStoppingMeetingRecording else { return }
+
+        let meetingID = activeMeetingID
+        let promptID = meetingID.map { "meeting-signal-lost:\($0)" } ?? "meeting-signal-lost"
+        guard meetingNotification.currentPromptID != promptID || !meetingNotification.isVisible else { return }
+
+        isMeetingSignalLossPromptSuppressed = true
+        let response = activeMeetingSignalLossResponse
+        let didShow = meetingNotification.show(
+            promptID: promptID,
+            title: "Meeting signal lost",
+            subtitle: "Still recording. Stop if the meeting ended.",
+            actionLabel: "Stop Recording",
+            dismissAfter: 30,
+            onStartRecording: { [weak self] in
+                self?.stopMeetingRecording()
+            },
+            onDismiss: { [weak self] in
+                self?.isMeetingSignalLossPromptSuppressed = true
+            },
+            onAutoDismiss: { [weak self] in
+                guard let self else { return }
+                self.isMeetingSignalLossPromptSuppressed = true
+                guard response == .autoStopAfterWarning else { return }
+                fputs("[meeting] auto-stopping recording after meeting source disappeared and warning timed out\n", stderr)
+                self.stopMeetingRecording()
+            }
+        )
+
+        if !didShow, response == .autoStopAfterWarning {
+            fputs("[meeting] auto-stopping recording after meeting source disappeared; warning unavailable\n", stderr)
             stopMeetingRecording()
         }
     }
@@ -5839,7 +5913,8 @@ final class MuesliController: NSObject {
                 guard let self else { return }
                 if self.startForegroundMeetingRecording(
                     title: title,
-                    autoStopSource: MeetingAutoStopSource(candidate: candidate)
+                    autoStopSource: MeetingAutoStopSource(candidate: candidate),
+                    startOrigin: .detectedPrompt
                 ) {
                     self.meetingMonitor.markRecordingStarted(candidate)
                     self.presentedMeetingCandidate = nil
@@ -7217,7 +7292,8 @@ final class MuesliController: NSObject {
                     title: title,
                     calendarEventID: event.id,
                     endDate: calendarEndDate,
-                    autoStopSource: autoStopSource
+                    autoStopSource: autoStopSource,
+                    startOrigin: .scheduledMeetingPrompt
                 )
             },
             onJoinAndRecord: meetingURL != nil ? { [weak self] in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5840,6 +5840,7 @@ final class MuesliController: NSObject {
         } ?? false
         if matchedSource {
             isMeetingSignalLossPromptSuppressed = false
+            dismissMeetingSignalLossPromptIfVisible(for: activeMeetingID)
         }
         if activeMeetingAutoStop.observe(
             candidate: candidate,
@@ -5850,6 +5851,18 @@ final class MuesliController: NSObject {
         }
     }
 
+    private func meetingSignalLossPromptID(for meetingID: Int64?) -> String {
+        meetingID.map { "meeting-signal-lost:\($0)" } ?? "meeting-signal-lost"
+    }
+
+    private func dismissMeetingSignalLossPromptIfVisible(for meetingID: Int64?) {
+        guard meetingNotification.isVisible,
+              meetingNotification.currentPromptID == meetingSignalLossPromptID(for: meetingID) else {
+            return
+        }
+        meetingNotification.close()
+    }
+
     private func presentMeetingSignalLossPromptIfNeeded() {
         guard activeMeetingSignalLossResponse != .none,
               !isMeetingSignalLossPromptSuppressed,
@@ -5857,7 +5870,7 @@ final class MuesliController: NSObject {
               !isStoppingMeetingRecording else { return }
 
         let meetingID = activeMeetingID
-        let promptID = meetingID.map { "meeting-signal-lost:\($0)" } ?? "meeting-signal-lost"
+        let promptID = meetingSignalLossPromptID(for: meetingID)
         guard meetingNotification.currentPromptID != promptID || !meetingNotification.isVisible else { return }
 
         isMeetingSignalLossPromptSuppressed = true
@@ -5871,7 +5884,8 @@ final class MuesliController: NSObject {
             // MeetingNotificationController uses onStartRecording as its generic
             // primary-action slot; here the primary action is stopping recording.
             onStartRecording: { [weak self] in
-                self?.stopMeetingRecording()
+                guard let self, self.activeMeetingID == meetingID else { return }
+                self.stopMeetingRecording()
             },
             onDismiss: { [weak self] in
                 self?.isMeetingSignalLossPromptSuppressed = true
@@ -5880,6 +5894,7 @@ final class MuesliController: NSObject {
                 guard let self else { return }
                 self.isMeetingSignalLossPromptSuppressed = true
                 guard response == .autoStopAfterWarning else { return }
+                guard self.activeMeetingID == meetingID else { return }
                 fputs("[meeting] auto-stopping recording after meeting source disappeared and warning timed out\n", stderr)
                 self.stopMeetingRecording()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5888,7 +5888,8 @@ final class MuesliController: NSObject {
                 self.stopMeetingRecording()
             },
             onDismiss: { [weak self] in
-                self?.meetingSignalLossPromptState.markDismissedByUser()
+                guard let self, self.activeMeetingID == meetingID else { return }
+                self.meetingSignalLossPromptState.markDismissedByUser()
             },
             onAutoDismiss: { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -318,7 +318,7 @@ final class MuesliController: NSObject {
     private var latestMeetingActivityCandidateObservedAt: Date?
     private var activeMeetingAutoStop = MeetingAutoStopTracker()
     private var activeMeetingSignalLossResponse: MeetingSignalLossResponse = .none
-    private var isMeetingSignalLossPromptSuppressed = false
+    private var meetingSignalLossPromptState = MeetingSignalLossPromptState()
     private let meetingAutoStopGracePeriod: TimeInterval = 20
     private var meetingActivity: NSObjectProtocol?
     private var isStoppingMeetingRecording = false
@@ -5766,7 +5766,7 @@ final class MuesliController: NSObject {
     ) {
         activeMeetingAutoStop.arm(source: source)
         activeMeetingSignalLossResponse = source == nil ? .none : response
-        isMeetingSignalLossPromptSuppressed = false
+        meetingSignalLossPromptState.resetForRecording()
         syncMeetingDetectionMonitor()
     }
 
@@ -5796,7 +5796,7 @@ final class MuesliController: NSObject {
     private func disarmMeetingAutoStop() {
         activeMeetingAutoStop.disarm()
         activeMeetingSignalLossResponse = .none
-        isMeetingSignalLossPromptSuppressed = false
+        meetingSignalLossPromptState.resetForRecording()
         latestMeetingActivityCandidate = nil
         latestMeetingActivityCandidateObservedAt = nil
         syncMeetingDetectionMonitor()
@@ -5839,7 +5839,7 @@ final class MuesliController: NSObject {
             }
         } ?? false
         if matchedSource {
-            isMeetingSignalLossPromptSuppressed = false
+            meetingSignalLossPromptState.markSourceRecovered()
             dismissMeetingSignalLossPromptIfVisible(for: activeMeetingID)
         }
         if activeMeetingAutoStop.observe(
@@ -5865,7 +5865,7 @@ final class MuesliController: NSObject {
 
     private func presentMeetingSignalLossPromptIfNeeded() {
         guard activeMeetingSignalLossResponse != .none,
-              !isMeetingSignalLossPromptSuppressed,
+              meetingSignalLossPromptState.canPresentPrompt,
               activeMeetingSession?.isRecording == true,
               !isStoppingMeetingRecording else { return }
 
@@ -5873,7 +5873,7 @@ final class MuesliController: NSObject {
         let promptID = meetingSignalLossPromptID(for: meetingID)
         guard meetingNotification.currentPromptID != promptID || !meetingNotification.isVisible else { return }
 
-        isMeetingSignalLossPromptSuppressed = true
+        meetingSignalLossPromptState.markPromptPresented()
         let response = activeMeetingSignalLossResponse
         let didShow = meetingNotification.show(
             promptID: promptID,
@@ -5888,11 +5888,11 @@ final class MuesliController: NSObject {
                 self.stopMeetingRecording()
             },
             onDismiss: { [weak self] in
-                self?.isMeetingSignalLossPromptSuppressed = true
+                self?.meetingSignalLossPromptState.markDismissedByUser()
             },
             onAutoDismiss: { [weak self] in
                 guard let self else { return }
-                self.isMeetingSignalLossPromptSuppressed = true
+                self.meetingSignalLossPromptState.markAutoDismissed()
                 guard response == .autoStopAfterWarning else { return }
                 guard self.activeMeetingID == meetingID else { return }
                 fputs("[meeting] auto-stopping recording after meeting source disappeared and warning timed out\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5893,9 +5893,9 @@ final class MuesliController: NSObject {
             },
             onAutoDismiss: { [weak self] in
                 guard let self else { return }
+                guard self.activeMeetingID == meetingID else { return }
                 self.meetingSignalLossPromptState.markAutoDismissed()
                 guard response == .autoStopAfterWarning else { return }
-                guard self.activeMeetingID == meetingID else { return }
                 fputs("[meeting] auto-stopping recording after meeting source disappeared and warning timed out\n", stderr)
                 self.stopMeetingRecording()
             }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -176,6 +176,32 @@ struct MeetingAutoStopPolicyTests {
         }
     }
 
+    @Test("signal loss prompt can reappear after source recovery when not dismissed")
+    func signalLossPromptCanReappearAfterSourceRecoveryWhenNotDismissed() {
+        var state = MeetingSignalLossPromptState()
+
+        #expect(state.canPresentPrompt)
+        state.markPromptPresented()
+        #expect(!state.canPresentPrompt)
+
+        state.markSourceRecovered()
+        #expect(state.canPresentPrompt)
+    }
+
+    @Test("user dismissed signal loss prompt stays suppressed for recording")
+    func userDismissedSignalLossPromptStaysSuppressedForRecording() {
+        var state = MeetingSignalLossPromptState()
+
+        state.markPromptPresented()
+        state.markDismissedByUser()
+        state.markSourceRecovered()
+
+        #expect(!state.canPresentPrompt)
+
+        state.resetForRecording()
+        #expect(state.canPresentPrompt)
+    }
+
     @Test("tracker waits for a recording-time observation before auto-stopping")
     func trackerWaitsForRecordingTimeObservationBeforeAutoStopping() {
         var tracker = MeetingAutoStopTracker()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -138,6 +138,40 @@ struct MeetingAutoStopPolicyTests {
         #expect(source.hasObservedCandidate)
     }
 
+    @Test("manual start origin tracks signal loss for warning only")
+    func manualStartOriginTracksSignalLossForWarningOnly() {
+        let explicitSource = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let recentSource = MeetingAutoStopSource(candidate: teamsCandidate())
+
+        let resolvedSource = MeetingRecordingStartOrigin.manual.signalLossSource(
+            explicitSource: explicitSource,
+            recentSource: recentSource
+        )
+
+        #expect(!MeetingRecordingStartOrigin.manual.enablesMeetingAutoStop)
+        #expect(MeetingRecordingStartOrigin.manual.signalLossResponse == .warnOnly)
+        #expect(resolvedSource == explicitSource)
+    }
+
+    @Test("source-backed start origins can auto-stop after warning")
+    func sourceBackedStartOriginsCanAutoStopAfterWarning() {
+        let explicitSource = MeetingAutoStopSource(candidate: googleMeetCandidate())
+        let recentSource = MeetingAutoStopSource(candidate: teamsCandidate())
+        let origins: [MeetingRecordingStartOrigin] = [
+            .detectedPrompt,
+            .calendarAutoRecord,
+            .scheduledMeetingPrompt,
+            .joinAndRecord,
+        ]
+
+        for origin in origins {
+            #expect(origin.enablesMeetingAutoStop)
+            #expect(origin.signalLossResponse == .autoStopAfterWarning)
+            #expect(origin.signalLossSource(explicitSource: explicitSource, recentSource: recentSource) == explicitSource)
+            #expect(origin.signalLossSource(explicitSource: nil, recentSource: recentSource) == recentSource)
+        }
+    }
+
     @Test("tracker waits for a recording-time observation before auto-stopping")
     func trackerWaitsForRecordingTimeObservationBeforeAutoStopping() {
         var tracker = MeetingAutoStopTracker()
@@ -245,6 +279,21 @@ struct MeetingAutoStopPolicyTests {
             sourceBundleID: "com.google.Chrome",
             sourcePID: 1234,
             suppressionID: "browser:com.google.Chrome:session:1800000000"
+        )
+    }
+
+    private func teamsCandidate() -> MeetingCandidate {
+        MeetingCandidate(
+            id: "app:com.microsoft.teams2:session:1800000000",
+            platform: .teams,
+            appName: "Teams",
+            url: nil,
+            evidence: [.audioInputProcess, .dedicatedApp],
+            startedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            meetingTitle: nil,
+            sourceBundleID: "com.microsoft.teams2",
+            sourcePID: 4321,
+            suppressionID: "app:com.microsoft.teams2:session:1800000000"
         )
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -151,6 +151,10 @@ struct MeetingAutoStopPolicyTests {
         #expect(!MeetingRecordingStartOrigin.manual.enablesMeetingAutoStop)
         #expect(MeetingRecordingStartOrigin.manual.signalLossResponse == .warnOnly)
         #expect(resolvedSource == explicitSource)
+        #expect(MeetingRecordingStartOrigin.manual.signalLossSource(
+            explicitSource: nil,
+            recentSource: recentSource
+        ) == recentSource)
     }
 
     @Test("source-backed start origins can auto-stop after warning")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -138,8 +138,8 @@ struct MeetingAutoStopPolicyTests {
         #expect(source.hasObservedCandidate)
     }
 
-    @Test("manual start origin tracks signal loss for warning only")
-    func manualStartOriginTracksSignalLossForWarningOnly() {
+    @Test("manual start origin does not track meeting signal loss")
+    func manualStartOriginDoesNotTrackMeetingSignalLoss() {
         let explicitSource = MeetingAutoStopSource(candidate: googleMeetCandidate())
         let recentSource = MeetingAutoStopSource(candidate: teamsCandidate())
 
@@ -149,12 +149,12 @@ struct MeetingAutoStopPolicyTests {
         )
 
         #expect(!MeetingRecordingStartOrigin.manual.enablesMeetingAutoStop)
-        #expect(MeetingRecordingStartOrigin.manual.signalLossResponse == .warnOnly)
-        #expect(resolvedSource == explicitSource)
+        #expect(MeetingRecordingStartOrigin.manual.signalLossResponse == .none)
+        #expect(resolvedSource == nil)
         #expect(MeetingRecordingStartOrigin.manual.signalLossSource(
             explicitSource: nil,
             recentSource: recentSource
-        ) == recentSource)
+        ) == nil)
     }
 
     @Test("source-backed start origins can auto-stop after warning")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNotificationControllerTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import MuesliNativeApp
@@ -32,6 +33,21 @@ struct MeetingNotificationControllerTests {
     func autoDismissCallbackSkippedWhenPausedDuringFadeOut() {
         #expect(MeetingNotificationController.firesAutoDismissCallbackAfterFade(wasDismissPaused: false))
         #expect(!MeetingNotificationController.firesAutoDismissCallbackAfterFade(wasDismissPaused: true))
+    }
+
+    @Test("Single-action prompts use available text width")
+    @MainActor
+    func singleActionPromptsUseAvailableTextWidth() {
+        let subtitle = "Still recording. Stop if the meeting ended." as NSString
+        let subtitleWidth = subtitle.size(withAttributes: [.font: NSFont.systemFont(ofSize: 11)]).width
+        let cardWidth = MeetingNotificationController.singleActionCardWidth(
+            requiredTextWidth: subtitleWidth,
+            textX: 14
+        )
+        let textWidth = MeetingNotificationController.singleActionTextWidth(cardWidth: cardWidth, textX: 14)
+
+        #expect(cardWidth > 344)
+        #expect(textWidth >= subtitleWidth)
     }
 
     @Test("Completion notification can show during recording but not over prompts")


### PR DESCRIPTION
## Summary
- distinguish manual meeting recording starts from source-backed starts for meeting signal loss handling
- keep manual recordings from auto-stopping when the detected meeting signal disappears
- show a top-right warning before stopping source-backed recordings after signal loss, with a Stop Recording action

## Root Cause
Manual starts flowed through the same `startMeetingRecording` path as detected/calendar starts and could inherit `recentMeetingAutoStopSource()`. If the resolver later lost the meeting candidate, the tracker stopped the recording after the grace period, splitting one meeting into multiple records.

## Behavior
- Manual starts and resumed meetings are warning-only when signal loss is detected.
- Detected prompt, calendar auto-record, scheduled prompt/menu, and Join & Record starts still use source-backed stop behavior.
- Source-backed auto-stop now warns first; if the warning times out, it stops recording.

Fixes #217.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-manual-no-autostop" --filter MeetingAutoStopPolicyTests`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785633927&installation_id=136549638&pr_number=268&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F268&signature=ded89099bb3ab86bbfed60d3542f653cb2876f332c854f4367345aa1330379c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meeting recordings now apply auto-stop and signal-loss handling based on how the recording was started (manual, detected, calendar-driven, scheduled, or join-and-record).

* **Bug Fixes**
  * Improved signal-loss prompt behavior and state transitions across meeting start flows, including suppression, recovery, and auto-stop-after-warning handling.
  * Refined single-action meeting notification layout to better size text and buttons.

* **Tests**
  * Expanded unit tests for start-origin policy, signal-loss response/source selection, and prompt reappearance/suppression rules.
  * Added a sizing test to ensure notification prompts use available text width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->