### PR TITLE
Harden the first dictation after app updates

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
@@ -463,8 +463,9 @@ enum ActivityHeatmapCalendarLayout {
         calendar: Calendar
     ) -> [[InsightsDailyActivity]] {
         Dictionary(grouping: activity) { day -> Date in
-            let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: day.date)
-            return calendar.date(from: components) ?? day.date
+            let startOfDay = calendar.startOfDay(for: day.date)
+            let daysSinceSunday = calendar.component(.weekday, from: startOfDay) - 1
+            return calendar.date(byAdding: .day, value: -daysSinceSunday, to: startOfDay) ?? startOfDay
         }
         .sorted { $0.key < $1.key }
         .map { _, days in days.sorted { $0.date < $1.date } }

--- a/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
@@ -457,30 +457,87 @@ private enum InsightsPalette {
     }
 }
 
+enum ActivityHeatmapCalendarLayout {
+    static func weeks(
+        from activity: [InsightsDailyActivity],
+        calendar: Calendar
+    ) -> [[InsightsDailyActivity]] {
+        Dictionary(grouping: activity) { day -> Date in
+            let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: day.date)
+            return calendar.date(from: components) ?? day.date
+        }
+        .sorted { $0.key < $1.key }
+        .map { _, days in days.sorted { $0.date < $1.date } }
+    }
+
+    static func monthMarker(
+        for week: [InsightsDailyActivity],
+        at index: Int,
+        calendar: Calendar
+    ) -> Date? {
+        if let monthStart = week.first(where: { calendar.component(.day, from: $0.date) == 1 }) {
+            return monthStart.date
+        }
+        return index == 0 ? week.first?.date : nil
+    }
+}
+
 private struct ActivityHeatmap: View {
     let activity: [InsightsDailyActivity]
     let metric: InsightsMetric
     private let cell: CGFloat = 14
     private let gap: CGFloat = 4
+    private let monthLabelHeight: CGFloat = 14
+    private let weekdayLabels = ["", "Mon", "", "Wed", "", "Fri", ""]
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(alignment: .top, spacing: gap) {
-                    ForEach(Array(weeks.enumerated()), id: \.offset) { _, week in
-                        VStack(spacing: gap) {
-                            ForEach(0..<7, id: \.self) { weekday in
-                                if let day = week.first(where: { Calendar.current.component(.weekday, from: $0.date) - 1 == weekday }) {
-                                    cellView(day)
-                                } else {
-                                    Color.clear.frame(width: cell, height: cell)
-                                }
-                            }
-                        }
-                        .id(week.first?.date)
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .trailing, spacing: gap) {
+                    Color.clear.frame(width: 24, height: monthLabelHeight)
+                    ForEach(Array(weekdayLabels.enumerated()), id: \.offset) { _, label in
+                        Text(label)
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(InsightsPalette.tertiaryText)
+                            .frame(width: 24, height: cell, alignment: .trailing)
                     }
                 }
-                .padding(.vertical, 3)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(alignment: .top, spacing: gap) {
+                        ForEach(Array(weeks.enumerated()), id: \.offset) { index, week in
+                            VStack(alignment: .leading, spacing: gap) {
+                                Color.clear
+                                    .frame(width: cell, height: monthLabelHeight)
+                                    .overlay(alignment: .leading) {
+                                        if let marker = ActivityHeatmapCalendarLayout.monthMarker(
+                                            for: week,
+                                            at: index,
+                                            calendar: calendar
+                                        ) {
+                                            Text(marker.formatted(.dateTime.month(.abbreviated)))
+                                                .font(.system(size: 9, weight: .medium))
+                                                .foregroundStyle(InsightsPalette.tertiaryText)
+                                                .fixedSize()
+                                        }
+                                    }
+                                VStack(spacing: gap) {
+                                    ForEach(0..<7, id: \.self) { weekday in
+                                        if let day = week.first(where: {
+                                            calendar.component(.weekday, from: $0.date) - 1 == weekday
+                                        }) {
+                                            cellView(day)
+                                        } else {
+                                            Color.clear.frame(width: cell, height: cell)
+                                        }
+                                    }
+                                }
+                                .id(week.first?.date)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 3)
+                }
             }
             .onAppear { scrollToLatest(proxy) }
             .onChange(of: activity.last?.date) { _, _ in scrollToLatest(proxy) }
@@ -495,14 +552,10 @@ private struct ActivityHeatmap: View {
         }
     }
 
+    private var calendar: Calendar { Calendar.current }
+
     private var weeks: [[InsightsDailyActivity]] {
-        Dictionary(grouping: activity) { day -> Date in
-            let calendar = Calendar.current
-            let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: day.date)
-            return calendar.date(from: components) ?? day.date
-        }
-        .sorted { $0.key < $1.key }
-        .map(\.value)
+        ActivityHeatmapCalendarLayout.weeks(from: activity, calendar: calendar)
     }
 
     private var maximum: Int {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -22,6 +22,27 @@ private enum DictationOutputMode {
     }
 }
 
