### PR TITLE
Bound summary prompts so long meetings stop failing

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -359,6 +359,7 @@ enum MeetingSummaryClient {
         var marker = summaryTranscriptTruncationMarker(omittedCount: omittedCount)
         var contentBudget = maxCharacters - marker.count
 
+        // Marker length depends on the omitted-count digits, so recalculate until stable.
         while contentBudget > 0 {
             let nextOmittedCount = transcript.count - contentBudget
             guard nextOmittedCount != omittedCount else { break }
@@ -368,11 +369,18 @@ enum MeetingSummaryClient {
         }
 
         guard contentBudget > 0 else {
-            return String(marker.prefix(maxCharacters))
+            // Tiny budgets cannot fit the marker; avoid returning a misleading partial marker.
+            let boundedTranscript = String(transcript.prefix(maxCharacters))
+            logSummaryTranscriptTruncated(
+                originalCharacters: transcript.count,
+                omittedCharacters: transcript.count - boundedTranscript.count
+            )
+            return boundedTranscript
         }
 
         let openingCharacters = contentBudget / 2
         let closingCharacters = contentBudget - openingCharacters
+        logSummaryTranscriptTruncated(originalCharacters: transcript.count, omittedCharacters: omittedCount)
         return String(transcript.prefix(openingCharacters))
             + marker
             + String(transcript.suffix(closingCharacters))
@@ -380,6 +388,11 @@ enum MeetingSummaryClient {
 
     private static func summaryTranscriptTruncationMarker(omittedCount: Int) -> String {
         "\n\n[... transcript truncated: \(omittedCount) characters omitted ...]\n\n"
+    }
+
+    private static func logSummaryTranscriptTruncated(originalCharacters: Int, omittedCharacters: Int) {
+        logger.info("summary transcript truncated originalChars=\(originalCharacters) omittedChars=\(omittedCharacters)")
+        fputs("[summary] transcript truncated originalChars=\(originalCharacters) omittedChars=\(omittedCharacters)\n", stderr)
     }
 
     static func notesByRetainingManualNotes(generatedNotes: String, manualNotes: String?) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -135,6 +135,7 @@ enum MeetingSummaryClient {
     private static let lmStudioTitleTimeout: TimeInterval = 120
     private static let customLLMSummaryTimeout: TimeInterval = 300
     private static let customLLMTitleTimeout: TimeInterval = 120
+    private static let summaryTranscriptCharacterLimit = 24_000
 
     private static let titleInstructions = """
     Generate a short, descriptive meeting title (3-7 words) from these transcript excerpts. \
@@ -343,8 +344,42 @@ enum MeetingSummaryClient {
             prompt += "Protected written notes typed by the user during the meeting. Preserve these verbatim and place them where they belong in the summary:\n\(trimmedManualNotes)\n\n"
         }
 
-        prompt += "Raw transcript:\n\(transcript)"
+        prompt += "Raw transcript:\n\(summaryTranscriptForPrompt(transcript))"
         return prompt
+    }
+
+    static func summaryTranscriptForPrompt(
+        _ transcript: String,
+        maxCharacters: Int = summaryTranscriptCharacterLimit
+    ) -> String {
+        guard maxCharacters > 0 else { return "" }
+        guard transcript.count > maxCharacters else { return transcript }
+
+        var omittedCount = transcript.count
+        var marker = summaryTranscriptTruncationMarker(omittedCount: omittedCount)
+        var contentBudget = maxCharacters - marker.count
+
+        while contentBudget > 0 {
+            let nextOmittedCount = transcript.count - contentBudget
+            guard nextOmittedCount != omittedCount else { break }
+            omittedCount = nextOmittedCount
+            marker = summaryTranscriptTruncationMarker(omittedCount: omittedCount)
+            contentBudget = maxCharacters - marker.count
+        }
+
+        guard contentBudget > 0 else {
+            return String(marker.prefix(maxCharacters))
+        }
+
+        let openingCharacters = contentBudget / 2
+        let closingCharacters = contentBudget - openingCharacters
+        return String(transcript.prefix(openingCharacters))
+            + marker
+            + String(transcript.suffix(closingCharacters))
+    }
+
+    private static func summaryTranscriptTruncationMarker(omittedCount: Int) -> String {
+        "\n\n[... transcript truncated: \(omittedCount) characters omitted ...]\n\n"
     }
 
     static func notesByRetainingManualNotes(generatedNotes: String, manualNotes: String?) -> String {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -157,6 +157,18 @@ struct MeetingSummaryClientTests {
         #expect(omittedCount == transcript.count - (bounded.count - marker.count))
     }
 
+    @Test("summary transcript uses raw prefix when marker cannot fit")
+    func summaryTranscriptUsesRawPrefixWhenMarkerCannotFit() {
+        let transcript = "abcdef"
+
+        let bounded = MeetingSummaryClient.summaryTranscriptForPrompt(
+            transcript,
+            maxCharacters: 3
+        )
+
+        #expect(bounded == "abc")
+    }
+
     @Test("ChatGPT WHAM parser reads top-level output text")
     func chatGPTWHAMParserReadsTopLevelOutputText() {
         let payload: [String: Any] = [

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -94,6 +94,69 @@ struct MeetingSummaryClientTests {
         #expect(prompt.contains("- User typed decision"))
     }
 
+    @Test("summary transcript passes through under budget")
+    func summaryTranscriptPassesThroughUnderBudget() {
+        let transcript = "Opening\nMiddle\nClosing"
+
+        let bounded = MeetingSummaryClient.summaryTranscriptForPrompt(
+            transcript,
+            maxCharacters: transcript.count + 10
+        )
+
+        #expect(bounded == transcript)
+    }
+
+    @Test("summary transcript passes through at exact budget")
+    func summaryTranscriptPassesThroughAtExactBudget() {
+        let transcript = String(repeating: "x", count: 80)
+
+        let bounded = MeetingSummaryClient.summaryTranscriptForPrompt(
+            transcript,
+            maxCharacters: transcript.count
+        )
+
+        #expect(bounded == transcript)
+    }
+
+    @Test("summary transcript keeps head tail and marker over budget")
+    func summaryTranscriptKeepsHeadTailAndMarkerOverBudget() {
+        let transcript = "OPENING-" + String(repeating: "a", count: 120)
+            + "MIDDLE-" + String(repeating: "b", count: 120) + "-CLOSING"
+
+        let bounded = MeetingSummaryClient.summaryTranscriptForPrompt(
+            transcript,
+            maxCharacters: 120
+        )
+
+        #expect(bounded.count <= 120)
+        #expect(bounded.hasPrefix("OPENING-"))
+        #expect(bounded.contains("[... transcript truncated:"))
+        #expect(bounded.contains("characters omitted ...]"))
+        #expect(!bounded.contains("MIDDLE-"))
+        #expect(bounded.hasSuffix("-CLOSING"))
+    }
+
+    @Test("summary transcript marker contains omitted count")
+    func summaryTranscriptMarkerContainsOmittedCount() throws {
+        let transcript = "OPENING-" + String(repeating: "a", count: 120)
+            + "MIDDLE-" + String(repeating: "b", count: 120) + "-CLOSING"
+
+        let bounded = MeetingSummaryClient.summaryTranscriptForPrompt(
+            transcript,
+            maxCharacters: 120
+        )
+        let markerLine = try #require(
+            bounded.split(separator: "\n").first { $0.contains("characters omitted") }
+        )
+        let omittedText = String(markerLine)
+            .components(separatedBy: CharacterSet.decimalDigits.inverted)
+            .joined()
+        let omittedCount = try #require(Int(omittedText))
+        let marker = "\n\n\(markerLine)\n\n"
+
+        #expect(omittedCount == transcript.count - (bounded.count - marker.count))
+    }
+
     @Test("ChatGPT WHAM parser reads top-level output text")
     func chatGPTWHAMParserReadsTopLevelOutputText() {
         let payload: [String: Any] = [

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -148,11 +148,17 @@ struct MeetingSummaryClientTests {
         let markerLine = try #require(
             bounded.split(separator: "\n").first { $0.contains("characters omitted") }
         )
+        let markerRange = try #require(
+            bounded.range(
+                of: #"\n\n\[\.\.\. transcript truncated: \d+ characters omitted \.\.\.\]\n\n"#,
+                options: .regularExpression
+            )
+        )
         let omittedText = String(markerLine)
             .components(separatedBy: CharacterSet.decimalDigits.inverted)
             .joined()
         let omittedCount = try #require(Int(omittedText))
-        let marker = "\n\n\(markerLine)\n\n"
+        let marker = bounded[markerRange]
 
         #expect(omittedCount == transcript.count - (bounded.count - marker.count))
     }


### PR DESCRIPTION
## Problem

The meeting summary prompt embeds the entire transcript (`summarizeOnce` path in `MeetingSummaryClient`). Multi-hour meetings exceed the model context window and the summary fails with an opaque provider error — on every backend. Title generation already has excerpt logic; summaries had none.

## Fix

Transcript input to the shared summary prompt builder is capped at 24,000 characters. Over-budget transcripts are middle-truncated with an explicit marker line (`[... transcript truncated: N characters omitted ...]`) so the model still sees both how the meeting started and how it ended. Under-budget transcripts are untouched, and behavior is identical across all backends since the cap lives in the shared prompt-construction point.

## Tests

Under-budget passthrough, over-budget head+tail+marker, exact boundary, omitted-count in marker. Full suite passes (1222 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785863388&installation_id=136549638&pr_number=272&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F272&signature=3e98f367e1f045e7216829669d230f362341f5405bbe0211e2739cc54c916970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Meeting summaries now cap transcript content sent for summarization to a fixed character budget.
  * When transcripts exceed the limit, the summary prompt uses a truncation marker that indicates omitted characters while preserving the transcript’s start and end.
* **Tests**
  * Added unit tests for truncation behavior under budget, exactly at the limit, over budget, and for very small budgets where only a head prefix is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->