### PR TITLE
Add configurable meeting recordings folder

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -261,7 +261,11 @@ enum AudioFileImportController {
         try Task.checkCancellation()
 
         // Persist the converted WAV as a saved recording so retranscription works
-        let savedRecordingPath = try persistRecording(wavURL: wavURL, title: generatedTitle)
+        let savedRecordingPath = try persistRecording(
+            wavURL: wavURL,
+            title: generatedTitle,
+            config: config
+        )
 
         progress("Saving...")
         let now = Date()
@@ -373,11 +377,18 @@ enum AudioFileImportController {
         return samples
     }
 
-    /// Copies the converted WAV to the meeting-recordings directory so the imported
+    /// Copies the converted WAV to the configured recordings directory so the imported
     /// meeting can be retranscribed later.
-    private static func persistRecording(wavURL: URL, title: String) throws -> String {
-        let recordingsDirectory = AppIdentity.supportDirectoryURL
-            .appendingPathComponent("meeting-recordings", isDirectory: true)
+    static func persistRecording(
+        wavURL: URL,
+        title: String,
+        config: AppConfig,
+        supportDirectory: URL = AppIdentity.supportDirectoryURL
+    ) throws -> String {
+        let recordingsDirectory = MeetingRecordingStorage.directory(
+            config: config,
+            supportDirectory: supportDirectory
+        )
         try FileManager.default.createDirectory(
             at: recordingsDirectory,
             withIntermediateDirectories: true

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -230,8 +230,11 @@ struct MeetingDetailView: View {
             }
 
             if let savedRecordingPath = meeting.savedRecordingPath,
-               FileManager.default.fileExists(atPath: savedRecordingPath) {
-                MeetingRecordingPlayerView(recordingPath: savedRecordingPath)
+               MeetingRecordingStorage.resolvedFileURL(
+                   forStoredPath: savedRecordingPath,
+                   config: appState.config
+               ) != nil {
+                MeetingRecordingPlayerView(recordingPath: savedRecordingPath, config: appState.config)
             }
 
             activeMeetingAudioWarningBanner(for: meeting)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingPlayerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingPlayerView.swift
@@ -270,6 +270,12 @@ struct MeetingRecordingPlayerView: View {
         currentTime = 0
         isPlaying = false
 
+        do {
+            try Task.checkCancellation()
+        } catch {
+            return
+        }
+
         guard let url = MeetingRecordingStorage.resolvedFileURL(
             forStoredPath: recordingPath,
             config: config
@@ -281,11 +287,16 @@ struct MeetingRecordingPlayerView: View {
             let loadedWaveform = try await Task.detached(priority: .utility) {
                 try await RecordingWaveformCache.shared.waveform(for: url)
             }.value
+            try Task.checkCancellation()
             let loadedPlayer = try AVAudioPlayer(contentsOf: url)
             loadedPlayer.prepareToPlay()
+            try Task.checkCancellation()
             waveform = loadedWaveform
             player = loadedPlayer
+        } catch is CancellationError {
+            return
         } catch {
+            if Task.isCancelled { return }
             loadFailed = true
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingPlayerView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingPlayerView.swift
@@ -163,6 +163,7 @@ private extension Data {
 
 struct MeetingRecordingPlayerView: View {
     let recordingPath: String
+    let config: AppConfig
 
     @State private var waveform: RecordingWaveformData?
     @State private var player: AVAudioPlayer?
@@ -269,7 +270,13 @@ struct MeetingRecordingPlayerView: View {
         currentTime = 0
         isPlaying = false
 
-        let url = URL(fileURLWithPath: recordingPath)
+        guard let url = MeetingRecordingStorage.resolvedFileURL(
+            forStoredPath: recordingPath,
+            config: config
+        ) else {
+            loadFailed = true
+            return
+        }
         do {
             let loadedWaveform = try await Task.detached(priority: .utility) {
                 try await RecordingWaveformCache.shared.waveform(for: url)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingStorage.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingStorage.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+enum MeetingRecordingStorage {
+    private static let directoryName = "meeting-recordings"
+
+    static func defaultDirectory(supportDirectory: URL = AppIdentity.supportDirectoryURL) -> URL {
+        supportDirectory.appendingPathComponent(directoryName, isDirectory: true)
+            .standardizedFileURL
+    }
+
+    static func directory(
+        config: AppConfig,
+        supportDirectory: URL = AppIdentity.supportDirectoryURL
+    ) -> URL {
+        let path = config.meetingRecordingFolderPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else {
+            return defaultDirectory(supportDirectory: supportDirectory)
+        }
+        return URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+    }
+
+    static func resolvedFileURL(
+        forStoredPath storedPath: String,
+        config: AppConfig,
+        supportDirectory: URL = AppIdentity.supportDirectoryURL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let trimmedPath = storedPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else { return nil }
+
+        let storedURL = URL(fileURLWithPath: trimmedPath).standardizedFileURL
+        if fileManager.fileExists(atPath: storedURL.path) {
+            return storedURL
+        }
+
+        let configuredURL = directory(config: config, supportDirectory: supportDirectory)
+            .appendingPathComponent(storedURL.lastPathComponent)
+            .standardizedFileURL
+        if configuredURL.path != storedURL.path,
+           fileManager.fileExists(atPath: configuredURL.path) {
+            return configuredURL
+        }
+
+        return nil
+    }
+
+    static func validateWritableDirectory(_ url: URL, fileManager: FileManager = .default) throws {
+        let directoryURL = url.standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw NSError(
+                domain: "MeetingRecordingStorage",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Choose an existing folder."]
+            )
+        }
+        guard fileManager.isWritableFile(atPath: directoryURL.path) else {
+            throw NSError(
+                domain: "MeetingRecordingStorage",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Muesli cannot write to this folder."]
+            )
+        }
+
+        let probeURL = directoryURL.appendingPathComponent(".muesli-write-test-\(UUID().uuidString)")
+        do {
+            try Data().write(to: probeURL, options: .withoutOverwriting)
+            try? fileManager.removeItem(at: probeURL)
+        } catch {
+            try? fileManager.removeItem(at: probeURL)
+            throw NSError(
+                domain: "MeetingRecordingStorage",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Muesli cannot write to this folder. \(error.localizedDescription)"]
+            )
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingStorage.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingStorage.swift
@@ -16,6 +16,9 @@ enum MeetingRecordingStorage {
         guard !path.isEmpty else {
             return defaultDirectory(supportDirectory: supportDirectory)
         }
+        guard path.hasPrefix("/") else {
+            return defaultDirectory(supportDirectory: supportDirectory)
+        }
         return URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
     }
 
@@ -44,7 +47,11 @@ enum MeetingRecordingStorage {
         return nil
     }
 
-    static func validateWritableDirectory(_ url: URL, fileManager: FileManager = .default) throws {
+    static func validateWritableDirectory(
+        _ url: URL,
+        fileManager: FileManager = .default,
+        probeFileName: String = ".muesli-write-test-\(UUID().uuidString)"
+    ) throws {
         let directoryURL = url.standardizedFileURL
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory),
@@ -63,7 +70,7 @@ enum MeetingRecordingStorage {
             )
         }
 
-        let probeURL = directoryURL.appendingPathComponent(".muesli-write-test-\(UUID().uuidString)")
+        let probeURL = directoryURL.appendingPathComponent(probeFileName)
         do {
             try Data().write(to: probeURL, options: .withoutOverwriting)
             try? fileManager.removeItem(at: probeURL)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingRecordingWriter.swift
@@ -117,11 +117,9 @@ final class MeetingRecordingWriter {
         from tempURL: URL,
         meetingTitle: String,
         startedAt: Date,
-        supportDirectory: URL,
+        recordingsDirectory: URL,
         fileFormat: MeetingRecordingFileFormat = .m4a
     ) async throws -> URL {
-        let recordingsDirectory = supportDirectory
-            .appendingPathComponent("meeting-recordings", isDirectory: true)
         try FileManager.default.createDirectory(
             at: recordingsDirectory,
             withIntermediateDirectories: true

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -966,6 +966,7 @@ struct AppConfig: Codable {
     var mutedMeetingDetectionAppBundleIDs: [String] = []
     var meetingRecordingSavePolicy: MeetingRecordingSavePolicy = .never
     var meetingRecordingFileFormat: String = MeetingRecordingFileFormat.m4a.rawValue
+    var meetingRecordingFolderPath: String = ""
     var darkMode: Bool = true
     var enableDoubleTapDictation: Bool = true
     var hotkeyTriggerThresholdMS: Int = HotkeyTriggerTiming.defaultThresholdMilliseconds
@@ -1077,6 +1078,7 @@ struct AppConfig: Codable {
         case mutedMeetingDetectionAppBundleIDs = "muted_meeting_detection_app_bundle_ids"
         case meetingRecordingSavePolicy = "meeting_recording_save_policy"
         case meetingRecordingFileFormat = "meeting_recording_file_format"
+        case meetingRecordingFolderPath = "meeting_recording_folder_path"
         case darkMode = "dark_mode"
         case enableDoubleTapDictation = "enable_double_tap_dictation"
         case hotkeyTriggerThresholdMS = "hotkey_trigger_threshold_ms"
@@ -1210,6 +1212,7 @@ struct AppConfig: Codable {
             ?? defaults.meetingRecordingFileFormat
         meetingRecordingFileFormat = MeetingRecordingFileFormat(rawValue: decodedMeetingRecordingFileFormat)?.rawValue
             ?? defaults.meetingRecordingFileFormat
+        meetingRecordingFolderPath = (try? c.decode(String.self, forKey: .meetingRecordingFolderPath)) ?? defaults.meetingRecordingFolderPath
         darkMode = (try? c.decode(Bool.self, forKey: .darkMode)) ?? defaults.darkMode
         iCloudSyncEnabled = (try? c.decode(Bool.self, forKey: .iCloudSyncEnabled)) ?? defaults.iCloudSyncEnabled
         showIOSCompanionPrompt = (try? c.decode(Bool.self, forKey: .showIOSCompanionPrompt)) ?? defaults.showIOSCompanionPrompt

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -152,7 +152,7 @@ struct MeetingRecordingSaveRequest: Sendable {
     let tempURL: URL
     let meetingTitle: String
     let startedAt: Date
-    let supportDirectory: URL
+    let recordingsDirectory: URL
     let fileFormat: MeetingRecordingFileFormat
 }
 
@@ -3493,8 +3493,10 @@ final class MuesliController: NSObject {
                       !savedRecordingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     throw MeetingRetranscriptionError.recordingUnavailable
                 }
-                let recordingURL = URL(fileURLWithPath: savedRecordingPath)
-                guard FileManager.default.fileExists(atPath: recordingURL.path) else {
+                guard let recordingURL = MeetingRecordingStorage.resolvedFileURL(
+                    forStoredPath: savedRecordingPath,
+                    config: self.config
+                ) else {
                     throw MeetingRetranscriptionError.recordingUnavailable
                 }
                 guard let backend = self.normalizeMeetingTranscriptionSelectionForAvailability() else {
@@ -4024,7 +4026,7 @@ final class MuesliController: NSObject {
         }
 
         do {
-            try clearSavedMeetingRecordingsDirectory()
+            try clearSavedMeetingRecordings()
         } catch {
             presentErrorAlert(
                 title: "Couldn't Clear Meeting History",
@@ -5316,8 +5318,7 @@ final class MuesliController: NSObject {
     }
 
     func revealMeetingRecordingInFinder(path: String) {
-        let url = URL(fileURLWithPath: path)
-        guard FileManager.default.fileExists(atPath: url.path) else {
+        guard let url = MeetingRecordingStorage.resolvedFileURL(forStoredPath: path, config: config) else {
             presentErrorAlert(
                 title: "Recording Not Found",
                 message: "The saved meeting recording is no longer available on disk."
@@ -5539,7 +5540,7 @@ final class MuesliController: NSObject {
             tempURL: retainedRecordingURL,
             meetingTitle: result.title,
             startedAt: result.startTime,
-            supportDirectory: AppIdentity.supportDirectoryURL,
+            recordingsDirectory: MeetingRecordingStorage.directory(config: config),
             fileFormat: config.resolvedMeetingRecordingFileFormat
         ))
     }
@@ -5569,7 +5570,7 @@ final class MuesliController: NSObject {
                     from: request.tempURL,
                     meetingTitle: request.meetingTitle,
                     startedAt: request.startedAt,
-                    supportDirectory: request.supportDirectory,
+                    recordingsDirectory: request.recordingsDirectory,
                     fileFormat: request.fileFormat
                 )
                 return PreparedMeetingRecordingSave(path: outputURL.path, error: nil)
@@ -5609,16 +5610,22 @@ final class MuesliController: NSObject {
         }
     }
 
-    private func clearSavedMeetingRecordingsDirectory() throws {
-        let recordingsDirectory = AppIdentity.supportDirectoryURL
-            .appendingPathComponent("meeting-recordings", isDirectory: true)
-        guard FileManager.default.fileExists(atPath: recordingsDirectory.path) else { return }
-        try FileManager.default.removeItem(at: recordingsDirectory)
+    private func clearSavedMeetingRecordings() throws {
+        let paths = try dictationStore.recentMeetings().compactMap(\.savedRecordingPath)
+        for path in Set(paths) {
+            try deleteSavedMeetingRecording(at: path)
+        }
+
+        let defaultDirectory = MeetingRecordingStorage.defaultDirectory()
+        if FileManager.default.fileExists(atPath: defaultDirectory.path) {
+            try FileManager.default.removeItem(at: defaultDirectory)
+        }
     }
 
     private func deleteSavedMeetingRecording(at path: String) throws {
-        let url = URL(fileURLWithPath: path)
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        guard let url = MeetingRecordingStorage.resolvedFileURL(forStoredPath: path, config: config) else {
+            return
+        }
 
         do {
             try FileManager.default.removeItem(at: url)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1153,11 +1153,11 @@ struct SettingsView: View {
                         controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
                     }
                 }
-                Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Recordings folder") {
-                    meetingRecordingFolderPicker
-                }
                 if appState.config.meetingRecordingSavePolicy != .never {
+                    Divider().background(MuesliTheme.surfaceBorder)
+                    settingsRow("Recordings folder") {
+                        meetingRecordingFolderPicker
+                    }
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Recording format") {
                         settingsMenu(
@@ -1718,12 +1718,9 @@ struct SettingsView: View {
     }
 
     private func preferredMeetingRecordingDirectoryURL() -> URL {
-        let configuredPath = appState.config.meetingRecordingFolderPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !configuredPath.isEmpty {
-            let configuredURL = URL(fileURLWithPath: configuredPath).standardizedFileURL
-            if FileManager.default.fileExists(atPath: configuredURL.path) {
-                return configuredURL
-            }
+        let candidate = MeetingRecordingStorage.directory(config: appState.config)
+        if FileManager.default.fileExists(atPath: candidate.path) {
+            return candidate
         }
         return MeetingRecordingStorage.defaultDirectory()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -103,6 +103,7 @@ struct SettingsView: View {
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
     @State private var hasRefreshedMeetingCalendarSources = false
+    @State private var meetingRecordingFolderError: String?
 
     // Uniform width for standard right-side controls.
     private let controlWidth: CGFloat = 220
@@ -269,6 +270,19 @@ struct SettingsView: View {
             }
         } message: {
             Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, then relaunch Muesli to turn suggestions on.")
+        }
+        .alert(
+            "Recording Folder",
+            isPresented: Binding(
+                get: { meetingRecordingFolderError != nil },
+                set: { if !$0 { meetingRecordingFolderError = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                meetingRecordingFolderError = nil
+            }
+        } message: {
+            Text(meetingRecordingFolderError ?? "")
         }
         .sheet(isPresented: $isCleanupPromptManagerPresented) {
             TranscriptCleanupPromptsManagerView(
@@ -1139,6 +1153,10 @@ struct SettingsView: View {
                         controller.updateConfig { $0.meetingRecordingSavePolicy = policy }
                     }
                 }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Recordings folder") {
+                    meetingRecordingFolderPicker
+                }
                 if appState.config.meetingRecordingSavePolicy != .never {
                     Divider().background(MuesliTheme.surfaceBorder)
                     settingsRow("Recording format") {
@@ -1677,6 +1695,37 @@ struct SettingsView: View {
         presentOpenPanel(panel) { url in
             controller.updateConfig { $0.autoExportMarkdownFolderPath = url.standardizedFileURL.path }
         }
+    }
+
+    private func pickMeetingRecordingFolder() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a folder for meeting recordings"
+        panel.prompt = "Choose Folder"
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = preferredMeetingRecordingDirectoryURL()
+
+        presentOpenPanel(panel) { url in
+            do {
+                try MeetingRecordingStorage.validateWritableDirectory(url)
+                controller.updateConfig { $0.meetingRecordingFolderPath = url.standardizedFileURL.path }
+            } catch {
+                meetingRecordingFolderError = error.localizedDescription
+            }
+        }
+    }
+
+    private func preferredMeetingRecordingDirectoryURL() -> URL {
+        let configuredPath = appState.config.meetingRecordingFolderPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !configuredPath.isEmpty {
+            let configuredURL = URL(fileURLWithPath: configuredPath).standardizedFileURL
+            if FileManager.default.fileExists(atPath: configuredURL.path) {
+                return configuredURL
+            }
+        }
+        return MeetingRecordingStorage.defaultDirectory()
     }
 
     private func preferredAutoExportDirectoryURL() -> URL {
@@ -2419,20 +2468,54 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
+    private var meetingRecordingFolderPicker: some View {
+        folderPathPicker(
+            path: appState.config.meetingRecordingFolderPath,
+            emptyLabel: "Default Muesli folder",
+            emptyHelp: MeetingRecordingStorage.defaultDirectory().path,
+            clearLabel: "Reset recordings folder to default",
+            chooseLabel: "Choose recordings folder",
+            onClear: { controller.updateConfig { $0.meetingRecordingFolderPath = "" } },
+            onChoose: pickMeetingRecordingFolder
+        )
+    }
+
+    @ViewBuilder
     private var autoExportFolderPicker: some View {
+        folderPathPicker(
+            path: appState.config.autoExportMarkdownFolderPath,
+            emptyLabel: "Choose a folder…",
+            emptyHelp: "No destination folder selected",
+            clearLabel: "Clear destination folder",
+            chooseLabel: "Choose destination folder",
+            onClear: { controller.updateConfig { $0.autoExportMarkdownFolderPath = "" } },
+            onChoose: pickAutoExportFolder
+        )
+    }
+
+    @ViewBuilder
+    private func folderPathPicker(
+        path: String,
+        emptyLabel: String,
+        emptyHelp: String,
+        clearLabel: String,
+        chooseLabel: String,
+        onClear: @escaping () -> Void,
+        onChoose: @escaping () -> Void
+    ) -> some View {
         HStack(spacing: 8) {
             HStack(spacing: 8) {
                 Image(systemName: "folder")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(MuesliTheme.textTertiary)
 
-                if appState.config.autoExportMarkdownFolderPath.isEmpty {
-                    Text("Choose a folder…")
+                if path.isEmpty {
+                    Text(emptyLabel)
                         .font(.system(size: 12))
                         .foregroundStyle(MuesliTheme.textTertiary)
                         .lineLimit(1)
                 } else {
-                    Text(appState.config.autoExportMarkdownFolderPath)
+                    Text(path)
                         .font(.system(size: 12))
                         .foregroundStyle(MuesliTheme.textPrimary)
                         .lineLimit(1)
@@ -2449,11 +2532,11 @@ struct SettingsView: View {
                 RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
-            .help(appState.config.autoExportMarkdownFolderPath.isEmpty ? "No destination folder selected" : appState.config.autoExportMarkdownFolderPath)
+            .help(path.isEmpty ? emptyHelp : path)
 
-            if !appState.config.autoExportMarkdownFolderPath.isEmpty {
+            if !path.isEmpty {
                 Button {
-                    controller.updateConfig { $0.autoExportMarkdownFolderPath = "" }
+                    onClear()
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 11, weight: .semibold))
@@ -2467,12 +2550,12 @@ struct SettingsView: View {
                         )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Clear destination folder")
-                .help("Clear destination folder")
+                .accessibilityLabel(clearLabel)
+                .help(clearLabel)
             }
 
             Button {
-                pickAutoExportFolder()
+                onChoose()
             } label: {
                 Image(systemName: "folder.badge.plus")
                     .font(.system(size: 12, weight: .medium))
@@ -2486,8 +2569,8 @@ struct SettingsView: View {
                     )
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Choose destination folder")
-            .help("Choose destination folder")
+            .accessibilityLabel(chooseLabel)
+            .help(chooseLabel)
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
@@ -236,6 +236,26 @@ struct AudioFileImportControllerTests {
         #expect(result.contains("Test transcript"))
     }
 
+    @Test("persist imported recording writes to configured recordings folder")
+    func persistImportedRecordingWritesToConfiguredFolder() throws {
+        let wavURL = try createTestAudioFile(duration: 0.25, sampleRate: 16000, channels: 1)
+        defer { try? FileManager.default.removeItem(at: wavURL) }
+        let supportDirectory = temporaryDirectory(prefix: "import-support")
+        let customDirectory = temporaryDirectory(prefix: "import-recordings")
+        var config = AppConfig()
+        config.meetingRecordingFolderPath = customDirectory.path
+
+        let savedPath = try AudioFileImportController.persistRecording(
+            wavURL: wavURL,
+            title: "Imported Recording",
+            config: config,
+            supportDirectory: supportDirectory
+        )
+
+        #expect(savedPath.hasPrefix(customDirectory.path))
+        #expect(FileManager.default.fileExists(atPath: savedPath))
+    }
+
     // MARK: - Helpers
 
     /// Creates a test audio file with a sine wave tone.
@@ -289,5 +309,12 @@ struct AudioFileImportControllerTests {
 
     private func localMidnight() -> Date {
         Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 0))
+    }
+
+    private func temporaryDirectory(prefix: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingStorageTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingStorageTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("MeetingRecordingStorage")
+struct MeetingRecordingStorageTests {
+    @Test("default directory uses support meeting-recordings folder")
+    func defaultDirectoryUsesSupportFolder() {
+        let supportDirectory = temporaryDirectory()
+
+        let directory = MeetingRecordingStorage.directory(
+            config: AppConfig(),
+            supportDirectory: supportDirectory
+        )
+
+        #expect(directory.path == supportDirectory.appendingPathComponent("meeting-recordings", isDirectory: true).path)
+    }
+
+    @Test("custom directory uses configured absolute path")
+    func customDirectoryUsesConfiguredPath() {
+        let supportDirectory = temporaryDirectory()
+        let customDirectory = temporaryDirectory()
+        var config = AppConfig()
+        config.meetingRecordingFolderPath = customDirectory.path
+
+        let directory = MeetingRecordingStorage.directory(
+            config: config,
+            supportDirectory: supportDirectory
+        )
+
+        #expect(directory.path == customDirectory.standardizedFileURL.path)
+    }
+
+    @Test("resolver keeps existing stored absolute path when custom folder is configured")
+    func resolverKeepsExistingStoredPath() throws {
+        let supportDirectory = temporaryDirectory()
+        let customDirectory = temporaryDirectory()
+        let oldDirectory = MeetingRecordingStorage.defaultDirectory(supportDirectory: supportDirectory)
+        try FileManager.default.createDirectory(at: oldDirectory, withIntermediateDirectories: true)
+        let oldRecording = oldDirectory.appendingPathComponent("meeting.wav")
+        try Data("old".utf8).write(to: oldRecording)
+        var config = AppConfig()
+        config.meetingRecordingFolderPath = customDirectory.path
+
+        let resolved = MeetingRecordingStorage.resolvedFileURL(
+            forStoredPath: oldRecording.path,
+            config: config,
+            supportDirectory: supportDirectory
+        )
+
+        #expect(resolved?.path == oldRecording.standardizedFileURL.path)
+    }
+
+    @Test("resolver falls back to configured folder by filename when stored path is missing")
+    func resolverFallsBackToConfiguredFolderByFilename() throws {
+        let supportDirectory = temporaryDirectory()
+        let customDirectory = temporaryDirectory()
+        let storedPath = supportDirectory
+            .appendingPathComponent("meeting-recordings", isDirectory: true)
+            .appendingPathComponent("meeting.wav")
+            .path
+        let movedRecording = customDirectory.appendingPathComponent("meeting.wav")
+        try Data("moved".utf8).write(to: movedRecording)
+        var config = AppConfig()
+        config.meetingRecordingFolderPath = customDirectory.path
+
+        let resolved = MeetingRecordingStorage.resolvedFileURL(
+            forStoredPath: storedPath,
+            config: config,
+            supportDirectory: supportDirectory
+        )
+
+        #expect(resolved?.path == movedRecording.standardizedFileURL.path)
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-recording-storage-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingStorageTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingStorageTests.swift
@@ -31,6 +31,20 @@ struct MeetingRecordingStorageTests {
         #expect(directory.path == customDirectory.standardizedFileURL.path)
     }
 
+    @Test("relative custom directory falls back to default")
+    func relativeCustomDirectoryFallsBackToDefault() {
+        let supportDirectory = temporaryDirectory()
+        var config = AppConfig()
+        config.meetingRecordingFolderPath = "relative-recordings"
+
+        let directory = MeetingRecordingStorage.directory(
+            config: config,
+            supportDirectory: supportDirectory
+        )
+
+        #expect(directory.path == MeetingRecordingStorage.defaultDirectory(supportDirectory: supportDirectory).path)
+    }
+
     @Test("resolver keeps existing stored absolute path when custom folder is configured")
     func resolverKeepsExistingStoredPath() throws {
         let supportDirectory = temporaryDirectory()
@@ -73,10 +87,60 @@ struct MeetingRecordingStorageTests {
         #expect(resolved?.path == movedRecording.standardizedFileURL.path)
     }
 
+    @Test("validateWritableDirectory accepts writable directories and cleans probe")
+    func validateWritableDirectoryAcceptsWritableDirectory() throws {
+        let directory = temporaryDirectory()
+        let probeFileName = ".probe-\(UUID().uuidString)"
+
+        try MeetingRecordingStorage.validateWritableDirectory(directory, probeFileName: probeFileName)
+
+        #expect(FileManager.default.fileExists(atPath: directory.appendingPathComponent(probeFileName).path) == false)
+    }
+
+    @Test("validateWritableDirectory rejects missing paths and files")
+    func validateWritableDirectoryRejectsMissingPathsAndFiles() throws {
+        let directory = temporaryDirectory()
+        let missingDirectory = directory.appendingPathComponent("missing", isDirectory: true)
+        let fileURL = directory.appendingPathComponent("not-a-directory")
+        try Data("file".utf8).write(to: fileURL)
+
+        #expect(validationErrorCode(for: missingDirectory) == 1)
+        #expect(validationErrorCode(for: fileURL) == 1)
+    }
+
+    @Test("validateWritableDirectory rejects unwritable directories and probe failures")
+    func validateWritableDirectoryRejectsWriteFailures() throws {
+        let unwritableDirectory = temporaryDirectory()
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: unwritableDirectory.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: unwritableDirectory.path)
+        }
+        #expect(validationErrorCode(for: unwritableDirectory) == 2)
+
+        let probeConflictDirectory = temporaryDirectory()
+        let probeFileName = ".probe-\(UUID().uuidString)"
+        try Data("exists".utf8).write(to: probeConflictDirectory.appendingPathComponent(probeFileName))
+
+        #expect(validationErrorCode(for: probeConflictDirectory, probeFileName: probeFileName) == 3)
+    }
+
     private func temporaryDirectory() -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("meeting-recording-storage-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private func validationErrorCode(for url: URL, probeFileName: String? = nil) -> Int? {
+        do {
+            if let probeFileName {
+                try MeetingRecordingStorage.validateWritableDirectory(url, probeFileName: probeFileName)
+            } else {
+                try MeetingRecordingStorage.validateWritableDirectory(url)
+            }
+            return nil
+        } catch {
+            return (error as NSError).code
+        }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingRecordingWriterTests.swift
@@ -49,13 +49,14 @@ struct MeetingRecordingWriterTests {
         writer.appendSystem([1200, -800, 400])
         let tempURL = try #require(writer.stop())
         let supportDirectory = makeTemporaryDirectory()
+        let recordingsDirectory = MeetingRecordingStorage.defaultDirectory(supportDirectory: supportDirectory)
         let startedAt = Date(timeIntervalSince1970: 1_711_000_000)
 
         let savedURL = try await MeetingRecordingWriter.persistTemporaryRecordingAsync(
             from: tempURL,
             meetingTitle: "Weekly Product Sync! With Very Long Title Extra Words",
             startedAt: startedAt,
-            supportDirectory: supportDirectory,
+            recordingsDirectory: recordingsDirectory,
             fileFormat: .wav
         )
 
@@ -71,13 +72,14 @@ struct MeetingRecordingWriterTests {
         writer.appendSystem(Array(repeating: Int16(1200), count: 16_000))
         let tempURL = try #require(writer.stop())
         let supportDirectory = makeTemporaryDirectory()
+        let recordingsDirectory = MeetingRecordingStorage.defaultDirectory(supportDirectory: supportDirectory)
         let startedAt = Date(timeIntervalSince1970: 1_711_000_000)
 
         let savedURL = try await MeetingRecordingWriter.persistTemporaryRecordingAsync(
             from: tempURL,
             meetingTitle: "Weekly Product Sync",
             startedAt: startedAt,
-            supportDirectory: supportDirectory
+            recordingsDirectory: recordingsDirectory
         )
 
         #expect(FileManager.default.fileExists(atPath: tempURL.path) == false)
@@ -87,6 +89,26 @@ struct MeetingRecordingWriterTests {
 
         let file = try AVAudioFile(forReading: savedURL)
         #expect(file.length > 0)
+    }
+
+    @Test("persistTemporaryRecording writes to custom recordings directory")
+    func persistTemporaryRecordingWritesToCustomDirectory() async throws {
+        let writer = try MeetingRecordingWriter()
+        writer.appendSystem([100, 200])
+        let tempURL = try #require(writer.stop())
+        let customDirectory = makeTemporaryDirectory()
+            .appendingPathComponent("custom-recordings", isDirectory: true)
+
+        let savedURL = try await MeetingRecordingWriter.persistTemporaryRecordingAsync(
+            from: tempURL,
+            meetingTitle: "Custom Location",
+            startedAt: Date(timeIntervalSince1970: 1_711_000_000),
+            recordingsDirectory: customDirectory,
+            fileFormat: .wav
+        )
+
+        #expect(savedURL.deletingLastPathComponent().path == customDirectory.path)
+        #expect(try readMonoPCM16WAVSamples(from: savedURL) == [100, 200])
     }
 
     private func makeTemporaryDirectory() -> URL {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -176,6 +176,47 @@ struct MeetingsNavigationTests {
         #expect(FileManager.default.fileExists(atPath: savedRecordingURL.path) == false)
     }
 
+    @Test("deleteMeeting removes saved recording from custom folder")
+    func deleteMeetingRemovesCustomFolderRecording() throws {
+        let store = try makeStore()
+        let recordingsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-recordings-custom-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
+        let savedRecordingURL = recordingsDirectory.appendingPathComponent("meeting.wav")
+        let unrelatedURL = recordingsDirectory.appendingPathComponent("keep.txt")
+        try Data("recording".utf8).write(to: savedRecordingURL)
+        try Data("keep".utf8).write(to: unrelatedURL)
+
+        let now = Date()
+        let meetingID = try store.insertMeeting(
+            title: "Delete Custom Recording",
+            calendarEventID: nil,
+            startTime: now,
+            endTime: now.addingTimeInterval(60),
+            rawTranscript: "Transcript",
+            formattedNotes: "## Notes",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: savedRecordingURL.path
+        )
+
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+
+        controller.deleteMeeting(id: meetingID)
+
+        #expect(try store.meeting(id: meetingID) == nil)
+        #expect(FileManager.default.fileExists(atPath: savedRecordingURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: unrelatedURL.path) == true)
+    }
+
     @Test("deleteMeeting refuses live meeting rows")
     func deleteMeetingRefusesLiveRows() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -526,6 +526,7 @@ struct AppConfigTests {
         #expect(config.mutedMeetingDetectionAppBundleIDs.isEmpty)
         #expect(config.openAIAPIKey.isEmpty)
         #expect(config.meetingRecordingFileFormat == MeetingRecordingFileFormat.m4a.rawValue)
+        #expect(config.meetingRecordingFolderPath.isEmpty)
         #expect(config.resolvedMeetingRecordingFileFormat == .m4a)
         #expect(config.openRouterAPIKey.isEmpty)
         #expect(config.meetingSummaryRetryCount == MeetingSummaryRetryPolicy.defaultRetryCount)
@@ -709,6 +710,7 @@ struct AppConfigTests {
         config.defaultMeetingTemplateID = "weekly-team-meeting"
         config.meetingRecordingSavePolicy = .always
         config.meetingRecordingFileFormat = MeetingRecordingFileFormat.wav.rawValue
+        config.meetingRecordingFolderPath = "/tmp/muesli-recordings"
         config.customMeetingTemplates = [
             CustomMeetingTemplate(
                 id: "tmpl_123",
@@ -785,6 +787,7 @@ struct AppConfigTests {
         #expect(decoded.defaultMeetingTemplateID == "weekly-team-meeting")
         #expect(decoded.meetingRecordingSavePolicy == .always)
         #expect(decoded.meetingRecordingFileFormat == MeetingRecordingFileFormat.wav.rawValue)
+        #expect(decoded.meetingRecordingFolderPath == "/tmp/muesli-recordings")
         #expect(decoded.resolvedMeetingRecordingFileFormat == .wav)
         #expect(decoded.customMeetingTemplates.count == 1)
         #expect(decoded.customMeetingTemplates.first?.name == "Customer Follow-Up")
@@ -872,6 +875,7 @@ struct AppConfigTests {
         #expect(json["default_meeting_template_id"] != nil)
         #expect(json["meeting_recording_save_policy"] != nil)
         #expect(json["meeting_recording_file_format"] != nil)
+        #expect(json["meeting_recording_folder_path"] != nil)
         #expect(json["show_scheduled_meeting_notifications"] != nil)
         #expect(json["show_meeting_detection_notification"] != nil)
         #expect(json["muted_meeting_detection_app_bundle_ids"] != nil)
@@ -941,6 +945,7 @@ struct AppConfigTests {
         #expect(config.hiddenCalendarEventSourceHints.isEmpty)
         #expect(config.meetingRecordingSavePolicy == .never)
         #expect(config.meetingRecordingFileFormat == MeetingRecordingFileFormat.m4a.rawValue)
+        #expect(config.meetingRecordingFolderPath.isEmpty)
         #expect(config.resolvedMeetingRecordingFileFormat == .m4a)
         #expect(config.showScheduledMeetingNotifications == true)
         #expect(config.showMeetingDetectionNotification == true)


### PR DESCRIPTION
## What

First step toward #261 (configurable data locations): the meeting recordings folder — the multi-gigabyte item — becomes user-configurable. Recordings can live on an external disk or a synced folder instead of being pinned inside Application Support.

## How

- New config key `meeting_recording_folder_path` (empty = current default under Application Support), migration-safe.
- A single folder-resolver is used by every path that touches recordings — writer, audio-file import, single-meeting delete, Clear Meeting History — so no code path lingers on the hardcoded location. Recordings saved under the old default remain playable: absolute stored paths are honored per file.
- Settings: folder picker row (NSOpenPanel directory chooser, same storage approach as the auto-export folder) with Reset-to-default; a non-writable choice is rejected and the default kept.

Models and other data locations are intentionally out of scope here — happy to follow up per #261 discussion.

## Tests

Resolver default/custom/legacy-fallback, config migration, writer/import/delete honoring a custom directory. Full suite passes (1226 tests). NSOpenPanel interaction itself is manual-only, as with the existing auto-export picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785880090&installation_id=136549638&pr_number=279&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F279&signature=57cc243c67ab87625672eff8a622b93563b6c563b781bc9f4f2e962da7444bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable “Recordings folder” setting with a folder picker and persisted path.
* **Bug Fixes**
  * Improved meeting recording discovery for playback, reveal, and retranscription by resolving stored recordings against the configured folder.
  * Enhanced error handling when the recordings folder is invalid or not writable (surfaced via a dedicated alert).
* **Tests**
  * Expanded automated coverage for validating folders, persisting imported recordings into the configured directory, and deleting recordings from custom folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->