### PR TITLE
Chunk long files for SenseVoice transcription

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -1,5 +1,82 @@
+import AVFoundation
 import FluidAudio
 import Foundation
+
+enum SenseVoiceFileChunking {
+    static let sampleRate = SenseVoiceConfig.sampleRate
+    static let passthroughThresholdSeconds: TimeInterval = 15
+    static let windowSeconds: TimeInterval = 15
+    static let overlapSeconds: TimeInterval = 2
+
+    static func shouldChunk(duration: TimeInterval) -> Bool {
+        duration > passthroughThresholdSeconds
+    }
+
+    static func shouldChunk(sampleCount: Int, sampleRate: Int = sampleRate) -> Bool {
+        guard sampleCount > 0, sampleRate > 0 else { return false }
+        return shouldChunk(duration: Double(sampleCount) / Double(sampleRate))
+    }
+
+    static func windows(sampleCount: Int, sampleRate: Int = sampleRate) -> [Range<Int>] {
+        guard sampleCount > 0 else { return [] }
+        guard shouldChunk(sampleCount: sampleCount, sampleRate: sampleRate) else {
+            return [0..<sampleCount]
+        }
+
+        let windowSamples = max(1, Int((windowSeconds * Double(sampleRate)).rounded()))
+        let overlapSamples = min(Int((overlapSeconds * Double(sampleRate)).rounded()), windowSamples - 1)
+        let stepSamples = windowSamples - overlapSamples
+        var result: [Range<Int>] = []
+        var start = 0
+
+        while start < sampleCount {
+            let end = min(start + windowSamples, sampleCount)
+            result.append(start..<end)
+            if end == sampleCount { break }
+            start += stepSamples
+        }
+
+        return result
+    }
+
+    static func mergeTranscripts(_ transcripts: [String]) -> String {
+        SenseVoiceTranscriptMerger.merge(transcripts)
+    }
+}
+
+private enum SenseVoiceTranscriptMerger {
+    private static let maxOverlapWords = 40
+
+    static func merge(_ transcripts: [String]) -> String {
+        var words: [String] = []
+        for transcript in transcripts {
+            let next = transcript.split(whereSeparator: \.isWhitespace).map(String.init)
+            guard !next.isEmpty else { continue }
+            let overlap = suffixPrefixOverlap(words, next)
+            words.append(contentsOf: next.dropFirst(overlap))
+        }
+        return words.joined(separator: " ")
+    }
+
+    private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
+        let limit = min(maxOverlapWords, left.count, right.count)
+        guard limit >= 2 else { return 0 }
+
+        let normalizedLeft = left.map(normalize)
+        let normalizedRight = right.map(normalize)
+        for count in stride(from: limit, through: 2, by: -1) {
+            let suffix = normalizedLeft.suffix(count)
+            if !suffix.contains(""), Array(suffix) == Array(normalizedRight.prefix(count)) {
+                return count
+            }
+        }
+        return 0
+    }
+
+    private static func normalize(_ word: String) -> String {
+        word.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+}
 
 /// Native Swift transcription backend for FunASR's SenseVoiceSmall via FluidAudio.
 actor SenseVoiceTranscriber {
@@ -45,7 +122,29 @@ actor SenseVoiceTranscriber {
     func transcribe(wavURL: URL) async throws -> (text: String, processingTime: Double) {
         guard let manager else { throw TranscriberError.notLoaded }
         let start = CFAbsoluteTimeGetCurrent()
-        let text = try await manager.transcribe(audioURL: wavURL)
+        let duration = try Self.audioDuration(url: wavURL)
+        if !SenseVoiceFileChunking.shouldChunk(duration: duration) {
+            let text = try await manager.transcribe(audioURL: wavURL)
+            return (text, CFAbsoluteTimeGetCurrent() - start)
+        }
+
+        let samples = try AudioConverter(sampleRate: Double(SenseVoiceFileChunking.sampleRate))
+            .resampleAudioFile(wavURL)
+        let windows = SenseVoiceFileChunking.windows(sampleCount: samples.count)
+        guard !windows.isEmpty else {
+            return ("", CFAbsoluteTimeGetCurrent() - start)
+        }
+
+        fputs("[sensevoice] chunked transcription: \(windows.count) windows, \(String(format: "%.1f", duration))s\n", stderr)
+        var transcripts: [String] = []
+        transcripts.reserveCapacity(windows.count)
+        for window in windows {
+            try Task.checkCancellation()
+            let text = try await manager.transcribe(audio: Array(samples[window]))
+            transcripts.append(text)
+        }
+
+        let text = SenseVoiceFileChunking.mergeTranscripts(transcripts)
         let processingTime = CFAbsoluteTimeGetCurrent() - start
         return (text, processingTime)
     }
@@ -145,6 +244,13 @@ actor SenseVoiceTranscriber {
         let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
         return SenseVoiceModels.modelsExist(at: directory, precision: precision)
             && fileManager.fileExists(atPath: vocabularyURL.path)
+    }
+
+    private nonisolated static func audioDuration(url: URL) throws -> TimeInterval {
+        let file = try AVAudioFile(forReading: url)
+        let sampleRate = file.fileFormat.sampleRate
+        guard sampleRate > 0 else { return 0 }
+        return Double(file.length) / sampleRate
     }
 
     private func warmupIfNeeded(progress: ((Double, String?) -> Void)?) async {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -72,7 +72,15 @@ private enum SenseVoiceTranscriptMerger {
             let next = Array(transcript.trimmingCharacters(in: .whitespacesAndNewlines))
             guard !next.isEmpty else { continue }
             let overlap = suffixPrefixCharacterOverlap(characters, next)
-            characters.append(contentsOf: next.dropFirst(overlap))
+            let tail = next.dropFirst(overlap)
+            if overlap == 0,
+               let last = characters.last,
+               let first = tail.first,
+               last.isASCII, first.isASCII,
+               (last.isLetter || last.isNumber), (first.isLetter || first.isNumber) {
+                characters.append(" ")
+            }
+            characters.append(contentsOf: tail)
         }
         return String(characters)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -46,20 +46,54 @@ enum SenseVoiceFileChunking {
 
 private enum SenseVoiceTranscriptMerger {
     private static let maxOverlapWords = 40
+    private static let maxOverlapCharacters = 120
 
     static func merge(_ transcripts: [String]) -> String {
+        if transcripts.contains(where: containsUnspacedCJKScript) {
+            return mergeCharacters(transcripts)
+        }
+        return mergeWords(transcripts)
+    }
+
+    private static func mergeWords(_ transcripts: [String]) -> String {
         var words: [String] = []
         for transcript in transcripts {
             let next = transcript.split(whereSeparator: \.isWhitespace).map(String.init)
             guard !next.isEmpty else { continue }
-            let overlap = suffixPrefixOverlap(words, next)
+            let overlap = suffixPrefixWordOverlap(words, next)
             words.append(contentsOf: next.dropFirst(overlap))
         }
         return words.joined(separator: " ")
     }
 
-    private static func suffixPrefixOverlap(_ left: [String], _ right: [String]) -> Int {
+    private static func mergeCharacters(_ transcripts: [String]) -> String {
+        var characters: [Character] = []
+        for transcript in transcripts {
+            let next = Array(transcript.trimmingCharacters(in: .whitespacesAndNewlines))
+            guard !next.isEmpty else { continue }
+            let overlap = suffixPrefixCharacterOverlap(characters, next)
+            characters.append(contentsOf: next.dropFirst(overlap))
+        }
+        return String(characters)
+    }
+
+    private static func suffixPrefixWordOverlap(_ left: [String], _ right: [String]) -> Int {
         let limit = min(maxOverlapWords, left.count, right.count)
+        guard limit >= 2 else { return 0 }
+
+        let normalizedLeft = left.map(normalize)
+        let normalizedRight = right.map(normalize)
+        for count in stride(from: limit, through: 2, by: -1) {
+            let suffix = normalizedLeft.suffix(count)
+            if !suffix.contains(""), Array(suffix) == Array(normalizedRight.prefix(count)) {
+                return count
+            }
+        }
+        return 0
+    }
+
+    private static func suffixPrefixCharacterOverlap(_ left: [Character], _ right: [Character]) -> Int {
+        let limit = min(maxOverlapCharacters, left.count, right.count)
         guard limit >= 2 else { return 0 }
 
         let normalizedLeft = left.map(normalize)
@@ -75,6 +109,126 @@ private enum SenseVoiceTranscriptMerger {
 
     private static func normalize(_ word: String) -> String {
         word.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    private static func normalize(_ character: Character) -> String {
+        String(character).lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    private static func containsUnspacedCJKScript(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF,
+                 0x3040...0x30FF,
+                 0xAC00...0xD7AF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+enum SenseVoiceAudioWindowReaderError: Error, LocalizedError {
+    case unsupportedFormat
+    case missingFloatChannelData
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat:
+            return "Could not create a SenseVoice audio conversion format."
+        case .missingFloatChannelData:
+            return "Converted SenseVoice audio did not contain float channel data."
+        }
+    }
+}
+
+final class SenseVoiceAudioWindowReader {
+    private static let targetSampleRate = Double(SenseVoiceFileChunking.sampleRate)
+
+    private let file: AVAudioFile
+    private let converter: AVAudioConverter
+    private let outputFormat: AVAudioFormat
+    private let sourceSampleRate: Double
+
+    let sampleCount: Int
+
+    init(url: URL) throws {
+        let file = try AVAudioFile(forReading: url)
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.targetSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: file.processingFormat, to: outputFormat) else {
+            throw SenseVoiceAudioWindowReaderError.unsupportedFormat
+        }
+
+        self.file = file
+        self.converter = converter
+        self.outputFormat = outputFormat
+        self.sourceSampleRate = file.processingFormat.sampleRate
+        self.sampleCount = max(
+            0,
+            Int((Double(file.length) * Self.targetSampleRate / file.processingFormat.sampleRate).rounded(.up))
+        )
+    }
+
+    func samples(for targetRange: Range<Int>) throws -> [Float] {
+        guard !targetRange.isEmpty else { return [] }
+
+        let sourceStart = AVAudioFramePosition(
+            (Double(targetRange.lowerBound) / Self.targetSampleRate * sourceSampleRate).rounded(.down)
+        )
+        let sourceEnd = AVAudioFramePosition(
+            (Double(targetRange.upperBound) / Self.targetSampleRate * sourceSampleRate).rounded(.up)
+        )
+        let clampedStart = min(max(0, sourceStart), file.length)
+        let clampedEnd = min(max(clampedStart, sourceEnd), file.length)
+        let sourceFrameCount = AVAudioFrameCount(clampedEnd - clampedStart)
+        guard sourceFrameCount > 0 else { return [] }
+
+        guard let inputBuffer = AVAudioPCMBuffer(
+            pcmFormat: file.processingFormat,
+            frameCapacity: sourceFrameCount
+        ) else {
+            throw SenseVoiceAudioWindowReaderError.unsupportedFormat
+        }
+
+        file.framePosition = clampedStart
+        try file.read(into: inputBuffer, frameCount: sourceFrameCount)
+        guard inputBuffer.frameLength > 0 else { return [] }
+
+        converter.reset()
+        let outputCapacity = AVAudioFrameCount(
+            max(1, Int((Double(inputBuffer.frameLength) * Self.targetSampleRate / sourceSampleRate).rounded(.up)) + 64)
+        )
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputCapacity) else {
+            throw SenseVoiceAudioWindowReaderError.unsupportedFormat
+        }
+
+        var didProvideInput = false
+        let inputBlock: AVAudioConverterInputBlock = { _, status in
+            if didProvideInput {
+                status.pointee = .endOfStream
+                return nil
+            }
+            didProvideInput = true
+            status.pointee = .haveData
+            return inputBuffer
+        }
+
+        var conversionError: NSError?
+        let status = converter.convert(to: outputBuffer, error: &conversionError, withInputFrom: inputBlock)
+        if let conversionError {
+            throw conversionError
+        }
+        guard status != .error, let outputChannel = outputBuffer.floatChannelData?[0] else {
+            throw SenseVoiceAudioWindowReaderError.missingFloatChannelData
+        }
+
+        let frameLength = min(Int(outputBuffer.frameLength), targetRange.count)
+        return Array(UnsafeBufferPointer(start: outputChannel, count: frameLength))
     }
 }
 
@@ -128,9 +282,8 @@ actor SenseVoiceTranscriber {
             return (text, CFAbsoluteTimeGetCurrent() - start)
         }
 
-        let samples = try AudioConverter(sampleRate: Double(SenseVoiceFileChunking.sampleRate))
-            .resampleAudioFile(wavURL)
-        let windows = SenseVoiceFileChunking.windows(sampleCount: samples.count)
+        let reader = try SenseVoiceAudioWindowReader(url: wavURL)
+        let windows = SenseVoiceFileChunking.windows(sampleCount: reader.sampleCount)
         guard !windows.isEmpty else {
             return ("", CFAbsoluteTimeGetCurrent() - start)
         }
@@ -140,7 +293,9 @@ actor SenseVoiceTranscriber {
         transcripts.reserveCapacity(windows.count)
         for window in windows {
             try Task.checkCancellation()
-            let text = try await manager.transcribe(audio: Array(samples[window]))
+            let audio = try reader.samples(for: window)
+            guard !audio.isEmpty else { continue }
+            let text = try await manager.transcribe(audio: audio)
             transcripts.append(text)
         }
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -189,6 +189,50 @@ struct CohereTranscribeUtilsTests {
     }
 }
 
+@Suite("SenseVoiceFileChunking")
+struct SenseVoiceFileChunkingTests {
+
+    @Test("short files use one passthrough window")
+    func shortFilesUseOnePassthroughWindow() {
+        let sampleCount = 15 * SenseVoiceFileChunking.sampleRate
+        #expect(SenseVoiceFileChunking.windows(sampleCount: sampleCount) == [0..<sampleCount])
+        #expect(!SenseVoiceFileChunking.shouldChunk(sampleCount: sampleCount))
+        #expect(!SenseVoiceFileChunking.shouldChunk(duration: 15))
+    }
+
+    @Test("long files use overlapping windows")
+    func longFilesUseOverlappingWindows() {
+        let sampleRate = SenseVoiceFileChunking.sampleRate
+        let sampleCount = 46 * sampleRate
+
+        #expect(SenseVoiceFileChunking.windows(sampleCount: sampleCount) == [
+            0..<(15 * sampleRate),
+            (13 * sampleRate)..<(28 * sampleRate),
+            (26 * sampleRate)..<(41 * sampleRate),
+            (39 * sampleRate)..<(46 * sampleRate),
+        ])
+    }
+
+    @Test("empty input stays empty")
+    func emptyInputStaysEmpty() {
+        #expect(SenseVoiceFileChunking.windows(sampleCount: 0).isEmpty)
+        #expect(!SenseVoiceFileChunking.shouldChunk(sampleCount: 0))
+        #expect(SenseVoiceFileChunking.mergeTranscripts([]) == "")
+        #expect(SenseVoiceFileChunking.mergeTranscripts(["", "   "]) == "")
+    }
+
+    @Test("merge deduplicates suffix prefix overlap")
+    func mergeDeduplicatesSuffixPrefixOverlap() {
+        let result = SenseVoiceFileChunking.mergeTranscripts([
+            "alpha beta gamma delta epsilon",
+            "gamma delta epsilon zeta eta",
+            "epsilon zeta eta theta iota",
+        ])
+
+        #expect(result == "alpha beta gamma delta epsilon zeta eta theta iota")
+    }
+}
+
 @Suite("TranscriptionEngineArtifactsFilter")
 struct TranscriptionEngineArtifactsFilterTests {
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -243,6 +243,16 @@ struct SenseVoiceFileChunkingTests {
         #expect(result == "今天我们讨论语音识别模型效果很好")
     }
 
+    @Test("merge preserves ASCII boundary in mixed CJK mode")
+    func mergePreservesASCIIBoundaryInMixedCJKMode() {
+        let result = SenseVoiceFileChunking.mergeTranscripts([
+            "今天 review ended",
+            "next 会议开始",
+        ])
+
+        #expect(result == "今天 review ended next 会议开始")
+    }
+
     @Test("window reader reads bounded chunks")
     func windowReaderReadsBoundedChunks() throws {
         let sampleRate = SenseVoiceFileChunking.sampleRate
@@ -258,6 +268,7 @@ struct SenseVoiceFileChunkingTests {
 
         #expect(first.count > 14 * sampleRate)
         #expect(first.count <= 15 * sampleRate)
+        #expect(second.count > 2 * sampleRate)
         #expect(second.count <= 3 * sampleRate + 64)
         #expect(first.count < reader.sampleCount)
     }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import AVFoundation
 import Foundation
 import MuesliCore
 @testable import MuesliNativeApp
@@ -230,6 +231,64 @@ struct SenseVoiceFileChunkingTests {
         ])
 
         #expect(result == "alpha beta gamma delta epsilon zeta eta theta iota")
+    }
+
+    @Test("merge deduplicates CJK character overlap")
+    func mergeDeduplicatesCJKCharacterOverlap() {
+        let result = SenseVoiceFileChunking.mergeTranscripts([
+            "今天我们讨论语音识别模型",
+            "语音识别模型效果很好",
+        ])
+
+        #expect(result == "今天我们讨论语音识别模型效果很好")
+    }
+
+    @Test("window reader reads bounded chunks")
+    func windowReaderReadsBoundedChunks() throws {
+        let sampleRate = SenseVoiceFileChunking.sampleRate
+        let url = try Self.writeWav(seconds: 16, sampleRate: sampleRate)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let reader = try SenseVoiceAudioWindowReader(url: url)
+        let windows = SenseVoiceFileChunking.windows(sampleCount: reader.sampleCount)
+
+        #expect(windows.count == 2)
+        let first = try reader.samples(for: windows[0])
+        let second = try reader.samples(for: windows[1])
+
+        #expect(first.count > 14 * sampleRate)
+        #expect(first.count <= 15 * sampleRate)
+        #expect(second.count <= 3 * sampleRate + 64)
+        #expect(first.count < reader.sampleCount)
+    }
+
+    private static func writeWav(seconds: Int, sampleRate: Int) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sensevoice-window-\(UUID().uuidString).wav")
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw NSError(domain: "SenseVoiceFileChunkingTests", code: 1)
+        }
+        let frameCount = seconds * sampleRate
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frameCount)
+        ), let channel = buffer.floatChannelData?[0] else {
+            throw NSError(domain: "SenseVoiceFileChunkingTests", code: 2)
+        }
+
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        for index in 0..<frameCount {
+            channel[index] = Float(sin(Double(index) * 0.01)) * 0.1
+        }
+
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        try file.write(from: buffer)
+        return url
     }
 }
 


