### PR TITLE
Tune live meeting chunking for GigaAM (part 2)

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DownloadUtils.swift
@@ -20,7 +20,8 @@ func downloadWithRetry(
     from url: URL,
     to destination: URL,
     maxRetries: Int = 3,
-    session: URLSession = .shared
+    session: URLSession = .shared,
+    progressHandler: ((Double) -> Void)? = nil
 ) async throws {
     var lastError: Error?
     for attempt in 0..<maxRetries {
@@ -31,14 +32,17 @@ func downloadWithRetry(
         }
         do {
             try Task.checkCancellation()
-            let (tempURL, response) = try await session.download(from: url)
+            let (tempURL, response) = try await downloadTemporaryFile(
+                from: url,
+                session: session,
+                progressHandler: progressHandler
+            )
             guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
                 let code = (response as? HTTPURLResponse)?.statusCode ?? -1
                 try? FileManager.default.removeItem(at: tempURL)
                 throw DownloadError.httpError(code, url.lastPathComponent)
             }
-            try? FileManager.default.removeItem(at: destination)
-            try FileManager.default.moveItem(at: tempURL, to: destination)
+            try moveDownloadedTemporaryFile(tempURL, to: destination)
             return
         } catch is CancellationError {
             throw CancellationError()
@@ -50,4 +54,150 @@ func downloadWithRetry(
         NSLocalizedDescriptionKey: "No download attempts were made",
     ])
     throw DownloadError.retriesExhausted(url.lastPathComponent, underlying)
+}
+
+func moveDownloadedTemporaryFile(_ tempURL: URL, to destination: URL) throws {
+    var movedToDestination = false
+    defer {
+        if !movedToDestination {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+    }
+
+    try? FileManager.default.removeItem(at: destination)
+    try FileManager.default.moveItem(at: tempURL, to: destination)
+    movedToDestination = true
+}
+
+private func downloadTemporaryFile(
+    from url: URL,
+    session: URLSession,
+    progressHandler: ((Double) -> Void)?
+) async throws -> (URL, URLResponse) {
+    guard let progressHandler else {
+        return try await session.download(from: url)
+    }
+
+    let delegate = ProgressDownloadDelegate(onProgress: progressHandler)
+    let progressSession = URLSession(configuration: session.configuration, delegate: delegate, delegateQueue: nil)
+    let invalidator = DownloadSessionInvalidator()
+    do {
+        let result = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                delegate.setContinuation(continuation)
+                progressSession.downloadTask(with: url).resume()
+            }
+        } onCancel: {
+            invalidator.cancel(progressSession)
+        }
+        invalidator.finish(progressSession)
+        return result
+    } catch {
+        if error is CancellationError {
+            invalidator.cancel(progressSession)
+        } else {
+            invalidator.finish(progressSession)
+        }
+        throw error
+    }
+}
+
+private final class DownloadSessionInvalidator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didInvalidate = false
+
+    func finish(_ session: URLSession) {
+        invalidate(session, action: { $0.finishTasksAndInvalidate() })
+    }
+
+    func cancel(_ session: URLSession) {
+        invalidate(session, action: { $0.invalidateAndCancel() })
+    }
+
+    private func invalidate(_ session: URLSession, action: (URLSession) -> Void) {
+        lock.lock()
+        guard !didInvalidate else {
+            lock.unlock()
+            return
+        }
+        didInvalidate = true
+        lock.unlock()
+        action(session)
+    }
+}
+
+private final class ProgressDownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let onProgress: (Double) -> Void
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<(URL, URLResponse), Error>?
+
+    init(onProgress: @escaping (Double) -> Void) {
+        self.onProgress = onProgress
+    }
+
+    func setContinuation(_ c: CheckedContinuation<(URL, URLResponse), Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        continuation = c
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        var movedURL: URL?
+        do {
+            let destination = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString + "." + downloadTask.originalRequestURLLastPathComponent)
+            try FileManager.default.moveItem(at: location, to: destination)
+            movedURL = destination
+            guard let response = downloadTask.response else {
+                throw URLError(.badServerResponse)
+            }
+            resumeOnce(.success((destination, response)))
+        } catch {
+            if let movedURL { try? FileManager.default.removeItem(at: movedURL) }
+            resumeOnce(.failure(error))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        resumeOnce(.failure(error))
+    }
+
+    private func resumeOnce(_ result: Result<(URL, URLResponse), Error>) {
+        lock.lock()
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+
+        guard let continuation else { return }
+        switch result {
+        case .success(let value):
+            continuation.resume(returning: value)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+private extension URLSessionDownloadTask {
+    var originalRequestURLLastPathComponent: String {
+        originalRequest?.url?.lastPathComponent.nonEmpty ?? "download.tmp"
+    }
+}
+
+private extension String {
+    var nonEmpty: String? {
+        isEmpty ? nil : self
+    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GigaAMV3Backend.swift
@@ -1,0 +1,828 @@
+@preconcurrency import CoreML
+import FluidAudio
+import Foundation
+
+struct GigaAMV3TranscriptionResult: Sendable {
+    let text: String
+    let duration: TimeInterval
+    let processingTime: TimeInterval
+}
+
+enum GigaAMV3FileChunking {
+    static let sampleRate = 16_000
+    static let passthroughThresholdSeconds: TimeInterval = 25
+    static let windowSeconds: TimeInterval = 20
+    static let overlapSeconds: TimeInterval = 2
+
+    static func windows(sampleCount: Int, sampleRate: Int = sampleRate) -> [Range<Int>] {
+        guard sampleCount > 0 else { return [] }
+        guard shouldChunk(sampleCount: sampleCount, sampleRate: sampleRate) else {
+            return [0..<sampleCount]
+        }
+
+        let windowSamples = max(1, Int((windowSeconds * Double(sampleRate)).rounded()))
+        let overlapSamples = min(Int((overlapSeconds * Double(sampleRate)).rounded()), windowSamples - 1)
+        let stepSamples = windowSamples - overlapSamples
+        var result: [Range<Int>] = []
+        var start = 0
+
+        while start < sampleCount {
+            let end = min(start + windowSamples, sampleCount)
+            result.append(start..<end)
+            if end == sampleCount {
+                break
+            }
+            start += stepSamples
+        }
+
+        return result
+    }
+
+    static func shouldChunk(sampleCount: Int, sampleRate: Int = sampleRate) -> Bool {
+        Double(sampleCount) / Double(sampleRate) > passthroughThresholdSeconds
+    }
+
+    static func mergeTranscripts(_ transcripts: [String]) -> String {
+        var chunks = transcripts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard var merged = chunks.first?.split(separator: " ").map(String.init) else {
+            return ""
+        }
+        chunks.removeFirst()
+
+        for chunk in chunks {
+            let words = chunk.split(separator: " ").map(String.init)
+            let overlap = suffixPrefixOverlap(merged, words)
+            merged.append(contentsOf: words.dropFirst(overlap))
+        }
+
+        return merged.joined(separator: " ")
+    }
+
+    private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
+        let limit = min(40, left.count, right.count)
+        guard limit >= 2 else { return 0 }
+
+        for count in stride(from: limit, through: 2, by: -1) {
+            let leftSuffix = left.suffix(count).map(normalizedWord)
+            let rightPrefix = right.prefix(count).map(normalizedWord)
+            if !leftSuffix.contains(""), leftSuffix == rightPrefix {
+                return count
+            }
+        }
+
+        return 0
+    }
+
+    private static func normalizedWord(_ word: String) -> String {
+        word.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+}
+
+enum GigaAMV3ModelStore {
+    static let repoID = "huggingfinger0/gigaam-v3-coreml"
+    static let cacheRelativePath = "Models/gigaam-v3-coreml"
+    static let downloadedModelSizeLabel = "~224 MB"
+    static let localSeedEnvironmentKey = "MUESLI_GIGAAM_V3_MODEL_DIR"
+
+    private struct RequiredFile {
+        let path: String
+        let progressWeight: Double
+        let minimumBytes: Int64
+        let remoteRepoID: String
+        let remotePath: String
+
+        init(
+            path: String,
+            progressWeight: Double,
+            minimumBytes: Int64,
+            remoteRepoID: String = GigaAMV3ModelStore.repoID,
+            remotePath: String? = nil
+        ) {
+            self.path = path
+            self.progressWeight = progressWeight
+            self.minimumBytes = minimumBytes
+            self.remoteRepoID = remoteRepoID
+            self.remotePath = remotePath ?? path
+        }
+    }
+
+    private static let requiredFileSpecs: [RequiredFile] = [
+        .init(path: "Encoder.mlmodelc/weights/weight.bin", progressWeight: 0.92, minimumBytes: 221_625_000),
+        .init(path: "Encoder.mlmodelc/model.mil", progressWeight: 0.01, minimumBytes: 590_000),
+        .init(path: "Encoder.mlmodelc/metadata.json", progressWeight: 0.005, minimumBytes: 2_000),
+        .init(path: "Encoder.mlmodelc/coremldata.bin", progressWeight: 0.001, minimumBytes: 400),
+        .init(path: "Predictor.mlmodelc/weights/weight.bin", progressWeight: 0.02, minimumBytes: 1_160_000),
+        .init(path: "Predictor.mlmodelc/model.mil", progressWeight: 0.005, minimumBytes: 9_000),
+        .init(path: "Predictor.mlmodelc/metadata.json", progressWeight: 0.002, minimumBytes: 3_000),
+        .init(path: "Predictor.mlmodelc/coremldata.bin", progressWeight: 0.001, minimumBytes: 400),
+        .init(path: "JointDecision.mlmodelc/weights/weight.bin", progressWeight: 0.01, minimumBytes: 685_000),
+        .init(path: "JointDecision.mlmodelc/model.mil", progressWeight: 0.003, minimumBytes: 6_000),
+        .init(path: "JointDecision.mlmodelc/metadata.json", progressWeight: 0.002, minimumBytes: 2_000),
+        .init(path: "JointDecision.mlmodelc/coremldata.bin", progressWeight: 0.001, minimumBytes: 400),
+        .init(path: "vocab.txt", progressWeight: 0.005, minimumBytes: 13_000),
+        .init(
+            path: "hann_window.f32.bin",
+            progressWeight: 0.001,
+            minimumBytes: 1_280,
+            remoteRepoID: "kruatech/gigaam-v3-mlx"
+        ),
+        .init(
+            path: "mel_filterbank_mel_freq.f32.bin",
+            progressWeight: 0.002,
+            minimumBytes: 41_216,
+            remoteRepoID: "kruatech/gigaam-v3-mlx"
+        ),
+    ]
+
+    static func cacheDirectory(fileManager: FileManager = .default) -> URL {
+        AppIdentity.supportDirectoryURL.appendingPathComponent(cacheRelativePath, isDirectory: true)
+    }
+
+    static func isAvailableLocally(fileManager: FileManager = .default) -> Bool {
+        let directory = cacheDirectory(fileManager: fileManager)
+        return isCompleteModelDirectory(directory, fileManager: fileManager)
+    }
+
+    static func isCompleteModelDirectory(_ directory: URL, fileManager: FileManager = .default) -> Bool {
+        requiredFileSpecs.allSatisfy { spec in
+            isCompleteLocalFile(
+                at: directory.appendingPathComponent(spec.path),
+                spec: spec,
+                fileManager: fileManager
+            )
+        }
+    }
+
+    static func deleteModelFiles(fileManager: FileManager = .default) throws {
+        let directory = cacheDirectory(fileManager: fileManager)
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try fileManager.removeItem(at: directory)
+    }
+
+    static func downloadIfNeeded(progress: ((Double, String?) -> Void)? = nil) async throws -> URL {
+        let directory = cacheDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        if isAvailableLocally() {
+            progress?(1.0, nil)
+            return directory
+        }
+
+        try seedFromLocalMirrors(to: directory, progress: progress)
+        if isAvailableLocally() {
+            fputs("[muesli-native] GigaAM v3 loaded from local CoreML cache\n", stderr)
+            progress?(0.95, "Loading GigaAM v3...")
+            return directory
+        }
+
+        progress?(0.05, "Preparing GigaAM v3...")
+
+        let totalWeight = max(requiredFileSpecs.reduce(0) { $0 + $1.progressWeight }, 1)
+        var completedWeight = requiredFileSpecs.reduce(0) { partial, spec in
+            let localFile = directory.appendingPathComponent(spec.path)
+            return partial + (isCompleteLocalFile(at: localFile, spec: spec) ? spec.progressWeight : 0)
+        }
+        reportDownloadProgress(completedWeight / totalWeight, progress: progress)
+
+        for spec in requiredFileSpecs {
+            try Task.checkCancellation()
+            let localFile = directory.appendingPathComponent(spec.path)
+            guard !isCompleteLocalFile(at: localFile, spec: spec) else {
+                continue
+            }
+            try? FileManager.default.removeItem(at: localFile)
+            try FileManager.default.createDirectory(
+                at: localFile.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            guard let remoteURL = URL(string: "https://huggingface.co/\(spec.remoteRepoID)/resolve/main/\(spec.remotePath)") else {
+                throw NSError(domain: "GigaAMV3ModelStore", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "Invalid GigaAM v3 download URL for \(spec.path)",
+                ])
+            }
+            fputs("[muesli-native] GigaAM v3 downloading \(spec.path)...\n", stderr)
+            try await downloadWithRetry(from: remoteURL, to: localFile) { fileProgress in
+                let weightedProgress = (completedWeight + spec.progressWeight * fileProgress) / totalWeight
+                reportDownloadProgress(weightedProgress, progress: progress)
+            }
+            completedWeight += spec.progressWeight
+            reportDownloadProgress(completedWeight / totalWeight, progress: progress)
+        }
+
+        guard isAvailableLocally() else {
+            throw NSError(domain: "GigaAMV3ModelStore", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 model did not finish downloading.",
+            ])
+        }
+        progress?(0.95, "Loading GigaAM v3...")
+        return directory
+    }
+
+    private static func seedFromLocalMirrors(
+        to directory: URL,
+        progress: ((Double, String?) -> Void)? = nil,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var copied = 0
+        for seedDirectory in localSeedDirectories() {
+            for (index, spec) in requiredFileSpecs.enumerated() {
+                let source = seedDirectory.appendingPathComponent(spec.path)
+                let destination = directory.appendingPathComponent(spec.path)
+                guard isCompleteLocalFile(at: source, spec: spec, fileManager: fileManager),
+                      !isCompleteLocalFile(at: destination, spec: spec, fileManager: fileManager) else {
+                    continue
+                }
+                try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try? fileManager.removeItem(at: destination)
+                try fileManager.copyItem(at: source, to: destination)
+                copied += 1
+                let fraction = 0.05 + (Double(index + 1) / Double(requiredFileSpecs.count)) * 0.85
+                progress?(fraction, "Copying local GigaAM v3 model...")
+            }
+        }
+
+        if copied > 0 {
+            fputs("[muesli-native] GigaAM v3 seeded \(copied) CoreML files from local mirrors\n", stderr)
+        }
+    }
+
+    private static func localSeedDirectories() -> [URL] {
+        var directories: [URL] = []
+        let environment = ProcessInfo.processInfo.environment
+
+        if let rawValue = environment[localSeedEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawValue.isEmpty {
+            directories.append(URL(fileURLWithPath: (rawValue as NSString).expandingTildeInPath, isDirectory: true))
+        }
+
+        if let resourceURL = Bundle.main.resourceURL {
+            directories.append(resourceURL.appendingPathComponent(cacheRelativePath, isDirectory: true))
+        }
+
+        var seen = Set<String>()
+        return directories.filter { url in
+            let path = url.standardizedFileURL.path
+            if seen.contains(path) {
+                return false
+            }
+            seen.insert(path)
+            return true
+        }
+    }
+
+    private static func isCompleteLocalFile(
+        at url: URL,
+        spec: RequiredFile,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let size = attributes[.size] as? NSNumber else {
+            return false
+        }
+        return size.int64Value >= spec.minimumBytes
+    }
+
+    private static func reportDownloadProgress(
+        _ rawValue: Double,
+        progress: ((Double, String?) -> Void)?
+    ) {
+        let clamped = min(max(rawValue, 0), 1)
+        let fraction = 0.05 + clamped * 0.85
+        let percent = Int((fraction * 100).rounded())
+        progress?(fraction, "Downloading GigaAM v3 (\(percent)%)...")
+    }
+}
+
+private final class GigaAMV3CoreMLRecognizer {
+    private let encoder: MLModel
+    private let predictor: MLModel
+    private let joint: MLModel
+    private let melProcessor: GigaAMV3MelSpectrogram
+    private let vocabulary: [Int: String]
+    private let initialToken: Int32 = 1_024
+    private let blankToken = 1_024
+    private let featureFrames = 3_000
+
+    init(modelDirectory: URL) throws {
+        let config = MLModelConfiguration()
+        config.computeUnits = .all
+        encoder = try MLModel(contentsOf: modelDirectory.appendingPathComponent("Encoder.mlmodelc"), configuration: config)
+        predictor = try MLModel(contentsOf: modelDirectory.appendingPathComponent("Predictor.mlmodelc"), configuration: config)
+        joint = try MLModel(contentsOf: modelDirectory.appendingPathComponent("JointDecision.mlmodelc"), configuration: config)
+        melProcessor = try GigaAMV3MelSpectrogram(assetsDirectory: modelDirectory)
+        vocabulary = try Self.loadVocabulary(modelDirectory.appendingPathComponent("vocab.txt"))
+    }
+
+    struct Result {
+        let text: String
+        let steps: Int
+    }
+
+    func transcribe(samples: [Float], sampleRate: Int) throws -> Result {
+        guard sampleRate == GigaAMV3FileChunking.sampleRate else {
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 CoreML expects 16 kHz mono audio.",
+            ])
+        }
+
+        let windows = GigaAMV3FileChunking.windows(sampleCount: samples.count, sampleRate: sampleRate)
+        fputs("[muesli-native] GigaAM v3 CoreML chunked transcription: \(windows.count) windows, \(String(format: "%.1f", Double(samples.count) / Double(sampleRate)))s\n", stderr)
+
+        var texts: [String] = []
+        var totalSteps = 0
+        texts.reserveCapacity(windows.count)
+
+        for window in windows {
+            try Task.checkCancellation()
+            let decoded = try autoreleasepool { () throws -> (text: String, steps: Int) in
+                var chunk = Array(samples[window])
+                if chunk.count < melProcessor.winLength {
+                    chunk.append(contentsOf: repeatElement(0, count: melProcessor.winLength - chunk.count))
+                }
+
+                let raw = try melProcessor.computeFlat(samples: chunk)
+                let features = Self.padFeatures(raw.features, sourceFrames: raw.length, targetFrames: featureFrames)
+                let decodeFrames = min(750, max(1, (raw.length + 3) / 4))
+                let decoded = try decode(features: features, decodeFrames: decodeFrames)
+                let text = decodeTokens(decoded.tokens).trimmingCharacters(in: .whitespacesAndNewlines)
+                return (text, decoded.steps)
+            }
+            totalSteps += decoded.steps
+            if !decoded.text.isEmpty {
+                texts.append(decoded.text)
+            }
+        }
+
+        return Result(text: GigaAMV3FileChunking.mergeTranscripts(texts), steps: totalSteps)
+    }
+
+    private func decode(features: [Float], decodeFrames: Int) throws -> (tokens: [Int], steps: Int) {
+        let audioSignal = try Self.floatArray(shape: Self.shape(1, 64, featureFrames))
+        Self.copy(features, to: audioSignal)
+
+        let encoderOutput = try prediction(encoder, dictionary: [
+            "audio_signal": MLFeatureValue(multiArray: audioSignal),
+        ])
+        guard let encoded = encoderOutput.featureValue(for: "encoded")?.multiArrayValue else {
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "CoreML encoder missing encoded output.",
+            ])
+        }
+
+        var hState = try Self.zeroFloatArray(shape: Self.shape(1, 1, 320))
+        var cState = try Self.zeroFloatArray(shape: Self.shape(1, 1, 320))
+        var cachedDec: MLMultiArray?
+        var cachedH: MLMultiArray?
+        var cachedC: MLMultiArray?
+        var lastToken = initialToken
+        var tokens: [Int] = []
+        var steps = 0
+
+        let frameLimit = min(decodeFrames, encoded.shape[2].intValue)
+        for frame in 0..<frameLimit {
+            var emitted = 0
+            while emitted < 10 {
+                if cachedDec == nil {
+                    let token = try Self.intArray(value: lastToken, shape: Self.shape(1, 1))
+                    let predictorOutput = try prediction(predictor, dictionary: [
+                        "x": MLFeatureValue(multiArray: token),
+                        "hi": MLFeatureValue(multiArray: hState),
+                        "ci": MLFeatureValue(multiArray: cState),
+                    ])
+                    cachedDec = try predictorOutput.gigaAMV3Array("dec")
+                    cachedH = try predictorOutput.gigaAMV3Array("ho")
+                    cachedC = try predictorOutput.gigaAMV3Array("co")
+                }
+
+                let encFrame = try Self.encodedFrame(encoded, frame: frame)
+                let decFrame = try Self.decoderFrame(cachedDec!)
+                let jointOutput = try prediction(joint, dictionary: [
+                    "enc": MLFeatureValue(multiArray: encFrame),
+                    "dec": MLFeatureValue(multiArray: decFrame),
+                ])
+                let predicted = try jointOutput.gigaAMV3Array("token_id").gigaAMV3Int32Value(at: 0)
+                steps += 1
+                if predicted == blankToken {
+                    break
+                }
+
+                tokens.append(predicted)
+                emitted += 1
+                lastToken = Int32(predicted)
+                hState = try Self.float32Copy(cachedH!)
+                cState = try Self.float32Copy(cachedC!)
+                cachedDec = nil
+                cachedH = nil
+                cachedC = nil
+            }
+        }
+        return (tokens, steps)
+    }
+
+    private func decodeTokens(_ tokenIds: [Int]) -> String {
+        var text = tokenIds.map { vocabulary[$0] ?? "" }.joined()
+        text = text.replacingOccurrences(of: "▁", with: " ")
+        if text.hasPrefix(" ") {
+            text.removeFirst()
+        }
+        return text
+    }
+
+    private func prediction(_ model: MLModel, dictionary: [String: MLFeatureValue]) throws -> MLFeatureProvider {
+        try autoreleasepool {
+            try model.prediction(from: MLDictionaryFeatureProvider(dictionary: dictionary))
+        }
+    }
+
+    private static func loadVocabulary(_ url: URL) throws -> [Int: String] {
+        let lines = try String(contentsOf: url, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+        var vocabulary: [Int: String] = [:]
+        for line in lines {
+            guard let space = line.lastIndex(of: " ") else { continue }
+            let piece = String(line[..<space])
+            guard let id = Int(line[line.index(after: space)...]), piece != "<blk>" else { continue }
+            vocabulary[id] = piece == "<unk>" ? "" : piece
+        }
+        return vocabulary
+    }
+
+    private static func padFeatures(_ source: [Float], sourceFrames: Int, targetFrames: Int) -> [Float] {
+        var output = [Float](repeating: 0, count: 64 * targetFrames)
+        let frames = min(sourceFrames, targetFrames)
+        for mel in 0..<64 {
+            let sourceOffset = mel * sourceFrames
+            let outputOffset = mel * targetFrames
+            output[outputOffset..<outputOffset + frames] = source[sourceOffset..<sourceOffset + frames]
+        }
+        return output
+    }
+
+    private static func floatArray(shape: [NSNumber]) throws -> MLMultiArray {
+        try MLMultiArray(shape: shape, dataType: .float32)
+    }
+
+    private static func shape(_ values: Int...) -> [NSNumber] {
+        values.map { NSNumber(value: $0) }
+    }
+
+    private static func zeroFloatArray(shape: [NSNumber]) throws -> MLMultiArray {
+        let array = try floatArray(shape: shape)
+        memset(array.dataPointer, 0, array.count * MemoryLayout<Float>.size)
+        return array
+    }
+
+    private static func intArray(value: Int32, shape: [NSNumber]) throws -> MLMultiArray {
+        let array = try MLMultiArray(shape: shape, dataType: .int32)
+        array.dataPointer.bindMemory(to: Int32.self, capacity: array.count)[0] = value
+        return array
+    }
+
+    private static func copy(_ values: [Float], to array: MLMultiArray) {
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: array.count)
+        values.withUnsafeBufferPointer { source in
+            guard let baseAddress = source.baseAddress else { return }
+            ptr.update(from: baseAddress, count: min(values.count, array.count))
+        }
+    }
+
+    private static func encodedFrame(_ encoded: MLMultiArray, frame: Int) throws -> MLMultiArray {
+        let output = try floatArray(shape: shape(1, 768, 1))
+        let dst = output.dataPointer.bindMemory(to: Float.self, capacity: output.count)
+        let channelStride = encoded.strides[1].intValue
+        let frameStride = encoded.strides[2].intValue
+        switch encoded.dataType {
+        case .float16:
+            let src = encoded.dataPointer.bindMemory(to: Float16.self, capacity: encoded.count)
+            for channel in 0..<768 {
+                dst[channel] = Float(src[channel * channelStride + frame * frameStride])
+            }
+        case .float32:
+            let src = encoded.dataPointer.bindMemory(to: Float.self, capacity: encoded.count)
+            for channel in 0..<768 {
+                dst[channel] = src[channel * channelStride + frame * frameStride]
+            }
+        default:
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 20, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported encoded dtype \(encoded.dataType.rawValue).",
+            ])
+        }
+        return output
+    }
+
+    private static func decoderFrame(_ dec: MLMultiArray) throws -> MLMultiArray {
+        let output = try floatArray(shape: shape(1, 320, 1))
+        let dst = output.dataPointer.bindMemory(to: Float.self, capacity: output.count)
+        switch dec.dataType {
+        case .float16:
+            let src = dec.dataPointer.bindMemory(to: Float16.self, capacity: dec.count)
+            for index in 0..<320 { dst[index] = Float(src[index]) }
+        case .float32:
+            let src = dec.dataPointer.bindMemory(to: Float.self, capacity: dec.count)
+            for index in 0..<320 { dst[index] = src[index] }
+        default:
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 21, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported decoder dtype \(dec.dataType.rawValue).",
+            ])
+        }
+        return output
+    }
+
+    private static func float32Copy(_ array: MLMultiArray) throws -> MLMultiArray {
+        let output = try floatArray(shape: array.shape)
+        let dst = output.dataPointer.bindMemory(to: Float.self, capacity: output.count)
+        switch array.dataType {
+        case .float16:
+            let src = array.dataPointer.bindMemory(to: Float16.self, capacity: array.count)
+            for index in 0..<array.count { dst[index] = Float(src[index]) }
+        case .float32:
+            let src = array.dataPointer.bindMemory(to: Float.self, capacity: array.count)
+            for index in 0..<array.count { dst[index] = src[index] }
+        default:
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 22, userInfo: [
+                NSLocalizedDescriptionKey: "Unsupported state dtype \(array.dataType.rawValue).",
+            ])
+        }
+        return output
+    }
+}
+
+private final class GigaAMV3MelSpectrogram {
+    let winLength = 320
+
+    private let nMels = 64
+    private let nFFT = 320
+    private let hopLength = 160
+    private let nFreqs = 161
+
+    private let window: [Float]
+    private let filterbank: [Float]
+    private let cosTable: [Float]
+    private let sinTable: [Float]
+
+    init(assetsDirectory: URL) throws {
+        let windowURL = assetsDirectory.appendingPathComponent("hann_window.f32.bin")
+        let filterbankURL = assetsDirectory.appendingPathComponent("mel_filterbank_mel_freq.f32.bin")
+        window = try Self.readFloat32Binary(windowURL, expectedCount: winLength)
+        filterbank = try Self.readFloat32Binary(filterbankURL, expectedCount: nMels * nFreqs)
+
+        var cosTable = [Float](repeating: 0, count: nFreqs * nFFT)
+        var sinTable = [Float](repeating: 0, count: nFreqs * nFFT)
+        let twoPi = 2.0 * Double.pi
+        for freq in 0..<nFreqs {
+            let offset = freq * nFFT
+            for n in 0..<nFFT {
+                let angle = twoPi * Double(freq * n) / Double(nFFT)
+                cosTable[offset + n] = Float(cos(angle))
+                sinTable[offset + n] = Float(sin(angle))
+            }
+        }
+        self.cosTable = cosTable
+        self.sinTable = sinTable
+    }
+
+    func computeFlat(samples: [Float]) throws -> (features: [Float], length: Int) {
+        guard samples.count >= winLength else {
+            throw NSError(domain: "GigaAMV3MelSpectrogram", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Audio is shorter than GigaAM v3 window length.",
+            ])
+        }
+
+        let frameCount = ((samples.count - winLength) / hopLength) + 1
+        var power = [Float](repeating: 0, count: nFreqs * frameCount)
+
+        for frame in 0..<frameCount {
+            let frameOffset = frame * hopLength
+            for freq in 0..<nFreqs {
+                let tableOffset = freq * nFFT
+                var real = Float(0)
+                var imag = Float(0)
+                for n in 0..<nFFT {
+                    let sample = samples[frameOffset + n] * window[n]
+                    real += sample * cosTable[tableOffset + n]
+                    imag -= sample * sinTable[tableOffset + n]
+                }
+                power[freq * frameCount + frame] = real * real + imag * imag
+            }
+        }
+
+        var result = [Float](repeating: 0, count: nMels * frameCount)
+        for mel in 0..<nMels {
+            let melOffset = mel * nFreqs
+            let outputOffset = mel * frameCount
+            for frame in 0..<frameCount {
+                var value = Float(0)
+                for freq in 0..<nFreqs {
+                    value += filterbank[melOffset + freq] * power[freq * frameCount + frame]
+                }
+                result[outputOffset + frame] = logf(min(max(value, 1e-9), 1e9))
+            }
+        }
+
+        return (result, frameCount)
+    }
+
+    private static func readFloat32Binary(_ url: URL, expectedCount: Int) throws -> [Float] {
+        let data = try Data(contentsOf: url)
+        guard data.count == expectedCount * MemoryLayout<Float>.size else {
+            throw NSError(domain: "GigaAMV3MelSpectrogram", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid GigaAM v3 frontend asset size at \(url.path).",
+            ])
+        }
+        var values = [Float](repeating: 0, count: expectedCount)
+        _ = values.withUnsafeMutableBytes { destination in
+            data.copyBytes(to: destination)
+        }
+        return values
+    }
+}
+
+private extension MLFeatureProvider {
+    func gigaAMV3Array(_ name: String) throws -> MLMultiArray {
+        guard let array = featureValue(for: name)?.multiArrayValue else {
+            throw NSError(domain: "GigaAMV3CoreMLRecognizer", code: 30, userInfo: [
+                NSLocalizedDescriptionKey: "Missing CoreML output \(name).",
+            ])
+        }
+        return array
+    }
+}
+
+private extension MLMultiArray {
+    func gigaAMV3Int32Value(at index: Int) -> Int {
+        switch dataType {
+        case .int32:
+            Int(dataPointer.bindMemory(to: Int32.self, capacity: count)[index])
+        default:
+            self[index].intValue
+        }
+    }
+}
+
+actor GigaAMV3Transcriber {
+    private var recognizer: GigaAMV3CoreMLRecognizer?
+    private var isLoading = false
+    private var activeDownloadTask: Task<URL, Error>?
+    private var loadWaiters: [CheckedContinuation<Void, Error>] = []
+    private var loadGeneration = 0
+
+    func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+        try await loadModels(progress: progress, allowDownload: true)
+    }
+
+    private func loadModels(
+        progress: ((Double, String?) -> Void)? = nil,
+        allowDownload: Bool
+    ) async throws {
+        if recognizer != nil {
+            progress?(1.0, nil)
+            return
+        }
+        if isLoading {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                loadWaiters.append(continuation)
+            }
+            progress?(1.0, nil)
+            return
+        }
+
+        isLoading = true
+        let generation = loadGeneration
+        do {
+            let directory: URL
+            if allowDownload {
+                let downloadTask = Task {
+                    try await GigaAMV3ModelStore.downloadIfNeeded(progress: progress)
+                }
+                activeDownloadTask = downloadTask
+                directory = try await downloadTask.value
+            } else {
+                guard GigaAMV3ModelStore.isAvailableLocally() else {
+                    throw NSError(domain: "GigaAMV3Transcriber", code: 2, userInfo: [
+                        NSLocalizedDescriptionKey: "GigaAM v3 models are not downloaded. Download them before transcribing.",
+                    ])
+                }
+                progress?(0.95, "Loading GigaAM v3...")
+                directory = GigaAMV3ModelStore.cacheDirectory()
+            }
+            guard generation == loadGeneration else {
+                throw NSError(domain: "GigaAMV3Transcriber", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "GigaAM v3 load was cancelled.",
+                ])
+            }
+            activeDownloadTask = nil
+            let loadedRecognizer = try GigaAMV3CoreMLRecognizer(modelDirectory: directory)
+            guard generation == loadGeneration else {
+                throw NSError(domain: "GigaAMV3Transcriber", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "GigaAM v3 load was cancelled.",
+                ])
+            }
+            recognizer = loadedRecognizer
+            isLoading = false
+            completeLoadWaiters()
+            progress?(1.0, nil)
+        } catch {
+            if generation == loadGeneration {
+                activeDownloadTask = nil
+                isLoading = false
+                completeLoadWaiters(throwing: error)
+            }
+            throw error
+        }
+    }
+
+    func transcribe(wavURL: URL) async throws -> GigaAMV3TranscriptionResult {
+        if recognizer == nil {
+            try await loadModels(allowDownload: false)
+        }
+        guard let recognizer else {
+            throw NSError(domain: "GigaAMV3Transcriber", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 recognizer is not loaded.",
+            ])
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        do {
+            let prepared = try await AudioFileImportController.convertToWAV(sourceURL: wavURL)
+            defer {
+                if prepared.wavURL.standardizedFileURL.path != wavURL.standardizedFileURL.path {
+                    try? FileManager.default.removeItem(at: prepared.wavURL)
+                }
+            }
+            let samples = try AudioConverter().resampleAudioFile(prepared.wavURL)
+            let result = try recognizer.transcribe(samples: samples, sampleRate: GigaAMV3FileChunking.sampleRate)
+
+            return GigaAMV3TranscriptionResult(
+                text: result.text,
+                duration: prepared.duration,
+                processingTime: CFAbsoluteTimeGetCurrent() - start
+            )
+        } catch {
+            throw Self.readableTranscriptionError(error)
+        }
+    }
+
+    func transcribe(samples: [Float], sampleRate: Int) async throws -> GigaAMV3TranscriptionResult {
+        if recognizer == nil {
+            try await loadModels(allowDownload: false)
+        }
+        guard let recognizer else {
+            throw NSError(domain: "GigaAMV3Transcriber", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "GigaAM v3 recognizer is not loaded.",
+            ])
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        do {
+            let result = try recognizer.transcribe(samples: samples, sampleRate: sampleRate)
+
+            return GigaAMV3TranscriptionResult(
+                text: result.text,
+                duration: Double(samples.count) / Double(sampleRate),
+                processingTime: CFAbsoluteTimeGetCurrent() - start
+            )
+        } catch {
+            throw Self.readableTranscriptionError(error)
+        }
+    }
+
+    func shutdown() {
+        loadGeneration += 1
+        activeDownloadTask?.cancel()
+        activeDownloadTask = nil
+        recognizer = nil
+        isLoading = false
+        completeLoadWaiters(throwing: NSError(domain: "GigaAMV3Transcriber", code: 4, userInfo: [
+            NSLocalizedDescriptionKey: "GigaAM v3 load was shut down.",
+        ]))
+    }
+
+    private func completeLoadWaiters(throwing error: Error? = nil) {
+        let waiters = loadWaiters
+        loadWaiters.removeAll()
+        for waiter in waiters {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
+    }
+
+    private nonisolated static func readableTranscriptionError(_ error: Error) -> Error {
+        let nsError = error as NSError
+        if nsError.domain == "GigaAMV3Transcriber" {
+            return error
+        }
+
+        return NSError(domain: "GigaAMV3Transcriber", code: 5, userInfo: [
+            NSLocalizedDescriptionKey: "GigaAM v3 transcription failed: \(error.localizedDescription)",
+            NSUnderlyingErrorKey: error,
+        ])
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingChunkTimingTracker.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingChunkTimingTracker.swift
@@ -29,14 +29,15 @@ struct MeetingChunkTimingTracker: Sendable {
         currentChunkSampleCount += Int64(sampleCount)
     }
 
-    mutating func rotate() -> MeetingChunkTimingSnapshot? {
+    mutating func rotate(overlapSampleCount: Int = 0) -> MeetingChunkTimingSnapshot? {
         guard let currentChunkStartSampleIndex else { return nil }
         let snapshot = MeetingChunkTimingSnapshot(
             startSampleIndex: currentChunkStartSampleIndex,
             sampleCount: currentChunkSampleCount
         )
-        self.currentChunkStartSampleIndex = currentChunkStartSampleIndex + currentChunkSampleCount
-        currentChunkSampleCount = 0
+        let carriedSamples = min(max(Int64(overlapSampleCount), 0), currentChunkSampleCount)
+        self.currentChunkStartSampleIndex = currentChunkStartSampleIndex + currentChunkSampleCount - carriedSamples
+        currentChunkSampleCount = carriedSamples
         return snapshot
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -7,6 +7,7 @@ import os
 final class MeetingChunkCollector {
     private struct PendingTask {
         let id: UUID
+        let sequence: Int
         let task: Task<[SpeechSegment], Never>
     }
 
@@ -16,6 +17,9 @@ final class MeetingChunkCollector {
         // accumulate for the full meeting duration.
         var pendingTasks: [PendingTask] = []
         var completedSegments: [SpeechSegment] = []
+        var nextSequence = 0
+        var nextLiveSequenceToEmit = 0
+        var completedLiveChunks: [Int: [SpeechSegment]] = [:]
         var isClosed = false
     }
 
@@ -27,7 +31,9 @@ final class MeetingChunkCollector {
         let id = UUID()
         let registered = lock.withLock { state in
             guard !state.isClosed else { return false }
-            state.pendingTasks.append(PendingTask(id: id, task: task))
+            let sequence = state.nextSequence
+            state.nextSequence += 1
+            state.pendingTasks.append(PendingTask(id: id, sequence: sequence, task: task))
             return true
         }
         return (registered, id)
@@ -35,12 +41,22 @@ final class MeetingChunkCollector {
 
     /// Move a completed task's result into the collector and drop the Task reference.
     /// Must be called from the watcher Task after awaiting the transcription task's value.
-    func retire(id: UUID, segments: [SpeechSegment]) -> Bool {
+    func retire(id: UUID, segments: [SpeechSegment]) -> [[SpeechSegment]]? {
         lock.withLock { state in
-            guard !state.isClosed else { return false }
+            guard !state.isClosed else { return nil }
+            guard let pending = state.pendingTasks.first(where: { $0.id == id }) else {
+                return []
+            }
             state.completedSegments.append(contentsOf: segments)
             state.pendingTasks.removeAll { $0.id == id }
-            return true
+            state.completedLiveChunks[pending.sequence] = segments
+
+            var readyChunks: [[SpeechSegment]] = []
+            while let ready = state.completedLiveChunks.removeValue(forKey: state.nextLiveSequenceToEmit) {
+                readyChunks.append(ready)
+                state.nextLiveSequenceToEmit += 1
+            }
+            return readyChunks
         }
     }
 
@@ -51,6 +67,7 @@ final class MeetingChunkCollector {
             let completed = state.completedSegments
             state.pendingTasks.removeAll()
             state.completedSegments.removeAll()
+            state.completedLiveChunks.removeAll()
             return (tasks, completed)
         }
 
@@ -73,6 +90,7 @@ final class MeetingChunkCollector {
             let tasks = state.pendingTasks.map { $0.task }
             state.pendingTasks.removeAll()
             state.completedSegments.removeAll()
+            state.completedLiveChunks.removeAll()
             return tasks
         }
         tasksToCancel.forEach { $0.cancel() }
@@ -136,6 +154,43 @@ private enum MeetingTranscriptRecoveryResult {
     case replace([SpeechSegment])
 }
 
+struct LiveMeetingChunkingConfiguration: Equatable, Sendable {
+    static let defaultSampleRate = 16_000
+
+    let minChunkDuration: TimeInterval
+    let maxChunkDuration: TimeInterval
+    let overlapSampleCount: Int
+    let deduplicatesText: Bool
+
+    static func configuration(for backend: BackendOption) -> LiveMeetingChunkingConfiguration {
+        if backend.backend == BackendOption.gigaAMV3Russian.backend {
+            return LiveMeetingChunkingConfiguration(
+                minChunkDuration: 3.0,
+                maxChunkDuration: 20.0,
+                overlapSampleCount: 2 * defaultSampleRate,
+                deduplicatesText: true
+            )
+        }
+
+        return LiveMeetingChunkingConfiguration(
+            minChunkDuration: 3.0,
+            maxChunkDuration: 5.0,
+            overlapSampleCount: 0,
+            deduplicatesText: false
+        )
+    }
+}
+
+private enum LiveMeetingTrack {
+    case mic
+    case system
+}
+
+private struct LiveMeetingOverlapState {
+    var micText = ""
+    var systemText = ""
+}
+
 final class MeetingSession {
     private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingSession")
 
@@ -144,6 +199,7 @@ final class MeetingSession {
     private let backendLock = OSAllocatedUnfairLock(initialState: BackendOption.whisper)
     private let runtime: RuntimePaths
     private let config: AppConfig
+    private let liveChunkingConfiguration: LiveMeetingChunkingConfiguration
     private let templateSnapshot: MeetingTemplateSnapshot
     private let transcriptionCoordinator: TranscriptionCoordinator
     private let systemAudioRecorder: SystemAudioCapturing
@@ -162,6 +218,7 @@ final class MeetingSession {
     private let micChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let systemChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let micHealthTracker = MeetingMicHealthTracker()
+    private let liveOverlapLock = OSAllocatedUnfairLock(initialState: LiveMeetingOverlapState())
     private let chunkRotationQueue = DispatchQueue(label: "MuesliNative.MeetingSession.chunkRotation")
     private let pausedDisplayLock = OSAllocatedUnfairLock(initialState: false)
     private var chunkTimingTracker = MeetingChunkTimingTracker()
@@ -207,6 +264,7 @@ final class MeetingSession {
         backendLock.withLock { $0 = backend }
         self.runtime = runtime
         self.config = config
+        self.liveChunkingConfiguration = Self.liveChunkingConfiguration(for: backend)
         self.templateSnapshot = templateSnapshot
         self.transcriptionCoordinator = transcriptionCoordinator
         self.meetingMicRecorder = meetingMicRecorder
@@ -225,10 +283,34 @@ final class MeetingSession {
         backendLock.withLock { $0 }
     }
 
+    static func liveChunkingConfiguration(for backend: BackendOption) -> LiveMeetingChunkingConfiguration {
+        LiveMeetingChunkingConfiguration.configuration(for: backend)
+    }
+
+    static func deduplicateLiveSegments(
+        _ segments: [SpeechSegment],
+        enabled: Bool,
+        previousText: inout String
+    ) -> [SpeechSegment] {
+        guard enabled else { return segments }
+
+        return segments.compactMap { segment in
+            let text = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            let addition = TranscriptOverlapMerger
+                .uniqueAddition(previous: previousText, next: text)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            previousText = TranscriptOverlapMerger.merge([previousText, text])
+            guard !addition.isEmpty else { return nil }
+            return SpeechSegment(start: segment.start, end: segment.end, text: addition)
+        }
+    }
+
     func start() async throws {
         let vadManager = await transcriptionCoordinator.getVadManager()
         let now = Date()
         diagnostics = MeetingSessionDiagnostics(title: title, startedAt: now)
+        liveOverlapLock.withLock { $0 = LiveMeetingOverlapState() }
 
         // AEC must be loaded before audio pipeline starts (streaming mode)
         await neuralAec.preload()
@@ -482,6 +564,11 @@ final class MeetingSession {
             }
         }
 
+        if liveChunkingConfiguration.deduplicatesText {
+            micSegments = TranscriptOverlapMerger.deduplicateSegments(micSegments)
+            systemSegments = TranscriptOverlapMerger.deduplicateSegments(systemSegments)
+        }
+
         fputs("[meeting] \(micSegments.count) mic chunks transcribed during meeting\n", stderr)
         fputs("[meeting] \(systemSegments.count) system chunks transcribed during meeting\n", stderr)
 
@@ -606,7 +693,9 @@ final class MeetingSession {
     private func rotateChunkOnQueue() {
         guard isRecording, !isPaused else { return }
         appendFlushedStreamingMicOnQueue()
-        guard let chunkTiming = chunkTimingTracker.rotate() else {
+        guard let chunkTiming = chunkTimingTracker.rotate(
+            overlapSampleCount: liveChunkingConfiguration.overlapSampleCount
+        ) else {
             return
         }
         let rawChunkURL = rawMicChunkRecorder?.rotateFile()
@@ -637,9 +726,13 @@ final class MeetingSession {
         if registered {
             Task { [weak self] in
                 let segments = await task.value
-                guard self?.micChunkCollector.retire(id: retireID, segments: segments) == true else { return }
-                guard !segments.isEmpty else { return }
-                self?.onChunkTranscribed?(segments, "You")
+                guard let self else { return }
+                guard let readyChunks = self.micChunkCollector.retire(id: retireID, segments: segments) else { return }
+                for readySegments in readyChunks {
+                    let liveSegments = self.liveSegmentsForEmission(readySegments, track: .mic)
+                    guard !liveSegments.isEmpty else { continue }
+                    self.onChunkTranscribed?(liveSegments, "You")
+                }
             }
         } else {
             task.cancel()
@@ -656,7 +749,9 @@ final class MeetingSession {
     private func rotateSystemChunkOnQueue() {
         guard isRecording, !isPaused else { return }
         guard let chunkURL = systemChunkRecorder?.rotateFile(),
-              let chunkTiming = systemChunkTimingTracker.rotate() else {
+              let chunkTiming = systemChunkTimingTracker.rotate(
+                overlapSampleCount: liveChunkingConfiguration.overlapSampleCount
+              ) else {
             return
         }
 
@@ -705,9 +800,13 @@ final class MeetingSession {
         if registered {
             Task { [weak self] in
                 let segments = await task.value
-                guard self?.systemChunkCollector.retire(id: retireID, segments: segments) == true else { return }
-                guard !segments.isEmpty else { return }
-                self?.onChunkTranscribed?(segments, "Others")
+                guard let self else { return }
+                guard let readyChunks = self.systemChunkCollector.retire(id: retireID, segments: segments) else { return }
+                for readySegments in readyChunks {
+                    let liveSegments = self.liveSegmentsForEmission(readySegments, track: .system)
+                    guard !liveSegments.isEmpty else { continue }
+                    self.onChunkTranscribed?(liveSegments, "Others")
+                }
             }
         } else {
             task.cancel()
@@ -729,14 +828,24 @@ final class MeetingSession {
     }
 
     private func prepareRealtimeAudioPipeline(vadManager: VadManager?) throws {
-        rawMicChunkRecorder = try PCMChunkRecorder(directoryName: "muesli-meeting-mic-chunks")
-        systemChunkRecorder = try PCMChunkRecorder(directoryName: "muesli-meeting-system-chunks")
+        rawMicChunkRecorder = try PCMChunkRecorder(
+            directoryName: "muesli-meeting-mic-chunks",
+            overlapSampleCount: liveChunkingConfiguration.overlapSampleCount
+        )
+        systemChunkRecorder = try PCMChunkRecorder(
+            directoryName: "muesli-meeting-system-chunks",
+            overlapSampleCount: liveChunkingConfiguration.overlapSampleCount
+        )
         configureRealtimeAudioCallbacks(vadManager: vadManager)
     }
 
     private func configureRealtimeAudioCallbacks(vadManager: VadManager?) {
         if let vadManager {
-            let controller = StreamingVadController(vadManager: vadManager)
+            let controller = StreamingVadController(
+                vadManager: vadManager,
+                minChunkDuration: liveChunkingConfiguration.minChunkDuration,
+                maxChunkDuration: liveChunkingConfiguration.maxChunkDuration
+            )
             controller.onChunkBoundary = { [weak self] in
                 // Streaming VAD callbacks can arrive off-main; serialize chunk rotation explicitly.
                 self?.chunkRotationQueue.async { [weak self] in
@@ -746,7 +855,11 @@ final class MeetingSession {
             controller.start()
             vadController = controller
 
-            let systemController = StreamingVadController(vadManager: vadManager)
+            let systemController = StreamingVadController(
+                vadManager: vadManager,
+                minChunkDuration: liveChunkingConfiguration.minChunkDuration,
+                maxChunkDuration: liveChunkingConfiguration.maxChunkDuration
+            )
             systemController.onChunkBoundary = { [weak self] in
                 // Streaming VAD callbacks can arrive off-main; serialize chunk rotation explicitly.
                 self?.chunkRotationQueue.async { [weak self] in
@@ -765,6 +878,29 @@ final class MeetingSession {
         }
         systemAudioRecorder.onPCMSamples = { [weak self] samples in
             self?.enqueueRealtimeSystemSamples(samples)
+        }
+    }
+
+    private func liveSegmentsForEmission(
+        _ segments: [SpeechSegment],
+        track: LiveMeetingTrack
+    ) -> [SpeechSegment] {
+        guard liveChunkingConfiguration.deduplicatesText else { return segments }
+        return liveOverlapLock.withLock { state in
+            switch track {
+            case .mic:
+                return Self.deduplicateLiveSegments(
+                    segments,
+                    enabled: true,
+                    previousText: &state.micText
+                )
+            case .system:
+                return Self.deduplicateLiveSegments(
+                    segments,
+                    enabled: true,
+                    previousText: &state.systemText
+                )
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -20,7 +20,48 @@ final class MeetingChunkCollector {
         var nextSequence = 0
         var nextLiveSequenceToEmit = 0
         var completedLiveChunks: [Int: [SpeechSegment]] = [:]
+        var retiredChunkCount = 0
         var isClosed = false
+    }
+
+    struct Snapshot: Equatable {
+        let registeredChunkCount: Int
+        let retiredChunkCount: Int
+        let pendingChunkCount: Int
+        let bufferedLiveChunkCount: Int
+    }
+
+    private enum DrainPoll {
+        case ready([(Int, [SpeechSegment])])
+        case waiting
+        case timedOut
+    }
+
+    private final class DrainResults: @unchecked Sendable {
+        private let lock = NSLock()
+        private var chunks: [(Int, [SpeechSegment])] = []
+        private var lastProgress = Date()
+
+        func append(sequence: Int, segments: [SpeechSegment]) {
+            lock.withLock {
+                chunks.append((sequence, segments))
+                lastProgress = Date()
+            }
+        }
+
+        func poll(inactivityTimeout: TimeInterval) -> DrainPoll {
+            lock.withLock {
+                if !chunks.isEmpty {
+                    let result = chunks.sorted { $0.0 < $1.0 }
+                    chunks.removeAll(keepingCapacity: true)
+                    return .ready(result)
+                }
+                if Date().timeIntervalSince(lastProgress) >= inactivityTimeout {
+                    return .timedOut
+                }
+                return .waiting
+            }
+        }
     }
 
     private let lock = OSAllocatedUnfairLock(initialState: State())
@@ -49,6 +90,7 @@ final class MeetingChunkCollector {
             }
             state.completedSegments.append(contentsOf: segments)
             state.pendingTasks.removeAll { $0.id == id }
+            state.retiredChunkCount += 1
             state.completedLiveChunks[pending.sequence] = segments
 
             var readyChunks: [[SpeechSegment]] = []
@@ -60,10 +102,24 @@ final class MeetingChunkCollector {
         }
     }
 
-    func closeAndDrainSortedSegments() async -> [SpeechSegment] {
+    func snapshot() -> Snapshot {
+        lock.withLock { state in
+            Snapshot(
+                registeredChunkCount: state.nextSequence,
+                retiredChunkCount: state.retiredChunkCount,
+                pendingChunkCount: state.pendingTasks.count,
+                bufferedLiveChunkCount: state.completedLiveChunks.count
+            )
+        }
+    }
+
+    func closeAndDrainSortedSegments(
+        inactivityTimeout: TimeInterval = 120,
+        logger: ((String) -> Void)? = nil
+    ) async -> [SpeechSegment] {
         let (tasksToAwait, alreadyCompleted) = lock.withLock { state in
             state.isClosed = true
-            let tasks = state.pendingTasks.map { $0.task }
+            let tasks = state.pendingTasks
             let completed = state.completedSegments
             state.pendingTasks.removeAll()
             state.completedSegments.removeAll()
@@ -72,11 +128,46 @@ final class MeetingChunkCollector {
         }
 
         var segments = alreadyCompleted
-        for task in tasksToAwait {
-            segments.append(contentsOf: await task.value)
+        guard !tasksToAwait.isEmpty else { return Self.sorted(segments) }
+
+        let drainResults = DrainResults()
+        let watcherTasks = tasksToAwait.map { pending in
+            Task {
+                let chunkSegments = await pending.task.value
+                drainResults.append(sequence: pending.sequence, segments: chunkSegments)
+            }
         }
 
-        return segments.sorted { lhs, rhs in
+        var remainingTaskCount = tasksToAwait.count
+        var pendingSequences = Set(tasksToAwait.map(\.sequence))
+        drainLoop: while remainingTaskCount > 0 {
+            switch drainResults.poll(inactivityTimeout: inactivityTimeout) {
+            case .ready(let ready):
+                for (sequence, chunkSegments) in ready {
+                    segments.append(contentsOf: chunkSegments)
+                    pendingSequences.remove(sequence)
+                }
+                remainingTaskCount -= ready.count
+
+            case .timedOut:
+                tasksToAwait.forEach { $0.task.cancel() }
+                watcherTasks.forEach { $0.cancel() }
+                logger?("[live-collector] drain timeout pending=\(remainingTaskCount) flushedSegments=\(segments.count)")
+                for sequence in pendingSequences.sorted() {
+                    logger?("[live-collector] dropped pending chunk sequence=\(sequence) reason=drain_timeout")
+                }
+                break drainLoop
+
+            case .waiting:
+                try? await Task.sleep(for: .milliseconds(20))
+            }
+        }
+
+        return Self.sorted(segments)
+    }
+
+    private static func sorted(_ segments: [SpeechSegment]) -> [SpeechSegment] {
+        segments.sorted { lhs, rhs in
             if lhs.start == rhs.start {
                 return lhs.text < rhs.text
             }
@@ -538,7 +629,16 @@ final class MeetingSession {
             }
         }
 
-        micSegments.append(contentsOf: await micChunkCollector.closeAndDrainSortedSegments())
+        let micCollectorSnapshot = micChunkCollector.snapshot()
+        let systemCollectorSnapshot = systemChunkCollector.snapshot()
+        let micHealthSnapshot = micChunkHealthTracker.snapshot()
+        let systemHealthSnapshot = systemChunkHealthTracker.snapshot()
+        fputs(
+            "[live-collector] stop mic registered=\(micCollectorSnapshot.registeredChunkCount) retired=\(micCollectorSnapshot.retiredChunkCount) pending=\(micCollectorSnapshot.pendingChunkCount) buffered=\(micCollectorSnapshot.bufferedLiveChunkCount) failed=\(micHealthSnapshot.failedChunkCount); system registered=\(systemCollectorSnapshot.registeredChunkCount) retired=\(systemCollectorSnapshot.retiredChunkCount) pending=\(systemCollectorSnapshot.pendingChunkCount) buffered=\(systemCollectorSnapshot.bufferedLiveChunkCount) failed=\(systemHealthSnapshot.failedChunkCount)\n",
+            stderr
+        )
+
+        micSegments.append(contentsOf: await micChunkCollector.closeAndDrainSortedSegments(logger: { fputs("\($0)\n", stderr) }))
         micSegments.sort { lhs, rhs in
             if lhs.start == rhs.start {
                 return lhs.text < rhs.text
@@ -546,7 +646,7 @@ final class MeetingSession {
             return lhs.start < rhs.start
         }
 
-        systemSegments.append(contentsOf: await systemChunkCollector.closeAndDrainSortedSegments())
+        systemSegments.append(contentsOf: await systemChunkCollector.closeAndDrainSortedSegments(logger: { fputs("\($0)\n", stderr) }))
         systemSegments.sort { lhs, rhs in
             if lhs.start == rhs.start {
                 return lhs.text < rhs.text

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -199,7 +199,7 @@ final class MeetingSession {
     private let backendLock = OSAllocatedUnfairLock(initialState: BackendOption.whisper)
     private let runtime: RuntimePaths
     private let config: AppConfig
-    private let liveChunkingConfiguration: LiveMeetingChunkingConfiguration
+    private var liveChunkingConfiguration: LiveMeetingChunkingConfiguration
     private let templateSnapshot: MeetingTemplateSnapshot
     private let transcriptionCoordinator: TranscriptionCoordinator
     private let systemAudioRecorder: SystemAudioCapturing
@@ -275,8 +275,14 @@ final class MeetingSession {
         }
     }
 
-    func updateBackend(_ backend: BackendOption) {
-        backendLock.withLock { $0 = backend }
+    @discardableResult
+    func updateBackend(_ backend: BackendOption) -> Bool {
+        chunkRotationQueue.sync {
+            guard !isRecording else { return false }
+            backendLock.withLock { $0 = backend }
+            liveChunkingConfiguration = Self.liveChunkingConfiguration(for: backend)
+            return true
+        }
     }
 
     private func currentBackend() -> BackendOption {
@@ -300,11 +306,23 @@ final class MeetingSession {
             let addition = TranscriptOverlapMerger
                 .uniqueAddition(previous: previousText, next: text)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            previousText = TranscriptOverlapMerger.merge([previousText, text])
+            previousText = TranscriptOverlapMerger.retainedContextAfterAppending(addition, to: previousText)
             guard !addition.isEmpty else { return nil }
             return SpeechSegment(start: segment.start, end: segment.end, text: addition)
         }
     }
+
+#if DEBUG
+    func setRecordingForTesting(_ recording: Bool) {
+        chunkRotationQueue.sync {
+            isRecording = recording
+        }
+    }
+
+    func currentBackendForTesting() -> BackendOption {
+        currentBackend()
+    }
+#endif
 
     func start() async throws {
         let vadManager = await transcriptionCoordinator.getVadManager()

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -73,6 +73,15 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
+    static let gigaAMV3Russian = BackendOption(
+        backend: "gigaam_v3",
+        model: "huggingfinger0/gigaam-v3-coreml",
+        label: "GigaAM v3 (Russian)",
+        sizeLabel: GigaAMV3ModelStore.downloadedModelSizeLabel,
+        description: "Russian-first offline ASR via precompiled CoreML. Runs locally on Apple Silicon; no Python server or cloud.",
+        recommended: false
+    )
+
     static let canaryQwen = BackendOption(
         backend: "canary",
         model: "phequals/canary-qwen-2.5b-coreml-int8",
@@ -134,7 +143,7 @@ struct BackendOption: Equatable {
     ]
 
     /// Models available for download and use.
-    static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe, .nemotron35Multilingual] + experimental
+    static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe, .nemotron35Multilingual, .gigaAMV3Russian] + experimental
 
     /// Curated first-run choices shown in onboarding's "Other models" section.
     /// This is a deliberate hand-picked list, not a derived rule. Experimental models
@@ -198,6 +207,8 @@ struct BackendOption: Equatable {
             let path = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/muesli/models/nemotron35-multilingual-2240ms/encoder.mlmodelc/coremldata.bin")
             return fm.fileExists(atPath: path.path)
+        case "gigaam_v3":
+            return GigaAMV3ModelStore.isAvailableLocally()
         case "canary":
             return CanaryQwenModelStore.isAvailableLocally()
         case "cohere":

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -65,6 +65,8 @@ struct ModelsView: View {
 
                 modelCard(option: .nemotron35Multilingual, logo: "nvidia-logo")
 
+                modelCard(option: .gigaAMV3Russian)
+
                 experimentalSection
 
                 postProcessorSection
@@ -479,6 +481,7 @@ struct ModelsView: View {
         case "fluidaudio": return "nvidia-logo"
         case "whisper": return "openai-logo"
         case "cohere": return "cohere-logo"
+        case "gigaam_v3": return nil
         case "qwen": return "qwen-logo"
         case "nemotron35": return "nvidia-logo"
         case "canary": return "qwen-logo"
@@ -1001,6 +1004,8 @@ struct ModelsView: View {
             try removeItemIfPresent(at: CanaryQwenModelStore.cacheDirectory(), fileManager: fm)
         case "cohere":
             try removeItemIfPresent(at: CohereTranscribeModelStore.cacheDirectory(), fileManager: fm)
+        case "gigaam_v3":
+            try GigaAMV3ModelStore.deleteModelFiles(fileManager: fm)
         case "indicasr":
             if IndicASRModelStore.localOverrideDirectory() == nil {
                 try removeItemIfPresent(at: IndicASRModelStore.cacheDirectory(), fileManager: fm)
@@ -1096,6 +1101,8 @@ struct ModelsView: View {
             return CanaryQwenModelStore.isAvailableLocally()
         case "cohere":
             return CohereTranscribeModelStore.isAvailableLocally()
+        case "gigaam_v3":
+            return GigaAMV3ModelStore.isAvailableLocally()
         case "indicasr":
             return IndicASRModelStore.isAvailableLocally()
         case "sensevoice":

--- a/native/MuesliNative/Sources/MuesliNativeApp/PCMChunkRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PCMChunkRecorder.swift
@@ -6,14 +6,18 @@ final class PCMChunkRecorder {
         var fileHandle: FileHandle?
         var fileURL: URL?
         var bytesWritten = 0
+        var freshBytesWritten = 0
+        var tailSamples: [Int16] = []
     }
 
     private let directoryName: String
+    private let overlapSampleCount: Int
     private let lock = OSAllocatedUnfairLock(initialState: State())
 
-    init(directoryName: String) throws {
+    init(directoryName: String, overlapSampleCount: Int = 0) throws {
         self.directoryName = directoryName
-        let initialState = try createFileState()
+        self.overlapSampleCount = max(0, overlapSampleCount)
+        let initialState = try createFileState(carryoverSamples: [])
         lock.withLock {
             $0 = initialState
         }
@@ -25,24 +29,25 @@ final class PCMChunkRecorder {
         lock.withLock { state in
             state.fileHandle?.write(pcmData)
             state.bytesWritten += pcmData.count
+            state.freshBytesWritten += pcmData.count
+            guard overlapSampleCount > 0 else { return }
+            state.tailSamples = Array((state.tailSamples + samples).suffix(overlapSampleCount))
         }
     }
 
     func rotateFile() -> URL? {
-        let newState: State
-        do {
-            newState = try createFileState()
-        } catch {
-            fputs("[pcm-chunk-recorder] failed to rotate file: \(error)\n", stderr)
-            return nil
-        }
-
-        let completedState = lock.withLock { state -> State in
+        let completedState = lock.withLock { state -> State? in
             let oldState = state
-            state = newState
-            return oldState
+            do {
+                state = try createFileState(carryoverSamples: oldState.tailSamples)
+                return oldState
+            } catch {
+                fputs("[pcm-chunk-recorder] failed to rotate file: \(error)\n", stderr)
+                return nil
+            }
         }
 
+        guard let completedState else { return nil }
         return finalizeFile(completedState)
     }
 
@@ -67,7 +72,7 @@ final class PCMChunkRecorder {
         }
     }
 
-    private func createFileState() throws -> State {
+    private func createFileState(carryoverSamples: [Int16]) throws -> State {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(directoryName, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -81,7 +86,17 @@ final class PCMChunkRecorder {
             )
         }
         fileHandle.write(WavWriter.header(dataSize: 0))
-        return State(fileHandle: fileHandle, fileURL: fileURL, bytesWritten: 0)
+        if !carryoverSamples.isEmpty {
+            let carryoverData = carryoverSamples.withUnsafeBufferPointer { Data(buffer: $0) }
+            fileHandle.write(carryoverData)
+        }
+        return State(
+            fileHandle: fileHandle,
+            fileURL: fileURL,
+            bytesWritten: carryoverSamples.count * MemoryLayout<Int16>.size,
+            freshBytesWritten: 0,
+            tailSamples: carryoverSamples
+        )
     }
 
     private func finalizeFile(_ state: State) -> URL? {
@@ -91,7 +106,7 @@ final class PCMChunkRecorder {
         fileHandle.write(WavWriter.header(dataSize: UInt32(state.bytesWritten)))
         fileHandle.closeFile()
 
-        guard state.bytesWritten > 0 else {
+        guard state.freshBytesWritten > 0 else {
             try? FileManager.default.removeItem(at: fileURL)
             return nil
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/PCMChunkRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PCMChunkRecorder.swift
@@ -31,23 +31,40 @@ final class PCMChunkRecorder {
             state.bytesWritten += pcmData.count
             state.freshBytesWritten += pcmData.count
             guard overlapSampleCount > 0 else { return }
-            state.tailSamples = Array((state.tailSamples + samples).suffix(overlapSampleCount))
+            let combinedCount = state.tailSamples.count + samples.count
+            if combinedCount > overlapSampleCount {
+                let excess = combinedCount - overlapSampleCount
+                if excess >= state.tailSamples.count {
+                    state.tailSamples = Array(samples.suffix(overlapSampleCount))
+                } else {
+                    state.tailSamples.removeFirst(excess)
+                    state.tailSamples.append(contentsOf: samples)
+                }
+            } else {
+                state.tailSamples.append(contentsOf: samples)
+            }
         }
     }
 
     func rotateFile() -> URL? {
-        let completedState = lock.withLock { state -> State? in
-            let oldState = state
-            do {
-                state = try createFileState(carryoverSamples: oldState.tailSamples)
-                return oldState
-            } catch {
-                fputs("[pcm-chunk-recorder] failed to rotate file: \(error)\n", stderr)
-                return nil
-            }
+        let carryoverSamples = lock.withLock { state in
+            state.tailSamples
         }
 
-        guard let completedState else { return nil }
+        let newState: State
+        do {
+            newState = try createFileState(carryoverSamples: carryoverSamples)
+        } catch {
+            fputs("[pcm-chunk-recorder] failed to rotate file: \(error)\n", stderr)
+            return nil
+        }
+
+        let completedState = lock.withLock { state -> State in
+            let oldState = state
+            state = newState
+            return oldState
+        }
+
         return finalizeFile(completedState)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingVadController.swift
@@ -35,11 +35,14 @@ final class StreamingVadController: @unchecked Sendable {
     private let maxChunkDuration: TimeInterval
     private var maxDurationTimer: Timer?
 
-    convenience init(vadManager: VadManager) {
+    convenience init(
+        vadManager: VadManager,
+        minChunkDuration: TimeInterval = 3.0,
+        maxChunkDuration: TimeInterval = 5.0
+    ) {
         self.init(
-            minChunkDuration: 3.0,
-            // Keep live transcript latency bounded by forcing shorter meeting chunks.
-            maxChunkDuration: 5.0,
+            minChunkDuration: minChunkDuration,
+            maxChunkDuration: maxChunkDuration,
             makeInitialState: { await vadManager.makeStreamState() },
             processStreamChunk: { samples, state in
                 try await vadManager.processStreamingChunk(samples, state: state)
@@ -57,6 +60,14 @@ final class StreamingVadController: @unchecked Sendable {
         self.maxChunkDuration = maxChunkDuration
         self.makeInitialState = makeInitialState
         self.processStreamChunk = processStreamChunk
+    }
+
+    var configuredMinChunkDurationForTesting: TimeInterval {
+        minChunkDuration
+    }
+
+    var configuredMaxChunkDurationForTesting: TimeInterval {
+        maxChunkDuration
     }
 
     func start() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptOverlapMerger.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptOverlapMerger.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+enum TranscriptOverlapMerger {
+    static func merge(_ transcripts: [String]) -> String {
+        guard transcripts.count > 1 else {
+            return transcripts.first ?? ""
+        }
+
+        var merged = transcripts[0]
+        for transcript in transcripts.dropFirst() {
+            let addition = uniqueAddition(previous: merged, next: transcript)
+            if !addition.isEmpty {
+                merged += (merged.isEmpty ? "" : " ") + addition
+            }
+        }
+
+        return merged
+    }
+
+    static func uniqueAddition(previous: String, next: String) -> String {
+        let previousWords = previous.split(separator: " ").map(String.init)
+        let nextWords = next.split(separator: " ").map(String.init)
+        guard !previousWords.isEmpty, !nextWords.isEmpty else {
+            return next
+        }
+
+        let tailSize = min(previousWords.count, 40)
+        let tail = previousWords.suffix(tailSize).map(normalizedWord)
+        var trigramIndex: [String: Int] = [:]
+        if tail.count >= 3 {
+            for index in 0...(tail.count - 3) {
+                trigramIndex["\(tail[index])|\(tail[index + 1])|\(tail[index + 2])"] = index
+            }
+        }
+
+        let headSize = min(nextWords.count, 40)
+        let head = nextWords.prefix(headSize).map(normalizedWord)
+        var bestAnchorStart = -1
+        var bestRunEnd = 0
+
+        if head.count >= 3 {
+            for index in 0...(head.count - 3) {
+                let key = "\(head[index])|\(head[index + 1])|\(head[index + 2])"
+                guard let tailPosition = trigramIndex[key] else { continue }
+
+                var run = 3
+                var tailIndex = tailPosition + 3
+                var headIndex = index + 3
+                while tailIndex < tail.count, headIndex < head.count, tail[tailIndex] == head[headIndex] {
+                    run += 1
+                    tailIndex += 1
+                    headIndex += 1
+                }
+                if bestAnchorStart < 0 {
+                    bestAnchorStart = index
+                    bestRunEnd = index + run
+                }
+            }
+        }
+
+        guard bestAnchorStart >= 0 else {
+            let overlap = suffixPrefixOverlap(previousWords, nextWords)
+            return nextWords.dropFirst(overlap).joined(separator: " ")
+        }
+
+        let preAnchor = nextWords.prefix(bestAnchorStart).joined(separator: " ")
+        let postOverlap = nextWords.dropFirst(bestRunEnd).joined(separator: " ")
+        return [preAnchor, postOverlap].filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
+    static func deduplicateSegments(_ segments: [SpeechSegment]) -> [SpeechSegment] {
+        var previousText = ""
+        return segments.compactMap { segment in
+            let text = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            let addition = uniqueAddition(previous: previousText, next: text)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            previousText = merge([previousText, text])
+            guard !addition.isEmpty else { return nil }
+            return SpeechSegment(start: segment.start, end: segment.end, text: addition)
+        }
+    }
+
+    private static func normalizedWord(_ word: String) -> String {
+        word.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
+        let limit = min(40, left.count, right.count)
+        guard limit >= 2 else { return 0 }
+
+        for count in stride(from: limit, through: 2, by: -1) {
+            let leftSuffix = left.suffix(count).map(normalizedWord)
+            let rightPrefix = right.prefix(count).map(normalizedWord)
+            if !leftSuffix.contains(""), leftSuffix == rightPrefix {
+                return count
+            }
+        }
+
+        return 0
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptOverlapMerger.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptOverlapMerger.swift
@@ -1,17 +1,22 @@
 import Foundation
 
 enum TranscriptOverlapMerger {
+    private static let overlapSearchWordLimit = 15
+    private static let retainedContextWordLimit = 80
+
     static func merge(_ transcripts: [String]) -> String {
         guard transcripts.count > 1 else {
             return transcripts.first ?? ""
         }
 
         var merged = transcripts[0]
+        var context = retainedContext(from: merged)
         for transcript in transcripts.dropFirst() {
-            let addition = uniqueAddition(previous: merged, next: transcript)
+            let addition = uniqueAddition(previous: context, next: transcript)
             if !addition.isEmpty {
                 merged += (merged.isEmpty ? "" : " ") + addition
             }
+            context = retainedContextAfterAppending(addition, to: context)
         }
 
         return merged
@@ -24,7 +29,7 @@ enum TranscriptOverlapMerger {
             return next
         }
 
-        let tailSize = min(previousWords.count, 40)
+        let tailSize = min(previousWords.count, overlapSearchWordLimit)
         let tail = previousWords.suffix(tailSize).map(normalizedWord)
         var trigramIndex: [String: Int] = [:]
         if tail.count >= 3 {
@@ -33,7 +38,7 @@ enum TranscriptOverlapMerger {
             }
         }
 
-        let headSize = min(nextWords.count, 40)
+        let headSize = min(nextWords.count, overlapSearchWordLimit)
         let head = nextWords.prefix(headSize).map(normalizedWord)
         var bestAnchorStart = -1
         var bestRunEnd = 0
@@ -75,10 +80,17 @@ enum TranscriptOverlapMerger {
             guard !text.isEmpty else { return nil }
             let addition = uniqueAddition(previous: previousText, next: text)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            previousText = merge([previousText, text])
+            previousText = retainedContextAfterAppending(addition, to: previousText)
             guard !addition.isEmpty else { return nil }
             return SpeechSegment(start: segment.start, end: segment.end, text: addition)
         }
+    }
+
+    static func retainedContextAfterAppending(_ addition: String, to previous: String) -> String {
+        guard !addition.isEmpty else {
+            return retainedContext(from: previous)
+        }
+        return retainedContext(from: [previous, addition].filter { !$0.isEmpty }.joined(separator: " "))
     }
 
     private static func normalizedWord(_ word: String) -> String {
@@ -86,7 +98,7 @@ enum TranscriptOverlapMerger {
     }
 
     private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
-        let limit = min(40, left.count, right.count)
+        let limit = min(overlapSearchWordLimit, left.count, right.count)
         guard limit >= 2 else { return 0 }
 
         for count in stride(from: limit, through: 2, by: -1) {
@@ -98,5 +110,11 @@ enum TranscriptOverlapMerger {
         }
 
         return 0
+    }
+
+    private static func retainedContext(from text: String) -> String {
+        let words = text.split(separator: " ")
+        guard words.count > retainedContextWordLimit else { return text }
+        return words.suffix(retainedContextWordLimit).joined(separator: " ")
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -15,7 +15,7 @@ struct SpeechTranscriptionResult: Sendable {
 
 actor TranscriptionCoordinator {
     static let explicitlyRoutedBackendIdentifiers: Set<String> = [
-        "whisper", "nemotron35", "qwen", "canary", "cohere", "indicasr", "sensevoice",
+        "whisper", "nemotron35", "gigaam_v3", "qwen", "canary", "cohere", "indicasr", "sensevoice",
     ]
 
     private let fluidTranscriber = FluidAudioTranscriber()
@@ -25,6 +25,7 @@ actor TranscriptionCoordinator {
     private var _canaryQwenTranscriber: Any?
     private var _cohereTranscriber: Any?
     private var _indicASRTranscriber: Any?
+    private let gigaAMV3Transcriber = GigaAMV3Transcriber()
     private let senseVoiceTranscriber = SenseVoiceTranscriber()
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
@@ -272,6 +273,8 @@ actor TranscriptionCoordinator {
                     NSLocalizedDescriptionKey: "Nemotron 3.5 requires macOS 15 or later.",
                 ])
             }
+        case "gigaam_v3":
+            try await gigaAMV3Transcriber.loadModels(progress: progress)
         case "qwen":
             if #available(macOS 15, *) {
                 try await qwen3Transcriber.loadModels(progress: progress)
@@ -435,6 +438,7 @@ actor TranscriptionCoordinator {
     func shutdown() async {
         await fluidTranscriber.shutdown()
         await whisperTranscriber.shutdown()
+        await gigaAMV3Transcriber.shutdown()
         await senseVoiceTranscriber.shutdown()
         if #available(macOS 15, *) {
             if let nemotron35 = _nemotron35Transcriber as? Nemotron35StreamingTranscriber {
@@ -664,6 +668,8 @@ actor TranscriptionCoordinator {
             return try await transcribeWithWhisperKit(url: url)
         case "nemotron35":
             return try await transcribeWithNemotron35(url: url)
+        case "gigaam_v3":
+            return try await transcribeWithGigaAMV3(url: url)
         case "qwen":
             return try await transcribeWithQwen3(url: url)
         case "canary":
@@ -705,6 +711,19 @@ actor TranscriptionCoordinator {
         return SpeechTranscriptionResult(
             text: text,
             segments: text.isEmpty ? [] : [SpeechSegment(start: 0, end: 0, text: text)]
+        )
+    }
+
+    // MARK: - GigaAM v3 Russian ASR (CoreML)
+
+    private func transcribeWithGigaAMV3(url: URL) async throws -> SpeechTranscriptionResult {
+        fputs("[muesli-native] transcribing with GigaAM v3: \(url.lastPathComponent)\n", stderr)
+        let result = try await gigaAMV3Transcriber.transcribe(wavURL: url)
+        fputs("[muesli-native] GigaAM v3 result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return SpeechTranscriptionResult(
+            text: text,
+            segments: text.isEmpty ? [] : [SpeechSegment(start: 0, end: result.duration, text: text)]
         )
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingLiveChunkingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingLiveChunkingTests.swift
@@ -158,6 +158,104 @@ struct MeetingLiveChunkingTests {
 
         #expect(ready?.map { $0.map(\.text) } == [["first"], ["second"]])
     }
+
+    @Test("chunk collector releases tail after failed earlier chunk retires empty")
+    func chunkCollectorFailureRetiresSlotAndReleasesTail() async {
+        let collector = MeetingChunkCollector()
+        let failedChunk = Task { [SpeechSegment]() }
+        let tailChunk = Task { [SpeechSegment(start: 3, end: 4, text: "tail")] }
+
+        let failed = collector.add(failedChunk)
+        let tail = collector.add(tailChunk)
+
+        #expect(failed.registered)
+        #expect(tail.registered)
+        #expect(collector.retire(id: tail.retireID, segments: await tailChunk.value)?.isEmpty == true)
+
+        let ready = collector.retire(id: failed.retireID, segments: await failedChunk.value)
+
+        #expect(ready?.map { $0.map(\.text) } == [[], ["tail"]])
+    }
+
+    @Test("chunk collector final drain flushes buffered tail past stalled slot")
+    func chunkCollectorFinalDrainFlushesBufferedTailPastStalledSlot() async {
+        let collector = MeetingChunkCollector()
+        let stalled = Task<[SpeechSegment], Never> {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            return []
+        }
+        let tailChunk = Task { [SpeechSegment(start: 3, end: 4, text: "tail")] }
+
+        let stalledRegistration = collector.add(stalled)
+        let tailRegistration = collector.add(tailChunk)
+
+        #expect(stalledRegistration.registered)
+        #expect(tailRegistration.registered)
+        #expect(collector.retire(id: tailRegistration.retireID, segments: await tailChunk.value)?.isEmpty == true)
+
+        var logs: [String] = []
+        let drained = await collector.closeAndDrainSortedSegments(inactivityTimeout: 0.05) { logs.append($0) }
+
+        #expect(drained.map(\.text) == ["tail"])
+        #expect(logs.contains { $0.contains("[live-collector] dropped pending chunk sequence=0 reason=drain_timeout") })
+    }
+
+    @Test("chunk collector final drain does not race progress timeout")
+    func chunkCollectorFinalDrainDoesNotRaceProgressTimeout() async {
+        for _ in 0..<50 {
+            let collector = MeetingChunkCollector()
+            let chunks = ControlledSpeechChunks()
+            for index in 0..<4 {
+                _ = collector.add(
+                    Task {
+                        await chunks.wait(for: index)
+                    }
+                )
+            }
+
+            while await chunks.readyCount() < 4 {
+                await Task.yield()
+            }
+
+            var logs: [String] = []
+            let drainTask = Task {
+                await collector.closeAndDrainSortedSegments(inactivityTimeout: 0.25) { logs.append($0) }
+            }
+
+            for index in 0..<4 {
+                await chunks.resume(
+                    index: index,
+                    with: [SpeechSegment(start: Double(index), end: Double(index + 1), text: "chunk \(index)")]
+                )
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+
+            let drained = await drainTask.value
+
+            #expect(drained.map(\.text) == (0..<4).map { "chunk \($0)" })
+            #expect(logs.isEmpty)
+        }
+    }
+}
+
+private actor ControlledSpeechChunks {
+    private var continuations: [Int: CheckedContinuation<[SpeechSegment], Never>] = [:]
+
+    func wait(for index: Int) async -> [SpeechSegment] {
+        await withCheckedContinuation { continuation in
+            continuations[index] = continuation
+        }
+    }
+
+    func readyCount() -> Int {
+        continuations.count
+    }
+
+    func resume(index: Int, with segments: [SpeechSegment]) {
+        continuations.removeValue(forKey: index)?.resume(returning: segments)
+    }
 }
 
 #if DEBUG

--- a/native/MuesliNative/Tests/MuesliTests/MeetingLiveChunkingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingLiveChunkingTests.swift
@@ -1,0 +1,103 @@
+import FluidAudio
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting live chunking")
+struct MeetingLiveChunkingTests {
+    @Test("GigaAM uses longer live chunks with overlap")
+    func gigaAMUsesLongerLiveChunksWithOverlap() {
+        let chunking = MeetingSession.liveChunkingConfiguration(for: .gigaAMV3Russian)
+
+        #expect(chunking.minChunkDuration == 3)
+        #expect(chunking.maxChunkDuration == 20)
+        #expect(chunking.overlapSampleCount == 32_000)
+        #expect(chunking.deduplicatesText)
+    }
+
+    @Test("non-GigaAM backends keep default live chunking")
+    func nonGigaAMBackendsKeepDefaultLiveChunking() {
+        for backend in BackendOption.all where backend != .gigaAMV3Russian {
+            let chunking = MeetingSession.liveChunkingConfiguration(for: backend)
+
+            #expect(chunking.minChunkDuration == 3)
+            #expect(chunking.maxChunkDuration == 5)
+            #expect(chunking.overlapSampleCount == 0)
+            #expect(!chunking.deduplicatesText)
+        }
+    }
+
+    @Test("GigaAM config reaches VAD controller")
+    func gigaAMConfigReachesVadController() {
+        let chunking = MeetingSession.liveChunkingConfiguration(for: .gigaAMV3Russian)
+        let controller = StreamingVadController(
+            minChunkDuration: chunking.minChunkDuration,
+            maxChunkDuration: chunking.maxChunkDuration,
+            makeInitialState: { VadStreamState.initial() },
+            processStreamChunk: { _, state in
+                VadStreamResult(state: state, event: nil, probability: 0)
+            }
+        )
+
+        #expect(controller.configuredMinChunkDurationForTesting == 3)
+        #expect(controller.configuredMaxChunkDurationForTesting == 20)
+    }
+
+    @Test("overlapped live text deduplicates per track only when enabled")
+    func overlappedLiveTextDeduplicatesPerTrackOnlyWhenEnabled() {
+        var micPrevious = ""
+        var systemPrevious = ""
+
+        let firstMic = MeetingSession.deduplicateLiveSegments(
+            [SpeechSegment(start: 0, end: 10, text: "alpha beta gamma delta epsilon")],
+            enabled: true,
+            previousText: &micPrevious
+        )
+        let secondMic = MeetingSession.deduplicateLiveSegments(
+            [SpeechSegment(start: 8, end: 18, text: "gamma delta epsilon zeta eta")],
+            enabled: true,
+            previousText: &micPrevious
+        )
+        let firstSystem = MeetingSession.deduplicateLiveSegments(
+            [SpeechSegment(start: 8, end: 18, text: "gamma delta epsilon system words")],
+            enabled: true,
+            previousText: &systemPrevious
+        )
+
+        var disabledPrevious = ""
+        _ = MeetingSession.deduplicateLiveSegments(
+            [SpeechSegment(start: 0, end: 10, text: "alpha beta gamma delta epsilon")],
+            enabled: false,
+            previousText: &disabledPrevious
+        )
+        let disabledDuplicate = MeetingSession.deduplicateLiveSegments(
+            [SpeechSegment(start: 8, end: 18, text: "gamma delta epsilon zeta eta")],
+            enabled: false,
+            previousText: &disabledPrevious
+        )
+
+        #expect(firstMic.map(\.text) == ["alpha beta gamma delta epsilon"])
+        #expect(secondMic.map(\.text) == ["zeta eta"])
+        #expect(firstSystem.map(\.text) == ["gamma delta epsilon system words"])
+        #expect(disabledDuplicate.map(\.text) == ["gamma delta epsilon zeta eta"])
+        #expect(disabledPrevious.isEmpty)
+    }
+
+    @Test("chunk collector releases live chunks in registration order")
+    func chunkCollectorReleasesLiveChunksInRegistrationOrder() async {
+        let collector = MeetingChunkCollector()
+        let firstTask = Task { [SpeechSegment(start: 0, end: 1, text: "first")] }
+        let secondTask = Task { [SpeechSegment(start: 1, end: 2, text: "second")] }
+
+        let first = collector.add(firstTask)
+        let second = collector.add(secondTask)
+
+        #expect(first.registered)
+        #expect(second.registered)
+        #expect(collector.retire(id: second.retireID, segments: await secondTask.value)?.isEmpty == true)
+
+        let ready = collector.retire(id: first.retireID, segments: await firstTask.value)
+
+        #expect(ready?.map { $0.map(\.text) } == [["first"], ["second"]])
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingLiveChunkingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingLiveChunkingTests.swift
@@ -1,3 +1,4 @@
+import CoreAudio
 import FluidAudio
 import Foundation
 import Testing
@@ -83,6 +84,63 @@ struct MeetingLiveChunkingTests {
         #expect(disabledPrevious.isEmpty)
     }
 
+    @Test("live overlap context stays bounded")
+    func liveOverlapContextStaysBounded() {
+        var previous = (0..<100).map { "p\($0)" }.joined(separator: " ")
+
+        let segments = MeetingSession.deduplicateLiveSegments(
+            [SpeechSegment(start: 8, end: 18, text: "p97 p98 p99 fresh words")],
+            enabled: true,
+            previousText: &previous
+        )
+
+        #expect(segments.map(\.text) == ["fresh words"])
+        #expect(previous.split(separator: " ").count <= 80)
+        #expect(previous.hasSuffix("fresh words"))
+    }
+
+    @Test("late repeated trigram does not drop new words")
+    func lateRepeatedTrigramDoesNotDropNewWords() {
+        let filler = (0..<16).map { "fresh\($0)" }.joined(separator: " ")
+        let next = "\(filler) alpha beta gamma still new"
+
+        let addition = TranscriptOverlapMerger.uniqueAddition(
+            previous: "alpha beta gamma",
+            next: next
+        )
+
+        #expect(addition == next)
+    }
+
+#if DEBUG
+    @Test("backend update is rejected while recording")
+    func backendUpdateIsRejectedWhileRecording() {
+        let session = MeetingSession(
+            title: "Test",
+            calendarEventID: nil,
+            backend: .whisper,
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            config: AppConfig(),
+            templateSnapshot: MeetingTemplates.auto.snapshot,
+            transcriptionCoordinator: TranscriptionCoordinator(),
+            meetingMicRecorder: FakeMeetingMicRecorder()
+        )
+
+        #expect(session.updateBackend(.gigaAMV3Russian))
+        #expect(session.currentBackendForTesting() == .gigaAMV3Russian)
+
+        session.setRecordingForTesting(true)
+
+        #expect(!session.updateBackend(.whisper))
+        #expect(session.currentBackendForTesting() == .gigaAMV3Russian)
+    }
+#endif
+
     @Test("chunk collector releases live chunks in registration order")
     func chunkCollectorReleasesLiveChunksInRegistrationOrder() async {
         let collector = MeetingChunkCollector()
@@ -101,3 +159,27 @@ struct MeetingLiveChunkingTests {
         #expect(ready?.map { $0.map(\.text) } == [["first"], ["second"]])
     }
 }
+
+#if DEBUG
+private final class FakeMeetingMicRecorder: MeetingMicRecording {
+    var preferredInputDeviceID: AudioObjectID?
+    var onRawPCMSamples: (([Int16]) -> Void)?
+    var onRecordingFailed: ((Error) -> Void)?
+
+    func prepare() throws {}
+    func start() throws {}
+    func pause() {}
+    func resume() {}
+    func stop() -> URL? { nil }
+    func cancel() {}
+    func currentPower() -> Float { -80 }
+
+    func diagnosticsSnapshot() -> MeetingMicRecorderDiagnosticsSnapshot {
+        MeetingMicRecorderDiagnosticsSnapshot(
+            recorderKind: .systemDefaultStreaming,
+            preferredInputDeviceID: preferredInputDeviceID,
+            route: nil
+        )
+    }
+}
+#endif

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -25,7 +25,7 @@ struct BackendOptionTests {
 
     @Test("backend field is one of the known backends")
     func knownBackends() {
-        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron35", "canary", "cohere", "indicasr", "sensevoice"]
+        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron35", "gigaam_v3", "canary", "cohere", "indicasr", "sensevoice"]
         for option in BackendOption.all {
             #expect(known.contains(option.backend), "Unknown backend: \(option.backend)")
         }
@@ -72,6 +72,7 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.indicASR))
         #expect(BackendOption.all.contains(.senseVoiceSmall))
         #expect(BackendOption.all.contains(.nemotron35Multilingual))
+        #expect(BackendOption.all.contains(.gigaAMV3Russian))
     }
 
     @Test("Cohere uses cohere backend")

--- a/native/MuesliNative/Tests/MuesliTests/PCMChunkRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PCMChunkRecorderTests.swift
@@ -18,6 +18,58 @@ struct PCMChunkRecorderTests {
         #expect(try readMonoPCM16WAVSamples(from: secondChunkURL) == [400, 500])
     }
 
+    @Test("rotateFile carries overlap bytes across multiple rotations")
+    func rotateFileCarriesOverlapAcrossMultipleRotations() throws {
+        let recorder = try PCMChunkRecorder(
+            directoryName: "pcm-chunk-recorder-tests",
+            overlapSampleCount: 3
+        )
+        recorder.append([1, 2, 3, 4, 5])
+        let firstChunkURL = try #require(recorder.rotateFile())
+        recorder.append([6, 7, 8, 9])
+        let secondChunkURL = try #require(recorder.rotateFile())
+        recorder.append([10])
+        let finalChunkURL = try #require(recorder.stop())
+
+        let firstBytes = try readPCMBytes(from: firstChunkURL)
+        let secondBytes = try readPCMBytes(from: secondChunkURL)
+        let finalBytes = try readPCMBytes(from: finalChunkURL)
+        let overlapBytes = 3 * MemoryLayout<Int16>.size
+
+        #expect(try readMonoPCM16WAVSamples(from: firstChunkURL) == [1, 2, 3, 4, 5])
+        #expect(try readMonoPCM16WAVSamples(from: secondChunkURL) == [3, 4, 5, 6, 7, 8, 9])
+        #expect(try readMonoPCM16WAVSamples(from: finalChunkURL) == [7, 8, 9, 10])
+        #expect(Array(firstBytes.suffix(overlapBytes)) == Array(secondBytes.prefix(overlapBytes)))
+        #expect(Array(secondBytes.suffix(overlapBytes)) == Array(finalBytes.prefix(overlapBytes)))
+    }
+
+    @Test("overlap preserves short trailing fresh chunks")
+    func overlapPreservesShortTrailingFreshChunks() throws {
+        let recorder = try PCMChunkRecorder(
+            directoryName: "pcm-chunk-recorder-tests",
+            overlapSampleCount: 2
+        )
+        recorder.append([100, 200, 300])
+        _ = try #require(recorder.rotateFile())
+        recorder.append([400])
+
+        let finalChunkURL = try #require(recorder.stop())
+
+        #expect(try readMonoPCM16WAVSamples(from: finalChunkURL) == [200, 300, 400])
+    }
+
+    @Test("carryover-only chunks are dropped")
+    func carryoverOnlyChunksAreDropped() throws {
+        let recorder = try PCMChunkRecorder(
+            directoryName: "pcm-chunk-recorder-tests",
+            overlapSampleCount: 2
+        )
+        recorder.append([100, 200, 300])
+        _ = try #require(recorder.rotateFile())
+
+        #expect(recorder.stop() == nil)
+    }
+
     @Test("cancel removes the in-progress chunk file")
     func cancelRemovesTempFile() throws {
         let recorder = try PCMChunkRecorder(directoryName: "pcm-chunk-recorder-tests")
@@ -33,5 +85,10 @@ struct PCMChunkRecorderTests {
         return sampleBytes.withUnsafeBytes { rawBuffer in
             Array(rawBuffer.bindMemory(to: Int16.self)).map(Int16.init(littleEndian:))
         }
+    }
+
+    private func readPCMBytes(from url: URL) throws -> Data {
+        let data = try Data(contentsOf: url)
+        return data.subdata(in: 44..<data.count)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -297,8 +297,8 @@ struct MeetingChunkCollectorTests {
         lateTask.cancel()
     }
 
-    @Test("collector retire returns false after drain closes collector")
-    func collectorRetireReturnsFalseAfterDrain() async {
+    @Test("collector retire returns nil after drain closes collector")
+    func collectorRetireReturnsNilAfterDrain() async {
         let collector = MeetingChunkCollector()
         let task = Task<[SpeechSegment], Never> {
             try? await Task.sleep(for: .milliseconds(10))
@@ -311,7 +311,7 @@ struct MeetingChunkCollectorTests {
         let retired = collector.retire(id: registration.retireID, segments: await task.value)
 
         #expect(drained.map(\.text) == ["first"])
-        #expect(retired == false)
+        #expect(retired == nil)
     }
 
     @Test("collector flattens timed segments from a single chunk and sorts them")
@@ -356,5 +356,21 @@ struct MeetingChunkTimingTrackerTests {
         #expect(second?.sampleCount == 800)
         #expect(second?.startTimeSeconds == 0.1)
         #expect(second?.durationSeconds == 0.05)
+    }
+
+    @Test("tracks overlap as the next chunk start")
+    func tracksOverlapAsNextChunkStart() {
+        var tracker = MeetingChunkTimingTracker()
+        tracker.start()
+        tracker.append(sampleCount: 1600)
+
+        let first = tracker.rotate(overlapSampleCount: 400)
+        tracker.append(sampleCount: 800)
+        let second = tracker.finish()
+
+        #expect(first?.startSampleIndex == 0)
+        #expect(first?.sampleCount == 1600)
+        #expect(second?.startSampleIndex == 1200)
+        #expect(second?.sampleCount == 1200)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -189,6 +189,47 @@ struct CohereTranscribeUtilsTests {
     }
 }
 
+@Suite("GigaAMV3FileChunking")
+struct GigaAMV3FileChunkingTests {
+
+    @Test("short files use one passthrough window")
+    func shortFilesUseOnePassthroughWindow() {
+        let sampleCount = 25 * GigaAMV3FileChunking.sampleRate
+        #expect(GigaAMV3FileChunking.windows(sampleCount: sampleCount) == [0..<sampleCount])
+        #expect(!GigaAMV3FileChunking.shouldChunk(sampleCount: sampleCount))
+    }
+
+    @Test("long files use 20 second windows with 2 second overlap")
+    func longFilesUseOverlappingWindows() {
+        let sampleRate = GigaAMV3FileChunking.sampleRate
+        let sampleCount = 61 * sampleRate
+        let windows = GigaAMV3FileChunking.windows(sampleCount: sampleCount)
+
+        #expect(windows == [
+            0..<(20 * sampleRate),
+            (18 * sampleRate)..<(38 * sampleRate),
+            (36 * sampleRate)..<(56 * sampleRate),
+            (54 * sampleRate)..<(61 * sampleRate),
+        ])
+    }
+
+    @Test("empty audio produces no windows")
+    func emptyAudioProducesNoWindows() {
+        #expect(GigaAMV3FileChunking.windows(sampleCount: 0).isEmpty)
+    }
+
+    @Test("merge deduplicates overlap")
+    func mergeDeduplicatesOverlap() {
+        let result = GigaAMV3FileChunking.mergeTranscripts([
+            "alpha beta gamma delta epsilon",
+            "gamma delta epsilon zeta eta",
+            "zeta eta theta iota",
+        ])
+
+        #expect(result == "alpha beta gamma delta epsilon zeta eta theta iota")
+    }
+}
+
 @Suite("TranscriptionEngineArtifactsFilter")
 struct TranscriptionEngineArtifactsFilterTests {
 


### PR DESCRIPTION
## What

Part 2 of the GigaAM series (stacked on #275 — its commit appears in this diff until #275 merges; the part-2 delta is `04fd7959`).

GigaAM is a full-utterance conformer: the fixed 3–5s live VAD chunks cut speech mid-word and noticeably degrade live meeting transcription. This PR adds per-backend live chunking configuration: GigaAM meetings use 3–20s VAD windows with 2s of audio carried over between consecutive chunk files, and overlapped text is deduplicated per track. Every other backend keeps the exact current behavior (3–5s, no overlap, no dedup).

## How

- `PCMChunkRecorder`: optional `overlapSampleCount` — each rotated chunk file starts with the last 2s of the previous one; a fresh-bytes guard drops carryover-only chunks.
- `StreamingVadController`: injectable min/max chunk durations (defaults unchanged).
- `MeetingSession`: wires the per-backend config to both mic and system tracks; overlap dedup only when enabled.

## Tests

Byte-identity of carryover across multiple rotations, short-trailing-chunk preservation, per-backend config selection, dedup gating. Full suite passes (1232 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785867146&installation_id=136549638&pr_number=277&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F277&signature=beca47f7f3f6aca9f43f2646e9f478baa0df0289682003a330e0a04da0c39f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “GigaAM v3 (Russian)” offline speech recognition backend and model UI support.
  * Improved live transcription with backend-tuned VAD chunk durations, overlap-aware chunking, and ordered live emission with per-track overlap deduplication.
* **Bug Fixes**
  * Fixed audio chunk file rotation to correctly carry overlap samples and drop carryover-only chunks.
  * Improved transcript merging/deduplication to reduce repeated words across overlapping segments.
* **Chores**
  * Added/expanded tests covering overlap chunking, live emission, and the new backend.
  * Enhanced download handling with optional progress reporting and safer temp-file cleanup/cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->