### PR TITLE
Add surgical CI change classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,15 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Detect which files changed. This gates expensive native CI only; security
   # checks live in security.yml and are intentionally not path-filtered here.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
       app_source: ${{ steps.classify.outputs.app_source }}
@@ -34,14 +38,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Classify changed files
         id: classify
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+            if ! FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"); then
+              FILES=""
+            fi
           elif [ "${{ github.event_name }}" = "push" ]; then
-            FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
+            if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+              FILES=""
+            elif ! FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}"); then
+              FILES=""
+            fi
           else
             FILES=$(git diff --name-only HEAD^ HEAD 2>/dev/null || true)
           fi
@@ -56,6 +67,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Test changed-file classifier
         run: ./scripts/test_classify_changed_files.sh
@@ -69,6 +82,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Build (release)
         run: swift build --package-path native/MuesliNative -c release --product MuesliNativeApp
@@ -87,6 +102,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Run test shard
         run: bash ./scripts/run_ci_test_shard.sh "${{ matrix.shard }}"
@@ -100,6 +117,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Verify packaged CLI bundle
         run: ./scripts/test_packaged_cli.sh
@@ -114,6 +133,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Verify Sparkle update metadata
         run: ./scripts/verify_update_flow.sh --skip-dmg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,50 +12,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detect which files changed — no third-party actions
+  # Detect which files changed. This gates expensive native CI only; security
+  # checks live in security.yml and are intentionally not path-filtered here.
   changes:
     runs-on: ubuntu-latest
     outputs:
