### PR TITLE
[codex] Add cloud-aware dictation cleanup

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -75,6 +75,7 @@ final class AppState {
     var selectedBackend: BackendOption = .whisper
     var selectedMeetingTranscriptionBackend: BackendOption = .whisper
     var selectedMeetingSummaryBackend: MeetingSummaryBackendOption = .chatGPT
+    var selectedPostProcessorBackend: TranscriptCleanupBackendOption = .local
     var activePostProcessor: PostProcessorOption = PostProcessorOption.defaultOption
     var config: AppConfig = AppConfig()
     var launchAtLoginRegistrationState: LaunchAtLoginRegistrationState = .disabled

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+enum ChatGPTResponsesError: LocalizedError {
+    case backendFailed(statusCode: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .backendFailed(statusCode, message):
+            return "ChatGPT failed with status \(statusCode). \(message)"
+        }
+    }
+}
+
+enum ChatGPTResponsesClient {
+    private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
+
+    static func respond(
+        systemPrompt: String,
+        userPrompt: String,
+        model: String,
+        logCategory: String
+    ) async throws -> String {
+        let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
+        let body: [String: Any] = [
+            "model": model,
+            "store": false,
+            "stream": true,
+            "instructions": systemPrompt,
+            "input": [[
+                "role": "user",
+                "content": [["type": "input_text", "text": userPrompt]],
+            ] as [String: Any]],
+        ]
+
+        var request = URLRequest(url: whamURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard httpStatus == 200 else {
+            var errorData = Data()
+            for try await byte in bytes { errorData.append(byte) }
+            let message = extractErrorMessage(from: errorData)
+                ?? String(data: errorData, encoding: .utf8)
+                ?? "(unknown)"
+            fputs("[\(logCategory)] ChatGPT WHAM: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
+            throw ChatGPTResponsesError.backendFailed(statusCode: httpStatus, message: message)
+        }
+
+        var fullText = ""
+        for try await line in bytes.lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let jsonString = String(line.dropFirst(6))
+            if jsonString == "[DONE]" { break }
+            guard
+                let data = jsonString.data(using: .utf8),
+                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { continue }
+
+            if let delta = extractOutputTextDelta(from: json) {
+                fullText += delta
+                continue
+            }
+
+            if let outputText = extractOutputText(from: json), !outputText.isEmpty {
+                fullText = outputText
+            }
+        }
+
+        let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+        fputs("[\(logCategory)] ChatGPT WHAM: collected \(trimmed.count) chars\n", stderr)
+        return trimmed
+    }
+
+    static func extractOutputText(from payload: [String: Any]) -> String? {
+        if let outputText = payload["output_text"] as? String, !outputText.isEmpty {
+            return outputText
+        }
+        if let response = payload["response"] as? [String: Any],
+           let responseText = extractOutputText(from: response) {
+            return responseText
+        }
+        if let outputText = extractText(fromOutput: payload["output"]) {
+            return outputText
+        }
+        if let contentText = extractText(fromContent: payload["content"]) {
+            return contentText
+        }
+        return nil
+    }
+
+    static func extractOutputTextDelta(from payload: [String: Any]) -> String? {
+        guard
+            (payload["type"] as? String) == "response.output_text.delta",
+            let delta = payload["delta"] as? String,
+            !delta.isEmpty
+        else {
+            return nil
+        }
+        return delta
+    }
+
+    private static func extractText(fromOutput output: Any?) -> String? {
+        guard let output else { return nil }
+        if let outputText = output as? String, !outputText.isEmpty {
+            return outputText
+        }
+        if let item = output as? [String: Any] {
+            return extractText(fromContent: item["content"]) ?? (item["text"] as? String)
+        }
+        if let items = output as? [[String: Any]] {
+            let parts = items.compactMap { item -> String? in
+                extractText(fromContent: item["content"]) ?? (item["text"] as? String)
+            }
+            let joined = parts.joined(separator: "")
+            return joined.isEmpty ? nil : joined
+        }
+        return nil
+    }
+
+    private static func extractText(fromContent content: Any?) -> String? {
+        guard let content else { return nil }
+        if let text = content as? String, !text.isEmpty {
+            return text
+        }
+        if let item = content as? [String: Any] {
+            if let text = item["text"] as? String, !text.isEmpty { return text }
+            if let text = item["content"] as? String, !text.isEmpty { return text }
+            if let nested = item["text"] as? [String: Any],
+               let value = nested["value"] as? String,
+               !value.isEmpty {
+                return value
+            }
+        }
+        if let items = content as? [[String: Any]] {
+            let parts = items.compactMap { item -> String? in
+                if let text = item["text"] as? String, !text.isEmpty { return text }
+                if let text = item["content"] as? String, !text.isEmpty { return text }
+                if let nested = item["text"] as? [String: Any],
+                   let value = nested["value"] as? String,
+                   !value.isEmpty {
+                    return value
+                }
+                return nil
+            }
+            let joined = parts.joined(separator: "")
+            return joined.isEmpty ? nil : joined
+        }
+        return nil
+    }
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let error = json["error"] as? [String: Any] {
+            if let message = error["message"] as? String, !message.isEmpty { return message }
+            if let code = error["code"] as? String, !code.isEmpty { return code }
+            return String(describing: error)
+        }
+        if let message = json["message"] as? String, !message.isEmpty { return message }
+        if let detail = json["detail"] as? String, !detail.isEmpty { return detail }
+        return nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -13,6 +13,7 @@ enum ChatGPTResponsesError: LocalizedError {
 
 enum ChatGPTResponsesClient {
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
+    private static let requestTimeout: TimeInterval = 120
 
     static func respond(
         systemPrompt: String,
@@ -33,6 +34,7 @@ enum ChatGPTResponsesClient {
         ]
 
         var request = URLRequest(url: whamURL)
+        request.timeoutInterval = requestTimeout
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -53,7 +55,8 @@ enum ChatGPTResponsesClient {
             throw ChatGPTResponsesError.backendFailed(statusCode: httpStatus, message: message)
         }
 
-        var fullText = ""
+        var deltaText = ""
+        var finalText = ""
         for try await line in bytes.lines {
             guard line.hasPrefix("data: ") else { continue }
             let jsonString = String(line.dropFirst(6))
@@ -63,19 +66,28 @@ enum ChatGPTResponsesClient {
                 let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else { continue }
 
-            if let delta = extractOutputTextDelta(from: json) {
-                fullText += delta
-                continue
-            }
-
-            if let outputText = extractOutputText(from: json), !outputText.isEmpty {
-                fullText = outputText
-            }
+            applyStreamPayload(json, deltaText: &deltaText, finalText: &finalText)
         }
 
+        let fullText = accumulatedOutputText(deltaText: deltaText, finalText: finalText)
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         fputs("[\(logCategory)] ChatGPT WHAM: collected \(trimmed.count) chars\n", stderr)
         return trimmed
+    }
+
+    static func applyStreamPayload(_ payload: [String: Any], deltaText: inout String, finalText: inout String) {
+        if let delta = extractOutputTextDelta(from: payload) {
+            deltaText += delta
+            return
+        }
+
+        if let outputText = extractOutputText(from: payload), !outputText.isEmpty {
+            finalText = outputText
+        }
+    }
+
+    static func accumulatedOutputText(deltaText: String, finalText: String) -> String {
+        finalText.isEmpty ? deltaText : finalText
     }
 
     static func extractOutputText(from payload: [String: Any]) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -88,9 +88,11 @@ enum ChatGPTResponsesClient {
     }
 
     static func decodeStreamPayload(_ jsonString: String, httpStatus: Int) throws -> [String: Any]? {
-        guard !jsonString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        let trimmed = jsonString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if shouldIgnoreNonJSONStreamPayload(trimmed) { return nil }
         guard
-            let data = jsonString.data(using: .utf8),
+            let data = trimmed.data(using: .utf8),
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
             throw ChatGPTResponsesError.backendFailed(
@@ -99,6 +101,15 @@ enum ChatGPTResponsesClient {
             )
         }
         return json
+    }
+
+    private static func shouldIgnoreNonJSONStreamPayload(_ payload: String) -> Bool {
+        switch payload.lowercased() {
+        case "ping", "heartbeat", "keep-alive":
+            return true
+        default:
+            return false
+        }
     }
 
     static func extractOutputText(from payload: [String: Any]) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -61,10 +61,7 @@ enum ChatGPTResponsesClient {
             guard line.hasPrefix("data: ") else { continue }
             let jsonString = String(line.dropFirst(6))
             if jsonString == "[DONE]" { break }
-            guard
-                let data = jsonString.data(using: .utf8),
-                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { continue }
+            guard let json = try decodeStreamPayload(jsonString, httpStatus: httpStatus) else { continue }
 
             applyStreamPayload(json, deltaText: &deltaText, finalText: &finalText)
         }
@@ -88,6 +85,20 @@ enum ChatGPTResponsesClient {
 
     static func accumulatedOutputText(deltaText: String, finalText: String) -> String {
         finalText.isEmpty ? deltaText : finalText
+    }
+
+    static func decodeStreamPayload(_ jsonString: String, httpStatus: Int) throws -> [String: Any]? {
+        guard !jsonString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        guard
+            let data = jsonString.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw ChatGPTResponsesError.backendFailed(
+                statusCode: httpStatus,
+                message: "Malformed ChatGPT stream payload."
+            )
+        }
+        return json
     }
 
     static func extractOutputText(from payload: [String: Any]) -> String? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/LLMBackendOption.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/LLMBackendOption.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct LLMBackendOption: Equatable, Identifiable {
+    let backend: String
+    let label: String
+
+    var id: String { backend }
+
+    static let chatGPT = LLMBackendOption(backend: "chatgpt", label: "ChatGPT")
+    static let openAI = LLMBackendOption(backend: "openai", label: "OpenAI")
+    static let openRouter = LLMBackendOption(backend: "openrouter", label: "OpenRouter")
+    static let ollama = LLMBackendOption(backend: "ollama", label: "Ollama")
+    static let lmStudio = LLMBackendOption(backend: "lmstudio", label: "LM Studio")
+    static let customLLM = LLMBackendOption(backend: "custom_llm", label: "Custom LLM")
+
+    static let all: [LLMBackendOption] = [.chatGPT, .openAI, .openRouter, .ollama, .lmStudio, .customLLM]
+
+    static func resolved(_ backend: String?) -> LLMBackendOption? {
+        guard let backend else { return nil }
+        return all.first { $0.backend == backend }
+    }
+}
+
+struct TranscriptCleanupBackendOption: Equatable, Identifiable {
+    let backend: String
+    let label: String
+    let llmBackend: LLMBackendOption?
+
+    var id: String { backend }
+    var isLocal: Bool { llmBackend == nil }
+
+    static let local = TranscriptCleanupBackendOption(
+        backend: "local",
+        label: "Local Model",
+        llmBackend: nil
+    )
+
+    static func hosted(_ option: LLMBackendOption) -> TranscriptCleanupBackendOption {
+        TranscriptCleanupBackendOption(
+            backend: option.backend,
+            label: option.label,
+            llmBackend: option
+        )
+    }
+
+    static let all: [TranscriptCleanupBackendOption] = [.local] + LLMBackendOption.all.map(hosted)
+
+    static func resolved(_ backend: String?) -> TranscriptCleanupBackendOption {
+        guard let backend, let option = all.first(where: { $0.backend == backend }) else {
+            return .local
+        }
+        return option
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -24,7 +24,6 @@ enum MeetingSummaryClient {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingSummary")
     private static let openAIURL = URL(string: "https://api.openai.com/v1/responses")!
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
-    private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
     private static let defaultLMStudioBaseURL = URL(string: "http://localhost:1234")!
     private static let defaultOpenAIModel = "gpt-5.4-mini"
@@ -423,7 +422,7 @@ enum MeetingSummaryClient {
     ) async throws -> String {
         do {
             let instructions = summaryInstructions(for: template, existingNotes: existingNotes, manualNotes: manualNotes)
-            let text = try await callWHAM(
+            let text = try await ChatGPTResponsesClient.respond(
                 systemPrompt: instructions,
                 userPrompt: summaryUserPrompt(
                     transcript: transcript,
@@ -432,12 +431,13 @@ enum MeetingSummaryClient {
                     manualNotes: manualNotes,
                     visualContext: visualContext
                 ),
-                model: config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel
+                model: config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel,
+                logCategory: "summary"
             )
-            if let text, !text.isEmpty {
-                return text
+            guard !text.isEmpty else {
+                throw MeetingSummaryError.emptyResponse(backend: "ChatGPT")
             }
-            throw MeetingSummaryError.emptyResponse(backend: "ChatGPT")
+            return text
         } catch {
             fputs("[summary] ChatGPT summarization failed: \(error)\n", stderr)
             throw summaryRequestError(backend: "ChatGPT", error: error)
@@ -745,72 +745,6 @@ enum MeetingSummaryClient {
         }
     }
 
-    /// Call the WHAM streaming API and collect the full response text.
-    private static func callWHAM(systemPrompt: String, userPrompt: String, model: String) async throws -> String? {
-        let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
-
-        let body: [String: Any] = [
-            "model": model,
-            "store": false,
-            "stream": true,
-            "instructions": systemPrompt,
-            "input": [
-                [
-                    "role": "user",
-                    "content": [
-                        ["type": "input_text", "text": userPrompt],
-                    ],
-                ] as [String: Any],
-            ],
-        ]
-        // Note: WHAM does not support max_output_tokens
-
-        var request = URLRequest(url: whamURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        if !accountId.isEmpty {
-            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
-        }
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
-        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
-
-        guard httpStatus == 200 else {
-            // Collect error body
-            var errorData = Data()
-            for try await byte in bytes { errorData.append(byte) }
-            let message = extractErrorMessage(from: errorData) ?? String(data: errorData, encoding: .utf8) ?? "(unknown)"
-            fputs("[summary] ChatGPT WHAM: HTTP \(httpStatus): \(String(message.prefix(500)))\n", stderr)
-            throw MeetingSummaryError.backendFailed(backend: "ChatGPT", statusCode: httpStatus, message: message)
-        }
-
-        // Parse SSE stream: collect text deltas from response.output_text.delta events
-        var fullText = ""
-        for try await line in bytes.lines {
-            guard line.hasPrefix("data: ") else { continue }
-            let jsonStr = String(line.dropFirst(6))
-            if jsonStr == "[DONE]" { break }
-            guard let data = jsonStr.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
-
-            // Check for output_text.done with full text
-            if let outputText = json["output_text"] as? String, !outputText.isEmpty {
-                fullText = outputText
-            }
-
-            // Check for streaming delta
-            if let type = json["type"] as? String, type == "response.output_text.delta",
-               let delta = json["delta"] as? String {
-                fullText += delta
-            }
-        }
-
-        fputs("[summary] ChatGPT WHAM: collected \(fullText.count) chars\n", stderr)
-        return fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private static func extractOpenAIText(from payload: [String: Any]) -> String? {
         if let outputText = payload["output_text"] as? String, !outputText.isEmpty {
             return outputText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -872,6 +806,12 @@ enum MeetingSummaryClient {
     private static func summaryRequestError(backend: String, error: Error) -> Error {
         if error is MeetingSummaryError {
             return error
+        }
+        if let error = error as? ChatGPTResponsesError {
+            switch error {
+            case let .backendFailed(statusCode, message):
+                return MeetingSummaryError.backendFailed(backend: backend, statusCode: statusCode, message: message)
+            }
         }
         return MeetingSummaryError.requestFailed(backend: backend, underlying: error)
     }
@@ -1154,13 +1094,15 @@ enum MeetingSummaryClient {
     private static func generateTitleWithChatGPT(transcript: String, config: AppConfig) async -> String? {
         do {
             let model = config.chatGPTModel.isEmpty ? defaultChatGPTModel : config.chatGPTModel
-            let result = try await callWHAM(
+            let result = try await ChatGPTResponsesClient.respond(
                 systemPrompt: titleInstructions,
                 userPrompt: transcript,
-                model: model
+                model: model,
+                logCategory: "summary"
             )
-            let title = result?.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
-            fputs("[summary] ChatGPT generated title: \(title ?? "(nil)")\n", stderr)
+            let title = result.trimmingCharacters(in: .whitespacesAndNewlines.union(.init(charactersIn: "\"")))
+            guard !title.isEmpty else { return nil }
+            fputs("[summary] ChatGPT generated title: \(title)\n", stderr)
             return title
         } catch {
             fputs("[summary] ChatGPT title generation failed: \(error)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -589,7 +589,7 @@ struct PostProcessorOption: Identifiable, Equatable {
     static let defaultSystemPrompt = """
     Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.
 
-    The user input may include an <APP-CONTEXT> section with focused app, document, URL, or selected-text context. Use it only to resolve obvious transcription errors, names, acronyms, and formatting intent. Never copy app context into the output unless the user dictated it.
+    The user input may include an <APP-CONTEXT> section with focused app, document, URL, selected text, or OCR screen text. Use it only to resolve obvious transcription errors, names, acronyms, and formatting intent. Never copy app context into the output unless the user dictated it.
 
     You may: fix obvious misspellings, remove filler words (um, uh, like), apply 'scratch that' deletions, and format numbered or bullet lists when dictated.
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -589,6 +589,8 @@ struct PostProcessorOption: Identifiable, Equatable {
     static let defaultSystemPrompt = """
     Clean up speech-to-text transcription. Only make changes when there is a clear error. If the text is already correct, output it exactly as-is.
 
+    The user input may include an <APP-CONTEXT> section with focused app, document, URL, or selected-text context. Use it only to resolve obvious transcription errors, names, acronyms, and formatting intent. Never copy app context into the output unless the user dictated it.
+
     You may: fix obvious misspellings, remove filler words (um, uh, like), apply 'scratch that' deletions, and format numbered or bullet lists when dictated.
 
     Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1028,6 +1028,7 @@ struct AppConfig: Codable {
     var customTranscriptCleanupPrompts: [CustomTranscriptCleanupPrompt] = []
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     var enableScreenContext: Bool = false
+    var enableDictationOCRContext: Bool = false
     var useCoreAudioTap: Bool = true
     var meetingHookEnabled: Bool = false
     var meetingHookPath: String = ""
@@ -1135,6 +1136,7 @@ struct AppConfig: Codable {
         case customTranscriptCleanupPrompts = "custom_transcript_cleanup_prompts"
         case postProcessorSystemPrompt = "post_processor_system_prompt"
         case enableScreenContext = "enable_screen_context"
+        case enableDictationOCRContext = "enable_dictation_ocr_context"
         case useCoreAudioTap = "use_core_audio_tap"
         case meetingHookEnabled = "meeting_hook_enabled"
         case meetingHookPath = "meeting_hook_path"
@@ -1297,6 +1299,7 @@ struct AppConfig: Codable {
             activeTranscriptCleanupPromptId = defaults.activeTranscriptCleanupPromptId
         }
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
+        enableDictationOCRContext = (try? c.decode(Bool.self, forKey: .enableDictationOCRContext)) ?? defaults.enableDictationOCRContext
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap
         meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled
         meetingHookPath = (try? c.decode(String.self, forKey: .meetingHookPath)) ?? defaults.meetingHookPath

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1297,6 +1297,7 @@ struct AppConfig: Codable {
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
         if TranscriptCleanupPrompts.resolve(id: activeTranscriptCleanupPromptId, custom: customTranscriptCleanupPrompts).id != activeTranscriptCleanupPromptId {
             activeTranscriptCleanupPromptId = defaults.activeTranscriptCleanupPromptId
+            postProcessorSystemPrompt = defaults.postProcessorSystemPrompt
         }
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
         enableDictationOCRContext = (try? c.decode(Bool.self, forKey: .enableDictationOCRContext)) ?? defaults.enableDictationOCRContext

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -288,6 +288,8 @@ struct SummaryModelPreset {
 
     static let openAIModels: [SummaryModelPreset] = [
         SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini (default)"),
+        SummaryModelPreset(id: "gpt-5.5", label: "GPT-5.5"),
+        SummaryModelPreset(id: "chat-latest", label: "Chat Latest (Instant)"),
         SummaryModelPreset(id: "gpt-5.4-nano", label: "GPT-5.4 Nano"),
         SummaryModelPreset(id: "gpt-5.4", label: "GPT-5.4"),
         SummaryModelPreset(id: "gpt-5.4-pro", label: "GPT-5.4 Pro"),
@@ -297,10 +299,12 @@ struct SummaryModelPreset {
 
     static let chatGPTModels: [SummaryModelPreset] = [
         SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini (default)"),
-        SummaryModelPreset(id: "gpt-5.4-nano", label: "GPT-5.4 Nano"),
-        SummaryModelPreset(id: "gpt-5.4", label: "GPT-5.4"),
-        SummaryModelPreset(id: "gpt-5.2", label: "GPT-5.2"),
-        SummaryModelPreset(id: "gpt-4o", label: "GPT-4o"),
+        SummaryModelPreset(id: "gpt-5.5", label: "GPT-5.5"),
+    ]
+
+    private static let unsupportedChatGPTModelIDs: Set<String> = [
+        "chat-latest",
+        "gpt-5.4-nano",
     ]
 
     static let computerUsePlannerModels: [SummaryModelPreset] = [
@@ -322,6 +326,11 @@ struct SummaryModelPreset {
         guard !trimmedModel.isEmpty else { return presets }
         guard !presets.contains(where: { $0.id == trimmedModel }) else { return presets }
         return presets + [SummaryModelPreset(id: trimmedModel, label: "Custom: \(trimmedModel)")]
+    }
+
+    static func supportedChatGPTModel(_ model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return unsupportedChatGPTModelIDs.contains(trimmed) ? "" : trimmed
     }
 }
 
@@ -584,6 +593,48 @@ struct PostProcessorOption: Identifiable, Equatable {
 
     Do not: paraphrase, reword, add words, remove meaningful words, change the meaning in any way, wrap the output in markdown, code fences, tags, labels, or commentary, or repeat the output more than once. Preserve the speaker's original phrasing.
     """
+}
+
+struct TranscriptCleanupPromptPreset: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let prompt: String
+    let isCustom: Bool
+}
+
+struct CustomTranscriptCleanupPrompt: Codable, Equatable, Identifiable {
+    var id: String
+    var name: String
+    var prompt: String
+
+    init(id: String = UUID().uuidString, name: String, prompt: String) {
+        self.id = id
+        self.name = name
+        self.prompt = prompt
+    }
+}
+
+enum TranscriptCleanupPrompts {
+    static let defaultID = "default"
+
+    static let builtIns: [TranscriptCleanupPromptPreset] = [
+        TranscriptCleanupPromptPreset(
+            id: defaultID,
+            name: "Default Cleanup",
+            prompt: PostProcessorOption.defaultSystemPrompt,
+            isCustom: false
+        ),
+    ]
+
+    static func presets(custom: [CustomTranscriptCleanupPrompt]) -> [TranscriptCleanupPromptPreset] {
+        builtIns + custom.map {
+            TranscriptCleanupPromptPreset(id: $0.id, name: $0.name, prompt: $0.prompt, isCustom: true)
+        }
+    }
+
+    static func resolve(id: String, custom: [CustomTranscriptCleanupPrompt]) -> TranscriptCleanupPromptPreset {
+        presets(custom: custom).first { $0.id == id } ?? builtIns[0]
+    }
 }
 
 struct CustomWord: Codable, Equatable, Identifiable {
@@ -963,7 +1014,16 @@ struct AppConfig: Codable {
     var hiddenCalendarEventSourceHints: [String: String] = [:]
     var disabledCalendarIDs: [String] = []
     var enablePostProcessor: Bool = false
+    var postProcessorBackend: String = TranscriptCleanupBackendOption.local.backend
     var activePostProcessorId: String = PostProcessorOption.defaultOption.id
+    var postProcessorChatGPTModel: String = ""
+    var postProcessorOpenAIModel: String = ""
+    var postProcessorOpenRouterModel: String = ""
+    var postProcessorOllamaModel: String = ""
+    var postProcessorLMStudioModel: String = ""
+    var postProcessorCustomLLMModel: String = ""
+    var activeTranscriptCleanupPromptId: String = TranscriptCleanupPrompts.defaultID
+    var customTranscriptCleanupPrompts: [CustomTranscriptCleanupPrompt] = []
     var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     var enableScreenContext: Bool = false
     var useCoreAudioTap: Bool = true
@@ -1061,7 +1121,16 @@ struct AppConfig: Codable {
         case hiddenCalendarEventSourceHints = "hidden_calendar_event_source_hints"
         case disabledCalendarIDs = "disabled_calendar_ids"
         case enablePostProcessor = "enable_post_processor"
+        case postProcessorBackend = "post_processor_backend"
         case activePostProcessorId = "active_post_processor_id"
+        case postProcessorChatGPTModel = "post_processor_chatgpt_model"
+        case postProcessorOpenAIModel = "post_processor_openai_model"
+        case postProcessorOpenRouterModel = "post_processor_openrouter_model"
+        case postProcessorOllamaModel = "post_processor_ollama_model"
+        case postProcessorLMStudioModel = "post_processor_lmstudio_model"
+        case postProcessorCustomLLMModel = "post_processor_custom_llm_model"
+        case activeTranscriptCleanupPromptId = "active_transcript_cleanup_prompt_id"
+        case customTranscriptCleanupPrompts = "custom_transcript_cleanup_prompts"
         case postProcessorSystemPrompt = "post_processor_system_prompt"
         case enableScreenContext = "enable_screen_context"
         case useCoreAudioTap = "use_core_audio_tap"
@@ -1160,7 +1229,9 @@ struct AppConfig: Codable {
         openRouterAPIKey = (try? c.decode(String.self, forKey: .openRouterAPIKey)) ?? defaults.openRouterAPIKey
         openAIModel = (try? c.decode(String.self, forKey: .openAIModel)) ?? defaults.openAIModel
         openRouterModel = (try? c.decode(String.self, forKey: .openRouterModel)) ?? defaults.openRouterModel
-        chatGPTModel = (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
+        chatGPTModel = SummaryModelPreset.supportedChatGPTModel(
+            (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
+        )
         ollamaURL = (try? c.decode(String.self, forKey: .ollamaURL)) ?? defaults.ollamaURL
         ollamaModel = (try? c.decode(String.self, forKey: .ollamaModel)) ?? defaults.ollamaModel
         lmStudioURL = (try? c.decode(String.self, forKey: .lmStudioURL)) ?? defaults.lmStudioURL
@@ -1205,8 +1276,24 @@ struct AppConfig: Codable {
         )) ?? defaults.hiddenCalendarEventSourceHints
         disabledCalendarIDs = (try? c.decode([String].self, forKey: .disabledCalendarIDs)) ?? defaults.disabledCalendarIDs
         enablePostProcessor = (try? c.decode(Bool.self, forKey: .enablePostProcessor)) ?? defaults.enablePostProcessor
+        postProcessorBackend = TranscriptCleanupBackendOption
+            .resolved(try? c.decode(String.self, forKey: .postProcessorBackend))
+            .backend
         activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
+        postProcessorChatGPTModel = SummaryModelPreset.supportedChatGPTModel(
+            (try? c.decode(String.self, forKey: .postProcessorChatGPTModel)) ?? defaults.postProcessorChatGPTModel
+        )
+        postProcessorOpenAIModel = (try? c.decode(String.self, forKey: .postProcessorOpenAIModel)) ?? defaults.postProcessorOpenAIModel
+        postProcessorOpenRouterModel = (try? c.decode(String.self, forKey: .postProcessorOpenRouterModel)) ?? defaults.postProcessorOpenRouterModel
+        postProcessorOllamaModel = (try? c.decode(String.self, forKey: .postProcessorOllamaModel)) ?? defaults.postProcessorOllamaModel
+        postProcessorLMStudioModel = (try? c.decode(String.self, forKey: .postProcessorLMStudioModel)) ?? defaults.postProcessorLMStudioModel
+        postProcessorCustomLLMModel = (try? c.decode(String.self, forKey: .postProcessorCustomLLMModel)) ?? defaults.postProcessorCustomLLMModel
+        customTranscriptCleanupPrompts = (try? c.decode([CustomTranscriptCleanupPrompt].self, forKey: .customTranscriptCleanupPrompts)) ?? defaults.customTranscriptCleanupPrompts
+        activeTranscriptCleanupPromptId = (try? c.decode(String.self, forKey: .activeTranscriptCleanupPromptId)) ?? defaults.activeTranscriptCleanupPromptId
         postProcessorSystemPrompt = (try? c.decode(String.self, forKey: .postProcessorSystemPrompt)) ?? defaults.postProcessorSystemPrompt
+        if TranscriptCleanupPrompts.resolve(id: activeTranscriptCleanupPromptId, custom: customTranscriptCleanupPrompts).id != activeTranscriptCleanupPromptId {
+            activeTranscriptCleanupPromptId = defaults.activeTranscriptCleanupPromptId
+        }
         enableScreenContext = (try? c.decode(Bool.self, forKey: .enableScreenContext)) ?? defaults.enableScreenContext
         useCoreAudioTap = (try? c.decode(Bool.self, forKey: .useCoreAudioTap)) ?? defaults.useCoreAudioTap
         meetingHookEnabled = (try? c.decode(Bool.self, forKey: .meetingHookEnabled)) ?? defaults.meetingHookEnabled

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -21,8 +21,6 @@ struct ModelsView: View {
     @State private var downloadedPostProcModels: Set<String> = []
     @State private var downloadTasksPostProc: [String: Task<Void, Never>] = [:]
     @State private var postProcModelToDelete: PostProcessorOption?
-    @State private var isEditingSystemPrompt: Bool = false
-    @State private var editedSystemPrompt: String
 
     init(appState: AppState, controller: MuesliController) {
         self.appState = appState
@@ -32,7 +30,6 @@ struct ModelsView: View {
         _selectedParakeetModel = State(initialValue: BackendOption.parakeetFamily.contains(active) ? active.model : BackendOption.parakeetMultilingual.model)
         _selectedWhisperModel = State(initialValue: BackendOption.whisperFamily.contains(active) ? active.model : BackendOption.whisperSmall.model)
         _showExperimental = State(initialValue: false)
-        _editedSystemPrompt = State(initialValue: appState.config.postProcessorSystemPrompt)
     }
 
     var body: some View {
@@ -238,8 +235,6 @@ struct ModelsView: View {
                     postProcModelCard(option)
                 }
             }
-
-            systemPromptCard
         }
     }
 
@@ -354,101 +349,6 @@ struct ModelsView: View {
         .overlay(
             RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
                 .strokeBorder(isActive ? MuesliTheme.accent.opacity(0.5) : MuesliTheme.surfaceBorder, lineWidth: isActive ? 1.5 : 1)
-        )
-    }
-
-    private var systemPromptCard: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-            HStack {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                    Text("System Prompt")
-                        .font(MuesliTheme.headline())
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("Controls how the model cleans up transcriptions. Applies to the active post-processor model.")
-                        .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.textSecondary)
-                }
-                Spacer()
-                if !isEditingSystemPrompt {
-                    Button("Edit") {
-                        editedSystemPrompt = appState.config.postProcessorSystemPrompt
-                        isEditingSystemPrompt = true
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuesliTheme.accent)
-                    .padding(.horizontal, MuesliTheme.spacing12)
-                    .padding(.vertical, 4)
-                    .background(MuesliTheme.accentSubtle)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-            }
-
-            if isEditingSystemPrompt {
-                TextEditor(text: $editedSystemPrompt)
-                    .font(.system(size: 12, design: .monospaced))
-                    .frame(minHeight: 120)
-                    .scrollContentBackground(.hidden)
-                    .padding(8)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                    )
-
-                HStack(spacing: MuesliTheme.spacing8) {
-                    Button("Save") {
-                        controller.updatePostProcessorSystemPrompt(editedSystemPrompt)
-                        isEditingSystemPrompt = false
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuesliTheme.accent)
-                    .padding(.horizontal, MuesliTheme.spacing12)
-                    .padding(.vertical, 4)
-                    .background(MuesliTheme.accentSubtle)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-
-                    Button("Cancel") {
-                        isEditingSystemPrompt = false
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .padding(.horizontal, MuesliTheme.spacing12)
-                    .padding(.vertical, 4)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-
-                    Button("Reset to Default") {
-                        editedSystemPrompt = PostProcessorOption.defaultSystemPrompt
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                    .padding(.horizontal, MuesliTheme.spacing12)
-                    .padding(.vertical, 4)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-            } else {
-                Text(appState.config.postProcessorSystemPrompt)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .lineLimit(6)
-                    .padding(8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            }
-        }
-        .padding(MuesliTheme.spacing16)
-        .background(MuesliTheme.backgroundRaised)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -6819,11 +6819,12 @@ final class MuesliController: NSObject {
     private func captureDictationContextAsync() {
         guard shouldCaptureDictationContext else { return }
         let traceID = dictationLatencyTraceID
+        let includeScreenOCR = CGPreflightScreenCaptureAccess()
         markDictationLatency("context_capture_enqueue")
-        DispatchQueue.global(qos: .utility).async { [weak self, traceID] in
+        Task.detached(priority: .utility) { [weak self, traceID, includeScreenOCR] in
             guard AXIsProcessTrusted() else { return }
-            let context = DictationContextCapture.capture()
-            DispatchQueue.main.async { [weak self, traceID] in
+            let context = await DictationContextCapture.capture(includeScreenOCR: includeScreenOCR)
+            await MainActor.run { [weak self, traceID] in
                 guard let self,
                       self.dictationLatencyTraceID == traceID,
                       self.shouldCaptureDictationContext,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -6819,7 +6819,7 @@ final class MuesliController: NSObject {
     private func captureDictationContextAsync() {
         guard shouldCaptureDictationContext else { return }
         let traceID = dictationLatencyTraceID
-        let includeScreenOCR = CGPreflightScreenCaptureAccess()
+        let includeScreenOCR = config.enableDictationOCRContext && CGPreflightScreenCaptureAccess()
         markDictationLatency("context_capture_enqueue")
         Task.detached(priority: .utility) { [weak self, traceID, includeScreenOCR] in
             guard AXIsProcessTrusted() else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1355,6 +1355,10 @@ final class MuesliController: NSObject {
         bridgeDiscoveryTriggered: Bool = false
     ) {
         guard config.iCloudSyncEnabled else { return }
+        guard MuesliICloudSyncEngine.hasRequiredEntitlement else {
+            disableICloudSyncForUnavailableEntitlement()
+            return
+        }
         enableICloudPersistentSync()
         if bridgeDiscoveryTriggered {
             bridgeDiscoveryPending = true
@@ -1380,6 +1384,10 @@ final class MuesliController: NSObject {
             }
             appState.iCloudBridgeState = .notConfigured
             appState.iCloudBridgeMessage = nil
+            return
+        }
+        guard MuesliICloudSyncEngine.hasRequiredEntitlement else {
+            disableICloudSyncForUnavailableEntitlement()
             return
         }
         guard iCloudSyncTask == nil else {
@@ -1529,9 +1537,6 @@ final class MuesliController: NSObject {
     }
 
     private func disableICloudSyncForUnavailableEntitlement() {
-        if config.iCloudSyncEnabled {
-            updateConfig { $0.iCloudSyncEnabled = false }
-        }
         cancelActiveICloudSyncTask()
         iCloudSyncDebounceTask?.cancel()
         iCloudSyncDebounceTask = nil
@@ -1567,6 +1572,11 @@ final class MuesliController: NSObject {
             return
         }
         if !config.iCloudSyncEnabled {
+            appState.iCloudBridgeState = .notConfigured
+            appState.iCloudBridgeMessage = nil
+            return
+        }
+        if !MuesliICloudSyncEngine.hasRequiredEntitlement {
             appState.iCloudBridgeState = .notConfigured
             appState.iCloudBridgeMessage = nil
             return
@@ -6819,7 +6829,9 @@ final class MuesliController: NSObject {
     private func captureDictationContextAsync() {
         guard shouldCaptureDictationContext else { return }
         let traceID = dictationLatencyTraceID
-        let includeScreenOCR = config.enableDictationOCRContext && CGPreflightScreenCaptureAccess()
+        let includeScreenOCR = config.enableDictationOCRContext
+            && !isMeetingRecording()
+            && CGPreflightScreenCaptureAccess()
         markDictationLatency("context_capture_enqueue")
         Task.detached(priority: .utility) { [weak self, traceID, includeScreenOCR] in
             guard AXIsProcessTrusted() else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1887,8 +1887,9 @@ final class MuesliController: NSObject {
             guard let index = $0.customTranscriptCleanupPrompts.firstIndex(where: { $0.id == id }) else { return }
             $0.customTranscriptCleanupPrompts[index].name = trimmedName
             $0.customTranscriptCleanupPrompts[index].prompt = trimmedPrompt
-            $0.activeTranscriptCleanupPromptId = id
-            $0.postProcessorSystemPrompt = trimmedPrompt
+            if $0.activeTranscriptCleanupPromptId == id {
+                $0.postProcessorSystemPrompt = trimmedPrompt
+            }
         }
         preloadExperimentalTranscriptionFeatures()
     }
@@ -6826,6 +6827,14 @@ final class MuesliController: NSObject {
         config.enableScreenContext && config.enablePostProcessor && !isDictationTestMode
     }
 
+    @MainActor
+    private func shouldContinueDictationOCRContextCapture(traceID: UUID?) -> Bool {
+        dictationLatencyTraceID == traceID
+            && shouldCaptureDictationContext
+            && dictationState == .recording
+            && !isMeetingRecording()
+    }
+
     private func captureDictationContextAsync() {
         guard shouldCaptureDictationContext else { return }
         let traceID = dictationLatencyTraceID
@@ -6835,7 +6844,12 @@ final class MuesliController: NSObject {
         markDictationLatency("context_capture_enqueue")
         Task.detached(priority: .utility) { [weak self, traceID, includeScreenOCR] in
             guard AXIsProcessTrusted() else { return }
-            let context = await DictationContextCapture.capture(includeScreenOCR: includeScreenOCR)
+            let context = await DictationContextCapture.capture(
+                includeScreenOCR: includeScreenOCR,
+                shouldCaptureScreenOCR: { [weak self] in
+                    await self?.shouldContinueDictationOCRContextCapture(traceID: traceID) ?? false
+                }
+            )
             await MainActor.run { [weak self, traceID] in
                 guard let self,
                       self.dictationLatencyTraceID == traceID,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -293,6 +293,7 @@ final class MuesliController: NSObject {
     private(set) var selectedBackend: BackendOption
     private(set) var selectedMeetingTranscriptionBackend: BackendOption
     private(set) var selectedMeetingSummaryBackend: MeetingSummaryBackendOption
+    private(set) var selectedPostProcessorBackend: TranscriptCleanupBackendOption
     private var activeMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
     private var activeMeetingAudioWarning: ActiveMeetingAudioWarning?
@@ -409,6 +410,7 @@ final class MuesliController: NSObject {
         self.selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == loadedConfig.meetingSummaryBackend
         }) ?? .chatGPT
+        self.selectedPostProcessorBackend = TranscriptCleanupBackendOption.resolved(loadedConfig.postProcessorBackend)
         self.indicator = FloatingIndicatorController(configStore: configStore)
         ComputerUseCursorOverlay.shared.attachIndicator(self.indicator)
         super.init()
@@ -563,8 +565,12 @@ final class MuesliController: NSObject {
         historyWindowController = RecentHistoryWindowController(store: dictationStore, controller: self)
         refreshUI()
         if config.iCloudSyncEnabled {
-            enableICloudPersistentSync()
-            scheduleICloudSync(delay: 0.5, userInitiated: false)
+            if MuesliICloudSyncEngine.hasRequiredEntitlement {
+                enableICloudPersistentSync()
+                scheduleICloudSync(delay: 0.5, userInitiated: false)
+            } else {
+                disableICloudSyncForUnavailableEntitlement()
+            }
         }
 
         meetingMonitor.calendarEventProvider = { [weak self] in
@@ -627,19 +633,14 @@ final class MuesliController: NSObject {
                 let includesMeetings = self.config.resolvedOnboardingUseCase.includesMeetings
                 let ppOption = self.runtimePostProcessorOption()
                 if #available(macOS 15, *) {
-                    if let ppOption {
-                        await self.transcriptionCoordinator.setActivePostProcessor(
-                            option: ppOption,
-                            systemPrompt: self.config.postProcessorSystemPrompt
-                        )
-                    }
+                    await self.configureTranscriptCleanupForRuntime(option: ppOption)
                     await self.transcriptionCoordinator.setNemotron35PromptId(
                         self.config.resolvedNemotron35Language.promptId
                     )
                 }
                 await self.transcriptionCoordinator.preload(
                     backend: self.selectedBackend,
-                    enablePostProcessor: self.config.enablePostProcessor && ppOption != nil,
+                    enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
                     includeMeetingHelpers: includesMeetings
                 )
                 if includesMeetings, self.selectedMeetingTranscriptionBackend != self.selectedBackend {
@@ -826,6 +827,7 @@ final class MuesliController: NSObject {
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
+        appState.selectedPostProcessorBackend = selectedPostProcessorBackend
         appState.activePostProcessor = PostProcessorOption.resolve(id: config.activePostProcessorId)
         appState.config = config
         appState.isMeetingRecording = isMeetingRecording()
@@ -995,6 +997,7 @@ final class MuesliController: NSObject {
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == config.meetingSummaryBackend
         }) ?? .chatGPT
+        selectedPostProcessorBackend = TranscriptCleanupBackendOption.resolved(config.postProcessorBackend)
         statusBarController?.refresh()
         statusBarController?.refreshIcon()
         indicator.refreshIcon()
@@ -1013,6 +1016,7 @@ final class MuesliController: NSObject {
         appState.selectedBackend = selectedBackend
         appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
         appState.selectedMeetingSummaryBackend = selectedMeetingSummaryBackend
+        appState.selectedPostProcessorBackend = selectedPostProcessorBackend
         appState.config = config
         appState.isChatGPTAuthenticated = chatGPTAuth.isAuthenticated
         syncCalendarMonitor()
@@ -1196,6 +1200,10 @@ final class MuesliController: NSObject {
 
     func setICloudSyncEnabledFromSettings(_ enabled: Bool) {
         if enabled {
+            guard MuesliICloudSyncEngine.hasRequiredEntitlement else {
+                disableICloudSyncForUnavailableEntitlement()
+                return
+            }
             enableIPhoneBridgeSync()
         } else if config.iCloudSyncEnabled {
             updateConfig { $0.iCloudSyncEnabled = false }
@@ -1205,6 +1213,10 @@ final class MuesliController: NSObject {
     }
 
     func enableIPhoneBridgeSync() {
+        guard MuesliICloudSyncEngine.hasRequiredEntitlement else {
+            disableICloudSyncForUnavailableEntitlement()
+            return
+        }
         if config.iCloudSyncEnabled {
             performICloudSync()
             return
@@ -1516,6 +1528,22 @@ final class MuesliController: NSObject {
         appState.iCloudBridgeMessage = nil
     }
 
+    private func disableICloudSyncForUnavailableEntitlement() {
+        if config.iCloudSyncEnabled {
+            updateConfig { $0.iCloudSyncEnabled = false }
+        }
+        cancelActiveICloudSyncTask()
+        iCloudSyncDebounceTask?.cancel()
+        iCloudSyncDebounceTask = nil
+        iCloudSubscriptionTask?.cancel()
+        iCloudSubscriptionTask = nil
+        resetICloudSubscriptionState()
+        resetBridgeDiscoveryRuntimeState()
+        appState.iCloudSyncStatus = "iCloud sync is unavailable in this local-only build."
+        appState.iCloudBridgeState = .notConfigured
+        appState.iCloudBridgeMessage = nil
+    }
+
     private func resetBridgeDiscoveryRuntimeState() {
         bridgeActivationPending = false
         bridgeDiscoveryPending = false
@@ -1641,17 +1669,10 @@ final class MuesliController: NSObject {
                 }
             }
             let ppOption = self.runtimePostProcessorOption()
-            if #available(macOS 15, *) {
-                if let ppOption {
-                    await self.transcriptionCoordinator.setActivePostProcessor(
-                        option: ppOption,
-                        systemPrompt: self.config.postProcessorSystemPrompt
-                    )
-                }
-            }
+            await self.configureTranscriptCleanupForRuntime(option: ppOption)
             await self.transcriptionCoordinator.preload(
                 backend: option,
-                enablePostProcessor: self.config.enablePostProcessor && ppOption != nil,
+                enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
                 includeMeetingHelpers: self.config.resolvedOnboardingUseCase.includesMeetings
             )
             await MainActor.run {
@@ -1710,7 +1731,7 @@ final class MuesliController: NSObject {
     }
 
     var isPostProcessorReady: Bool {
-        config.enablePostProcessor && runtimePostProcessorOption() != nil
+        canRunTranscriptCleanup(option: runtimePostProcessorOption())
     }
 
     @discardableResult
@@ -1727,11 +1748,33 @@ final class MuesliController: NSObject {
     }
 
     private func runtimePostProcessorOption() -> PostProcessorOption? {
-        PostProcessorOption.runtimeOption(id: config.activePostProcessorId)
+        guard selectedPostProcessorBackend == .local else { return nil }
+        return PostProcessorOption.runtimeOption(id: config.activePostProcessorId)
+    }
+
+    private func canRunTranscriptCleanup(option: PostProcessorOption?) -> Bool {
+        guard config.enablePostProcessor else { return false }
+        if selectedPostProcessorBackend == .local {
+            return option != nil
+        }
+        return TranscriptCleanupClient.hasRequiredSettings(
+            for: selectedPostProcessorBackend,
+            config: config,
+            isChatGPTAuthenticated: chatGPTAuth.isAuthenticated
+        )
+    }
+
+    private func configureTranscriptCleanupForRuntime(option: PostProcessorOption? = nil) async {
+        await transcriptionCoordinator.configurePostProcessor(
+            backend: selectedPostProcessorBackend,
+            option: option ?? runtimePostProcessorOption(),
+            systemPrompt: config.postProcessorSystemPrompt,
+            config: config
+        )
     }
 
     func setPostProcessorEnabled(_ enabled: Bool) {
-        if enabled {
+        if enabled, selectedPostProcessorBackend == .local {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
                 appState.selectedTab = .models
@@ -1744,49 +1787,124 @@ final class MuesliController: NSObject {
 
     func preloadExperimentalTranscriptionFeatures() {
         let ppOption = runtimePostProcessorOption()
-        let enabled = config.enablePostProcessor && ppOption != nil
-        let ppPrompt = config.postProcessorSystemPrompt
+        let enabled = canRunTranscriptCleanup(option: ppOption)
         Task { [weak self] in
             guard let self else { return }
-            if let ppOption, #available(macOS 15, *) {
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: ppOption,
-                    systemPrompt: ppPrompt
-                )
-            }
+            await self.configureTranscriptCleanupForRuntime(option: ppOption)
             await self.transcriptionCoordinator.preloadPostProcessorIfNeeded(enabled: enabled)
         }
     }
 
     func selectPostProcessor(_ option: PostProcessorOption) {
-        updateConfig { $0.activePostProcessorId = option.id }
+        updateConfig {
+            $0.postProcessorBackend = TranscriptCleanupBackendOption.local.backend
+            $0.activePostProcessorId = option.id
+        }
+        selectedPostProcessorBackend = .local
+        appState.selectedPostProcessorBackend = .local
         appState.activePostProcessor = option
         guard config.enablePostProcessor else { return }
-        let systemPrompt = config.postProcessorSystemPrompt
         Task { [weak self] in
             guard let self else { return }
-            if #available(macOS 15, *) {
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: option,
-                    systemPrompt: systemPrompt
-                )
-            }
+            await self.configureTranscriptCleanupForRuntime(option: option)
         }
     }
 
     func updatePostProcessorSystemPrompt(_ prompt: String) {
-        updateConfig { $0.postProcessorSystemPrompt = prompt }
+        updateConfig {
+            $0.postProcessorSystemPrompt = prompt
+            $0.activeTranscriptCleanupPromptId = TranscriptCleanupPrompts.defaultID
+        }
         let ppOption = runtimePostProcessorOption()
         guard config.enablePostProcessor else { return }
         Task { [weak self] in
             guard let self else { return }
-            if let ppOption, #available(macOS 15, *) {
-                await self.transcriptionCoordinator.setActivePostProcessor(
-                    option: ppOption,
-                    systemPrompt: prompt
-                )
+            await self.configureTranscriptCleanupForRuntime(option: ppOption)
+        }
+    }
+
+    func selectPostProcessorBackend(_ option: TranscriptCleanupBackendOption) {
+        updateConfig { $0.postProcessorBackend = option.backend }
+        selectedPostProcessorBackend = option
+        appState.selectedPostProcessorBackend = option
+        if option == .local, config.enablePostProcessor {
+            guard normalizePostProcessorSelectionForAvailability() != nil else {
+                updateConfig { $0.enablePostProcessor = false }
+                appState.selectedTab = .models
+                return
             }
         }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
+    func updatePostProcessorModel(_ model: String, for backend: TranscriptCleanupBackendOption) {
+        updateConfig { config in
+            switch backend.llmBackend {
+            case .some(.chatGPT):
+                config.postProcessorChatGPTModel = model
+            case .some(.openAI):
+                config.postProcessorOpenAIModel = model
+            case .some(.openRouter):
+                config.postProcessorOpenRouterModel = model
+            case .some(.ollama):
+                config.postProcessorOllamaModel = model
+            case .some(.lmStudio):
+                config.postProcessorLMStudioModel = model
+            case .some(.customLLM):
+                config.postProcessorCustomLLMModel = model
+            default:
+                break
+            }
+        }
+        guard config.enablePostProcessor else { return }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
+    func selectTranscriptCleanupPrompt(id: String) {
+        let preset = TranscriptCleanupPrompts.resolve(id: id, custom: config.customTranscriptCleanupPrompts)
+        updateConfig {
+            $0.activeTranscriptCleanupPromptId = preset.id
+            $0.postProcessorSystemPrompt = preset.prompt
+        }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
+    func createTranscriptCleanupPrompt(name: String, prompt: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty, !trimmedPrompt.isEmpty else { return }
+        let preset = CustomTranscriptCleanupPrompt(name: trimmedName, prompt: trimmedPrompt)
+        updateConfig {
+            $0.customTranscriptCleanupPrompts.append(preset)
+            $0.activeTranscriptCleanupPromptId = preset.id
+            $0.postProcessorSystemPrompt = preset.prompt
+        }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
+    func updateTranscriptCleanupPrompt(id: String, name: String, prompt: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty, !trimmedPrompt.isEmpty else { return }
+        updateConfig {
+            guard let index = $0.customTranscriptCleanupPrompts.firstIndex(where: { $0.id == id }) else { return }
+            $0.customTranscriptCleanupPrompts[index].name = trimmedName
+            $0.customTranscriptCleanupPrompts[index].prompt = trimmedPrompt
+            $0.activeTranscriptCleanupPromptId = id
+            $0.postProcessorSystemPrompt = trimmedPrompt
+        }
+        preloadExperimentalTranscriptionFeatures()
+    }
+
+    func deleteTranscriptCleanupPrompt(id: String) {
+        updateConfig {
+            $0.customTranscriptCleanupPrompts.removeAll { $0.id == id }
+            if $0.activeTranscriptCleanupPromptId == id {
+                $0.activeTranscriptCleanupPromptId = TranscriptCleanupPrompts.defaultID
+                $0.postProcessorSystemPrompt = PostProcessorOption.defaultSystemPrompt
+            }
+        }
+        preloadExperimentalTranscriptionFeatures()
     }
 
     func selectMeetingSummaryBackend(_ option: MeetingSummaryBackendOption) {
@@ -1862,11 +1980,14 @@ final class MuesliController: NSObject {
     }
 
     /// Returns nil on success, or an error message on failure.
-    func signInWithChatGPT() async -> String? {
+    func signInWithChatGPT(selectMeetingSummaryBackend shouldSelectMeetingSummaryBackend: Bool = true) async -> String? {
         do {
             try await chatGPTAuth.signIn()
-            selectMeetingSummaryBackend(.chatGPT)
+            if shouldSelectMeetingSummaryBackend {
+                selectMeetingSummaryBackend(.chatGPT)
+            }
             syncAppState()
+            preloadExperimentalTranscriptionFeatures()
             return nil
         } catch {
             fputs("[muesli-native] ChatGPT sign-in failed: \(error)\n", stderr)
@@ -7126,12 +7247,15 @@ final class MuesliController: NSObject {
             }
 
             do {
+                let ppOption = self.runtimePostProcessorOption()
+                await self.configureTranscriptCleanupForRuntime(option: ppOption)
+                let enableTranscriptCleanup = self.canRunTranscriptCleanup(option: ppOption)
                 let result = try await self.transcriptionCoordinator.transcribeDictation(
                     at: wavURL,
                     backend: transcriptionBackend,
                     cohereLanguage: transcriptionLanguage,
                     indicASRLanguage: indicTranscriptionLanguage,
-                    enablePostProcessor: self.isPostProcessorReady,
+                    enablePostProcessor: enableTranscriptCleanup,
                     customWords: self.serializedCustomWords(),
                     appContext: promptContext
                 )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1810,19 +1810,6 @@ final class MuesliController: NSObject {
         }
     }
 
-    func updatePostProcessorSystemPrompt(_ prompt: String) {
-        updateConfig {
-            $0.postProcessorSystemPrompt = prompt
-            $0.activeTranscriptCleanupPromptId = TranscriptCleanupPrompts.defaultID
-        }
-        let ppOption = runtimePostProcessorOption()
-        guard config.enablePostProcessor else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            await self.configureTranscriptCleanupForRuntime(option: ppOption)
-        }
-    }
-
     func selectPostProcessorBackend(_ option: TranscriptCleanupBackendOption) {
         updateConfig { $0.postProcessorBackend = option.backend }
         selectedPostProcessorBackend = option

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -1,6 +1,7 @@
 import CloudKit
 import Foundation
 import MuesliCore
+import Security
 
 struct ICloudSyncKindCounts: Equatable {
     private(set) var dictations = 0
@@ -282,6 +283,27 @@ final class MuesliICloudSyncEngine {
     private let defaults: UserDefaults
     private static let dirtyUploadBatchSize = 200
     private static let maxDirtyUploadBatchesPerSync = 50
+
+    static var hasRequiredEntitlement: Bool {
+        guard
+            let task = SecTaskCreateFromSelf(nil),
+            let value = SecTaskCopyValueForEntitlement(
+                task,
+                "com.apple.developer.icloud-container-identifiers" as CFString,
+                nil
+            )
+        else {
+            return false
+        }
+
+        if let containers = value as? [String] {
+            return containers.contains(Schema.containerIdentifier)
+        }
+        if let container = value as? String {
+            return container == Schema.containerIdentifier
+        }
+        return false
+    }
 
     init(
         container: CKContainer = CKContainer(identifier: Schema.containerIdentifier),

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -112,6 +112,10 @@ enum Qwen3PostProcessorOutputCleaner {
         guard !trimmed.isEmpty else { return true }
 
         let lower = trimmed.lowercased()
+        if isPlaceholderOutput(trimmed) {
+            return true
+        }
+
         let assistantMarkers = [
             "the user is asking",
             "**analysis:**",
@@ -137,6 +141,19 @@ enum Qwen3PostProcessorOutputCleaner {
             return expansion > 2.5 && trimmed.count > 150
         }
         return expansion > 2.0 && trimmed.count > 200
+    }
+
+    private static func isPlaceholderOutput(_ text: String) -> Bool {
+        let normalized = text
+            .replacingOccurrences(of: "…", with: "...")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized == "..." || normalized == ". . ." {
+            return true
+        }
+        let punctuationOnly = normalized.allSatisfy { character in
+            character.isWhitespace || ".…-_,;:!?()[]{}".contains(character)
+        }
+        return punctuationOnly && normalized.count <= 8
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3PostProcessor.swift
@@ -163,11 +163,16 @@ enum Qwen3PostProcessorConfig {
     static let legacyDirectoryEnvOverride = "MUESLI_QWEN3_POSTPROC_DIR"
     // Dictation-only cleanup cap. Keep bounded to avoid slow local inference; long dictations may be truncated by LLM.swift.
     static let maxContextTokens: Int32 = 1024
+    static let defaultAppContextCharacterLimit = 1_200
 
-    static func formatInput(_ text: String, appContext: String? = nil) -> String {
+    static func formatInput(
+        _ text: String,
+        appContext: String? = nil,
+        maxAppContextCharacters: Int = defaultAppContextCharacterLimit
+    ) -> String {
         var parts = ""
         if let appContext, !appContext.isEmpty {
-            parts += "<APP-CONTEXT>\n\(String(appContext.prefix(1200)))\n</APP-CONTEXT>\n\n"
+            parts += "<APP-CONTEXT>\n\(String(appContext.prefix(maxAppContextCharacters)))\n</APP-CONTEXT>\n\n"
         }
         parts += "<USER-INPUT>\n\(text)\n</USER-INPUT>"
         return parts

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
@@ -191,42 +191,20 @@ struct ScreenContext {
 
 enum ScreenContextCapture {
 
-    /// Captures the visible screen and runs on-device OCR. The screenshot itself
+    /// Captures the frontmost app window and runs on-device OCR. The screenshot itself
     /// is not persisted or sent to cleanup backends; only recognized text is used.
     static func captureVisibleScreen() async -> ScreenContext? {
-        guard CGPreflightScreenCaptureAccess() else { return nil }
-        let app = NSWorkspace.shared.frontmostApplication
-        let appName = app?.localizedName ?? "Unknown"
-        let bundleID = app?.bundleIdentifier ?? ""
-
-        guard let image = CGWindowListCreateImage(
-            .infinite,
-            .optionOnScreenOnly,
-            kCGNullWindowID,
-            [.bestResolution, .boundsIgnoreFraming]
-        ) else {
-            fputs("[muesli-native] screen context: visible screen capture failed\n", stderr)
-            return nil
-        }
-
-        do {
-            let text = try await ocrImage(image)
-            fputs("[muesli-native] screen context: captured \(text.count) visible-screen OCR chars from \(appName)\n", stderr)
-            return ScreenContext(
-                appName: appName,
-                bundleID: bundleID,
-                ocrText: text,
-                capturedAt: Date()
-            )
-        } catch {
-            fputs("[muesli-native] screen context: visible-screen OCR failed: \(error)\n", stderr)
-            return nil
-        }
+        await captureFrontmostWindow(logLabel: "dictation OCR")
     }
 
     /// Captures a screenshot of the focused window and runs on-device OCR.
     /// Used for meeting context only — heavier than AX but provides visual content.
     static func captureOnce() async -> ScreenContext? {
+        await captureFrontmostWindow(logLabel: "meeting OCR")
+    }
+
+    private static func captureFrontmostWindow(logLabel: String) async -> ScreenContext? {
+        guard CGPreflightScreenCaptureAccess() else { return nil }
         let app = NSWorkspace.shared.frontmostApplication
         let appName = app?.localizedName ?? "Unknown"
         let bundleID = app?.bundleIdentifier ?? ""
@@ -254,7 +232,7 @@ enum ScreenContextCapture {
 
         do {
             let text = try await ocrImage(image)
-            fputs("[muesli-native] screen context: captured \(text.count) chars from \(appName)\n", stderr)
+            fputs("[muesli-native] screen context: captured \(text.count) \(logLabel) chars from \(appName)\n", stderr)
             return ScreenContext(
                 appName: appName,
                 bundleID: bundleID,
@@ -262,7 +240,7 @@ enum ScreenContextCapture {
                 capturedAt: Date()
             )
         } catch {
-            fputs("[muesli-native] screen context: OCR failed: \(error)\n", stderr)
+            fputs("[muesli-native] screen context: \(logLabel) failed: \(error)\n", stderr)
             return nil
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
@@ -17,10 +17,13 @@ enum DictationContextCapture {
 
     /// Captures focused app name + text context via Accessibility API, with optional
     /// on-device OCR when Screen Recording permission is already granted.
-    static func capture(includeScreenOCR: Bool) async -> DictationContext {
+    static func capture(
+        includeScreenOCR: Bool,
+        shouldCaptureScreenOCR: (@Sendable () async -> Bool)? = nil
+    ) async -> DictationContext {
         let base = capture()
         guard includeScreenOCR, CGPreflightScreenCaptureAccess() else { return base }
-        let screenContext = await ScreenContextCapture.captureVisibleScreen()
+        let screenContext = await ScreenContextCapture.captureVisibleScreen(shouldCapture: shouldCaptureScreenOCR)
         let ocrText = screenContext?.ocrText.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !ocrText.isEmpty else { return base }
         return DictationContext(
@@ -193,8 +196,8 @@ enum ScreenContextCapture {
 
     /// Captures the frontmost app window and runs on-device OCR. The screenshot itself
     /// is not persisted or sent to cleanup backends; only recognized text is used.
-    static func captureVisibleScreen() async -> ScreenContext? {
-        await captureFrontmostWindow(logLabel: "dictation OCR")
+    static func captureVisibleScreen(shouldCapture: (@Sendable () async -> Bool)? = nil) async -> ScreenContext? {
+        await captureFrontmostWindow(logLabel: "dictation OCR", shouldCapture: shouldCapture)
     }
 
     /// Captures a screenshot of the focused window and runs on-device OCR.
@@ -203,7 +206,10 @@ enum ScreenContextCapture {
         await captureFrontmostWindow(logLabel: "meeting OCR")
     }
 
-    private static func captureFrontmostWindow(logLabel: String) async -> ScreenContext? {
+    private static func captureFrontmostWindow(
+        logLabel: String,
+        shouldCapture: (@Sendable () async -> Bool)? = nil
+    ) async -> ScreenContext? {
         guard CGPreflightScreenCaptureAccess() else { return nil }
         let app = NSWorkspace.shared.frontmostApplication
         let appName = app?.localizedName ?? "Unknown"
@@ -218,6 +224,9 @@ enum ScreenContextCapture {
         })
         guard let windowID = appWindow?[kCGWindowNumber] as? CGWindowID else {
             fputs("[muesli-native] screen context: no window found for \(appName)\n", stderr)
+            return nil
+        }
+        if let shouldCapture, !(await shouldCapture()) {
             return nil
         }
         guard let image = CGWindowListCreateImage(

--- a/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ScreenContextCapture.swift
@@ -2,7 +2,7 @@ import AppKit
 import ApplicationServices
 import Vision
 
-// MARK: - Dictation context (Accessibility API — deterministic, low-token)
+// MARK: - Dictation context (Accessibility + optional on-device OCR)
 
 struct DictationContext {
     let appName: String
@@ -10,9 +10,28 @@ struct DictationContext {
     let documentContext: String
     let selectedText: String
     let url: String?
+    let ocrText: String
 }
 
 enum DictationContextCapture {
+
+    /// Captures focused app name + text context via Accessibility API, with optional
+    /// on-device OCR when Screen Recording permission is already granted.
+    static func capture(includeScreenOCR: Bool) async -> DictationContext {
+        let base = capture()
+        guard includeScreenOCR, CGPreflightScreenCaptureAccess() else { return base }
+        let screenContext = await ScreenContextCapture.captureVisibleScreen()
+        let ocrText = screenContext?.ocrText.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !ocrText.isEmpty else { return base }
+        return DictationContext(
+            appName: base.appName,
+            bundleID: base.bundleID,
+            documentContext: base.documentContext,
+            selectedText: base.selectedText,
+            url: base.url,
+            ocrText: ocrText
+        )
+    }
 
     /// Captures focused app name + text context via Accessibility API.
     /// Lightweight and deterministic — no screenshots, no OCR.
@@ -38,7 +57,8 @@ enum DictationContextCapture {
             bundleID: bundleID,
             documentContext: docContext,
             selectedText: selectedText,
-            url: url
+            url: url,
+            ocrText: ""
         )
     }
 
@@ -53,6 +73,9 @@ enum DictationContextCapture {
         }
         if !ctx.selectedText.isEmpty {
             parts += "\nSelected text: \(ctx.selectedText)"
+        }
+        if !ctx.ocrText.isEmpty {
+            parts += "\nOCR screen text: \(ctx.ocrText)"
         }
         return parts
     }
@@ -167,6 +190,39 @@ struct ScreenContext {
 }
 
 enum ScreenContextCapture {
+
+    /// Captures the visible screen and runs on-device OCR. The screenshot itself
+    /// is not persisted or sent to cleanup backends; only recognized text is used.
+    static func captureVisibleScreen() async -> ScreenContext? {
+        guard CGPreflightScreenCaptureAccess() else { return nil }
+        let app = NSWorkspace.shared.frontmostApplication
+        let appName = app?.localizedName ?? "Unknown"
+        let bundleID = app?.bundleIdentifier ?? ""
+
+        guard let image = CGWindowListCreateImage(
+            .infinite,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            [.bestResolution, .boundsIgnoreFraming]
+        ) else {
+            fputs("[muesli-native] screen context: visible screen capture failed\n", stderr)
+            return nil
+        }
+
+        do {
+            let text = try await ocrImage(image)
+            fputs("[muesli-native] screen context: captured \(text.count) visible-screen OCR chars from \(appName)\n", stderr)
+            return ScreenContext(
+                appName: appName,
+                bundleID: bundleID,
+                ocrText: text,
+                capturedAt: Date()
+            )
+        } catch {
+            fputs("[muesli-native] screen context: visible-screen OCR failed: \(error)\n", stderr)
+            return nil
+        }
+    }
 
     /// Captures a screenshot of the focused window and runs on-device OCR.
     /// Used for meeting context only — heavier than AX but provides visual content.

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -91,6 +91,7 @@ struct SettingsView: View {
     @State private var dictationInputDevices: [AudioInputDeviceInfo] = []
     @State private var permissionPollTimer: Timer?
     @State private var isEditingCleanupPrompt = false
+    @State private var isCleanupPromptManagerPresented = false
     @State private var editedCleanupPrompt = ""
     @State private var cleanupPromptName = ""
     @State private var micGranted = false
@@ -271,6 +272,13 @@ struct SettingsView: View {
             }
         } message: {
             Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, then relaunch Muesli to turn suggestions on.")
+        }
+        .sheet(isPresented: $isCleanupPromptManagerPresented) {
+            TranscriptCleanupPromptsManagerView(
+                appState: appState,
+                controller: controller,
+                onClose: { isCleanupPromptManagerPresented = false }
+            )
         }
     }
 
@@ -844,6 +852,9 @@ struct SettingsView: View {
 
                 HStack {
                     Spacer()
+                    compactActionButton("Manage Presets…", systemImage: "slider.horizontal.3") {
+                        isCleanupPromptManagerPresented = true
+                    }
                     compactActionButton("Edit Prompt", systemImage: "pencil") {
                         editedCleanupPrompt = appState.config.postProcessorSystemPrompt
                         cleanupPromptName = selectedCleanupPromptName

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -90,10 +90,7 @@ struct SettingsView: View {
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
     @State private var dictationInputDevices: [AudioInputDeviceInfo] = []
     @State private var permissionPollTimer: Timer?
-    @State private var isEditingCleanupPrompt = false
     @State private var isCleanupPromptManagerPresented = false
-    @State private var editedCleanupPrompt = ""
-    @State private var cleanupPromptName = ""
     @State private var micGranted = false
     @State private var accessibilityGranted = false
     @State private var inputMonitoringGranted = false
@@ -777,89 +774,28 @@ struct SettingsView: View {
                     onSelectIndex: { index in
                         guard index >= 0, index < cleanupPromptPresets.count else { return }
                         controller.selectTranscriptCleanupPrompt(id: cleanupPromptPresets[index].id)
-                        editedCleanupPrompt = cleanupPromptPresets[index].prompt
-                        cleanupPromptName = cleanupPromptPresets[index].name
                     }
                 )
                 .frame(height: 24)
             }
 
-            if isEditingCleanupPrompt {
-                TextEditor(text: $editedCleanupPrompt)
-                    .font(.system(size: 12, design: .monospaced))
-                    .frame(minHeight: 150)
-                    .scrollContentBackground(.hidden)
-                    .padding(10)
-                    .background(MuesliTheme.surfacePrimary.opacity(0.7))
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                    )
+            Text(appState.config.postProcessorSystemPrompt)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .lineLimit(4)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(MuesliTheme.surfacePrimary.opacity(0.7))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
 
-                HStack(spacing: MuesliTheme.spacing8) {
-                    PastableTextField(
-                        text: cleanupPromptName,
-                        placeholder: "Preset name",
-                        onChange: { cleanupPromptName = $0 }
-                    )
-                    .frame(width: meetingControlWidth, height: 24)
-
-                    Spacer(minLength: MuesliTheme.spacing12)
-
-                    compactActionButton("Save as Preset") {
-                        controller.createTranscriptCleanupPrompt(
-                            name: cleanupPromptName,
-                            prompt: editedCleanupPrompt
-                        )
-                        isEditingCleanupPrompt = false
-                    }
-
-                    if let active = cleanupPromptPresets.first(where: { $0.id == appState.config.activeTranscriptCleanupPromptId }),
-                       active.isCustom {
-                        compactActionButton("Update Preset") {
-                            controller.updateTranscriptCleanupPrompt(
-                                id: active.id,
-                                name: cleanupPromptName,
-                                prompt: editedCleanupPrompt
-                            )
-                            isEditingCleanupPrompt = false
-                        }
-
-                        compactActionButton("Delete", role: .destructive) {
-                            controller.deleteTranscriptCleanupPrompt(id: active.id)
-                            isEditingCleanupPrompt = false
-                        }
-                    }
-
-                    compactActionButton("Cancel") {
-                        isEditingCleanupPrompt = false
-                    }
-                }
-            } else {
-                Text(appState.config.postProcessorSystemPrompt)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .lineLimit(4)
-                    .padding(10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(MuesliTheme.surfacePrimary.opacity(0.7))
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                    )
-
-                HStack {
-                    Spacer()
-                    compactActionButton("Manage Presets…", systemImage: "slider.horizontal.3") {
-                        isCleanupPromptManagerPresented = true
-                    }
-                    compactActionButton("Edit Prompt", systemImage: "pencil") {
-                        editedCleanupPrompt = appState.config.postProcessorSystemPrompt
-                        cleanupPromptName = selectedCleanupPromptName
-                        isEditingCleanupPrompt = true
-                    }
+            HStack {
+                Spacer()
+                compactActionButton("Manage Presets…", systemImage: "slider.horizontal.3") {
+                    isCleanupPromptManagerPresented = true
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -325,9 +325,9 @@ struct SettingsView: View {
             return "Turn on App context first."
         }
         if !screenRecordingGranted {
-            return "Grant Screen Recording to add visible screen OCR text."
+            return "Grant Screen Recording to add frontmost-window OCR text."
         }
-        return "Adds visible screen OCR text. Cloud cleanup may send this text to the selected provider."
+        return "Adds frontmost-window OCR text. Cloud cleanup may send this text to the selected provider."
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -54,6 +54,7 @@ struct SettingsView: View {
     private enum SettingsPane: String, CaseIterable, Identifiable {
         case general
         case sync
+        case aiModels
         case dictation
         case computerUse
         case meetings
@@ -65,6 +66,7 @@ struct SettingsView: View {
             switch self {
             case .general: return "General"
             case .sync: return "Sync"
+            case .aiModels: return "AI Models"
             case .dictation: return "Dictation"
             case .computerUse: return "Computer Use"
             case .meetings: return "Meetings"
@@ -88,6 +90,9 @@ struct SettingsView: View {
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
     @State private var dictationInputDevices: [AudioInputDeviceInfo] = []
     @State private var permissionPollTimer: Timer?
+    @State private var isEditingCleanupPrompt = false
+    @State private var editedCleanupPrompt = ""
+    @State private var cleanupPromptName = ""
     @State private var micGranted = false
     @State private var accessibilityGranted = false
     @State private var inputMonitoringGranted = false
@@ -101,8 +106,9 @@ struct SettingsView: View {
     @State private var openRouterFreeModelsError: String?
     @State private var hasRefreshedMeetingCalendarSources = false
 
-    // Uniform width for all right-side controls
+    // Uniform width for standard right-side controls.
     private let controlWidth: CGFloat = 220
+    // Wider controls keep model/provider selections visually consistent in AI Models.
     private let meetingControlWidth: CGFloat = 275
     private let iOSCompanionURL = IPhoneBridgeLinks.installURL
     private let screenContextGrantIntentTimeout: TimeInterval = 15 * 60
@@ -132,6 +138,24 @@ struct SettingsView: View {
             return appState.selectedMeetingTranscriptionBackend.label
         }
         return meetingBackendOptions.first?.label ?? "No downloaded models"
+    }
+
+    private var cleanupPromptPresets: [TranscriptCleanupPromptPreset] {
+        TranscriptCleanupPrompts.presets(custom: appState.config.customTranscriptCleanupPrompts)
+    }
+
+    private var selectedCleanupPromptName: String {
+        cleanupPromptPresets.first { $0.id == appState.config.activeTranscriptCleanupPromptId }?.name
+            ?? TranscriptCleanupPrompts.builtIns[0].name
+    }
+
+    private var cleanupBackendDescription: String {
+        if appState.selectedPostProcessorBackend == .local {
+            return downloadedPostProcOptions.isEmpty
+                ? "Download a cleanup model in Models to refine dictations on this Mac."
+                : "Refines dictated text on this Mac."
+        }
+        return "Sends dictated text to \(appState.selectedPostProcessorBackend.label) and may add latency."
     }
 
     private var selectedCohereLanguage: CohereTranscribeLanguage {
@@ -338,6 +362,8 @@ struct SettingsView: View {
             generalSettingsPane
         case .sync:
             syncSettingsPane
+        case .aiModels:
+            aiModelsSettingsPane
         case .dictation:
             dictationSettingsPane
         case .computerUse:
@@ -522,10 +548,10 @@ struct SettingsView: View {
         }
     }
 
-    private var dictationSettingsPane: some View {
+    private var aiModelsSettingsPane: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
-            settingsSection("Transcription") {
-                settingsRow("Dictation model") {
+            settingsSection("Speech Recognition") {
+                settingsRow("Dictation model", controlWidth: meetingControlWidth) {
                     settingsMenu(
                         selection: appState.selectedBackend.label,
                         options: dictationBackendOptions.map(\.label)
@@ -535,9 +561,28 @@ struct SettingsView: View {
                         }
                     }
                 }
-                if appState.selectedBackend.backend == BackendOption.cohereTranscribe.backend {
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Meeting model", controlWidth: meetingControlWidth) {
+                    if meetingBackendOptions.isEmpty {
+                        Text("No downloaded models")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    } else {
+                        settingsMenu(
+                            selection: selectedMeetingBackendLabel,
+                            options: meetingBackendOptions.map(\.label)
+                        ) { label in
+                            if let option = meetingBackendOptions.first(where: { $0.label == label }) {
+                                controller.selectMeetingTranscriptionBackend(option)
+                            }
+                        }
+                    }
+                }
+                if appState.selectedBackend.backend == BackendOption.cohereTranscribe.backend
+                    || appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cohere language") {
+                    settingsRow("Cohere language", controlWidth: meetingControlWidth) {
                         settingsMenu(
                             selection: selectedCohereLanguage.label,
                             options: CohereTranscribeLanguage.allCases.map(\.label)
@@ -547,9 +592,10 @@ struct SettingsView: View {
                         }
                     }
                 }
-                if appState.selectedBackend.backend == BackendOption.indicASR.backend {
+                if appState.selectedBackend.backend == BackendOption.indicASR.backend
+                    || appState.selectedMeetingTranscriptionBackend.backend == BackendOption.indicASR.backend {
                     Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Indic language") {
+                    settingsRow("Indic language", controlWidth: meetingControlWidth) {
                         FixedWidthPopUp(
                             selection: selectedIndicASRLanguage.label,
                             options: IndicASRLanguage.allCases.map(\.label),
@@ -561,7 +607,390 @@ struct SettingsView: View {
                         .frame(height: 24)
                     }
                 }
+            }
+
+            settingsSection("Dictation Cleanup") {
+                settingsRow(
+                    "Cleanup backend",
+                    description: cleanupBackendDescription,
+                    controlWidth: meetingControlWidth
+                ) {
+                    settingsMenu(
+                        selection: appState.selectedPostProcessorBackend.label,
+                        options: TranscriptCleanupBackendOption.all.map(\.label)
+                    ) { label in
+                        if let option = TranscriptCleanupBackendOption.all.first(where: { $0.label == label }) {
+                            controller.selectPostProcessorBackend(option)
+                        }
+                    }
+                }
+                if appState.selectedPostProcessorBackend == .local {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                        if downloadedPostProcOptions.isEmpty {
+                            Text("Download a cleanup model in Models")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: meetingControlWidth, alignment: .trailing)
+                        } else {
+                            let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
+                                ? appState.activePostProcessor.label
+                                : (downloadedPostProcOptions.first?.label ?? "")
+                            settingsMenu(
+                                selection: selection,
+                                options: downloadedPostProcOptions.map(\.label)
+                            ) { label in
+                                if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
+                                    controller.selectPostProcessor(option)
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    hostedCleanupSettings(for: appState.selectedPostProcessorBackend)
+                }
+
                 Divider().background(MuesliTheme.surfaceBorder)
+                cleanupPromptSettings
+            }
+
+            meetingSummarySettingsSection
+        }
+    }
+
+    @ViewBuilder
+    private func hostedCleanupSettings(for backend: TranscriptCleanupBackendOption) -> some View {
+        switch backend.llmBackend {
+        case .some(.chatGPT):
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Account", controlWidth: meetingControlWidth) {
+                chatGPTAccountControl(selectMeetingSummaryBackend: false)
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                settingsModelMenu(
+                    currentModel: appState.config.postProcessorChatGPTModel,
+                    presets: SummaryModelPreset.chatGPTModels
+                ) { controller.updatePostProcessorModel($0, for: backend) }
+            }
+        case .some(.openAI):
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("API Key", controlWidth: meetingControlWidth) {
+                PastableSecureField(
+                    text: appState.config.openAIAPIKey,
+                    placeholder: "sk-...",
+                    onChange: { val in controller.updateConfig { $0.openAIAPIKey = val } }
+                )
+                .frame(height: 22)
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                settingsModelMenu(
+                    currentModel: appState.config.postProcessorOpenAIModel,
+                    presets: SummaryModelPreset.openAIModels
+                ) { controller.updatePostProcessorModel($0, for: backend) }
+            }
+            keyStatusRow(key: appState.config.openAIAPIKey)
+        case .some(.openRouter):
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("API Key", controlWidth: meetingControlWidth) {
+                PastableSecureField(
+                    text: appState.config.openRouterAPIKey,
+                    placeholder: "sk-or-...",
+                    onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
+                )
+                .frame(height: 22)
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                settingsModelMenu(
+                    currentModel: appState.config.postProcessorOpenRouterModel,
+                    presets: SummaryModelPreset.openRouterModels
+                ) { controller.updatePostProcessorModel($0, for: backend) }
+            }
+            keyStatusRow(key: appState.config.openRouterAPIKey)
+        case .some(.ollama):
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Ollama URL", controlWidth: meetingControlWidth) {
+                PastableTextField(
+                    text: appState.config.ollamaURL,
+                    placeholder: "http://localhost:11434",
+                    onChange: { val in controller.updateConfig { $0.ollamaURL = val } }
+                )
+                .frame(height: 22)
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                settingsModelTextField(
+                    currentModel: appState.config.postProcessorOllamaModel,
+                    placeholder: TranscriptCleanupClient.defaultModel(for: backend)
+                ) { controller.updatePostProcessorModel($0, for: backend) }
+            }
+        case .some(.lmStudio):
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
+                PastableTextField(
+                    text: appState.config.lmStudioURL,
+                    placeholder: "http://localhost:1234",
+                    onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
+                )
+                .frame(height: 22)
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                settingsModelTextField(
+                    currentModel: appState.config.postProcessorLMStudioModel,
+                    placeholder: "Loaded LM Studio model"
+                ) { controller.updatePostProcessorModel($0, for: backend) }
+            }
+        case .some(.customLLM):
+            customLLMSettingsRows(model: appState.config.postProcessorCustomLLMModel) {
+                controller.updatePostProcessorModel($0, for: backend)
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    private var cleanupPromptSettings: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            settingsRow("Prompt preset", controlWidth: meetingControlWidth) {
+                FixedWidthPopUp(
+                    selection: selectedCleanupPromptName,
+                    options: cleanupPromptPresets.map(\.name),
+                    onSelectIndex: { index in
+                        guard index >= 0, index < cleanupPromptPresets.count else { return }
+                        controller.selectTranscriptCleanupPrompt(id: cleanupPromptPresets[index].id)
+                        editedCleanupPrompt = cleanupPromptPresets[index].prompt
+                        cleanupPromptName = cleanupPromptPresets[index].name
+                    }
+                )
+                .frame(height: 24)
+            }
+
+            if isEditingCleanupPrompt {
+                TextEditor(text: $editedCleanupPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .frame(minHeight: 150)
+                    .scrollContentBackground(.hidden)
+                    .padding(10)
+                    .background(MuesliTheme.surfacePrimary.opacity(0.7))
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+
+                HStack(spacing: MuesliTheme.spacing8) {
+                    PastableTextField(
+                        text: cleanupPromptName,
+                        placeholder: "Preset name",
+                        onChange: { cleanupPromptName = $0 }
+                    )
+                    .frame(width: meetingControlWidth, height: 24)
+
+                    Spacer(minLength: MuesliTheme.spacing12)
+
+                    compactActionButton("Save as Preset") {
+                        controller.createTranscriptCleanupPrompt(
+                            name: cleanupPromptName,
+                            prompt: editedCleanupPrompt
+                        )
+                        isEditingCleanupPrompt = false
+                    }
+
+                    if let active = cleanupPromptPresets.first(where: { $0.id == appState.config.activeTranscriptCleanupPromptId }),
+                       active.isCustom {
+                        compactActionButton("Update Preset") {
+                            controller.updateTranscriptCleanupPrompt(
+                                id: active.id,
+                                name: cleanupPromptName,
+                                prompt: editedCleanupPrompt
+                            )
+                            isEditingCleanupPrompt = false
+                        }
+
+                        compactActionButton("Delete", role: .destructive) {
+                            controller.deleteTranscriptCleanupPrompt(id: active.id)
+                            isEditingCleanupPrompt = false
+                        }
+                    }
+
+                    compactActionButton("Cancel") {
+                        isEditingCleanupPrompt = false
+                    }
+                }
+            } else {
+                Text(appState.config.postProcessorSystemPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(4)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MuesliTheme.surfacePrimary.opacity(0.7))
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+
+                HStack {
+                    Spacer()
+                    compactActionButton("Edit Prompt", systemImage: "pencil") {
+                        editedCleanupPrompt = appState.config.postProcessorSystemPrompt
+                        cleanupPromptName = selectedCleanupPromptName
+                        isEditingCleanupPrompt = true
+                    }
+                }
+            }
+        }
+    }
+
+    private var meetingSummarySettingsSection: some View {
+        settingsSection("Meeting Summaries") {
+            settingsRow("Summary backend", controlWidth: meetingControlWidth) {
+                settingsMenu(
+                    selection: appState.selectedMeetingSummaryBackend.label,
+                    options: MeetingSummaryBackendOption.all.map(\.label)
+                ) { label in
+                    if let option = MeetingSummaryBackendOption.all.first(where: { $0.label == label }) {
+                        controller.selectMeetingSummaryBackend(option)
+                    }
+                }
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+
+            if appState.selectedMeetingSummaryBackend == .chatGPT {
+                settingsRow("Account", controlWidth: meetingControlWidth) {
+                    chatGPTAccountControl()
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Model", controlWidth: meetingControlWidth) {
+                    settingsModelMenu(
+                        currentModel: appState.config.chatGPTModel,
+                        presets: SummaryModelPreset.chatGPTModels
+                    ) { val in controller.updateConfig { $0.chatGPTModel = val } }
+                }
+            } else if appState.selectedMeetingSummaryBackend == .openAI {
+                settingsRow("API Key", controlWidth: meetingControlWidth) {
+                    PastableSecureField(
+                        text: appState.config.openAIAPIKey,
+                        placeholder: "sk-...",
+                        onChange: { val in controller.updateConfig { $0.openAIAPIKey = val } }
+                    )
+                    .frame(height: 22)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Model", controlWidth: meetingControlWidth) {
+                    settingsModelMenu(
+                        currentModel: appState.config.openAIModel,
+                        presets: SummaryModelPreset.openAIModels
+                    ) { val in controller.updateConfig { $0.openAIModel = val } }
+                }
+                keyStatusRow(key: appState.config.openAIAPIKey)
+            } else if appState.selectedMeetingSummaryBackend == .ollama {
+                settingsRow("Ollama URL", controlWidth: meetingControlWidth) {
+                    PastableTextField(
+                        text: appState.config.ollamaURL,
+                        placeholder: "http://localhost:11434",
+                        onChange: { val in controller.updateConfig { $0.ollamaURL = val } }
+                    )
+                    .frame(height: 22)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Model", controlWidth: meetingControlWidth) {
+                    settingsModelTextField(
+                        currentModel: appState.config.ollamaModel,
+                        placeholder: "qwen3.5"
+                    ) { val in controller.updateConfig { $0.ollamaModel = val } }
+                }
+            } else if appState.selectedMeetingSummaryBackend == .lmStudio {
+                settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
+                    PastableTextField(
+                        text: appState.config.lmStudioURL,
+                        placeholder: "http://localhost:1234",
+                        onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
+                    )
+                    .frame(height: 22)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Model", controlWidth: meetingControlWidth) {
+                    settingsModelTextField(
+                        currentModel: appState.config.lmStudioModel,
+                        placeholder: "Select a loaded LM Studio model"
+                    ) { val in controller.updateConfig { $0.lmStudioModel = val } }
+                }
+            } else if appState.selectedMeetingSummaryBackend == .customLLM {
+                customLLMSettingsRows(model: appState.config.customLLMModel) {
+                    val in controller.updateConfig { $0.customLLMModel = val }
+                }
+            } else {
+                settingsRow("API Key", controlWidth: meetingControlWidth) {
+                    PastableSecureField(
+                        text: appState.config.openRouterAPIKey,
+                        placeholder: "sk-or-...",
+                        onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
+                    )
+                    .frame(height: 22)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Model", controlWidth: meetingControlWidth) {
+                    openRouterFreeModelMenu
+                }
+                keyStatusRow(key: appState.config.openRouterAPIKey)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func customLLMSettingsRows(model: String, onModelChange: @escaping (String) -> Void) -> some View {
+        Divider().background(MuesliTheme.surfaceBorder)
+        settingsRow("API Format", controlWidth: meetingControlWidth) {
+            settingsMenu(
+                selection: CustomLLMFormat(rawValue: appState.config.customLLMFormat)?.label ?? CustomLLMFormat.openAI.label,
+                options: CustomLLMFormat.allCases.map(\.label)
+            ) { label in
+                guard let format = CustomLLMFormat.allCases.first(where: { $0.label == label }) else { return }
+                controller.updateConfig { $0.customLLMFormat = format.rawValue }
+            }
+        }
+        Divider().background(MuesliTheme.surfaceBorder)
+        settingsRow("Endpoint", controlWidth: meetingControlWidth) {
+            PastableTextField(
+                text: appState.config.customLLMURL,
+                placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
+                    ? "https://api.anthropic.com"
+                    : "http://localhost:8080/v1",
+                onChange: { val in controller.updateConfig { $0.customLLMURL = val } }
+            )
+            .frame(height: 22)
+        }
+        Divider().background(MuesliTheme.surfaceBorder)
+        settingsRow("API Key", controlWidth: meetingControlWidth) {
+            PastableSecureField(
+                text: appState.config.customLLMAPIKey,
+                placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
+                    ? "Required for Anthropic API"
+                    : "Optional for local servers",
+                onChange: { val in controller.updateConfig { $0.customLLMAPIKey = val } }
+            )
+            .frame(height: 22)
+        }
+        Divider().background(MuesliTheme.surfaceBorder)
+        settingsRow("Model", controlWidth: meetingControlWidth) {
+            settingsModelTextField(
+                currentModel: model,
+                placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
+                    ? "claude-3-5-sonnet-20241022"
+                    : "custom-model-id"
+            ) { val in onModelChange(val) }
+        }
+    }
+
+    private var dictationSettingsPane: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            settingsSection("Transcription") {
                 settingsRow(
                     "Microphone",
                     description: "Automatic uses system input, or Mac mic with AirPods."
@@ -594,31 +1023,6 @@ struct SettingsView: View {
                     }
                     .help("Briefly reads focused app text after dictation to detect corrections.")
                 }
-                if appState.config.enablePostProcessor && !downloadedPostProcOptions.isEmpty {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cleanup model") {
-                        let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
-                            ? appState.activePostProcessor.label
-                            : (downloadedPostProcOptions.first?.label ?? "")
-                        settingsMenu(
-                            selection: selection,
-                            options: downloadedPostProcOptions.map(\.label)
-                        ) { label in
-                            if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
-                                controller.selectPostProcessor(option)
-                            }
-                        }
-                    }
-                } else if appState.config.enablePostProcessor {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cleanup model") {
-                        Text("Download a cleanup model in Models")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .multilineTextAlignment(.trailing)
-                            .frame(width: controlWidth, alignment: .trailing)
-                    }
-                }
             }
 
             settingsSection("Advanced") {
@@ -648,7 +1052,7 @@ struct SettingsView: View {
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Account", controlWidth: meetingControlWidth) {
-                    chatGPTAccountControl
+                    chatGPTAccountControl()
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Planner model", controlWidth: meetingControlWidth) {
@@ -680,192 +1084,11 @@ struct SettingsView: View {
 
     private var meetingsSettingsPane: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
-            settingsSection("Meeting Transcription") {
-                settingsRow("Meeting model", controlWidth: meetingControlWidth) {
-                    if meetingBackendOptions.isEmpty {
-                        Text("No downloaded models")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    } else {
-                        settingsMenu(
-                            selection: selectedMeetingBackendLabel,
-                            options: meetingBackendOptions.map(\.label)
-                        ) { label in
-                            if let option = meetingBackendOptions.first(where: { $0.label == label }) {
-                                controller.selectMeetingTranscriptionBackend(option)
-                            }
-                        }
-                    }
-                }
-                if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cohere language") {
-                        settingsMenu(
-                            selection: selectedCohereLanguage.label,
-                            options: CohereTranscribeLanguage.allCases.map(\.label)
-                        ) { label in
-                            guard let language = CohereTranscribeLanguage.allCases.first(where: { $0.label == label }) else { return }
-                            controller.selectCohereLanguage(language)
-                        }
-                    }
-                }
-                if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.indicASR.backend {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Indic language") {
-                        FixedWidthPopUp(
-                            selection: selectedIndicASRLanguage.label,
-                            options: IndicASRLanguage.allCases.map(\.label),
-                            onSelectIndex: { index in
-                                guard index >= 0, index < IndicASRLanguage.allCases.count else { return }
-                                controller.selectIndicASRLanguage(IndicASRLanguage.allCases[index])
-                            }
-                        )
-                        .frame(height: 24)
-                    }
-                }
-                Divider().background(MuesliTheme.surfaceBorder)
+            settingsSection("Meeting Context") {
                 screenContextRow("Meeting context")
             }
 
-            settingsSection("Meeting Summaries") {
-                settingsRow("Summary backend", controlWidth: meetingControlWidth) {
-                    settingsMenu(
-                        selection: appState.selectedMeetingSummaryBackend.label,
-                        options: MeetingSummaryBackendOption.all.map(\.label)
-                    ) { label in
-                        if let option = MeetingSummaryBackendOption.all.first(where: { $0.label == label }) {
-                            controller.selectMeetingSummaryBackend(option)
-                        }
-                    }
-                }
-                Divider().background(MuesliTheme.surfaceBorder)
-
-                if appState.selectedMeetingSummaryBackend == .chatGPT {
-                    settingsRow("Account", controlWidth: meetingControlWidth) {
-                        chatGPTAccountControl
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelMenu(
-                            currentModel: appState.config.chatGPTModel,
-                            presets: SummaryModelPreset.chatGPTModels
-                        ) { val in controller.updateConfig { $0.chatGPTModel = val } }
-                    }
-                } else if appState.selectedMeetingSummaryBackend == .openAI {
-                    settingsRow("API Key", controlWidth: meetingControlWidth) {
-                        PastableSecureField(
-                            text: appState.config.openAIAPIKey,
-                            placeholder: "sk-...",
-                            onChange: { val in controller.updateConfig { $0.openAIAPIKey = val } }
-                        )
-                        .frame(height: 22)
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelMenu(
-                            currentModel: appState.config.openAIModel,
-                            presets: SummaryModelPreset.openAIModels
-                        ) { val in controller.updateConfig { $0.openAIModel = val } }
-                    }
-                    keyStatusRow(key: appState.config.openAIAPIKey)
-                } else if appState.selectedMeetingSummaryBackend == .ollama {
-                    settingsRow("Ollama URL", controlWidth: meetingControlWidth) {
-                        PastableTextField(
-                            text: appState.config.ollamaURL,
-                            placeholder: "http://localhost:11434",
-                            onChange: { val in controller.updateConfig { $0.ollamaURL = val } }
-                        )
-                        .frame(height: 22)
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelTextField(
-                            currentModel: appState.config.ollamaModel,
-                            placeholder: "qwen3.5"
-                        ) { val in controller.updateConfig { $0.ollamaModel = val } }
-                    }
-                } else if appState.selectedMeetingSummaryBackend == .lmStudio {
-                    settingsRow("LM Studio URL", controlWidth: meetingControlWidth) {
-                        PastableTextField(
-                            text: appState.config.lmStudioURL,
-                            placeholder: "http://localhost:1234",
-                            onChange: { val in controller.updateConfig { $0.lmStudioURL = val } }
-                        )
-                        .frame(height: 22)
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelTextField(
-                            currentModel: appState.config.lmStudioModel,
-                            placeholder: "Select a loaded LM Studio model"
-                        ) { val in controller.updateConfig { $0.lmStudioModel = val } }
-                    }
-                } else if appState.selectedMeetingSummaryBackend == .customLLM {
-                    settingsRow("API Format", controlWidth: meetingControlWidth) {
-                        settingsMenu(
-                            selection: CustomLLMFormat(rawValue: appState.config.customLLMFormat)?.label ?? CustomLLMFormat.openAI.label,
-                            options: CustomLLMFormat.allCases.map(\.label)
-                        ) { label in
-                            guard let format = CustomLLMFormat.allCases.first(where: { $0.label == label }) else { return }
-                            controller.updateConfig { $0.customLLMFormat = format.rawValue }
-                        }
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Endpoint", controlWidth: meetingControlWidth) {
-                        PastableTextField(
-                            text: appState.config.customLLMURL,
-                            placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
-                                ? "https://api.anthropic.com"
-                                : "http://localhost:8080/v1",
-                            onChange: { val in controller.updateConfig { $0.customLLMURL = val } }
-                        )
-                        .frame(height: 22)
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("API Key", controlWidth: meetingControlWidth) {
-                        PastableSecureField(
-                            text: appState.config.customLLMAPIKey,
-                            placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
-                                ? "Required for Anthropic API"
-                                : "Optional for local servers",
-                            onChange: { val in controller.updateConfig { $0.customLLMAPIKey = val } }
-                        )
-                        .frame(height: 22)
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Model", controlWidth: meetingControlWidth) {
-                        settingsModelTextField(
-                            currentModel: appState.config.customLLMModel,
-                            placeholder: appState.config.customLLMFormat == CustomLLMFormat.anthropic.rawValue
-                                ? "claude-3-5-sonnet-20241022"
-                                : "custom-model-id"
-                        ) { val in controller.updateConfig { $0.customLLMModel = val } }
-                    }
-                } else {
-                    settingsRow("API Key", controlWidth: meetingControlWidth) {
-                        PastableSecureField(
-                            text: appState.config.openRouterAPIKey,
-                            placeholder: "sk-or-...",
-                            onChange: { val in controller.updateConfig { $0.openRouterAPIKey = val } }
-                        )
-                        .frame(height: 22)
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Free model", controlWidth: meetingControlWidth) {
-                        openRouterFreeModelMenu
-                    }
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
-                        settingsModelTextField(
-                            currentModel: appState.config.openRouterModel,
-                            placeholder: "provider/model or openrouter/free"
-                        ) { val in controller.updateConfig { $0.openRouterModel = val } }
-                    }
-                    keyStatusRow(key: appState.config.openRouterAPIKey)
-                }
-
-                Divider().background(MuesliTheme.surfaceBorder)
+            settingsSection("Meeting Notes") {
                 settingsRow("Default template", controlWidth: meetingControlWidth) {
                     meetingTemplateMenu(selectionID: appState.config.defaultMeetingTemplateID) { id in
                         controller.updateDefaultMeetingTemplate(id: id)
@@ -1174,7 +1397,7 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private var chatGPTAccountControl: some View {
+    private func chatGPTAccountControl(selectMeetingSummaryBackend: Bool = true) -> some View {
         if appState.isChatGPTAuthenticated {
             Button {
                 controller.signOutChatGPT()
@@ -1209,7 +1432,7 @@ struct SettingsView: View {
                     isSigningInChatGPT = true
                     chatGPTSignInError = nil
                     Task {
-                        let error = await controller.signInWithChatGPT()
+                        let error = await controller.signInWithChatGPT(selectMeetingSummaryBackend: selectMeetingSummaryBackend)
                         isSigningInChatGPT = false
                         chatGPTSignInError = error
                     }
@@ -1793,6 +2016,37 @@ struct SettingsView: View {
     private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
         FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
             .frame(height: 24)
+    }
+
+    @ViewBuilder
+    private func compactActionButton(
+        _ title: String,
+        systemImage: String? = nil,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        let isDestructive = role == .destructive
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                Text(title)
+                    .lineLimit(1)
+            }
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(isDestructive ? MuesliTheme.recording : MuesliTheme.textPrimary)
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+            .background(isDestructive ? MuesliTheme.recording.opacity(0.1) : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(isDestructive ? MuesliTheme.recording.opacity(0.25) : MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
     }
 
     private var mutedMeetingDetectionAppsControl: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -656,8 +656,6 @@ struct SettingsView: View {
                     hostedCleanupSettings(for: appState.selectedPostProcessorBackend)
                 }
 
-                Divider().background(MuesliTheme.surfaceBorder)
-                cleanupPromptSettings
             }
 
             meetingSummarySettingsSection
@@ -767,7 +765,7 @@ struct SettingsView: View {
 
     private var cleanupPromptSettings: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-            settingsRow("Prompt preset", controlWidth: meetingControlWidth) {
+            settingsRow("Cleanup preset", controlWidth: meetingControlWidth) {
                 FixedWidthPopUp(
                     selection: selectedCleanupPromptName,
                     options: cleanupPromptPresets.map(\.name),
@@ -967,6 +965,8 @@ struct SettingsView: View {
                         controller.setPostProcessorEnabled(newValue)
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                cleanupPromptSettings
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow(
                     "Dictionary suggestions",

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -307,25 +307,42 @@ struct SettingsView: View {
         ("1e1e2e", "Dark"),
     ]
 
-    private var screenContextDescription: String {
+    private func screenContextDescription(includesScreenOCR: Bool) -> String {
         if !accessibilityGranted {
             return "Grant Accessibility, then toggle again if needed."
         }
-        if !screenRecordingGranted {
+        if includesScreenOCR, !screenRecordingGranted {
             return "Adds nearby app text for post-processing. Screen Recording enables OCR context."
         }
-        return "Adds nearby app text and OCR context. Processed on-device."
+        if includesScreenOCR {
+            return "Adds nearby app text and OCR context."
+        }
+        return "Adds nearby app text for post-processing."
+    }
+
+    private var dictationOCRContextDescription: String {
+        if !appState.config.enableScreenContext {
+            return "Turn on App context first."
+        }
+        if !screenRecordingGranted {
+            return "Grant Screen Recording to add visible screen OCR text."
+        }
+        return "Adds visible screen OCR text. Cloud cleanup may send this text to the selected provider."
     }
 
     @ViewBuilder
-    private func screenContextRow(_ title: String, controlWidth rowControlWidth: CGFloat? = nil) -> some View {
+    private func screenContextRow(
+        _ title: String,
+        includesScreenOCR: Bool = false,
+        controlWidth rowControlWidth: CGFloat? = nil
+    ) -> some View {
         let width = rowControlWidth ?? controlWidth
         HStack(alignment: .top, spacing: 20) {
             VStack(alignment: .leading, spacing: 6) {
                 Text(title)
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textPrimary)
-                Text(screenContextDescription)
+                Text(screenContextDescription(includesScreenOCR: includesScreenOCR))
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .lineLimit(2)
@@ -338,6 +355,32 @@ struct SettingsView: View {
             ZStack(alignment: .trailing) {
                 Color.clear.frame(width: width, height: 1)
                 screenContextControl(width: width)
+            }
+        }
+        .frame(minHeight: 52)
+    }
+
+    @ViewBuilder
+    private var dictationOCRContextRow: some View {
+        let width = controlWidth
+        HStack(alignment: .top, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Screen OCR context")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(dictationOCRContextDescription)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 20)
+
+            ZStack(alignment: .trailing) {
+                Color.clear.frame(width: width, height: 1)
+                dictationOCRContextControl(width: width)
             }
         }
         .frame(minHeight: 52)
@@ -991,7 +1034,10 @@ struct SettingsView: View {
                         controller.updateConfig { $0.muteSystemAudioDuringDictation = newValue }
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
                 screenContextRow("App context")
+                Divider().background(MuesliTheme.surfaceBorder)
+                dictationOCRContextRow
             }
         }
     }
@@ -1039,7 +1085,7 @@ struct SettingsView: View {
     private var meetingsSettingsPane: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
             settingsSection("Meeting Context") {
-                screenContextRow("Meeting context")
+                screenContextRow("Meeting context", includesScreenOCR: true)
             }
 
             settingsSection("Meeting Notes") {
@@ -1772,11 +1818,42 @@ struct SettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private func dictationOCRContextControl(width: CGFloat? = nil) -> some View {
+        if !appState.config.enableScreenContext {
+            settingsSwitch(isOn: false) { _ in }
+                .frame(width: width, alignment: .trailing)
+                .disabled(true)
+        } else if screenRecordingGranted {
+            settingsSwitch(isOn: appState.config.enableDictationOCRContext) { newValue in
+                controller.updateConfig { $0.enableDictationOCRContext = newValue }
+            }
+            .frame(width: width, alignment: .trailing)
+        } else {
+            Button {
+                _ = CGRequestScreenCaptureAccess()
+                refreshPermissionStatuses()
+            } label: {
+                Text("Grant")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .frame(width: width)
+                    .frame(minHeight: 32)
+                    .background(MuesliTheme.accentSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
     @discardableResult
     private func handleScreenContextToggle(_ enabled: Bool) -> Bool {
         guard enabled else {
             clearPendingScreenContextEnable()
-            controller.updateConfig { $0.enableScreenContext = false }
+            controller.updateConfig {
+                $0.enableScreenContext = false
+                $0.enableDictationOCRContext = false
+            }
             return false
         }
 
@@ -1835,7 +1912,13 @@ struct SettingsView: View {
         }
         if !accessibilityGranted && appState.config.enableScreenContext {
             clearPendingScreenContextEnable()
-            controller.updateConfig { $0.enableScreenContext = false }
+            controller.updateConfig {
+                $0.enableScreenContext = false
+                $0.enableDictationOCRContext = false
+            }
+        }
+        if (!appState.config.enableScreenContext || !screenRecordingGranted) && appState.config.enableDictationOCRContext {
+            controller.updateConfig { $0.enableDictationOCRContext = false }
         }
         controller.reclassifyVoiceNotesAsDictationIfReady(
             microphoneGranted: micGranted,

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -703,10 +703,17 @@ struct SettingsView: View {
                 .frame(height: 22)
             }
             Divider().background(MuesliTheme.surfaceBorder)
-            settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+            settingsRow("Model preset", controlWidth: meetingControlWidth) {
                 settingsModelMenu(
                     currentModel: appState.config.postProcessorOpenRouterModel,
                     presets: SummaryModelPreset.openRouterModels
+                ) { controller.updatePostProcessorModel($0, for: backend) }
+            }
+            Divider().background(MuesliTheme.surfaceBorder)
+            settingsRow("Custom model ID", controlWidth: meetingControlWidth) {
+                settingsModelTextField(
+                    currentModel: appState.config.postProcessorOpenRouterModel,
+                    placeholder: "provider/model"
                 ) { controller.updatePostProcessorModel($0, for: backend) }
             }
             keyStatusRow(key: appState.config.openRouterAPIKey)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -1,0 +1,423 @@
+import Foundation
+
+enum TranscriptCleanupError: LocalizedError {
+    case missingConfiguration(String)
+    case rejectedOutput
+    case emptyResponse(String)
+    case backendFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingConfiguration(message):
+            return message
+        case .rejectedOutput:
+            return "Transcript cleanup output was rejected by safety checks."
+        case let .emptyResponse(backend):
+            return "\(backend) returned an empty transcript cleanup response."
+        case let .backendFailed(message):
+            return message
+        }
+    }
+}
+
+struct TranscriptCleanupResult {
+    let rawOutput: String
+    let cleanedOutput: String
+    let model: String
+}
+
+enum TranscriptCleanupClient {
+    private static let openAIResponsesURL = URL(string: "https://api.openai.com/v1/responses")!
+    private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
+    private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
+    private static let requestTimeout: TimeInterval = 120
+    private static let defaultMaxOutputTokens = 1000
+
+    static func defaultModel(for backend: TranscriptCleanupBackendOption) -> String {
+        switch backend.llmBackend {
+        case .some(.chatGPT):
+            return SummaryModelPreset.chatGPTModels.first?.id ?? "gpt-5.4-mini"
+        case .some(.openAI):
+            return SummaryModelPreset.openAIModels.first?.id ?? "gpt-5.4-mini"
+        case .some(.openRouter):
+            return SummaryModelPreset.openRouterModels.first?.id ?? "stepfun/step-3.5-flash:free"
+        case .some(.ollama):
+            return "qwen3.5"
+        case .some(.lmStudio), .some(.customLLM):
+            return ""
+        case nil:
+            return PostProcessorOption.defaultOption.id
+        default:
+            return ""
+        }
+    }
+
+    static func configuredModel(for backend: TranscriptCleanupBackendOption, config: AppConfig) -> String {
+        let raw: String
+        switch backend.llmBackend {
+        case .some(.chatGPT):
+            raw = config.postProcessorChatGPTModel
+        case .some(.openAI):
+            raw = config.postProcessorOpenAIModel
+        case .some(.openRouter):
+            raw = config.postProcessorOpenRouterModel
+        case .some(.ollama):
+            raw = config.postProcessorOllamaModel
+        case .some(.lmStudio):
+            raw = config.postProcessorLMStudioModel
+        case .some(.customLLM):
+            raw = config.postProcessorCustomLLMModel
+        case nil:
+            raw = config.activePostProcessorId
+        default:
+            raw = ""
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultModel(for: backend) : trimmed
+    }
+
+    static func hasRequiredSettings(for backend: TranscriptCleanupBackendOption, config: AppConfig, isChatGPTAuthenticated: Bool) -> Bool {
+        switch backend.llmBackend {
+        case .some(.chatGPT):
+            return isChatGPTAuthenticated
+        case .some(.openAI):
+            return !config.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || ProcessInfo.processInfo.environment["OPENAI_API_KEY"] != nil
+        case .some(.openRouter):
+            return !config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
+        case .some(.ollama):
+            return true
+        case .some(.lmStudio):
+            return !configuredModel(for: backend, config: config).isEmpty
+        case .some(.customLLM):
+            let model = configuredModel(for: backend, config: config)
+            let key = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !model.isEmpty && (!MeetingSummaryClient.customLLMRequiresAPIKey(config: config) || !key.isEmpty)
+        case nil:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func clean(
+        text: String,
+        systemPrompt: String,
+        appContext: String?,
+        backend: TranscriptCleanupBackendOption,
+        config: AppConfig
+    ) async throws -> TranscriptCleanupResult {
+        guard let llmBackend = backend.llmBackend else {
+            throw TranscriptCleanupError.missingConfiguration("Local cleanup is handled by Qwen3PostProcessor.")
+        }
+
+        let model = configuredModel(for: backend, config: config)
+        let userPrompt = Qwen3PostProcessorConfig.formatInput(text, appContext: appContext)
+        let raw: String
+
+        switch llmBackend {
+        case .chatGPT:
+            raw = try await ChatGPTResponsesClient.respond(
+                systemPrompt: systemPrompt,
+                userPrompt: userPrompt,
+                model: model,
+                logCategory: "postproc"
+            )
+        case .openAI:
+            raw = try await cleanWithOpenAI(systemPrompt: systemPrompt, userPrompt: userPrompt, model: model, config: config)
+        case .openRouter:
+            raw = try await cleanWithChatCompletions(
+                backend: "OpenRouter",
+                requestURL: openRouterURL,
+                apiKey: config.openRouterAPIKey,
+                systemPrompt: systemPrompt,
+                userPrompt: userPrompt,
+                model: model
+            )
+        case .ollama:
+            raw = try await cleanWithOllama(systemPrompt: systemPrompt, userPrompt: userPrompt, model: model, config: config)
+        case .lmStudio:
+            guard let requestURL = MeetingSummaryClient.resolveLMStudioURL(config: cleanupConfig(config, model: model)) else {
+                throw TranscriptCleanupError.missingConfiguration("Invalid LM Studio URL: \(config.lmStudioURL)")
+            }
+            raw = try await cleanWithChatCompletions(
+                backend: "LM Studio",
+                requestURL: requestURL,
+                apiKey: "",
+                systemPrompt: systemPrompt,
+                userPrompt: userPrompt,
+                model: model
+            )
+        case .customLLM:
+            let format = CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI
+            guard let requestURL = MeetingSummaryClient.resolveCustomLLMURL(config: config, format: format) else {
+                throw TranscriptCleanupError.missingConfiguration("Invalid custom URL: \(config.customLLMURL)")
+            }
+            switch format {
+            case .openAI:
+                raw = try await cleanWithChatCompletions(
+                    backend: "Custom LLM",
+                    requestURL: requestURL,
+                    apiKey: config.customLLMAPIKey,
+                    systemPrompt: systemPrompt,
+                    userPrompt: userPrompt,
+                    model: model
+                )
+            case .anthropic:
+                raw = try await cleanWithAnthropic(
+                    requestURL: requestURL,
+                    apiKey: config.customLLMAPIKey,
+                    systemPrompt: systemPrompt,
+                    userPrompt: userPrompt,
+                    model: model
+                )
+            }
+        default:
+            throw TranscriptCleanupError.missingConfiguration("Unsupported transcript cleanup backend: \(backend.label)")
+        }
+
+        let cleaned = cleanOutput(raw)
+        let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty, Qwen3DeletionCueDetector.containsDeletionCue(text) {
+            return TranscriptCleanupResult(rawOutput: raw, cleanedOutput: trimmed, model: model)
+        }
+        if Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(cleaned: trimmed, input: text) {
+            throw TranscriptCleanupError.rejectedOutput
+        }
+        return TranscriptCleanupResult(rawOutput: raw, cleanedOutput: trimmed, model: model)
+    }
+
+    static func cleanOutput(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+        var result = Qwen3PostProcessorOutputCleaner.clean(text)
+        result = result.replacingOccurrences(of: #"\r\n?"#, with: "\n", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"[ \t]+([,.;:!?])"#, with: "$1", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"[ \t]{2,}"#, with: " ", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"(?m)[ \t]+$"#, with: "", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"[ \t]*\n[ \t]*"#, with: "\n", options: .regularExpression)
+        result = result.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func cleanupConfig(_ config: AppConfig, model: String) -> AppConfig {
+        var copy = config
+        copy.lmStudioModel = model
+        return copy
+    }
+
+    private static func cleanWithOpenAI(
+        systemPrompt: String,
+        userPrompt: String,
+        model: String,
+        config: AppConfig
+    ) async throws -> String {
+        let key = config.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = key.isEmpty ? (ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? "") : key
+        guard !apiKey.isEmpty else {
+            throw TranscriptCleanupError.missingConfiguration("OpenAI API key is not configured.")
+        }
+        let body: [String: Any] = [
+            "model": model,
+            "instructions": systemPrompt,
+            "input": userPrompt,
+            "max_output_tokens": defaultMaxOutputTokens,
+        ]
+        var request = URLRequest(url: openAIResponsesURL)
+        request.timeoutInterval = requestTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validateHTTPResponse(response, data: data, backend: "OpenAI")
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let text = extractResponsesText(from: json),
+            !text.isEmpty
+        else {
+            throw TranscriptCleanupError.emptyResponse("OpenAI")
+        }
+        return text
+    }
+
+    private static func cleanWithOllama(
+        systemPrompt: String,
+        userPrompt: String,
+        model: String,
+        config: AppConfig
+    ) async throws -> String {
+        let rawURL = config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseURL = rawURL.isEmpty ? defaultOllamaBaseURL : URL(string: rawURL)
+        guard let baseURL else {
+            throw TranscriptCleanupError.missingConfiguration("Invalid Ollama URL: \(rawURL)")
+        }
+        let chatURL = baseURL.appendingPathComponent("api/chat")
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userPrompt],
+            ],
+            "stream": false,
+            "options": ["num_predict": defaultMaxOutputTokens],
+        ]
+        var request = URLRequest(url: chatURL)
+        request.timeoutInterval = requestTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validateHTTPResponse(response, data: data, backend: "Ollama")
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let message = json["message"] as? [String: Any],
+            let text = message["content"] as? String,
+            !text.isEmpty
+        else {
+            throw TranscriptCleanupError.emptyResponse("Ollama")
+        }
+        return text
+    }
+
+    private static func cleanWithChatCompletions(
+        backend: String,
+        requestURL: URL,
+        apiKey: String,
+        systemPrompt: String,
+        userPrompt: String,
+        model: String
+    ) async throws -> String {
+        var body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": userPrompt],
+            ],
+        ]
+        let tokenKey = requestURL.host?.contains("openai.com") == true ? "max_completion_tokens" : "max_tokens"
+        body[tokenKey] = defaultMaxOutputTokens
+        var request = URLRequest(url: requestURL)
+        request.timeoutInterval = requestTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedKey.isEmpty {
+            request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validateHTTPResponse(response, data: data, backend: backend)
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let text = extractChatCompletionsText(from: json),
+            !text.isEmpty
+        else {
+            throw TranscriptCleanupError.emptyResponse(backend)
+        }
+        return text
+    }
+
+    private static func cleanWithAnthropic(
+        requestURL: URL,
+        apiKey: String,
+        systemPrompt: String,
+        userPrompt: String,
+        model: String
+    ) async throws -> String {
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": defaultMaxOutputTokens,
+            "system": systemPrompt,
+            "messages": [["role": "user", "content": userPrompt]],
+        ]
+        var request = URLRequest(url: requestURL)
+        request.timeoutInterval = requestTimeout
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedKey.isEmpty {
+            request.setValue(trimmedKey, forHTTPHeaderField: "x-api-key")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try validateHTTPResponse(response, data: data, backend: "Custom LLM")
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let text = extractAnthropicText(from: json),
+            !text.isEmpty
+        else {
+            throw TranscriptCleanupError.emptyResponse("Custom LLM")
+        }
+        return text
+    }
+
+    private static func validateHTTPResponse(_ response: URLResponse, data: Data, backend: String) throws {
+        guard let http = response as? HTTPURLResponse else { return }
+        guard (200..<300).contains(http.statusCode) else {
+            let message = extractErrorMessage(from: data)
+                ?? String(data: data, encoding: .utf8)
+                ?? "HTTP \(http.statusCode)"
+            throw TranscriptCleanupError.backendFailed("\(backend) cleanup failed. \(message)")
+        }
+    }
+
+    private static func extractResponsesText(from payload: [String: Any]) -> String? {
+        if let outputText = payload["output_text"] as? String, !outputText.isEmpty {
+            return outputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let output = payload["output"] as? [[String: Any]] {
+            let parts = output.flatMap { item -> [String] in
+                guard let content = item["content"] as? [[String: Any]] else { return [] }
+                return content.compactMap { $0["text"] as? String }
+            }
+            let joined = parts.joined()
+            return joined.isEmpty ? nil : joined.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    private static func extractChatCompletionsText(from payload: [String: Any]) -> String? {
+        guard let choices = payload["choices"] as? [[String: Any]] else { return nil }
+        for choice in choices {
+            if let message = choice["message"] as? [String: Any],
+               let content = message["content"] as? String,
+               !content.isEmpty {
+                return content.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            if let text = choice["text"] as? String, !text.isEmpty {
+                return text.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        return nil
+    }
+
+    private static func extractAnthropicText(from payload: [String: Any]) -> String? {
+        guard let content = payload["content"] as? [[String: Any]] else { return nil }
+        let parts = content.compactMap { item -> String? in
+            guard (item["type"] as? String) == nil || (item["type"] as? String) == "text" else { return nil }
+            return item["text"] as? String
+        }
+        let joined = parts.joined()
+        return joined.isEmpty ? nil : joined.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let error = json["error"] as? [String: Any] {
+            if let message = error["message"] as? String, !message.isEmpty { return message }
+            if let code = error["code"] as? String, !code.isEmpty { return code }
+            return String(describing: error)
+        }
+        if let message = json["message"] as? String, !message.isEmpty { return message }
+        if let detail = json["detail"] as? String, !detail.isEmpty { return detail }
+        return nil
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -89,7 +89,9 @@ enum TranscriptCleanupClient {
         case .some(.ollama):
             return true
         case .some(.lmStudio):
-            return !configuredModel(for: backend, config: config).isEmpty
+            let model = configuredModel(for: backend, config: config)
+            return !model.isEmpty
+                && MeetingSummaryClient.resolveLMStudioURL(config: cleanupConfig(config, model: model)) != nil
         case .some(.customLLM):
             let model = configuredModel(for: backend, config: config)
             let key = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -88,7 +88,7 @@ enum TranscriptCleanupClient {
             return !config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] != nil
         case .some(.ollama):
-            return true
+            return resolveConfiguredOllamaURL(config: config) != nil
         case .some(.lmStudio):
             let model = configuredModel(for: backend, config: config)
             return !model.isEmpty
@@ -285,10 +285,9 @@ enum TranscriptCleanupClient {
         model: String,
         config: AppConfig
     ) async throws -> String {
-        let rawURL = config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let baseURL = rawURL.isEmpty ? defaultOllamaBaseURL : URL(string: rawURL)
+        let baseURL = resolveConfiguredOllamaURL(config: config)
         guard let baseURL else {
-            throw TranscriptCleanupError.missingConfiguration("Invalid Ollama URL: \(rawURL)")
+            throw TranscriptCleanupError.missingConfiguration("Invalid Ollama URL: \(config.ollamaURL)")
         }
         let chatURL = baseURL.appendingPathComponent("api/chat")
         let body: [String: Any] = [
@@ -317,6 +316,22 @@ enum TranscriptCleanupClient {
             throw TranscriptCleanupError.emptyResponse("Ollama")
         }
         return text
+    }
+
+    private static func resolveConfiguredOllamaURL(config: AppConfig) -> URL? {
+        let rawURL = config.ollamaURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawURL.isEmpty else { return defaultOllamaBaseURL }
+        guard
+            let url = URL(string: rawURL),
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let scheme = components.scheme?.lowercased(),
+            scheme == "http" || scheme == "https",
+            let host = components.host,
+            !host.isEmpty
+        else {
+            return nil
+        }
+        return url
     }
 
     private static func cleanWithChatCompletions(

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -116,30 +116,31 @@ enum TranscriptCleanupClient {
 
         let model = configuredModel(for: backend, config: config)
         let userPrompt = Qwen3PostProcessorConfig.formatInput(text, appContext: appContext)
+        let effectiveSystemPrompt = systemPromptWithAppContextGuidance(systemPrompt, appContext: appContext)
         let raw: String
 
         switch llmBackend {
         case .chatGPT:
             raw = try await ChatGPTResponsesClient.respond(
-                systemPrompt: systemPrompt,
+                systemPrompt: effectiveSystemPrompt,
                 userPrompt: userPrompt,
                 model: model,
                 logCategory: "postproc"
             )
         case .openAI:
-            raw = try await cleanWithOpenAI(systemPrompt: systemPrompt, userPrompt: userPrompt, model: model, config: config)
+            raw = try await cleanWithOpenAI(systemPrompt: effectiveSystemPrompt, userPrompt: userPrompt, model: model, config: config)
         case .openRouter:
             let apiKey = resolvedOpenRouterAPIKey(config: config)
             raw = try await cleanWithChatCompletions(
                 backend: "OpenRouter",
                 requestURL: openRouterURL,
                 apiKey: apiKey,
-                systemPrompt: systemPrompt,
+                systemPrompt: effectiveSystemPrompt,
                 userPrompt: userPrompt,
                 model: model
             )
         case .ollama:
-            raw = try await cleanWithOllama(systemPrompt: systemPrompt, userPrompt: userPrompt, model: model, config: config)
+            raw = try await cleanWithOllama(systemPrompt: effectiveSystemPrompt, userPrompt: userPrompt, model: model, config: config)
         case .lmStudio:
             guard let requestURL = MeetingSummaryClient.resolveLMStudioURL(config: cleanupConfig(config, model: model)) else {
                 throw TranscriptCleanupError.missingConfiguration("Invalid LM Studio URL: \(config.lmStudioURL)")
@@ -148,7 +149,7 @@ enum TranscriptCleanupClient {
                 backend: "LM Studio",
                 requestURL: requestURL,
                 apiKey: "",
-                systemPrompt: systemPrompt,
+                systemPrompt: effectiveSystemPrompt,
                 userPrompt: userPrompt,
                 model: model
             )
@@ -163,7 +164,7 @@ enum TranscriptCleanupClient {
                     backend: "Custom LLM",
                     requestURL: requestURL,
                     apiKey: config.customLLMAPIKey,
-                    systemPrompt: systemPrompt,
+                    systemPrompt: effectiveSystemPrompt,
                     userPrompt: userPrompt,
                     model: model
                 )
@@ -171,7 +172,7 @@ enum TranscriptCleanupClient {
                 raw = try await cleanWithAnthropic(
                     requestURL: requestURL,
                     apiKey: config.customLLMAPIKey,
-                    systemPrompt: systemPrompt,
+                    systemPrompt: effectiveSystemPrompt,
                     userPrompt: userPrompt,
                     model: model
                 )
@@ -202,6 +203,16 @@ enum TranscriptCleanupClient {
         result = result.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    static func systemPromptWithAppContextGuidance(_ systemPrompt: String, appContext: String?) -> String {
+        guard let appContext, !appContext.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return systemPrompt
+        }
+        guard !systemPrompt.contains("<APP-CONTEXT>") else { return systemPrompt }
+        return systemPrompt + "\n\n" + appContextGuidance
+    }
+
+    private static let appContextGuidance = "The user input may include an <APP-CONTEXT> section with focused app, document, URL, or selected-text context. Use it only to resolve obvious transcription errors, names, acronyms, and formatting intent. Never copy app context into the output unless the user dictated it."
 
     static func resolvedOpenRouterAPIKey(
         config: AppConfig,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -95,8 +95,11 @@ enum TranscriptCleanupClient {
                 && MeetingSummaryClient.resolveLMStudioURL(config: cleanupConfig(config, model: model)) != nil
         case .some(.customLLM):
             let model = configuredModel(for: backend, config: config)
+            let format = CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI
             let key = config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
-            return !model.isEmpty && (!MeetingSummaryClient.customLLMRequiresAPIKey(config: config) || !key.isEmpty)
+            return !model.isEmpty
+                && resolveConfiguredCustomLLMURL(config: config, format: format) != nil
+                && (!MeetingSummaryClient.customLLMRequiresAPIKey(config: config) || !key.isEmpty)
         case nil:
             return true
         default:
@@ -160,7 +163,7 @@ enum TranscriptCleanupClient {
             )
         case .customLLM:
             let format = CustomLLMFormat(rawValue: config.customLLMFormat) ?? .openAI
-            guard let requestURL = MeetingSummaryClient.resolveCustomLLMURL(config: config, format: format) else {
+            guard let requestURL = resolveConfiguredCustomLLMURL(config: config, format: format) else {
                 throw TranscriptCleanupError.missingConfiguration("Invalid custom URL: \(config.customLLMURL)")
             }
             switch format {
@@ -231,6 +234,13 @@ enum TranscriptCleanupClient {
         var copy = config
         copy.lmStudioModel = model
         return copy
+    }
+
+    private static func resolveConfiguredCustomLLMURL(config: AppConfig, format: CustomLLMFormat) -> URL? {
+        guard !config.customLLMURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return MeetingSummaryClient.resolveCustomLLMURL(config: config, format: format)
     }
 
     private static func cleanWithOpenAI(

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -129,10 +129,11 @@ enum TranscriptCleanupClient {
         case .openAI:
             raw = try await cleanWithOpenAI(systemPrompt: systemPrompt, userPrompt: userPrompt, model: model, config: config)
         case .openRouter:
+            let apiKey = resolvedOpenRouterAPIKey(config: config)
             raw = try await cleanWithChatCompletions(
                 backend: "OpenRouter",
                 requestURL: openRouterURL,
-                apiKey: config.openRouterAPIKey,
+                apiKey: apiKey,
                 systemPrompt: systemPrompt,
                 userPrompt: userPrompt,
                 model: model
@@ -200,6 +201,14 @@ enum TranscriptCleanupClient {
         result = result.replacingOccurrences(of: #"[ \t]*\n[ \t]*"#, with: "\n", options: .regularExpression)
         result = result.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func resolvedOpenRouterAPIKey(
+        config: AppConfig,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        let key = config.openRouterAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return key.isEmpty ? (environment["OPENROUTER_API_KEY"] ?? "") : key
     }
 
     private static func cleanupConfig(_ config: AppConfig, model: String) -> AppConfig {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -32,6 +32,7 @@ enum TranscriptCleanupClient {
     private static let defaultOllamaBaseURL = URL(string: "http://localhost:11434")!
     private static let requestTimeout: TimeInterval = 120
     private static let defaultMaxOutputTokens = 1000
+    private static let hostedAppContextCharacterLimit = 5_000
 
     static func defaultModel(for backend: TranscriptCleanupBackendOption) -> String {
         switch backend.llmBackend {
@@ -115,7 +116,11 @@ enum TranscriptCleanupClient {
         }
 
         let model = configuredModel(for: backend, config: config)
-        let userPrompt = Qwen3PostProcessorConfig.formatInput(text, appContext: appContext)
+        let userPrompt = Qwen3PostProcessorConfig.formatInput(
+            text,
+            appContext: appContext,
+            maxAppContextCharacters: hostedAppContextCharacterLimit
+        )
         let effectiveSystemPrompt = systemPromptWithAppContextGuidance(systemPrompt, appContext: appContext)
         let raw: String
 
@@ -212,7 +217,7 @@ enum TranscriptCleanupClient {
         return systemPrompt + "\n\n" + appContextGuidance
     }
 
-    private static let appContextGuidance = "The user input may include an <APP-CONTEXT> section with focused app, document, URL, or selected-text context. Use it only to resolve obvious transcription errors, names, acronyms, and formatting intent. Never copy app context into the output unless the user dictated it."
+    private static let appContextGuidance = "The user input may include an <APP-CONTEXT> section with focused app, document, URL, selected text, or OCR screen text. Use it only to resolve obvious transcription errors, names, acronyms, and formatting intent. Never copy app context into the output unless the user dictated it."
 
     static func resolvedOpenRouterAPIKey(
         config: AppConfig,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
@@ -9,6 +9,7 @@ enum TranscriptCleanupDebugLogger {
         let cleanupBackend: String
         let cleanupModel: String
         let asrBackend: String
+        let appContextText: String?
         let rawASRText: String
         let rawCleanupOutputText: String?
         let cleanupOutputText: String?
@@ -21,6 +22,7 @@ enum TranscriptCleanupDebugLogger {
         cleanupBackend: TranscriptCleanupBackendOption,
         cleanupModel: String,
         asrBackend: String,
+        appContextText: String? = nil,
         rawASRText: String,
         rawCleanupOutputText: String? = nil,
         cleanupOutputText: String? = nil,
@@ -36,6 +38,7 @@ enum TranscriptCleanupDebugLogger {
             cleanupBackend: cleanupBackend.backend,
             cleanupModel: cleanupModel,
             asrBackend: asrBackend,
+            appContextText: appContextText,
             rawASRText: rawASRText,
             rawCleanupOutputText: rawCleanupOutputText,
             cleanupOutputText: cleanupOutputText,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum TranscriptCleanupDebugLogger {
+    private static let logEnv = "MUESLI_LOG_TRANSCRIPT_CLEANUP_DEBUG"
+
+    struct Entry: Encodable {
+        let ts: String
+        let status: String
+        let cleanupBackend: String
+        let cleanupModel: String
+        let asrBackend: String
+        let rawASRText: String
+        let rawCleanupOutputText: String?
+        let cleanupOutputText: String?
+        let errorDescription: String?
+        let elapsedMs: Double?
+    }
+
+    static func append(
+        status: String,
+        cleanupBackend: TranscriptCleanupBackendOption,
+        cleanupModel: String,
+        asrBackend: String,
+        rawASRText: String,
+        rawCleanupOutputText: String? = nil,
+        cleanupOutputText: String? = nil,
+        errorDescription: String? = nil,
+        elapsedMs: Double? = nil
+    ) {
+        guard isEnabled else { return }
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let entry = Entry(
+            ts: iso8601.string(from: Date()),
+            status: status,
+            cleanupBackend: cleanupBackend.backend,
+            cleanupModel: cleanupModel,
+            asrBackend: asrBackend,
+            rawASRText: rawASRText,
+            rawCleanupOutputText: rawCleanupOutputText,
+            cleanupOutputText: cleanupOutputText,
+            errorDescription: errorDescription,
+            elapsedMs: elapsedMs
+        )
+        append(entry, to: AppIdentity.supportDirectoryURL.appendingPathComponent("transcript-cleanup-debug.jsonl"))
+    }
+
+    private static var isEnabled: Bool {
+        let raw = ProcessInfo.processInfo.environment[logEnv]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "yes" || Qwen3PostProcessorLogging.isPairLoggingEnabled
+    }
+
+    private static func append(_ entry: Entry, to logURL: URL) {
+        guard var data = try? JSONEncoder().encode(entry) else { return }
+        data.append(0x0A)
+        try? FileManager.default.createDirectory(at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: logURL.path),
+           let fh = try? FileHandle(forWritingTo: logURL) {
+            defer { try? fh.close() }
+            fh.seekToEndOfFile()
+            fh.write(data)
+        } else {
+            try? data.write(to: logURL, options: .atomic)
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupDebugLogger.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum TranscriptCleanupDebugLogger {
     private static let logEnv = "MUESLI_LOG_TRANSCRIPT_CLEANUP_DEBUG"
+    private static let maxLoggedTextCharacters = 4_000
+    private static let maxLogFileBytes: UInt64 = 5 * 1024 * 1024
+    private static let writeQueue = DispatchQueue(label: "MuesliNative.TranscriptCleanupDebugLogger")
 
     struct Entry: Encodable {
         let ts: String
@@ -38,10 +41,10 @@ enum TranscriptCleanupDebugLogger {
             cleanupBackend: cleanupBackend.backend,
             cleanupModel: cleanupModel,
             asrBackend: asrBackend,
-            appContextText: appContextText,
-            rawASRText: rawASRText,
-            rawCleanupOutputText: rawCleanupOutputText,
-            cleanupOutputText: cleanupOutputText,
+            appContextText: appContextText.map(bounded),
+            rawASRText: bounded(rawASRText),
+            rawCleanupOutputText: rawCleanupOutputText.map(bounded),
+            cleanupOutputText: cleanupOutputText.map(bounded),
             errorDescription: errorDescription,
             elapsedMs: elapsedMs
         )
@@ -54,16 +57,33 @@ enum TranscriptCleanupDebugLogger {
     }
 
     private static func append(_ entry: Entry, to logURL: URL) {
-        guard var data = try? JSONEncoder().encode(entry) else { return }
-        data.append(0x0A)
-        try? FileManager.default.createDirectory(at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        if FileManager.default.fileExists(atPath: logURL.path),
-           let fh = try? FileHandle(forWritingTo: logURL) {
-            defer { try? fh.close() }
-            fh.seekToEndOfFile()
-            fh.write(data)
-        } else {
-            try? data.write(to: logURL, options: .atomic)
+        writeQueue.sync {
+            guard var data = try? JSONEncoder().encode(entry) else { return }
+            data.append(0x0A)
+            try? FileManager.default.createDirectory(at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            rotateIfNeeded(logURL)
+            if FileManager.default.fileExists(atPath: logURL.path),
+               let fh = try? FileHandle(forWritingTo: logURL) {
+                defer { try? fh.close() }
+                fh.seekToEndOfFile()
+                fh.write(data)
+            } else {
+                try? data.write(to: logURL, options: .atomic)
+            }
         }
+    }
+
+    private static func bounded(_ text: String) -> String {
+        guard text.count > maxLoggedTextCharacters else { return text }
+        return "\(text.prefix(maxLoggedTextCharacters))...[truncated]"
+    }
+
+    private static func rotateIfNeeded(_ logURL: URL) {
+        guard
+            let attributes = try? FileManager.default.attributesOfItem(atPath: logURL.path),
+            let size = attributes[.size] as? UInt64,
+            size > maxLogFileBytes
+        else { return }
+        try? FileManager.default.removeItem(at: logURL)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupPromptsManagerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupPromptsManagerView.swift
@@ -9,7 +9,7 @@ struct TranscriptCleanupPromptsManagerView: View {
     @State private var editingPromptID: String?
     @State private var draftPromptName = ""
     @State private var draftPrompt = ""
-    @State private var showNameValidationError = false
+    @State private var nameValidationMessage: String?
     @State private var showPromptValidationError = false
     @State private var promptToDelete: CustomTranscriptCleanupPrompt?
 
@@ -248,17 +248,17 @@ struct TranscriptCleanupPromptsManagerView: View {
                     .overlay {
                         RoundedRectangle(cornerRadius: 6)
                             .strokeBorder(
-                                showNameValidationError ? MuesliTheme.recording.opacity(0.75) : .clear,
+                                nameValidationMessage == nil ? .clear : MuesliTheme.recording.opacity(0.75),
                                 lineWidth: 1
                             )
                     }
                     .onChange(of: draftPromptName) { _, newValue in
                         if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            showNameValidationError = false
+                            nameValidationMessage = nil
                         }
                     }
-                if showNameValidationError {
-                    Text("Enter a preset name.")
+                if let nameValidationMessage {
+                    Text(nameValidationMessage)
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.recording)
                 }
@@ -318,14 +318,14 @@ struct TranscriptCleanupPromptsManagerView: View {
         isCreatingPrompt = true
         editingPromptID = nil
         draftPromptName = ""
-        draftPrompt = appState.config.postProcessorSystemPrompt
+        draftPrompt = ""
         clearValidationErrors()
     }
 
     private func beginDuplicatingPrompt(name: String, prompt: String) {
         isCreatingPrompt = true
         editingPromptID = nil
-        draftPromptName = "Copy of \(name)"
+        draftPromptName = suggestedUniqueName(for: "\(name) Copy")
         draftPrompt = prompt
         clearValidationErrors()
     }
@@ -349,9 +349,14 @@ struct TranscriptCleanupPromptsManagerView: View {
     private func savePromptEditor() {
         let trimmedName = draftPromptName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPrompt = draftPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        showNameValidationError = trimmedName.isEmpty
+        nameValidationMessage = nil
         showPromptValidationError = trimmedPrompt.isEmpty
-        guard !trimmedName.isEmpty, !trimmedPrompt.isEmpty else { return }
+        if trimmedName.isEmpty {
+            nameValidationMessage = "Enter a preset name."
+        } else if presetNameExists(trimmedName, excludingID: editingPromptID) {
+            nameValidationMessage = "Use a unique preset name."
+        }
+        guard nameValidationMessage == nil, !trimmedPrompt.isEmpty else { return }
 
         if let editingPromptID {
             controller.updateTranscriptCleanupPrompt(
@@ -373,8 +378,39 @@ struct TranscriptCleanupPromptsManagerView: View {
     }
 
     private func clearValidationErrors() {
-        showNameValidationError = false
+        nameValidationMessage = nil
         showPromptValidationError = false
+    }
+
+    private func presetNameExists(_ name: String, excludingID: String?) -> Bool {
+        let normalizedName = normalizedPresetName(name)
+        if builtInPresets.contains(where: { normalizedPresetName($0.name) == normalizedName }) {
+            return true
+        }
+        return customPresets.contains { preset in
+            preset.id != excludingID && normalizedPresetName(preset.name) == normalizedName
+        }
+    }
+
+    private func suggestedUniqueName(for baseName: String) -> String {
+        let trimmedBase = baseName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackBase = trimmedBase.isEmpty ? "Custom Cleanup" : trimmedBase
+        if !presetNameExists(fallbackBase, excludingID: nil) {
+            return fallbackBase
+        }
+        for suffix in 2...99 {
+            let candidate = "\(fallbackBase) \(suffix)"
+            if !presetNameExists(candidate, excludingID: nil) {
+                return candidate
+            }
+        }
+        return "\(fallbackBase) \(UUID().uuidString.prefix(4))"
+    }
+
+    private func normalizedPresetName(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .lowercased()
     }
 
     private func actionButton(

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupPromptsManagerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupPromptsManagerView.swift
@@ -1,0 +1,411 @@
+import SwiftUI
+
+struct TranscriptCleanupPromptsManagerView: View {
+    let appState: AppState
+    let controller: MuesliController
+    let onClose: () -> Void
+
+    @State private var isCreatingPrompt = false
+    @State private var editingPromptID: String?
+    @State private var draftPromptName = ""
+    @State private var draftPrompt = ""
+    @State private var showNameValidationError = false
+    @State private var showPromptValidationError = false
+    @State private var promptToDelete: CustomTranscriptCleanupPrompt?
+
+    private var activePromptID: String {
+        appState.config.activeTranscriptCleanupPromptId
+    }
+
+    private var builtInPresets: [TranscriptCleanupPromptPreset] {
+        TranscriptCleanupPrompts.builtIns
+    }
+
+    private var customPresets: [CustomTranscriptCleanupPrompt] {
+        appState.config.customTranscriptCleanupPrompts
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+            header
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+                    presetSection(title: "Built-in Presets") {
+                        VStack(spacing: MuesliTheme.spacing8) {
+                            ForEach(builtInPresets) { preset in
+                                builtInPresetRow(preset)
+                            }
+                        }
+                    }
+
+                    presetSection(title: "Custom Presets") {
+                        if customPresets.isEmpty {
+                            emptyState
+                        } else {
+                            VStack(spacing: MuesliTheme.spacing8) {
+                                ForEach(customPresets) { preset in
+                                    customPresetRow(preset)
+                                }
+                            }
+                        }
+                    }
+
+                    if isCreatingPrompt || editingPromptID != nil {
+                        promptEditor
+                    }
+                }
+                .padding(.bottom, MuesliTheme.spacing4)
+            }
+        }
+        .padding(MuesliTheme.spacing24)
+        .frame(minWidth: 760, minHeight: 560)
+        .background(MuesliTheme.backgroundBase)
+        .alert(
+            "Delete \"\(promptToDelete?.name ?? "")\"?",
+            isPresented: Binding(
+                get: { promptToDelete != nil },
+                set: { if !$0 { promptToDelete = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                promptToDelete = nil
+            }
+            Button("Delete", role: .destructive) {
+                guard let preset = promptToDelete else { return }
+                controller.deleteTranscriptCleanupPrompt(id: preset.id)
+                if editingPromptID == preset.id {
+                    resetPromptEditor()
+                }
+                promptToDelete = nil
+            }
+        } message: {
+            Text("This prompt preset will be permanently removed. Existing dictations are not affected.")
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Manage Cleanup Presets")
+                    .font(MuesliTheme.title2())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text("Create reusable prompts for local and cloud dictation cleanup.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+
+            Spacer()
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                if isCreatingPrompt || editingPromptID != nil {
+                    actionButton("Cancel", systemImage: "xmark") {
+                        resetPromptEditor()
+                    }
+                } else {
+                    actionButton("New preset", systemImage: "plus") {
+                        beginCreatingPrompt()
+                    }
+                }
+
+                actionButton("Done", systemImage: "checkmark") {
+                    onClose()
+                }
+                .disabled(isEditingPromptInProgress)
+                .opacity(isEditingPromptInProgress ? 0.55 : 1)
+                .help(isEditingPromptInProgress ? "Finish or cancel prompt editing before closing." : "Close prompt manager")
+            }
+        }
+    }
+
+    private func presetSection<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Text(title.uppercased())
+                .font(MuesliTheme.captionMedium())
+                .foregroundStyle(MuesliTheme.textTertiary)
+            content()
+        }
+    }
+
+    private var emptyState: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: "text.badge.plus")
+                .font(.system(size: 11))
+                .foregroundStyle(MuesliTheme.textTertiary)
+            Text("No custom cleanup presets yet.")
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textTertiary)
+        }
+        .padding(.horizontal, MuesliTheme.spacing12)
+        .padding(.vertical, 10)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private func builtInPresetRow(_ preset: TranscriptCleanupPromptPreset) -> some View {
+        presetRow(
+            name: preset.name,
+            prompt: preset.prompt,
+            isActive: activePromptID == preset.id,
+            systemImage: "sparkles"
+        ) {
+            actionButton("Use", systemImage: "checkmark") {
+                controller.selectTranscriptCleanupPrompt(id: preset.id)
+            }
+            .disabled(activePromptID == preset.id)
+
+            actionButton("Duplicate", systemImage: "doc.on.doc") {
+                beginDuplicatingPrompt(name: preset.name, prompt: preset.prompt)
+            }
+        }
+    }
+
+    private func customPresetRow(_ preset: CustomTranscriptCleanupPrompt) -> some View {
+        presetRow(
+            name: preset.name,
+            prompt: preset.prompt,
+            isActive: activePromptID == preset.id,
+            systemImage: "text.badge.checkmark"
+        ) {
+            actionButton("Use", systemImage: "checkmark") {
+                controller.selectTranscriptCleanupPrompt(id: preset.id)
+            }
+            .disabled(activePromptID == preset.id)
+
+            actionButton("Edit", systemImage: "pencil") {
+                beginEditingPrompt(preset)
+            }
+
+            actionButton("Delete", systemImage: "trash", role: .destructive) {
+                promptToDelete = preset
+            }
+        }
+    }
+
+    private func presetRow<Actions: View>(
+        name: String,
+        prompt: String,
+        isActive: Bool,
+        systemImage: String,
+        @ViewBuilder actions: () -> Actions
+    ) -> some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Image(systemName: systemImage)
+                            .font(.system(size: 10))
+                            .foregroundStyle(MuesliTheme.accent)
+                        Text(name)
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                        if isActive {
+                            Text("Active")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(MuesliTheme.accent)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(MuesliTheme.accentSubtle)
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        }
+                    }
+                    Text(prompt)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .lineLimit(2)
+                }
+                Spacer()
+                HStack(spacing: MuesliTheme.spacing8) {
+                    actions()
+                }
+            }
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(isActive ? MuesliTheme.accent.opacity(0.35) : MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private var promptEditor: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            Text(isCreatingPrompt ? "New preset" : "Edit preset")
+                .font(MuesliTheme.captionMedium())
+                .foregroundStyle(MuesliTheme.textPrimary)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Name")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                TextField("Context-aware cleanup", text: $draftPromptName)
+                    .textFieldStyle(.roundedBorder)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(
+                                showNameValidationError ? MuesliTheme.recording.opacity(0.75) : .clear,
+                                lineWidth: 1
+                            )
+                    }
+                    .onChange(of: draftPromptName) { _, newValue in
+                        if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            showNameValidationError = false
+                        }
+                    }
+                if showNameValidationError {
+                    Text("Enter a preset name.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.recording)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Prompt")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                TextEditor(text: $draftPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 180)
+                    .padding(MuesliTheme.spacing8)
+                    .background(MuesliTheme.backgroundBase)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                            .strokeBorder(
+                                showPromptValidationError ? MuesliTheme.recording.opacity(0.75) : MuesliTheme.surfaceBorder,
+                                lineWidth: 1
+                            )
+                    )
+                    .onChange(of: draftPrompt) { _, newValue in
+                        if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            showPromptValidationError = false
+                        }
+                    }
+                if showPromptValidationError {
+                    Text("Enter cleanup instructions for this preset.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.recording)
+                }
+            }
+
+            HStack {
+                Spacer()
+                actionButton(
+                    isCreatingPrompt ? "Create preset" : "Save changes",
+                    systemImage: isCreatingPrompt ? "plus.circle" : "checkmark.circle"
+                ) {
+                    savePromptEditor()
+                }
+            }
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.surfacePrimary.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+
+    private func beginCreatingPrompt() {
+        isCreatingPrompt = true
+        editingPromptID = nil
+        draftPromptName = ""
+        draftPrompt = appState.config.postProcessorSystemPrompt
+        clearValidationErrors()
+    }
+
+    private func beginDuplicatingPrompt(name: String, prompt: String) {
+        isCreatingPrompt = true
+        editingPromptID = nil
+        draftPromptName = "Copy of \(name)"
+        draftPrompt = prompt
+        clearValidationErrors()
+    }
+
+    private func beginEditingPrompt(_ preset: CustomTranscriptCleanupPrompt) {
+        isCreatingPrompt = false
+        editingPromptID = preset.id
+        draftPromptName = preset.name
+        draftPrompt = preset.prompt
+        clearValidationErrors()
+    }
+
+    private func resetPromptEditor() {
+        isCreatingPrompt = false
+        editingPromptID = nil
+        draftPromptName = ""
+        draftPrompt = ""
+        clearValidationErrors()
+    }
+
+    private func savePromptEditor() {
+        let trimmedName = draftPromptName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPrompt = draftPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        showNameValidationError = trimmedName.isEmpty
+        showPromptValidationError = trimmedPrompt.isEmpty
+        guard !trimmedName.isEmpty, !trimmedPrompt.isEmpty else { return }
+
+        if let editingPromptID {
+            controller.updateTranscriptCleanupPrompt(
+                id: editingPromptID,
+                name: trimmedName,
+                prompt: trimmedPrompt
+            )
+        } else {
+            controller.createTranscriptCleanupPrompt(
+                name: trimmedName,
+                prompt: trimmedPrompt
+            )
+        }
+        resetPromptEditor()
+    }
+
+    private var isEditingPromptInProgress: Bool {
+        isCreatingPrompt || editingPromptID != nil
+    }
+
+    private func clearValidationErrors() {
+        showNameValidationError = false
+        showPromptValidationError = false
+    }
+
+    private func actionButton(
+        _ title: String,
+        systemImage: String? = nil,
+        role: ButtonRole? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        let isDestructive = role == .destructive
+        return Button(role: role, action: action) {
+            HStack(spacing: 6) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(isDestructive ? MuesliTheme.recording : MuesliTheme.textPrimary)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .frame(height: 28)
+            .background(isDestructive ? MuesliTheme.recording.opacity(0.1) : MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(
+                        isDestructive ? MuesliTheme.recording.opacity(0.2) : MuesliTheme.surfaceBorder,
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -614,6 +614,18 @@ actor TranscriptionCoordinator {
                 text: trimmed,
                 segments: Qwen3PostProcessorLogging.isVerboseEnabled && !trimmed.isEmpty ? result.segments : []
             )
+        } catch TranscriptCleanupError.rejectedOutput {
+            Qwen3PostProcessorLogging.logVerbose("\(postProcessorSnapshot.backend.label) post-processor output rejected, falling back")
+            TranscriptCleanupDebugLogger.append(
+                status: "fallback_rejected_output",
+                cleanupBackend: postProcessorSnapshot.backend,
+                cleanupModel: postProcessorSnapshot.modelId,
+                asrBackend: backend.backend,
+                appContextText: appContext,
+                rawASRText: result.text,
+                errorDescription: TranscriptCleanupError.rejectedOutput.localizedDescription
+            )
+            return nil
         } catch {
             Qwen3PostProcessorLogging.logVerbose("\(postProcessorSnapshot.backend.label) post-processor failed, falling back: \(error)")
             TranscriptCleanupDebugLogger.append(

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -93,6 +93,13 @@ actor TranscriptionCoordinator {
     private var postProcessorBackend: TranscriptCleanupBackendOption = .local
     private var postProcessorConfig: AppConfig = AppConfig()
 
+    private struct PostProcessorSnapshot {
+        let backend: TranscriptCleanupBackendOption
+        let systemPrompt: String
+        let modelId: String
+        let config: AppConfig
+    }
+
     @available(macOS 15, *)
     private var qwen3PostProcessor: Qwen3PostProcessor {
         if _qwen3PostProcessor == nil {
@@ -143,7 +150,7 @@ actor TranscriptionCoordinator {
         let asr: String
     }
 
-    private func logPostProcPair(raw: String, processed: String, asr: String) {
+    private func logPostProcPair(raw: String, processed: String, model: String, asr: String) {
         guard Qwen3PostProcessorLogging.isPairLoggingEnabled else { return }
         let logURL = AppIdentity.supportDirectoryURL.appendingPathComponent("postproc-pairs.jsonl")
         let iso8601 = ISO8601DateFormatter()
@@ -153,7 +160,7 @@ actor TranscriptionCoordinator {
             ts: ts,
             raw: raw,
             processed: processed,
-            model: postProcessorModelId,
+            model: model,
             asr: asr
         )
         guard var data = try? JSONEncoder().encode(entry) else { return }
@@ -318,6 +325,15 @@ actor TranscriptionCoordinator {
         }
     }
 
+    private func currentPostProcessorSnapshot() -> PostProcessorSnapshot {
+        PostProcessorSnapshot(
+            backend: postProcessorBackend,
+            systemPrompt: postProcessorSystemPrompt,
+            modelId: postProcessorModelId,
+            config: postProcessorConfig
+        )
+    }
+
     func transcribeDictation(
         at url: URL,
         backend: BackendOption,
@@ -327,6 +343,7 @@ actor TranscriptionCoordinator {
         customWords: [[String: Any]] = [],
         appContext: String? = nil
     ) async throws -> SpeechTranscriptionResult {
+        let postProcessorSnapshot = currentPostProcessorSnapshot()
         // Qwen3 post-processing is intentionally dictation-only. Meeting transcription should keep raw backend/Parakeet output.
         // Cohere decodes hallucinated text from silence — skip if VAD detects no speech
         if backend.backend == "cohere", let vadManager {
@@ -350,6 +367,7 @@ actor TranscriptionCoordinator {
             result,
             backend: backend,
             enabled: enablePostProcessor,
+            postProcessorSnapshot: postProcessorSnapshot,
             appContext: appContext
         ) ?? removeFillersWithLogging(result)
         let final = applyCustomWords(result, customWords: customWords)
@@ -462,6 +480,7 @@ actor TranscriptionCoordinator {
         _ result: SpeechTranscriptionResult,
         backend: BackendOption,
         enabled: Bool,
+        postProcessorSnapshot: PostProcessorSnapshot,
         appContext: String? = nil
     ) async -> SpeechTranscriptionResult? {
         guard enabled else {
@@ -476,10 +495,11 @@ actor TranscriptionCoordinator {
             Qwen3PostProcessorLogging.logVerbose("Post-processor skipped: empty transcript")
             return nil
         }
-        if !postProcessorBackend.isLocal {
+        if !postProcessorSnapshot.backend.isLocal {
             return await postProcessDictationWithHostedBackend(
                 result,
                 backend: backend,
+                postProcessorSnapshot: postProcessorSnapshot,
                 appContext: appContext
             )
         }
@@ -500,8 +520,8 @@ actor TranscriptionCoordinator {
                 Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
                 TranscriptCleanupDebugLogger.append(
                     status: "fallback_empty_output",
-                    cleanupBackend: postProcessorBackend,
-                    cleanupModel: postProcessorModelId,
+                    cleanupBackend: postProcessorSnapshot.backend,
+                    cleanupModel: postProcessorSnapshot.modelId,
                     asrBackend: backend.backend,
                     appContextText: appContext,
                     rawASRText: result.text,
@@ -513,11 +533,11 @@ actor TranscriptionCoordinator {
             }
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor final output: \(trimmed)")
-            logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
+            logPostProcPair(raw: result.text, processed: trimmed, model: postProcessorSnapshot.modelId, asr: backend.backend)
             TranscriptCleanupDebugLogger.append(
                 status: "applied",
-                cleanupBackend: postProcessorBackend,
-                cleanupModel: postProcessorModelId,
+                cleanupBackend: postProcessorSnapshot.backend,
+                cleanupModel: postProcessorSnapshot.modelId,
                 asrBackend: backend.backend,
                 appContextText: appContext,
                 rawASRText: result.text,
@@ -534,8 +554,8 @@ actor TranscriptionCoordinator {
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor failed, falling back: \(error)")
             TranscriptCleanupDebugLogger.append(
                 status: "fallback_error",
-                cleanupBackend: postProcessorBackend,
-                cleanupModel: postProcessorModelId,
+                cleanupBackend: postProcessorSnapshot.backend,
+                cleanupModel: postProcessorSnapshot.modelId,
                 asrBackend: backend.backend,
                 appContextText: appContext,
                 rawASRText: result.text,
@@ -548,24 +568,25 @@ actor TranscriptionCoordinator {
     private func postProcessDictationWithHostedBackend(
         _ result: SpeechTranscriptionResult,
         backend: BackendOption,
+        postProcessorSnapshot: PostProcessorSnapshot,
         appContext: String?
     ) async -> SpeechTranscriptionResult? {
         do {
             let start = CFAbsoluteTimeGetCurrent()
             let cleanup = try await TranscriptCleanupClient.clean(
                 text: result.text,
-                systemPrompt: postProcessorSystemPrompt,
+                systemPrompt: postProcessorSnapshot.systemPrompt,
                 appContext: appContext,
-                backend: postProcessorBackend,
-                config: postProcessorConfig
+                backend: postProcessorSnapshot.backend,
+                config: postProcessorSnapshot.config
             )
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
             let trimmed = cleanup.cleanedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
-                Qwen3PostProcessorLogging.logVerbose("\(postProcessorBackend.label) post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
+                Qwen3PostProcessorLogging.logVerbose("\(postProcessorSnapshot.backend.label) post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
                 TranscriptCleanupDebugLogger.append(
                     status: "fallback_empty_output",
-                    cleanupBackend: postProcessorBackend,
+                    cleanupBackend: postProcessorSnapshot.backend,
                     cleanupModel: cleanup.model,
                     asrBackend: backend.backend,
                     appContextText: appContext,
@@ -576,11 +597,11 @@ actor TranscriptionCoordinator {
                 )
                 return nil
             }
-            Qwen3PostProcessorLogging.logVerbose("\(postProcessorBackend.label) post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
-            logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
+            Qwen3PostProcessorLogging.logVerbose("\(postProcessorSnapshot.backend.label) post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
+            logPostProcPair(raw: result.text, processed: trimmed, model: cleanup.model, asr: backend.backend)
             TranscriptCleanupDebugLogger.append(
                 status: "applied",
-                cleanupBackend: postProcessorBackend,
+                cleanupBackend: postProcessorSnapshot.backend,
                 cleanupModel: cleanup.model,
                 asrBackend: backend.backend,
                 appContextText: appContext,
@@ -594,11 +615,11 @@ actor TranscriptionCoordinator {
                 segments: Qwen3PostProcessorLogging.isVerboseEnabled && !trimmed.isEmpty ? result.segments : []
             )
         } catch {
-            Qwen3PostProcessorLogging.logVerbose("\(postProcessorBackend.label) post-processor failed, falling back: \(error)")
+            Qwen3PostProcessorLogging.logVerbose("\(postProcessorSnapshot.backend.label) post-processor failed, falling back: \(error)")
             TranscriptCleanupDebugLogger.append(
                 status: "fallback_error",
-                cleanupBackend: postProcessorBackend,
-                cleanupModel: postProcessorModelId,
+                cleanupBackend: postProcessorSnapshot.backend,
+                cleanupModel: postProcessorSnapshot.modelId,
                 asrBackend: backend.backend,
                 appContextText: appContext,
                 rawASRText: result.text,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -503,6 +503,7 @@ actor TranscriptionCoordinator {
                     cleanupBackend: postProcessorBackend,
                     cleanupModel: postProcessorModelId,
                     asrBackend: backend.backend,
+                    appContextText: appContext,
                     rawASRText: result.text,
                     rawCleanupOutputText: processed,
                     cleanupOutputText: trimmed,
@@ -518,6 +519,7 @@ actor TranscriptionCoordinator {
                 cleanupBackend: postProcessorBackend,
                 cleanupModel: postProcessorModelId,
                 asrBackend: backend.backend,
+                appContextText: appContext,
                 rawASRText: result.text,
                 rawCleanupOutputText: processed,
                 cleanupOutputText: trimmed,
@@ -535,6 +537,7 @@ actor TranscriptionCoordinator {
                 cleanupBackend: postProcessorBackend,
                 cleanupModel: postProcessorModelId,
                 asrBackend: backend.backend,
+                appContextText: appContext,
                 rawASRText: result.text,
                 errorDescription: String(describing: error)
             )
@@ -565,6 +568,7 @@ actor TranscriptionCoordinator {
                     cleanupBackend: postProcessorBackend,
                     cleanupModel: cleanup.model,
                     asrBackend: backend.backend,
+                    appContextText: appContext,
                     rawASRText: result.text,
                     rawCleanupOutputText: cleanup.rawOutput,
                     cleanupOutputText: trimmed,
@@ -579,6 +583,7 @@ actor TranscriptionCoordinator {
                 cleanupBackend: postProcessorBackend,
                 cleanupModel: cleanup.model,
                 asrBackend: backend.backend,
+                appContextText: appContext,
                 rawASRText: result.text,
                 rawCleanupOutputText: cleanup.rawOutput,
                 cleanupOutputText: trimmed,
@@ -595,6 +600,7 @@ actor TranscriptionCoordinator {
                 cleanupBackend: postProcessorBackend,
                 cleanupModel: postProcessorModelId,
                 asrBackend: backend.backend,
+                appContextText: appContext,
                 rawASRText: result.text,
                 errorDescription: String(describing: error)
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -90,6 +90,8 @@ actor TranscriptionCoordinator {
     private var postProcessorModelURL: URL = PostProcessorOption.defaultOption.modelURL
     private var postProcessorSystemPrompt: String = PostProcessorOption.defaultSystemPrompt
     private var postProcessorModelId: String = PostProcessorOption.defaultOption.id
+    private var postProcessorBackend: TranscriptCleanupBackendOption = .local
+    private var postProcessorConfig: AppConfig = AppConfig()
 
     @available(macOS 15, *)
     private var qwen3PostProcessor: Qwen3PostProcessor {
@@ -104,11 +106,32 @@ actor TranscriptionCoordinator {
 
     @available(macOS 15, *)
     func setActivePostProcessor(option: PostProcessorOption, systemPrompt: String) async {
-        postProcessorModelURL = option.modelURL
+        await configurePostProcessor(
+            backend: .local,
+            option: option,
+            systemPrompt: systemPrompt,
+            config: postProcessorConfig
+        )
+    }
+
+    func configurePostProcessor(
+        backend: TranscriptCleanupBackendOption,
+        option: PostProcessorOption?,
+        systemPrompt: String,
+        config: AppConfig
+    ) async {
+        postProcessorBackend = backend
         postProcessorSystemPrompt = systemPrompt
-        postProcessorModelId = option.id
-        if let existing = _qwen3PostProcessor as? Qwen3PostProcessor {
-            await existing.reconfigure(modelURL: option.modelURL, systemPrompt: systemPrompt)
+        postProcessorConfig = config
+
+        if let option {
+            postProcessorModelURL = option.modelURL
+            postProcessorModelId = option.id
+            if #available(macOS 15, *), let existing = _qwen3PostProcessor as? Qwen3PostProcessor {
+                await existing.reconfigure(modelURL: option.modelURL, systemPrompt: systemPrompt)
+            }
+        } else if !backend.isLocal {
+            postProcessorModelId = TranscriptCleanupClient.configuredModel(for: backend, config: config)
         }
     }
 
@@ -286,7 +309,7 @@ actor TranscriptionCoordinator {
     }
 
     func preloadPostProcessorIfNeeded(enabled: Bool) async {
-        if enabled, #available(macOS 15, *) {
+        if enabled, postProcessorBackend == .local, #available(macOS 15, *) {
             do {
                 try await qwen3PostProcessor.prepare()
             } catch {
@@ -450,8 +473,15 @@ actor TranscriptionCoordinator {
             return nil
         }
         guard !result.text.isEmpty else {
-            Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor skipped: empty transcript")
+            Qwen3PostProcessorLogging.logVerbose("Post-processor skipped: empty transcript")
             return nil
+        }
+        if !postProcessorBackend.isLocal {
+            return await postProcessDictationWithHostedBackend(
+                result,
+                backend: backend,
+                appContext: appContext
+            )
         }
         guard #available(macOS 15, *) else {
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor skipped: requires macOS 15+")
@@ -468,11 +498,31 @@ actor TranscriptionCoordinator {
             let trimmed = processed.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
                 Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
+                TranscriptCleanupDebugLogger.append(
+                    status: "fallback_empty_output",
+                    cleanupBackend: postProcessorBackend,
+                    cleanupModel: postProcessorModelId,
+                    asrBackend: backend.backend,
+                    rawASRText: result.text,
+                    rawCleanupOutputText: processed,
+                    cleanupOutputText: trimmed,
+                    elapsedMs: elapsedMs
+                )
                 return nil
             }
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor final output: \(trimmed)")
             logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
+            TranscriptCleanupDebugLogger.append(
+                status: "applied",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                rawCleanupOutputText: processed,
+                cleanupOutputText: trimmed,
+                elapsedMs: elapsedMs
+            )
             return SpeechTranscriptionResult(
                 text: trimmed,
                 // Original ASR segments describe pre-cleanup text. Keep them only for debug diagnostics.
@@ -480,6 +530,74 @@ actor TranscriptionCoordinator {
             )
         } catch {
             Qwen3PostProcessorLogging.logVerbose("Qwen3 post-processor failed, falling back: \(error)")
+            TranscriptCleanupDebugLogger.append(
+                status: "fallback_error",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                errorDescription: String(describing: error)
+            )
+            return nil
+        }
+    }
+
+    private func postProcessDictationWithHostedBackend(
+        _ result: SpeechTranscriptionResult,
+        backend: BackendOption,
+        appContext: String?
+    ) async -> SpeechTranscriptionResult? {
+        do {
+            let start = CFAbsoluteTimeGetCurrent()
+            let cleanup = try await TranscriptCleanupClient.clean(
+                text: result.text,
+                systemPrompt: postProcessorSystemPrompt,
+                appContext: appContext,
+                backend: postProcessorBackend,
+                config: postProcessorConfig
+            )
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            let trimmed = cleanup.cleanedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty, !Qwen3DeletionCueDetector.containsDeletionCue(result.text) {
+                Qwen3PostProcessorLogging.logVerbose("\(postProcessorBackend.label) post-processor returned empty output in \(String(format: "%.1f", elapsedMs))ms; falling back")
+                TranscriptCleanupDebugLogger.append(
+                    status: "fallback_empty_output",
+                    cleanupBackend: postProcessorBackend,
+                    cleanupModel: cleanup.model,
+                    asrBackend: backend.backend,
+                    rawASRText: result.text,
+                    rawCleanupOutputText: cleanup.rawOutput,
+                    cleanupOutputText: trimmed,
+                    elapsedMs: elapsedMs
+                )
+                return nil
+            }
+            Qwen3PostProcessorLogging.logVerbose("\(postProcessorBackend.label) post-processor applied to \(backend.label) in \(String(format: "%.1f", elapsedMs))ms (chars=\(trimmed.count))")
+            logPostProcPair(raw: result.text, processed: trimmed, asr: backend.backend)
+            TranscriptCleanupDebugLogger.append(
+                status: "applied",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: cleanup.model,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                rawCleanupOutputText: cleanup.rawOutput,
+                cleanupOutputText: trimmed,
+                elapsedMs: elapsedMs
+            )
+            return SpeechTranscriptionResult(
+                text: trimmed,
+                segments: Qwen3PostProcessorLogging.isVerboseEnabled && !trimmed.isEmpty ? result.segments : []
+            )
+        } catch {
+            Qwen3PostProcessorLogging.logVerbose("\(postProcessorBackend.label) post-processor failed, falling back: \(error)")
+            TranscriptCleanupDebugLogger.append(
+                status: "fallback_error",
+                cleanupBackend: postProcessorBackend,
+                cleanupModel: postProcessorModelId,
+                asrBackend: backend.backend,
+                rawASRText: result.text,
+                errorDescription: String(describing: error)
+            )
             return nil
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -113,6 +113,18 @@ struct MeetingSummaryClientTests {
         #expect(ChatGPTResponsesClient.extractOutputTextDelta(from: payload) == "streamed text")
     }
 
+    @Test("ChatGPT WHAM parser rejects malformed stream payloads")
+    func chatGPTWHAMParserRejectsMalformedStreamPayloads() {
+        #expect(throws: ChatGPTResponsesError.self) {
+            _ = try ChatGPTResponsesClient.decodeStreamPayload("{", httpStatus: 200)
+        }
+    }
+
+    @Test("ChatGPT WHAM parser ignores blank stream payloads")
+    func chatGPTWHAMParserIgnoresBlankStreamPayloads() throws {
+        #expect(try ChatGPTResponsesClient.decodeStreamPayload("   ", httpStatus: 200) == nil)
+    }
+
     @Test("ChatGPT WHAM parser prefers final output over streamed deltas")
     func chatGPTWHAMParserPrefersFinalOutputOverDeltas() {
         var deltaText = ""

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -113,6 +113,35 @@ struct MeetingSummaryClientTests {
         #expect(ChatGPTResponsesClient.extractOutputTextDelta(from: payload) == "streamed text")
     }
 
+    @Test("ChatGPT WHAM parser prefers final output over streamed deltas")
+    func chatGPTWHAMParserPrefersFinalOutputOverDeltas() {
+        var deltaText = ""
+        var finalText = ""
+
+        ChatGPTResponsesClient.applyStreamPayload(
+            [
+                "type": "response.output_text.delta",
+                "delta": "partial ",
+            ],
+            deltaText: &deltaText,
+            finalText: &finalText
+        )
+        ChatGPTResponsesClient.applyStreamPayload(
+            [
+                "type": "response.completed",
+                "response": [
+                    "output_text": "final cleaned text",
+                ],
+            ],
+            deltaText: &deltaText,
+            finalText: &finalText
+        )
+
+        #expect(deltaText == "partial ")
+        #expect(finalText == "final cleaned text")
+        #expect(ChatGPTResponsesClient.accumulatedOutputText(deltaText: deltaText, finalText: finalText) == "final cleaned text")
+    }
+
     @Test("ChatGPT WHAM parser reads nested final response payload")
     func chatGPTWHAMParserReadsNestedFinalResponsePayload() {
         let payload: [String: Any] = [

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -120,9 +120,34 @@ struct MeetingSummaryClientTests {
         }
     }
 
+    @Test("ChatGPT WHAM parser ignores heartbeat stream payloads")
+    func chatGPTWHAMParserIgnoresHeartbeatPayloads() throws {
+        #expect(try ChatGPTResponsesClient.decodeStreamPayload("ping", httpStatus: 200) == nil)
+    }
+
     @Test("ChatGPT WHAM parser ignores blank stream payloads")
     func chatGPTWHAMParserIgnoresBlankStreamPayloads() throws {
         #expect(try ChatGPTResponsesClient.decodeStreamPayload("   ", httpStatus: 200) == nil)
+    }
+
+    @Test("ChatGPT WHAM parser ignores valid unknown stream events")
+    func chatGPTWHAMParserIgnoresValidUnknownStreamEvents() throws {
+        var deltaText = "partial"
+        var finalText = ""
+        let decoded = try ChatGPTResponsesClient.decodeStreamPayload(
+            #"{"type":"response.created","response":{"id":"resp_1"}}"#,
+            httpStatus: 200
+        )
+        let payload = try #require(decoded)
+
+        ChatGPTResponsesClient.applyStreamPayload(
+            payload,
+            deltaText: &deltaText,
+            finalText: &finalText
+        )
+
+        #expect(deltaText == "partial")
+        #expect(finalText.isEmpty)
     }
 
     @Test("ChatGPT WHAM parser prefers final output over streamed deltas")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -94,6 +94,70 @@ struct MeetingSummaryClientTests {
         #expect(prompt.contains("- User typed decision"))
     }
 
+    @Test("ChatGPT WHAM parser reads top-level output text")
+    func chatGPTWHAMParserReadsTopLevelOutputText() {
+        let payload: [String: Any] = [
+            "output_text": "Cleaned dictation text",
+        ]
+
+        #expect(ChatGPTResponsesClient.extractOutputText(from: payload) == "Cleaned dictation text")
+    }
+
+    @Test("ChatGPT WHAM parser reads streaming deltas")
+    func chatGPTWHAMParserReadsStreamingDeltas() {
+        let payload: [String: Any] = [
+            "type": "response.output_text.delta",
+            "delta": "streamed text",
+        ]
+
+        #expect(ChatGPTResponsesClient.extractOutputTextDelta(from: payload) == "streamed text")
+    }
+
+    @Test("ChatGPT WHAM parser reads nested final response payload")
+    func chatGPTWHAMParserReadsNestedFinalResponsePayload() {
+        let payload: [String: Any] = [
+            "type": "response.completed",
+            "response": [
+                "output": [
+                    [
+                        "content": [
+                            [
+                                "type": "output_text",
+                                "text": [
+                                    "value": "Nested final response text",
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        #expect(ChatGPTResponsesClient.extractOutputText(from: payload) == "Nested final response text")
+    }
+
+    @Test("ChatGPT WHAM parser reads output content text")
+    func chatGPTWHAMParserReadsOutputContentText() {
+        let payload: [String: Any] = [
+            "output": [
+                [
+                    "content": [
+                        [
+                            "type": "output_text",
+                            "text": "Part one ",
+                        ],
+                        [
+                            "type": "output_text",
+                            "text": "part two",
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        #expect(ChatGPTResponsesClient.extractOutputText(from: payload) == "Part one part two")
+    }
+
     @Test("final notes retain manual notes verbatim")
     func finalNotesRetainManualNotesVerbatim() {
         let result = MeetingSummaryClient.notesByRetainingManualNotes(

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -906,6 +906,33 @@ struct AppConfigTests {
         )
     }
 
+    @Test("default cleanup prompt explains app context")
+    func defaultCleanupPromptExplainsAppContext() {
+        #expect(PostProcessorOption.defaultSystemPrompt.contains("<APP-CONTEXT>"))
+        #expect(PostProcessorOption.defaultSystemPrompt.contains("Never copy app context into the output"))
+    }
+
+    @Test("hosted cleanup augments custom prompts when app context is present")
+    func hostedCleanupAugmentsCustomPromptsWhenAppContextIsPresent() {
+        let prompt = TranscriptCleanupClient.systemPromptWithAppContextGuidance(
+            "Preserve the user's words.",
+            appContext: "App: Notes"
+        )
+
+        #expect(prompt.contains("Preserve the user's words."))
+        #expect(prompt.contains("<APP-CONTEXT>"))
+    }
+
+    @Test("hosted cleanup does not duplicate app context guidance")
+    func hostedCleanupDoesNotDuplicateAppContextGuidance() {
+        let prompt = TranscriptCleanupClient.systemPromptWithAppContextGuidance(
+            PostProcessorOption.defaultSystemPrompt,
+            appContext: "App: Notes"
+        )
+
+        #expect(prompt == PostProcessorOption.defaultSystemPrompt)
+    }
+
     @Test("unsupported ChatGPT model selections fall back to default")
     func unsupportedChatGPTModelSelectionsFallBackToDefault() throws {
         let json = """

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -604,6 +604,34 @@ struct AppConfigTests {
         ))
     }
 
+    @Test("Ollama cleanup readiness requires valid URL")
+    func ollamaCleanupReadinessRequiresValidURL() {
+        let backend = TranscriptCleanupBackendOption.hosted(.ollama)
+        var config = AppConfig()
+
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.ollamaURL = "not a url"
+
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.ollamaURL = "http://localhost:11434"
+
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+    }
+
     @Test("Custom LLM cleanup readiness requires model and explicit valid URL")
     func customLLMCleanupReadinessRequiresModelAndExplicitValidURL() {
         let backend = TranscriptCleanupBackendOption.hosted(.customLLM)
@@ -969,7 +997,7 @@ struct AppConfigTests {
         let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
 
         #expect(config.activeTranscriptCleanupPromptId == TranscriptCleanupPrompts.defaultID)
-        #expect(config.postProcessorSystemPrompt == "Legacy user-edited cleanup prompt")
+        #expect(config.postProcessorSystemPrompt == PostProcessorOption.defaultSystemPrompt)
         #expect(
             TranscriptCleanupPrompts
                 .resolve(id: config.activeTranscriptCleanupPromptId, custom: config.customTranscriptCleanupPrompts)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -604,6 +604,52 @@ struct AppConfigTests {
         ))
     }
 
+    @Test("Custom LLM cleanup readiness requires model and explicit valid URL")
+    func customLLMCleanupReadinessRequiresModelAndExplicitValidURL() {
+        let backend = TranscriptCleanupBackendOption.hosted(.customLLM)
+        var config = AppConfig()
+        config.postProcessorCustomLLMModel = "cleanup-model"
+
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.customLLMURL = "not a url"
+
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.customLLMURL = "http://localhost:8080"
+
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.customLLMFormat = CustomLLMFormat.anthropic.rawValue
+        config.customLLMAPIKey = ""
+
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.customLLMAPIKey = "sk-ant-test"
+
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+    }
+
     @Test("OpenRouter cleanup key falls back to environment")
     func openRouterCleanupKeyFallsBackToEnvironment() {
         var config = AppConfig()

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -332,7 +332,26 @@ struct SummaryModelPresetTests {
     @Test("OpenAI presets have valid model IDs")
     func openAIModels() {
         #expect(!SummaryModelPreset.openAIModels.isEmpty)
+        #expect(SummaryModelPreset.openAIModels.first?.id == "gpt-5.4-mini")
+        #expect(SummaryModelPreset.openAIModels.contains { $0.id == "gpt-5.5" })
+        #expect(SummaryModelPreset.openAIModels.contains { $0.id == "chat-latest" })
         for preset in SummaryModelPreset.openAIModels {
+            #expect(!preset.id.isEmpty)
+            #expect(!preset.label.isEmpty)
+        }
+    }
+
+    @Test("ChatGPT presets include supported fast options")
+    func chatGPTModels() {
+        #expect(!SummaryModelPreset.chatGPTModels.isEmpty)
+        #expect(SummaryModelPreset.chatGPTModels.first?.id == "gpt-5.4-mini")
+        #expect(SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.5" })
+        #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.4-nano" })
+        #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "chat-latest" })
+        #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.4" })
+        #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.2" })
+        #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-4o" })
+        for preset in SummaryModelPreset.chatGPTModels {
             #expect(!preset.id.isEmpty)
             #expect(!preset.label.isEmpty)
         }
@@ -517,6 +536,15 @@ struct AppConfigTests {
         #expect(config.customLLMAPIKey.isEmpty)
         #expect(config.customLLMModel.isEmpty)
         #expect(config.customLLMFormat == "openai")
+        #expect(config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(config.postProcessorChatGPTModel.isEmpty)
+        #expect(config.postProcessorOpenAIModel.isEmpty)
+        #expect(config.postProcessorOpenRouterModel.isEmpty)
+        #expect(config.postProcessorOllamaModel.isEmpty)
+        #expect(config.postProcessorLMStudioModel.isEmpty)
+        #expect(config.postProcessorCustomLLMModel.isEmpty)
+        #expect(config.activeTranscriptCleanupPromptId == TranscriptCleanupPrompts.defaultID)
+        #expect(config.customTranscriptCleanupPrompts.isEmpty)
         #expect(config.dictationHotkey == .default)
         #expect(config.computerUseHotkey == .computerUseDefault)
         #expect(config.enableComputerUseHotkey == false)
@@ -597,6 +625,22 @@ struct AppConfigTests {
         config.customLLMAPIKey = "custom-key"
         config.customLLMModel = "custom-model"
         config.customLLMFormat = "anthropic"
+        config.postProcessorBackend = TranscriptCleanupBackendOption.hosted(.openRouter).backend
+        config.postProcessorChatGPTModel = "gpt-5.4-mini"
+        config.postProcessorOpenAIModel = "gpt-5.4-mini"
+        config.postProcessorOpenRouterModel = "openrouter/test-model"
+        config.postProcessorOllamaModel = "qwen3.5"
+        config.postProcessorLMStudioModel = "lmstudio-loaded"
+        config.postProcessorCustomLLMModel = "custom-cleanup"
+        config.activeTranscriptCleanupPromptId = "cleanup_custom_1"
+        config.customTranscriptCleanupPrompts = [
+            CustomTranscriptCleanupPrompt(
+                id: "cleanup_custom_1",
+                name: "Strict Dictation",
+                prompt: "Preserve labels and quotes."
+            )
+        ]
+        config.postProcessorSystemPrompt = "Preserve labels and quotes."
         config.contributionPromptNextWordCount = 31_000
         config.contributionPromptNextMeetingCount = 75
         config.contributionGitHubStarClicked = true
@@ -654,6 +698,17 @@ struct AppConfigTests {
         #expect(decoded.customLLMAPIKey == "custom-key")
         #expect(decoded.customLLMModel == "custom-model")
         #expect(decoded.customLLMFormat == "anthropic")
+        #expect(decoded.postProcessorBackend == "openrouter")
+        #expect(decoded.postProcessorChatGPTModel == "gpt-5.4-mini")
+        #expect(decoded.postProcessorOpenAIModel == "gpt-5.4-mini")
+        #expect(decoded.postProcessorOpenRouterModel == "openrouter/test-model")
+        #expect(decoded.postProcessorOllamaModel == "qwen3.5")
+        #expect(decoded.postProcessorLMStudioModel == "lmstudio-loaded")
+        #expect(decoded.postProcessorCustomLLMModel == "custom-cleanup")
+        #expect(decoded.activeTranscriptCleanupPromptId == "cleanup_custom_1")
+        #expect(decoded.customTranscriptCleanupPrompts.count == 1)
+        #expect(decoded.customTranscriptCleanupPrompts.first?.name == "Strict Dictation")
+        #expect(decoded.postProcessorSystemPrompt == "Preserve labels and quotes.")
         #expect(decoded.contributionPromptNextWordCount == 31_000)
         #expect(decoded.contributionPromptNextMeetingCount == 75)
         #expect(decoded.contributionGitHubStarClicked == true)
@@ -717,6 +772,15 @@ struct AppConfigTests {
         #expect(json["custom_llm_api_key"] != nil)
         #expect(json["custom_llm_model"] != nil)
         #expect(json["custom_llm_format"] != nil)
+        #expect(json["post_processor_backend"] != nil)
+        #expect(json["post_processor_chatgpt_model"] != nil)
+        #expect(json["post_processor_openai_model"] != nil)
+        #expect(json["post_processor_openrouter_model"] != nil)
+        #expect(json["post_processor_ollama_model"] != nil)
+        #expect(json["post_processor_lmstudio_model"] != nil)
+        #expect(json["post_processor_custom_llm_model"] != nil)
+        #expect(json["active_transcript_cleanup_prompt_id"] != nil)
+        #expect(json["custom_transcript_cleanup_prompts"] != nil)
     }
 
     @Test("decodes with missing fields using defaults")
@@ -765,6 +829,55 @@ struct AppConfigTests {
         #expect(config.customLLMAPIKey.isEmpty)
         #expect(config.customLLMModel.isEmpty)
         #expect(config.customLLMFormat == "openai")
+        #expect(config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(config.activeTranscriptCleanupPromptId == TranscriptCleanupPrompts.defaultID)
+        #expect(config.customTranscriptCleanupPrompts.isEmpty)
+    }
+
+    @Test("unknown cleanup backend resolves to local")
+    func unknownCleanupBackendResolvesToLocal() throws {
+        let json = """
+        {
+          "post_processor_backend": "future_provider"
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(TranscriptCleanupBackendOption.resolved(config.postProcessorBackend) == .local)
+    }
+
+    @Test("missing cleanup prompt preset falls back to built-in default")
+    func missingCleanupPromptPresetFallsBackToDefault() throws {
+        let json = """
+        {
+          "active_transcript_cleanup_prompt_id": "deleted-preset",
+          "post_processor_system_prompt": "Legacy user-edited cleanup prompt"
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.activeTranscriptCleanupPromptId == TranscriptCleanupPrompts.defaultID)
+        #expect(config.postProcessorSystemPrompt == "Legacy user-edited cleanup prompt")
+        #expect(
+            TranscriptCleanupPrompts
+                .resolve(id: config.activeTranscriptCleanupPromptId, custom: config.customTranscriptCleanupPrompts)
+                .prompt == PostProcessorOption.defaultSystemPrompt
+        )
+    }
+
+    @Test("unsupported ChatGPT model selections fall back to default")
+    func unsupportedChatGPTModelSelectionsFallBackToDefault() throws {
+        let json = """
+        {
+          "chatgpt_model": "chat-latest",
+          "post_processor_chatgpt_model": "gpt-5.4-nano"
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.chatGPTModel.isEmpty)
+        #expect(config.postProcessorChatGPTModel.isEmpty)
     }
 
     @Test("legacy completed onboarding enables meetings when use case is missing")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -909,7 +909,40 @@ struct AppConfigTests {
     @Test("default cleanup prompt explains app context")
     func defaultCleanupPromptExplainsAppContext() {
         #expect(PostProcessorOption.defaultSystemPrompt.contains("<APP-CONTEXT>"))
+        #expect(PostProcessorOption.defaultSystemPrompt.contains("OCR screen text"))
         #expect(PostProcessorOption.defaultSystemPrompt.contains("Never copy app context into the output"))
+    }
+
+    @Test("dictation app context prompt includes OCR text")
+    func dictationAppContextPromptIncludesOCRText() {
+        let ocrText = String(repeating: "a", count: 3_200) + "tail"
+        let context = DictationContext(
+            appName: "Notes",
+            bundleID: "com.apple.Notes",
+            documentContext: "Project Apollo",
+            selectedText: "Mercury",
+            url: "https://example.com",
+            ocrText: ocrText
+        )
+        let prompt = DictationContextCapture.formatForPrompt(context)
+
+        #expect(prompt.contains("App: Notes (https://example.com)"))
+        #expect(prompt.contains("Document context: Project Apollo"))
+        #expect(prompt.contains("Selected text: Mercury"))
+        #expect(prompt.contains("OCR screen text: "))
+        #expect(prompt.contains("tail"))
+    }
+
+    @Test("post processor input caps app context")
+    func postProcessorInputCapsAppContext() {
+        let prompt = Qwen3PostProcessorConfig.formatInput(
+            "hello",
+            appContext: String(repeating: "a", count: 20),
+            maxAppContextCharacters: 5
+        )
+
+        #expect(prompt.contains("<APP-CONTEXT>\naaaaa\n</APP-CONTEXT>"))
+        #expect(prompt.contains("<USER-INPUT>\nhello\n</USER-INPUT>"))
     }
 
     @Test("hosted cleanup augments custom prompts when app context is present")
@@ -921,6 +954,7 @@ struct AppConfigTests {
 
         #expect(prompt.contains("Preserve the user's words."))
         #expect(prompt.contains("<APP-CONTEXT>"))
+        #expect(prompt.contains("OCR screen text"))
     }
 
     @Test("hosted cleanup does not duplicate app context guidance")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -580,6 +580,28 @@ struct AppConfigTests {
         #expect(config.hiddenCalendarEventSourceHints.isEmpty)
     }
 
+    @Test("LM Studio cleanup readiness requires model and valid URL")
+    func lmStudioCleanupReadinessRequiresModelAndValidURL() {
+        let backend = TranscriptCleanupBackendOption.hosted(.lmStudio)
+        var config = AppConfig()
+        config.postProcessorLMStudioModel = "local-cleanup-model"
+        config.lmStudioURL = "not a url"
+
+        #expect(!TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+
+        config.lmStudioURL = "http://localhost:1234"
+
+        #expect(TranscriptCleanupClient.hasRequiredSettings(
+            for: backend,
+            config: config,
+            isChatGPTAuthenticated: false
+        ))
+    }
+
     @Test("JSON encode/decode round-trip")
     func jsonRoundTrip() throws {
         var config = AppConfig()

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -545,6 +545,8 @@ struct AppConfigTests {
         #expect(config.postProcessorCustomLLMModel.isEmpty)
         #expect(config.activeTranscriptCleanupPromptId == TranscriptCleanupPrompts.defaultID)
         #expect(config.customTranscriptCleanupPrompts.isEmpty)
+        #expect(config.enableScreenContext == false)
+        #expect(config.enableDictationOCRContext == false)
         #expect(config.dictationHotkey == .default)
         #expect(config.computerUseHotkey == .computerUseDefault)
         #expect(config.enableComputerUseHotkey == false)
@@ -681,6 +683,8 @@ struct AppConfigTests {
             )
         ]
         config.postProcessorSystemPrompt = "Preserve labels and quotes."
+        config.enableScreenContext = true
+        config.enableDictationOCRContext = true
         config.contributionPromptNextWordCount = 31_000
         config.contributionPromptNextMeetingCount = 75
         config.contributionGitHubStarClicked = true
@@ -749,6 +753,8 @@ struct AppConfigTests {
         #expect(decoded.customTranscriptCleanupPrompts.count == 1)
         #expect(decoded.customTranscriptCleanupPrompts.first?.name == "Strict Dictation")
         #expect(decoded.postProcessorSystemPrompt == "Preserve labels and quotes.")
+        #expect(decoded.enableScreenContext == true)
+        #expect(decoded.enableDictationOCRContext == true)
         #expect(decoded.contributionPromptNextWordCount == 31_000)
         #expect(decoded.contributionPromptNextMeetingCount == 75)
         #expect(decoded.contributionGitHubStarClicked == true)
@@ -821,6 +827,23 @@ struct AppConfigTests {
         #expect(json["post_processor_custom_llm_model"] != nil)
         #expect(json["active_transcript_cleanup_prompt_id"] != nil)
         #expect(json["custom_transcript_cleanup_prompts"] != nil)
+        #expect(json["enable_screen_context"] != nil)
+        #expect(json["enable_dictation_ocr_context"] != nil)
+    }
+
+    @Test("decodes screen context flags from snake_case")
+    func decodesScreenContextFlagsFromSnakeCase() throws {
+        let json = """
+        {
+            "enable_screen_context": true,
+            "enable_dictation_ocr_context": true
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let config = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(config.enableScreenContext == true)
+        #expect(config.enableDictationOCRContext == true)
     }
 
     @Test("decodes with missing fields using defaults")
@@ -872,6 +895,8 @@ struct AppConfigTests {
         #expect(config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
         #expect(config.activeTranscriptCleanupPromptId == TranscriptCleanupPrompts.defaultID)
         #expect(config.customTranscriptCleanupPrompts.isEmpty)
+        #expect(config.enableScreenContext == false)
+        #expect(config.enableDictationOCRContext == false)
     }
 
     @Test("unknown cleanup backend resolves to local")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -602,6 +602,24 @@ struct AppConfigTests {
         ))
     }
 
+    @Test("OpenRouter cleanup key falls back to environment")
+    func openRouterCleanupKeyFallsBackToEnvironment() {
+        var config = AppConfig()
+        config.openRouterAPIKey = ""
+
+        #expect(TranscriptCleanupClient.resolvedOpenRouterAPIKey(
+            config: config,
+            environment: ["OPENROUTER_API_KEY": "sk-or-env"]
+        ) == "sk-or-env")
+
+        config.openRouterAPIKey = " sk-or-config "
+
+        #expect(TranscriptCleanupClient.resolvedOpenRouterAPIKey(
+            config: config,
+            environment: ["OPENROUTER_API_KEY": "sk-or-env"]
+        ) == "sk-or-config")
+    }
+
     @Test("JSON encode/decode round-trip")
     func jsonRoundTrip() throws {
         var config = AppConfig()

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -320,4 +320,32 @@ struct Qwen3PostProcessingOutputCleanerTests {
             input: "um yeah"
         ))
     }
+
+    @Test("rejects placeholder punctuation cleanup output")
+    func rejectsPlaceholderPunctuationCleanupOutput() {
+        for cleaned in ["...", ". . .", "---", "??"] {
+            #expect(Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+                cleaned: cleaned,
+                input: "Please send the update to Priyanka."
+            ))
+        }
+    }
+
+    @Test("hosted cleanup sanitizer preserves dictated labels and quotes")
+    func hostedCleanupSanitizerPreservesLabelsAndQuotes() {
+        let raw = """
+        Subject: "Muesli launch notes"
+
+        Body: Ask Priyanka to review the "AI Models" settings copy.
+        """
+
+        let cleaned = TranscriptCleanupClient.cleanOutput(raw)
+
+        #expect(cleaned.contains(#"Subject: "Muesli launch notes""#))
+        #expect(cleaned.contains(#"Body: Ask Priyanka to review the "AI Models" settings copy."#))
+        #expect(!Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+            cleaned: cleaned,
+            input: #"Subject quote Muesli launch notes body ask Priyanka to review the quote AI Models quote settings copy"#
+        ))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -331,6 +331,16 @@ struct Qwen3PostProcessingOutputCleanerTests {
         }
     }
 
+    @Test("accepts short legitimate cleanup output")
+    func acceptsShortLegitimateCleanupOutput() {
+        for cleaned in ["OK.", "Sure.", "No."] {
+            #expect(!Qwen3PostProcessorOutputCleaner.shouldFallbackToInput(
+                cleaned: cleaned,
+                input: "okay sounds good"
+            ))
+        }
+    }
+
     @Test("hosted cleanup sanitizer preserves dictated labels and quotes")
     func hostedCleanupSanitizerPreservesLabelsAndQuotes() {
         let raw = """


### PR DESCRIPTION
## Summary
- Adds a shared LLM backend layer for dictation cleanup, covering local Qwen plus ChatGPT, OpenAI, OpenRouter, Ollama, LM Studio, and Custom LLM.
- Adds a shared ChatGPT WHAM responses client, with attribution to the useful direction from PR #230 while avoiding its conflicting/narrow implementation.
- Moves model/provider selection into Settings > AI Models, keeps Dictation/Meetings panes focused on workflow settings, and keeps Models as local model file management.
- Adds cleanup prompt presets, hosted cleanup diagnostics, output safety checks, and local-only iCloud entitlement guards for dev builds.

## Notes
- Hosted cleanup remains opt-in and does not silently fail over to another cloud backend.
- Personal dictionary custom-word replacement runs after cleanup; dictionary suggestion prompts run after paste.
- ChatGPT cleanup presets intentionally exclude `chat-latest` and `gpt-5.4-nano` because this ChatGPT/Codex-account WHAM backend rejected both during smoke testing. Stale saved values migrate back to the default `gpt-5.4-mini`.

## Validation
- `swift build --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/worktrees/48e7/dev" -c debug --product MuesliNativeApp`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/test-transcript-cleanup-cloud" --filter ModelsTests --filter TranscriptionRuntimeTests --filter MeetingSummaryClientTests`
- `bash scripts/run_ci_test_shard.sh dictation-transcription`
- `swift test --package-path native/MuesliNative --scratch-path "/Volumes/MuesliBuildCache/muesli-spm/worktrees/48e7/test-model-presets" --filter SummaryModelPresetTests --filter AppConfigTests`
- `MUESLI_SWIFTPM_SCRATCH_PATH="/Volumes/MuesliBuildCache/muesli-spm/worktrees/48e7/dev" ./scripts/dev-test.sh --local-only`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785748887&installation_id=136549638&pr_number=269&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F269&signature=704af8e760145d59ed52e1721b136f74ccf3aec8a0b02de724bc0219b0304ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “AI Models” settings area to configure transcription, meeting summaries, and dictation cleanup (prompt presets + backend/model selection).
  * Enabled optional on-screen OCR to enrich dictation context.
  * Upgraded dictation cleanup to support local and hosted LLM backends, including saved preferences.
* **Bug Fixes**
  * Improved transcript cleanup reliability with stricter placeholder-like output detection and safer fallback behavior.
  * Enhanced ChatGPT meeting summaries/titles to use the streaming responses workflow and handle empty/failed responses.
  * iCloud sync is now fully gated by entitlement availability with a clear unavailable state.
* **Tests**
  * Expanded parsing/stream handling and model/cleanup configuration coverage, including new placeholder fallback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->