### PR TITLE
Add v0.8 in-product feature walkthrough

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -96,6 +96,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller?.focusSearchField()
     }
 
+    @objc func showWhatsNew(_ sender: Any?) {
+        controller?.showWhatsNew()
+    }
+
     private func installStandardEditMenu() {
         let mainMenu = NSMenu()
 
@@ -108,6 +112,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         settingsItem.target = self
         appMenu.addItem(settingsItem)
+        let whatsNewItem = NSMenuItem(
+            title: "What's New in Muesli",
+            action: #selector(AppDelegate.showWhatsNew(_:)),
+            keyEquivalent: ""
+        )
+        whatsNewItem.target = self
+        appMenu.addItem(whatsNewItem)
         appMenu.addItem(.separator())
         appMenu.addItem(
             withTitle: "Quit \(AppIdentity.displayName)",

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppIdentity.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppIdentity.swift
@@ -12,6 +12,10 @@ enum AppIdentity {
         stringValue(for: "CFBundleDisplayName") ?? bundleName
     }
 
+    static var marketingVersion: String {
+        stringValue(for: "CFBundleShortVersionString") ?? "0.0.0"
+    }
+
     static var supportDirectoryName: String {
         stringValue(for: "MuesliSupportDirectoryName") ?? displayName
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -20,6 +20,44 @@ enum InsightsSection: String, CaseIterable, Sendable {
     case meetings
 }
 
+enum SettingsPane: String, CaseIterable, Identifiable {
+    case general
+    case sync
+    case dictation
+    case computerUse
+    case meetings
+    case appearance
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general: return "General"
+        case .sync: return "Sync"
+        case .dictation: return "Dictation"
+        case .computerUse: return "Computer Use"
+        case .meetings: return "Meetings"
+        case .appearance: return "Appearance"
+        }
+    }
+}
+
+enum ModelsCategory: String, CaseIterable, Identifiable {
+    case dictation
+    case streaming
+    case postProcessing
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .dictation: return "Dictation"
+        case .streaming: return "Streaming"
+        case .postProcessing: return "Post-processing"
+        }
+    }
+}
+
 enum MeetingsNavigationState: Equatable {
     case browser
     case document(Int64)
@@ -160,6 +198,11 @@ final class AppState {
     // Navigation
     var selectedTab: DashboardTab = .dictations
     var insightsInitialSection: InsightsSection = .words
+    var selectedSettingsPane: SettingsPane = .general
+    var selectedModelsCategory: ModelsCategory = .dictation
+    var pendingFeatureTourInvitation: FeatureTour?
+    var activeFeatureTour: FeatureTour?
+    var featureTourStepIndex: Int = 0
 
     // Computed
     var selectedMeeting: MeetingRecord? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -4,6 +4,7 @@ import MuesliCore
 struct DashboardRootView: View {
     let appState: AppState
     let controller: MuesliController
+    @State private var featureTourTargetFrames: [FeatureTourTarget: CGRect] = [:]
 
     var body: some View {
         NavigationSplitView {
@@ -17,6 +18,40 @@ struct DashboardRootView: View {
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 900, minHeight: 600)
         .preferredColorScheme(appState.config.darkMode ? .dark : .light)
+        .onPreferenceChange(FeatureTourTargetPreferenceKey.self) { frames in
+            featureTourTargetFrames = frames
+        }
+        .overlay {
+            GeometryReader { proxy in
+                if let invitation = appState.pendingFeatureTourInvitation {
+                    FeatureTourInvitationView(
+                        tour: invitation,
+                        onAccept: { controller.acceptFeatureTourInvitation() },
+                        onSkip: { controller.skipFeatureTourInvitation() }
+                    )
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+                    .zIndex(101)
+                } else if let tour = appState.activeFeatureTour,
+                   tour.steps.indices.contains(appState.featureTourStepIndex),
+                   let globalTargetFrame = featureTourTargetFrames[tour.steps[appState.featureTourStepIndex].target] {
+                    let globalRootFrame = proxy.frame(in: .global)
+                    let targetFrame = globalTargetFrame.offsetBy(
+                        dx: -globalRootFrame.minX,
+                        dy: -globalRootFrame.minY
+                    )
+                    FeatureTourOverlay(
+                        tour: tour,
+                        stepIndex: appState.featureTourStepIndex,
+                        spotlightRect: targetFrame,
+                        containerSize: proxy.size,
+                        onBack: { controller.showPreviousFeatureTourStep() },
+                        onNext: { controller.showNextFeatureTourStep() },
+                        onDismiss: { controller.dismissFeatureTour() }
+                    )
+                    .zIndex(100)
+                }
+            }
+        }
         .alert(
             appState.contributionMilestonePrompt?.title ?? "Muesli milestone",
             isPresented: Binding(

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -19,6 +19,10 @@ struct DashboardRootView: View {
         .frame(minWidth: 900, minHeight: 600)
         .preferredColorScheme(appState.config.darkMode ? .dark : .light)
         .onPreferenceChange(FeatureTourTargetPreferenceKey.self) { frames in
+            guard FeatureTourFrameTracking.hasMeaningfulChange(
+                from: featureTourTargetFrames,
+                to: frames
+            ) else { return }
             featureTourTargetFrames = frames
         }
         .overlay {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+struct MarketingVersion: Comparable, Equatable {
+    let components: [Int]
+
+    init?(_ value: String) {
+        let numericPrefix = value.split(separator: "-", maxSplits: 1).first ?? Substring(value)
+        let parts = numericPrefix.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parts.isEmpty,
+              parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }) else {
+            return nil
+        }
+        components = parts.compactMap { Int($0) }
+    }
+
+    static func == (lhs: MarketingVersion, rhs: MarketingVersion) -> Bool {
+        !(lhs < rhs) && !(rhs < lhs)
+    }
+
+    static func < (lhs: MarketingVersion, rhs: MarketingVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        for index in 0..<count {
+            let left = index < lhs.components.count ? lhs.components[index] : 0
+            let right = index < rhs.components.count ? rhs.components[index] : 0
+            if left != right { return left < right }
+        }
+        return false
+    }
+}
+
+enum FeatureTourTarget: String, Hashable {
+    case insightsEntry
+    case meetingsSidebar
+    case liveCaptionsSetting
+    case cloudCleanupSetting
+    case experimentalModels
+}
+
+struct FeatureTourStep: Identifiable, Equatable {
+    let id: String
+    let eyebrow: String
+    let title: String
+    let message: String
+    let systemImage: String
+    let target: FeatureTourTarget
+}
+
+struct FeatureTour: Equatable {
+    let version: String
+    let steps: [FeatureTourStep]
+}
+
+enum FeatureTourCatalog {
+    static var latest: FeatureTour {
+        latest(includeCloudCleanup: false)
+    }
+
+    static func latest(includeCloudCleanup: Bool) -> FeatureTour {
+        var steps = [
+            FeatureTourStep(
+                id: "insights",
+                eyebrow: "LOCAL INSIGHTS",
+                title: "Your stats now open Insights",
+                message: "Select any stat card to explore private word, meeting, pace, streak, and daily activity trends calculated from your local history.",
+                systemImage: "chart.bar.xaxis",
+                target: .insightsEntry
+            ),
+            FeatureTourStep(
+                id: "meeting-workspace",
+                eyebrow: "MEETING WORKSPACE",
+                title: "Continue work after the call",
+                message: "Open Meetings to see what is coming up, resume a recording, follow detected links, organize folders, and export notes, transcripts, or compressed audio.",
+                systemImage: "person.2.fill",
+                target: .meetingsSidebar
+            ),
+            FeatureTourStep(
+                id: "live-captions",
+                eyebrow: "LIVE MEETING CAPTIONS",
+                title: "Choose how meetings appear live",
+                message: "Live captions remain off by default. Download a supported streaming model, then choose it here to preview speech while a meeting is running.",
+                systemImage: "captions.bubble.fill",
+                target: .liveCaptionsSetting
+            ),
+        ]
+
+        if includeCloudCleanup {
+            steps.append(FeatureTourStep(
+                id: "cloud-cleanup",
+                eyebrow: "CLOUD DICTATION CLEANUP",
+                title: "Your ChatGPT connection can refine dictation",
+                message: "Choose ChatGPT as the cleanup backend to remove filler words, format spoken lists, and apply your cleanup preset after local transcription.",
+                systemImage: "wand.and.stars",
+                target: .cloudCleanupSetting
+            ))
+        }
+
+        steps.append(
+            FeatureTourStep(
+                id: "models",
+                eyebrow: "NEW MODEL OPTIONS",
+                title: "New streaming and experimental models",
+                message: "Use the new tabs to find Nemotron 3.5 and Parakeet Realtime for streaming, plus Indic ASR and the Gemma 4 evaluation backend under Experimental.",
+                systemImage: "cpu",
+                target: .experimentalModels
+            )
+        )
+
+        return FeatureTour(version: "0.8.0", steps: steps)
+    }
+}
+
+enum FeatureTourPresentationPolicy {
+    static func shouldPresentAutomatically(
+        currentVersion: String,
+        previousVersion: String?,
+        lastPresentedTourVersion: String?,
+        hasCompletedOnboarding: Bool,
+        tour: FeatureTour
+    ) -> Bool {
+        guard hasCompletedOnboarding,
+              let current = MarketingVersion(currentVersion),
+              let target = MarketingVersion(tour.version),
+              current >= target else {
+            return false
+        }
+
+        if let lastPresentedTourVersion,
+           let lastPresented = MarketingVersion(lastPresentedTourVersion),
+           lastPresented >= target {
+            return false
+        }
+
+        guard let previousVersion else {
+            // 0.8 is the first release with this marker. A completed onboarding
+            // identifies an existing pre-0.8 install rather than a fresh install.
+            return true
+        }
+        guard let previous = MarketingVersion(previousVersion) else { return true }
+        return previous < target
+    }
+}
+
+final class FeatureTourStore {
+    private enum Key {
+        static let lastLaunchedVersion = "featureTour.lastLaunchedVersion"
+        static let lastPresentedVersion = "featureTour.lastPresentedVersion"
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func automaticTour(
+        currentVersion: String,
+        hasCompletedOnboarding: Bool,
+        canPresent: Bool,
+        tour: FeatureTour = FeatureTourCatalog.latest
+    ) -> FeatureTour? {
+        if !hasCompletedOnboarding {
+            defaults.set(currentVersion, forKey: Key.lastLaunchedVersion)
+            return nil
+        }
+
+        // Permission-repair onboarding owns the foreground. Leave the previous
+        // version untouched so the tour remains eligible on the next healthy launch.
+        guard canPresent else { return nil }
+
+        let shouldPresent = FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: currentVersion,
+            previousVersion: defaults.string(forKey: Key.lastLaunchedVersion),
+            lastPresentedTourVersion: defaults.string(forKey: Key.lastPresentedVersion),
+            hasCompletedOnboarding: true,
+            tour: tour
+        )
+        defaults.set(currentVersion, forKey: Key.lastLaunchedVersion)
+        return shouldPresent ? tour : nil
+    }
+
+    func markOffered(_ tour: FeatureTour) {
+        defaults.set(tour.version, forKey: Key.lastPresentedVersion)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -39,7 +39,19 @@ enum FeatureTourTarget: String, Hashable {
     case meetingsSidebar
     case liveCaptionsSetting
     case cloudCleanupSetting
+    case streamingModels
     case experimentalModels
+
+    var modelsCategory: ModelsCategory? {
+        switch self {
+        case .streamingModels:
+            return .streaming
+        case .experimentalModels:
+            return .dictation
+        case .insightsEntry, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
+            return nil
+        }
+    }
 }
 
 struct FeatureTourStep: Identifiable, Equatable {
@@ -58,6 +70,14 @@ struct FeatureTour: Equatable {
     var displayVersion: String {
         guard let marketingVersion = MarketingVersion(version) else { return version }
         return marketingVersion.components.prefix(2).map(String.init).joined(separator: ".")
+    }
+}
+
+extension AppState {
+    var activeFeatureTourTarget: FeatureTourTarget? {
+        guard let activeFeatureTour,
+              activeFeatureTour.steps.indices.contains(featureTourStepIndex) else { return nil }
+        return activeFeatureTour.steps[featureTourStepIndex].target
     }
 }
 
@@ -105,16 +125,24 @@ enum FeatureTourCatalog {
             ))
         }
 
-        steps.append(
+        steps.append(contentsOf: [
             FeatureTourStep(
-                id: "models",
-                eyebrow: "NEW MODEL OPTIONS",
-                title: "New streaming and experimental models",
-                message: "Use the new tabs to find Nemotron 3.5 and Parakeet Realtime for streaming, plus Indic ASR and the Gemma 4 evaluation backend under Experimental.",
+                id: "streaming-models",
+                eyebrow: "LIVE MODEL OPTIONS",
+                title: "Choose your live transcription engine",
+                message: "The Streaming tab groups Nemotron 3.5 for live and final meeting transcripts with Parakeet Realtime for low-latency live preview.",
+                systemImage: "waveform.badge.mic",
+                target: .streamingModels
+            ),
+            FeatureTourStep(
+                id: "experimental-models",
+                eyebrow: "EXPERIMENTAL MODELS",
+                title: "Try new local dictation backends",
+                message: "Expand Experimental to evaluate SenseVoice, Qwen3 ASR, Indic ASR, and Gemma 4 without mixing them into the default model choices.",
                 systemImage: "cpu",
                 target: .experimentalModels
             )
-        )
+        ])
 
         return FeatureTour(version: "0.8.0", steps: steps)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -10,7 +10,13 @@ struct MarketingVersion: Comparable, Equatable {
               parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }) else {
             return nil
         }
-        components = parts.compactMap { Int($0) }
+        var parsedComponents: [Int] = []
+        parsedComponents.reserveCapacity(parts.count)
+        for part in parts {
+            guard let component = Int(part) else { return nil }
+            parsedComponents.append(component)
+        }
+        components = parsedComponents
     }
 
     static func == (lhs: MarketingVersion, rhs: MarketingVersion) -> Bool {
@@ -48,6 +54,11 @@ struct FeatureTourStep: Identifiable, Equatable {
 struct FeatureTour: Equatable {
     let version: String
     let steps: [FeatureTourStep]
+
+    var displayVersion: String {
+        guard let marketingVersion = MarketingVersion(version) else { return version }
+        return marketingVersion.components.prefix(2).map(String.init).joined(separator: ".")
+    }
 }
 
 enum FeatureTourCatalog {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+
+struct FeatureTourTargetPreferenceKey: PreferenceKey {
+    static var defaultValue: [FeatureTourTarget: CGRect] = [:]
+
+    static func reduce(
+        value: inout [FeatureTourTarget: CGRect],
+        nextValue: () -> [FeatureTourTarget: CGRect]
+    ) {
+        value.merge(nextValue(), uniquingKeysWith: { _, latest in latest })
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func featureTourTarget(_ target: FeatureTourTarget?) -> some View {
+        if let target {
+            background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: FeatureTourTargetPreferenceKey.self,
+                        value: [
+                            target: proxy.frame(in: .global)
+                        ]
+                    )
+                }
+            }
+        } else {
+            self
+        }
+    }
+}
+
+struct FeatureTourOverlay: View {
+    let tour: FeatureTour
+    let stepIndex: Int
+    let spotlightRect: CGRect
+    let containerSize: CGSize
+    let onBack: () -> Void
+    let onNext: () -> Void
+    let onDismiss: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var step: FeatureTourStep {
+        tour.steps[stepIndex]
+    }
+
+    private var expandedSpotlight: CGRect {
+        spotlightRect.insetBy(dx: -8, dy: -8)
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color.clear
+                .contentShape(Rectangle())
+
+            FeatureTourDimmingShape(spotlight: expandedSpotlight, cornerRadius: 10)
+                .fill(
+                    Color.black.opacity(0.72),
+                    style: FillStyle(eoFill: true, antialiased: true)
+                )
+                .allowsHitTesting(false)
+
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(MuesliTheme.accent, lineWidth: 2)
+                .frame(width: expandedSpotlight.width, height: expandedSpotlight.height)
+                .position(x: expandedSpotlight.midX, y: expandedSpotlight.midY)
+                .shadow(color: MuesliTheme.accent.opacity(0.55), radius: 10)
+                .allowsHitTesting(false)
+
+            callout
+                .frame(width: 380)
+                .position(calloutPosition)
+        }
+        .frame(width: containerSize.width, height: containerSize.height)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: step.id)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var callout: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                Image(systemName: step.systemImage)
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .frame(width: 24, height: 24)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(step.eyebrow)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(MuesliTheme.accent)
+                    Text(step.title)
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: MuesliTheme.spacing8)
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .help("End walkthrough")
+                .accessibilityLabel("End walkthrough")
+            }
+
+            Text(step.message)
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: MuesliTheme.spacing12) {
+                Text("\(stepIndex + 1) of \(tour.steps.count)")
+                    .font(MuesliTheme.caption())
+                    .monospacedDigit()
+                    .foregroundStyle(MuesliTheme.textTertiary)
+
+                Spacer()
+
+                if stepIndex > 0 {
+                    Button(action: onBack) {
+                        Label("Back", systemImage: "chevron.left")
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                Button(action: onNext) {
+                    Label(
+                        stepIndex == tour.steps.count - 1 ? "Done" : "Next",
+                        systemImage: stepIndex == tour.steps.count - 1 ? "checkmark" : "chevron.right"
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(MuesliTheme.spacing20)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.45), radius: 24, x: 0, y: 12)
+    }
+
+    private var calloutPosition: CGPoint {
+        let calloutWidth: CGFloat = 380
+        let calloutHeight: CGFloat = 230
+        let margin: CGFloat = 20
+        let gap: CGFloat = 24
+
+        let proposedX: CGFloat
+        let proposedY: CGFloat
+        switch step.target {
+        case .meetingsSidebar:
+            proposedX = expandedSpotlight.maxX + gap + calloutWidth / 2
+            proposedY = expandedSpotlight.midY
+        case .insightsEntry, .liveCaptionsSetting:
+            proposedX = expandedSpotlight.midX
+            proposedY = expandedSpotlight.maxY + gap + calloutHeight / 2
+        case .cloudCleanupSetting, .experimentalModels:
+            proposedX = expandedSpotlight.midX
+            proposedY = expandedSpotlight.minY - gap - calloutHeight / 2
+        }
+
+        return CGPoint(
+            x: min(max(proposedX, margin + calloutWidth / 2), containerSize.width - margin - calloutWidth / 2),
+            y: min(max(proposedY, margin + calloutHeight / 2), containerSize.height - margin - calloutHeight / 2)
+        )
+    }
+}
+
+struct FeatureTourInvitationView: View {
+    let tour: FeatureTour
+    let onAccept: () -> Void
+    let onSkip: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.66)
+                .contentShape(Rectangle())
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+                HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .frame(width: 26, height: 26)
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("MUESLI 0.8")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(MuesliTheme.accent)
+                        Text("Want a quick tour of what’s new?")
+                            .font(.system(size: 21, weight: .bold))
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                    }
+
+                    Spacer(minLength: MuesliTheme.spacing8)
+
+                    Button(action: onSkip) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 12, weight: .semibold))
+                            .frame(width: 24, height: 24)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .help("Skip walkthrough")
+                    .accessibilityLabel("Skip walkthrough")
+                }
+
+                Text("See \(tour.steps.count) additions in the places where you’ll actually use them. You can replay this later from What’s New in Muesli.")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: MuesliTheme.spacing12) {
+                    Spacer()
+                    Button("Skip", action: onSkip)
+                        .buttonStyle(.bordered)
+                    Button(action: onAccept) {
+                        Label("Take the Tour", systemImage: "arrow.right")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(MuesliTheme.spacing24)
+            .frame(width: 460)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+            .shadow(color: Color.black.opacity(0.5), radius: 28, x: 0, y: 14)
+        }
+    }
+}
+
+private struct FeatureTourDimmingShape: Shape {
+    let spotlight: CGRect
+    let cornerRadius: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path(rect)
+        path.addRoundedRect(
+            in: spotlight,
+            cornerSize: CGSize(width: cornerRadius, height: cornerRadius)
+        )
+        return path
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -86,7 +86,7 @@ struct FeatureTourCalloutLayout {
             return [.trailing, .leading, .below, .above]
         case .insightsEntry, .liveCaptionsSetting:
             return [.below, .above, .trailing, .leading]
-        case .cloudCleanupSetting, .experimentalModels:
+        case .cloudCleanupSetting, .streamingModels, .experimentalModels:
             return [.above, .below, .trailing, .leading]
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -11,6 +11,147 @@ struct FeatureTourTargetPreferenceKey: PreferenceKey {
     }
 }
 
+struct FeatureTourFrameTracking {
+    static func hasMeaningfulChange(
+        from current: [FeatureTourTarget: CGRect],
+        to updated: [FeatureTourTarget: CGRect],
+        tolerance: CGFloat = 0.5
+    ) -> Bool {
+        guard Set(current.keys) == Set(updated.keys) else { return true }
+        return updated.contains { target, rect in
+            guard let existing = current[target] else { return true }
+            return abs(existing.minX - rect.minX) > tolerance
+                || abs(existing.minY - rect.minY) > tolerance
+                || abs(existing.width - rect.width) > tolerance
+                || abs(existing.height - rect.height) > tolerance
+        }
+    }
+}
+
+private struct FeatureTourCalloutSizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        if next.width > 0, next.height > 0 {
+            value = next
+        }
+    }
+}
+
+private enum FeatureTourCalloutEdge {
+    case above
+    case below
+    case leading
+    case trailing
+}
+
+struct FeatureTourCalloutLayout {
+    static func position(
+        spotlight: CGRect,
+        containerSize: CGSize,
+        calloutSize: CGSize,
+        target: FeatureTourTarget,
+        margin: CGFloat = 20,
+        gap: CGFloat = 24
+    ) -> CGPoint {
+        let bounds = CGRect(
+            x: margin,
+            y: margin,
+            width: max(0, containerSize.width - margin * 2),
+            height: max(0, containerSize.height - margin * 2)
+        )
+        let candidates = preferredEdges(for: target).map {
+            center(for: $0, spotlight: spotlight, calloutSize: calloutSize, gap: gap)
+        }
+
+        if let fitting = candidates.first(where: {
+            bounds.contains(frame(centeredAt: $0, size: calloutSize))
+        }) {
+            return fitting
+        }
+
+        let clamped = candidates.map {
+            clamp($0, calloutSize: calloutSize, to: bounds)
+        }
+        return clamped.min { lhs, rhs in
+            overlapArea(frame(centeredAt: lhs, size: calloutSize), spotlight)
+                < overlapArea(frame(centeredAt: rhs, size: calloutSize), spotlight)
+        } ?? CGPoint(x: containerSize.width / 2, y: containerSize.height / 2)
+    }
+
+    private static func preferredEdges(for target: FeatureTourTarget) -> [FeatureTourCalloutEdge] {
+        switch target {
+        case .meetingsSidebar:
+            return [.trailing, .leading, .below, .above]
+        case .insightsEntry, .liveCaptionsSetting:
+            return [.below, .above, .trailing, .leading]
+        case .cloudCleanupSetting, .experimentalModels:
+            return [.above, .below, .trailing, .leading]
+        }
+    }
+
+    private static func center(
+        for edge: FeatureTourCalloutEdge,
+        spotlight: CGRect,
+        calloutSize: CGSize,
+        gap: CGFloat
+    ) -> CGPoint {
+        switch edge {
+        case .above:
+            return CGPoint(x: spotlight.midX, y: spotlight.minY - gap - calloutSize.height / 2)
+        case .below:
+            return CGPoint(x: spotlight.midX, y: spotlight.maxY + gap + calloutSize.height / 2)
+        case .leading:
+            return CGPoint(x: spotlight.minX - gap - calloutSize.width / 2, y: spotlight.midY)
+        case .trailing:
+            return CGPoint(x: spotlight.maxX + gap + calloutSize.width / 2, y: spotlight.midY)
+        }
+    }
+
+    private static func frame(centeredAt center: CGPoint, size: CGSize) -> CGRect {
+        CGRect(
+            x: center.x - size.width / 2,
+            y: center.y - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    private static func clamp(_ center: CGPoint, calloutSize: CGSize, to bounds: CGRect) -> CGPoint {
+        CGPoint(
+            x: clampedCoordinate(
+                center.x,
+                lower: bounds.minX + calloutSize.width / 2,
+                upper: bounds.maxX - calloutSize.width / 2,
+                fallback: bounds.midX
+            ),
+            y: clampedCoordinate(
+                center.y,
+                lower: bounds.minY + calloutSize.height / 2,
+                upper: bounds.maxY - calloutSize.height / 2,
+                fallback: bounds.midY
+            )
+        )
+    }
+
+    private static func clampedCoordinate(
+        _ value: CGFloat,
+        lower: CGFloat,
+        upper: CGFloat,
+        fallback: CGFloat
+    ) -> CGFloat {
+        guard lower <= upper else { return fallback }
+        return min(max(value, lower), upper)
+    }
+
+    private static func overlapArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull else { return 0 }
+        return intersection.width * intersection.height
+    }
+}
+
 extension View {
     @ViewBuilder
     func featureTourTarget(_ target: FeatureTourTarget?) -> some View {
@@ -41,6 +182,7 @@ struct FeatureTourOverlay: View {
     let onDismiss: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var calloutSize: CGSize = .zero
 
     private var step: FeatureTourStep {
         tour.steps[stepIndex]
@@ -71,9 +213,23 @@ struct FeatureTourOverlay: View {
 
             callout
                 .frame(width: 380)
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: FeatureTourCalloutSizePreferenceKey.self,
+                            value: proxy.size
+                        )
+                    }
+                }
+                .opacity(calloutSize == .zero ? 0 : 1)
                 .position(calloutPosition)
         }
         .frame(width: containerSize.width, height: containerSize.height)
+        .onPreferenceChange(FeatureTourCalloutSizePreferenceKey.self) { size in
+            guard abs(size.width - calloutSize.width) > 0.5
+                    || abs(size.height - calloutSize.height) > 0.5 else { return }
+            calloutSize = size
+        }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: step.id)
         .accessibilityElement(children: .contain)
     }
