### PR TITLE
Turn Nemotron tensor layout traps into errors

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/NemotronRNNTEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/NemotronRNNTEngine.swift
@@ -116,6 +116,25 @@ func nemotronValidateArray(
     return (shape, strides, storageSpan)
 }
 
+func nemotronPredictedToken(from logits: MLMultiArray) throws -> Int {
+    let layout = try nemotronValidateArray(
+        logits,
+        name: "logits",
+        dataType: .float32,
+        shape: [1, 1, 1, nil]
+    )
+    let logitsCount = layout.shape[3]
+    let logitsStride = layout.strides[3]
+    guard logitsStride > 0 else {
+        throw NemotronRNNTError.decodingFailed("logits stride must be positive, got strides \(layout.strides)")
+    }
+    let logitsPtr = logits.dataPointer.bindMemory(to: Float.self, capacity: layout.storageSpan)
+    var maxVal: Float = -Float.infinity
+    var maxIdx: vDSP_Length = 0
+    vDSP_maxvi(logitsPtr, vDSP_Stride(logitsStride), &maxVal, &maxIdx, vDSP_Length(logitsCount))
+    return Int(maxIdx) / logitsStride
+}
+
 /// Create a fresh streaming state with zero-initialized caches sized for `config`.
 func nemotronMakeStreamState(config: NemotronRNNTConfig) throws -> RNNTStreamState {
     let cacheChannel = try MLMultiArray(
@@ -325,17 +344,7 @@ func nemotronTranscribeChunk(
             guard let logits = jointOutput.featureValue(for: "logits")?.multiArrayValue else {
                 throw NemotronRNNTError.decodingFailed("No joint logits")
             }
-            guard logits.dataType == .float32, logits.count > 0 else {
-                throw NemotronRNNTError.decodingFailed("logits expected non-empty float32 array, got \(logits.dataType) count \(logits.count)")
-            }
-
-            // Argmax
-            let logitsCount = logits.count
-            let logitsPtr = logits.dataPointer.bindMemory(to: Float.self, capacity: logitsCount)
-            var maxVal: Float = -Float.infinity
-            var maxIdx: vDSP_Length = 0
-            vDSP_maxvi(logitsPtr, 1, &maxVal, &maxIdx, vDSP_Length(logitsCount))
-            let predictedToken = Int(maxIdx)
+            let predictedToken = try nemotronPredictedToken(from: logits)
 
             if predictedToken == config.blankTokenId {
                 break

--- a/native/MuesliNative/Sources/MuesliNativeApp/NemotronRNNTEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/NemotronRNNTEngine.swift
@@ -65,6 +65,57 @@ func nemotronZeroFill(_ array: MLMultiArray) {
     memset(ptr, 0, array.count * MemoryLayout<Float>.size)
 }
 
+func nemotronValidateArray(
+    _ array: MLMultiArray,
+    name: String,
+    dataType: MLMultiArrayDataType,
+    shape expectedShape: [Int?],
+    failure: (String) -> NemotronRNNTError = NemotronRNNTError.decodingFailed
+) throws -> (shape: [Int], strides: [Int], storageSpan: Int) {
+    let shape = array.shape.map(\.intValue)
+    let strides = array.strides.map(\.intValue)
+    let expected = "[" + expectedShape.map { $0.map(String.init) ?? "*" }.joined(separator: ", ") + "]"
+
+    guard array.dataType == dataType else {
+        throw failure("\(name) expected \(dataType), got \(array.dataType)")
+    }
+    guard shape.count == expectedShape.count else {
+        throw failure("\(name) expected shape \(expected), got shape \(shape)")
+    }
+    guard strides.count == shape.count else {
+        throw failure("\(name) shape rank \(shape.count) does not match strides rank \(strides.count)")
+    }
+
+    for index in expectedShape.indices {
+        guard shape[index] > 0 else {
+            throw failure("\(name) dimension \(index) must be positive, got \(shape[index]) in shape \(shape)")
+        }
+        if let expectedDimension = expectedShape[index], shape[index] != expectedDimension {
+            throw failure("\(name) dimension \(index) expected \(expectedDimension), got \(shape[index]) in shape \(shape)")
+        }
+    }
+
+    var maxOffset = 0
+    for (dimension, stride) in zip(shape, strides) where dimension > 1 {
+        guard stride > 0 else {
+            throw failure("\(name) stride must be positive for non-singleton dimensions, got strides \(strides)")
+        }
+        let (scaledOffset, multipliedOverflow) = (dimension - 1).multipliedReportingOverflow(by: stride)
+        let (newMaxOffset, addedOverflow) = maxOffset.addingReportingOverflow(scaledOffset)
+        guard !multipliedOverflow, !addedOverflow else {
+            throw failure("\(name) shape \(shape) and strides \(strides) overflow offset validation")
+        }
+        maxOffset = newMaxOffset
+    }
+
+    let (storageSpan, spanOverflow) = maxOffset.addingReportingOverflow(1)
+    guard !spanOverflow else {
+        throw failure("\(name) shape \(shape) and strides \(strides) overflow storage-span validation")
+    }
+
+    return (shape, strides, storageSpan)
+}
+
 /// Create a fresh streaming state with zero-initialized caches sized for `config`.
 func nemotronMakeStreamState(config: NemotronRNNTConfig) throws -> RNNTStreamState {
     let cacheChannel = try MLMultiArray(
@@ -141,16 +192,38 @@ func nemotronTranscribeChunk(
     }
 
     // 2. Pad/crop mel to totalMelFrames for the encoder
+    let melLayout = try nemotronValidateArray(
+        mel,
+        name: "mel",
+        dataType: .float32,
+        shape: [1, 128, nil],
+        failure: NemotronRNNTError.preprocessingFailed
+    )
+    guard melLayout.strides[2] == 1 else {
+        throw NemotronRNNTError.preprocessingFailed("mel frame stride must be 1 for row copy, got strides \(melLayout.strides)")
+    }
+    _ = try nemotronValidateArray(
+        melLength,
+        name: "mel_length",
+        dataType: .int32,
+        shape: [1],
+        failure: NemotronRNNTError.preprocessingFailed
+    )
     let actualMelFrames = melLength[0].intValue
     let totalMelFrames = config.totalMelFrames
+    guard (0...melLayout.shape[2]).contains(actualMelFrames) else {
+        throw NemotronRNNTError.preprocessingFailed(
+            "mel_length value \(actualMelFrames) outside valid range 0...\(melLayout.shape[2]) for mel shape \(melLayout.shape)"
+        )
+    }
     let encoderMel = try MLMultiArray(shape: [1, 128, NSNumber(value: totalMelFrames)], dataType: .float32)
-    let melSrcPtr = mel.dataPointer.bindMemory(to: Float.self, capacity: mel.count)
+    let melSrcPtr = mel.dataPointer.bindMemory(to: Float.self, capacity: melLayout.storageSpan)
     let melDstPtr = encoderMel.dataPointer.bindMemory(to: Float.self, capacity: encoderMel.count)
     memset(melDstPtr, 0, encoderMel.count * MemoryLayout<Float>.size)
 
-    let melFramesToCopy = min(mel.shape[2].intValue, totalMelFrames)
+    let melFramesToCopy = min(melLayout.shape[2], totalMelFrames)
     for bin in 0..<128 {
-        let srcOffset = bin * mel.shape[2].intValue
+        let srcOffset = bin * melLayout.strides[1]
         let dstOffset = bin * totalMelFrames
         memcpy(melDstPtr.advanced(by: dstOffset), melSrcPtr.advanced(by: srcOffset), melFramesToCopy * MemoryLayout<Float>.size)
     }
@@ -183,8 +256,25 @@ func nemotronTranscribeChunk(
     if let cl = encOutput.featureValue(for: "cache_len_out")?.multiArrayValue { state.cacheLen = cl }
 
     // 4. RNNT greedy decode over encoder frames
+    let encodedLayout = try nemotronValidateArray(
+        encoded,
+        name: "encoded",
+        dataType: .float32,
+        shape: [1, config.encoderDim, nil]
+    )
+    _ = try nemotronValidateArray(
+        encodedLength,
+        name: "encoded_length",
+        dataType: .int32,
+        shape: [1]
+    )
     let numFrames = encodedLength[0].intValue
-    let encodedPtr = encoded.dataPointer.bindMemory(to: Float.self, capacity: encoded.count)
+    guard (0...encodedLayout.shape[2]).contains(numFrames) else {
+        throw NemotronRNNTError.decodingFailed(
+            "encoded_length value \(numFrames) outside valid range 0...\(encodedLayout.shape[2]) for encoded shape \(encodedLayout.shape)"
+        )
+    }
+    let encodedPtr = encoded.dataPointer.bindMemory(to: Float.self, capacity: encodedLayout.storageSpan)
     let encoderDim = config.encoderDim
 
     for t in 0..<numFrames {
@@ -220,9 +310,10 @@ func nemotronTranscribeChunk(
             // Encoded is [1, encoderDim, numFrames]; access [0, d, t] via stride.
             let encFrame = try MLMultiArray(shape: [1, NSNumber(value: encoderDim), 1], dataType: .float32)
             let encFramePtr = encFrame.dataPointer.bindMemory(to: Float.self, capacity: encoderDim)
-            let encodedStride1 = encoded.strides[1].intValue
+            let encodedStride1 = encodedLayout.strides[1]
+            let encodedStride2 = encodedLayout.strides[2]
             for d in 0..<encoderDim {
-                encFramePtr[d] = encodedPtr[d * encodedStride1 + t]
+                encFramePtr[d] = encodedPtr[d * encodedStride1 + t * encodedStride2]
             }
 
             let jointInput = try MLDictionaryFeatureProvider(dictionary: [
@@ -233,6 +324,9 @@ func nemotronTranscribeChunk(
 
             guard let logits = jointOutput.featureValue(for: "logits")?.multiArrayValue else {
                 throw NemotronRNNTError.decodingFailed("No joint logits")
+            }
+            guard logits.dataType == .float32, logits.count > 0 else {
+                throw NemotronRNNTError.decodingFailed("logits expected non-empty float32 array, got \(logits.dataType) count \(logits.count)")
             }
 
             // Argmax

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -936,6 +936,23 @@ struct NemotronRNNTShapeGuardTests {
         #expect(layout.storageSpan == 34)
     }
 
+    @Test("logits argmax follows validated last-axis stride")
+    func logitsArgmaxUsesLastAxisStride() throws {
+        let logits = try makeStridedFloatArray(
+            shape: [1, 1, 1, 4],
+            strides: [12, 12, 12, 3],
+            storageSpan: 10
+        )
+        let pointer = logits.dataPointer.bindMemory(to: Float.self, capacity: 10)
+        pointer[0] = 0.1
+        pointer[1] = 99
+        pointer[3] = 0.4
+        pointer[6] = 1.4
+        pointer[9] = 0.9
+
+        #expect(try nemotronPredictedToken(from: logits) == 2)
+    }
+
     private func makeStridedFloatArray(shape: [Int], strides: [Int], storageSpan: Int) throws -> MLMultiArray {
         let pointer = UnsafeMutableRawPointer.allocate(
             byteCount: storageSpan * MemoryLayout<Float>.stride,

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import CoreAudio
+import CoreML
 @testable import MuesliNativeApp
 
 @Suite("StreamingDictationController")
@@ -825,6 +826,131 @@ struct Nemotron35StreamStateTests {
         let _ = StreamingDictationController(
             transcriber: transcriber as NemotronStreamingTranscribing,
             chunkSamples: 35840
+        )
+    }
+}
+
+@Suite("Nemotron RNNT shape guards")
+struct NemotronRNNTShapeGuardTests {
+
+    @Test("mel validation rejects wrong rank with descriptive error")
+    func melValidationRejectsWrongRank() throws {
+        let mel = try MLMultiArray(shape: [1, 128], dataType: .float32)
+
+        do {
+            _ = try nemotronValidateArray(
+                mel,
+                name: "mel",
+                dataType: .float32,
+                shape: [1, 128, nil],
+                failure: NemotronRNNTError.preprocessingFailed
+            )
+            Issue.record("Expected mel shape validation to throw")
+        } catch let error as NemotronRNNTError {
+            let description = error.localizedDescription
+            #expect(description.contains("mel"))
+            #expect(description.contains("expected shape [1, 128, *]"))
+            #expect(description.contains("got shape [1, 128]"))
+        }
+    }
+
+    @Test("mel validation rejects wrong data type with descriptive error")
+    func melValidationRejectsWrongDataType() throws {
+        let mel = try MLMultiArray(shape: [1, 128, 1], dataType: .float16)
+
+        do {
+            _ = try nemotronValidateArray(
+                mel,
+                name: "mel",
+                dataType: .float32,
+                shape: [1, 128, nil],
+                failure: NemotronRNNTError.preprocessingFailed
+            )
+            Issue.record("Expected mel data type validation to throw")
+        } catch let error as NemotronRNNTError {
+            let description = error.localizedDescription
+            #expect(description.contains("mel"))
+            #expect(description.contains("expected"))
+            #expect(description.contains("got"))
+        }
+    }
+
+    @Test("encoded validation rejects mismatched encoder dimension")
+    func encodedValidationRejectsBadShape() throws {
+        let encoded = try MLMultiArray(shape: [1, 2, 3], dataType: .float32)
+
+        do {
+            _ = try nemotronValidateArray(
+                encoded,
+                name: "encoded",
+                dataType: .float32,
+                shape: [1, 4, nil]
+            )
+            Issue.record("Expected encoded shape validation to throw")
+        } catch let error as NemotronRNNTError {
+            let description = error.localizedDescription
+            #expect(description.contains("encoded"))
+            #expect(description.contains("dimension 1 expected 4"))
+            #expect(description.contains("got 2"))
+        }
+    }
+
+    @Test("encoded validation accepts padded CoreML strides")
+    func encodedValidationAcceptsPaddedStrides() throws {
+        let encoded = try makeStridedFloatArray(
+            shape: [1, 1024, 28],
+            strides: [32768, 32, 1],
+            storageSpan: 32764
+        )
+
+        let layout = try nemotronValidateArray(
+            encoded,
+            name: "encoded",
+            dataType: .float32,
+            shape: [1, 1024, nil]
+        )
+
+        #expect(encoded.count == 28672)
+        #expect(layout.shape == [1, 1024, 28])
+        #expect(layout.strides == [32768, 32, 1])
+        #expect(layout.storageSpan == 32764)
+        #expect(layout.storageSpan > encoded.count)
+    }
+
+    @Test("storage span uses maximum stride offset")
+    func storageSpanUsesMaximumStrideOffset() throws {
+        let array = try makeStridedFloatArray(
+            shape: [2, 3, 4],
+            strides: [20, 5, 1],
+            storageSpan: 34
+        )
+
+        let layout = try nemotronValidateArray(
+            array,
+            name: "fixture",
+            dataType: .float32,
+            shape: [2, 3, 4]
+        )
+
+        #expect(array.count == 24)
+        #expect(layout.storageSpan == 34)
+    }
+
+    private func makeStridedFloatArray(shape: [Int], strides: [Int], storageSpan: Int) throws -> MLMultiArray {
+        let pointer = UnsafeMutableRawPointer.allocate(
+            byteCount: storageSpan * MemoryLayout<Float>.stride,
+            alignment: MemoryLayout<Float>.alignment
+        )
+        pointer.initializeMemory(as: Float.self, repeating: 0, count: storageSpan)
+
+        return try MLMultiArray(
+            dataPointer: pointer,
+            shape: shape.map(NSNumber.init(value:)),
+            dataType: .float32,
+            strides: strides.map(NSNumber.init(value:)),
+            deallocator: { pointer in
+                pointer.deallocate()
+            }
         )
     }
 }


### PR DESCRIPTION
## Problem

`NemotronRNNTEngine` reads MLMultiArray shapes, strides, and raw pointers without validation (mel shape/pointers, encoded output/length, downstream stride assumptions). A corrupt or partially downloaded `.mlmodelc`, or a model-version skew, produces an index trap or out-of-bounds read that kills the whole app instead of failing the transcription with a readable error.

## Fix

Dtype, rank, dimensions, strides, and length arrays are validated before any pointer access; failures throw descriptive errors. One subtlety handled explicitly: CoreML legally returns padded/non-contiguous layouts where the maximum stride offset **exceeds** `MLMultiArray.count`, so pointer capacity is derived from the stride-based storage span rather than the logical element count — valid real-world padded outputs (e.g. shape `[1, 1024, 28]` with strides `[32768, 32, 1]`) are accepted, not rejected.

## Tests

Wrong-rank/dtype rejection, padded-strides acceptance with a fixture mirroring a real padded layout, storage-span math. Full suite passes (1220 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785918470&installation_id=136549638&pr_number=282&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F282&signature=6d44c74cebf91dec7d634f875927325244457d79f1238e663123c675ec8c1747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Core ML tensor validation during transcription, including shape/dtype checks, stride compatibility, and overflow-safe storage handling.
  * Added stricter bounds checks and safer mel frame copying (including padding/cropping for fixed-size buffering).
  * Made encoder and logits decoding stride-aware, improving reliability with non-contiguous/padded layouts.

* **Tests**
  * Added new RNNT shape-guard test suite covering invalid rank/dtype and encoder dimension mismatch scenarios with descriptive errors.
  * Added coverage for stride/padded layouts, storage span derivation, and stride-aware logits token prediction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->