### PR TITLE
Add global CLI audio transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ Muesli bundles an agent-friendly local CLI inside the app bundle:
 
 - Installed path: `/Applications/Muesli.app/Contents/MacOS/muesli-cli`
 - Dev path: `native/MuesliNative/.build/arm64-apple-macosx/debug/muesli-cli`
+- Future Homebrew alias: `muesli` once the official cask exposes the bundled binary as a command
 
-The CLI is designed for coding agents such as Codex and Claude Code. It exposes meetings, dictations, raw transcripts, and stored notes as stable JSON so an agent can analyze them with its own model and write notes back without requiring a user-supplied OpenAI or OpenRouter key.
+The CLI is designed for coding agents such as Codex and Claude Code. It exposes meetings, dictations, raw transcripts, stored notes, and local audio-file transcription. Existing data commands return stable JSON so an agent can analyze them with its own model and write notes back without requiring a user-supplied OpenAI or OpenRouter key. `transcribe` prints plain transcript text by default so it works naturally in shell pipelines.
 
 ### What agents should do
 
@@ -125,18 +126,26 @@ The CLI is designed for coding agents such as Codex and Claude Code. It exposes 
    ```bash
    /Applications/Muesli.app/Contents/MacOS/muesli-cli spec
    ```
-3. List recent meetings or dictations:
+3. Transcribe a local audio file:
+   ```bash
+   /Applications/Muesli.app/Contents/MacOS/muesli-cli transcribe file.mp3
+   ```
+   Homebrew users should eventually be able to use:
+   ```bash
+   muesli transcribe file.mp3
+   ```
+4. List recent meetings or dictations:
    ```bash
    /Applications/Muesli.app/Contents/MacOS/muesli-cli meetings list --limit 10
    /Applications/Muesli.app/Contents/MacOS/muesli-cli dictations list --limit 10
    ```
-4. Fetch a full record:
+5. Fetch a full record:
    ```bash
    /Applications/Muesli.app/Contents/MacOS/muesli-cli meetings get 125
    /Applications/Muesli.app/Contents/MacOS/muesli-cli dictations get 42
    ```
-5. Summarize or analyze locally in the agent.
-6. Write improved meeting notes back:
+6. Summarize or analyze locally in the agent.
+7. Write improved meeting notes back:
    ```bash
    cat notes.md | /Applications/Muesli.app/Contents/MacOS/muesli-cli meetings update-notes 125 --stdin
    ```
@@ -145,15 +154,75 @@ The CLI is designed for coding agents such as Codex and Claude Code. It exposes 
 
 - `muesli-cli spec`
 - `muesli-cli info`
+- `muesli-cli transcribe <file> [--format text|json|markdown] [--model parakeet-v3|parakeet-v2] [--summarize] [--save-meeting] [--title TITLE] [--output PATH]`
 - `muesli-cli meetings list [--limit N] [--folder-id ID]`
 - `muesli-cli meetings get <id>`
 - `muesli-cli meetings update-notes <id> (--stdin | --file <path>)`
 - `muesli-cli dictations list [--limit N]`
 - `muesli-cli dictations get <id>`
 
+### Audio transcription
+
+Supported input files: `.mp3`, `.mp4`, `.m4a`, and `.wav`.
+
+Default output is transcript text only:
+
+```bash
+muesli-cli transcribe interview.mp3
+```
+
+Agent-friendly JSON output uses the normal CLI envelope:
+
+```bash
+muesli-cli transcribe interview.m4a --format json
+```
+
+```json
+{
+  "ok": true,
+  "command": "muesli-cli transcribe",
+  "data": {
+    "transcript": "Raw transcript text...",
+    "summary": null,
+    "durationSeconds": 123.4,
+    "wordCount": 420,
+    "model": "parakeet-v3",
+    "warnings": [],
+    "savedMeetingID": null,
+    "title": "interview"
+  },
+  "meta": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-07-08T00:00:00Z",
+    "dbPath": "/Users/example/Library/Application Support/Muesli/muesli.db",
+    "warnings": []
+  }
+}
+```
+
+Generate markdown notes with the configured API/local summary backend when available:
+
+```bash
+muesli-cli transcribe interview.mp4 --summarize --format markdown --output notes.md
+```
+
+`--summarize` uses configured OpenAI, OpenRouter, Ollama, LM Studio, or Custom LLM settings. If the configured backend is unavailable in headless CLI mode, Muesli keeps the transcript and reports a warning instead of discarding the transcription.
+
+Save the import into Muesli as `source = audio_import`:
+
+```bash
+muesli-cli transcribe interview.wav --save-meeting --title "Customer Interview"
+```
+
+Direct app-bundle fallback path:
+
+```bash
+/Applications/Muesli.app/Contents/MacOS/muesli-cli transcribe file.mp3
+```
+
 ### JSON contract
 
-All CLI commands return JSON on stdout.
+Data commands return JSON on stdout. `transcribe` returns plain text by default; pass `--format json` to use the envelope below.
 
 Success shape:
 
@@ -209,6 +278,7 @@ Important meeting fields:
 ### Notes for agent authors
 
 - The CLI is JSON-first and intended to be machine-consumed.
+- `transcribe` is text-first by default; use `--format json` for structured agent workflows.
 - `formattedNotes` is the only write-back surface in v1.
 - `rawTranscript` is read-only and should be treated as source material.
 - If `notesState` is `missing` or `raw_transcript_fallback`, agents should prefer summarizing from `rawTranscript`.

--- a/native/MuesliNative/Sources/MuesliCLI/MuesliCLI.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/MuesliCLI.swift
@@ -287,7 +287,7 @@ struct MuesliCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "muesli-cli",
         abstract: "Agent-friendly CLI for local Muesli meetings and dictations.",