@@ -150,28 +306,11 @@ struct FeatureTourOverlay: View {
     }
 
     private var calloutPosition: CGPoint {
-        let calloutWidth: CGFloat = 380
-        let calloutHeight: CGFloat = 230
-        let margin: CGFloat = 20
-        let gap: CGFloat = 24
-
-        let proposedX: CGFloat
-        let proposedY: CGFloat
-        switch step.target {
-        case .meetingsSidebar:
-            proposedX = expandedSpotlight.maxX + gap + calloutWidth / 2
-            proposedY = expandedSpotlight.midY
-        case .insightsEntry, .liveCaptionsSetting:
-            proposedX = expandedSpotlight.midX
-            proposedY = expandedSpotlight.maxY + gap + calloutHeight / 2
-        case .cloudCleanupSetting, .experimentalModels:
-            proposedX = expandedSpotlight.midX
-            proposedY = expandedSpotlight.minY - gap - calloutHeight / 2
-        }
-
-        return CGPoint(
-            x: min(max(proposedX, margin + calloutWidth / 2), containerSize.width - margin - calloutWidth / 2),
-            y: min(max(proposedY, margin + calloutHeight / 2), containerSize.height - margin - calloutHeight / 2)
+        FeatureTourCalloutLayout.position(
+            spotlight: expandedSpotlight,
+            containerSize: containerSize,
+            calloutSize: calloutSize,
+            target: step.target
         )
     }
 }
