### PR TITLE
Skip Claude Code Review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs never receive the id-token permission, so the action's OIDC
+    # exchange fails; skip cleanly instead of reporting a spurious failure.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

The `claude-review` check fails on every PR opened from a fork with:

> Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

The workflow already declares `id-token: write`, but GitHub never grants that permission to `pull_request` runs from forks, so the action's OIDC token exchange can't succeed for outside contributors — the red ✗ is unavoidable noise (seen live on #287).

## Change

One job-level guard so fork PRs skip the job cleanly instead of failing:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Same-repo PRs are unaffected and keep their Claude reviews. Fork PRs still get automated review from Greptile and CodeRabbit, which don't rely on OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994402&installation_id=136549638&pr_number=288&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F288&signature=ca7f6e8a089f27ea45f03483e1a6f63b79c2eaac63f175ae4c5981206a38c1a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a review workflow from failing on pull requests from forks.
  * Improved check reliability by skipping a step that cannot run in that context, avoiding misleading failure reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->