+enum DictationBackendReadiness: Equatable {
+    case preparing
+    case ready
+    case failed
+
+    var allowsDictation: Bool {
+        self == .ready
+    }
+
+    func blockingMessage(backendLabel: String) -> String? {
+        switch self {
+        case .preparing:
+            return "Warming up \(backendLabel)..."
+        case .ready:
+            return nil
+        case .failed:
+            return "\(backendLabel) unavailable"
+        }
+    }
+}
+
 enum DictionaryCorrectionPromptsToggleResult {
     case updated
     case needsAccessibilityPermission
@@ -313,6 +334,7 @@ final class MuesliController: NSObject {
     private let liveManualNotesPersistInterval: TimeInterval = 0.75
     private var staleLiveMeetingRecoveryFailures = Set<Int64>()
     private var dictationState: DictationState = .idle
+    private var dictationBackendReadiness: DictationBackendReadiness = .preparing
     private var dictationStartedAt: Date?
     private var dictationLatencyTraceID: UUID?
     private var dictationLatencyTraceStartedAt: Date?
@@ -661,8 +683,10 @@ final class MuesliController: NSObject {
                         self.config.resolvedNemotron35Language.promptId
                     )
                 }
-                await self.transcriptionCoordinator.preload(
-                    backend: self.selectedBackend,
+                let dictationBackend = self.selectedBackend
+                guard await self.prepareDictationBackend(dictationBackend) else { return }
+                await self.preloadOptionalTranscriptionResources(
+                    for: dictationBackend,
                     enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
                     includeMeetingHelpers: includesMeetings
                 )
@@ -670,7 +694,7 @@ final class MuesliController: NSObject {
                     await self.transcriptionCoordinator.preload(
                         backend: self.selectedMeetingTranscriptionBackend,
                         enablePostProcessor: false,
-                        includeMeetingHelpers: true
+                        includeMeetingHelpers: false
                     )
                 }
                 await MainActor.run {
@@ -1786,6 +1810,7 @@ final class MuesliController: NSObject {
                 }
             }
         }
+        dictationBackendReadiness = .preparing
         Task { [weak self] in
             guard let self else { return }
             // Push the selected Nemotron 3.5 language before preload so the loaded
@@ -1799,11 +1824,14 @@ final class MuesliController: NSObject {
             }
             let ppOption = self.runtimePostProcessorOption()
             await self.configureTranscriptCleanupForRuntime(option: ppOption)
-            await self.transcriptionCoordinator.preload(
-                backend: option,
-                enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
-                includeMeetingHelpers: self.config.resolvedOnboardingUseCase.includesMeetings
-            )
+            let prepared = await self.prepareDictationBackend(option)
+            if prepared {
+                await self.preloadOptionalTranscriptionResources(
+                    for: option,
+                    enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
+                    includeMeetingHelpers: self.config.resolvedOnboardingUseCase.includesMeetings
+                )
+            }
             await MainActor.run {
                 if needsWarmup {
                     self.indicator.hideLoading()
@@ -1811,6 +1839,39 @@ final class MuesliController: NSObject {
                 self.statusBarController?.refresh()
                 self.historyWindowController?.updateBackendLabel()
             }
+        }
+    }
+
+    private func prepareDictationBackend(_ backend: BackendOption) async -> Bool {
+        do {
+            try await transcriptionCoordinator.preloadRequired(
+                backend: backend,
+                enablePostProcessor: false,
+                includeMeetingHelpers: false
+            )
+            guard selectedBackend == backend else { return false }
+            dictationBackendReadiness = .ready
+            indicator.hideLoading()
+            return true
+        } catch {
+            fputs("[muesli-native] dictation backend preparation failed for \(backend.backend)/\(backend.model): \(error)\n", stderr)
+            guard selectedBackend == backend else { return false }
+            dictationBackendReadiness = .failed
+            return false
+        }
+    }
+
+    private func preloadOptionalTranscriptionResources(
+        for backend: BackendOption,
+        enablePostProcessor: Bool,
+        includeMeetingHelpers: Bool
+    ) async {
+        await transcriptionCoordinator.preloadPostProcessorIfNeeded(
+            enabled: enablePostProcessor,
+            transcriptionBackend: backend
+        )
+        if includeMeetingHelpers {
+            await transcriptionCoordinator.preloadMeetingHelpers()
         }
     }
 
@@ -7004,7 +7065,28 @@ final class MuesliController: NSObject {
         selectedBackend.isStreamingDictationBackend
     }
 
+    private func ensureDictationBackendReady() -> Bool {
+        guard !isDictationTestMode else { return true }
+        guard !dictationBackendReadiness.allowsDictation else { return true }
+        guard let message = dictationBackendReadiness.blockingMessage(
+            backendLabel: selectedBackend.label
+        ) else { return true }
+
+        statusBarController?.setStatus(message)
+        statusBarController?.refresh()
+        switch dictationBackendReadiness {
+        case .preparing:
+            indicator.showLoading(message)
+        case .failed:
+            indicator.showWarning(message, icon: "!")
+        case .ready:
+            break
+        }
+        return false
+    }
+
     private func handlePrepare() {
+        guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
         fputs("[muesli-native] prepare\n", stderr)
@@ -7024,6 +7106,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleArm() {
+        guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
         if dictationLatencyTraceID == nil {
@@ -7307,6 +7390,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleStart() {
+        guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
 
@@ -7480,6 +7564,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
+        guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1856,6 +1856,7 @@ final class MuesliController: NSObject {
         } catch {
             fputs("[muesli-native] dictation backend preparation failed for \(backend.backend)/\(backend.model): \(error)\n", stderr)
             guard selectedBackend == backend else { return false }
+            indicator.hideLoading()
             dictationBackendReadiness = .failed
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -232,27 +232,7 @@ actor TranscriptionCoordinator {
         activeBackend = backend.backend
 
         if includeMeetingHelpers {
-            // Meeting helpers are intentionally loaded only when the caller needs meeting behavior.
-            if vadManager == nil {
-                do {
-                    vadManager = try await VadManager()
-                    fputs("[muesli-native] Silero VAD loaded\n", stderr)
-                } catch {
-                    fputs("[muesli-native] VAD load failed (non-critical): \(error)\n", stderr)
-                }
-            }
-
-            if diarizerManager == nil {
-                do {
-                    let diarizer = DiarizerManager()
-                    let models = try await DiarizerModels.download()
-                    diarizer.initialize(models: models)
-                    diarizerManager = diarizer
-                    fputs("[muesli-native] Speaker diarization loaded\n", stderr)
-                } catch {
-                    fputs("[muesli-native] Diarization load failed (non-critical): \(error)\n", stderr)
-                }
-            }
+            await preloadMeetingHelpers()
         }
 
         switch backend.backend {
@@ -322,6 +302,29 @@ actor TranscriptionCoordinator {
         }
 
         await preloadPostProcessorIfNeeded(enabled: enablePostProcessor, transcriptionBackend: backend)
+    }
+
+    func preloadMeetingHelpers() async {
+        if vadManager == nil {
+            do {
+                vadManager = try await VadManager()
+                fputs("[muesli-native] Silero VAD loaded\n", stderr)
+            } catch {
+                fputs("[muesli-native] VAD load failed (non-critical): \(error)\n", stderr)
+            }
+        }
+
+        if diarizerManager == nil {
+            do {
+                let diarizer = DiarizerManager()
+                let models = try await DiarizerModels.download()
+                diarizer.initialize(models: models)
+                diarizerManager = diarizer
+                fputs("[muesli-native] Speaker diarization loaded\n", stderr)
+            } catch {
+                fputs("[muesli-native] Diarization load failed (non-critical): \(error)\n", stderr)
+            }
+        }
     }
 
     func preloadPostProcessorIfNeeded(

--- a/native/MuesliNative/Tests/MuesliTests/InsightsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InsightsTests.swift
@@ -299,6 +299,31 @@ struct InsightsTests {
         #expect(smallest == 13)
     }
 
+    @Test("activity heatmap marks the visible starting month and later month boundaries")
+    func activityHeatmapMonthMarkers() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let start = calendar.date(from: DateComponents(year: 2026, month: 6, day: 20))!
+        let activity = (0..<45).map { offset in
+            InsightsDailyActivity(
+                date: calendar.date(byAdding: .day, value: offset, to: start)!,
+                words: 0,
+                meetings: 0
+            )
+        }
+
+        let weeks = ActivityHeatmapCalendarLayout.weeks(from: activity, calendar: calendar)
+        let markerMonths = weeks.enumerated().compactMap { index, week in
+            ActivityHeatmapCalendarLayout.monthMarker(
+                for: week,
+                at: index,
+                calendar: calendar
+            ).map { calendar.component(.month, from: $0) }
+        }
+
+        #expect(markerMonths == [6, 7, 8])
+    }
+
     @Test("word flow layout wraps after the available width and uses the tallest row item")
     func wordFlowLayoutWrapsAndTracksRowHeight() {
         let result = WordFlowLayout(spacing: 10).layout(

--- a/native/MuesliNative/Tests/MuesliTests/InsightsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InsightsTests.swift
@@ -324,6 +324,26 @@ struct InsightsTests {
         #expect(markerMonths == [6, 7, 8])
     }
 
+    @Test("activity heatmap keeps Sunday through Saturday in one column across locales")
+    func activityHeatmapUsesSundayFirstColumns() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 2
+        let sunday = calendar.date(from: DateComponents(year: 2026, month: 6, day: 28))!
+        let activity = (0..<7).map { offset in
+            InsightsDailyActivity(
+                date: calendar.date(byAdding: .day, value: offset, to: sunday)!,
+                words: 0,
+                meetings: 0
+            )
+        }
+
+        let weeks = ActivityHeatmapCalendarLayout.weeks(from: activity, calendar: calendar)
+
+        #expect(weeks.count == 1)
+        #expect(weeks[0].map { calendar.component(.weekday, from: $0.date) } == Array(1...7))
+    }
+
     @Test("word flow layout wraps after the available width and uses the tallest row item")
     func wordFlowLayoutWrapsAndTracksRowHeight() {
         let result = WordFlowLayout(spacing: 10).layout(

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -4,6 +4,33 @@ import Foundation
 import MuesliCore
 @testable import MuesliNativeApp
 
+@Suite("Dictation backend readiness")
+struct DictationBackendReadinessTests {
+    @Test("preparing backend blocks dictation with existing warmup copy")
+    func preparingBlocksDictation() {
+        let readiness = DictationBackendReadiness.preparing
+
+        #expect(!readiness.allowsDictation)
+        #expect(readiness.blockingMessage(backendLabel: "Parakeet v3") == "Warming up Parakeet v3...")
+    }
+
+    @Test("ready backend allows dictation")
+    func readyAllowsDictation() {
+        let readiness = DictationBackendReadiness.ready
+
+        #expect(readiness.allowsDictation)
+        #expect(readiness.blockingMessage(backendLabel: "Parakeet v3") == nil)
+    }
+
+    @Test("failed backend remains blocked with actionable status")
+    func failedBlocksDictation() {
+        let readiness = DictationBackendReadiness.failed
+
+        #expect(!readiness.allowsDictation)
+        #expect(readiness.blockingMessage(backendLabel: "Parakeet v3") == "Parakeet v3 unavailable")
+    }
+}
+
 // MARK: - ChatGPT File-based Token Storage
 
 @Suite("ChatGPT Token Storage")


### PR DESCRIPTION
## Why

Some users report that the first dictation immediately after updating Muesli records audio but does not produce or paste a transcript. Quitting and reopening the app makes later dictations work.

The startup hotkey path becomes available before the selected transcription backend has necessarily finished loading. That race is most visible after an update, when model and graph caches may be cold.

## What changed

- Track whether the selected dictation backend is preparing, ready, or unavailable.
- Block normal dictation entry points until required backend loading and warm-up complete.
- Reuse the existing floating `Warming up...` status instead of starting a recording that cannot yet be transcribed.
- Keep optional transcript cleanup and meeting VAD/diarization preloads from delaying basic dictation readiness.
- Preserve the existing onboarding dictation-test flow and normal ready-state dictation behavior.
- Add month and weekday orientation labels to the Local Insights activity heatmap as a small accompanying UI correction.

This intentionally avoids adding retries or redesigning the established dictation pipeline. Once the backend is ready, the hero dictation path is unchanged.

## Validation

- 163 adjacent dictation, recorder, hotkey, paste, backend, and transcription-runtime tests passed.
- 24 focused Local Insights and backend-readiness tests passed.
- `git diff --check` passed.
- Built, signed, installed, and launched as isolated `MuesliDevA` through the shared eSSD SwiftPM cache.

A real Sparkle post-update cycle remains the release-stage acceptance test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786490877&installation_id=136549638&pr_number=311&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F311&signature=06dab38acf513fbe0cd40658ab4994c3075ba364dc20587f47b6993a266bd269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the activity heatmap to use a fixed weekday label column with a horizontally scrollable week grid and month markers.
  * Added clearer dictation backend readiness states, including loading and unavailable messaging.
  * Dictation now waits for required backend preparation before allowing start/arm/enable actions.
* **Bug Fixes**
  * Improved calendar grouping and month-boundary calculations for the heatmap.
* **Tests**
  * Added tests for activity heatmap month markers and dictation backend readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->