### PR TITLE
Ensure dictated text ends with sentence punctuation

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -2,6 +2,29 @@ import FluidAudio
 import Foundation
 import MuesliCore
 
+enum DictationFinalPunctuationGuard {
+    private static let closingDelimiters: Set<Character> = [
+        "\"", "'", "”", "’", "»", "›", ")", "]", "}", "）", "】", "」", "』", "》", "〉",
+    ]
+
+    static func apply(_ text: String) -> String {
+        guard let lastContentIndex = text.lastIndex(where: { !$0.isWhitespace }) else { return text }
+
+        var inspectedIndex = lastContentIndex
+        while closingDelimiters.contains(text[inspectedIndex]) {
+            guard inspectedIndex != text.startIndex else { return text }
+            inspectedIndex = text.index(before: inspectedIndex)
+        }
+
+        let terminal = text[inspectedIndex]
+        guard terminal.isLetter || terminal.isNumber else { return text }
+
+        var result = text
+        result.insert(".", at: result.index(after: lastContentIndex))
+        return result
+    }
+}
+
 struct SpeechSegment: Sendable {
     let start: Double
     let end: Double
@@ -370,7 +393,11 @@ actor TranscriptionCoordinator {
             postProcessorSnapshot: postProcessorSnapshot,
             appContext: appContext
         ) ?? removeFillersWithLogging(result)
-        let final = applyCustomWords(result, customWords: customWords)
+        let corrected = applyCustomWords(result, customWords: customWords)
+        let final = SpeechTranscriptionResult(
+            text: DictationFinalPunctuationGuard.apply(corrected.text),
+            segments: corrected.segments
+        )
         if !final.text.isEmpty {
             Qwen3PostProcessorLogging.logVerbose("Dictation final transcript: \(final.text)")
         }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -39,6 +39,39 @@ struct SpeechTranscriptionResultTests {
     }
 }
 
+@Suite("DictationFinalPunctuationGuard")
+struct DictationFinalPunctuationGuardTests {
+
+    @Test("adds period after terminal letters and digits")
+    func addsPeriodAfterLettersAndDigits() {
+        #expect(DictationFinalPunctuationGuard.apply("hello") == "hello.")
+        #expect(DictationFinalPunctuationGuard.apply("что дальше") == "что дальше.")
+        #expect(DictationFinalPunctuationGuard.apply("今日は晴れ") == "今日は晴れ.")
+        #expect(DictationFinalPunctuationGuard.apply("Release 42") == "Release 42.")
+    }
+
+    @Test("preserves existing terminal punctuation and empty strings")
+    func preservesTerminalPunctuationAndEmptyStrings() {
+        #expect(DictationFinalPunctuationGuard.apply("") == "")
+        #expect(DictationFinalPunctuationGuard.apply("done.") == "done.")
+        #expect(DictationFinalPunctuationGuard.apply("done?") == "done?")
+        #expect(DictationFinalPunctuationGuard.apply("done!") == "done!")
+        #expect(DictationFinalPunctuationGuard.apply("done…") == "done…")
+        #expect(DictationFinalPunctuationGuard.apply("done,") == "done,")
+        #expect(DictationFinalPunctuationGuard.apply("done:") == "done:")
+        #expect(DictationFinalPunctuationGuard.apply("done;") == "done;")
+    }
+
+    @Test("handles trailing whitespace and closing delimiters")
+    func handlesTrailingWhitespaceAndClosingDelimiters() {
+        #expect(DictationFinalPunctuationGuard.apply("done  \n") == "done.  \n")
+        #expect(DictationFinalPunctuationGuard.apply("\"done.\"") == "\"done.\"")
+        #expect(DictationFinalPunctuationGuard.apply("(done.)") == "(done.)")
+        // Closing quote after a word gets an outside period; moving it inside would rewrite dictated text.
+        #expect(DictationFinalPunctuationGuard.apply("\"done\"") == "\"done\".")
+    }
+}
+
 @Suite("Qwen3 inference gate")
 struct Qwen3InferenceGateTests {
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -69,6 +69,8 @@ struct DictationFinalPunctuationGuardTests {
         #expect(DictationFinalPunctuationGuard.apply("(done.)") == "(done.)")
         // Closing quote after a word gets an outside period; moving it inside would rewrite dictated text.
         #expect(DictationFinalPunctuationGuard.apply("\"done\"") == "\"done\".")
+        #expect(DictationFinalPunctuationGuard.apply("“done”") == "“done”.")
+        #expect(DictationFinalPunctuationGuard.apply("‘done’") == "‘done’.")
     }
 }
 


### PR DESCRIPTION
## Problem

Several ASR backends emit no sentence-final punctuation, and cleanup models follow the input, so dictated text is frequently pasted without a closing period — every dictation needs a manual touch-up.

## Fix

A deterministic guard at the single exit point of dictation post-processing (applies to both cleaned and raw-fallback output): if the final non-whitespace character is a letter or digit (any script, including Cyrillic), append a period. Existing terminal punctuation (`. ! ? … , : ;`), quotes/brackets after punctuation, and empty strings are left untouched. Dictation only — meeting transcripts are not modified.

## Tests

Edge cases covered: Latin/Cyrillic/digit endings, existing `.`/`?`/`!`/`…`, quote after period, quote after letter, trailing whitespace, empty string, single word.

Full suite passes (1222 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785863309&installation_id=136549638&pr_number=271&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F271&signature=e3b3ec174ef6609b3eb993729ca0a8c036467357c2dd5b69a655a5c0b5a022f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation cleanup by ensuring a final period is added when the transcript ends with a letter or number.
  * Preserves any existing ending punctuation (including ellipses and common punctuation).
  * Correctly places the added period when the final word is followed by trailing whitespace and closing quotes or brackets.
  * Keeps the dictation output otherwise the same as before, aside from this punctuation normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->