### PR TITLE
Clean up orphaned temp files from failed model downloads

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
@@ -22,6 +22,20 @@ func downloadWithRetry(
     maxRetries: Int = 3,
     session: URLSession = .shared
 ) async throws {
+    try await downloadWithRetry(
+        from: url,
+        to: destination,
+        maxRetries: maxRetries,
+        download: { try await session.download(from: $0) }
+    )
+}
+
+func downloadWithRetry(
+    from url: URL,
+    to destination: URL,
+    maxRetries: Int = 3,
+    download: (URL) async throws -> (URL, URLResponse)
+) async throws {
     var lastError: Error?
     for attempt in 0..<maxRetries {
         if attempt > 0 {
@@ -31,14 +45,13 @@ func downloadWithRetry(
         }
         do {
             try Task.checkCancellation()
-            let (tempURL, response) = try await session.download(from: url)
+            let (tempURL, response) = try await download(url)
             guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
                 let code = (response as? HTTPURLResponse)?.statusCode ?? -1
                 try? FileManager.default.removeItem(at: tempURL)
                 throw DownloadError.httpError(code, url.lastPathComponent)
             }
-            try? FileManager.default.removeItem(at: destination)
-            try FileManager.default.moveItem(at: tempURL, to: destination)
+            try moveDownloadedTemporaryFile(tempURL, to: destination)
             return
         } catch is CancellationError {
             throw CancellationError()
@@ -50,4 +63,17 @@ func downloadWithRetry(
         NSLocalizedDescriptionKey: "No download attempts were made",
     ])
     throw DownloadError.retriesExhausted(url.lastPathComponent, underlying)
+}
+
+func moveDownloadedTemporaryFile(_ tempURL: URL, to destination: URL) throws {
+    var movedToDestination = false
+    defer {
+        if !movedToDestination {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+    }
+
+    try? FileManager.default.removeItem(at: destination)
+    try FileManager.default.moveItem(at: tempURL, to: destination)
+    movedToDestination = true
 }

--- a/native/MuesliNative/Tests/MuesliTests/DownloadUtilsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DownloadUtilsTests.swift
@@ -8,8 +8,7 @@ struct DownloadUtilsTests {
     @Test("failed move removes downloaded temp file")
     func failedMoveRemovesDownloadedTempFile() async throws {
         let tempDirectory = makeTemporaryDirectory()
-        let tempURL = tempDirectory.appendingPathComponent("download.tmp")
-        try Data("payload".utf8).write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
         let destination = tempDirectory
             .appendingPathComponent("missing", isDirectory: true)
             .appendingPathComponent("model.bin")
@@ -19,49 +18,47 @@ struct DownloadUtilsTests {
                 from: requestURL,
                 to: destination,
                 maxRetries: 1,
-                download: { _ in (tempURL, okResponse) }
+                download: downloadPayload(in: tempDirectory, response: okResponse)
             )
         }
 
-        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: tempDirectory.path).isEmpty)
         #expect(FileManager.default.fileExists(atPath: destination.path) == false)
     }
 
     @Test("successful move leaves no temp file")
     func successfulMoveLeavesNoTempFile() async throws {
         let tempDirectory = makeTemporaryDirectory()
-        let tempURL = tempDirectory.appendingPathComponent("download.tmp")
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
         let destination = tempDirectory.appendingPathComponent("model.bin")
-        try Data("payload".utf8).write(to: tempURL)
 
         try await downloadWithRetry(
             from: requestURL,
             to: destination,
             maxRetries: 1,
-            download: { _ in (tempURL, okResponse) }
+            download: downloadPayload(in: tempDirectory, response: okResponse)
         )
 
-        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: tempDirectory.path) == ["model.bin"])
         #expect(try Data(contentsOf: destination) == Data("payload".utf8))
     }
 
     @Test("HTTP error removes downloaded temp file")
     func httpErrorRemovesDownloadedTempFile() async throws {
         let tempDirectory = makeTemporaryDirectory()
-        let tempURL = tempDirectory.appendingPathComponent("download.tmp")
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
         let destination = tempDirectory.appendingPathComponent("model.bin")
-        try Data("payload".utf8).write(to: tempURL)
 
         await #expect(throws: DownloadError.self) {
             try await downloadWithRetry(
                 from: requestURL,
                 to: destination,
                 maxRetries: 1,
-                download: { _ in (tempURL, errorResponse) }
+                download: downloadPayload(in: tempDirectory, response: errorResponse)
             )
         }
 