### PR DESCRIPTION
## Problem

`SenseVoiceBackend` passes the entire audio file to FluidAudio's `SenseVoiceManager` in a single call. The manager builds one input tensor over all samples and clamps internally, so a long imported recording silently transcribes only its opening seconds — the rest of the audio is dropped with no error — while also allocating a very large transient tensor.

## Fix

Long files are transcribed app-side in ~15s windows with a short overlap, sequentially, and the window texts are merged with suffix-prefix overlap deduplication (backend-private helper). Short files keep the existing single-call path unchanged.

## Tests

Window math (boundaries, overlap, passthrough, empty input) and merge dedup on synthetic strings. Full suite passes (1220 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785918879&installation_id=136549638&pr_number=284&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F284&signature=ce543471e86300134bfac6dbf89be4caef6130c5279d6e55c5d4f9d449d8f151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transcription for longer audio by automatically splitting it into overlapping chunks based on detected duration.
  * Enhanced transcript merging to reduce duplicated text and improve stitching across spaced and unspaced languages, including special handling for CJK and alphanumeric boundaries.
  * Added more accurate audio duration detection and reliable window-based audio sample reading to support chunked transcription.
* **Tests**
  * Added coverage for chunking decisions, overlap-based transcript merging behavior, and audio window reading correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->