### PR TITLE
Migrate legacy WAV recordings to compact M4A

### DIFF
--- a/REVIEW_RESPONSE.md
+++ b/REVIEW_RESPONSE.md
@@ -1,0 +1,7 @@
+Ready-to-post reply:
+
+Fixed. `migrateLegacyWAVRecordings` now isolates `deleteOrphanedWAVStubs` failures: if the orphan sweep cannot list the recordings directory, it logs that sweep failure, reports `deletedOrphanStubs = 0`, and still returns the migrated count so `startLegacyRecordingMigration` reaches `MuesliNotifications.postDataDidChange()`.
+
+Added regression coverage with an injected `FileManager` whose `contentsOfDirectory` throws for the recordings directory. The test proves a successful WAV-to-M4A migration returns `migrated == 1`, reports `deletedOrphanStubs == 0`, and does not throw.
+
+Validated with `swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-spm-prwav --filter MeetingRecordingWriterTests` and `swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-spm-prwav`.

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -2756,6 +2756,9 @@ public final class DictationStore {
         if sqlite3_exec(db, "PRAGMA journal_mode=WAL", nil, nil, nil) != SQLITE_OK {
             throw lastError(db)
         }
+        if sqlite3_exec(db, "PRAGMA busy_timeout=5000", nil, nil, nil) != SQLITE_OK {
+            throw lastError(db)
+        }
         return db
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -617,14 +617,26 @@ public final class DictationStore {
     }
 
     public func savedRecordingReferenceCount(path: String, excludingMeetingID: Int64? = nil) throws -> Int {
+        try savedRecordingReferenceCount(paths: [path], excludingMeetingID: excludingMeetingID)
+    }
+
+    public func savedRecordingReferenceCount(paths: [String], excludingMeetingID: Int64? = nil) throws -> Int {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
-        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        var matchingPaths: [String] = []
+        for path in paths {
+            for candidatePath in [path, URL(fileURLWithPath: path).standardizedFileURL.path] where !matchingPaths.contains(candidatePath) {
+                matchingPaths.append(candidatePath)
+            }
+        }
+        guard !matchingPaths.isEmpty else { return 0 }
+
+        let placeholders = Array(repeating: "?", count: matchingPaths.count).joined(separator: ", ")
         var sql = """
         SELECT COUNT(*)
         FROM meetings
-        WHERE saved_recording_path IN (?, ?)
+        WHERE saved_recording_path IN (\(placeholders))
           AND deleted_at IS NULL
         """
         if excludingMeetingID != nil {
@@ -637,10 +649,11 @@ public final class DictationStore {
         }
         defer { sqlite3_finalize(statement) }
 
-        sqlite3_bind_text(statement, 1, (path as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(statement, 2, (standardizedPath as NSString).utf8String, -1, nil)
+        for (index, path) in matchingPaths.enumerated() {
+            sqlite3_bind_text(statement, Int32(index + 1), (path as NSString).utf8String, -1, nil)
+        }
         if let excludingMeetingID {
-            sqlite3_bind_int64(statement, 3, excludingMeetingID)
+            sqlite3_bind_int64(statement, Int32(matchingPaths.count + 1), excludingMeetingID)
         }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -591,6 +591,64 @@ public final class DictationStore {
         return makeMeetingRecord(statement)
     }
 
+    public func legacyWAVMeetingRecordingPaths() throws -> [(id: Int64, path: String)] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT id, saved_recording_path
+        FROM meetings
+        WHERE saved_recording_path IS NOT NULL
+          AND lower(saved_recording_path) LIKE '%.wav'
+          AND deleted_at IS NULL
+        ORDER BY id ASC
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var rows: [(id: Int64, path: String)] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append((sqlite3_column_int64(statement, 0), stringColumn(statement, index: 1)))
+        }
+        return rows
+    }
+
+    public func savedRecordingReferenceCount(path: String, excludingMeetingID: Int64? = nil) throws -> Int {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        var sql = """
+        SELECT COUNT(*)
+        FROM meetings
+        WHERE saved_recording_path IN (?, ?)
+          AND deleted_at IS NULL
+        """
+        if excludingMeetingID != nil {
+            sql += " AND id != ?"
+        }
+
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        sqlite3_bind_text(statement, 1, (path as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (standardizedPath as NSString).utf8String, -1, nil)
+        if let excludingMeetingID {
+            sqlite3_bind_int64(statement, 3, excludingMeetingID)
+        }
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw lastError(db)
+        }
+        return Int(sqlite3_column_int(statement, 0))
+    }
+
     @discardableResult
     public func insertMeeting(
         title: String,

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -260,8 +260,8 @@ enum AudioFileImportController {
 
         try Task.checkCancellation()
 
-        // Persist the converted WAV as a saved recording so retranscription works
-        let savedRecordingPath = try persistRecording(wavURL: wavURL, title: generatedTitle)
+        // Persist the converted WAV as compact saved audio so retranscription works.
+        let savedRecordingPath = try await persistRecording(wavURL: wavURL, title: generatedTitle)
 
         progress("Saving...")
         let now = Date()
@@ -373,37 +373,21 @@ enum AudioFileImportController {
         return samples
     }
 
-    /// Copies the converted WAV to the meeting-recordings directory so the imported
-    /// meeting can be retranscribed later.
-    private static func persistRecording(wavURL: URL, title: String) throws -> String {
-        let recordingsDirectory = AppIdentity.supportDirectoryURL
-            .appendingPathComponent("meeting-recordings", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: recordingsDirectory,
-            withIntermediateDirectories: true
+    /// Stores the converted WAV as M4A so the imported meeting can be retranscribed later.
+    static func persistRecording(
+        wavURL: URL,
+        title: String,
+        startedAt: Date = Date(),
+        supportDirectory: URL = AppIdentity.supportDirectoryURL
+    ) async throws -> String {
+        let savedURL = try await MeetingRecordingWriter.persistTemporaryRecordingAsync(
+            from: wavURL,
+            meetingTitle: title,
+            startedAt: startedAt,
+            supportDirectory: supportDirectory,
+            fileFormat: .m4a
         )
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
-        let datePrefix = dateFormatter.string(from: Date())
-        let safeTitle = safeFilenameComponent(title)
-        let filename = "\(datePrefix)_\(safeTitle)_\(UUID().uuidString.prefix(8)).wav"
-        let destinationURL = recordingsDirectory.appendingPathComponent(filename)
-
-        try FileManager.default.copyItem(at: wavURL, to: destinationURL)
-        return destinationURL.path
-    }
-
-    private static func safeFilenameComponent(_ value: String) -> String {
-        let allowed = CharacterSet.alphanumerics.union(.whitespaces).union(CharacterSet(charactersIn: "-_"))
-        let scalars = value.unicodeScalars.map { scalar in
-            allowed.contains(scalar) ? Character(scalar) : "-"
-        }
-        let collapsed = String(scalars)
-            .split(whereSeparator: { $0.isWhitespace || $0 == "-" })
-            .joined(separator: "-")
-            .trimmingCharacters(in: CharacterSet(charactersIn: "-_ "))
-        return collapsed.isEmpty ? "Imported-Recording" : String(collapsed.prefix(80))
+        return savedURL.path
     }
 
     private static func importedTranscriptTimelineStart() -> Date {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -165,15 +165,16 @@ final class MeetingRecordingWriter {
             let sourceURL = URL(fileURLWithPath: candidate.path).standardizedFileURL
             guard sourceURL.pathExtension.lowercased() == "wav",
                   fileManager.fileExists(atPath: sourceURL.path) else { continue }
-            let attributes = try fileManager.attributesOfItem(atPath: sourceURL.path)
-            let fileSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
-            guard fileSize >= 1024 else { continue }
 
             let destinationURL = sourceURL.deletingPathExtension().appendingPathExtension("m4a")
             let temporaryURL = sourceURL
                 .deletingLastPathComponent()
                 .appendingPathComponent(".\(sourceURL.deletingPathExtension().lastPathComponent).migrating.m4a")
             do {
+                let attributes = try fileManager.attributesOfItem(atPath: sourceURL.path)
+                let fileSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+                guard fileSize >= 1024 else { continue }
+
                 try? fileManager.removeItem(at: temporaryURL)
                 try await encode(sourceURL, temporaryURL)
                 try Task.checkCancellation()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -180,7 +180,10 @@ final class MeetingRecordingWriter {
                 try Task.checkCancellation()
                 try atomicallyRenameItem(at: temporaryURL, to: destinationURL)
                 try store.updateMeetingSavedRecordingPath(id: candidate.id, path: destinationURL.path)
-                if try store.savedRecordingReferenceCount(path: sourceURL.path, excludingMeetingID: candidate.id) == 0 {
+                if try store.savedRecordingReferenceCount(
+                    paths: [candidate.path, sourceURL.path],
+                    excludingMeetingID: candidate.id
+                ) == 0 {
                     do {
                         try fileManager.removeItem(at: sourceURL)
                     } catch {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -172,17 +172,19 @@ final class MeetingRecordingWriter {
             let destinationURL = sourceURL.deletingPathExtension().appendingPathExtension("m4a")
             let temporaryURL = sourceURL
                 .deletingLastPathComponent()
-                .appendingPathComponent(".\(destinationURL.lastPathComponent).migrating")
+                .appendingPathComponent(".\(sourceURL.deletingPathExtension().lastPathComponent).migrating.m4a")
             do {
                 try? fileManager.removeItem(at: temporaryURL)
                 try await encode(sourceURL, temporaryURL)
                 try Task.checkCancellation()
                 try atomicallyRenameItem(at: temporaryURL, to: destinationURL)
                 try store.updateMeetingSavedRecordingPath(id: candidate.id, path: destinationURL.path)
-                do {
-                    try fileManager.removeItem(at: sourceURL)
-                } catch {
-                    fputs("[muesli-native] failed to delete migrated wav \(sourceURL.path): \(error)\n", stderr)
+                if try store.savedRecordingReferenceCount(path: sourceURL.path, excludingMeetingID: candidate.id) == 0 {
+                    do {
+                        try fileManager.removeItem(at: sourceURL)
+                    } catch {
+                        fputs("[muesli-native] failed to delete migrated wav \(sourceURL.path): \(error)\n", stderr)
+                    }
                 }
                 migrated += 1
             } catch is CancellationError {
@@ -314,11 +316,19 @@ final class MeetingRecordingWriter {
 
         var deleted = 0
         for file in files where file.pathExtension.lowercased() == "wav" {
-            let values = try file.resourceValues(forKeys: [.fileSizeKey])
-            guard (values.fileSize ?? 0) < 1024,
-                  try store.savedRecordingReferenceCount(path: file.path) == 0 else { continue }
-            try fileManager.removeItem(at: file)
-            deleted += 1
+            do {
+                let values = try file.resourceValues(forKeys: [.fileSizeKey])
+                let fileSize = values.fileSize ?? 0
+                let hasMigratedSibling = fileManager.fileExists(
+                    atPath: file.deletingPathExtension().appendingPathExtension("m4a").path
+                )
+                guard (fileSize < 1024 || hasMigratedSibling),
+                      try store.savedRecordingReferenceCount(path: file.path) == 0 else { continue }
+                try fileManager.removeItem(at: file)
+                deleted += 1
+            } catch {
+                fputs("[muesli-native] failed to evaluate/delete orphan wav \(file.path): \(error)\n", stderr)
+            }
         }
         return deleted
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -1,5 +1,7 @@
 import AVFoundation
+import Darwin
 import Foundation
+import MuesliCore
 import os
 
 enum MeetingRecordingFileFormat: String, CaseIterable, Sendable {
@@ -30,6 +32,8 @@ enum MeetingRecordingFileFormat: String, CaseIterable, Sendable {
 }
 
 final class MeetingRecordingWriter {
+    typealias M4AEncoder = (_ sourceURL: URL, _ destinationURL: URL) async throws -> Void
+
     private final class ExportSessionBox: @unchecked Sendable {
         let session: AVAssetExportSession
 
@@ -136,7 +140,7 @@ final class MeetingRecordingWriter {
         switch fileFormat {
         case .m4a:
             do {
-                try await transcodeWAVToM4AAsync(sourceURL: tempURL, destinationURL: destinationURL)
+                try await encodeWAVToM4AAsync(sourceURL: tempURL, destinationURL: destinationURL)
                 try FileManager.default.removeItem(at: tempURL)
             } catch {
                 try? FileManager.default.removeItem(at: destinationURL)
@@ -146,6 +150,56 @@ final class MeetingRecordingWriter {
             try FileManager.default.moveItem(at: tempURL, to: destinationURL)
         }
         return destinationURL
+    }
+
+    @discardableResult
+    static func migrateLegacyWAVRecordings(
+        store: DictationStore,
+        recordingsDirectory: URL,
+        fileManager: FileManager = .default,
+        encode: M4AEncoder = MeetingRecordingWriter.encodeWAVToM4AAsync
+    ) async throws -> (migrated: Int, deletedOrphanStubs: Int) {
+        var migrated = 0
+        for candidate in try store.legacyWAVMeetingRecordingPaths() {
+            try Task.checkCancellation()
+            let sourceURL = URL(fileURLWithPath: candidate.path).standardizedFileURL
+            guard sourceURL.pathExtension.lowercased() == "wav",
+                  fileManager.fileExists(atPath: sourceURL.path) else { continue }
+            let attributes = try fileManager.attributesOfItem(atPath: sourceURL.path)
+            let fileSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+            guard fileSize >= 1024 else { continue }
+
+            let destinationURL = sourceURL.deletingPathExtension().appendingPathExtension("m4a")
+            let temporaryURL = sourceURL
+                .deletingLastPathComponent()
+                .appendingPathComponent(".\(destinationURL.lastPathComponent).migrating")
+            do {
+                try? fileManager.removeItem(at: temporaryURL)
+                try await encode(sourceURL, temporaryURL)
+                try Task.checkCancellation()
+                try atomicallyRenameItem(at: temporaryURL, to: destinationURL)
+                try store.updateMeetingSavedRecordingPath(id: candidate.id, path: destinationURL.path)
+                do {
+                    try fileManager.removeItem(at: sourceURL)
+                } catch {
+                    fputs("[muesli-native] failed to delete migrated wav \(sourceURL.path): \(error)\n", stderr)
+                }
+                migrated += 1
+            } catch is CancellationError {
+                try? fileManager.removeItem(at: temporaryURL)
+                throw CancellationError()
+            } catch {
+                try? fileManager.removeItem(at: temporaryURL)
+                fputs("[muesli-native] failed to migrate legacy wav \(sourceURL.path): \(error)\n", stderr)
+            }
+        }
+
+        let deletedOrphanStubs = try deleteOrphanedWAVStubs(
+            in: recordingsDirectory,
+            store: store,
+            fileManager: fileManager
+        )
+        return (migrated, deletedOrphanStubs)
     }
 
     private func append(_ samples: [Int16], toMic: Bool) {
@@ -214,7 +268,7 @@ final class MeetingRecordingWriter {
         return output
     }
 
-    private static func transcodeWAVToM4AAsync(sourceURL: URL, destinationURL: URL) async throws {
+    static func encodeWAVToM4AAsync(sourceURL: URL, destinationURL: URL) async throws {
         let asset = AVURLAsset(url: sourceURL)
         guard let exportSession = AVAssetExportSession(
             asset: asset,
@@ -243,6 +297,45 @@ final class MeetingRecordingWriter {
                 }
                 continuation.resume(returning: ())
             }
+        }
+    }
+
+    private static func deleteOrphanedWAVStubs(
+        in recordingsDirectory: URL,
+        store: DictationStore,
+        fileManager: FileManager
+    ) throws -> Int {
+        guard fileManager.fileExists(atPath: recordingsDirectory.path) else { return 0 }
+        let files = try fileManager.contentsOfDirectory(
+            at: recordingsDirectory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        var deleted = 0
+        for file in files where file.pathExtension.lowercased() == "wav" {
+            let values = try file.resourceValues(forKeys: [.fileSizeKey])
+            guard (values.fileSize ?? 0) < 1024,
+                  try store.savedRecordingReferenceCount(path: file.path) == 0 else { continue }
+            try fileManager.removeItem(at: file)
+            deleted += 1
+        }
+        return deleted
+    }
+
+    private static func atomicallyRenameItem(at sourceURL: URL, to destinationURL: URL) throws {
+        let result = sourceURL.withUnsafeFileSystemRepresentation { sourcePath in
+            destinationURL.withUnsafeFileSystemRepresentation { destinationPath -> Int32 in
+                guard let sourcePath, let destinationPath else {
+                    errno = EINVAL
+                    return -1
+                }
+                return Darwin.rename(sourcePath, destinationPath)
+            }
+        }
+        guard result == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            throw POSIXError(code)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -200,11 +200,17 @@ final class MeetingRecordingWriter {
             }
         }
 
-        let deletedOrphanStubs = try deleteOrphanedWAVStubs(
-            in: recordingsDirectory,
-            store: store,
-            fileManager: fileManager
-        )
+        let deletedOrphanStubs: Int
+        do {
+            deletedOrphanStubs = try deleteOrphanedWAVStubs(
+                in: recordingsDirectory,
+                store: store,
+                fileManager: fileManager
+            )
+        } catch {
+            fputs("[muesli-native] failed to sweep orphan wav stubs: \(error)\n", stderr)
+            deletedOrphanStubs = 0
+        }
         return (migrated, deletedOrphanStubs)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -361,6 +361,7 @@ final class MuesliController: NSObject {
     /// Present only while a resume is in flight; consumed at stop to merge old + new
     /// transcript, and cleared on success or restored-on-failure.
     private var pendingResumePriorTranscript: [Int64: String] = [:]
+    private var legacyRecordingMigrationTask: Task<Void, Never>?
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncGeneration = 0
     private var iCloudSyncDebounceTask: Task<Void, Never>?
@@ -437,6 +438,7 @@ final class MuesliController: NSObject {
         } catch {
             fputs("[muesli-native] startup error: \(error)\n", stderr)
         }
+        startLegacyRecordingMigration()
         recoverStaleLiveMeetings()
         normalizeMeetingTranscriptionSelectionForAvailability()
         SoundController.prewarmLifecycleSounds()
@@ -690,6 +692,8 @@ final class MuesliController: NSObject {
             NSWorkspace.shared.notificationCenter.removeObserver(iCloudWakeObserver)
             self.iCloudWakeObserver = nil
         }
+        legacyRecordingMigrationTask?.cancel()
+        legacyRecordingMigrationTask = nil
         cancelActiveICloudSyncTask()
         iCloudSyncDebounceTask?.cancel()
         iCloudSyncDebounceTask = nil
@@ -745,6 +749,31 @@ final class MuesliController: NSObject {
             return row
         }
         return try? dictationStore.meeting(id: id)
+    }
+
+    private func startLegacyRecordingMigration() {
+        legacyRecordingMigrationTask?.cancel()
+        let store = dictationStore
+        let recordingsDirectory = AppIdentity.supportDirectoryURL
+            .appendingPathComponent("meeting-recordings", isDirectory: true)
+        legacyRecordingMigrationTask = Task.detached(priority: .utility) {
+            do {
+                let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+                    store: store,
+                    recordingsDirectory: recordingsDirectory
+                )
+                guard summary.migrated > 0 || summary.deletedOrphanStubs > 0 else { return }
+                fputs(
+                    "[muesli-native] migrated \(summary.migrated) legacy wav recordings, deleted \(summary.deletedOrphanStubs) orphan stubs\n",
+                    stderr
+                )
+                MuesliNotifications.postDataDidChange()
+            } catch is CancellationError {
+                return
+            } catch {
+                fputs("[muesli-native] legacy recording migration failed: \(error)\n", stderr)
+            }
+        }
     }
 
     func dictationStats() -> DictationStats {

--- a/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
@@ -96,6 +96,28 @@ struct AudioFileImportControllerTests {
         #expect(!AudioFileImportController.isSupportedFileURL(URL(fileURLWithPath: "/tmp/test.txt")))
     }
 
+    @Test("persistRecording stores imported audio as M4A")
+    func persistRecordingStoresImportedAudioAsM4A() async throws {
+        let wavURL = try createTestAudioFile(duration: 1.0, sampleRate: 16000, channels: 1)
+        let supportDirectory = makeTemporaryDirectory()
+
+        let savedPath = try await AudioFileImportController.persistRecording(
+            wavURL: wavURL,
+            title: "Imported Recording",
+            startedAt: Date(timeIntervalSince1970: 1_711_000_000),
+            supportDirectory: supportDirectory
+        )
+
+        let savedURL = URL(fileURLWithPath: savedPath)
+        #expect(FileManager.default.fileExists(atPath: wavURL.path) == false)
+        #expect(savedURL.pathExtension == "m4a")
+        #expect(savedURL.deletingLastPathComponent().lastPathComponent == "meeting-recordings")
+        #expect(savedURL.lastPathComponent.hasSuffix("-imported-recording.m4a"))
+
+        let file = try AVAudioFile(forReading: savedURL)
+        #expect(file.length > 0)
+    }
+
     // MARK: - Speaker Formatting Tests
 
     @Test("formatTranscriptWithSpeakers returns raw text when no segments")
@@ -274,6 +296,13 @@ struct AudioFileImportControllerTests {
         let file = try AVAudioFile(forWriting: url, settings: format.settings, commonFormat: .pcmFormatInt16, interleaved: false)
         try file.write(from: buffer)
 
+        return url
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("audio-import-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -323,6 +323,59 @@ struct MeetingRecordingWriterTests {
         #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
     }
 
+    @Test("legacy wav migration keeps raw-path shared wav until sibling migrates")
+    func legacyWAVMigrationKeepsRawPathSharedWAVUntilSiblingMigrates() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("shared.wav")
+        let rawLegacyPath = recordingsDirectory.path + "/nested/../shared.wav"
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+
+        #expect(rawLegacyPath != legacyWAVURL.path)
+        #expect(URL(fileURLWithPath: rawLegacyPath).standardizedFileURL == legacyWAVURL.standardizedFileURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let firstID = try store.insertMeeting(
+            title: "First",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "first",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: rawLegacyPath
+        )
+        let secondID = try store.insertMeeting(
+            title: "Second",
+            calendarEventID: nil,
+            startTime: now.addingTimeInterval(120),
+            endTime: now.addingTimeInterval(180),
+            rawTranscript: "second",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: rawLegacyPath
+        )
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            encode: { sourceURL, destinationURL in
+                #expect(sourceURL == legacyWAVURL.standardizedFileURL)
+                try Data("m4a".utf8).write(to: destinationURL)
+            }
+        )
+
+        let firstPath = try #require(try store.meeting(id: firstID)?.savedRecordingPath)
+        let secondPath = try #require(try store.meeting(id: secondID)?.savedRecordingPath)
+        #expect(summary.migrated == 2)
+        #expect(firstPath == secondPath)
+        #expect(firstPath.hasSuffix(".m4a"))
+        #expect(FileManager.default.fileExists(atPath: firstPath))
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
+    }
+
     @Test("legacy wav migration keeps wav and database path when encode fails")
     func legacyWAVMigrationKeepsWAVWhenEncodeFails() async throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -97,9 +97,15 @@ struct MeetingRecordingWriterTests {
         let legacyWAVURL = recordingsDirectory.appendingPathComponent("legacy.wav")
         let orphanStubURL = recordingsDirectory.appendingPathComponent("orphan.wav")
         let referencedStubURL = recordingsDirectory.appendingPathComponent("referenced-stub.wav")
+        let strandedWAVURL = recordingsDirectory.appendingPathComponent("stranded.wav")
+        let strandedM4AURL = recordingsDirectory.appendingPathComponent("stranded.m4a")
+        let unrelatedWAVURL = recordingsDirectory.appendingPathComponent("unrelated.wav")
         try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
         try Data([0]).write(to: orphanStubURL)
         try Data([1]).write(to: referencedStubURL)
+        try Data(repeating: 2, count: 2_048).write(to: strandedWAVURL)
+        try Data("m4a".utf8).write(to: strandedM4AURL)
+        try Data(repeating: 3, count: 2_048).write(to: unrelatedWAVURL)
 
         let now = Date(timeIntervalSince1970: 1_711_000_000)
         let migratedID = try store.insertMeeting(
@@ -130,6 +136,8 @@ struct MeetingRecordingWriterTests {
             recordingsDirectory: recordingsDirectory,
             encode: { sourceURL, destinationURL in
                 #expect(sourceURL == legacyWAVURL.standardizedFileURL)
+                #expect(destinationURL.pathExtension == "m4a")
+                #expect(destinationURL.lastPathComponent.contains(".migrating"))
                 try Data("m4a".utf8).write(to: destinationURL)
             }
         )
@@ -137,12 +145,15 @@ struct MeetingRecordingWriterTests {
         let migrated = try #require(try store.meeting(id: migratedID))
         let migratedPath = try #require(migrated.savedRecordingPath)
         #expect(summary.migrated == 1)
-        #expect(summary.deletedOrphanStubs == 1)
+        #expect(summary.deletedOrphanStubs == 2)
         #expect(migratedPath.hasSuffix(".m4a"))
         #expect(try Data(contentsOf: URL(fileURLWithPath: migratedPath)) == Data("m4a".utf8))
         #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
         #expect(FileManager.default.fileExists(atPath: orphanStubURL.path) == false)
         #expect(FileManager.default.fileExists(atPath: referencedStubURL.path))
+        #expect(FileManager.default.fileExists(atPath: strandedWAVURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: strandedM4AURL.path))
+        #expect(FileManager.default.fileExists(atPath: unrelatedWAVURL.path))
 
         let secondSummary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
             store: store,
@@ -154,6 +165,54 @@ struct MeetingRecordingWriterTests {
         #expect(secondSummary.migrated == 0)
         #expect(secondSummary.deletedOrphanStubs == 0)
         #expect(try store.meeting(id: migratedID)?.savedRecordingPath == migratedPath)
+    }
+
+    @Test("legacy wav migration deletes shared wav only after last reference migrates")
+    func legacyWAVMigrationDeletesSharedWAVAfterLastReferenceMigrates() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("shared.wav")
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let firstID = try store.insertMeeting(
+            title: "First",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "first",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+        let secondID = try store.insertMeeting(
+            title: "Second",
+            calendarEventID: nil,
+            startTime: now.addingTimeInterval(120),
+            endTime: now.addingTimeInterval(180),
+            rawTranscript: "second",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            encode: { _, destinationURL in
+                try Data("m4a".utf8).write(to: destinationURL)
+            }
+        )
+
+        let firstPath = try #require(try store.meeting(id: firstID)?.savedRecordingPath)
+        let secondPath = try #require(try store.meeting(id: secondID)?.savedRecordingPath)
+        #expect(summary.migrated == 2)
+        #expect(firstPath == secondPath)
+        #expect(firstPath.hasSuffix(".m4a"))
+        #expect(FileManager.default.fileExists(atPath: firstPath))
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
     }
 
     @Test("legacy wav migration keeps wav and database path when encode fails")
@@ -193,7 +252,50 @@ struct MeetingRecordingWriterTests {
             at: recordingsDirectory,
             includingPropertiesForKeys: nil
         )
-        #expect(!leftovers.contains { $0.lastPathComponent.hasSuffix(".migrating") })
+        #expect(!leftovers.contains { $0.lastPathComponent.contains(".migrating") })
+    }
+
+    @Test("legacy wav migration rethrows cancellation and removes temp file")
+    func legacyWAVMigrationRethrowsCancellationAndRemovesTempFile() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("legacy.wav")
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let meetingID = try store.insertMeeting(
+            title: "Legacy",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "legacy",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+
+        do {
+            _ = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+                store: store,
+                recordingsDirectory: recordingsDirectory,
+                encode: { _, destinationURL in
+                    try Data("partial".utf8).write(to: destinationURL)
+                    throw CancellationError()
+                }
+            )
+            Issue.record("Migration should rethrow cancellation")
+        } catch is CancellationError {
+        }
+
+        let meeting = try #require(try store.meeting(id: meetingID))
+        #expect(meeting.savedRecordingPath == legacyWAVURL.path)
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path))
+        let leftovers = try FileManager.default.contentsOfDirectory(
+            at: recordingsDirectory,
+            includingPropertiesForKeys: nil
+        )
+        #expect(!leftovers.contains { $0.lastPathComponent.contains(".migrating") })
     }
 
     private func makeTemporaryDirectory() -> URL {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -218,6 +218,63 @@ struct MeetingRecordingWriterTests {
         #expect(FileManager.default.fileExists(atPath: migratedSiblingURL.path))
     }
 
+    @Test("legacy wav migration continues after one attributes failure")
+    func legacyWAVMigrationContinuesAfterAttributesFailure() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let failedWAVURL = recordingsDirectory.appendingPathComponent("failed.wav")
+        let migratedWAVURL = recordingsDirectory.appendingPathComponent("migrated.wav")
+        try Data(repeating: 1, count: 2_048).write(to: failedWAVURL)
+        try Data(repeating: 2, count: 2_048).write(to: migratedWAVURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let failedID = try store.insertMeeting(
+            title: "Failed",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "failed",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: failedWAVURL.path
+        )
+        let migratedID = try store.insertMeeting(
+            title: "Migrated",
+            calendarEventID: nil,
+            startTime: now.addingTimeInterval(120),
+            endTime: now.addingTimeInterval(180),
+            rawTranscript: "migrated",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: migratedWAVURL.path
+        )
+        let fileManager = StubAttributesFailureFileManager(failingURL: failedWAVURL)
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            fileManager: fileManager,
+            encode: { sourceURL, destinationURL in
+                #expect(sourceURL == migratedWAVURL.standardizedFileURL)
+                try Data("m4a".utf8).write(to: destinationURL)
+            }
+        )
+
+        let failedMeeting = try #require(try store.meeting(id: failedID))
+        let migratedMeeting = try #require(try store.meeting(id: migratedID))
+        let migratedPath = try #require(migratedMeeting.savedRecordingPath)
+        #expect(summary.migrated == 1)
+        #expect(summary.deletedOrphanStubs == 0)
+        #expect(fileManager.failedAttributesAttempts == 1)
+        #expect(failedMeeting.savedRecordingPath == failedWAVURL.path)
+        #expect(migratedPath.hasSuffix(".m4a"))
+        #expect(FileManager.default.fileExists(atPath: failedWAVURL.path))
+        #expect(FileManager.default.fileExists(atPath: migratedWAVURL.path) == false)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: migratedPath)) == Data("m4a".utf8))
+    }
+
     @Test("legacy wav migration deletes shared wav only after last reference migrates")
     func legacyWAVMigrationDeletesSharedWAVAfterLastReferenceMigrates() async throws {
         let store = try makeStore()
@@ -403,5 +460,23 @@ private final class StubDeleteFailureFileManager: FileManager {
             throw NSError(domain: "MeetingRecordingWriterTests", code: 2)
         }
         try super.removeItem(at: URL)
+    }
+}
+
+private final class StubAttributesFailureFileManager: FileManager {
+    private let failingPath: String
+    private(set) var failedAttributesAttempts = 0
+
+    init(failingURL: URL) {
+        self.failingPath = failingURL.standardizedFileURL.path
+        super.init()
+    }
+
+    override func attributesOfItem(atPath path: String) throws -> [FileAttributeKey: Any] {
+        guard URL(fileURLWithPath: path).standardizedFileURL.path != failingPath else {
+            failedAttributesAttempts += 1
+            throw NSError(domain: "MeetingRecordingWriterTests", code: 3)
+        }
+        return try super.attributesOfItem(atPath: path)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -218,6 +218,46 @@ struct MeetingRecordingWriterTests {
         #expect(FileManager.default.fileExists(atPath: migratedSiblingURL.path))
     }
 
+    @Test("legacy wav migration returns after orphan directory listing failure")
+    func legacyWAVMigrationReturnsAfterOrphanDirectoryListingFailure() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("legacy.wav")
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let meetingID = try store.insertMeeting(
+            title: "Legacy",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "legacy",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+        let fileManager = OrphanListingFailureFileManager(failingURL: recordingsDirectory)
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            fileManager: fileManager,
+            encode: { _, destinationURL in
+                try Data("m4a".utf8).write(to: destinationURL)
+            }
+        )
+
+        let meeting = try #require(try store.meeting(id: meetingID))
+        let migratedPath = try #require(meeting.savedRecordingPath)
+        #expect(summary.migrated == 1)
+        #expect(summary.deletedOrphanStubs == 0)
+        #expect(fileManager.failedListingAttempts == 1)
+        #expect(migratedPath.hasSuffix(".m4a"))
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: migratedPath)) == Data("m4a".utf8))
+    }
+
     @Test("legacy wav migration continues after one attributes failure")
     func legacyWAVMigrationContinuesAfterAttributesFailure() async throws {
         let store = try makeStore()
@@ -513,6 +553,28 @@ private final class StubDeleteFailureFileManager: FileManager {
             throw NSError(domain: "MeetingRecordingWriterTests", code: 2)
         }
         try super.removeItem(at: URL)
+    }
+}
+
+private final class OrphanListingFailureFileManager: FileManager {
+    private let failingPath: String
+    private(set) var failedListingAttempts = 0
+
+    init(failingURL: URL) {
+        self.failingPath = failingURL.standardizedFileURL.path
+        super.init()
+    }
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions
+    ) throws -> [URL] {
+        guard url.standardizedFileURL.path != failingPath else {
+            failedListingAttempts += 1
+            throw NSError(domain: "MeetingRecordingWriterTests", code: 4)
+        }
+        return try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import MuesliCore
 import Testing
 @testable import MuesliNativeApp
 
@@ -89,11 +90,125 @@ struct MeetingRecordingWriterTests {
         #expect(file.length > 0)
     }
 
+    @Test("legacy wav migration updates referenced recordings and removes orphan stubs")
+    func legacyWAVMigrationUpdatesRecordingsAndDeletesOrphanStubs() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("legacy.wav")
+        let orphanStubURL = recordingsDirectory.appendingPathComponent("orphan.wav")
+        let referencedStubURL = recordingsDirectory.appendingPathComponent("referenced-stub.wav")
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+        try Data([0]).write(to: orphanStubURL)
+        try Data([1]).write(to: referencedStubURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let migratedID = try store.insertMeeting(
+            title: "Legacy",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "legacy",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+        try store.insertMeeting(
+            title: "Referenced Stub",
+            calendarEventID: nil,
+            startTime: now.addingTimeInterval(120),
+            endTime: now.addingTimeInterval(180),
+            rawTranscript: "stub",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: referencedStubURL.path
+        )
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            encode: { sourceURL, destinationURL in
+                #expect(sourceURL == legacyWAVURL.standardizedFileURL)
+                try Data("m4a".utf8).write(to: destinationURL)
+            }
+        )
+
+        let migrated = try #require(try store.meeting(id: migratedID))
+        let migratedPath = try #require(migrated.savedRecordingPath)
+        #expect(summary.migrated == 1)
+        #expect(summary.deletedOrphanStubs == 1)
+        #expect(migratedPath.hasSuffix(".m4a"))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: migratedPath)) == Data("m4a".utf8))
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: orphanStubURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: referencedStubURL.path))
+
+        let secondSummary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            encode: { _, _ in
+                Issue.record("Migration should be idempotent")
+            }
+        )
+        #expect(secondSummary.migrated == 0)
+        #expect(secondSummary.deletedOrphanStubs == 0)
+        #expect(try store.meeting(id: migratedID)?.savedRecordingPath == migratedPath)
+    }
+
+    @Test("legacy wav migration keeps wav and database path when encode fails")
+    func legacyWAVMigrationKeepsWAVWhenEncodeFails() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("legacy.wav")
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let meetingID = try store.insertMeeting(
+            title: "Legacy",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "legacy",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            encode: { _, _ in
+                throw NSError(domain: "MeetingRecordingWriterTests", code: 1)
+            }
+        )
+
+        let meeting = try #require(try store.meeting(id: meetingID))
+        #expect(summary.migrated == 0)
+        #expect(summary.deletedOrphanStubs == 0)
+        #expect(meeting.savedRecordingPath == legacyWAVURL.path)
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path))
+        let leftovers = try FileManager.default.contentsOfDirectory(
+            at: recordingsDirectory,
+            includingPropertiesForKeys: nil
+        )
+        #expect(!leftovers.contains { $0.lastPathComponent.hasSuffix(".migrating") })
+    }
+
     private func makeTemporaryDirectory() -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("meeting-writer-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-recording-migration-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
     }
 
     private func readMonoPCM16WAVSamples(from url: URL) throws -> [Int16] {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -167,6 +167,57 @@ struct MeetingRecordingWriterTests {
         #expect(try store.meeting(id: migratedID)?.savedRecordingPath == migratedPath)
     }
 
+    @Test("legacy wav orphan cleanup continues after one delete failure")
+    func legacyWAVMigrationContinuesAfterOrphanDeleteFailure() async throws {
+        let store = try makeStore()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let legacyWAVURL = recordingsDirectory.appendingPathComponent("legacy.wav")
+        let failedStubURL = recordingsDirectory.appendingPathComponent("failing-stub.wav")
+        let smallStubURL = recordingsDirectory.appendingPathComponent("small-stub.wav")
+        let migratedStubURL = recordingsDirectory.appendingPathComponent("migrated-stub.wav")
+        let migratedSiblingURL = recordingsDirectory.appendingPathComponent("migrated-stub.m4a")
+        try Data(repeating: 1, count: 2_048).write(to: legacyWAVURL)
+        try Data([0]).write(to: failedStubURL)
+        try Data([1]).write(to: smallStubURL)
+        try Data(repeating: 2, count: 2_048).write(to: migratedStubURL)
+        try Data("m4a".utf8).write(to: migratedSiblingURL)
+
+        let now = Date(timeIntervalSince1970: 1_711_000_000)
+        let meetingID = try store.insertMeeting(
+            title: "Legacy",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "legacy",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: legacyWAVURL.path
+        )
+        let fileManager = StubDeleteFailureFileManager(failingURL: failedStubURL)
+
+        let summary = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+            store: store,
+            recordingsDirectory: recordingsDirectory,
+            fileManager: fileManager,
+            encode: { _, destinationURL in
+                try Data("m4a".utf8).write(to: destinationURL)
+            }
+        )
+
+        let meeting = try #require(try store.meeting(id: meetingID))
+        let migratedPath = try #require(meeting.savedRecordingPath)
+        #expect(summary.migrated == 1)
+        #expect(summary.deletedOrphanStubs == 2)
+        #expect(migratedPath.hasSuffix(".m4a"))
+        #expect(fileManager.failedRemoveAttempts == 1)
+        #expect(FileManager.default.fileExists(atPath: legacyWAVURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: failedStubURL.path))
+        #expect(FileManager.default.fileExists(atPath: smallStubURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: migratedStubURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: migratedSiblingURL.path))
+    }
+
     @Test("legacy wav migration deletes shared wav only after last reference migrates")
     func legacyWAVMigrationDeletesSharedWAVAfterLastReferenceMigrates() async throws {
         let store = try makeStore()
@@ -275,8 +326,8 @@ struct MeetingRecordingWriterTests {
             savedRecordingPath: legacyWAVURL.path
         )
 
-        do {
-            _ = try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
+        await #expect(throws: CancellationError.self) {
+            try await MeetingRecordingWriter.migrateLegacyWAVRecordings(
                 store: store,
                 recordingsDirectory: recordingsDirectory,
                 encode: { _, destinationURL in
@@ -284,8 +335,6 @@ struct MeetingRecordingWriterTests {
                     throw CancellationError()
                 }
             )
-            Issue.record("Migration should rethrow cancellation")
-        } catch is CancellationError {
         }
 
         let meeting = try #require(try store.meeting(id: meetingID))
@@ -323,5 +372,36 @@ struct MeetingRecordingWriterTests {
             let buffer = rawBuffer.bindMemory(to: Int16.self)
             return Array(buffer.prefix(count)).map(Int16.init(littleEndian:))
         }
+    }
+}
+
+private final class StubDeleteFailureFileManager: FileManager {
+    private let failingPath: String
+    private(set) var failedRemoveAttempts = 0
+
+    init(failingURL: URL) {
+        self.failingPath = failingURL.standardizedFileURL.path
+        super.init()
+    }
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions
+    ) throws -> [URL] {
+        try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
+            .sorted { lhs, rhs in
+                if lhs.standardizedFileURL.path == failingPath { return true }
+                if rhs.standardizedFileURL.path == failingPath { return false }
+                return lhs.lastPathComponent < rhs.lastPathComponent
+            }
+    }
+
+    override func removeItem(at URL: URL) throws {
+        guard URL.standardizedFileURL.path != failingPath else {
+            failedRemoveAttempts += 1
+            throw NSError(domain: "MeetingRecordingWriterTests", code: 2)
+        }
+        try super.removeItem(at: URL)
     }
 }


### PR DESCRIPTION
## Problem

The compact M4A writer converts **new** retained recordings, but recordings saved before that change remain full-size WAVs on disk forever (a WAV hour is ~600 MB vs ~60 MB as M4A), and the audio-file import path still persists a converted WAV. Users with meeting history from before the M4A change keep paying the old disk cost. Follows up on the disk-usage concern from #267.

## Fix

- **Startup migration** (background, non-blocking, idempotent): meetings whose saved recording is a WAV on disk are re-encoded to M4A via a temp file + atomic rename; the DB path is updated and the WAV deleted only after a successful encode + DB update, so a quit mid-migration loses nothing. Sub-1KB orphaned `.wav` stubs that no meeting references are cleaned up.
- **Import path** now persists imported recordings as M4A through the same encoder as retained recordings.

## Tests

Migration idempotency, mid-failure safety (encode failure keeps the WAV and DB untouched), orphan stub cleanup, import produces M4A. Full suite passes (1222 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785879391&installation_id=136549638&pr_number=278&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F278&signature=b44d18b5ff879625f7df51faf6cd5a24c586bf988358b5473b3b56acebd27cc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a background startup migration to convert legacy WAV meeting recordings to M4A.
  * Imported audio is now persisted as M4A automatically.
* **Bug Fixes**
  * Improved migration reliability with atomic replacement, reference-aware cleanup, and cancellation-safe temporary file handling.
  * Added more robust database opening behavior to reduce “busy” contention during migration.
* **Tests**
  * Expanded async test coverage for migration success, idempotency, shared recordings, and error/cancellation cleanup edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->