-        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: tempDirectory.path).isEmpty)
         #expect(FileManager.default.fileExists(atPath: destination.path) == false)
     }
 
@@ -82,5 +79,16 @@ struct DownloadUtilsTests {
             .appendingPathComponent("download-utils-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private func downloadPayload(
+        in directory: URL,
+        response: HTTPURLResponse
+    ) -> (URL) async throws -> (URL, URLResponse) {
+        { _ in
+            let tempURL = directory.appendingPathComponent("download-\(UUID().uuidString).tmp")
+            try Data("payload".utf8).write(to: tempURL)
+            return (tempURL, response)
+        }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DownloadUtilsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DownloadUtilsTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("DownloadUtils")
+struct DownloadUtilsTests {
+
+    @Test("failed move removes downloaded temp file")
+    func failedMoveRemovesDownloadedTempFile() async throws {
+        let tempDirectory = makeTemporaryDirectory()
+        let tempURL = tempDirectory.appendingPathComponent("download.tmp")
+        try Data("payload".utf8).write(to: tempURL)
+        let destination = tempDirectory
+            .appendingPathComponent("missing", isDirectory: true)
+            .appendingPathComponent("model.bin")
+
+        await #expect(throws: DownloadError.self) {
+            try await downloadWithRetry(
+                from: requestURL,
+                to: destination,
+                maxRetries: 1,
+                download: { _ in (tempURL, okResponse) }
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: destination.path) == false)
+    }
+
+    @Test("successful move leaves no temp file")
+    func successfulMoveLeavesNoTempFile() async throws {
+        let tempDirectory = makeTemporaryDirectory()
+        let tempURL = tempDirectory.appendingPathComponent("download.tmp")
+        let destination = tempDirectory.appendingPathComponent("model.bin")
+        try Data("payload".utf8).write(to: tempURL)
+
+        try await downloadWithRetry(
+            from: requestURL,
+            to: destination,
+            maxRetries: 1,
+            download: { _ in (tempURL, okResponse) }
+        )
+
+        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+        #expect(try Data(contentsOf: destination) == Data("payload".utf8))
+    }
+
+    @Test("HTTP error removes downloaded temp file")
+    func httpErrorRemovesDownloadedTempFile() async throws {
+        let tempDirectory = makeTemporaryDirectory()
+        let tempURL = tempDirectory.appendingPathComponent("download.tmp")
+        let destination = tempDirectory.appendingPathComponent("model.bin")
+        try Data("payload".utf8).write(to: tempURL)
+
+        await #expect(throws: DownloadError.self) {
+            try await downloadWithRetry(
+                from: requestURL,
+                to: destination,
+                maxRetries: 1,
+                download: { _ in (tempURL, errorResponse) }
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: destination.path) == false)
+    }
+
+    private var requestURL: URL {
+        URL(string: "https://example.com/model.bin")!
+    }
+
+    private var okResponse: HTTPURLResponse {
+        HTTPURLResponse(url: requestURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    }
+
+    private var errorResponse: HTTPURLResponse {
+        HTTPURLResponse(url: requestURL, statusCode: 500, httpVersion: nil, headerFields: nil)!
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("download-utils-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}


### PR DESCRIPTION
## Problem

`downloadWithRetry` in `DownloadUtils.swift` removes the temporary download file only on HTTP-error paths. If the final `moveItem` to the destination throws (destination directory missing, disk full, cross-volume move), the multi-gigabyte temp file is orphaned — and each retry downloads a fresh copy, stranding up to several full model blobs on disk.

## Fix

Temp-file cleanup is now guaranteed on every failure path: the move step is isolated so a throw cleans up the temp file, while successful moves are untouched. Behavior on success and on HTTP errors is unchanged.

## Tests

- failed move cleans the temp file
- successful move leaves no temp behind
- HTTP-error path still cleans up

Full suite passes (1222 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785863271&installation_id=136549638&pr_number=270&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F270&signature=076de019c9737b622309afe1cb73bc4a61cfd559363f5f8783de4836b1585aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download-with-retry behavior to reliably clean up temporary files on HTTP errors and when moving the downloaded file fails.
  * Improved destination handling to safely replace existing files only after a successful download.

* **Tests**
  * Added async tests covering success, HTTP 500 failures, and file-move failures to confirm temporary file cleanup and correct destination creation/content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->