### PR TITLE
Fix beta release DMG: bundle llama.framework and all SPM frameworks/resources

### DIFF
--- a/.github/workflows/release-macos-app.yml
+++ b/.github/workflows/release-macos-app.yml
@@ -73,14 +73,37 @@ jobs:
           chmod +x "$APP_DIR/Contents/MacOS/Muesli"
           chmod +x "$APP_DIR/Contents/MacOS/muesli-cli"
 
-          # Bundle Sparkle framework (rpath is @loader_path, so it goes next to the binary)
-          if [ -d "$BIN_DIR/Sparkle.framework" ]; then
-            ditto "$BIN_DIR/Sparkle.framework" "$APP_DIR/Contents/MacOS/Sparkle.framework"
-          fi
+          # Bundle every SwiftPM-linked framework (rpath is @loader_path, so they go next to
+          # the binary). This includes Sparkle.framework AND llama.framework — the latter is
+          # required by the LLM.swift dependency, and the app crashes on launch with
+          # "Library not loaded: @rpath/llama.framework/..." when it is missing.
+          for framework in "$BIN_DIR"/*.framework; do
+            [ -d "$framework" ] || continue
+            ditto "$framework" "$APP_DIR/Contents/MacOS/$(basename "$framework")"
+          done
 
-          cp assets/menu_m_template.png "$APP_DIR/Contents/Resources/"
-          cp assets/muesli.icns "$APP_DIR/Contents/Resources/"
-          [ -d assets/fonts ] && cp -R assets/fonts "$APP_DIR/Contents/Resources/fonts"
+          # Bundle SPM resource bundles (CoreML models, privacy manifests, etc.).
+          for bundle in "$BIN_DIR"/*.bundle; do
+            [ -d "$bundle" ] || continue
+            ditto "$bundle" "$APP_DIR/Contents/Resources/$(basename "$bundle")"
+          done
+
+          # Bundle UI assets (mirrors scripts/build_native_app.sh).
+          cp assets/menu_m_template.png "$APP_DIR/Contents/Resources/menu_m_template.png"
+          cp assets/muesli.icns "$APP_DIR/Contents/Resources/muesli.icns"
+          cp assets/zoom-app.png "$APP_DIR/Contents/Resources/zoom-app.png"
+          cp "assets/Google_Meet_icon_(2020).svg.png" "$APP_DIR/Contents/Resources/google-meet.png"
+          cp "assets/Microsoft_Office_Teams_(2025–present).svg.png" "$APP_DIR/Contents/Resources/teams.png"
+          cp "assets/Slack_icon_2019.svg.png" "$APP_DIR/Contents/Resources/slack.png"
+          cp "assets/Nvidia_logo.svg.png" "$APP_DIR/Contents/Resources/nvidia-logo.png"
+          cp "assets/OpenAI_Logo.svg.png" "$APP_DIR/Contents/Resources/openai-logo.png"
+          cp assets/cohere.png "$APP_DIR/Contents/Resources/cohere-logo.png"
+          cp "assets/Qwen_logo.svg.png" "$APP_DIR/Contents/Resources/qwen-logo.png"
+          cp assets/AI4Bharat_logo.png "$APP_DIR/Contents/Resources/ai4bharat-logo.png"
+          cp assets/x-logo.png "$APP_DIR/Contents/Resources/x-logo.png"
+          cp assets/linkedin-logo.png "$APP_DIR/Contents/Resources/linkedin-logo.png"
+          [ -d assets/fonts ] && ditto assets/fonts "$APP_DIR/Contents/Resources/fonts"
+          [ -d assets/audio ] && ditto assets/audio "$APP_DIR/Contents/Resources/audio"
 
           VERSION="${{ steps.meta.outputs.version }}"
 


### PR DESCRIPTION
Fixes #295.

### Problem

The **Build macOS Beta App** workflow ships a DMG that crashes on launch on any clean machine. The `Package app bundle` step copies **only** `Sparkle.framework`, but the release binary also dynamically links `llama.framework` (via the `LLM.swift` dependency):

```
$ otool -L Muesli.app/Contents/MacOS/Muesli
	@rpath/llama.framework/Versions/Current/llama ...
	@rpath/Sparkle.framework/Versions/B/Sparkle ...
```

With `llama.framework` missing from the bundle, the app fails to launch:

```
dyld: Library not loaded: @rpath/llama.framework/Versions/Current/llama
```

The SPM `*.bundle` resources (CoreML models, privacy manifests) were dropped too.

### Fix

Bundle **every** SwiftPM-linked `*.framework` and `*.bundle` next to the binary, and copy the same UI assets as `scripts/build_native_app.sh`, so the beta DMG is self-contained. This mirrors the loops the canonical build script already uses:

```bash
for framework in "$BIN_DIR"/*.framework; do
  [ -d "$framework" ] || continue
  ditto "$framework" "$APP_DIR/Contents/MacOS/$(basename "$framework")"
done
for bundle in "$BIN_DIR"/*.bundle; do
  [ -d "$bundle" ] || continue
  ditto "$bundle" "$APP_DIR/Contents/Resources/$(basename "$bundle")"
done
```

### Scope

Single-file change to `.github/workflows/release-macos-app.yml`. No source or dependency changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786060260&installation_id=136549638&pr_number=296&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F296&signature=159718c195e37b422d0bfa3738691c4c37f511d5993a673953d894e6dad2516a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS beta app packaging so required frameworks and resource bundles are included more reliably.
  * Expanded bundled app resources, including additional images, fonts, and audio assets, to help prevent missing content in the released app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->