@@ -194,7 +333,7 @@ struct FeatureTourInvitationView: View {
                         .frame(width: 26, height: 26)
 
                     VStack(alignment: .leading, spacing: 5) {
-                        Text("MUESLI 0.8")
+                        Text("MUESLI \(tour.displayVersion)")
                             .font(.system(size: 10, weight: .bold))
                             .foregroundStyle(MuesliTheme.accent)
                         Text("Want a quick tour of what’s new?")

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -34,65 +34,41 @@ struct ModelsView: View {
         let active = appState.selectedBackend
         _selectedParakeetModel = State(initialValue: BackendOption.parakeetFamily.contains(active) ? active.model : BackendOption.parakeetMultilingual.model)
         _selectedWhisperModel = State(initialValue: BackendOption.whisperFamily.contains(active) ? active.model : BackendOption.whisperSmall.model)
-        _showExperimental = State(initialValue: false)
+        _showExperimental = State(initialValue: Self.activeFeatureTourTarget(in: appState) == .experimentalModels)
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
-                Text("Models")
-                    .font(MuesliTheme.title1())
-                    .foregroundStyle(MuesliTheme.textPrimary)
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+                    Text("Models")
+                        .font(MuesliTheme.title1())
+                        .foregroundStyle(MuesliTheme.textPrimary)
 
-                Text("Download and manage models for dictation, live captions, and meeting transcription.")
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textSecondary)
+                    Text("Download and manage models for dictation, streaming, and post-processing.")
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textSecondary)
 
-                familyCard(
-                    title: "Parakeet Family",
-                    subtitle: "NVIDIA speech models for fast everyday dictation.",
-                    defaultBadge: "Default: v3",
-                    logo: "nvidia-logo",
-                    selection: $selectedParakeetModel,
-                    options: BackendOption.parakeetFamily
-                )
-
-                familyCard(
-                    title: "Whisper",
-                    subtitle: "OpenAI Whisper variants. Runs on Apple Neural Engine via CoreML.",
-                    defaultBadge: "Default: Small",
-                    logo: "openai-logo",
-                    selection: $selectedWhisperModel,
-                    options: BackendOption.whisperFamily
-                )
-
-                modelCard(option: .cohereTranscribe, logo: "cohere-logo")
-
-                streamingSection
-
-                experimentalSection
-
-                postProcessorSection
-
-                if !BackendOption.comingSoon.isEmpty {
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                        Text("COMING SOON")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .textCase(.uppercase)
-                            .padding(.leading, 2)
-                            .padding(.top, MuesliTheme.spacing8)
-
-                        VStack(spacing: MuesliTheme.spacing12) {
-                            ForEach(BackendOption.comingSoon, id: \.model) { option in
-                                comingSoonCard(option: option)
-                            }
+                    Picker("Model category", selection: modelsCategorySelection) {
+                        ForEach(ModelsCategory.allCases) { category in
+                            Text(category.title).tag(category)
                         }
                     }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 520)
+
+                    selectedCategoryContent
                 }
+                .padding(MuesliTheme.spacing32)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(MuesliTheme.spacing32)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .onAppear {
+                revealFeatureTourTargetIfNeeded(using: proxy)
+            }
+            .onChange(of: activeFeatureTourTarget) { _, target in
+                guard target == .experimentalModels else { return }
+                revealFeatureTourTargetIfNeeded(using: proxy)
+            }
         }
         .background(MuesliTheme.backgroundBase)
         .onAppear {
@@ -151,6 +127,85 @@ struct ModelsView: View {
             }
         } message: {
             Text("Live meetings will fall back to committed VAD-chunk captions until this model is downloaded again.")
+        }
+    }
+
+    private var modelsCategorySelection: Binding<ModelsCategory> {
+        Binding(
+            get: { appState.selectedModelsCategory },
+            set: { appState.selectedModelsCategory = $0 }
+        )
+    }
+
+    @ViewBuilder
+    private var selectedCategoryContent: some View {
+        switch appState.selectedModelsCategory {
+        case .dictation:
+            familyCard(
+                title: "Parakeet Family",
+                subtitle: "NVIDIA speech models for fast everyday dictation.",
+                defaultBadge: "Default: v3",
+                logo: "nvidia-logo",
+                selection: $selectedParakeetModel,
+                options: BackendOption.parakeetFamily
+            )
+
+            familyCard(
+                title: "Whisper",
+                subtitle: "OpenAI Whisper variants. Runs on Apple Neural Engine via CoreML.",
+                defaultBadge: "Default: Small",
+                logo: "openai-logo",
+                selection: $selectedWhisperModel,
+                options: BackendOption.whisperFamily
+            )
+
+            modelCard(option: .cohereTranscribe, logo: "cohere-logo")
+            experimentalSection
+            comingSoonSection
+        case .streaming:
+            streamingSection
+        case .postProcessing:
+            postProcessorSection
+        }
+    }
+
+    @ViewBuilder
+    private var comingSoonSection: some View {
+        if !BackendOption.comingSoon.isEmpty {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                Text("COMING SOON")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .textCase(.uppercase)
+                    .padding(.leading, 2)
+                    .padding(.top, MuesliTheme.spacing8)
+
+                VStack(spacing: MuesliTheme.spacing12) {
+                    ForEach(BackendOption.comingSoon, id: \.model) { option in
+                        comingSoonCard(option: option)
+                    }
+                }
+            }
+        }
+    }
+
+    private var activeFeatureTourTarget: FeatureTourTarget? {
+        Self.activeFeatureTourTarget(in: appState)
+    }
+
+    private static func activeFeatureTourTarget(in appState: AppState) -> FeatureTourTarget? {
+        guard let tour = appState.activeFeatureTour,
+              tour.steps.indices.contains(appState.featureTourStepIndex) else { return nil }
+        return tour.steps[appState.featureTourStepIndex].target
+    }
+
+    private func revealFeatureTourTargetIfNeeded(using proxy: ScrollViewProxy) {
+        guard activeFeatureTourTarget == .experimentalModels else { return }
+        appState.selectedModelsCategory = .dictation
+        showExperimental = true
+        Task { @MainActor in
+            await Task.yield()
+            proxy.scrollTo(FeatureTourTarget.experimentalModels.rawValue, anchor: .center)
         }
     }
 
@@ -358,7 +413,7 @@ struct ModelsView: View {
                                 .foregroundStyle(MuesliTheme.textSecondary)
                         }
 
-                        Text("SenseVoice, Qwen, Indic ASR, and legacy streaming backends. Hidden by default because these are still slower and less polished.")
+                        Text("SenseVoice, Qwen, Indic ASR, and Gemma 4 evaluation backends. Hidden by default because these are still slower and less polished.")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(MuesliTheme.textPrimary)
                             .opacity(0.8)