-        subcommands: [SpecCommand.self, InfoCommand.self, MeetingsCommand.self, DictationsCommand.self]
+        subcommands: [SpecCommand.self, InfoCommand.self, TranscribeCommand.self, MeetingsCommand.self, DictationsCommand.self]
     )
 
     static func exit(withError error: Error? = nil) -> Never {
@@ -327,6 +327,7 @@ struct MuesliCLI: AsyncParsableCommand {
         CommandSpecPayload(commands: [
             .init(name: "spec", usage: "muesli-cli spec", summary: "Dump the command tree and CLI schema metadata.", examples: ["muesli-cli spec"]),
             .init(name: "info", usage: "muesli-cli info [--db-path <path>] [--support-dir <dir>]", summary: "Show resolved support and database paths.", examples: ["muesli-cli info", "muesli-cli info --support-dir ~/Library/Application\\ Support/Muesli"]),
+            .init(name: "transcribe", usage: "muesli-cli transcribe <file> [--format text|json|markdown] [--model parakeet-v3|parakeet-v2] [--summarize] [--save-meeting] [--title <title>] [--output <path>]", summary: "Transcribe a local mp3, mp4, m4a, or wav file with bundled Parakeet models.", examples: ["muesli-cli transcribe call.mp3", "muesli-cli transcribe call.m4a --format json", "muesli-cli transcribe call.wav --summarize --save-meeting"]),
             .init(name: "meetings list", usage: "muesli-cli meetings list [--limit <n>] [--folder-id <id>]", summary: "List recent meetings.", examples: ["muesli-cli meetings list --limit 5", "muesli-cli meetings list --folder-id 2"]),
             .init(name: "meetings get", usage: "muesli-cli meetings get <id>", summary: "Return a full meeting record.", examples: ["muesli-cli meetings get 42"]),
             .init(name: "meetings update-notes", usage: "muesli-cli meetings update-notes <id> (--stdin | --file <path>)", summary: "Replace stored meeting notes only.", examples: ["muesli-cli meetings update-notes 42 --file notes.md", "cat notes.md | muesli-cli meetings update-notes 42 --stdin"]),

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -1,0 +1,931 @@
+import ArgumentParser
+import AVFoundation
+import FluidAudio
+import Foundation
+import MuesliCore
+
+enum TranscribeOutputFormat: String, CaseIterable, ExpressibleByArgument {
+    case text
+    case json
+    case markdown
+}
+
+enum TranscribeModel: String, CaseIterable, ExpressibleByArgument, Encodable {
+    case parakeetV3 = "parakeet-v3"
+    case parakeetV2 = "parakeet-v2"
+
+    var asrModelVersion: AsrModelVersion {
+        switch self {
+        case .parakeetV3: return .v3
+        case .parakeetV2: return .v2
+        }
+    }
+}
+
+struct TranscribeJSONPayload: Encodable {
+    let transcript: String
+    let summary: String?
+    let durationSeconds: Double
+    let wordCount: Int
+    let model: String
+    let warnings: [String]
+    let savedMeetingID: Int64?
+    let title: String
+
+    enum CodingKeys: String, CodingKey {
+        case transcript
+        case summary
+        case durationSeconds
+        case wordCount
+        case model
+        case warnings
+        case savedMeetingID
+        case title
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(transcript, forKey: .transcript)
+        if let summary {
+            try container.encode(summary, forKey: .summary)
+        } else {
+            try container.encodeNil(forKey: .summary)
+        }
+        try container.encode(durationSeconds, forKey: .durationSeconds)
+        try container.encode(wordCount, forKey: .wordCount)
+        try container.encode(model, forKey: .model)
+        try container.encode(warnings, forKey: .warnings)
+        if let savedMeetingID {
+            try container.encode(savedMeetingID, forKey: .savedMeetingID)
+        } else {
+            try container.encodeNil(forKey: .savedMeetingID)
+        }
+        try container.encode(title, forKey: .title)
+    }
+}
+
+struct TranscribeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "transcribe",
+        abstract: "Transcribe a local audio file with Muesli's bundled Parakeet models."
+    )
+
+    @OptionGroup var global: GlobalOptions
+    @Argument(help: "Audio file to transcribe. Supported extensions: mp3, mp4, m4a, wav.")
+    var file: String
+    @Option(name: .long, help: "Output format: text, json, or markdown.")
+    var format: TranscribeOutputFormat = .text
+    @Option(name: .long, help: "Transcription model: parakeet-v3 or parakeet-v2.")
+    var model: TranscribeModel = .parakeetV3
+    @Flag(name: .long, help: "Generate meeting notes using the configured Muesli summary backend when available.")
+    var summarize = false
+    @Flag(name: .long, help: "Save the transcript as an imported Muesli meeting.")
+    var saveMeeting = false
+    @Option(name: .long, help: "Optional title override for saved meetings and markdown output.")
+    var title: String?
+    @Option(name: .long, help: "Write command output to a file instead of stdout.")
+    var output: String?
+
+    mutating func validate() throws {
+        let url = URL(fileURLWithPath: file)
+        guard MuesliAudioFilePreparer.isSupportedFileURL(url) else {
+            throw ValidationError("Unsupported audio file extension. Supported extensions: mp3, mp4, m4a, wav.")
+        }
+    }
+
+    func run() async throws {
+        let context = CLIContext(options: global)
+        let sourceURL = URL(fileURLWithPath: file).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            throw CLIError.notFound("Audio file does not exist: \(sourceURL.path)", fix: "Pass a local .mp3, .mp4, .m4a, or .wav file path.")
+        }
+
+        let pipeline = MuesliAudioTranscriptionPipeline()
+        let result = try await pipeline.run(
+            request: MuesliAudioTranscriptionRequest(
+                sourceURL: sourceURL,
+                model: model,
+                title: title,
+                summarize: summarize,
+                saveMeeting: saveMeeting
+            ),
+            context: context
+        )
+
+        let outputText: String
+        switch format {
+        case .text:
+            outputText = result.transcript + "\n"
+        case .markdown:
+            outputText = result.markdownOutput + "\n"
+        case .json:
+            let payload = TranscribeJSONPayload(result)
+            let envelope = SuccessEnvelope(
+                command: "muesli-cli transcribe",
+                data: payload,
+                meta: MetaBody(
+                    schemaVersion: 1,
+                    generatedAt: timestampString(),
+                    dbPath: context.databaseURL.path,
+                    warnings: result.warnings
+                )
+            )
+            outputText = String(decoding: try encodedJSON(envelope), as: UTF8.self)
+        }
+
+        if let output {
+            try writeOutput(outputText, to: URL(fileURLWithPath: output))
+        } else {
+            FileHandle.standardOutput.write(Data(outputText.utf8))
+        }
+    }
+}
+
+extension TranscribeJSONPayload {
+    init(_ result: MuesliAudioTranscriptionResult) {
+        self.init(
+            transcript: result.transcript,
+            summary: result.summary,
+            durationSeconds: result.durationSeconds,
+            wordCount: result.wordCount,
+            model: result.model.rawValue,
+            warnings: result.warnings,
+            savedMeetingID: result.savedMeetingID,
+            title: result.title
+        )
+    }
+}
+
+func encodedJSON<T: Encodable>(_ value: T) throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    var data = try encoder.encode(value)
+    data.append(Data("\n".utf8))
+    return data
+}
+
+func writeOutput(_ text: String, to url: URL) throws {
+    let directory = url.deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data(text.utf8).write(to: url, options: .atomic)
+}
+
+struct MuesliAudioTranscriptionRequest {
+    let sourceURL: URL
+    let model: TranscribeModel
+    let title: String?
+    let summarize: Bool
+    let saveMeeting: Bool
+}
+
+struct MuesliAudioTranscriptionResult {
+    let title: String
+    let transcript: String
+    let summary: String?
+    let durationSeconds: Double
+    let wordCount: Int
+    let model: TranscribeModel
+    let warnings: [String]
+    let savedMeetingID: Int64?
+
+    var markdownOutput: String {
+        var sections = ["# \(title)"]
+        if let summary, !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            sections.append(summary)
+        }
+        sections.append("## Raw Transcript\n\n\(transcript)")
+        return sections.joined(separator: "\n\n")
+    }
+}
+
+struct PreparedAudioFile {
+    let wavURL: URL
+    let durationSeconds: Double
+    let deleteWhenDone: Bool
+}
+
+protocol AudioPreparing {
+    func prepareAudio(sourceURL: URL) async throws -> PreparedAudioFile
+}
+
+protocol AudioTranscribing {
+    func transcribe(wavURL: URL, model: TranscribeModel, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription
+}
+
+protocol MeetingSummarizing {
+    func summarize(transcript: String, title: String, supportDirectory: URL) async throws -> String
+}
+
+struct HeadlessTranscription {
+    let text: String
+    let durationSeconds: Double?
+}
+
+struct MuesliAudioTranscriptionPipeline {
+    var audioPreparer: AudioPreparing
+    var transcriber: AudioTranscribing
+    var summarizer: MeetingSummarizing
+    var dataChangePoster: () -> Void
+
+    init(
+        audioPreparer: AudioPreparing = MuesliAudioFilePreparer(),
+        transcriber: AudioTranscribing = FluidAudioCLITranscriber(),
+        summarizer: MeetingSummarizing = ConfiguredCLIMeetingSummarizer(),
+        dataChangePoster: @escaping () -> Void = MuesliNotifications.postDataDidChange
+    ) {
+        self.audioPreparer = audioPreparer
+        self.transcriber = transcriber
+        self.summarizer = summarizer
+        self.dataChangePoster = dataChangePoster
+    }
+
+    func run(request: MuesliAudioTranscriptionRequest, context: CLIContext) async throws -> MuesliAudioTranscriptionResult {
+        fputs("[muesli-cli] preparing audio...\n", stderr)
+        let prepared = try await audioPreparer.prepareAudio(sourceURL: request.sourceURL)
+        defer {
+            if prepared.deleteWhenDone {
+                try? FileManager.default.removeItem(at: prepared.wavURL)
+            }
+        }
+
+        fputs("[muesli-cli] loading \(request.model.rawValue) and transcribing...\n", stderr)
+        let transcription = try await transcriber.transcribe(wavURL: prepared.wavURL, model: request.model) { message in
+            fputs("[muesli-cli] \(message)\n", stderr)
+        }
+        let transcript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !transcript.isEmpty else {
+            throw CLIError.invalidInput("No speech was transcribed from the selected audio file.", fix: "Check that the file contains audible speech and try again.")
+        }
+
+        var warnings: [String] = []
+        let title = resolvedTitle(override: request.title, sourceURL: request.sourceURL)
+        let duration = transcription.durationSeconds ?? prepared.durationSeconds
+        let wordCount = DictationStore.countWords(in: transcript)
+
+        let summary: String?
+        if request.summarize {
+            do {
+                summary = try await summarizer.summarize(transcript: transcript, title: title, supportDirectory: context.supportDirectory)
+            } catch {
+                let message = "Summary failed: \(error.localizedDescription)"
+                warnings.append(message)
+                fputs("[muesli-cli] \(message)\n", stderr)
+                summary = nil
+            }
+        } else {
+            summary = nil
+        }
+
+        let savedMeetingID: Int64?
+        if request.saveMeeting {
+            let savedRecordingPath = try persistRecording(wavURL: prepared.wavURL, title: title, supportDirectory: context.supportDirectory)
+            try context.store.migrateIfNeeded()
+            let now = Date()
+            let notes = summary ?? Self.rawTranscriptNotes(transcript: transcript, title: title, summaryRequested: request.summarize, warnings: warnings)
+            savedMeetingID = try context.store.insertMeeting(
+                title: title,
+                calendarEventID: nil,
+                startTime: now.addingTimeInterval(-max(duration, 0)),
+                endTime: now,
+                rawTranscript: transcript,
+                formattedNotes: notes,
+                micAudioPath: nil,
+                systemAudioPath: nil,
+                savedRecordingPath: savedRecordingPath,
+                selectedTemplateID: "cli-audio-import",
+                selectedTemplateName: "CLI Audio Import",
+                selectedTemplateKind: .custom,
+                selectedTemplatePrompt: nil,
+                source: .audioImport
+            )
+            dataChangePoster()
+        } else {
+            savedMeetingID = nil
+        }
+
+        return MuesliAudioTranscriptionResult(
+            title: title,
+            transcript: transcript,
+            summary: summary,
+            durationSeconds: duration,
+            wordCount: wordCount,
+            model: request.model,
+            warnings: warnings,
+            savedMeetingID: savedMeetingID
+        )
+    }
+
+    static func rawTranscriptNotes(transcript: String, title: String, summaryRequested: Bool, warnings: [String]) -> String {
+        var sections: [String] = []
+        if summaryRequested {
+            sections.append("## Summary unavailable")
+            if warnings.isEmpty {
+                sections.append("Muesli could not generate structured notes from the configured summary backend.")
+            } else {
+                sections.append(warnings.joined(separator: "\n"))
+            }
+        } else {
+            sections.append("## Summary")
+            sections.append("No generated summary was requested.")
+        }
+        sections.append("## Raw Transcript\n\n\(transcript)")
+        return sections.joined(separator: "\n\n")
+    }
+
+    private func resolvedTitle(override: String?, sourceURL: URL) -> String {
+        let trimmed = override?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmed.isEmpty { return trimmed }
+        let stem = sourceURL.deletingPathExtension().lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+        return stem.isEmpty ? "Imported Audio" : stem
+    }
+
+    private func persistRecording(wavURL: URL, title: String, supportDirectory: URL) throws -> String {
+        let recordingsDirectory = supportDirectory.appendingPathComponent("meeting-recordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
+        let filename = "\(formatter.string(from: Date()))_\(safeFilenameComponent(title))_\(UUID().uuidString.prefix(8)).wav"
+        let destinationURL = recordingsDirectory.appendingPathComponent(filename)
+        try FileManager.default.copyItem(at: wavURL, to: destinationURL)
+        return destinationURL.path
+    }
+
+    private func safeFilenameComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(.whitespaces).union(CharacterSet(charactersIn: "-_"))
+        let scalars = value.unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        let collapsed = String(scalars)
+            .split(whereSeparator: { $0.isWhitespace || $0 == "-" })
+            .joined(separator: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-_ "))
+        return collapsed.isEmpty ? "Imported-Audio" : String(collapsed.prefix(80))
+    }
+}
+
+struct MuesliAudioFilePreparer: AudioPreparing {
+    static let supportedExtensions: Set<String> = ["m4a", "mp4", "wav", "mp3"]
+
+    static func isSupportedFileURL(_ url: URL) -> Bool {
+        supportedExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    enum PreparationError: Error, LocalizedError {
+        case unsupportedFormat
+        case conversionFailed(String)
+        case noAudioTracks
+        case readError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedFormat:
+                return "This audio file format is not supported."
+            case .conversionFailed(let detail):
+                return "Could not convert the audio file. \(detail)"
+            case .noAudioTracks:
+                return "The selected file does not contain any audio tracks."
+            case .readError(let detail):
+                return "Could not read the audio file. \(detail)"
+            }
+        }
+    }
+
+    func prepareAudio(sourceURL: URL) async throws -> PreparedAudioFile {
+        guard Self.isSupportedFileURL(sourceURL) else {
+            throw PreparationError.unsupportedFormat
+        }
+        try Task.checkCancellation()
+
+        if let compatible = try compatibleWAVInfo(sourceURL: sourceURL) {
+            let outputURL = try temporaryWAVURL()
+            try FileManager.default.copyItem(at: sourceURL, to: outputURL)
+            return PreparedAudioFile(wavURL: outputURL, durationSeconds: compatible.duration, deleteWhenDone: true)
+        }
+
+        let duration = try await audioDuration(sourceURL: sourceURL)
+        try Task.checkCancellation()
+
+        let samples: [Float]
+        do {
+            samples = try AudioConverter().resampleAudioFile(sourceURL)
+        } catch {
+            samples = try await decodeSamplesWithAssetReader(sourceURL: sourceURL)
+        }
+        guard !samples.isEmpty else {
+            throw PreparationError.noAudioTracks
+        }
+
+        let wavURL = try CLIWavWriter.writeTemporaryWAV(samples: samples, directoryName: "muesli-cli-import")
+        let resolvedDuration = duration ?? Double(samples.count) / Double(CLIWavWriter.sampleRate)
+        guard resolvedDuration > 0, resolvedDuration.isFinite else {
+            try? FileManager.default.removeItem(at: wavURL)
+            throw PreparationError.readError("Invalid audio duration.")
+        }
+        return PreparedAudioFile(wavURL: wavURL, durationSeconds: resolvedDuration, deleteWhenDone: true)
+    }
+
+    private struct CompatibleWAVInfo {
+        let duration: TimeInterval
+    }
+
+    private func compatibleWAVInfo(sourceURL: URL) throws -> CompatibleWAVInfo? {
+        guard sourceURL.pathExtension.lowercased() == "wav" else { return nil }
+        let file = try AVAudioFile(forReading: sourceURL)
+        let format = file.fileFormat
+        guard format.sampleRate == Double(CLIWavWriter.sampleRate),
+              format.channelCount == UInt32(CLIWavWriter.channels),
+              format.commonFormat == .pcmFormatInt16 else {
+            return nil
+        }
+        let duration = Double(file.length) / format.sampleRate
+        guard duration > 0, duration.isFinite else {
+            throw PreparationError.readError("Invalid audio duration.")
+        }
+        return CompatibleWAVInfo(duration: duration)
+    }
+
+    private func temporaryWAVURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-cli-import", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("import_\(UUID().uuidString).wav")
+    }
+
+    private func audioDuration(sourceURL: URL) async throws -> TimeInterval? {
+        let asset = AVURLAsset(url: sourceURL)
+        let tracks = try await asset.load(.tracks)
+        guard tracks.contains(where: { $0.mediaType == .audio }) else {
+            throw PreparationError.noAudioTracks
+        }
+        let duration = CMTimeGetSeconds(try await asset.load(.duration))
+        return duration > 0 && duration.isFinite ? duration : nil
+    }
+
+    private func decodeSamplesWithAssetReader(sourceURL: URL) async throws -> [Float] {
+        let asset = AVURLAsset(url: sourceURL)
+        let tracks = try await asset.load(.tracks)
+        guard let audioTrack = tracks.first(where: { $0.mediaType == .audio }) else {
+            throw PreparationError.noAudioTracks
+        }
+
+        let reader = try AVAssetReader(asset: asset)
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        let output = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: outputSettings)
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else {
+            throw PreparationError.conversionFailed("Could not read audio samples from the selected file.")
+        }
+        reader.add(output)
+
+        guard reader.startReading() else {
+            throw PreparationError.readError(reader.error?.localizedDescription ?? "Unknown read error")
+        }
+
+        let converter = AudioConverter()
+        var samples: [Float] = []
+        while reader.status == .reading {
+            try Task.checkCancellation()
+            guard let sampleBuffer = output.copyNextSampleBuffer() else { break }
+            samples.append(contentsOf: try converter.resampleSampleBuffer(sampleBuffer))
+        }
+        guard reader.status == .completed else {
+            throw PreparationError.readError(reader.error?.localizedDescription ?? "Read did not complete")
+        }
+        return samples
+    }
+}
+
+actor FluidAudioCLITranscriber: AudioTranscribing {
+    private var asrManager: AsrManager?
+    private var loadedModel: TranscribeModel?
+
+    func transcribe(wavURL: URL, model: TranscribeModel, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
+        try await load(model: model, progress: progress)
+        guard let asrManager else {
+            throw CLIError.invalidInput("FluidAudio model was not loaded.", fix: "Run the command again after the model finishes downloading.")
+        }
+        var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
+        let result = try await asrManager.transcribe(wavURL, decoderState: &decoderState)
+        progress("transcription complete in \(String(format: "%.2f", result.processingTime))s")
+        return HeadlessTranscription(
+            text: result.text,
+            durationSeconds: result.duration > 0 ? result.duration : nil
+        )
+    }
+
+    private func load(model: TranscribeModel, progress: @escaping (String) -> Void) async throws {
+        if loadedModel == model, asrManager != nil { return }
+        progress("loading \(model.rawValue)")
+        let models = try await AsrModels.downloadAndLoad(version: model.asrModelVersion) { downloadProgress in
+            let percent = Int((downloadProgress.fractionCompleted * 100).rounded())
+            progress("model \(percent)%")
+        }
+        let manager = AsrManager(config: .default)
+        try await manager.loadModels(models)
+        asrManager = manager
+        loadedModel = model
+        progress("model ready")
+    }
+}
+
+enum CLIWavWriter {
+    static let sampleRate: UInt32 = 16_000
+    static let channels: UInt16 = 1
+    static let bitsPerSample: UInt16 = 16
+
+    static func writeTemporaryWAV(samples: [Float], directoryName: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+        try writeWAV(samples: samples, to: url)
+        return url
+    }
+
+    static func writeWAV(samples: [Float], to url: URL) throws {
+        let int16Samples = samples.map { sample -> Int16 in
+            Int16(max(-1.0, min(1.0, sample)) * 32767)
+        }
+        var data = Data()
+        data.append(header(dataSize: UInt32(int16Samples.count * 2)))
+        int16Samples.withUnsafeBufferPointer { data.append(Data(buffer: $0)) }
+        try data.write(to: url)
+    }
+
+    private static func header(dataSize: UInt32) -> Data {
+        let byteRate = sampleRate * UInt32(channels) * UInt32(bitsPerSample / 8)
+        let blockAlign = channels * (bitsPerSample / 8)
+        var header = Data()
+        header.append(contentsOf: "RIFF".utf8)
+        header.append(contentsOf: withUnsafeBytes(of: (dataSize + 36).littleEndian) { Array($0) })
+        header.append(contentsOf: "WAVE".utf8)
+        header.append(contentsOf: "fmt ".utf8)
+        header.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: UInt16(1).littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: channels.littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: sampleRate.littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: byteRate.littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: blockAlign.littleEndian) { Array($0) })
+        header.append(contentsOf: withUnsafeBytes(of: bitsPerSample.littleEndian) { Array($0) })
+        header.append(contentsOf: "data".utf8)
+        header.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
+        return header
+    }
+}
+
+struct ConfiguredCLIMeetingSummarizer: MeetingSummarizing {
+    func summarize(transcript: String, title: String, supportDirectory: URL) async throws -> String {
+        let config = CLISummaryConfig.load(from: supportDirectory)
+        return try await CLISummaryClient.summarize(transcript: transcript, title: title, config: config)
+    }
+}
+
+struct CLISummaryConfig: Decodable {
+    var meetingSummaryBackend = "chatgpt"
+    var openAIAPIKey = ""
+    var openRouterAPIKey = ""
+    var openAIModel = ""
+    var openRouterModel = ""
+    var ollamaURL = "http://localhost:11434"
+    var ollamaModel = "qwen3.5"
+    var lmStudioURL = "http://localhost:1234"
+    var lmStudioModel = ""
+    var customLLMURL = ""
+    var customLLMAPIKey = ""
+    var customLLMModel = ""
+    var customLLMFormat = "openai"
+
+    enum CodingKeys: String, CodingKey {
+        case meetingSummaryBackend
+        case openAIAPIKey
+        case openRouterAPIKey
+        case openAIModel
+        case openRouterModel
+        case ollamaURL
+        case ollamaModel
+        case lmStudioURL
+        case lmStudioModel
+        case customLLMURL
+        case customLLMAPIKey
+        case customLLMModel
+        case customLLMFormat
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        meetingSummaryBackend = try container.decodeIfPresent(String.self, forKey: .meetingSummaryBackend) ?? meetingSummaryBackend
+        openAIAPIKey = try container.decodeIfPresent(String.self, forKey: .openAIAPIKey) ?? openAIAPIKey
+        openRouterAPIKey = try container.decodeIfPresent(String.self, forKey: .openRouterAPIKey) ?? openRouterAPIKey
+        openAIModel = try container.decodeIfPresent(String.self, forKey: .openAIModel) ?? openAIModel
+        openRouterModel = try container.decodeIfPresent(String.self, forKey: .openRouterModel) ?? openRouterModel
+        ollamaURL = try container.decodeIfPresent(String.self, forKey: .ollamaURL) ?? ollamaURL
+        ollamaModel = try container.decodeIfPresent(String.self, forKey: .ollamaModel) ?? ollamaModel
+        lmStudioURL = try container.decodeIfPresent(String.self, forKey: .lmStudioURL) ?? lmStudioURL
+        lmStudioModel = try container.decodeIfPresent(String.self, forKey: .lmStudioModel) ?? lmStudioModel
+        customLLMURL = try container.decodeIfPresent(String.self, forKey: .customLLMURL) ?? customLLMURL
+        customLLMAPIKey = try container.decodeIfPresent(String.self, forKey: .customLLMAPIKey) ?? customLLMAPIKey
+        customLLMModel = try container.decodeIfPresent(String.self, forKey: .customLLMModel) ?? customLLMModel
+        customLLMFormat = try container.decodeIfPresent(String.self, forKey: .customLLMFormat) ?? customLLMFormat
+    }
+
+    static func load(from supportDirectory: URL) -> CLISummaryConfig {
+        let url = supportDirectory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url),
+              let config = try? JSONDecoder().decode(CLISummaryConfig.self, from: data) else {
+            return CLISummaryConfig()
+        }
+        return config
+    }
+}
+
+enum CLISummaryError: LocalizedError {
+    case unavailable(String)
+    case backendFailed(String)
+    case emptyResponse(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let message), .backendFailed(let message), .emptyResponse(let message):
+            return message
+        }
+    }
+}
+
+enum CLISummaryClient {
+    private static let defaultOpenAIModel = "gpt-5.4-mini"
+    private static let defaultOpenRouterModel = "stepfun/step-3.5-flash:free"
+    private static let defaultSummaryMaxOutputTokens = 2500
+
+    static func summarize(transcript: String, title: String, config: CLISummaryConfig) async throws -> String {
+        let backend = config.meetingSummaryBackend.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch backend.isEmpty ? "chatgpt" : backend {
+        case "openai":
+            let key = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? config.openAIAPIKey
+            guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw CLISummaryError.unavailable("OpenAI summary settings are missing an API key.")
+            }
+            return try await responsesSummary(
+                backend: "OpenAI",
+                url: URL(string: "https://api.openai.com/v1/responses")!,
+                apiKey: key,
+                model: config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel,
+                transcript: transcript,
+                title: title
+            )
+        case "openrouter":
+            let key = ProcessInfo.processInfo.environment["OPENROUTER_API_KEY"] ?? config.openRouterAPIKey
+            guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw CLISummaryError.unavailable("OpenRouter summary settings are missing an API key.")
+            }
+            return try await chatCompletionsSummary(
+                backend: "OpenRouter",
+                url: URL(string: "https://openrouter.ai/api/v1/chat/completions")!,
+                apiKey: key,
+                model: config.openRouterModel.isEmpty ? defaultOpenRouterModel : config.openRouterModel,
+                transcript: transcript,
+                title: title
+            )
+        case "ollama":
+            let baseURL = URL(string: config.ollamaURL.isEmpty ? "http://localhost:11434" : config.ollamaURL)
+            guard let baseURL else { throw CLISummaryError.unavailable("Invalid Ollama URL.") }
+            return try await ollamaSummary(
+                url: baseURL.appendingPathComponent("api/chat"),
+                model: config.ollamaModel.isEmpty ? "qwen3.5" : config.ollamaModel,
+                transcript: transcript,
+                title: title
+            )
+        case "lmstudio":
+            guard !config.lmStudioModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw CLISummaryError.unavailable("LM Studio summary settings are missing a selected model.")
+            }
+            guard let url = resolveEndpointURL(config.lmStudioURL.isEmpty ? "http://localhost:1234" : config.lmStudioURL, endpointSuffix: "v1/chat/completions") else {
+                throw CLISummaryError.unavailable("Invalid LM Studio URL.")
+            }
+            return try await chatCompletionsSummary(
+                backend: "LM Studio",
+                url: url,
+                apiKey: "",
+                model: config.lmStudioModel,
+                transcript: transcript,
+                title: title
+            )
+        case "custom_llm":
+            guard !config.customLLMModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw CLISummaryError.unavailable("Custom LLM summary settings are missing a selected model.")
+            }
+            if config.customLLMFormat == "anthropic" {
+                guard !config.customLLMAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw CLISummaryError.unavailable("Custom Anthropic summary settings are missing an API key.")
+                }
+                guard let url = resolveEndpointURL(config.customLLMURL.isEmpty ? "https://api.anthropic.com" : config.customLLMURL, endpointSuffix: "v1/messages") else {
+                    throw CLISummaryError.unavailable("Invalid Custom LLM URL.")
+                }
+                return try await anthropicSummary(url: url, apiKey: config.customLLMAPIKey, model: config.customLLMModel, transcript: transcript, title: title)
+            }
+            guard let url = resolveEndpointURL(config.customLLMURL.isEmpty ? "http://localhost:8080" : config.customLLMURL, endpointSuffix: "v1/chat/completions") else {
+                throw CLISummaryError.unavailable("Invalid Custom LLM URL.")
+            }
+            return try await chatCompletionsSummary(
+                backend: "Custom LLM",
+                url: url,
+                apiKey: config.customLLMAPIKey,
+                model: config.customLLMModel,
+                transcript: transcript,
+                title: title
+            )
+        default:
+            throw CLISummaryError.unavailable("The configured ChatGPT session summary backend is app-only in headless CLI mode. Select OpenAI, OpenRouter, Ollama, LM Studio, or Custom LLM in Muesli settings for `muesli-cli transcribe --summarize`.")
+        }
+    }
+
+    private static func systemPrompt() -> String {
+        """
+        You are a meeting notes assistant. Given a raw meeting transcript, produce concise, professional markdown notes.
+        Do not invent facts. Prefer concrete takeaways over filler. Capture owners only when they are actually mentioned.
+        If a requested section has no content, write "None noted."
+
+        Follow this markdown template:
+
+        ## Summary
+        - Main points
+
+        ## Decisions
+        - Decisions made
+
+        ## Action Items
+        - Owner: task
+        """
+    }
+
+    private static func userPrompt(transcript: String, title: String) -> String {
+        "Meeting title: \(title)\n\nRaw transcript:\n\(transcript)"
+    }
+
+    private static func responsesSummary(backend: String, url: URL, apiKey: String, model: String, transcript: String, title: String) async throws -> String {
+        let body: [String: Any] = [
+            "model": model,
+            "input": [
+                ["role": "system", "content": systemPrompt()],
+                ["role": "user", "content": userPrompt(transcript: transcript, title: title)],
+            ],
+            "reasoning": ["effort": "low"],
+            "text": ["verbosity": "low"],
+            "max_output_tokens": defaultSummaryMaxOutputTokens,
+        ]
+        let data = try await postJSON(url: url, apiKey: apiKey, body: body, backend: backend)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let text = extractOpenAIText(from: json),
+              !text.isEmpty else {
+            throw CLISummaryError.emptyResponse("\(backend) returned an empty summary response.")
+        }
+        return text
+    }
+
+    private static func chatCompletionsSummary(backend: String, url: URL, apiKey: String, model: String, transcript: String, title: String) async throws -> String {
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt()],
+                ["role": "user", "content": userPrompt(transcript: transcript, title: title)],
+            ],
+            "max_tokens": defaultSummaryMaxOutputTokens,
+        ]
+        let data = try await postJSON(url: url, apiKey: apiKey, body: body, backend: backend)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let text = extractChatCompletionsText(from: json),
+              !text.isEmpty else {
+            throw CLISummaryError.emptyResponse("\(backend) returned an empty summary response.")
+        }
+        return text
+    }
+
+    private static func ollamaSummary(url: URL, model: String, transcript: String, title: String) async throws -> String {
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt()],
+                ["role": "user", "content": userPrompt(transcript: transcript, title: title)],
+            ],
+            "stream": false,
+            "options": ["num_predict": defaultSummaryMaxOutputTokens],
+        ]
+        let data = try await postJSON(url: url, apiKey: "", body: body, backend: "Ollama")
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = json["message"] as? [String: Any],
+              let text = message["content"] as? String,
+              !text.isEmpty else {
+            throw CLISummaryError.emptyResponse("Ollama returned an empty summary response.")
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func anthropicSummary(url: URL, apiKey: String, model: String, transcript: String, title: String) async throws -> String {
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": defaultSummaryMaxOutputTokens,
+            "system": systemPrompt(),
+            "messages": [
+                ["role": "user", "content": userPrompt(transcript: transcript, title: title)],
+            ],
+        ]
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 300
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let data = try await send(request: request, backend: "Custom LLM")
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]] else {
+            throw CLISummaryError.emptyResponse("Custom LLM returned an empty summary response.")
+        }
+        let text = content.compactMap { $0["text"] as? String }.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw CLISummaryError.emptyResponse("Custom LLM returned an empty summary response.")
+        }
+        return text
+    }
+
+    private static func postJSON(url: URL, apiKey: String, body: [String: Any], backend: String) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 300
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return try await send(request: request, backend: backend)
+    }
+
+    private static func send(request: URLRequest, backend: String) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            let message = extractErrorMessage(from: data)
+                ?? String(data: data, encoding: .utf8)
+                ?? HTTPURLResponse.localizedString(forStatusCode: http.statusCode)
+            throw CLISummaryError.backendFailed("\(backend) summary failed with HTTP \(http.statusCode): \(String(message.prefix(500)))")
+        }
+        return data
+    }
+
+    private static func extractOpenAIText(from payload: [String: Any]) -> String? {
+        if let outputText = payload["output_text"] as? String, !outputText.isEmpty {
+            return outputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let output = payload["output"] as? [[String: Any]] ?? []
+        for item in output where (item["type"] as? String) == "message" {
+            let content = item["content"] as? [[String: Any]] ?? []
+            for entry in content {
+                if let text = entry["text"] as? String, !text.isEmpty {
+                    return text.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func extractChatCompletionsText(from payload: [String: Any]) -> String? {
+        let choices = payload["choices"] as? [[String: Any]] ?? []
+        guard let message = choices.first?["message"] as? [String: Any] else { return nil }
+        if let content = message["content"] as? String, !content.isEmpty {
+            return content.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let error = json["error"] as? [String: Any] {
+            return error["message"] as? String ?? error["code"] as? String ?? String(describing: error)
+        }
+        return json["message"] as? String ?? json["detail"] as? String
+    }
+
+    private static func resolveEndpointURL(_ rawURL: String, endpointSuffix: String) -> URL? {
+        guard var components = URLComponents(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)),
+              components.scheme != nil,
+              components.host != nil else {
+            return nil
+        }
+        let suffixParts = endpointSuffix.split(separator: "/").map(String.init)
+        var pathParts = components.path.split(separator: "/").map(String.init)
+        if pathParts.isEmpty {
+            pathParts = suffixParts
+        } else if pathParts.last == suffixParts.first {
+            pathParts = Array(pathParts.dropLast()) + suffixParts
+        } else if !pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+            pathParts.append(contentsOf: suffixParts)
+        }
+        components.path = "/" + pathParts.joined(separator: "/")
+        return components.url
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -115,7 +115,7 @@ struct TranscribeCommand: AsyncParsableCommand {
         let outputText: String
         switch format {
         case .text:
-            outputText = result.transcript + "\n"
+            outputText = result.textOutput
         case .markdown:
             outputText = result.markdownOutput + "\n"
         case .json:
@@ -187,6 +187,10 @@ struct MuesliAudioTranscriptionResult {
     let model: TranscribeModel
     let warnings: [String]
     let savedMeetingID: Int64?
+
+    var textOutput: String {
+        transcript + "\n"
+    }
 
     var markdownOutput: String {
         var sections = ["# \(title)"]
@@ -278,8 +282,16 @@ struct MuesliAudioTranscriptionPipeline {
 
         let savedMeetingID: Int64?
         if request.saveMeeting {
-            let savedRecordingPath = try persistRecording(wavURL: prepared.wavURL, title: title, supportDirectory: context.supportDirectory)
             try context.store.migrateIfNeeded()
+            let savedRecordingPath: String?
+            do {
+                savedRecordingPath = try persistRecording(sourceURL: request.sourceURL, title: title, supportDirectory: context.supportDirectory)
+            } catch {
+                let message = "Saving audio copy failed: \(error.localizedDescription)"
+                warnings.append(message)
+                fputs("[muesli-cli] \(message)\n", stderr)
+                savedRecordingPath = nil
+            }
             let now = Date()
             let notes = summary ?? Self.rawTranscriptNotes(transcript: transcript, title: title, summaryRequested: request.summarize, warnings: warnings)
             savedMeetingID = try context.store.insertMeeting(
@@ -339,14 +351,17 @@ struct MuesliAudioTranscriptionPipeline {
         return stem.isEmpty ? "Imported Audio" : stem
     }
 
-    private func persistRecording(wavURL: URL, title: String, supportDirectory: URL) throws -> String {
+    private func persistRecording(sourceURL: URL, title: String, supportDirectory: URL) throws -> String {
         let recordingsDirectory = supportDirectory.appendingPathComponent("meeting-recordings", isDirectory: true)
         try FileManager.default.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
-        let filename = "\(formatter.string(from: Date()))_\(safeFilenameComponent(title))_\(UUID().uuidString.prefix(8)).wav"
+        let fileExtension = sourceURL.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "wav"
+            : sourceURL.pathExtension.lowercased()
+        let filename = "\(formatter.string(from: Date()))_\(safeFilenameComponent(title))_\(UUID().uuidString.prefix(8)).\(fileExtension)"
         let destinationURL = recordingsDirectory.appendingPathComponent(filename)
-        try FileManager.default.copyItem(at: wavURL, to: destinationURL)
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
         return destinationURL.path
     }
 
@@ -405,23 +420,17 @@ struct MuesliAudioFilePreparer: AudioPreparing {
         let duration = try await audioDuration(sourceURL: sourceURL)
         try Task.checkCancellation()
 
-        let samples: [Float]
-        do {
-            samples = try AudioConverter().resampleAudioFile(sourceURL)
-        } catch {
-            samples = try await decodeSamplesWithAssetReader(sourceURL: sourceURL)
-        }
-        guard !samples.isEmpty else {
+        let decoded = try await decodeAssetReaderToTemporaryWAV(sourceURL: sourceURL)
+        guard decoded.sampleCount > 0 else {
+            try? FileManager.default.removeItem(at: decoded.wavURL)
             throw PreparationError.noAudioTracks
         }
-
-        let wavURL = try CLIWavWriter.writeTemporaryWAV(samples: samples, directoryName: "muesli-cli-import")
-        let resolvedDuration = duration ?? Double(samples.count) / Double(CLIWavWriter.sampleRate)
+        let resolvedDuration = duration ?? Double(decoded.sampleCount) / Double(CLIWavWriter.sampleRate)
         guard resolvedDuration > 0, resolvedDuration.isFinite else {
-            try? FileManager.default.removeItem(at: wavURL)
+            try? FileManager.default.removeItem(at: decoded.wavURL)
             throw PreparationError.readError("Invalid audio duration.")
         }
-        return PreparedAudioFile(wavURL: wavURL, durationSeconds: resolvedDuration, deleteWhenDone: true)
+        return PreparedAudioFile(wavURL: decoded.wavURL, durationSeconds: resolvedDuration, deleteWhenDone: true)
     }
 
     private struct CompatibleWAVInfo {
@@ -461,7 +470,7 @@ struct MuesliAudioFilePreparer: AudioPreparing {
         return duration > 0 && duration.isFinite ? duration : nil
     }
 
-    private func decodeSamplesWithAssetReader(sourceURL: URL) async throws -> [Float] {
+    private func decodeAssetReaderToTemporaryWAV(sourceURL: URL) async throws -> (wavURL: URL, sampleCount: Int) {
         let asset = AVURLAsset(url: sourceURL)
         let tracks = try await asset.load(.tracks)
         guard let audioTrack = tracks.first(where: { $0.mediaType == .audio }) else {
@@ -488,16 +497,26 @@ struct MuesliAudioFilePreparer: AudioPreparing {
         }
 
         let converter = AudioConverter()
-        var samples: [Float] = []
-        while reader.status == .reading {
-            try Task.checkCancellation()
-            guard let sampleBuffer = output.copyNextSampleBuffer() else { break }
-            samples.append(contentsOf: try converter.resampleSampleBuffer(sampleBuffer))
+        let wavURL = try CLIWavWriter.temporaryWAVURL(directoryName: "muesli-cli-import")
+        do {
+            let sampleCount = try CLIWavWriter.writeWAV(to: wavURL) { handle in
+                var totalSamples = 0
+                while reader.status == .reading {
+                    try Task.checkCancellation()
+                    guard let sampleBuffer = output.copyNextSampleBuffer() else { break }
+                    let chunk = try converter.resampleSampleBuffer(sampleBuffer)
+                    totalSamples += try CLIWavWriter.append(samples: chunk, to: handle)
+                }
+                guard reader.status == .completed else {
+                    throw PreparationError.readError(reader.error?.localizedDescription ?? "Read did not complete")
+                }
+                return totalSamples
+            }
+            return (wavURL, sampleCount)
+        } catch {
+            try? FileManager.default.removeItem(at: wavURL)
+            throw error
         }
-        guard reader.status == .completed else {
-            throw PreparationError.readError(reader.error?.localizedDescription ?? "Read did not complete")
-        }
-        return samples
     }
 }
 
@@ -539,22 +558,54 @@ enum CLIWavWriter {
     static let channels: UInt16 = 1
     static let bitsPerSample: UInt16 = 16
 
-    static func writeTemporaryWAV(samples: [Float], directoryName: String) throws -> URL {
+    static func temporaryWAVURL(directoryName: String) throws -> URL {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let url = dir.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+        return dir.appendingPathComponent(UUID().uuidString).appendingPathExtension("wav")
+    }
+
+    static func writeTemporaryWAV(samples: [Float], directoryName: String) throws -> URL {
+        let url = try temporaryWAVURL(directoryName: directoryName)
         try writeWAV(samples: samples, to: url)
         return url
     }
 
     static func writeWAV(samples: [Float], to url: URL) throws {
-        let int16Samples = samples.map { sample -> Int16 in
-            Int16(max(-1.0, min(1.0, sample)) * 32767)
+        _ = try writeWAV(to: url) { handle in
+            try append(samples: samples, to: handle)
         }
+    }
+
+    @discardableResult
+    static func writeWAV(to url: URL, writeSamples: (FileHandle) throws -> Int) throws -> Int {
+        _ = FileManager.default.createFile(atPath: url.path, contents: header(dataSize: 0))
+        let handle = try FileHandle(forWritingTo: url)
+        do {
+            try handle.seekToEnd()
+            let sampleCount = try writeSamples(handle)
+            let dataSize = UInt32(sampleCount * Int(bitsPerSample / 8))
+            try handle.seek(toOffset: 0)
+            try handle.write(contentsOf: header(dataSize: dataSize))
+            try handle.close()
+            return sampleCount
+        } catch {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: url)
+            throw error
+        }
+    }
+
+    @discardableResult
+    static func append(samples: [Float], to handle: FileHandle) throws -> Int {
+        guard !samples.isEmpty else { return 0 }
         var data = Data()
-        data.append(header(dataSize: UInt32(int16Samples.count * 2)))
-        int16Samples.withUnsafeBufferPointer { data.append(Data(buffer: $0)) }
-        try data.write(to: url)
+        data.reserveCapacity(samples.count * 2)
+        for sample in samples {
+            var value = Int16(max(-1.0, min(1.0, sample)) * 32767).littleEndian
+            withUnsafeBytes(of: &value) { data.append(contentsOf: $0) }
+        }
+        try handle.write(contentsOf: data)
+        return samples.count
     }
 
     private static func header(dataSize: UInt32) -> Data {
@@ -922,10 +973,23 @@ enum CLISummaryClient {
             pathParts = suffixParts
         } else if pathParts.last == suffixParts.first {
             pathParts = Array(pathParts.dropLast()) + suffixParts
-        } else if !pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+        } else if !isCompleteEndpointPath(pathParts, endpointSuffixParts: suffixParts) {
             pathParts.append(contentsOf: suffixParts)
         }
         components.path = "/" + pathParts.joined(separator: "/")
         return components.url
+    }
+
+    private static func isCompleteEndpointPath(_ pathParts: [String], endpointSuffixParts suffixParts: [String]) -> Bool {
+        if pathParts.suffix(suffixParts.count).elementsEqual(suffixParts) {
+            return true
+        }
+        if suffixParts == ["v1", "chat", "completions"] {
+            return pathParts.suffix(2).elementsEqual(["chat", "completions"])
+        }
+        if suffixParts == ["v1", "messages"] {
+            return pathParts.count >= suffixParts.count && pathParts.last == "messages"
+        }
+        return false
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1760,6 +1760,16 @@ final class MuesliController: NSObject {
             normalizeMeetingTranscriptionSelectionForAvailability()
             return
         }
+        if !requireDownloaded {
+            config.meetingTranscriptionBackend = option.backend
+            config.meetingTranscriptionModel = option.model
+            configStore.save(config)
+            selectedMeetingTranscriptionBackend = option
+            appState.selectedMeetingTranscriptionBackend = option
+            appState.config = config
+            activeMeetingSession?.updateBackend(option)
+            return
+        }
         updateConfig {
             $0.meetingTranscriptionBackend = option.backend
             $0.meetingTranscriptionModel = option.model

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1040,6 +1040,13 @@ final class MuesliController: NSObject {
             $0.backend == config.meetingSummaryBackend
         }) ?? .chatGPT
         selectedPostProcessorBackend = TranscriptCleanupBackendOption.resolved(config.postProcessorBackend)
+        applyConfigRuntimeSideEffects(
+            wasICloudSyncEnabled: wasICloudSyncEnabled,
+            hotkeyTriggerThresholdChanged: hotkeyTriggerThresholdChanged
+        )
+    }
+
+    private func applyConfigRuntimeSideEffects(wasICloudSyncEnabled: Bool, hotkeyTriggerThresholdChanged: Bool) {
         statusBarController?.refresh()
         statusBarController?.refreshIcon()
         indicator.refreshIcon()
@@ -1761,6 +1768,7 @@ final class MuesliController: NSObject {
             return
         }
         if !requireDownloaded {
+            let wasICloudSyncEnabled = config.iCloudSyncEnabled
             config.meetingTranscriptionBackend = option.backend
             config.meetingTranscriptionModel = option.model
             configStore.save(config)
@@ -1768,6 +1776,10 @@ final class MuesliController: NSObject {
             appState.selectedMeetingTranscriptionBackend = option
             appState.config = config
             activeMeetingSession?.updateBackend(option)
+            applyConfigRuntimeSideEffects(
+                wasICloudSyncEnabled: wasICloudSyncEnabled,
+                hotkeyTriggerThresholdChanged: false
+            )
             return
         }
         updateConfig {

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
@@ -11,6 +11,7 @@ struct MuesliCLITests {
 
         #expect(names.contains("spec"))
         #expect(names.contains("info"))
+        #expect(names.contains("transcribe"))
         #expect(names.contains("meetings list"))
         #expect(names.contains("meetings get"))
         #expect(names.contains("meetings update-notes"))
@@ -64,5 +65,211 @@ struct MuesliCLITests {
         #expect(listRow.selectedTemplateName == "Weekly Team Meeting")
         #expect(listRow.selectedTemplateKind == "builtin")
         #expect(detailPayload.selectedTemplatePrompt == "## Weekly Overview")
+    }
+
+    @Test("transcribe validation rejects unsupported file extensions")
+    func transcribeRejectsUnsupportedExtension() {
+        #expect(throws: Error.self) {
+            _ = try TranscribeCommand.parse(["recording.aiff"])
+        }
+    }
+
+    @Test("transcribe enums accept documented model and format values")
+    func transcribeEnumsAcceptDocumentedValues() {
+        #expect(TranscribeModel(argument: "parakeet-v3") == .parakeetV3)
+        #expect(TranscribeModel(argument: "parakeet-v2") == .parakeetV2)
+        #expect(TranscribeModel(argument: "canary-qwen") == nil)
+        #expect(TranscribeOutputFormat(argument: "text") == .text)
+        #expect(TranscribeOutputFormat(argument: "json") == .json)
+        #expect(TranscribeOutputFormat(argument: "markdown") == .markdown)
+        #expect(TranscribeOutputFormat(argument: "xml") == nil)
+    }
+
+    @Test("transcribe text output is transcript only")
+    func transcribeTextOutputIsTranscriptOnly() throws {
+        let result = MuesliAudioTranscriptionResult(
+            title: "Demo",
+            transcript: "hello from muesli",
+            summary: nil,
+            durationSeconds: 2,
+            wordCount: 3,
+            model: .parakeetV3,
+            warnings: [],
+            savedMeetingID: nil
+        )
+
+        #expect(result.transcript + "\n" == "hello from muesli\n")
+    }
+
+    @Test("transcribe json payload follows CLI envelope")
+    func transcribeJSONPayloadUsesEnvelope() throws {
+        let payload = TranscribeJSONPayload(
+            MuesliAudioTranscriptionResult(
+                title: "Demo",
+                transcript: "hello from muesli",
+                summary: "## Summary\n\n- Done",
+                durationSeconds: 4,
+                wordCount: 3,
+                model: .parakeetV2,
+                warnings: ["summary warning"],
+                savedMeetingID: 12
+            )
+        )
+        let envelope = SuccessEnvelope(
+            command: "muesli-cli transcribe",
+            data: payload,
+            meta: MetaBody(schemaVersion: 1, generatedAt: "2026-07-08T00:00:00Z", dbPath: "/tmp/muesli.db", warnings: ["summary warning"])
+        )
+        let data = try encodedJSON(envelope)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(json["ok"] as? Bool == true)
+        #expect(json["command"] as? String == "muesli-cli transcribe")
+        let payloadData = try #require(json["data"] as? [String: Any])
+        #expect(payloadData["transcript"] as? String == "hello from muesli")
+        #expect(payloadData["model"] as? String == "parakeet-v2")
+        #expect(payloadData["savedMeetingID"] as? Int == 12)
+        #expect(payloadData["summary"] as? String == "## Summary\n\n- Done")
+
+        let nilPayload = TranscribeJSONPayload(
+            MuesliAudioTranscriptionResult(
+                title: "No Summary",
+                transcript: "raw only",
+                summary: nil,
+                durationSeconds: 2,
+                wordCount: 2,
+                model: .parakeetV3,
+                warnings: [],
+                savedMeetingID: nil
+            )
+        )
+        let nilData = try encodedJSON(nilPayload)
+        let nilJSON = try #require(JSONSerialization.jsonObject(with: nilData) as? [String: Any])
+        #expect(nilJSON.keys.contains("summary"))
+        #expect(nilJSON["summary"] is NSNull)
+        #expect(nilJSON.keys.contains("savedMeetingID"))
+        #expect(nilJSON["savedMeetingID"] is NSNull)
+    }
+
+    @Test("transcribe summary failure keeps transcript with warning")
+    func transcribeSummaryFailureKeepsTranscript() async throws {
+        let fixture = try TranscribeFixture()
+        let pipeline = MuesliAudioTranscriptionPipeline(
+            audioPreparer: FakeAudioPreparer(wavURL: fixture.wavURL, durationSeconds: 3),
+            transcriber: FakeTranscriber(text: "important transcript"),
+            summarizer: FailingSummarizer(),
+            dataChangePoster: {}
+        )
+
+        let result = try await pipeline.run(
+            request: MuesliAudioTranscriptionRequest(
+                sourceURL: fixture.sourceURL,
+                model: .parakeetV3,
+                title: "Failure Demo",
+                summarize: true,
+                saveMeeting: false
+            ),
+            context: fixture.context
+        )
+
+        #expect(result.transcript == "important transcript")
+        #expect(result.summary == nil)
+        #expect(result.warnings.count == 1)
+        #expect(result.warnings[0].contains("Summary failed"))
+    }
+
+    @Test("transcribe save meeting inserts audio import and posts data change")
+    func transcribeSaveMeetingInsertsAudioImport() async throws {
+        let fixture = try TranscribeFixture()
+        var posted = 0
+        let pipeline = MuesliAudioTranscriptionPipeline(
+            audioPreparer: FakeAudioPreparer(wavURL: fixture.wavURL, durationSeconds: 5),
+            transcriber: FakeTranscriber(text: "save this imported meeting"),
+            summarizer: SuccessfulSummarizer(notes: "## Summary\n\n- Saved"),
+            dataChangePoster: { posted += 1 }
+        )
+
+        let result = try await pipeline.run(
+            request: MuesliAudioTranscriptionRequest(
+                sourceURL: fixture.sourceURL,
+                model: .parakeetV3,
+                title: "Saved Import",
+                summarize: true,
+                saveMeeting: true
+            ),
+            context: fixture.context
+        )
+
+        let id = try #require(result.savedMeetingID)
+        let meeting = try #require(try fixture.context.store.meeting(id: id))
+        #expect(meeting.title == "Saved Import")
+        #expect(meeting.rawTranscript == "save this imported meeting")
+        #expect(meeting.formattedNotes == "## Summary\n\n- Saved")
+        #expect(meeting.source == .audioImport)
+        #expect(posted == 1)
+    }
+
+    @Test("transcribe output writes file content")
+    func transcribeOutputWritesFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-cli-output-\(UUID().uuidString)", isDirectory: true)
+        let outputURL = directory.appendingPathComponent("transcript.txt")
+        try writeOutput("plain transcript\n", to: outputURL)
+
+        #expect(try String(contentsOf: outputURL, encoding: .utf8) == "plain transcript\n")
+    }
+}
+
+private struct TranscribeFixture {
+    let directory: URL
+    let sourceURL: URL
+    let wavURL: URL
+    let context: CLIContext
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-cli-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        sourceURL = directory.appendingPathComponent("recording.wav")
+        wavURL = directory.appendingPathComponent("prepared.wav")
+        let samples = Array(repeating: Float(0.1), count: 16_000)
+        try CLIWavWriter.writeWAV(samples: samples, to: sourceURL)
+        try CLIWavWriter.writeWAV(samples: samples, to: wavURL)
+        context = CLIContext(
+            dbPath: directory.appendingPathComponent("muesli.db").path,
+            supportDir: directory.path
+        )
+    }
+}
+
+private struct FakeAudioPreparer: AudioPreparing {
+    let wavURL: URL
+    let durationSeconds: Double
+
+    func prepareAudio(sourceURL: URL) async throws -> PreparedAudioFile {
+        PreparedAudioFile(wavURL: wavURL, durationSeconds: durationSeconds, deleteWhenDone: false)
+    }
+}
+
+private struct FakeTranscriber: AudioTranscribing {
+    let text: String
+
+    func transcribe(wavURL: URL, model: TranscribeModel, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
+        progress("fake")
+        return HeadlessTranscription(text: text, durationSeconds: nil)
+    }
+}
+
+private struct SuccessfulSummarizer: MeetingSummarizing {
+    let notes: String
+
+    func summarize(transcript: String, title: String, supportDirectory: URL) async throws -> String {
+        notes
+    }
+}
+
+private struct FailingSummarizer: MeetingSummarizing {
+    func summarize(transcript: String, title: String, supportDirectory: URL) async throws -> String {
+        throw CLISummaryError.unavailable("summary backend unavailable")
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
@@ -98,7 +98,33 @@ struct MuesliCLITests {
             savedMeetingID: nil
         )
 
-        #expect(result.transcript + "\n" == "hello from muesli\n")
+        #expect(result.textOutput == "hello from muesli\n")
+    }
+
+    @Test("transcribe markdown output includes title summary and transcript")
+    func transcribeMarkdownOutputIncludesSections() throws {
+        let result = MuesliAudioTranscriptionResult(
+            title: "Demo",
+            transcript: "hello from muesli",
+            summary: "## Summary\n\n- Done",
+            durationSeconds: 2,
+            wordCount: 3,
+            model: .parakeetV3,
+            warnings: [],
+            savedMeetingID: nil
+        )
+
+        #expect(result.markdownOutput == """
+        # Demo
+
+        ## Summary
+
+        - Done
+
+        ## Raw Transcript
+
+        hello from muesli
+        """)
     }
 
     @Test("transcribe json payload follows CLI envelope")
@@ -206,6 +232,9 @@ struct MuesliCLITests {
         #expect(meeting.rawTranscript == "save this imported meeting")
         #expect(meeting.formattedNotes == "## Summary\n\n- Saved")
         #expect(meeting.source == .audioImport)
+        let savedRecordingPath = try #require(meeting.savedRecordingPath)
+        #expect(FileManager.default.fileExists(atPath: savedRecordingPath))
+        #expect(URL(fileURLWithPath: savedRecordingPath).pathExtension == fixture.sourceURL.pathExtension)
         #expect(posted == 1)
     }
 

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -182,6 +182,13 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   brew install --cask muesli
   ```
 
+- [ ] **Verify the Homebrew CLI alias when the cask exposes the bundled binary**
+  ```bash
+  brew install muesli
+  command -v muesli
+  muesli transcribe --help
+  ```
+
 ## Post-release
 
 - [ ] Verify GitHub Pages serves appcast: `curl -s https://muesli-hq.github.io/muesli/appcast.xml | head -5`

--- a/scripts/test_packaged_cli.sh
+++ b/scripts/test_packaged_cli.sh
@@ -9,6 +9,7 @@ APP_PATH="$INSTALL_ROOT/$APP_BUNDLE_NAME"
 APP_BIN="$APP_PATH/Contents/MacOS/Muesli"
 CLI_BIN="$APP_PATH/Contents/MacOS/muesli-cli"
 SPEC_OUTPUT="$INSTALL_ROOT/muesli-cli-spec.json"
+TRANSCRIBE_HELP_OUTPUT="$INSTALL_ROOT/muesli-cli-transcribe-help.txt"
 
 cleanup() {
   rm -rf "$INSTALL_ROOT"
@@ -37,10 +38,17 @@ if [[ ! -x "$CLI_BIN" ]]; then
 fi
 
 "$CLI_BIN" spec > "$SPEC_OUTPUT"
+"$CLI_BIN" transcribe --help > "$TRANSCRIBE_HELP_OUTPUT"
 
 if ! grep -q '"command" : "muesli-cli spec"' "$SPEC_OUTPUT"; then
   echo "Packaged CLI did not return the expected spec payload." >&2
   cat "$SPEC_OUTPUT" >&2
+  exit 1
+fi
+
+if ! grep -q 'USAGE: muesli-cli transcribe' "$TRANSCRIBE_HELP_OUTPUT"; then
+  echo "Packaged CLI did not return transcribe help." >&2
+  cat "$TRANSCRIBE_HELP_OUTPUT" >&2
   exit 1
 fi
 

--- a/skills/muesli-agent/SKILL.md
+++ b/skills/muesli-agent/SKILL.md
@@ -11,11 +11,11 @@ Use the local `muesli-cli` CLI as the source of truth for meeting and dictation 
 
 Resolve the binary in this order:
 1. `command -v muesli-cli`
-2. `command -v muesli` for Homebrew installs that expose the cask alias
+2. `command -v muesli` only when the resolved path is a Homebrew cask alias to `Muesli.app/Contents/MacOS/muesli-cli`; verify with `muesli info`
 3. `/Applications/Muesli.app/Contents/MacOS/muesli-cli`
 4. A local SwiftPM build path inside this repo
 
-If discovery is uncertain, run `muesli-cli info` first.
+If discovery is uncertain, run the candidate binary with `info` first and reject unrelated `muesli` executables.
 
 ## Core workflow
 
@@ -32,7 +32,7 @@ If discovery is uncertain, run `muesli-cli info` first.
 
 ## Rules
 
-- Treat CLI stdout as the API. Data commands are JSON by default; `transcribe` is plain text by default and JSON with `--format json`.
+- Treat CLI stdout as the API. Data commands are JSON by default; `transcribe` is plain text by default, Markdown with `--format markdown`, and JSON with `--format json`.
 - Treat stderr as informational only.
 - Do not mutate `rawTranscript`; only update `formattedNotes`.
 - Prefer the meeting transcript when `notesState` is `missing` or `raw_transcript_fallback`.

--- a/skills/muesli-agent/SKILL.md
+++ b/skills/muesli-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: muesli-agent
-description: Use when working with local Muesli meetings, notes, dictations, or raw transcripts through the bundled `muesli-cli` CLI. Prefer this skill when a coding agent needs to inspect transcripts, summarize meetings with its own model, or write notes back into Muesli without requiring the user's API keys.
+description: Use when working with local Muesli meetings, notes, dictations, audio-file transcription, or raw transcripts through the bundled `muesli-cli` CLI. Prefer this skill when a coding agent needs to transcribe local audio, inspect transcripts, summarize meetings with its own model, or write notes back into Muesli without requiring the user's API keys.
 ---
 
 # Muesli Agent
@@ -11,24 +11,28 @@ Use the local `muesli-cli` CLI as the source of truth for meeting and dictation 
 
 Resolve the binary in this order:
 1. `command -v muesli-cli`
-2. `/Applications/Muesli.app/Contents/MacOS/muesli-cli`
-3. A local SwiftPM build path inside this repo
+2. `command -v muesli` for Homebrew installs that expose the cask alias
+3. `/Applications/Muesli.app/Contents/MacOS/muesli-cli`
+4. A local SwiftPM build path inside this repo
 
 If discovery is uncertain, run `muesli-cli info` first.
 
 ## Core workflow
 
 1. Inspect capabilities with `muesli-cli spec` if you do not know the exact subcommand shape.
-2. List candidate meetings with `muesli-cli meetings list --limit 10`.
-3. Fetch a full record with `muesli-cli meetings get <id>`.
-4. Use the coding agent's own model to analyze `rawTranscript` and `formattedNotes`.
-5. If you want to persist improved notes, write markdown back with:
+2. To transcribe a local audio file, run `muesli-cli transcribe <file>` and read plain transcript text from stdout.
+3. Use `muesli-cli transcribe <file> --format json` when you need duration, word count, model, warnings, summary, or saved meeting ID.
+4. Add `--save-meeting` to persist an imported meeting with `source = audio_import`.
+5. List candidate meetings with `muesli-cli meetings list --limit 10`.
+6. Fetch a full record with `muesli-cli meetings get <id>`.
+7. Use the coding agent's own model to analyze `rawTranscript` and `formattedNotes`.
+8. If you want to persist improved notes, write markdown back with:
    - `cat notes.md | muesli-cli meetings update-notes <id> --stdin`
    - or `muesli-cli meetings update-notes <id> --file notes.md`
 
 ## Rules
 
-- Treat CLI stdout as the machine-readable API. It is JSON by default.
+- Treat CLI stdout as the API. Data commands are JSON by default; `transcribe` is plain text by default and JSON with `--format json`.
 - Treat stderr as informational only.
 - Do not mutate `rawTranscript`; only update `formattedNotes`.
 - Prefer the meeting transcript when `notesState` is `missing` or `raw_transcript_fallback`.

--- a/skills/muesli-agent/references/cli-contract.md
+++ b/skills/muesli-agent/references/cli-contract.md
@@ -13,7 +13,7 @@
 
 ## Output shape
 
-Data commands return JSON to stdout. `transcribe` returns plain transcript text by default; pass `--format json` to use the same success envelope.
+Data commands return JSON to stdout. `transcribe` returns plain transcript text by default, `--format markdown` emits markdown text with title, optional summary, and raw transcript sections, and `--format json` uses the same success envelope.
 
 Success envelope:
 ```json

--- a/skills/muesli-agent/references/cli-contract.md
+++ b/skills/muesli-agent/references/cli-contract.md
@@ -4,6 +4,7 @@
 
 - `muesli-cli spec`
 - `muesli-cli info`
+- `muesli-cli transcribe <file> [--format text|json|markdown] [--model parakeet-v3|parakeet-v2] [--summarize] [--save-meeting] [--title TITLE] [--output PATH]`
 - `muesli-cli meetings list [--limit N] [--folder-id ID]`
 - `muesli-cli meetings get <id>`
 - `muesli-cli meetings update-notes <id> (--stdin | --file <path>)`
@@ -12,7 +13,7 @@
 
 ## Output shape
 
-All commands return JSON to stdout.
+Data commands return JSON to stdout. `transcribe` returns plain transcript text by default; pass `--format json` to use the same success envelope.
 
 Success envelope:
 ```json
@@ -77,8 +78,40 @@ Dictation details include:
 - `timestamp`
 - `durationSeconds`
 
+Transcribe JSON data includes:
+- `transcript`
+- `summary`
+- `durationSeconds`
+- `wordCount`
+- `model`
+- `warnings`
+- `savedMeetingID`
+- `title`
+
+Supported transcribe inputs:
+- `.mp3`
+- `.mp4`
+- `.m4a`
+- `.wav`
+
+Supported transcribe models:
+- `parakeet-v3` (default)
+- `parakeet-v2`
+
+Transcribe behavior:
+- progress and model logs go to stderr
+- default stdout is transcript text only
+- `--format json` includes warnings in both `data.warnings` and `meta.warnings`
+- `--summarize` preserves the transcript if summary generation fails and returns a warning
+- `--summarize` uses configured OpenAI, OpenRouter, Ollama, LM Studio, or Custom LLM settings when available; the app's ChatGPT session backend is not driven from headless CLI mode
+- `--save-meeting` stores the meeting as `source = audio_import`
+- `--output <path>` writes the selected output format to a file and keeps stdout clean
+
 ## Expected agent pattern
 
+- `transcribe <file>` for raw local transcription
+- `transcribe <file> --format json` when structured metadata is needed
+- `transcribe <file> --save-meeting` when the imported audio should appear in Muesli
 - `list` to discover IDs
 - `get` to fetch full text
 - external summarize/analyze in the coding agent


### PR DESCRIPTION
## Summary

- Adds `muesli-cli transcribe <file>` for `.mp3`, `.mp4`, `.m4a`, and `.wav` using FluidAudio Parakeet v3 by default with optional Parakeet v2.
- Supports text, JSON, and markdown output, `--output`, `--summarize`, `--save-meeting`, `--title`, `--db-path`, and `--support-dir`.
- Persists saved imports as `source = audio_import` and posts the existing data-change notification.
- Documents the command in README, the agent CLI skill contract, release checklist, and packaged CLI smoke checks.
- Fixes meeting transcription backend selection when callers intentionally pass `requireDownloaded: false`.

## Real local validation

Used the installed MuesliDev bundle:

```bash
/Applications/MuesliDev.app/Contents/MacOS/muesli-cli transcribe --help
/Applications/MuesliDev.app/Contents/MacOS/muesli-cli spec
```

Ran real Parakeet v3 transcription against benchmark WAVs under `~/Desktop/hacks/muesli-mlx-swift-port`:

```bash
/Applications/MuesliDev.app/Contents/MacOS/muesli-cli transcribe \
  --support-dir "$HOME/Library/Application Support/MuesliDev" \
  --model parakeet-v3 \
  --output /tmp/muesli-cli-real-benchmark/reference.txt \
  ~/Desktop/hacks/muesli-mlx-swift-port/reference.wav

/Applications/MuesliDev.app/Contents/MacOS/muesli-cli transcribe \
  --support-dir "$HOME/Library/Application Support/MuesliDev" \
  --model parakeet-v3 \
  --format json \
  --output /tmp/muesli-cli-real-benchmark/sambandam-fixed.json \
  ~/Desktop/hacks/muesli-mlx-swift-port/sambandam.wav
```

Observed FluidAudio using the existing local model cache:

```text
Found parakeet-tdt-0.6b-v3 locally, no download needed
```

Representative output:

- `reference.wav`: “Hi, my name is Pranavuhari and this is a test audio for converting my voice into an American accent. Hope you can do it.”
- `sambandam.wav`: JSON returned `ok=true`, `model=parakeet-v3`, `durationSeconds=28.2666875`, `wordCount=51`, `summary=null`, `savedMeetingID=null`, and an empty warning list.

Also validated real-audio `--save-meeting --summarize` against an isolated temporary support directory so MuesliDev user data was not polluted. It inserted `savedMeetingID=1`, preserved the transcript, wrote a saved recording file, and returned a headless ChatGPT-session warning rather than dropping the transcript.

## Tests

- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/7cb2/cli-transcribe-test" --filter MuesliCLI`
- `swift test --package-path native/MuesliNative --scratch-path "$HOME/Library/Caches/muesli-spm/worktrees/7cb2/cli-transcribe-test"`
- `./scripts/dev-test.sh`
- `bash -n scripts/test_packaged_cli.sh`

Note: `/Volumes/eSSD/MuesliBuildCache.sparsebundle` did not attach earlier in this worktree, so validation reused the existing local SwiftPM cache under `~/Library/Caches/muesli-spm` instead of creating a new cache root.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786119723&installation_id=136549638&pr_number=300&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F300&signature=953cde602a73891fdc25ca9b0dd9290579e419688bd490dcf3b5748439e8e443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `muesli-cli transcribe` with support for text/markdown/JSON output, Parakeet model selection, optional summarization, optional meeting save, title override, and output-to-file.
* **Bug Fixes**
  * Improved summarization fallback so transcripts are retained with a warning when a backend is unavailable.
  * Updated meeting transcription backend switching so changes apply immediately in more cases.
* **Documentation**
  * Expanded CLI/agent documentation to reflect the new `transcribe` command, flags, and output contract.
* **Tests**
  * Added coverage for `transcribe` help, formatting, JSON envelope, and pipeline behaviors.
* **Chores**
  * Added packaged CLI smoke checks and release checklist verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->