-      native_or_packaging: ${{ steps.check.outputs.native_or_packaging }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      app_source: ${{ steps.classify.outputs.app_source }}
+      release_surface: ${{ steps.classify.outputs.release_surface }}
+      workflow: ${{ steps.classify.outputs.workflow }}
+      ci_config: ${{ steps.classify.outputs.ci_config }}
+      site_or_metadata: ${{ steps.classify.outputs.site_or_metadata }}
+      repo_policy: ${{ steps.classify.outputs.repo_policy }}
+      unknown: ${{ steps.classify.outputs.unknown }}
+      source_or_release: ${{ steps.classify.outputs.source_or_release }}
+      full_ci: ${{ steps.classify.outputs.full_ci }}
+      workflow_ci: ${{ steps.classify.outputs.workflow_ci }}
+      review_worthy: ${{ steps.classify.outputs.review_worthy }}
+      native_or_packaging: ${{ steps.classify.outputs.native_or_packaging }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
-      - name: Check for native or packaging changes
-        id: check
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only HEAD^1 HEAD -- \
-              'native/' \
-              'assets/' \
-              'docs/appcast.xml' \
-              'scripts/build_native_app.sh' \
-              'scripts/verify_update_flow.sh' \
-              'scripts/test_packaged_cli.sh' \
-              '.github/workflows/ci.yml')
+            FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
           else
-            FILES=$(git diff --name-only HEAD~1 HEAD -- \
-              'native/' \
-              'assets/' \
-              'docs/appcast.xml' \
-              'scripts/build_native_app.sh' \
-              'scripts/verify_update_flow.sh' \
-              'scripts/test_packaged_cli.sh' \
-              '.github/workflows/ci.yml')
+            FILES=$(git diff --name-only HEAD^ HEAD 2>/dev/null || true)
           fi
-          if [ -n "$FILES" ]; then
-            echo "native_or_packaging=true" >> "$GITHUB_OUTPUT"
-            echo "Native or packaging files changed:"
-            echo "$FILES"
-          else
-            echo "native_or_packaging=false" >> "$GITHUB_OUTPUT"
-            echo "No native or packaging files changed — skipping build"
-          fi
+
+          echo "Changed files:"
+          printf '%s\n' "$FILES"
+          printf '%s\n' "$FILES" | ./scripts/classify_changed_files.sh
+
+  classifier-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Test changed-file classifier
+        run: ./scripts/test_classify_changed_files.sh
 
   # Release build — validate the app product compiles in release mode
   build_release:
     needs: changes
-    if: needs.changes.outputs.native_or_packaging == 'true'
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: macos-15
     timeout-minutes: 30
     steps:
@@ -68,7 +76,7 @@ jobs:
   # Swift tests — sharded by domain to reduce end-to-end wall time
   test_shards:
     needs: changes
-    if: needs.changes.outputs.native_or_packaging == 'true'
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: macos-15
     timeout-minutes: 30
     strategy:
@@ -86,7 +94,7 @@ jobs:
   # Packaged CLI smoke test — verify the app bundle contains muesli-cli
   cli-smoke:
     needs: changes
-    if: needs.changes.outputs.native_or_packaging == 'true'
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: macos-15
     timeout-minutes: 30
     steps:
@@ -100,7 +108,7 @@ jobs:
   # missing signatures, accidental delta entries, and malformed appcast XML.
   update-flow:
     needs: changes
-    if: needs.changes.outputs.native_or_packaging == 'true'
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -114,17 +122,19 @@ jobs:
   # This is the only required check in branch protection
   ci-gate:
     if: always()
-    needs: [changes, build_release, test_shards, cli-smoke, update-flow]
+    needs: [changes, classifier-tests, build_release, test_shards, cli-smoke, update-flow]
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
-          if [[ "${{ needs.build_release.result }}" =~ ^(success|skipped)$ ]] && \
+          if [[ "${{ needs.changes.result }}" == "success" ]] && \
+             [[ "${{ needs.classifier-tests.result }}" == "success" ]] && \
+             [[ "${{ needs.build_release.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.test_shards.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.cli-smoke.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.update-flow.result }}" =~ ^(success|skipped)$ ]]; then
-            echo "CI passed (build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
+            echo "CI passed (changes: ${{ needs.changes.result }}, classifier-tests: ${{ needs.classifier-tests.result }}, build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
           else
-            echo "CI failed (build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
+            echo "CI failed (changes: ${{ needs.changes.result }}, classifier-tests: ${{ needs.classifier-tests.result }}, build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
             exit 1
           fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       review_worthy: ${{ steps.classify.outputs.review_worthy }}
     steps:
@@ -20,14 +23,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Classify changed files
         id: classify
         run: |
-          FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          if ! FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"); then
+            FILES=""
+          fi
           echo "Changed files:"
           printf '%s\n' "$FILES"
-          printf '%s\n' "$FILES" | ./scripts/classify_changed_files.sh
+          if ! printf '%s\n' "$FILES" | ./scripts/classify_changed_files.sh; then
+            echo "::warning::Changed-file classifier failed; running Claude review as a fail-open fallback."
+            echo "review_worthy=true" >> "$GITHUB_OUTPUT"
+          fi
 
   claude-review:
     needs: changes
@@ -55,6 +64,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,10 +11,29 @@ on:
     #   - "src/**/*.jsx"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      review_worthy: ${{ steps.classify.outputs.review_worthy }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        run: |
+          FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          echo "Changed files:"
+          printf '%s\n' "$FILES"
+          printf '%s\n' "$FILES" | ./scripts/classify_changed_files.sh
+
   claude-review:
+    needs: changes
     # Fork PRs never receive the id-token permission, so the action's OIDC
     # exchange fails; skip cleanly instead of reporting a spurious failure.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.review_worthy == 'true'
 
     # Optional: Filter by PR author
     # if: |

--- a/scripts/classify_changed_files.sh
+++ b/scripts/classify_changed_files.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docs_only=true
+app_source=false
+release_surface=false
+workflow=false
+ci_config=false
+site_or_metadata=false
+repo_policy=false
+unknown=false
+count=0
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  count=$((count + 1))
+
+  case "$file" in
+    native/*)
+      app_source=true
+      docs_only=false
+      ;;
+
+    assets/sponsors/*|assets/repository-open-graph*|assets/muesli-readme-og.jpg|assets/muesli-github-ss.png)
+      site_or_metadata=true
+      ;;
+
+    assets/*)
+      app_source=true
+      docs_only=false
+      ;;
+
+    scripts/classify_changed_files.sh|scripts/test_classify_changed_files.sh)
+      ci_config=true
+      docs_only=false
+      ;;
+
+    scripts/build_native_app.sh|scripts/release*.sh|scripts/notarize_app.sh|scripts/test_packaged_cli.sh|scripts/verify_update_flow.sh|scripts/run_ci_test_shard.sh|scripts/muesli_spm_cache.sh)
+      release_surface=true
+      docs_only=false
+      ;;
+
+    scripts/*)
+      release_surface=true
+      docs_only=false
+      ;;
+
+    .github/workflows/*)
+      workflow=true
+      docs_only=false
+      case "$file" in
+        .github/workflows/ci.yml|.github/workflows/claude-code-review.yml)
+          ci_config=true
+          ;;
+      esac
+      ;;
+
+    .github/FUNDING.yml|README.md|LICENSE|docs/*.md|docs/reports/*|docs/plans/*|Context/*)
+      ;;
+
+    docs/appcast*.xml|docs/index.html|docs/download/*|docs/llms.txt)
+      release_surface=true
+      site_or_metadata=true
+      docs_only=false
+      ;;
+
+    docs/privacy.html|docs/terms.html|docs/*)
+      site_or_metadata=true
+      ;;
+
+    AGENTS.md|CLAUDE.md|CONTRIBUTING.md|REVIEW.md|.openhands/*)
+      repo_policy=true
+      ;;
+
+    *)
+      unknown=true
+      docs_only=false
+      ;;
+  esac
+done
+
+if [[ "$count" -eq 0 ]]; then
+  unknown=true
+  docs_only=false
+fi
+
+source_or_release=false
+full_ci=false
+workflow_ci=false
+review_worthy=false
+
+if [[ "$app_source" == true || "$release_surface" == true ]]; then
+  source_or_release=true
+fi
+
+if [[ "$source_or_release" == true || "$ci_config" == true || "$unknown" == true ]]; then
+  full_ci=true
+fi
+
+if [[ "$workflow" == true && "$full_ci" == false ]]; then
+  workflow_ci=true
+fi
+
+if [[ "$source_or_release" == true || "$workflow" == true || "$repo_policy" == true || "$unknown" == true ]]; then
+  review_worthy=true
+fi
+
+emit() {
+  printf '%s=%s\n' "$1" "$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+emit docs_only "$docs_only"
+emit app_source "$app_source"
+emit release_surface "$release_surface"
+emit workflow "$workflow"
+emit ci_config "$ci_config"
+emit site_or_metadata "$site_or_metadata"
+emit repo_policy "$repo_policy"
+emit unknown "$unknown"
+emit source_or_release "$source_or_release"
+emit full_ci "$full_ci"
+emit workflow_ci "$workflow_ci"
+emit review_worthy "$review_worthy"
+emit native_or_packaging "$full_ci"

--- a/scripts/classify_changed_files.sh
+++ b/scripts/classify_changed_files.sh
@@ -101,7 +101,7 @@ if [[ "$workflow" == true && "$full_ci" == false ]]; then
   workflow_ci=true
 fi
 
-if [[ "$source_or_release" == true || "$workflow" == true || "$repo_policy" == true || "$unknown" == true ]]; then
+if [[ "$source_or_release" == true || "$workflow" == true || "$ci_config" == true || "$repo_policy" == true || "$unknown" == true ]]; then
   review_worthy=true
 fi
 

--- a/scripts/test_classify_changed_files.sh
+++ b/scripts/test_classify_changed_files.sh
@@ -13,80 +13,222 @@ run_case() {
   shift 2
 
   local output="$tmpdir/$name.out"
+  local expected_file="$tmpdir/$name.expected"
   printf '%s\n' "$files" | "$CLASSIFIER" > "$output"
+  printf '%s\n' "$@" > "$expected_file"
 
-  local expected
-  for expected in "$@"; do
-    if ! grep -qx "$expected" "$output"; then
-      echo "FAIL $name: expected '$expected'"
-      echo "Actual output:"
-      cat "$output"
-      exit 1
-    fi
-  done
+  if ! diff -u "$expected_file" "$output"; then
+    echo "FAIL $name"
+    exit 1
+  fi
 }
 
 run_case readme_docs_only \
   "README.md" \
   "docs_only=true" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=false" \
   "full_ci=false" \
-  "review_worthy=false"
+  "workflow_ci=false" \
+  "review_worthy=false" \
+  "native_or_packaging=false"
 
 run_case docs_report_only \
   "docs/reports/ci.md" \
   "docs_only=true" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=false" \
   "full_ci=false" \
-  "review_worthy=false"
+  "workflow_ci=false" \
+  "review_worthy=false" \
+  "native_or_packaging=false"
 
 run_case native_source \
   "native/MuesliNative/Sources/App.swift" \
+  "docs_only=false" \
   "app_source=true" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=true" \
   "full_ci=true" \
-  "review_worthy=true"
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
 
 run_case sponsor_asset \
   "assets/sponsors/acme.svg" \
   "docs_only=true" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
   "site_or_metadata=true" \
-  "full_ci=false"
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=false" \
+  "full_ci=false" \
+  "workflow_ci=false" \
+  "review_worthy=false" \
+  "native_or_packaging=false"
 
 run_case bundled_asset \
   "assets/AppIcon.iconset/icon_512x512.png" \
+  "docs_only=false" \
   "app_source=true" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=true" \
   "full_ci=true" \
-  "review_worthy=true"
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
 
 run_case ci_workflow \
   ".github/workflows/ci.yml" \
+  "docs_only=false" \
+  "app_source=false" \
+  "release_surface=false" \
   "workflow=true" \
   "ci_config=true" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=false" \
   "full_ci=true" \
-  "review_worthy=true"
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
 
 run_case non_ci_workflow \
   ".github/workflows/claude.yml" \
+  "docs_only=false" \
+  "app_source=false" \
+  "release_surface=false" \
   "workflow=true" \
   "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=false" \
   "full_ci=false" \
   "workflow_ci=true" \
-  "review_worthy=true"
+  "review_worthy=true" \
+  "native_or_packaging=false"
 
 run_case release_script \
   "scripts/build_native_app.sh" \
+  "docs_only=false" \
+  "app_source=false" \
   "release_surface=true" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=true" \
   "full_ci=true" \
-  "review_worthy=true"
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
 
 run_case unknown_path \
   "tools/new-helper.sh" \
+  "docs_only=false" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
   "unknown=true" \
+  "source_or_release=false" \
   "full_ci=true" \
-  "review_worthy=true"
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
 
 run_case appcast_metadata \
   "docs/appcast.xml" \
+  "docs_only=false" \
+  "app_source=false" \
   "release_surface=true" \
+  "workflow=false" \
+  "ci_config=false" \
   "site_or_metadata=true" \
-  "full_ci=true"
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=true" \
+  "full_ci=true" \
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
+
+run_case empty_input \
+  "" \
+  "docs_only=false" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=true" \
+  "source_or_release=false" \
+  "full_ci=true" \
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
+
+run_case repo_policy \
+  "CONTRIBUTING.md" \
+  "docs_only=true" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=true" \
+  "unknown=false" \
+  "source_or_release=false" \
+  "full_ci=false" \
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=false"
+
+run_case mixed_docs_and_source \
+  $'README.md\nnative/MuesliNative/Sources/App.swift' \
+  "docs_only=false" \
+  "app_source=true" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=false" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=true" \
+  "full_ci=true" \
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
 
 echo "classifier tests passed"

--- a/scripts/test_classify_changed_files.sh
+++ b/scripts/test_classify_changed_files.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLASSIFIER="$ROOT_DIR/scripts/classify_changed_files.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+run_case() {
+  local name="$1"
+  local files="$2"
+  shift 2
+
+  local output="$tmpdir/$name.out"
+  printf '%s\n' "$files" | "$CLASSIFIER" > "$output"
+
+  local expected
+  for expected in "$@"; do
+    if ! grep -qx "$expected" "$output"; then
+      echo "FAIL $name: expected '$expected'"
+      echo "Actual output:"
+      cat "$output"
+      exit 1
+    fi
+  done
+}
+
+run_case readme_docs_only \
+  "README.md" \
+  "docs_only=true" \
+  "full_ci=false" \
+  "review_worthy=false"
+
+run_case docs_report_only \
+  "docs/reports/ci.md" \
+  "docs_only=true" \
+  "full_ci=false" \
+  "review_worthy=false"
+
+run_case native_source \
+  "native/MuesliNative/Sources/App.swift" \
+  "app_source=true" \
+  "full_ci=true" \
+  "review_worthy=true"
+
+run_case sponsor_asset \
+  "assets/sponsors/acme.svg" \
+  "docs_only=true" \
+  "site_or_metadata=true" \
+  "full_ci=false"
+
+run_case bundled_asset \
+  "assets/AppIcon.iconset/icon_512x512.png" \
+  "app_source=true" \
+  "full_ci=true" \
+  "review_worthy=true"
+
+run_case ci_workflow \
+  ".github/workflows/ci.yml" \
+  "workflow=true" \
+  "ci_config=true" \
+  "full_ci=true" \
+  "review_worthy=true"
+
+run_case non_ci_workflow \
+  ".github/workflows/claude.yml" \
+  "workflow=true" \
+  "ci_config=false" \
+  "full_ci=false" \
+  "workflow_ci=true" \
+  "review_worthy=true"
+
+run_case release_script \
+  "scripts/build_native_app.sh" \
+  "release_surface=true" \
+  "full_ci=true" \
+  "review_worthy=true"
+
+run_case unknown_path \
+  "tools/new-helper.sh" \
+  "unknown=true" \
+  "full_ci=true" \
+  "review_worthy=true"
+
+run_case appcast_metadata \
+  "docs/appcast.xml" \
+  "release_surface=true" \
+  "site_or_metadata=true" \
+  "full_ci=true"
+
+echo "classifier tests passed"

--- a/scripts/test_classify_changed_files.sh
+++ b/scripts/test_classify_changed_files.sh
@@ -151,6 +151,22 @@ run_case release_script \
   "review_worthy=true" \
   "native_or_packaging=true"
 
+run_case classifier_script \
+  "scripts/classify_changed_files.sh" \
+  "docs_only=false" \
+  "app_source=false" \
+  "release_surface=false" \
+  "workflow=false" \
+  "ci_config=true" \
+  "site_or_metadata=false" \
+  "repo_policy=false" \
+  "unknown=false" \
+  "source_or_release=false" \
+  "full_ci=true" \
+  "workflow_ci=false" \
+  "review_worthy=true" \
+  "native_or_packaging=true"
+
 run_case unknown_path \
   "tools/new-helper.sh" \
   "docs_only=false" \


### PR DESCRIPTION
## Summary
- add a central changed-file classifier for docs-only, source/release, workflow, CI config, and review-worthy changes
- use the classifier to gate expensive native CI without duplicating path rules in YAML
- use the same classifier to skip Claude review for low-risk docs-only changes
- add a cheap classifier test job to CI and make `ci-gate` fail if classification itself fails

## Security posture
- CodeQL and Socket remain independent of this classifier and are not path-filtered by this PR.
- The current PR checks confirm those independent security surfaces still run separately from the CI classifier.
- Unknown paths intentionally fail closed into full CI and review.
- CI workflow edits and classifier edits intentionally trigger full CI.

## Validation
- `bash -n scripts/classify_changed_files.sh scripts/test_classify_changed_files.sh`
- `scripts/test_classify_changed_files.sh`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CI change detection with classifier-based routing to run build, test, smoke, and update checks only when relevant files change.
  * Added additional classifier coverage to support pull request review-worthiness decisions.
* **Tests**
  * Introduced automated scenario tests to verify classifier outputs and prevent regressions in CI gating behavior.
* **Bug Fixes**
  * Tightened and broadened CI gating rules to require successful classifier-related checks, improving reliability and reducing unnecessary work.
  * Improved pull request review triggering behavior when classification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->