@@ -377,6 +432,7 @@ struct ModelsView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .featureTourTarget(.experimentalModels)
 
             if showExperimental {
                 VStack(spacing: MuesliTheme.spacing12) {
@@ -393,6 +449,7 @@ struct ModelsView: View {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+        .id(FeatureTourTarget.experimentalModels.rawValue)
     }
 
     private var cohereLanguageSelection: Binding<CohereTranscribeLanguage> {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -34,7 +34,7 @@ struct ModelsView: View {
         let active = appState.selectedBackend
         _selectedParakeetModel = State(initialValue: BackendOption.parakeetFamily.contains(active) ? active.model : BackendOption.parakeetMultilingual.model)
         _selectedWhisperModel = State(initialValue: BackendOption.whisperFamily.contains(active) ? active.model : BackendOption.whisperSmall.model)
-        _showExperimental = State(initialValue: Self.activeFeatureTourTarget(in: appState) == .experimentalModels)
+        _showExperimental = State(initialValue: appState.activeFeatureTourTarget == .experimentalModels)
     }
 
     var body: some View {
@@ -66,7 +66,7 @@ struct ModelsView: View {
                 revealFeatureTourTargetIfNeeded(using: proxy)
             }
             .onChange(of: activeFeatureTourTarget) { _, target in
-                guard target == .experimentalModels else { return }
+                guard target == .streamingModels || target == .experimentalModels else { return }
                 revealFeatureTourTargetIfNeeded(using: proxy)
             }
         }
@@ -190,22 +190,25 @@ struct ModelsView: View {
     }
 
     private var activeFeatureTourTarget: FeatureTourTarget? {
-        Self.activeFeatureTourTarget(in: appState)
-    }
-
-    private static func activeFeatureTourTarget(in appState: AppState) -> FeatureTourTarget? {
-        guard let tour = appState.activeFeatureTour,
-              tour.steps.indices.contains(appState.featureTourStepIndex) else { return nil }
-        return tour.steps[appState.featureTourStepIndex].target
+        appState.activeFeatureTourTarget
     }
 
     private func revealFeatureTourTargetIfNeeded(using proxy: ScrollViewProxy) {
-        guard activeFeatureTourTarget == .experimentalModels else { return }
-        appState.selectedModelsCategory = .dictation
-        showExperimental = true
+        let target: FeatureTourTarget
+        switch activeFeatureTourTarget {
+        case .streamingModels:
+            target = .streamingModels
+            appState.selectedModelsCategory = .streaming
+        case .experimentalModels:
+            target = .experimentalModels
+            appState.selectedModelsCategory = .dictation
+            showExperimental = true
+        default:
+            return
+        }
         Task { @MainActor in
             await Task.yield()
-            proxy.scrollTo(FeatureTourTarget.experimentalModels.rawValue, anchor: .center)
+            proxy.scrollTo(target.rawValue, anchor: .center)
         }
     }
 
@@ -222,6 +225,8 @@ struct ModelsView: View {
             }
             .padding(.leading, 2)
             .padding(.top, MuesliTheme.spacing8)
+            .id(FeatureTourTarget.streamingModels.rawValue)
+            .featureTourTarget(.streamingModels)
 
             ForEach(BackendOption.streaming, id: \.model) { option in
                 if let liveCaptionBackend = MeetingLiveCaptionBackend(rawValue: option.backend) {
@@ -437,8 +442,7 @@ struct ModelsView: View {
             if showExperimental {
                 VStack(spacing: MuesliTheme.spacing12) {
                     ForEach(BackendOption.experimental, id: \.model) { option in
-                        if option == .gemma4E2BLiteRT,
-                           appState.selectedPostProcessorBackend == .gemma4LiteRT {
+                        if !appState.selectedPostProcessorBackend.isCompatible(with: option) {
                             modelCard(
                                 option: option,
                                 logo: logoForBackend(option),
@@ -1308,8 +1312,7 @@ struct ModelsView: View {
            appState.config.resolvedMeetingLiveCaptionBackend == .nemotron35 {
             controller.updateConfig { $0.enableLiveStreamingPartials = false }
         }
-        if option.backend == BackendOption.gemma4E2BLiteRT.backend,
-           appState.selectedPostProcessorBackend == .gemma4LiteRT {
+        if !appState.selectedPostProcessorBackend.isCompatible(with: option) {
             controller.selectPostProcessorBackend(.local)
         }
         if appState.selectedBackend == option {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -437,7 +437,17 @@ struct ModelsView: View {
             if showExperimental {
                 VStack(spacing: MuesliTheme.spacing12) {
                     ForEach(BackendOption.experimental, id: \.model) { option in
-                        modelCard(option: option, logo: logoForBackend(option))
+                        if option == .gemma4E2BLiteRT,
+                           appState.selectedPostProcessorBackend == .gemma4LiteRT {
+                            modelCard(
+                                option: option,
+                                logo: logoForBackend(option),
+                                downloadedLabel: "Used for Cleanup",
+                                activationDisabledReason: "Unavailable while Gemma 4 is selected for cleanup. Choose another cleanup backend first."
+                            )
+                        } else {
+                            modelCard(option: option, logo: logoForBackend(option))
+                        }
                     }
                 }
             }
@@ -492,11 +502,36 @@ struct ModelsView: View {
             .padding(.top, MuesliTheme.spacing8)
 
             VStack(spacing: MuesliTheme.spacing12) {
+                gemmaCleanupModelCard
+
                 ForEach(PostProcessorOption.all) { option in
                     postProcModelCard(option)
                 }
             }
         }
+    }
+
+    private var gemmaCleanupModelCard: some View {
+        let option = BackendOption.gemma4E2BLiteRT
+        let isDownloaded = downloadedModels.contains(option.model)
+        let isCompatible = TranscriptCleanupBackendOption.gemma4LiteRT
+            .isCompatible(with: appState.selectedBackend)
+
+        return modelCard(
+            option: option,
+            logo: "google-logo",
+            isActive: isDownloaded && appState.selectedPostProcessorBackend == .gemma4LiteRT,
+            onSetActive: {
+                controller.selectPostProcessorBackend(.gemma4LiteRT)
+            },
+            description: "On-device Gemma cleanup for filler removal, formatting, and transcript correction. Shares one download with the experimental Gemma dictation backend.",
+            activeLabel: "Cleanup Active",
+            downloadedLabel: isCompatible ? "Downloaded" : "Used for Dictation",
+            actionTitle: "Use for Cleanup",
+            activationDisabledReason: isCompatible
+                ? nil
+                : "Unavailable while Gemma 4 is selected for dictation. Choose another dictation model first."
+        )
     }
 
     private func postProcModelCard(_ option: PostProcessorOption) -> some View {
@@ -756,6 +791,8 @@ struct ModelsView: View {
         isActive: Bool,
         isDownloaded: Bool,
         isDownloading: Bool,
+        actionTitle: String = "Set Active",
+        activationDisabledReason: String? = nil,
         onSetActive: (() -> Void)? = nil
     ) -> some View {
         HStack(spacing: MuesliTheme.spacing8) {
@@ -772,7 +809,7 @@ struct ModelsView: View {
                 .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             } else if isDownloaded {
                 if !isActive {
-                    Button("Set Active") {
+                    Button(actionTitle) {
                         if let onSetActive {
                             onSetActive()
                         } else {
@@ -781,11 +818,13 @@ struct ModelsView: View {
                     }
                     .buttonStyle(.plain)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MuesliTheme.accent)
+                    .foregroundStyle(activationDisabledReason == nil ? MuesliTheme.accent : MuesliTheme.textTertiary)
                     .padding(.horizontal, MuesliTheme.spacing12)
                     .padding(.vertical, 4)
-                    .background(MuesliTheme.accentSubtle)
+                    .background(activationDisabledReason == nil ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary)
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .disabled(activationDisabledReason != nil)
+                    .help(activationDisabledReason ?? actionTitle)
                 }
 
                 Button {
@@ -816,7 +855,12 @@ struct ModelsView: View {
         option: BackendOption,
         logo: String? = nil,
         isActive activeOverride: Bool? = nil,
-        onSetActive: (() -> Void)? = nil
+        onSetActive: (() -> Void)? = nil,
+        description: String? = nil,
+        activeLabel: String = "Active",
+        downloadedLabel: String = "Downloaded",
+        actionTitle: String = "Set Active",
+        activationDisabledReason: String? = nil
     ) -> some View {
         let isActive = activeOverride ?? (appState.selectedBackend == option)
         let isDownloaded = downloadedModels.contains(option.model)
@@ -847,7 +891,7 @@ struct ModelsView: View {
                             .foregroundStyle(MuesliTheme.textTertiary)
                     }
 
-                    Text(option.description)
+                    Text(description ?? option.description)
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }
@@ -856,7 +900,7 @@ struct ModelsView: View {
 
                 // Status badge
                 if isActive {
-                    Text("Active")
+                    Text(activeLabel)
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(MuesliTheme.success)
                         .padding(.horizontal, 8)
@@ -864,7 +908,7 @@ struct ModelsView: View {
                         .background(MuesliTheme.success.opacity(0.15))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
                 } else if isDownloaded {
-                    Text("Downloaded")
+                    Text(downloadedLabel)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(MuesliTheme.textTertiary)
                         .padding(.horizontal, 8)
@@ -954,11 +998,19 @@ struct ModelsView: View {
                 }
             }
 
+            if let activationDisabledReason, isDownloaded, !isActive {
+                Label(activationDisabledReason, systemImage: "exclamationmark.lock")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+
             actionButtons(
                 for: option,
                 isActive: isActive,
                 isDownloaded: isDownloaded,
                 isDownloading: isDownloading,
+                actionTitle: actionTitle,
+                activationDisabledReason: activationDisabledReason,
                 onSetActive: onSetActive
             )
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1408,7 +1408,7 @@ struct ModelsView: View {
             selectedWhisperModel = active.model
         }
         if BackendOption.experimental.contains(active) {
-            return
+            showExperimental = true
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -840,15 +840,16 @@ final class MuesliController: NSObject {
     }
 
     @objc func showWhatsNew() {
-        beginFeatureTour(
-            FeatureTourCatalog.latest(includeCloudCleanup: chatGPTAuth.isAuthenticated),
-            source: "manual"
-        )
+        let tour = FeatureTourCatalog.latest(includeCloudCleanup: chatGPTAuth.isAuthenticated)
+        guard beginFeatureTour(tour, source: "manual") else { return }
+        featureTourStore.markOffered(tour)
     }
 
     @discardableResult
     private func offerFeatureTour(_ tour: FeatureTour) -> Bool {
         guard !tour.steps.isEmpty,
+              appState.pendingFeatureTourInvitation == nil,
+              appState.activeFeatureTour == nil,
               ensureBasicDictationPermissionsBeforeDashboard() else { return false }
 
         appState.pendingFeatureTourInvitation = tour
@@ -967,8 +968,10 @@ final class MuesliController: NSObject {
         case .cloudCleanupSetting:
             appState.selectedSettingsPane = .dictation
             appState.selectedTab = .settings
-        case .experimentalModels:
-            showModels(category: .dictation)
+        case .streamingModels, .experimentalModels:
+            if let category = step.target.modelsCategory {
+                showModels(category: category)
+            }
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -311,6 +311,7 @@ final class MuesliController: NSObject {
     private var historyWindowController: RecentHistoryWindowController?
     private var preferencesWindowController: PreferencesWindowController?
     private var onboardingWindowController: OnboardingWindowController?
+    private let featureTourStore = FeatureTourStore()
     var updaterController: SPUStandardUpdaterController?
     private var busyStatusGeneration = 0
 
@@ -608,6 +609,15 @@ final class MuesliController: NSObject {
         statusBarController = StatusBarController(controller: self, runtime: runtime)
         preferencesWindowController = PreferencesWindowController(controller: self)
         historyWindowController = RecentHistoryWindowController(store: dictationStore, controller: self)
+        let latestFeatureTour = FeatureTourCatalog.latest(
+            includeCloudCleanup: chatGPTAuth.isAuthenticated
+        )
+        let automaticFeatureTour = featureTourStore.automaticTour(
+            currentVersion: AppIdentity.marketingVersion,
+            hasCompletedOnboarding: config.hasCompletedOnboarding,
+            canPresent: canRunMainApp,
+            tour: latestFeatureTour
+        )
         refreshUI()
         if config.iCloudSyncEnabled {
             if MuesliICloudSyncEngine.hasRequiredEntitlement {
@@ -717,6 +727,13 @@ final class MuesliController: NSObject {
 
         if canRunMainApp {
             PostInstallChecker.check()
+            if let automaticFeatureTour {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self,
+                          self.offerFeatureTour(automaticFeatureTour) else { return }
+                    self.featureTourStore.markOffered(automaticFeatureTour)
+                }
+            }
         }
     }
 
@@ -812,6 +829,147 @@ final class MuesliController: NSObject {
     func openInsights(section: InsightsSection) {
         appState.insightsInitialSection = section
         appState.selectedTab = .insights
+    }
+
+    func showModels(category: ModelsCategory) {
+        if appState.isSearchActive {
+            clearSearch()
+        }
+        appState.selectedModelsCategory = category
+        appState.selectedTab = .models
+    }
+
+    @objc func showWhatsNew() {
+        beginFeatureTour(
+            FeatureTourCatalog.latest(includeCloudCleanup: chatGPTAuth.isAuthenticated),
+            source: "manual"
+        )
+    }
+
+    @discardableResult
+    private func offerFeatureTour(_ tour: FeatureTour) -> Bool {
+        guard !tour.steps.isEmpty,
+              ensureBasicDictationPermissionsBeforeDashboard() else { return false }
+
+        appState.pendingFeatureTourInvitation = tour
+        presentHistoryWindow()
+        TelemetryDeck.signal("feature_walkthrough.invitation_shown", parameters: [
+            "version": tour.version,
+            "step_count": "\(tour.steps.count)",
+            "includes_cloud_cleanup": "\(tour.steps.contains { $0.target == .cloudCleanupSetting })",
+        ])
+        // The normal startup preload task continues while this invitation and
+        // the walkthrough are on screen, so no second backend load is started.
+        return true
+    }
+
+    func acceptFeatureTourInvitation() {
+        guard let tour = appState.pendingFeatureTourInvitation else { return }
+        appState.pendingFeatureTourInvitation = nil
+        TelemetryDeck.signal("feature_walkthrough.decision", parameters: [
+            "version": tour.version,
+            "decision": "accepted",
+            "step_count": "\(tour.steps.count)",
+        ])
+        beginFeatureTour(tour, source: "automatic")
+    }
+
+    func skipFeatureTourInvitation() {
+        guard let tour = appState.pendingFeatureTourInvitation else { return }
+        appState.pendingFeatureTourInvitation = nil
+        TelemetryDeck.signal("feature_walkthrough.decision", parameters: [
+            "version": tour.version,
+            "decision": "skipped",
+            "step_count": "\(tour.steps.count)",
+        ])
+    }
+
+    @discardableResult
+    private func beginFeatureTour(_ tour: FeatureTour, source: String) -> Bool {
+        guard !tour.steps.isEmpty,
+              ensureBasicDictationPermissionsBeforeDashboard() else { return false }
+
+        appState.pendingFeatureTourInvitation = nil
+        appState.activeFeatureTour = tour
+        appState.featureTourStepIndex = 0
+        navigateToFeatureTourStep(tour.steps[0])
+        presentHistoryWindow()
+        TelemetryDeck.signal("feature_walkthrough.started", parameters: [
+            "version": tour.version,
+            "source": source,
+            "step_count": "\(tour.steps.count)",
+        ])
+        return true
+    }
+
+    func showPreviousFeatureTourStep() {
+        guard let tour = appState.activeFeatureTour else { return }
+        let index = max(0, appState.featureTourStepIndex - 1)
+        showFeatureTourStep(index, in: tour)
+    }
+
+    func showNextFeatureTourStep() {
+        guard let tour = appState.activeFeatureTour else { return }
+        let nextIndex = appState.featureTourStepIndex + 1
+        guard tour.steps.indices.contains(nextIndex) else {
+            completeFeatureTour()
+            return
+        }
+        showFeatureTourStep(nextIndex, in: tour)
+    }
+
+    func dismissFeatureTour() {
+        if let tour = appState.activeFeatureTour,
+           tour.steps.indices.contains(appState.featureTourStepIndex) {
+            TelemetryDeck.signal("feature_walkthrough.dismissed", parameters: [
+                "version": tour.version,
+                "step": tour.steps[appState.featureTourStepIndex].id,
+                "step_index": "\(appState.featureTourStepIndex + 1)",
+            ])
+        }
+        appState.activeFeatureTour = nil
+        appState.featureTourStepIndex = 0
+    }
+
+    private func completeFeatureTour() {
+        if let tour = appState.activeFeatureTour {
+            TelemetryDeck.signal("feature_walkthrough.completed", parameters: [
+                "version": tour.version,
+                "step_count": "\(tour.steps.count)",
+            ])
+        }
+        appState.activeFeatureTour = nil
+        appState.featureTourStepIndex = 0
+        appState.selectedTab = .dictations
+    }
+
+    private func showFeatureTourStep(_ index: Int, in tour: FeatureTour) {
+        guard tour.steps.indices.contains(index) else { return }
+        appState.featureTourStepIndex = index
+        navigateToFeatureTourStep(tour.steps[index])
+    }
+
+    private func navigateToFeatureTourStep(_ step: FeatureTourStep) {
+        if appState.isSearchActive {
+            clearSearch()
+        }
+        switch step.target {
+        case .insightsEntry:
+            appState.selectedTab = .dictations
+        case .meetingsSidebar:
+            appState.selectedTab = .meetings
+            appState.meetingsNavigationState = .browser
+            appState.selectedMeetingID = nil
+            appState.selectedMeetingRecord = nil
+        case .liveCaptionsSetting:
+            appState.selectedSettingsPane = .meetings
+            appState.selectedTab = .settings
+        case .cloudCleanupSetting:
+            appState.selectedSettingsPane = .dictation
+            appState.selectedTab = .settings
+        case .experimentalModels:
+            showModels(category: .dictation)
+        }
     }
 
     func closeInsights() {
@@ -1999,14 +2157,13 @@ final class MuesliController: NSObject {
         if enabled, selectedPostProcessorBackend == .local {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
-                appState.selectedTab = .models
                 return
             }
         }
         if enabled, selectedPostProcessorBackend == .gemma4LiteRT,
            !Gemma4LiteRTModelStore.isAvailableLocally() {
             updateConfig { $0.enablePostProcessor = false }
-            appState.selectedTab = .models
+            showModels(category: .dictation)
             return
         }
         updateConfig { $0.enablePostProcessor = enabled }
@@ -2055,14 +2212,13 @@ final class MuesliController: NSObject {
         if option == .local, config.enablePostProcessor {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
-                appState.selectedTab = .models
                 return
             }
         }
         if option == .gemma4LiteRT, config.enablePostProcessor,
            !Gemma4LiteRTModelStore.isAvailableLocally() {
             updateConfig { $0.enablePostProcessor = false }
-            appState.selectedTab = .models
+            showModels(category: .dictation)
             return
         }
         preloadExperimentalTranscriptionFeatures()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2157,6 +2157,7 @@ final class MuesliController: NSObject {
         if enabled, selectedPostProcessorBackend == .local {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
+                showModels(category: .postProcessing)
                 return
             }
         }
@@ -2212,6 +2213,7 @@ final class MuesliController: NSObject {
         if option == .local, config.enablePostProcessor {
             guard normalizePostProcessorSelectionForAvailability() != nil else {
                 updateConfig { $0.enablePostProcessor = false }
+                showModels(category: .postProcessing)
                 return
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2163,7 +2163,7 @@ final class MuesliController: NSObject {
         if enabled, selectedPostProcessorBackend == .gemma4LiteRT,
            !Gemma4LiteRTModelStore.isAvailableLocally() {
             updateConfig { $0.enablePostProcessor = false }
-            showModels(category: .dictation)
+            showModels(category: .postProcessing)
             return
         }
         updateConfig { $0.enablePostProcessor = enabled }
@@ -2218,7 +2218,7 @@ final class MuesliController: NSObject {
         if option == .gemma4LiteRT, config.enablePostProcessor,
            !Gemma4LiteRTModelStore.isAvailableLocally() {
             updateConfig { $0.enablePostProcessor = false }
-            showModels(category: .dictation)
+            showModels(category: .postProcessing)
             return
         }
         preloadExperimentalTranscriptionFeatures()

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -111,7 +111,7 @@ struct SettingsView: View {
     }
 
     private var disabledDictationBackendLabels: Set<String> {
-        guard appState.selectedPostProcessorBackend == .gemma4LiteRT,
+        guard !appState.selectedPostProcessorBackend.isCompatible(with: .gemma4E2BLiteRT),
               dictationBackendOptions.contains(.gemma4E2BLiteRT) else { return [] }
         return [BackendOption.gemma4E2BLiteRT.label]
     }
@@ -221,9 +221,7 @@ struct SettingsView: View {
     }
 
     private var activeFeatureTourTarget: FeatureTourTarget? {
-        guard let tour = appState.activeFeatureTour,
-              tour.steps.indices.contains(appState.featureTourStepIndex) else { return nil }
-        return tour.steps[appState.featureTourStepIndex].target
+        appState.activeFeatureTourTarget
     }
 
     var body: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -51,28 +51,6 @@ struct SettingsView: View {
         }
     }
 
-    private enum SettingsPane: String, CaseIterable, Identifiable {
-        case general
-        case sync
-        case dictation
-        case computerUse
-        case meetings
-        case appearance
-
-        var id: String { rawValue }
-
-        var title: String {
-            switch self {
-            case .general: return "General"
-            case .sync: return "Sync"
-            case .dictation: return "Dictation"
-            case .computerUse: return "Computer Use"
-            case .meetings: return "Meetings"
-            case .appearance: return "Appearance"
-            }
-        }
-    }
-
     let appState: AppState
     let controller: MuesliController
 
@@ -83,7 +61,7 @@ struct SettingsView: View {
     @State private var pendingDataDestruction: PendingDataDestruction?
     @State private var isShowingDictionaryAccessibilityPrompt = false
     @State private var isPreviewingClip = false
-    @State private var selectedPane: SettingsPane = .general
+    @State private var selectedPane: SettingsPane
     @State private var downloadedBackendOptions: [BackendOption] = []
     @State private var downloadedPostProcOptions: [PostProcessorOption] = []
     @State private var downloadedMeetingLiveCaptionBackends: [MeetingLiveCaptionBackend] = []
@@ -102,6 +80,12 @@ struct SettingsView: View {
     @State private var isLoadingOpenRouterFreeModels = false
     @State private var openRouterFreeModelsError: String?
     @State private var hasRefreshedMeetingCalendarSources = false
+
+    init(appState: AppState, controller: MuesliController) {
+        self.appState = appState
+        self.controller = controller
+        _selectedPane = State(initialValue: appState.selectedSettingsPane)
+    }
 
     // Uniform width for standard right-side controls.
     private let controlWidth: CGFloat = 220
@@ -224,97 +208,127 @@ struct SettingsView: View {
         return dictationMicrophoneOptions.first(where: { $0.uid == selectedUID })?.label ?? "Automatic"
     }
 
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
-                Text("Settings")
-                    .font(MuesliTheme.title1())
-                    .foregroundStyle(MuesliTheme.textPrimary)
+    private var activeFeatureTourTarget: FeatureTourTarget? {
+        guard let tour = appState.activeFeatureTour,
+              tour.steps.indices.contains(appState.featureTourStepIndex) else { return nil }
+        return tour.steps[appState.featureTourStepIndex].target
+    }
 
-                settingsPanePicker
-                paneContent
+    var body: some View {
+        ScrollViewReader { scrollProxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+                    Text("Settings")
+                        .font(MuesliTheme.title1())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+
+                    settingsPanePicker
+                    paneContent
+                }
+                .padding(MuesliTheme.spacing32)
             }
-            .padding(MuesliTheme.spacing32)
-        }
-        .background(MuesliTheme.backgroundBase)
-        .onAppear {
-            refreshDownloadedModelOptions()
-            refreshDictationInputDevices()
-            startPermissionPolling()
-            if appState.selectedMeetingSummaryBackend == .openRouter {
-                loadOpenRouterFreeModelsIfNeeded()
-            }
-        }
-        .onDisappear {
-            SoundController.stopMaraudersMapClip()
-            isPreviewingClip = false
-            stopPermissionPolling()
-        }
-        .onChange(of: appState.selectedTab) { _, tab in
-            if tab == .settings {
+            .background(MuesliTheme.backgroundBase)
+            .onAppear {
                 refreshDownloadedModelOptions()
                 refreshDictationInputDevices()
+                startPermissionPolling()
+                if appState.selectedMeetingSummaryBackend == .openRouter {
+                    loadOpenRouterFreeModelsIfNeeded()
+                }
+                scrollToFeatureTourTarget(activeFeatureTourTarget, using: scrollProxy)
+            }
+            .onDisappear {
+                SoundController.stopMaraudersMapClip()
+                isPreviewingClip = false
+                stopPermissionPolling()
+            }
+            .onChange(of: appState.selectedTab) { _, tab in
+                if tab == .settings {
+                    selectedPane = appState.selectedSettingsPane
+                    refreshDownloadedModelOptions()
+                    refreshDictationInputDevices()
+                    refreshPermissionStatuses()
+                }
+            }
+            .onChange(of: appState.selectedSettingsPane) { _, pane in
+                selectedPane = pane
+            }
+            .onChange(of: selectedPane) { _, pane in
+                appState.selectedSettingsPane = pane
+                scrollToFeatureTourTarget(activeFeatureTourTarget, using: scrollProxy)
+            }
+            .onChange(of: activeFeatureTourTarget) { _, target in
+                scrollToFeatureTourTarget(target, using: scrollProxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                guard appState.selectedTab == .settings else { return }
                 refreshPermissionStatuses(refreshLaunchAtLogin: true)
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            guard appState.selectedTab == .settings else { return }
-            refreshPermissionStatuses(refreshLaunchAtLogin: true)
-        }
-        .onChange(of: appState.selectedBackend) { _, _ in
-            refreshDownloadedModelOptions()
-        }
-        .onChange(of: appState.selectedMeetingTranscriptionBackend) { _, _ in
-            refreshDownloadedModelOptions()
-        }
-        .onChange(of: appState.selectedMeetingSummaryBackend) { _, backend in
-            if backend == .openRouter {
-                loadOpenRouterFreeModelsIfNeeded()
+            .onChange(of: appState.selectedBackend) { _, _ in
+                refreshDownloadedModelOptions()
             }
-        }
-        .alert(
-            pendingDataDestruction?.title ?? "Confirm Destructive Action",
-            isPresented: Binding(
-                get: { pendingDataDestruction != nil },
-                set: { if !$0 { pendingDataDestruction = nil } }
-            )
-        ) {
-            Button("Cancel", role: .cancel) {
-                pendingDataDestruction = nil
+            .onChange(of: appState.selectedMeetingTranscriptionBackend) { _, _ in
+                refreshDownloadedModelOptions()
             }
-            Button(pendingDataDestruction?.confirmLabel ?? "Delete", role: .destructive) {
-                switch pendingDataDestruction {
-                case .dictations:
-                    controller.clearDictationHistory()
-                case .meetings:
-                    controller.clearMeetingHistory()
-                case nil:
-                    break
+            .onChange(of: appState.selectedMeetingSummaryBackend) { _, backend in
+                if backend == .openRouter {
+                    loadOpenRouterFreeModelsIfNeeded()
                 }
-                pendingDataDestruction = nil
             }
-        } message: {
-            Text(pendingDataDestruction?.message ?? "")
+            .alert(
+                pendingDataDestruction?.title ?? "Confirm Destructive Action",
+                isPresented: Binding(
+                    get: { pendingDataDestruction != nil },
+                    set: { if !$0 { pendingDataDestruction = nil } }
+                )
+            ) {
+                Button("Cancel", role: .cancel) {
+                    pendingDataDestruction = nil
+                }
+                Button(pendingDataDestruction?.confirmLabel ?? "Delete", role: .destructive) {
+                    switch pendingDataDestruction {
+                    case .dictations:
+                        controller.clearDictationHistory()
+                    case .meetings:
+                        controller.clearMeetingHistory()
+                    case nil:
+                        break
+                    }
+                    pendingDataDestruction = nil
+                }
+            } message: {
+                Text(pendingDataDestruction?.message ?? "")
+            }
+            .alert(
+                "Enable Accessibility?",
+                isPresented: $isShowingDictionaryAccessibilityPrompt
+            ) {
+                Button("Cancel", role: .cancel) {
+                    controller.cancelDictionaryCorrectionAccessibilityEnableRequest()
+                }
+                Button("Enable") {
+                    controller.requestDictionaryCorrectionAccessibilityEnable()
+                }
+            } message: {
+                Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, then relaunch Muesli to turn suggestions on.")
+            }
+            .sheet(isPresented: $isCleanupPromptManagerPresented) {
+                TranscriptCleanupPromptsManagerView(
+                    appState: appState,
+                    controller: controller,
+                    onClose: { isCleanupPromptManagerPresented = false }
+                )
+            }
         }
-        .alert(
-            "Enable Accessibility?",
-            isPresented: $isShowingDictionaryAccessibilityPrompt
-        ) {
-            Button("Cancel", role: .cancel) {
-                controller.cancelDictionaryCorrectionAccessibilityEnableRequest()
+    }
+
+    private func scrollToFeatureTourTarget(_ target: FeatureTourTarget?, using proxy: ScrollViewProxy) {
+        guard let target,
+              target == .liveCaptionsSetting || target == .cloudCleanupSetting else { return }
+        DispatchQueue.main.async {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                proxy.scrollTo(target.rawValue, anchor: .center)
             }
-            Button("Enable") {
-                controller.requestDictionaryCorrectionAccessibilityEnable()
-            }
-        } message: {
-            Text("Dictionary suggestions briefly read focused app text via Accessibility after dictation. Grant access, then relaunch Muesli to turn suggestions on.")
-        }
-        .sheet(isPresented: $isCleanupPromptManagerPresented) {
-            TranscriptCleanupPromptsManagerView(
-                appState: appState,
-                controller: controller,
-                onClose: { isCleanupPromptManagerPresented = false }
-            )
         }
     }
 
@@ -700,6 +714,8 @@ struct SettingsView: View {
                         .frame(width: meetingControlWidth, alignment: .trailing)
                 }
             }
+            .id(FeatureTourTarget.liveCaptionsSetting.rawValue)
+            .featureTourTarget(.liveCaptionsSetting)
             Divider().background(MuesliTheme.surfaceBorder)
             settingsRow("Final transcript", controlWidth: meetingControlWidth) {
                 if usesUnifiedMeetingTranscript {
@@ -758,15 +774,16 @@ struct SettingsView: View {
                     }
                 }
             }
+            .id(FeatureTourTarget.cloudCleanupSetting.rawValue)
+            .featureTourTarget(.cloudCleanupSetting)
             if appState.selectedPostProcessorBackend == .local {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
                     if downloadedPostProcOptions.isEmpty {
-                        Text("Download a cleanup model from Models")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .multilineTextAlignment(.trailing)
-                            .frame(width: meetingControlWidth, alignment: .trailing)
+                        compactActionButton("View cleanup models", systemImage: "arrow.right") {
+                            controller.showModels(category: .postProcessing)
+                        }
+                        .frame(width: meetingControlWidth, alignment: .trailing)
                     } else {
                         let selection = downloadedPostProcOptions.contains(where: { $0.id == appState.activePostProcessor.id })
                             ? appState.activePostProcessor.label
@@ -2034,7 +2051,9 @@ struct SettingsView: View {
     }
 
     private func startPermissionPolling() {
-        refreshPermissionStatuses(refreshLaunchAtLogin: true)
+        // Startup already synchronizes this state. Querying SMAppService here can
+        // block the main thread long enough to make Settings appear unresponsive.
+        refreshPermissionStatuses()
         permissionPollTimer?.invalidate()
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             refreshPermissionStatuses()

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -110,6 +110,12 @@ struct SettingsView: View {
         backendOptions(including: appState.selectedBackend)
     }
 
+    private var disabledDictationBackendLabels: Set<String> {
+        guard appState.selectedPostProcessorBackend == .gemma4LiteRT,
+              dictationBackendOptions.contains(.gemma4E2BLiteRT) else { return [] }
+        return [BackendOption.gemma4E2BLiteRT.label]
+    }
+
     private var meetingBackendOptions: [BackendOption] {
         downloadedBackendOptions.filter(\.supportsMeetingTranscription)
     }
@@ -153,7 +159,13 @@ struct SettingsView: View {
     }
 
     private var cleanupBackendOptions: [TranscriptCleanupBackendOption] {
-        TranscriptCleanupBackendOption.available(for: appState.selectedBackend)
+        TranscriptCleanupBackendOption.all
+    }
+
+    private var disabledCleanupBackendLabels: Set<String> {
+        Set(cleanupBackendOptions.lazy
+            .filter { !$0.isCompatible(with: appState.selectedBackend) }
+            .map(\.label))
     }
 
     private var selectedCleanupPromptName: String {
@@ -653,12 +665,16 @@ struct SettingsView: View {
             settingsRow("Dictation model", controlWidth: meetingControlWidth) {
                 settingsMenu(
                     selection: appState.selectedBackend.label,
-                    options: dictationBackendOptions.map(\.label)
+                    options: dictationBackendOptions.map(\.label),
+                    disabledOptions: disabledDictationBackendLabels
                 ) { label in
                     if let option = dictationBackendOptions.first(where: { $0.label == label }) {
                         controller.selectBackend(option)
                     }
                 }
+            }
+            if !disabledDictationBackendLabels.isEmpty {
+                settingsDescription("Gemma 4 dictation is unavailable while Gemma 4 is the cleanup backend.")
             }
             if appState.selectedBackend.backend == BackendOption.cohereTranscribe.backend {
                 Divider().background(MuesliTheme.surfaceBorder)
@@ -767,7 +783,8 @@ struct SettingsView: View {
             ) {
                 settingsMenu(
                     selection: appState.selectedPostProcessorBackend.label,
-                    options: cleanupBackendOptions.map(\.label)
+                    options: cleanupBackendOptions.map(\.label),
+                    disabledOptions: disabledCleanupBackendLabels
                 ) { label in
                     if let option = cleanupBackendOptions.first(where: { $0.label == label }) {
                         controller.selectPostProcessorBackend(option)
@@ -776,6 +793,9 @@ struct SettingsView: View {
             }
             .id(FeatureTourTarget.cloudCleanupSetting.rawValue)
             .featureTourTarget(.cloudCleanupSetting)
+            if !disabledCleanupBackendLabels.isEmpty {
+                settingsDescription("Gemma 4 cleanup is unavailable while Gemma 4 is the dictation model.")
+            }
             if appState.selectedPostProcessorBackend == .local {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
@@ -801,14 +821,17 @@ struct SettingsView: View {
             } else if appState.selectedPostProcessorBackend == .gemma4LiteRT {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
-                    Text(Gemma4LiteRTModelStore.isAvailableLocally() ? "Gemma 4 E2B (Downloaded)" : "Gemma 4 E2B")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(
-                            Gemma4LiteRTModelStore.isAvailableLocally()
-                                ? MuesliTheme.textSecondary
-                                : MuesliTheme.textTertiary
-                        )
+                    if Gemma4LiteRTModelStore.isAvailableLocally() {
+                        Text("Gemma 4 E2B (Downloaded)")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .frame(width: meetingControlWidth, alignment: .trailing)
+                    } else {
+                        compactActionButton("View Gemma model", systemImage: "arrow.right") {
+                            controller.showModels(category: .postProcessing)
+                        }
                         .frame(width: meetingControlWidth, alignment: .trailing)
+                    }
                 }
             } else {
                 hostedCleanupSettings(for: appState.selectedPostProcessorBackend)
@@ -2236,8 +2259,18 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func settingsMenu(selection: String, options: [String], onChange: @escaping (String) -> Void) -> some View {
-        FixedWidthPopUp(selection: selection, options: options, onChange: onChange)
+    private func settingsMenu(
+        selection: String,
+        options: [String],
+        disabledOptions: Set<String> = [],
+        onChange: @escaping (String) -> Void
+    ) -> some View {
+        FixedWidthPopUp(
+            selection: selection,
+            options: options,
+            disabledOptions: disabledOptions,
+            onChange: onChange
+        )
             .frame(height: 24)
     }
 
@@ -2987,28 +3020,48 @@ class EditableNSSecureTextField: NSSecureTextField {
 struct FixedWidthPopUp: NSViewRepresentable {
     let selection: String
     let options: [String]
+    let disabledOptions: Set<String>
     /// Reports the selected index, avoiding label collision issues.
     let onSelectionIndex: (Int) -> Void
 
-    init(selection: String, options: [String], onChange: @escaping (String) -> Void) {
+    init(
+        selection: String,
+        options: [String],
+        disabledOptions: Set<String> = [],
+        onChange: @escaping (String) -> Void
+    ) {
         self.selection = selection
         self.options = options
+        self.disabledOptions = disabledOptions
         self.onSelectionIndex = { index in
             guard index >= 0 && index < options.count else { return }
+            guard !disabledOptions.contains(options[index]) else { return }
             onChange(options[index])
         }
     }
 
-    init(selection: String, options: [String], onSelectIndex: @escaping (Int) -> Void) {
+    init(
+        selection: String,
+        options: [String],
+        disabledOptions: Set<String> = [],
+        onSelectIndex: @escaping (Int) -> Void
+    ) {
         self.selection = selection
         self.options = options
-        self.onSelectionIndex = onSelectIndex
+        self.disabledOptions = disabledOptions
+        self.onSelectionIndex = { index in
+            guard index >= 0 && index < options.count else { return }
+            guard !disabledOptions.contains(options[index]) else { return }
+            onSelectIndex(index)
+        }
     }
 
     func makeNSView(context: Context) -> NSPopUpButton {
         let button = NSPopUpButton(frame: .zero, pullsDown: false)
         button.removeAllItems()
         button.addItems(withTitles: options)
+        button.menu?.autoenablesItems = false
+        updateEnabledItems(in: button)
         button.selectItem(withTitle: selection)
         button.target = context.coordinator
         button.action = #selector(Coordinator.selectionChanged(_:))
@@ -3023,10 +3076,17 @@ struct FixedWidthPopUp: NSViewRepresentable {
             button.removeAllItems()
             button.addItems(withTitles: options)
         }
+        updateEnabledItems(in: button)
         if button.titleOfSelectedItem != selection {
             button.selectItem(withTitle: selection)
         }
         context.coordinator.onSelectionIndex = onSelectionIndex
+    }
+
+    private func updateEnabledItems(in button: NSPopUpButton) {
+        for item in button.itemArray {
+            item.isEnabled = !disabledOptions.contains(item.title)
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(onSelectionIndex: onSelectionIndex) }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -284,6 +284,7 @@ struct SidebarView: View {
             )
             .contentShape(Rectangle())
             .padding(.horizontal, sidebarRowOuterPadding)
+            .featureTourTarget(.meetingsSidebar)
 
             if meetingsExpanded {
                 let folderTree = folderTreePresentation

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatsHeaderView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatsHeaderView.swift
@@ -41,6 +41,7 @@ struct StatsHeaderView: View {
                 action: { onSelect(.meetings) }
             )
         }
+        .featureTourTarget(.insightsEntry)
         .padding(.horizontal, MuesliTheme.spacing24)
         .padding(.vertical, MuesliTheme.spacing20)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -172,6 +172,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Settings…", action: #selector(MuesliController.openSettingsTab)))
+        menu.addItem(actionItem(title: "What's New in Muesli", action: #selector(MuesliController.showWhatsNew)))
         menu.addItem(checkForUpdatesItem())
         menu.addItem(.separator())
         menu.addItem(actionItem(title: "Quit", action: #selector(MuesliController.quitApp)))

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -127,21 +127,25 @@ struct FeatureTourTests {
     @Test("0.8 catalog points each walkthrough step at a unique product location")
     func catalogShape() {
         #expect(tour.version == "0.8.0")
-        #expect(tour.steps.count == 4)
+        #expect(tour.steps.count == 5)
         #expect(Set(tour.steps.map(\.id)).count == tour.steps.count)
         #expect(Set(tour.steps.map(\.target)).count == tour.steps.count)
 
         let authenticatedTour = FeatureTourCatalog.latest(includeCloudCleanup: true)
-        #expect(authenticatedTour.steps.count == 5)
+        #expect(authenticatedTour.steps.count == 6)
         #expect(authenticatedTour.steps.contains { $0.target == .cloudCleanupSetting })
 
-        let modelsStep = tour.steps.last
-        #expect(modelsStep?.id == "models")
-        #expect(modelsStep?.target == .experimentalModels)
-        #expect(modelsStep?.message.contains("Nemotron 3.5") == true)
-        #expect(modelsStep?.message.contains("Parakeet Realtime") == true)
-        #expect(modelsStep?.message.contains("Indic ASR") == true)
-        #expect(modelsStep?.message.contains("Gemma 4") == true)
+        let streamingStep = tour.steps.first { $0.target == .streamingModels }
+        #expect(streamingStep?.message.contains("Nemotron 3.5") == true)
+        #expect(streamingStep?.message.contains("Parakeet Realtime") == true)
+        #expect(streamingStep?.target.modelsCategory == .streaming)
+
+        let experimentalStep = tour.steps.last
+        #expect(experimentalStep?.id == "experimental-models")
+        #expect(experimentalStep?.target == .experimentalModels)
+        #expect(experimentalStep?.message.contains("Indic ASR") == true)
+        #expect(experimentalStep?.message.contains("Gemma 4") == true)
+        #expect(experimentalStep?.target.modelsCategory == .dictation)
     }
 
     @Test("store suppresses fresh installs and presents a legacy upgrade only once")

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Feature tour")
+struct FeatureTourTests {
+    private let tour = FeatureTourCatalog.latest
+
+    @Test("marketing versions compare numeric components and ignore prerelease suffixes")
+    func versionComparison() throws {
+        #expect(try #require(MarketingVersion("0.7.1")) < #require(MarketingVersion("0.8.0")))
+        #expect(try #require(MarketingVersion("0.8")) == #require(MarketingVersion("0.8.0")))
+        #expect(try #require(MarketingVersion("0.8.0-preprod.1")) == #require(MarketingVersion("0.8.0")))
+        #expect(MarketingVersion("not-a-version") == nil)
+    }
+
+    @Test("existing users without legacy version markers see the first feature tour")
+    func legacyUpgrade() {
+        #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.8.0",
+            previousVersion: nil,
+            lastPresentedTourVersion: nil,
+            hasCompletedOnboarding: true,
+            tour: tour
+        ))
+    }
+
+    @Test("fresh installs and pre-target versions do not see the tour")
+    func ineligibleLaunches() {
+        #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.8.0",
+            previousVersion: nil,
+            lastPresentedTourVersion: nil,
+            hasCompletedOnboarding: false,
+            tour: tour
+        ))
+        #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.7.1",
+            previousVersion: "0.7.0",
+            lastPresentedTourVersion: nil,
+            hasCompletedOnboarding: true,
+            tour: tour
+        ))
+    }
+
+    @Test("upgrade crossing the target version presents once")
+    func crossingTarget() {
+        #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.8.0-preprod.1",
+            previousVersion: "0.7.1",
+            lastPresentedTourVersion: nil,
+            hasCompletedOnboarding: true,
+            tour: tour
+        ))
+        #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.8.0",
+            previousVersion: "0.7.1",
+            lastPresentedTourVersion: "0.8.0",
+            hasCompletedOnboarding: true,
+            tour: tour
+        ))
+        #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
+            currentVersion: "0.8.1",
+            previousVersion: "0.8.0",
+            lastPresentedTourVersion: nil,
+            hasCompletedOnboarding: true,
+            tour: tour
+        ))
+    }
+
+    @Test("0.8 catalog points each walkthrough step at a unique product location")
+    func catalogShape() {
+        #expect(tour.version == "0.8.0")
+        #expect(tour.steps.count == 4)
+        #expect(Set(tour.steps.map(\.id)).count == tour.steps.count)
+        #expect(Set(tour.steps.map(\.target)).count == tour.steps.count)
+
+        let authenticatedTour = FeatureTourCatalog.latest(includeCloudCleanup: true)
+        #expect(authenticatedTour.steps.count == 5)
+        #expect(authenticatedTour.steps.contains { $0.target == .cloudCleanupSetting })
+
+        let modelsStep = tour.steps.last
+        #expect(modelsStep?.id == "models")
+        #expect(modelsStep?.target == .experimentalModels)
+        #expect(modelsStep?.message.contains("Nemotron 3.5") == true)
+        #expect(modelsStep?.message.contains("Parakeet Realtime") == true)
+        #expect(modelsStep?.message.contains("Indic ASR") == true)
+        #expect(modelsStep?.message.contains("Gemma 4") == true)
+    }
+
+    @Test("store suppresses fresh installs and presents a legacy upgrade only once")
+    func storeLifecycle() throws {
+        let suiteName = "FeatureTourTests.storeLifecycle.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = FeatureTourStore(defaults: defaults)
+
+        #expect(store.automaticTour(
+            currentVersion: "0.8.0",
+            hasCompletedOnboarding: false,
+            canPresent: false
+        ) == nil)
+
+        // A fresh install that later completes onboarding is already recorded at
+        // 0.8 and does not receive a second onboarding-like flow.
+        #expect(store.automaticTour(
+            currentVersion: "0.8.0",
+            hasCompletedOnboarding: true,
+            canPresent: true
+        ) == nil)
+
+        defaults.removePersistentDomain(forName: suiteName)
+        let legacyStore = FeatureTourStore(defaults: defaults)
+        let presented = try #require(legacyStore.automaticTour(
+            currentVersion: "0.8.0",
+            hasCompletedOnboarding: true,
+            canPresent: true
+        ))
+        legacyStore.markOffered(presented)
+
+        #expect(legacyStore.automaticTour(
+            currentVersion: "0.8.0",
+            hasCompletedOnboarding: true,
+            canPresent: true
+        ) == nil)
+    }
+
+    @Test("permission repair defers the tour without consuming upgrade eligibility")
+    func permissionRepairDeferral() throws {
+        let suiteName = "FeatureTourTests.permissionRepair.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = FeatureTourStore(defaults: defaults)
+
+        #expect(store.automaticTour(
+            currentVersion: "0.8.0",
+            hasCompletedOnboarding: true,
+            canPresent: false
+        ) == nil)
+        #expect(store.automaticTour(
+            currentVersion: "0.8.0",
+            hasCompletedOnboarding: true,
+            canPresent: true
+        ) != nil)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -12,6 +12,62 @@ struct FeatureTourTests {
         #expect(try #require(MarketingVersion("0.8")) == #require(MarketingVersion("0.8.0")))
         #expect(try #require(MarketingVersion("0.8.0-preprod.1")) == #require(MarketingVersion("0.8.0")))
         #expect(MarketingVersion("not-a-version") == nil)
+        #expect(MarketingVersion("999999999999999999999999.0") == nil)
+        #expect(tour.displayVersion == "0.8")
+    }
+
+    @Test("target frame tracking ignores subpixel layout churn")
+    func frameTrackingTolerance() {
+        let current: [FeatureTourTarget: CGRect] = [
+            .insightsEntry: CGRect(x: 20, y: 30, width: 200, height: 80)
+        ]
+        #expect(!FeatureTourFrameTracking.hasMeaningfulChange(
+            from: current,
+            to: [.insightsEntry: CGRect(x: 20.25, y: 30.25, width: 200, height: 80)]
+        ))
+        #expect(FeatureTourFrameTracking.hasMeaningfulChange(
+            from: current,
+            to: [.insightsEntry: CGRect(x: 21, y: 30, width: 200, height: 80)]
+        ))
+        #expect(FeatureTourFrameTracking.hasMeaningfulChange(
+            from: current,
+            to: [.meetingsSidebar: CGRect(x: 20, y: 30, width: 200, height: 80)]
+        ))
+    }
+
+    @Test("callout layout uses rendered height and falls back to a visible edge")
+    func calloutLayout() {
+        let container = CGSize(width: 900, height: 600)
+        let callout = CGSize(width: 380, height: 310)
+        let bottomTarget = CGRect(x: 280, y: 500, width: 220, height: 50)
+
+        let bottomPosition = FeatureTourCalloutLayout.position(
+            spotlight: bottomTarget,
+            containerSize: container,
+            calloutSize: callout,
+            target: .liveCaptionsSetting
+        )
+        #expect(bottomPosition.y < bottomTarget.minY)
+
+        let topTarget = CGRect(x: 280, y: 30, width: 220, height: 50)
+        let abovePreferred = FeatureTourCalloutLayout.position(
+            spotlight: topTarget,
+            containerSize: container,
+            calloutSize: callout,
+            target: .experimentalModels
+        )
+        #expect(abovePreferred.y > topTarget.maxY)
+
+        let calloutFrame = CGRect(
+            x: abovePreferred.x - callout.width / 2,
+            y: abovePreferred.y - callout.height / 2,
+            width: callout.width,
+            height: callout.height
+        )
+        #expect(calloutFrame.minX >= 20)
+        #expect(calloutFrame.maxX <= container.width - 20)
+        #expect(calloutFrame.minY >= 20)
+        #expect(calloutFrame.maxY <= container.height - 20)
     }
 
     @Test("existing users without legacy version markers see the first feature tour")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1148,16 +1148,16 @@ struct MeetingsNavigationTests {
         config.postProcessorBackend = TranscriptCleanupBackendOption.gemma4LiteRT.backend
         config.enablePostProcessor = true
         configStore.save(config)
+        let persistedConfig = configStore.load()
+        #expect(persistedConfig.sttBackend == BackendOption.gemma4E2BLiteRT.backend)
+        #expect(persistedConfig.sttModel == BackendOption.gemma4E2BLiteRT.model)
 
         let controller = makeController(configStore: configStore)
 
-        #expect(controller.appState.selectedPostProcessorBackend == .local)
-        #expect(controller.appState.config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
-        #expect(!controller.appState.config.enablePostProcessor)
-        #expect(
-            controller.appState.selectedBackend != .gemma4E2BLiteRT
-                || controller.appState.selectedPostProcessorBackend != .gemma4LiteRT
-        )
+        #expect(controller.selectedPostProcessorBackend == .local)
+        #expect(controller.config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(!controller.config.enablePostProcessor)
+        #expect(controller.selectedBackend == .gemma4E2BLiteRT)
     }
 
     @Test("updateConfig persists normalized meeting transcription backend")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1125,6 +1125,41 @@ struct MeetingsNavigationTests {
         #expect(controller.appState.config.meetingTranscriptionModel == BackendOption.whisperLargeTurbo.model)
     }
 
+    @Test("selecting Gemma dictation replaces conflicting Gemma cleanup")
+    func selectingGemmaDictationReplacesGemmaCleanup() {
+        let controller = makeController()
+        controller.selectPostProcessorBackend(.gemma4LiteRT)
+
+        #expect(controller.appState.selectedPostProcessorBackend == .gemma4LiteRT)
+
+        controller.selectBackend(.gemma4E2BLiteRT)
+
+        #expect(controller.appState.selectedBackend == .gemma4E2BLiteRT)
+        #expect(controller.appState.selectedPostProcessorBackend == .local)
+        #expect(controller.appState.config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+    }
+
+    @Test("startup repairs a persisted Gemma dictation and cleanup conflict")
+    func startupRepairsPersistedGemmaConflict() {
+        let configStore = ConfigStore(supportDirectory: makeSupportDirectory())
+        var config = AppConfig()
+        config.sttBackend = BackendOption.gemma4E2BLiteRT.backend
+        config.sttModel = BackendOption.gemma4E2BLiteRT.model
+        config.postProcessorBackend = TranscriptCleanupBackendOption.gemma4LiteRT.backend
+        config.enablePostProcessor = true
+        configStore.save(config)
+
+        let controller = makeController(configStore: configStore)
+
+        #expect(controller.appState.selectedPostProcessorBackend == .local)
+        #expect(controller.appState.config.postProcessorBackend == TranscriptCleanupBackendOption.local.backend)
+        #expect(!controller.appState.config.enablePostProcessor)
+        #expect(
+            controller.appState.selectedBackend != .gemma4E2BLiteRT
+                || controller.appState.selectedPostProcessorBackend != .gemma4LiteRT
+        )
+    }
+
     @Test("updateConfig persists normalized meeting transcription backend")
     func updateConfigPersistsNormalizedMeetingTranscriptionBackend() {
         let controller = makeController()

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -349,6 +349,34 @@ struct PostProcessorOptionTests {
     }
 }
 
+@Suite("TranscriptCleanupBackendOption")
+struct TranscriptCleanupBackendOptionTests {
+
+    @Test("Gemma cleanup is unavailable only for Gemma dictation")
+    func gemmaCleanupCompatibility() {
+        #expect(!TranscriptCleanupBackendOption.gemma4LiteRT.isCompatible(with: .gemma4E2BLiteRT))
+
+        for backend in BackendOption.all where backend != .gemma4E2BLiteRT {
+            #expect(TranscriptCleanupBackendOption.gemma4LiteRT.isCompatible(with: backend))
+        }
+    }
+
+    @Test("Other cleanup backends remain available for Gemma dictation")
+    func otherCleanupBackendsRemainCompatible() {
+        for backend in TranscriptCleanupBackendOption.all where backend != .gemma4LiteRT {
+            #expect(backend.isCompatible(with: .gemma4E2BLiteRT))
+        }
+    }
+
+    @Test("Available cleanup options exclude only conflicting Gemma cleanup")
+    func availableOptionsExcludeGemmaConflict() {
+        let available = TranscriptCleanupBackendOption.available(for: .gemma4E2BLiteRT)
+
+        #expect(!available.contains(.gemma4LiteRT))
+        #expect(available.count == TranscriptCleanupBackendOption.all.count - 1)
+    }
+}
+
 @Suite("SummaryModelPreset")
 struct SummaryModelPresetTests {
 


### PR DESCRIPTION
## Summary

- add a dismissible v0.8 feature-tour invitation with TelemetryDeck tracking for invitation, accept, skip, dismissal, and completion
- guide users through Insights, Meetings, live captions, authenticated ChatGPT dictation cleanup, and the expanded model catalog using anchored spotlight overlays
- keep the existing dictation backend preload running while the invitation and walkthrough are visible
- allow manual replay from the app and status menus, permit dismissal at every step, and return completed tours to Dictations
- organize Models into Dictation, Streaming, and Post-processing tabs without resetting model download or activation state
- add an explicit Settings deep link that opens the Post-processing model catalog when no local cleanup model is installed
- avoid querying launch-at-login status during immediate Settings pane rendering, reducing the observed Settings navigation delay

## Why

v0.8 introduces several substantial capabilities that are difficult to discover through Sparkle release notes alone. The walkthrough points at the real controls in the existing interface, remains optional, and uses the normal startup model warmup time productively.

The Models reorganization also removes the need to scroll through one long catalog and makes local cleanup model installation discoverable from the setting that requires it.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Volumes/MuesliBuildCache/muesli-spm/worktrees/v080-feature-tour/test --filter 'FeatureTourTests|LaunchAtLoginManagerTests'`
  - 16 tests passed
- built, installed, and launched `MuesliDevC` through eSSD lane C
- manually verified all walkthrough steps and spotlight alignment
- manually verified authenticated ChatGPT cleanup inclusion
- manually verified Dictation, Streaming, and Post-processing model tabs
- manually verified the Settings cleanup-model link opens Post-processing
- manually verified completing the tour returns to Dictations
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786564575&installation_id=136549638&pr_number=313&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F313&signature=376d94bda3b1fc3c9cdcb3780036151fe10b9a8805cd6d44d39eec79d7f5f650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive in-app feature tour with invitations, spotlight callouts, and step-by-step navigation across the app.
  - Added “What’s New in Muesli” to the menu bar.
  - Improved models browsing with segmented categories, experimental targeting, and better routing into relevant sections.
- **Bug Fixes**
  - Fixed tour presentation so it appears only when eligible and won’t repeat unnecessarily.
  - Improved state repair and navigation when incompatible or missing local models (including Gemma) are involved.
- **Tests**
  - Added/expanded tests covering tour eligibility/geometry, callout placement, and cleanup backend compatibility and repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->