### PR TITLE
Scope model settings by workflow

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -140,12 +140,21 @@ struct BackendOption: Equatable {
         all.filter { $0.isDownloaded }
     }
 
+    /// Models that can keep up with post-meeting and imported recording transcription.
+    static var downloadedMeetingTranscription: [BackendOption] {
+        downloaded.filter(\.supportsMeetingTranscription)
+    }
+
     static func resolve(backend: String, model: String) -> BackendOption? {
         all.first { $0.backend == backend && $0.model == model }
     }
 
     var isStreamingDictationBackend: Bool {
         backend == "nemotron35"
+    }
+
+    var supportsMeetingTranscription: Bool {
+        !isStreamingDictationBackend
     }
 
     static func resolveDownloaded(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1013,7 +1013,6 @@ final class MuesliController: NSObject {
         let hotkeyTriggerThresholdChanged = config.hotkeyTriggerThresholdMS != previousHotkeyTriggerThresholdMS
             || config.computerUseHotkeyTriggerThresholdMS != previousComputerUseHotkeyTriggerThresholdMS
             || config.meetingRecordingHotkeyTriggerThresholdMS != previousMeetingRecordingHotkeyTriggerThresholdMS
-        configStore.save(config)
         MuesliTheme.accentOverrideHex = config.recordingColorHex == "1e1e2e" ? nil : config.recordingColorHex
         selectedBackend = BackendOption.all.first(where: {
             $0.backend == config.sttBackend && $0.model == config.sttModel
@@ -1021,10 +1020,19 @@ final class MuesliController: NSObject {
         let configuredMeetingTranscriptionBackend = BackendOption.all.first(where: {
             $0.backend == config.meetingTranscriptionBackend && $0.model == config.meetingTranscriptionModel
         })
-        selectedMeetingTranscriptionBackend = Self.fallbackMeetingTranscriptionBackend(
+        selectedMeetingTranscriptionBackend = Self.availableMeetingTranscriptionBackend(
+            config: config,
+            dictationBackend: selectedBackend
+        ) ?? Self.fallbackMeetingTranscriptionBackend(
             configured: configuredMeetingTranscriptionBackend,
             dictationBackend: selectedBackend
         )
+        if config.meetingTranscriptionBackend != selectedMeetingTranscriptionBackend.backend ||
+            config.meetingTranscriptionModel != selectedMeetingTranscriptionBackend.model {
+            config.meetingTranscriptionBackend = selectedMeetingTranscriptionBackend.backend
+            config.meetingTranscriptionModel = selectedMeetingTranscriptionBackend.model
+        }
+        configStore.save(config)
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == config.meetingSummaryBackend
         }) ?? .chatGPT

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -412,7 +412,10 @@ final class MuesliController: NSObject {
             config: loadedConfig,
             dictationBackend: self.selectedBackend,
             downloadedOptions: BackendOption.downloaded
-        ) ?? configuredMeetingBackend ?? self.selectedBackend
+        ) ?? Self.fallbackMeetingTranscriptionBackend(
+            configured: configuredMeetingBackend,
+            dictationBackend: self.selectedBackend
+        )
         self.selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == loadedConfig.meetingSummaryBackend
         }) ?? .chatGPT
@@ -922,12 +925,27 @@ final class MuesliController: NSObject {
         dictationBackend: BackendOption,
         downloadedOptions: [BackendOption] = BackendOption.downloaded
     ) -> BackendOption? {
-        BackendOption.resolveDownloaded(
+        let meetingOptions = downloadedOptions.filter(\.supportsMeetingTranscription)
+        let fallback = dictationBackend.supportsMeetingTranscription ? dictationBackend : nil
+        return BackendOption.resolveDownloaded(
             backend: config.meetingTranscriptionBackend,
             model: config.meetingTranscriptionModel,
-            fallback: dictationBackend,
-            downloadedOptions: downloadedOptions
+            fallback: fallback,
+            downloadedOptions: meetingOptions
         )
+    }
+
+    private static func fallbackMeetingTranscriptionBackend(
+        configured: BackendOption?,
+        dictationBackend: BackendOption
+    ) -> BackendOption {
+        if let configured, configured.supportsMeetingTranscription {
+            return configured
+        }
+        if dictationBackend.supportsMeetingTranscription {
+            return dictationBackend
+        }
+        return BackendOption.all.first(where: \.supportsMeetingTranscription) ?? .whisper
     }
 
     @discardableResult
@@ -943,10 +961,13 @@ final class MuesliController: NSObject {
             dictationBackend: dictationBackend,
             downloadedOptions: downloadedOptions
         ) else {
-            selectedMeetingTranscriptionBackend = BackendOption.resolve(
-                backend: config.meetingTranscriptionBackend,
-                model: config.meetingTranscriptionModel
-            ) ?? dictationBackend
+            selectedMeetingTranscriptionBackend = Self.fallbackMeetingTranscriptionBackend(
+                configured: BackendOption.resolve(
+                    backend: config.meetingTranscriptionBackend,
+                    model: config.meetingTranscriptionModel
+                ),
+                dictationBackend: dictationBackend
+            )
             appState.selectedMeetingTranscriptionBackend = selectedMeetingTranscriptionBackend
             appState.config = config
             return nil
@@ -997,9 +1018,13 @@ final class MuesliController: NSObject {
         selectedBackend = BackendOption.all.first(where: {
             $0.backend == config.sttBackend && $0.model == config.sttModel
         }) ?? .whisper
-        selectedMeetingTranscriptionBackend = BackendOption.all.first(where: {
+        let configuredMeetingTranscriptionBackend = BackendOption.all.first(where: {
             $0.backend == config.meetingTranscriptionBackend && $0.model == config.meetingTranscriptionModel
-        }) ?? selectedBackend
+        })
+        selectedMeetingTranscriptionBackend = Self.fallbackMeetingTranscriptionBackend(
+            configured: configuredMeetingTranscriptionBackend,
+            dictationBackend: selectedBackend
+        )
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {
             $0.backend == config.meetingSummaryBackend
         }) ?? .chatGPT
@@ -1708,6 +1733,14 @@ final class MuesliController: NSObject {
     }
 
     func selectMeetingTranscriptionBackend(_ option: BackendOption, requireDownloaded: Bool = true) {
+        guard option.supportsMeetingTranscription else {
+            presentErrorAlert(
+                title: "Meeting model unavailable",
+                message: "\(option.label) is optimized for dictation and cannot be used for meeting transcription."
+            )
+            normalizeMeetingTranscriptionSelectionForAvailability()
+            return
+        }
         guard !requireDownloaded || option.isDownloaded else {
             presentErrorAlert(
                 title: "Meeting model unavailable",

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -54,7 +54,6 @@ struct SettingsView: View {
     private enum SettingsPane: String, CaseIterable, Identifiable {
         case general
         case sync
-        case aiModels
         case dictation
         case computerUse
         case meetings
@@ -66,7 +65,6 @@ struct SettingsView: View {
             switch self {
             case .general: return "General"
             case .sync: return "Sync"
-            case .aiModels: return "AI Models"
             case .dictation: return "Dictation"
             case .computerUse: return "Computer Use"
             case .meetings: return "Meetings"
@@ -106,7 +104,7 @@ struct SettingsView: View {
 
     // Uniform width for standard right-side controls.
     private let controlWidth: CGFloat = 220
-    // Wider controls keep model/provider selections visually consistent in AI Models.
+    // Wider controls keep model/provider selections visually consistent in Settings.
     private let meetingControlWidth: CGFloat = 275
     private let iOSCompanionURL = IPhoneBridgeLinks.installURL
     private let screenContextGrantIntentTimeout: TimeInterval = 15 * 60
@@ -128,7 +126,7 @@ struct SettingsView: View {
     }
 
     private var meetingBackendOptions: [BackendOption] {
-        downloadedBackendOptions
+        downloadedBackendOptions.filter(\.supportsMeetingTranscription)
     }
 
     private var selectedMeetingBackendLabel: String {
@@ -150,7 +148,7 @@ struct SettingsView: View {
     private var cleanupBackendDescription: String {
         if appState.selectedPostProcessorBackend == .local {
             return downloadedPostProcOptions.isEmpty
-                ? "Download a cleanup model in Models to refine dictations on this Mac."
+                ? "Download a cleanup model from Models to refine dictations on this Mac."
                 : "Refines dictated text on this Mac."
         }
         return "Sends dictated text to \(appState.selectedPostProcessorBackend.label) and may add latency."
@@ -410,8 +408,6 @@ struct SettingsView: View {
             generalSettingsPane
         case .sync:
             syncSettingsPane
-        case .aiModels:
-            aiModelsSettingsPane
         case .dictation:
             dictationSettingsPane
         case .computerUse:
@@ -596,113 +592,132 @@ struct SettingsView: View {
         }
     }
 
-    private var aiModelsSettingsPane: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
-            settingsSection("Speech Recognition") {
-                settingsRow("Dictation model", controlWidth: meetingControlWidth) {
-                    settingsMenu(
-                        selection: appState.selectedBackend.label,
-                        options: dictationBackendOptions.map(\.label)
-                    ) { label in
-                        if let option = dictationBackendOptions.first(where: { $0.label == label }) {
-                            controller.selectBackend(option)
-                        }
+    private var dictationModelSettingsSection: some View {
+        settingsSection("Speech Recognition") {
+            settingsRow("Dictation model", controlWidth: meetingControlWidth) {
+                settingsMenu(
+                    selection: appState.selectedBackend.label,
+                    options: dictationBackendOptions.map(\.label)
+                ) { label in
+                    if let option = dictationBackendOptions.first(where: { $0.label == label }) {
+                        controller.selectBackend(option)
                     }
                 }
+            }
+            if appState.selectedBackend.backend == BackendOption.cohereTranscribe.backend {
                 Divider().background(MuesliTheme.surfaceBorder)
-                settingsRow("Meeting model", controlWidth: meetingControlWidth) {
-                    if meetingBackendOptions.isEmpty {
-                        Text("No downloaded models")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    } else {
-                        settingsMenu(
-                            selection: selectedMeetingBackendLabel,
-                            options: meetingBackendOptions.map(\.label)
-                        ) { label in
-                            if let option = meetingBackendOptions.first(where: { $0.label == label }) {
-                                controller.selectMeetingTranscriptionBackend(option)
-                            }
-                        }
-                    }
-                }
-                if appState.selectedBackend.backend == BackendOption.cohereTranscribe.backend
-                    || appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cohere language", controlWidth: meetingControlWidth) {
-                        settingsMenu(
-                            selection: selectedCohereLanguage.label,
-                            options: CohereTranscribeLanguage.allCases.map(\.label)
-                        ) { label in
-                            guard let language = CohereTranscribeLanguage.allCases.first(where: { $0.label == label }) else { return }
-                            controller.selectCohereLanguage(language)
-                        }
-                    }
-                }
-                if appState.selectedBackend.backend == BackendOption.indicASR.backend
-                    || appState.selectedMeetingTranscriptionBackend.backend == BackendOption.indicASR.backend {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Indic language", controlWidth: meetingControlWidth) {
-                        FixedWidthPopUp(
-                            selection: selectedIndicASRLanguage.label,
-                            options: IndicASRLanguage.allCases.map(\.label),
-                            onSelectIndex: { index in
-                                guard index >= 0, index < IndicASRLanguage.allCases.count else { return }
-                                controller.selectIndicASRLanguage(IndicASRLanguage.allCases[index])
-                            }
-                        )
-                        .frame(height: 24)
-                    }
+                settingsRow("Cohere language", controlWidth: meetingControlWidth) {
+                    cohereLanguageMenu
                 }
             }
-
-            settingsSection("Dictation Cleanup") {
-                settingsRow(
-                    "Cleanup backend",
-                    description: cleanupBackendDescription,
-                    controlWidth: meetingControlWidth
-                ) {
-                    settingsMenu(
-                        selection: appState.selectedPostProcessorBackend.label,
-                        options: TranscriptCleanupBackendOption.all.map(\.label)
-                    ) { label in
-                        if let option = TranscriptCleanupBackendOption.all.first(where: { $0.label == label }) {
-                            controller.selectPostProcessorBackend(option)
-                        }
-                    }
+            if appState.selectedBackend.backend == BackendOption.indicASR.backend {
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Indic language", controlWidth: meetingControlWidth) {
+                    indicLanguageMenu
                 }
-                if appState.selectedPostProcessorBackend == .local {
-                    Divider().background(MuesliTheme.surfaceBorder)
-                    settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
-                        if downloadedPostProcOptions.isEmpty {
-                            Text("Download a cleanup model in Models")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(MuesliTheme.textTertiary)
-                                .multilineTextAlignment(.trailing)
-                                .frame(width: meetingControlWidth, alignment: .trailing)
-                        } else {
-                            let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
-                                ? appState.activePostProcessor.label
-                                : (downloadedPostProcOptions.first?.label ?? "")
-                            settingsMenu(
-                                selection: selection,
-                                options: downloadedPostProcOptions.map(\.label)
-                            ) { label in
-                                if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
-                                    controller.selectPostProcessor(option)
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    hostedCleanupSettings(for: appState.selectedPostProcessorBackend)
-                }
-
             }
-
-            meetingSummarySettingsSection
         }
+    }
+
+    private var meetingTranscriptionSettingsSection: some View {
+        settingsSection("Transcription") {
+            settingsRow("Meeting model", controlWidth: meetingControlWidth) {
+                if meetingBackendOptions.isEmpty {
+                    Text("No downloaded models")
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    settingsMenu(
+                        selection: selectedMeetingBackendLabel,
+                        options: meetingBackendOptions.map(\.label)
+                    ) { label in
+                        if let option = meetingBackendOptions.first(where: { $0.label == label }) {
+                            controller.selectMeetingTranscriptionBackend(option)
+                        }
+                    }
+                }
+            }
+            if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.cohereTranscribe.backend {
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Cohere language", controlWidth: meetingControlWidth) {
+                    cohereLanguageMenu
+                }
+            }
+            if appState.selectedMeetingTranscriptionBackend.backend == BackendOption.indicASR.backend {
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Indic language", controlWidth: meetingControlWidth) {
+                    indicLanguageMenu
+                }
+            }
+        }
+    }
+
+    private var dictationCleanupSettingsSection: some View {
+        settingsSection("Dictation Cleanup") {
+            settingsRow(
+                "Cleanup backend",
+                description: cleanupBackendDescription,
+                controlWidth: meetingControlWidth
+            ) {
+                settingsMenu(
+                    selection: appState.selectedPostProcessorBackend.label,
+                    options: TranscriptCleanupBackendOption.all.map(\.label)
+                ) { label in
+                    if let option = TranscriptCleanupBackendOption.all.first(where: { $0.label == label }) {
+                        controller.selectPostProcessorBackend(option)
+                    }
+                }
+            }
+            if appState.selectedPostProcessorBackend == .local {
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
+                    if downloadedPostProcOptions.isEmpty {
+                        Text("Download a cleanup model from Models")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: meetingControlWidth, alignment: .trailing)
+                    } else {
+                        let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
+                            ? appState.activePostProcessor.label
+                            : (downloadedPostProcOptions.first?.label ?? "")
+                        settingsMenu(
+                            selection: selection,
+                            options: downloadedPostProcOptions.map(\.label)
+                        ) { label in
+                            if let option = downloadedPostProcOptions.first(where: { $0.label == label }) {
+                                controller.selectPostProcessor(option)
+                            }
+                        }
+                    }
+                }
+            } else {
+                hostedCleanupSettings(for: appState.selectedPostProcessorBackend)
+            }
+        }
+    }
+
+    private var cohereLanguageMenu: some View {
+        settingsMenu(
+            selection: selectedCohereLanguage.label,
+            options: CohereTranscribeLanguage.allCases.map(\.label)
+        ) { label in
+            guard let language = CohereTranscribeLanguage.allCases.first(where: { $0.label == label }) else { return }
+            controller.selectCohereLanguage(language)
+        }
+    }
+
+    private var indicLanguageMenu: some View {
+        FixedWidthPopUp(
+            selection: selectedIndicASRLanguage.label,
+            options: IndicASRLanguage.allCases.map(\.label),
+            onSelectIndex: { index in
+                guard index >= 0, index < IndicASRLanguage.allCases.count else { return }
+                controller.selectIndicASRLanguage(IndicASRLanguage.allCases[index])
+            }
+        )
+        .frame(height: 24)
     }
 
     @ViewBuilder
@@ -985,6 +1000,8 @@ struct SettingsView: View {
 
     private var dictationSettingsPane: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            dictationModelSettingsSection
+
             settingsSection("Transcription") {
                 settingsRow(
                     "Microphone",
@@ -1021,6 +1038,8 @@ struct SettingsView: View {
                     .help("Briefly reads focused app text after dictation to detect corrections.")
                 }
             }
+
+            dictationCleanupSettingsSection
 
             settingsSection("Advanced") {
                 settingsRow("Pause media during dictation") {
@@ -1084,9 +1103,13 @@ struct SettingsView: View {
 
     private var meetingsSettingsPane: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+            meetingTranscriptionSettingsSection
+
             settingsSection("Meeting Context") {
                 screenContextRow("Meeting context", includesScreenOCR: true)
             }
+
+            meetingSummarySettingsSection
 
             settingsSection("Meeting Notes") {
                 settingsRow("Default template", controlWidth: meetingControlWidth) {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -859,6 +859,30 @@ struct MeetingsNavigationTests {
         #expect(controller.appState.config.meetingTranscriptionModel == BackendOption.whisperLargeTurbo.model)
     }
 
+    @Test("updateConfig persists normalized meeting transcription backend")
+    func updateConfigPersistsNormalizedMeetingTranscriptionBackend() {
+        let controller = makeController()
+        let originalConfig = controller.config
+        defer {
+            controller.updateConfig { config in
+                config = originalConfig
+            }
+        }
+
+        controller.updateConfig {
+            $0.sttBackend = BackendOption.parakeetMultilingual.backend
+            $0.sttModel = BackendOption.parakeetMultilingual.model
+            $0.meetingTranscriptionBackend = BackendOption.nemotron35Multilingual.backend
+            $0.meetingTranscriptionModel = BackendOption.nemotron35Multilingual.model
+        }
+
+        #expect(controller.appState.selectedMeetingTranscriptionBackend.supportsMeetingTranscription)
+        #expect(controller.appState.config.meetingTranscriptionBackend != BackendOption.nemotron35Multilingual.backend)
+        #expect(controller.appState.config.meetingTranscriptionModel != BackendOption.nemotron35Multilingual.model)
+        #expect(controller.config.meetingTranscriptionBackend == controller.appState.selectedMeetingTranscriptionBackend.backend)
+        #expect(controller.config.meetingTranscriptionModel == controller.appState.selectedMeetingTranscriptionBackend.model)
+    }
+
     private func makeMeeting(
         id: Int64,
         title: String,

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -167,6 +167,14 @@ struct BackendOptionTests {
         #expect(streaming == [.nemotron35Multilingual])
     }
 
+    @Test("streaming dictation models are excluded from meeting transcription")
+    func streamingDictationModelsAreExcludedFromMeetingTranscription() {
+        #expect(!BackendOption.nemotron35Multilingual.supportsMeetingTranscription)
+        #expect(BackendOption.parakeetMultilingual.supportsMeetingTranscription)
+        #expect(BackendOption.whisperLargeTurbo.supportsMeetingTranscription)
+        #expect(!BackendOption.downloadedMeetingTranscription.contains(.nemotron35Multilingual))
+    }
+
     @Test("Whisper models use WhisperKit CoreML identifiers")
     func whisperKitModels() {
         // WhisperKit models use short variant names, not ggml- prefixed binaries


### PR DESCRIPTION
## Summary
- remove the Settings > AI Models pane and split those controls into Dictation and Meetings
- keep dictation model and cleanup backend/model settings in the Dictation tab
- keep meeting transcription and meeting summary settings in the Meetings tab
- exclude streaming dictation-only models, including Nemotron 3.5, from meeting transcription selection and saved-config normalization

## Why
Nemotron 3.5 is optimized for streaming dictation, not long meeting transcription. Allowing it as a meeting backend can put the meeting lifecycle on a path that accumulates ASR backlog and delays final processing.

## Validation
- `swift test --package-path native/MuesliNative --scratch-path /Volumes/eSSD/muesli-spm-direct/worktrees/5d67/test --filter BackendOptionTests`
- `MUESLI_EXTERNAL_SPM_CACHE_ROOT=/Volumes/eSSD/muesli-spm-direct ./scripts/dev-test.sh --lane A`
- visually verified `/Applications/MuesliDevA.app`: no AI Models tab, Dictation contains dictation/cleanup settings, Meetings contains meeting transcription/summaries, and the meeting model menu excludes Nemotron 3.5

## Note
The documented `/Volumes/eSSD/MuesliBuildCache.sparsebundle` did not attach during validation (`no mountable file systems` / then `Resource busy`), so the build used the existing eSSD cache directory at `/Volumes/eSSD/muesli-spm-direct`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786047534&installation_id=136549638&pr_number=294&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F294&signature=941808517ca9fed7b7a6ec36be9d734d27fff1192a2681541676a1b0a0153041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated meeting transcription model picker in Settings, reorganizing model selection into speech recognition, transcription, and dictation cleanup sections.
* **Bug Fixes**
  * Ensured meeting transcription only shows/selects meeting-capable backends and models (excluding streaming dictation options).
  * Improved selection validation with an alert for incompatible choices and more reliable fallback behavior.
  * Meeting transcription backend/model settings are now properly normalized and persisted.
* **Tests**
  * Added coverage for excluding unsupported models and persisting normalized meeting transcription selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->