### PR TITLE
Add GigaAM v3 Russian ASR backend (CoreML)

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/MuesliPaths.swift
+++ b/native/MuesliNative/Sources/MuesliCore/MuesliPaths.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum MuesliPaths {
-    public static func defaultSupportDirectoryURL(appName: String = "Muesli") -> URL {
-        FileManager.default.homeDirectoryForCurrentUser
+    public static func defaultSupportDirectoryURL(appName: String = "Muesli", fileManager: FileManager = .default) -> URL {
+        fileManager.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Application Support", isDirectory: true)
             .appendingPathComponent(appName, isDirectory: true)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
@@ -83,7 +83,11 @@ private func downloadTemporaryFile(
     let invalidator = DownloadSessionInvalidator()
     do {
         let result = try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(URL, URLResponse), Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
                 delegate.setContinuation(continuation)
                 progressSession.downloadTask(with: url).resume()
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
@@ -20,7 +20,8 @@ func downloadWithRetry(
     from url: URL,
     to destination: URL,
     maxRetries: Int = 3,
-    session: URLSession = .shared
+    session: URLSession = .shared,
+    progressHandler: ((Double) -> Void)? = nil
 ) async throws {
     var lastError: Error?
     for attempt in 0..<maxRetries {
@@ -31,14 +32,17 @@ func downloadWithRetry(
         }
         do {
             try Task.checkCancellation()
-            let (tempURL, response) = try await session.download(from: url)
+            let (tempURL, response) = try await downloadTemporaryFile(
+                from: url,
+                session: session,
+                progressHandler: progressHandler
+            )
             guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
                 let code = (response as? HTTPURLResponse)?.statusCode ?? -1
                 try? FileManager.default.removeItem(at: tempURL)
                 throw DownloadError.httpError(code, url.lastPathComponent)
             }
-            try? FileManager.default.removeItem(at: destination)
-            try FileManager.default.moveItem(at: tempURL, to: destination)
+            try moveDownloadedTemporaryFile(tempURL, to: destination)
             return
         } catch is CancellationError {
             throw CancellationError()
@@ -50,4 +54,150 @@ func downloadWithRetry(
         NSLocalizedDescriptionKey: "No download attempts were made",
     ])
     throw DownloadError.retriesExhausted(url.lastPathComponent, underlying)
+}
+
+func moveDownloadedTemporaryFile(_ tempURL: URL, to destination: URL) throws {
+    var movedToDestination = false
+    defer {
+        if !movedToDestination {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+    }
+
+    try? FileManager.default.removeItem(at: destination)
+    try FileManager.default.moveItem(at: tempURL, to: destination)
+    movedToDestination = true
+}
+
+private func downloadTemporaryFile(
+    from url: URL,
+    session: URLSession,
+    progressHandler: ((Double) -> Void)?
+) async throws -> (URL, URLResponse) {
+    guard let progressHandler else {
+        return try await session.download(from: url)
+    }
+
+    let delegate = ProgressDownloadDelegate(onProgress: progressHandler)
+    let progressSession = URLSession(configuration: session.configuration, delegate: delegate, delegateQueue: nil)
+    let invalidator = DownloadSessionInvalidator()
+    do {
+        let result = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                delegate.setContinuation(continuation)
+                progressSession.downloadTask(with: url).resume()
+            }
+        } onCancel: {
+            invalidator.cancel(progressSession)
+        }
+        invalidator.finish(progressSession)
+        return result
+    } catch {
+        if error is CancellationError {
+            invalidator.cancel(progressSession)
+        } else {
+            invalidator.finish(progressSession)
+        }
+        throw error
+    }
+}
+
+private final class DownloadSessionInvalidator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didInvalidate = false
+
+    func finish(_ session: URLSession) {
+        invalidate(session, action: { $0.finishTasksAndInvalidate() })
+    }
+
+    func cancel(_ session: URLSession) {
+        invalidate(session, action: { $0.invalidateAndCancel() })
+    }
+
+    private func invalidate(_ session: URLSession, action: (URLSession) -> Void) {
+        lock.lock()
+        guard !didInvalidate else {
+            lock.unlock()
+            return
+        }
+        didInvalidate = true
+        lock.unlock()
+        action(session)
+    }
+}
+
+private final class ProgressDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let onProgress: (Double) -> Void
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<(URL, URLResponse), Error>?
+
+    init(onProgress: @escaping (Double) -> Void) {
+        self.onProgress = onProgress
+    }
+
+    func setContinuation(_ c: CheckedContinuation<(URL, URLResponse), Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        continuation = c
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        var movedURL: URL?
+        do {
+            let destination = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString + "." + downloadTask.originalRequestURLLastPathComponent)
+            try FileManager.default.moveItem(at: location, to: destination)
+            movedURL = destination
+            guard let response = downloadTask.response else {
+                throw URLError(.badServerResponse)
+            }
+            resumeOnce(.success((destination, response)))
+        } catch {
+            if let movedURL { try? FileManager.default.removeItem(at: movedURL) }
+            resumeOnce(.failure(error))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        resumeOnce(.failure(error))
+    }
+
+    private func resumeOnce(_ result: Result<(URL, URLResponse), Error>) {
+        lock.lock()
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+
+        guard let continuation else { return }
+        switch result {
+        case .success(let value):
+            continuation.resume(returning: value)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+private extension URLSessionDownloadTask {
+    var originalRequestURLLastPathComponent: String {
+        originalRequest?.url?.lastPathComponent.nonEmpty ?? "download.tmp"
+    }
+}
+
+private extension String {
+    var nonEmpty: String? {
+        isEmpty ? nil : self
+    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
@@ -818,7 +818,10 @@ actor GigaAMV3Transcriber {
         }
     }
 
-    private nonisolated static func readableTranscriptionError(_ error: Error) -> Error {
+    nonisolated static func readableTranscriptionError(_ error: Error) -> Error {
+        if let cancellationError = cancellationError(in: error) {
+            return cancellationError
+        }
         let nsError = error as NSError
         if nsError.domain == "GigaAMV3Transcriber" {
             return error
@@ -828,5 +831,16 @@ actor GigaAMV3Transcriber {
             NSLocalizedDescriptionKey: "GigaAM v3 transcription failed: \(error.localizedDescription)",
             NSUnderlyingErrorKey: error,
         ])
+    }
+
+    private nonisolated static func cancellationError(in error: Error) -> Error? {
+        if error is CancellationError {
+            return error
+        }
+        let nsError = error as NSError
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return cancellationError(in: underlyingError)
+        }
+        return nil
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
@@ -1,6 +1,7 @@
 @preconcurrency import CoreML
 import FluidAudio
 import Foundation
+import MuesliCore
 
 struct GigaAMV3TranscriptionResult: Sendable {
     let text: String
@@ -62,9 +63,9 @@ enum GigaAMV3FileChunking {
 
     private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
         let limit = min(40, left.count, right.count)
-        guard limit >= 2 else { return 0 }
+        guard limit >= 1 else { return 0 }
 
-        for count in stride(from: limit, through: 2, by: -1) {
+        for count in stride(from: limit, through: 1, by: -1) {
             let leftSuffix = left.suffix(count).map(normalizedWord)
             let rightPrefix = right.prefix(count).map(normalizedWord)
             if !leftSuffix.contains(""), leftSuffix == rightPrefix {
@@ -137,7 +138,10 @@ enum GigaAMV3ModelStore {
     ]
 
     static func cacheDirectory(fileManager: FileManager = .default) -> URL {
-        AppIdentity.supportDirectoryURL.appendingPathComponent(cacheRelativePath, isDirectory: true)
+        MuesliPaths.defaultSupportDirectoryURL(
+            appName: AppIdentity.supportDirectoryName,
+            fileManager: fileManager
+        ).appendingPathComponent(cacheRelativePath, isDirectory: true)
     }
 
     static func isAvailableLocally(fileManager: FileManager = .default) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
@@ -1,0 +1,828 @@
+@preconcurrency import CoreML
+import FluidAudio
+import Foundation
+
+struct GigaAMV3TranscriptionResult: Sendable {
+    let text: String
+    let duration: TimeInterval
+    let processingTime: TimeInterval
+}
+
+enum GigaAMV3FileChunking {
+    static let sampleRate = 16_000
+    static let passthroughThresholdSeconds: TimeInterval = 25
+    static let windowSeconds: TimeInterval = 20
+    static let overlapSeconds: TimeInterval = 2
+
+    static func windows(sampleCount: Int, sampleRate: Int = sampleRate) -> [Range<Int>] {
+        guard sampleCount > 0 else { return [] }
+        guard shouldChunk(sampleCount: sampleCount, sampleRate: sampleRate) else {
+            return [0..<sampleCount]
+        }
+
+        let windowSamples = max(1, Int((windowSeconds * Double(sampleRate)).rounded()))
+        let overlapSamples = min(Int((overlapSeconds * Double(sampleRate)).rounded()), windowSamples - 1)
+        let stepSamples = windowSamples - overlapSamples
+        var result: [Range<Int>] = []
+        var start = 0
+
+        while start < sampleCount {
+            let end = min(start + windowSamples, sampleCount)
+            result.append(start..<end)
+            if end == sampleCount {
+                break
+            }
+            start += stepSamples
+        }
+
+        return result
+    }
+
+    static func shouldChunk(sampleCount: Int, sampleRate: Int = sampleRate) -> Bool {
+        Double(sampleCount) / Double(sampleRate) > passthroughThresholdSeconds
+    }
+
+    static func mergeTranscripts(_ transcripts: [String]) -> String {
+        var chunks = transcripts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard var merged = chunks.first?.split(separator: " ").map(String.init) else {
+            return ""
+        }
+        chunks.removeFirst()
+
+        for chunk in chunks {
+            let words = chunk.split(separator: " ").map(String.init)
+            let overlap = suffixPrefixOverlap(merged, words)
+            merged.append(contentsOf: words.dropFirst(overlap))
+        }
+
+        return merged.joined(separator: " ")
+    }
+
+    private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
+        let limit = min(40, left.count, right.count)
+        guard limit >= 2 else { return 0 }
+
+        for count in stride(from: limit, through: 2, by: -1) {
+            let leftSuffix = left.suffix(count).map(normalizedWord)
+            let rightPrefix = right.prefix(count).map(normalizedWord)
+            if !leftSuffix.contains(""), leftSuffix == rightPrefix {
+                return count
+            }
+        }
+
+        return 0
+    }
+
+    private static func normalizedWord(_ word: String) -> String {
+        word.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+}
+
+enum GigaAMV3ModelStore {
+    static let repoID = "huggingfinger0/gigaam-v3-coreml"
+    static let cacheRelativePath = "Models/gigaam-v3-coreml"
+    static let downloadedModelSizeLabel = "~224 MB"
+    static let localSeedEnvironmentKey = "MUESLI_GIGAAM_V3_MODEL_DIR"
+
+    private struct RequiredFile {
+        let path: String
+        let progressWeight: Double
+        let minimumBytes: Int64
+        let remoteRepoID: String
+        let remotePath: String
+
+        init(
+            path: String,
+            progressWeight: Double,
+            minimumBytes: Int64,
+            remoteRepoID: String = GigaAMV3ModelStore.repoID,
+            remotePath: String? = nil
+        ) {
+            self.path = path
+            self.progressWeight = progressWeight
+            self.minimumBytes = minimumBytes
+            self.remoteRepoID = remoteRepoID
+            self.remotePath = remotePath ?? path
+        }
+    }
+
+    private static let requiredFileSpecs: [RequiredFile] = [
+        .init(path: "Encoder.mlmodelc/weights/weight.bin", progressWeight: 0.92, minimumBytes: 221_625_000),
+        .init(path: "Encoder.mlmodelc/model.mil", progressWeight: 0.01, minimumBytes: 590_000),
+        .init(path: "Encoder.mlmodelc/metadata.json", progressWeight: 0.005, minimumBytes: 2_000),
+        .init(path: "Encoder.mlmodelc/coremldata.bin", progressWeight: 0.001, minimumBytes: 400),
+        .init(path: "Predictor.mlmodelc/weights/weight.bin", progressWeight: 0.02, minimumBytes: 1_160_000),
+        .init(path: "Predictor.mlmodelc/model.mil", progressWeight: 0.005, minimumBytes: 9_000),
+        .init(path: "Predictor.mlmodelc/metadata.json", progressWeight: 0.002, minimumBytes: 3_000),
+        .init(path: "Predictor.mlmodelc/coremldata.bin", progressWeight: 0.001, minimumBytes: 400),
+        .init(path: "JointDecision.mlmodelc/weights/weight.bin", progressWeight: 0.01, minimumBytes: 685_000),
+        .init(path: "JointDecision.mlmodelc/model.mil", progressWeight: 0.003, minimumBytes: 6_000),
+        .init(path: "JointDecision.mlmodelc/metadata.json", progressWeight: 0.002, minimumBytes: 2_000),
+        .init(path: "JointDecision.mlmodelc/coremldata.bin", progressWeight: 0.001, minimumBytes: 400),
+        .init(path: "vocab.txt", progressWeight: 0.005, minimumBytes: 13_000),
+        .init(
+            path: "hann_window.f32.bin",
+            progressWeight: 0.001,
+            minimumBytes: 1_280,
+            remoteRepoID: "kruatech/gigaam-v3-mlx"
+        ),
+        .init(
+            path: "mel_filterbank_mel_freq.f32.bin",
+            progressWeight: 0.002,
+            minimumBytes: 41_216,
+            remoteRepoID: "kruatech/gigaam-v3-mlx"
+        ),
+    ]
+
+    static func cacheDirectory(fileManager: FileManager = .default) -> URL {
+        AppIdentity.supportDirectoryURL.appendingPathComponent(cacheRelativePath, isDirectory: true)
+    }
+
+    static func isAvailableLocally(fileManager: FileManager = .default) -> Bool {
+        let directory = cacheDirectory(fileManager: fileManager)
+        return isCompleteModelDirectory(directory, fileManager: fileManager)
+    }
+
+    static func isCompleteModelDirectory(_ directory: URL, fileManager: FileManager = .default) -> Bool {
+        requiredFileSpecs.allSatisfy { spec in
+            isCompleteLocalFile(
+                at: directory.appendingPathComponent(spec.path),
+                spec: spec,
+                fileManager: fileManager
+            )
+        }
+    }
+
+    static func deleteModelFiles(fileManager: FileManager = .default) throws {
+        let directory = cacheDirectory(fileManager: fileManager)
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try fileManager.removeItem(at: directory)
+    }
+
+    static func downloadIfNeeded(progress: ((Double, String?) -> Void)? = nil) async throws -> URL {
+        let directory = cacheDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        if isAvailableLocally() {
+            progress?(1.0, nil)
+            return directory
+        }
+
+        try seedFromLocalMirrors(to: directory, progress: progress)
+        if isAvailableLocally() {
+            fputs("[muesli-native] GigaAM v3 loaded from local CoreML cache\n", stderr)
+            progress?(0.95, "Loading GigaAM v3...")
+            return directory
+        }
+
+        progress?(0.05, "Preparing GigaAM v3...")
+
+        let totalWeight = max(requiredFileSpecs.reduce(0) { $0 + $1.progressWeight }, 1)
+        var completedWeight = requiredFileSpecs.reduce(0) { partial, spec in
+            let localFile = directory.appendingPathComponent(spec.path)
+            return partial + (isCompleteLocalFile(at: localFile, spec: spec) ? spec.progressWeight : 0)
+        }
+        reportDownloadProgress(completedWeight / totalWeight, progress: progress)
+
+        for spec in requiredFileSpecs {
+            try Task.checkCancellation()
+            let localFile = directory.appendingPathComponent(spec.path)
+            guard !isCompleteLocalFile(at: localFile, spec: spec) else {
+                continue
+            }
+            try? FileManager.default.removeItem(at: localFile)
+            try FileManager.default.createDirectory(
+                at: localFile.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            guard let remoteURL = URL(string: "https://huggingface.co/\(spec.remoteRepoID)/resolve/main/\(spec.remotePath)") else {
+                throw NSError(domain: "GigaAMV3ModelStore", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "Invalid GigaAM v3 download URL for \(spec.path)",
+                ])
+            }
+            fputs("[muesli-native] GigaAM v3 downloading \(spec.path)...\n", stderr)
+            try await downloadWithRetry(from: remoteURL, to: localFile) { fileProgress in
+                let weightedProgress = (completedWeight + spec.progressWeight * fileProgress) / totalWeight
+                reportDownloadProgress(weightedProgress, progress: progress)
+            }
+            completedWeight += spec.progressWeight
+            reportDownloadProgress(completedWeight / totalWeight, progress: progress)
+        }
+
+        guard isAvailableLocally() else {
+            throw NSError(domain: "GigaAMV3ModelStore", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 model did not finish downloading.",
+            ])
+        }
+        progress?(0.95, "Loading GigaAM v3...")
+        return directory
+    }
+
+    private static func seedFromLocalMirrors(
+        to directory: URL,
+        progress: ((Double, String?) -> Void)? = nil,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var copied = 0
+        for seedDirectory in localSeedDirectories() {
+            for (index, spec) in requiredFileSpecs.enumerated() {
+                let source = seedDirectory.appendingPathComponent(spec.path)
+                let destination = directory.appendingPathComponent(spec.path)
+                guard isCompleteLocalFile(at: source, spec: spec, fileManager: fileManager),
+                      !isCompleteLocalFile(at: destination, spec: spec, fileManager: fileManager) else {
+                    continue
+                }
+                try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try? fileManager.removeItem(at: destination)
+                try fileManager.copyItem(at: source, to: destination)
+                copied += 1
+                let fraction = 0.05 + (Double(index + 1) / Double(requiredFileSpecs.count)) * 0.85
+                progress?(fraction, "Copying local GigaAM v3 model...")
+            }
+        }
+
+        if copied > 0 {
+            fputs("[muesli-native] GigaAM v3 seeded \(copied) CoreML files from local mirrors\n", stderr)
+        }
+    }
+
+    private static func localSeedDirectories() -> [URL] {
+        var directories: [URL] = []
+        let environment = ProcessInfo.processInfo.environment
+
+        if let rawValue = environment[localSeedEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawValue.isEmpty {
+            directories.append(URL(fileURLWithPath: (rawValue as NSString).expandingTildeInPath, isDirectory: true))
+        }
+
+        if let resourceURL = Bundle.main.resourceURL {
+            directories.append(resourceURL.appendingPathComponent(cacheRelativePath, isDirectory: true))
+        }
+
+        var seen = Set<String>()
+        return directories.filter { url in
+            let path = url.standardizedFileURL.path
+            if seen.contains(path) {
+                return false
+            }
+            seen.insert(path)
+            return true
+        }
+    }
+
+    private static func isCompleteLocalFile(
+        at url: URL,
+        spec: RequiredFile,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let size = attributes[.size] as? NSNumber else {
+            return false
+        }
+        return size.int64Value >= spec.minimumBytes
+    }
+
+    private static func reportDownloadProgress(
+        _ rawValue: Double,
+        progress: ((Double, String?) -> Void)?
+    ) {
+        let clamped = min(max(rawValue, 0), 1)
+        let fraction = 0.05 + clamped * 0.85
+        let percent = Int((fraction * 100).rounded())
+        progress?(fraction, "Downloading GigaAM v3 (\(percent)%)...")
+    }
+}
+
+private final class GigaAMV3CoreMLRecognizer {
+    private let encoder: MLModel
+    private let predictor: MLModel
+    private let joint: MLModel
+    private let melProcessor: GigaAMV3MelSpectrogram
+    private let vocabulary: [Int: String]
+    private let initialToken: Int32 = 1_024
+    private let blankToken = 1_024
+    private let featureFrames = 3_000
+
+    init(modelDirectory: URL) throws {
+        let config = MLModelConfiguration()
+        config.computeUnits = .all
+        encoder = try MLModel(contentsOf: modelDirectory.appendingPathComponent("Encoder.mlmodelc"), configuration: config)
+        predictor = try MLModel(contentsOf: modelDirectory.appendingPathComponent("Predictor.mlmodelc"), configuration: config)
+        joint = try MLModel(contentsOf: modelDirectory.appendingPathComponent("JointDecision.mlmodelc"), configuration: config)
+        melProcessor = try GigaAMV3MelSpectrogram(assetsDirectory: modelDirectory)
+        vocabulary = try Self.loadVocabulary(modelDirectory.appendingPathComponent("vocab.txt"))
+    }
+
+    struct Result {
+        let text: String
+        let steps: Int
+    }
+
+    func transcribe(samples: [Float], sampleRate: Int) throws -> Result {
+        guard sampleRate == GigaAMV3FileChunking.sampleRate else {
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 CoreML expects 16 kHz mono audio.",
+            ])
+        }
+
+        let windows = GigaAMV3FileChunking.windows(sampleCount: samples.count, sampleRate: sampleRate)
+        fputs("[muesli-native] GigaAM v3 CoreML chunked transcription: \(windows.count) windows, \(String(format: "%.1f", Double(samples.count) / Double(sampleRate)))s\n", stderr)
+
+        var texts: [String] = []
+        var totalSteps = 0
+        texts.reserveCapacity(windows.count)
+
+        for window in windows {
+            try Task.checkCancellation()
+            let decoded = try autoreleasepool { () throws -> (text: String, steps: Int) in
+                var chunk = Array(samples[window])
+                if chunk.count < melProcessor.winLength {
+                    chunk.append(contentsOf: repeatElement(0, count: melProcessor.winLength - chunk.count))
+                }
+
+                let raw = try melProcessor.computeFlat(samples: chunk)
+                let features = Self.padFeatures(raw.features, sourceFrames: raw.length, targetFrames: featureFrames)
+                let decodeFrames = min(750, max(1, (raw.length + 3) / 4))
+                let decoded = try decode(features: features, decodeFrames: decodeFrames)
+                let text = decodeTokens(decoded.tokens).trimmingCharacters(in: .whitespacesAndNewlines)
+                return (text, decoded.steps)
+            }
+            totalSteps += decoded.steps
+            if !decoded.text.isEmpty {
+                texts.append(decoded.text)
+            }
+        }
+
+        return Result(text: GigaAMV3FileChunking.mergeTranscripts(texts), steps: totalSteps)
+    }
+
+    private func decode(features: [Float], decodeFrames: Int) throws -> (tokens: [Int], steps: Int) {
+        let audioSignal = try Self.floatArray(shape: Self.shape(1, 64, featureFrames))
+        Self.copy(features, to: audioSignal)
+
+        let encoderOutput = try prediction(encoder, dictionary: [
+            "audio_signal": MLFeatureValue(multiArray: audioSignal),
+        ])
+        guard let encoded = encoderOutput.featureValue(for: "encoded")?.multiArrayValue else {
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "CoreML encoder missing encoded output.",
+            ])
+        }
+
+        var hState = try Self.zeroFloatArray(shape: Self.shape(1, 1, 320))
+        var cState = try Self.zeroFloatArray(shape: Self.shape(1, 1, 320))
+        var cachedDec: MLMultiArray?
+        var cachedH: MLMultiArray?
+        var cachedC: MLMultiArray?
+        var lastToken = initialToken
+        var tokens: [Int] = []
+        var steps = 0
+
+        let frameLimit = min(decodeFrames, encoded.shape[2].intValue)
+        for frame in 0..<frameLimit {
+            var emitted = 0
+            while emitted < 10 {
+                if cachedDec == nil {
+                    let token = try Self.intArray(value: lastToken, shape: Self.shape(1, 1))
+                    let predictorOutput = try prediction(predictor, dictionary: [
+                        "x": MLFeatureValue(multiArray: token),
+                        "hi": MLFeatureValue(multiArray: hState),
+                        "ci": MLFeatureValue(multiArray: cState),
+                    ])
+                    cachedDec = try predictorOutput.gigaAMV3Array("dec")
+                    cachedH = try predictorOutput.gigaAMV3Array("ho")
+                    cachedC = try predictorOutput.gigaAMV3Array("co")
+                }
+
+                let encFrame = try Self.encodedFrame(encoded, frame: frame)
+                let decFrame = try Self.decoderFrame(cachedDec!)
+                let jointOutput = try prediction(joint, dictionary: [
+                    "enc": MLFeatureValue(multiArray: encFrame),
+                    "dec": MLFeatureValue(multiArray: decFrame),
+                ])
+                let predicted = try jointOutput.gigaAMV3Array("token_id").gigaAMV3Int32Value(at: 0)
+                steps += 1
+                if predicted == blankToken {
+                    break
+                }
+
+                tokens.append(predicted)
+                emitted += 1
+                lastToken = Int32(predicted)
+                hState = try Self.float32Copy(cachedH!)
+                cState = try Self.float32Copy(cachedC!)
+                cachedDec = nil
+                cachedH = nil
+                cachedC = nil
+            }
+        }
+        return (tokens, steps)
+    }
+
+    private func decodeTokens(_ tokenIds: [Int]) -> String {
+        var text = tokenIds.map { vocabulary[$0] ?? "" }.joined()
+        text = text.replacingOccurrences(of: "▁", with: " ")
+        if text.hasPrefix(" ") {
+            text.removeFirst()
+        }
+        return text
+    }
+
+    private func prediction(_ model: MLModel, dictionary: [String: MLFeatureValue]) throws -> MLFeatureProvider {
+        try autoreleasepool {
+            try model.prediction(from: MLDictionaryFeatureProvider(dictionary: dictionary))
+        }
+    }
+
+    private static func loadVocabulary(_ url: URL) throws -> [Int: String] {
+        let lines = try String(contentsOf: url, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+        var vocabulary: [Int: String] = [:]
+        for line in lines {
+            guard let space = line.lastIndex(of: " ") else { continue }
+            let piece = String(line[..<space])
+            guard let id = Int(line[line.index(after: space)...]), piece != "<blk>" else { continue }
+            vocabulary[id] = piece == "<unk>" ? "" : piece
+        }
+        return vocabulary
+    }
+
+    private static func padFeatures(_ source: [Float], sourceFrames: Int, targetFrames: Int) -> [Float] {
+        var output = [Float](repeating: 0, count: 64 * targetFrames)
+        let frames = min(sourceFrames, targetFrames)
+        for mel in 0..<64 {
+            let sourceOffset = mel * sourceFrames
+            let outputOffset = mel * targetFrames
+            output[outputOffset..<outputOffset + frames] = source[sourceOffset..<sourceOffset + frames]
+        }
+        return output
+    }
+
+    private static func floatArray(shape: [NSNumber]) throws -> MLMultiArray {
+        try MLMultiArray(shape: shape, dataType: .float32)
+    }
+
+    private static func shape(_ values: Int...) -> [NSNumber] {
+        values.map { NSNumber(value: $0) }
+    }
+
+    private static func zeroFloatArray(shape: [NSNumber]) throws -> MLMultiArray {
+        let array = try floatArray(shape: shape)
+        memset(array.dataPointer, 0, array.count * MemoryLayout<Float>.size)
+        return array
+    }
+
+    private static func intArray(value: Int32, shape: [NSNumber]) throws -> MLMultiArray {
+        let array = try MLMultiArray(shape: shape, dataType: .int32)
+        array.dataPointer.bindMemory(to: Int32.self, capacity: array.count)[0] = value
+        return array
+    }
+
+    private static func copy(_ values: [Float], to array: MLMultiArray) {
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: array.count)
+        values.withUnsafeBufferPointer { source in
+            guard let baseAddress = source.baseAddress else { return }
+            ptr.update(from: baseAddress, count: min(values.count, array.count))
+        }
+    }
+
+    private static func encodedFrame(_ encoded: MLMultiArray, frame: Int) throws -> MLMultiArray {
+        let output = try floatArray(shape: shape(1, 768, 1))
+        let dst = output.dataPointer.bindMemory(to: Float.self, capacity: output.count)
+        let channelStride = encoded.strides[1].intValue
+        let frameStride = encoded.strides[2].intValue
+        switch encoded.dataType {
+        case .float16:
+            let src = encoded.dataPointer.bindMemory(to: Float16.self, capacity: encoded.count)
+            for channel in 0..<768 {
+                dst[channel] = Float(src[channel * channelStride + frame * frameStride])
+            }
+        case .float32:
+            let src = encoded.dataPointer.bindMemory(to: Float.self, capacity: encoded.count)
+            for channel in 0..<768 {
+                dst[channel] = src[channel * channelStride + frame * frameStride]
+            }
+        default:
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 20, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported encoded dtype \(encoded.dataType.rawValue).",
+            ])
+        }
+        return output
+    }
+
+    private static func decoderFrame(_ dec: MLMultiArray) throws -> MLMultiArray {
+        let output = try floatArray(shape: shape(1, 320, 1))
+        let dst = output.dataPointer.bindMemory(to: Float.self, capacity: output.count)
+        switch dec.dataType {
+        case .float16:
+            let src = dec.dataPointer.bindMemory(to: Float16.self, capacity: dec.count)
+            for index in 0..<320 { dst[index] = Float(src[index]) }
+        case .float32:
+            let src = dec.dataPointer.bindMemory(to: Float.self, capacity: dec.count)
+            for index in 0..<320 { dst[index] = src[index] }
+        default:
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 21, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported decoder dtype \(dec.dataType.rawValue).",
+            ])
+        }
+        return output
+    }
+
+    private static func float32Copy(_ array: MLMultiArray) throws -> MLMultiArray {
+        let output = try floatArray(shape: array.shape)
+        let dst = output.dataPointer.bindMemory(to: Float.self, capacity: output.count)
+        switch array.dataType {
+        case .float16:
+            let src = array.dataPointer.bindMemory(to: Float16.self, capacity: array.count)
+            for index in 0..<array.count { dst[index] = Float(src[index]) }
+        case .float32:
+            let src = array.dataPointer.bindMemory(to: Float.self, capacity: array.count)
+            for index in 0..<array.count { dst[index] = src[index] }
+        default:
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 22, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported state dtype \(array.dataType.rawValue).",
+            ])
+        }
+        return output
+    }
+}
+
+private final class GigaAMV3MelSpectrogram {
+    let winLength = 320
+
+    private let nMels = 64
+    private let nFFT = 320
+    private let hopLength = 160
+    private let nFreqs = 161
+
+    private let window: [Float]
+    private let filterbank: [Float]
+    private let cosTable: [Float]
+    private let sinTable: [Float]
+
+    init(assetsDirectory: URL) throws {
+        let windowURL = assetsDirectory.appendingPathComponent("hann_window.f32.bin")
+        let filterbankURL = assetsDirectory.appendingPathComponent("mel_filterbank_mel_freq.f32.bin")
+        window = try Self.readFloat32Binary(windowURL, expectedCount: winLength)
+        filterbank = try Self.readFloat32Binary(filterbankURL, expectedCount: nMels * nFreqs)
+
+        var cosTable = [Float](repeating: 0, count: nFreqs * nFFT)
+        var sinTable = [Float](repeating: 0, count: nFreqs * nFFT)
+        let twoPi = 2.0 * Double.pi
+        for freq in 0..<nFreqs {
+            let offset = freq * nFFT
+            for n in 0..<nFFT {
+                let angle = twoPi * Double(freq * n) / Double(nFFT)
+                cosTable[offset + n] = Float(cos(angle))
+                sinTable[offset + n] = Float(sin(angle))
+            }
+        }
+        self.cosTable = cosTable
+        self.sinTable = sinTable
+    }
+
+    func computeFlat(samples: [Float]) throws -> (features: [Float], length: Int) {
+        guard samples.count >= winLength else {
+            throw NSError(domain: "GigaAMV3MelSpectrogram", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Audio is shorter than GigaAM v3 window length.",
+            ])
+        }
+
+        let frameCount = ((samples.count - winLength) / hopLength) + 1
+        var power = [Float](repeating: 0, count: nFreqs * frameCount)
+
+        for frame in 0..<frameCount {
+            let frameOffset = frame * hopLength
+            for freq in 0..<nFreqs {
+                let tableOffset = freq * nFFT
+                var real = Float(0)
+                var imag = Float(0)
+                for n in 0..<nFFT {
+                    let sample = samples[frameOffset + n] * window[n]
+                    real += sample * cosTable[tableOffset + n]
+                    imag -= sample * sinTable[tableOffset + n]
+                }
+                power[freq * frameCount + frame] = real * real + imag * imag
+            }
+        }
+
+        var result = [Float](repeating: 0, count: nMels * frameCount)
+        for mel in 0..<nMels {
+            let melOffset = mel * nFreqs
+            let outputOffset = mel * frameCount
+            for frame in 0..<frameCount {
+                var value = Float(0)
+                for freq in 0..<nFreqs {
+                    value += filterbank[melOffset + freq] * power[freq * frameCount + frame]
+                }
+                result[outputOffset + frame] = logf(min(max(value, 1e-9), 1e9))
+            }
+        }
+
+        return (result, frameCount)
+    }
+
+    private static func readFloat32Binary(_ url: URL, expectedCount: Int) throws -> [Float] {
+        let data = try Data(contentsOf: url)
+        guard data.count == expectedCount * MemoryLayout<Float>.size else {
+            throw NSError(domain: "GigaAMV3MelSpectrogram", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid GigaAM v3 frontend asset size at \(url.path).",
+            ])
+        }
+        var values = [Float](repeating: 0, count: expectedCount)
+        _ = values.withUnsafeMutableBytes { destination in
+            data.copyBytes(to: destination)
+        }
+        return values
+    }
+}
+
+private extension MLFeatureProvider {
+    func gigaAMV3Array(_ name: String) throws -> MLMultiArray {
+        guard let array = featureValue(for: name)?.multiArrayValue else {
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 30, userInfo: [
+                NSLocalizedDescriptionKey: "Missing CoreML output \(name).",
+            ])
+        }
+        return array
+    }
+}
+
+private extension MLMultiArray {
+    func gigaAMV3Int32Value(at index: Int) -> Int {
+        switch dataType {
+        case .int32:
+            Int(dataPointer.bindMemory(to: Int32.self, capacity: count)[index])
+        default:
+            self[index].intValue
+        }
+    }
+}
+
+actor GigaAMV3Transcriber {
+    private var recognizer: GigaAMV3CoreMLRecognizer?
+    private var isLoading = false
+    private var activeDownloadTask: Task<URL, Error>?
+    private var loadWaiters: [CheckedContinuation<Void, Error>] = []
+    private var loadGeneration = 0
+
+    func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+        try await loadModels(progress: progress, allowDownload: true)
+    }
+
+    private func loadModels(
+        progress: ((Double, String?) -> Void)? = nil,
+        allowDownload: Bool
+    ) async throws {
+        if recognizer != nil {
+            progress?(1.0, nil)
+            return
+        }
+        if isLoading {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                loadWaiters.append(continuation)
+            }
+            progress?(1.0, nil)
+            return
+        }
+
+        isLoading = true
+        let generation = loadGeneration
+        do {
+            let directory: URL
+            if allowDownload {
+                let downloadTask = Task {
+                    try await GigaAMV3ModelStore.downloadIfNeeded(progress: progress)
+                }
+                activeDownloadTask = downloadTask
+                directory = try await downloadTask.value
+            } else {
+                guard GigaAMV3ModelStore.isAvailableLocally() else {
+                    throw NSError(domain: "GigaAMV3Transcriber", code: 2, userInfo: [
+                        NSLocalizedDescriptionKey: "GigaAM v3 models are not downloaded. Download them before transcribing.",
+                    ])
+                }
+                progress?(0.95, "Loading GigaAM v3...")
+                directory = GigaAMV3ModelStore.cacheDirectory()
+            }
+            guard generation == loadGeneration else {
+                throw NSError(domain: "GigaAMV3Transcriber", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "GigaAM v3 load was cancelled.",
+                ])
+            }
+            activeDownloadTask = nil
+            let loadedRecognizer = try GigaAMV3CoreMLRecognizer(modelDirectory: directory)
+            guard generation == loadGeneration else {
+                throw NSError(domain: "GigaAMV3Transcriber", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "GigaAM v3 load was cancelled.",
+                ])
+            }
+            recognizer = loadedRecognizer
+            isLoading = false
+            completeLoadWaiters()
+            progress?(1.0, nil)
+        } catch {
+            if generation == loadGeneration {
+                activeDownloadTask = nil
+                isLoading = false
+                completeLoadWaiters(throwing: error)
+            }
+            throw error
+        }
+    }
+
+    func transcribe(wavURL: URL) async throws -> GigaAMV3TranscriptionResult {
+        if recognizer == nil {
+            try await loadModels(allowDownload: false)
+        }
+        guard let recognizer else {
+            throw NSError(domain: "GigaAMV3Transcriber", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 recognizer is not loaded.",
+            ])
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        do {
+            let prepared = try await AudioFileImportController.convertToWAV(sourceURL: wavURL)
+            defer {
+                if prepared.wavURL.standardizedFileURL.path != wavURL.standardizedFileURL.path {
+                    try? FileManager.default.removeItem(at: prepared.wavURL)
+                }
+            }
+            let samples = try AudioConverter().resampleAudioFile(prepared.wavURL)
+            let result = try recognizer.transcribe(samples: samples, sampleRate: GigaAMV3FileChunking.sampleRate)
+
+            return GigaAMV3TranscriptionResult(
+                text: result.text,
+                duration: prepared.duration,
+                processingTime: CFAbsoluteTimeGetCurrent() - start
+            )
+        } catch {
+            throw Self.readableTranscriptionError(error)
+        }
+    }
+
+    func transcribe(samples: [Float], sampleRate: Int) async throws -> GigaAMV3TranscriptionResult {
+        if recognizer == nil {
+            try await loadModels(allowDownload: false)
+        }
+        guard let recognizer else {
+            throw NSError(domain: "GigaAMV3Transcriber", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 recognizer is not loaded.",
+            ])
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        do {
+            let result = try recognizer.transcribe(samples: samples, sampleRate: sampleRate)
+
+            return GigaAMV3TranscriptionResult(
+                text: result.text,
+                duration: Double(samples.count) / Double(sampleRate),
+                processingTime: CFAbsoluteTimeGetCurrent() - start
+            )
+        } catch {
+            throw Self.readableTranscriptionError(error)
+        }
+    }
+
+    func shutdown() {
+        loadGeneration += 1
+        activeDownloadTask?.cancel()
+        activeDownloadTask = nil
+        recognizer = nil
+        isLoading = false
+        completeLoadWaiters(throwing: NSError(domain: "GigaAMV3Transcriber", code: 4, userInfo: [
+            NSLocalizedDescriptionKey: "GigaAM v3 load was shut down.",
+        ]))
+    }
+
+    private func completeLoadWaiters(throwing error: Error? = nil) {
+        let waiters = loadWaiters
+        loadWaiters.removeAll()
+        for waiter in waiters {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
+    }
+
+    private nonisolated static func readableTranscriptionError(_ error: Error) -> Error {
+        let nsError = error as NSError
+        if nsError.domain == "GigaAMV3Transcriber" {
+            return error
+        }
+
+        return NSError(domain: "GigaAMV3Transcriber", code: 5, userInfo: [
+            NSLocalizedDescriptionKey: "GigaAM v3 transcription failed: \(error.localizedDescription)",
+            NSUnderlyingErrorKey: error,
+        ])
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -73,6 +73,15 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
+    static let gigaAMV3Russian = BackendOption(
+        backend: "gigaam_v3",
+        model: "huggingfinger0/gigaam-v3-coreml",
+        label: "GigaAM v3 (Russian)",
+        sizeLabel: GigaAMV3ModelStore.downloadedModelSizeLabel,
+        description: "Russian-first offline ASR via precompiled CoreML. Runs locally on Apple Silicon; no Python server or cloud.",
+        recommended: false
+    )
+
     static let canaryQwen = BackendOption(
         backend: "canary",
         model: "phequals/canary-qwen-2.5b-coreml-int8",
@@ -134,7 +143,7 @@ struct BackendOption: Equatable {
     ]
 
     /// Models available for download and use.
-    static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe, .nemotron35Multilingual] + experimental
+    static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe, .nemotron35Multilingual, .gigaAMV3Russian] + experimental
 
     /// Curated first-run choices shown in onboarding's "Other models" section.
     /// This is a deliberate hand-picked list, not a derived rule. Experimental models
@@ -198,6 +207,8 @@ struct BackendOption: Equatable {
             let path = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/muesli/models/nemotron35-multilingual-2240ms/encoder.mlmodelc/coremldata.bin")
             return fm.fileExists(atPath: path.path)
+        case "gigaam_v3":
+            return GigaAMV3ModelStore.isAvailableLocally()
         case "canary":
             return CanaryQwenModelStore.isAvailableLocally()
         case "cohere":

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -65,6 +65,8 @@ struct ModelsView: View {
 
                 modelCard(option: .nemotron35Multilingual, logo: "nvidia-logo")
 
+                modelCard(option: .gigaAMV3Russian)
+
                 experimentalSection
 
                 postProcessorSection
@@ -479,6 +481,7 @@ struct ModelsView: View {
         case "fluidaudio": return "nvidia-logo"
         case "whisper": return "openai-logo"
         case "cohere": return "cohere-logo"
+        case "gigaam_v3": return nil
         case "qwen": return "qwen-logo"
         case "nemotron35": return "nvidia-logo"
         case "canary": return "qwen-logo"
@@ -1001,6 +1004,8 @@ struct ModelsView: View {
             try removeItemIfPresent(at: CanaryQwenModelStore.cacheDirectory(), fileManager: fm)
         case "cohere":
             try removeItemIfPresent(at: CohereTranscribeModelStore.cacheDirectory(), fileManager: fm)
+        case "gigaam_v3":
+            try GigaAMV3ModelStore.deleteModelFiles(fileManager: fm)
         case "indicasr":
             if IndicASRModelStore.localOverrideDirectory() == nil {
                 try removeItemIfPresent(at: IndicASRModelStore.cacheDirectory(), fileManager: fm)
@@ -1096,6 +1101,8 @@ struct ModelsView: View {
             return CanaryQwenModelStore.isAvailableLocally()
         case "cohere":
             return CohereTranscribeModelStore.isAvailableLocally()
+        case "gigaam_v3":
+            return GigaAMV3ModelStore.isAvailableLocally()
         case "indicasr":
             return IndicASRModelStore.isAvailableLocally()
         case "sensevoice":

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -15,7 +15,7 @@ struct SpeechTranscriptionResult: Sendable {
 
 actor TranscriptionCoordinator {
     static let explicitlyRoutedBackendIdentifiers: Set<String> = [
-        "whisper", "nemotron35", "qwen", "canary", "cohere", "indicasr", "sensevoice",
+        "whisper", "nemotron35", "gigaam_v3", "qwen", "canary", "cohere", "indicasr", "sensevoice",
     ]
 
     private let fluidTranscriber = FluidAudioTranscriber()
@@ -25,6 +25,7 @@ actor TranscriptionCoordinator {
     private var _canaryQwenTranscriber: Any?
     private var _cohereTranscriber: Any?
     private var _indicASRTranscriber: Any?
+    private let gigaAMV3Transcriber = GigaAMV3Transcriber()
     private let senseVoiceTranscriber = SenseVoiceTranscriber()
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
@@ -272,6 +273,8 @@ actor TranscriptionCoordinator {
                     NSLocalizedDescriptionKey: "Nemotron 3.5 requires macOS 15 or later.",
                 ])
             }
+        case "gigaam_v3":
+            try await gigaAMV3Transcriber.loadModels(progress: progress)
         case "qwen":
             if #available(macOS 15, *) {
                 try await qwen3Transcriber.loadModels(progress: progress)
@@ -435,6 +438,7 @@ actor TranscriptionCoordinator {
     func shutdown() async {
         await fluidTranscriber.shutdown()
         await whisperTranscriber.shutdown()
+        await gigaAMV3Transcriber.shutdown()
         await senseVoiceTranscriber.shutdown()
         if #available(macOS 15, *) {
             if let nemotron35 = _nemotron35Transcriber as? Nemotron35StreamingTranscriber {
@@ -664,6 +668,8 @@ actor TranscriptionCoordinator {
             return try await transcribeWithWhisperKit(url: url)
         case "nemotron35":
             return try await transcribeWithNemotron35(url: url)
+        case "gigaam_v3":
+            return try await transcribeWithGigaAMV3(url: url)
         case "qwen":
             return try await transcribeWithQwen3(url: url)
         case "canary":
@@ -705,6 +711,19 @@ actor TranscriptionCoordinator {
         return SpeechTranscriptionResult(
             text: text,
             segments: text.isEmpty ? [] : [SpeechSegment(start: 0, end: 0, text: text)]
+        )
+    }
+
+    // MARK: - GigaAM v3 Russian ASR (CoreML)
+
+    private func transcribeWithGigaAMV3(url: URL) async throws -> SpeechTranscriptionResult {
+        fputs("[muesli-native] transcribing with GigaAM v3: \(url.lastPathComponent)\n", stderr)
+        let result = try await gigaAMV3Transcriber.transcribe(wavURL: url)
+        fputs("[muesli-native] GigaAM v3 result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return SpeechTranscriptionResult(
+            text: text,
+            segments: text.isEmpty ? [] : [SpeechSegment(start: 0, end: result.duration, text: text)]
         )
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -25,7 +25,7 @@ struct BackendOptionTests {
 
     @Test("backend field is one of the known backends")
     func knownBackends() {
-        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron35", "canary", "cohere", "indicasr", "sensevoice"]
+        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron35", "gigaam_v3", "canary", "cohere", "indicasr", "sensevoice"]
         for option in BackendOption.all {
             #expect(known.contains(option.backend), "Unknown backend: \(option.backend)")
         }
@@ -72,6 +72,7 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.indicASR))
         #expect(BackendOption.all.contains(.senseVoiceSmall))
         #expect(BackendOption.all.contains(.nemotron35Multilingual))
+        #expect(BackendOption.all.contains(.gigaAMV3Russian))
     }
 
     @Test("Cohere uses cohere backend")

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -228,6 +228,21 @@ struct GigaAMV3FileChunkingTests {
 
         #expect(result == "alpha beta gamma delta epsilon zeta eta theta iota")
     }
+
+    @Test("merge deduplicates single word overlap")
+    func mergeDeduplicatesSingleWordOverlap() {
+        let result = GigaAMV3FileChunking.mergeTranscripts([
+            "alpha beta",
+            "beta gamma",
+        ])
+
+        #expect(result == "alpha beta gamma")
+    }
+
+    @Test("gigaam cache path stays under app support")
+    func gigaAMCachePath() {
+        #expect(GigaAMV3ModelStore.cacheDirectory().path.hasSuffix("Library/Application Support/Muesli/Models/gigaam-v3-coreml"))
+    }
 }
 
 @Suite("TranscriptionEngineArtifactsFilter")

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -211,6 +211,7 @@ struct GigaAMV3FileChunkingTests {
             (36 * sampleRate)..<(56 * sampleRate),
             (54 * sampleRate)..<(61 * sampleRate),
         ])
+        #expect(GigaAMV3FileChunking.shouldChunk(sampleCount: sampleCount))
     }
 
     @Test("empty audio produces no windows")
@@ -242,6 +243,28 @@ struct GigaAMV3FileChunkingTests {
     @Test("gigaam cache path stays under app support")
     func gigaAMCachePath() {
         #expect(GigaAMV3ModelStore.cacheDirectory().path.hasSuffix("Library/Application Support/Muesli/Models/gigaam-v3-coreml"))
+    }
+}
+
+@Suite("GigaAMV3Transcriber errors")
+struct GigaAMV3TranscriberErrorTests {
+
+    @Test("cancellation errors pass through")
+    func cancellationErrorsPassThrough() {
+        let error = GigaAMV3Transcriber.readableTranscriptionError(CancellationError())
+        #expect(error is CancellationError)
+    }
+
+    @Test("wrapped cancellation errors pass through")
+    func wrappedCancellationErrorsPassThrough() {
+        let wrapped = NSError(
+            domain: "GigaAMV3TranscriberErrorTests",
+            code: 1,
+            userInfo: [NSUnderlyingErrorKey: CancellationError()]
+        )
+
+        let error = GigaAMV3Transcriber.readableTranscriptionError(wrapped)
+        #expect(error is CancellationError)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -189,6 +189,47 @@ struct CohereTranscribeUtilsTests {
     }
 }
 
+@Suite("GigaAMV3FileChunking")
+struct GigaAMV3FileChunkingTests {
+
+    @Test("short files use one passthrough window")
+    func shortFilesUseOnePassthroughWindow() {
+        let sampleCount = 25 * GigaAMV3FileChunking.sampleRate
+        #expect(GigaAMV3FileChunking.windows(sampleCount: sampleCount) == [0..<sampleCount])
+        #expect(!GigaAMV3FileChunking.shouldChunk(sampleCount: sampleCount))
+    }
+
+    @Test("long files use 20 second windows with 2 second overlap")
+    func longFilesUseOverlappingWindows() {
+        let sampleRate = GigaAMV3FileChunking.sampleRate
+        let sampleCount = 61 * sampleRate
+        let windows = GigaAMV3FileChunking.windows(sampleCount: sampleCount)
+
+        #expect(windows == [
+            0..<(20 * sampleRate),
+            (18 * sampleRate)..<(38 * sampleRate),
+            (36 * sampleRate)..<(56 * sampleRate),
+            (54 * sampleRate)..<(61 * sampleRate),
+        ])
+    }
+
+    @Test("empty audio produces no windows")
+    func emptyAudioProducesNoWindows() {
+        #expect(GigaAMV3FileChunking.windows(sampleCount: 0).isEmpty)
+    }
+
+    @Test("merge deduplicates overlap")
+    func mergeDeduplicatesOverlap() {
+        let result = GigaAMV3FileChunking.mergeTranscripts([
+            "alpha beta gamma delta epsilon",
+            "gamma delta epsilon zeta eta",
+            "zeta eta theta iota",
+        ])
+
+        #expect(result == "alpha beta gamma delta epsilon zeta eta theta iota")
+    }
+}
+
 @Suite("TranscriptionEngineArtifactsFilter")
 struct TranscriptionEngineArtifactsFilterTests {
 


### PR DESCRIPTION
## What

Adds GigaAM v3 as a local ASR backend — a Russian-first conformer/RNNT model running fully on-device via CoreML. Muesli already covers Russian through multilingual backends (Nemotron, SenseVoice); GigaAM's value is substantially better Russian transcription quality and latency, since it's a Russian-specialized model. In my daily use it clearly outperforms the multilingual options on Russian dictation and meetings.

## Scope (part 1 of 2)

- `GigaAMV3Backend.swift`: model download from Hugging Face (~224 MB CoreML bundles + tokenizer/mel assets), CoreML load (`computeUnits = .all`), file transcription. Long files are transcribed in 20s windows with 2s overlap and suffix-prefix merge (conformer self-attention is O(n²), so unbounded input is both an OOM and quality risk) — chunking is backend-private.
- Registry/routing/UI: backend option, `TranscriptionRuntime` preload/route wiring, model download card following the existing patterns.
- No new package dependencies, no default-model or onboarding changes, no live-meeting pipeline changes.

Part 2 (separate PR, stacked) will add meeting-optimized live chunking (3–20s VAD windows with 2s audio carryover and overlap dedup) — kept out of this PR to keep the live pipeline untouched here.

## Model asset notes

- CoreML bundles: `huggingfinger0/gigaam-v3-coreml` (main); frontend assets: `kruatech/gigaam-v3-mlx` (main)
- Cache: `Application Support/Muesli/Models/gigaam-v3-coreml`, validated by per-file minimum sizes; local seed override via `MUESLI_GIGAAM_V3_MODEL_DIR`

## Tests

File-chunking window math (boundaries/overlap/passthrough/empty), overlap merge on synthetic strings, backend registry/routing coverage. Full suite passes (1223 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785866268&installation_id=136549638&pr_number=275&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F275&signature=194f96900aa255a640e42804c763ba8d693efeb70817674a0fbbf873d429e148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GigaAM v3 Russian transcription backend with model management and end-to-end transcription support.
  * Updated the models screen and transcription runtime routing to include the new backend option.
  * Model downloads now support progress updates and more reliable retry behavior.

* **Bug Fixes**
  * Improved local availability checks and cached model deletion for the new backend.
  * Enhanced cancellation and error handling to ensure transcription and downloads stop cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->