### PR TITLE
Migrate Homebrew docs to official cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Download the latest `.dmg` from [Releases](https://github.com/Muesli-HQ/muesli/r
 ### Homebrew
 
 ```bash
-brew tap Muesli-HQ/muesli
 brew install --cask muesli
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Download the latest `.dmg` from [Releases](https://github.com/Muesli-HQ/muesli/r
 brew install --cask muesli
 ```
 
+Current Homebrew also resolves `brew install muesli` to the official cask; the
+`--cask` form is shown to make the app install explicit.
+
 ### Build from source
 
 **Requirements:** macOS 14.2+, Xcode 16+

--- a/docs/index.html
+++ b/docs/index.html
@@ -545,7 +545,7 @@
         <div class="install-alt">
           <span class="install-label">or install with homebrew</span>
           <span class="command-row">
-            <code id="brew-cmd">brew tap Muesli-HQ/muesli && brew install --cask muesli</code>
+            <code id="brew-cmd">brew install --cask muesli</code>
             <button aria-label="Copy Homebrew install command" title="Copy command" onclick="navigator.clipboard.writeText(document.getElementById('brew-cmd').textContent)">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <rect x="9" y="9" width="10" height="12" rx="2"></rect>

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -5,7 +5,7 @@ Run `./scripts/release.sh [version]` — it automates steps 1-9 and is the only 
 Source of truth:
 - GitHub Releases hosts the official DMG binaries
 - GitHub Pages hosts the Sparkle appcast consumed by the app
-- `Muesli-HQ/homebrew-muesli` mirrors the verified GitHub Release DMG via the Homebrew tap cask
+- The official `Homebrew/homebrew-cask` cask tracks the verified GitHub Release DMG
 - Marketing surfaces may link to those assets, but they are not release authorities
 
 This checklist is for **verification** after the script runs, and for manual recovery if any step fails.
@@ -167,17 +167,18 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   git push
   ```
 
-## Homebrew Tap
+## Homebrew Cask
 
-- [ ] **Update the Homebrew tap cask** in `Muesli-HQ/homebrew-muesli`
-  - `Casks/m/muesli.rb` must point at the new version and the hosted GitHub Release SHA256
-  - Commit message should be `muesli X.Y.Z`
-  - The canonical release flow now automates this inside `scripts/release.sh`
+- [ ] **Verify the official Homebrew cask autobump path**
+  - The canonical release flow runs `brew livecheck --cask muesli` after the GitHub Release is published
+  - It also runs `brew bump --cask --no-pull-requests muesli` to confirm BrewTestBot owns update PRs
+  - Homebrew's BrewTestBot owns official cask bump PRs for `muesli` and opens them automatically about every 3 hours
+  - If a PR does not appear after the next autobump cycle, investigate livecheck/autobump rather than using `brew bump-cask-pr`
+  - Set `MUESLI_SKIP_HOMEBREW_CHECK=1` only when intentionally skipping the release-time livecheck
 
-- [ ] **Verify the tap install path if the cask changed shape**
+- [ ] **Verify the official cask install path if the cask changed shape**
   ```bash
-  brew tap Muesli-HQ/muesli
-  brew install --cask Muesli-HQ/muesli/muesli
+  brew install --cask muesli
   ```
 
 ## Post-release

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -16,6 +16,7 @@ This checklist is for **verification** after the script runs, and for manual rec
 - [ ] `swift test --package-path native/MuesliNative` — all tests pass
 - [ ] Version bumped in `scripts/build_native_app.sh` (CFBundleVersion + CFBundleShortVersionString)
 - [ ] No uncommitted changes (`git status` clean)
+- [ ] Homebrew installed and updated enough to run post-release `brew livecheck --cask muesli`
 
 ## Signing Profiles
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 #   7. Re-download the hosted DMG from GitHub Releases and verify that exact file
 #   8. Update downstream release surfaces from the verified hosted DMG:
 #      - GitHub Pages appcast + landing-page metadata
-#      - Personal Homebrew tap cask
+#      - Official Homebrew cask livecheck/autobump verification
 #
 # Prerequisites:
 #   - Developer ID cert in keychain
@@ -56,12 +56,10 @@ INSTALL_DIR="${MUESLI_RELEASE_INSTALL_DIR:-$OUTPUT_DIR/install-root}"
 APP_DIR="${MUESLI_RELEASE_APP_DIR:-$INSTALL_DIR/Muesli.app}"
 GENERATE_APPCAST="$(muesli_spm_artifacts_dir "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
-TAP_REPO="${MUESLI_TAP_REPO:-Muesli-HQ/homebrew-muesli}"
-TAP_CASK_REL_PATH="${MUESLI_TAP_CASK_REL_PATH:-Casks/m/muesli.rb}"
-SKIP_TAP_UPDATE="${MUESLI_SKIP_TAP_UPDATE:-0}"
+HOMEBREW_CASK="${MUESLI_HOMEBREW_CASK:-muesli}"
+SKIP_HOMEBREW_CHECK="${MUESLI_SKIP_HOMEBREW_CHECK:-0}"
 VERIFY_DIR=""
 HOSTED_MOUNT_POINT=""
-TAP_WORK_DIR=""
 
 cleanup() {
   if [[ -n "$HOSTED_MOUNT_POINT" ]]; then
@@ -69,9 +67,6 @@ cleanup() {
   fi
   if [[ -n "$VERIFY_DIR" && -d "$VERIFY_DIR" ]]; then
     rm -rf "$VERIFY_DIR"
-  fi
-  if [[ -n "$TAP_WORK_DIR" && -d "$TAP_WORK_DIR" ]]; then
-    rm -rf "$TAP_WORK_DIR"
   fi
 }
 
@@ -138,33 +133,16 @@ Signed, notarized, and stapled by Apple.
 EOF
 )"
 
-update_personal_tap() {
-  if [[ "$SKIP_TAP_UPDATE" == "1" ]]; then
-    echo "  Skipping personal tap update because MUESLI_SKIP_TAP_UPDATE=1."
+verify_homebrew_autobump() {
+  if [[ "$SKIP_HOMEBREW_CHECK" == "1" ]]; then
+    echo "  Skipping official Homebrew cask livecheck because MUESLI_SKIP_HOMEBREW_CHECK=1."
     return 0
   fi
 
-  TAP_WORK_DIR="$(mktemp -d)"
-  echo "  Cloning $TAP_REPO..."
-  gh repo clone "$TAP_REPO" "$TAP_WORK_DIR" -- --quiet
-
-  local cask_path="$TAP_WORK_DIR/$TAP_CASK_REL_PATH"
-  if [[ ! -f "$cask_path" ]]; then
-    echo "ERROR: Personal tap cask not found at $TAP_CASK_REL_PATH in $TAP_REPO." >&2
-    return 1
-  fi
-
-  perl -0pi -e 's/version "[^"]+"/version "'"$VERSION"'"/; s/sha256 "[^"]+"/sha256 "'"$HOSTED_SHA"'"/' "$cask_path"
-
-  git -C "$TAP_WORK_DIR" add "$TAP_CASK_REL_PATH"
-  if git -C "$TAP_WORK_DIR" diff --cached --quiet; then
-    echo "  Personal tap already points at v${VERSION}."
-    return 0
-  fi
-
-  git -C "$TAP_WORK_DIR" commit -m "muesli ${VERSION}"
-  git -C "$TAP_WORK_DIR" push origin HEAD
-  echo "  Personal tap updated: https://github.com/$TAP_REPO"
+  echo "  Verifying official Homebrew cask livecheck for ${HOMEBREW_CASK}..."
+  brew livecheck --cask "$HOMEBREW_CASK"
+  brew bump --cask --no-pull-requests "$HOMEBREW_CASK"
+  echo "  BrewTestBot owns ${HOMEBREW_CASK} version bumps and should open a PR automatically."
 }
 
 echo "=== Muesli Release v${VERSION} ==="
@@ -448,9 +426,9 @@ else
   echo "  Pushed appcast and landing-page updates to main."
 fi
 
-# --- Step 13: Update the personal Homebrew tap from the verified hosted DMG ---
-echo "[13/13] Updating personal Homebrew tap..."
-update_personal_tap
+# --- Step 13: Verify the official Homebrew cask can see the new release ---
+echo "[13/13] Verifying official Homebrew cask livecheck..."
+verify_homebrew_autobump
 
 echo ""
 echo "=== Release complete ==="
@@ -458,6 +436,7 @@ echo "  Version: ${VERSION}"
 echo "  DMG: $DMG_PATH"
 echo "  Release: $RELEASE_URL"
 echo "  Hosted asset verified."
-if [[ "$SKIP_TAP_UPDATE" != "1" ]]; then
-  echo "  Personal tap: https://github.com/$TAP_REPO"
+if [[ "$SKIP_HOMEBREW_CHECK" != "1" ]]; then
+  echo "  Homebrew cask livecheck verified for ${HOMEBREW_CASK}."
+  echo "  Watch Homebrew/homebrew-cask for the BrewTestBot autobump PR."
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -61,6 +61,7 @@ HOMEBREW_CASK="${MUESLI_HOMEBREW_CASK:-muesli}"
 SKIP_HOMEBREW_CHECK="${MUESLI_SKIP_HOMEBREW_CHECK:-0}"
 VERIFY_DIR=""
 HOSTED_MOUNT_POINT=""
+HOMEBREW_CHECK_STATUS="skipped"
 
 cleanup() {
   if [[ -n "$HOSTED_MOUNT_POINT" ]]; then
@@ -137,15 +138,19 @@ EOF
 verify_homebrew_autobump() {
   if [[ "$SKIP_HOMEBREW_CHECK" == "1" ]]; then
     echo "  Skipping official Homebrew cask livecheck because MUESLI_SKIP_HOMEBREW_CHECK=1."
+    HOMEBREW_CHECK_STATUS="skipped"
     return 0
   fi
 
   echo "  Verifying official Homebrew cask livecheck for ${HOMEBREW_CASK}..."
+  HOMEBREW_CHECK_STATUS="verified"
   if ! brew livecheck --cask "$HOMEBREW_CASK"; then
     echo "  WARNING: Homebrew livecheck failed; check ${HOMEBREW_CASK} manually." >&2
+    HOMEBREW_CHECK_STATUS="warning"
   fi
   if ! brew bump --cask --no-pull-requests "$HOMEBREW_CASK"; then
     echo "  WARNING: Homebrew autobump verification failed; check ${HOMEBREW_CASK} manually." >&2
+    HOMEBREW_CHECK_STATUS="warning"
   fi
   echo "  BrewTestBot should open ${HOMEBREW_CASK} version bump PRs automatically."
 }
@@ -441,7 +446,9 @@ echo "  Version: ${VERSION}"
 echo "  DMG: $DMG_PATH"
 echo "  Release: $RELEASE_URL"
 echo "  Hosted asset verified."
-if [[ "$SKIP_HOMEBREW_CHECK" != "1" ]]; then
+if [[ "$HOMEBREW_CHECK_STATUS" == "verified" ]]; then
   echo "  Homebrew cask livecheck verified for ${HOMEBREW_CASK}."
   echo "  Watch Homebrew/homebrew-cask for the BrewTestBot autobump PR."
+elif [[ "$HOMEBREW_CHECK_STATUS" == "warning" ]]; then
+  echo "  Homebrew cask verification had warnings; check ${HOMEBREW_CASK} manually."
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 #       MUESLI_PROVISIONING_PROFILE=/path/to/profile.provisionprofile
 #   - Notary profile stored: xcrun notarytool store-credentials MuesliNotary
 #   - gh CLI authenticated
+#   - Homebrew installed for post-release cask livecheck/autobump verification
 #
 # Usage: ./scripts/release.sh [version]
 #   e.g.: ./scripts/release.sh 0.5.0
@@ -140,9 +141,13 @@ verify_homebrew_autobump() {
   fi
 
   echo "  Verifying official Homebrew cask livecheck for ${HOMEBREW_CASK}..."
-  brew livecheck --cask "$HOMEBREW_CASK"
-  brew bump --cask --no-pull-requests "$HOMEBREW_CASK"
-  echo "  BrewTestBot owns ${HOMEBREW_CASK} version bumps and should open a PR automatically."
+  if ! brew livecheck --cask "$HOMEBREW_CASK"; then
+    echo "  WARNING: Homebrew livecheck failed; check ${HOMEBREW_CASK} manually." >&2
+  fi
+  if ! brew bump --cask --no-pull-requests "$HOMEBREW_CASK"; then
+    echo "  WARNING: Homebrew autobump verification failed; check ${HOMEBREW_CASK} manually." >&2
+  fi
+  echo "  BrewTestBot should open ${HOMEBREW_CASK} version bump PRs automatically."
 }
 
 echo "=== Muesli Release v${VERSION} ==="


### PR DESCRIPTION
## Summary
- update README and website Homebrew install commands to use the official cask directly
- replace private tap release checklist steps with official Homebrew cask autobump verification
- remove the release script path that cloned and pushed `Muesli-HQ/homebrew-muesli`

## Validation
- `bash -n scripts/release.sh`
- `brew bump --cask --no-pull-requests muesli`

Homebrew reports `muesli` is autobumped by BrewTestBot, so future releases should verify livecheck/autobump rather than opening manual `brew bump-cask-pr` PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785867077&installation_id=136549638&pr_number=276&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F276&signature=138c8e6a3e12effe8d8ba8ee25d8802acf447259663259c559326f85d0a0e7ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Homebrew install instructions across the docs to use a single `brew install --cask muesli` command.
  * Refreshed the release checklist to follow the official Homebrew cask live-check and bump flow.

* **Chores**
  * Improved release-time Homebrew verification by switching from a tap-mirroring step to the canonical cask workflow, with clearer status reporting and an option to intentionally bypass the verification when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->