### PR TITLE
Harden iCloud sync and add device filters

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -415,13 +415,26 @@ public final class DictationStore {
         return makeDictationRecord(statement)
     }
 
-    public func meetingCounts() throws -> (total: Int, byFolder: [Int64: Int], directByFolder: [Int64: Int]) {
+    public func meetingCounts(
+        origin: RecordOriginFilter = .all
+    ) throws -> (total: Int, byFolder: [Int64: Int], directByFolder: [Int64: Int]) {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
+        let originCondition: String
+        switch origin {
+        case .all:
+            originCondition = ""
+        case .thisMac:
+            originCondition = " AND LOWER(TRIM(COALESCE(source, ''))) <> 'ios'"
+        case .fromIPhone:
+            originCondition = " AND LOWER(TRIM(COALESCE(source, ''))) = 'ios'"
+        }
+
         var total = 0
         var stmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM meetings WHERE deleted_at IS NULL", -1, &stmt, nil) == SQLITE_OK {
+        let totalSQL = "SELECT COUNT(*) FROM meetings WHERE deleted_at IS NULL\(originCondition)"
+        if sqlite3_prepare_v2(db, totalSQL, -1, &stmt, nil) == SQLITE_OK {
             if sqlite3_step(stmt) == SQLITE_ROW { total = Int(sqlite3_column_int(stmt, 0)) }
             sqlite3_finalize(stmt)
         } else {
@@ -431,7 +444,8 @@ public final class DictationStore {
         // Direct counts per folder.
         var directByFolder: [Int64: Int] = [:]
         var stmt2: OpaquePointer?
-        if sqlite3_prepare_v2(db, "SELECT folder_id, COUNT(*) FROM meetings WHERE folder_id IS NOT NULL AND deleted_at IS NULL GROUP BY folder_id", -1, &stmt2, nil) == SQLITE_OK {
+        let folderSQL = "SELECT folder_id, COUNT(*) FROM meetings WHERE folder_id IS NOT NULL AND deleted_at IS NULL\(originCondition) GROUP BY folder_id"
+        if sqlite3_prepare_v2(db, folderSQL, -1, &stmt2, nil) == SQLITE_OK {
             while sqlite3_step(stmt2) == SQLITE_ROW {
                 directByFolder[sqlite3_column_int64(stmt2, 0)] = Int(sqlite3_column_int(stmt2, 1))
             }

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -332,7 +332,13 @@ public final class DictationStore {
         return sqlite3_last_insert_rowid(db)
     }
 
-    public func recentDictations(limit: Int = 10, offset: Int = 0, fromDate: String? = nil, toDate: String? = nil) throws -> [DictationRecord] {
+    public func recentDictations(
+        limit: Int = 10,
+        offset: Int = 0,
+        fromDate: String? = nil,
+        toDate: String? = nil,
+        origin: RecordOriginFilter = .all
+    ) throws -> [DictationRecord] {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
@@ -345,6 +351,14 @@ public final class DictationStore {
         if let toDate {
             conditions.append("d.timestamp <= ?")
             boundValues.append(toDate)
+        }
+        switch origin {
+        case .all:
+            break
+        case .thisMac:
+            conditions.append("LOWER(TRIM(COALESCE(d.source, ''))) <> 'ios'")
+        case .fromIPhone:
+            conditions.append("LOWER(TRIM(COALESCE(d.source, ''))) = 'ios'")
         }
         conditions.insert("d.deleted_at IS NULL", at: 0)
         let whereClause = "WHERE " + conditions.joined(separator: " AND ")
@@ -480,9 +494,23 @@ public final class DictationStore {
         return rows
     }
 
-    public func recentMeetings(limit: Int? = nil, folderID: Int64? = nil) throws -> [MeetingRecord] {
+    public func recentMeetings(
+        limit: Int? = nil,
+        folderID: Int64? = nil,
+        origin: RecordOriginFilter = .all
+    ) throws -> [MeetingRecord] {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
+
+        let originCondition: String
+        switch origin {
+        case .all:
+            originCondition = ""
+        case .thisMac:
+            originCondition = " AND LOWER(TRIM(COALESCE(source, ''))) <> 'ios'"
+        case .fromIPhone:
+            originCondition = " AND LOWER(TRIM(COALESCE(source, ''))) = 'ios'"
+        }
 
         var sql: String
         if folderID != nil {
@@ -496,11 +524,11 @@ public final class DictationStore {
                     JOIN folder_tree ft ON mf.parent_id = ft.id
                 )
                 SELECT \(Self.meetingColumns) FROM meetings
-                WHERE folder_id IN (SELECT id FROM folder_tree) AND deleted_at IS NULL
+                WHERE folder_id IN (SELECT id FROM folder_tree) AND deleted_at IS NULL\(originCondition)
                 ORDER BY id DESC
                 """
         } else {
-            sql = "SELECT \(Self.meetingColumns) FROM meetings WHERE deleted_at IS NULL ORDER BY id DESC"
+            sql = "SELECT \(Self.meetingColumns) FROM meetings WHERE deleted_at IS NULL\(originCondition) ORDER BY id DESC"
         }
         if limit != nil { sql += " LIMIT ?" }
 

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -36,28 +36,6 @@ public enum RecordOriginFilter: String, Codable, CaseIterable, Hashable, Sendabl
     case all
     case thisMac
     case fromIPhone
-
-    public func matches(dictationSource: String) -> Bool {
-        let isFromIPhone = dictationSource
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased() == MeetingSource.iOS.rawValue
-        return matches(isFromIPhone: isFromIPhone)
-    }
-
-    public func matches(meetingSource: MeetingSource) -> Bool {
-        matches(isFromIPhone: meetingSource == .iOS)
-    }
-
-    private func matches(isFromIPhone: Bool) -> Bool {
-        switch self {
-        case .all:
-            return true
-        case .thisMac:
-            return !isFromIPhone
-        case .fromIPhone:
-            return isFromIPhone
-        }
-    }
 }
 
 public enum SyncTextRecordKind: String, Codable, Sendable {

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -32,6 +32,34 @@ public enum MeetingSource: String, Codable, Sendable {
     case audioImport = "audio_import"
 }
 
+public enum RecordOriginFilter: String, Codable, CaseIterable, Hashable, Sendable {
+    case all
+    case thisMac
+    case fromIPhone
+
+    public func matches(dictationSource: String) -> Bool {
+        let isFromIPhone = dictationSource
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() == MeetingSource.iOS.rawValue
+        return matches(isFromIPhone: isFromIPhone)
+    }
+
+    public func matches(meetingSource: MeetingSource) -> Bool {
+        matches(isFromIPhone: meetingSource == .iOS)
+    }
+
+    private func matches(isFromIPhone: Bool) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .thisMac:
+            return !isFromIPhone
+        case .fromIPhone:
+            return isFromIPhone
+        }
+    }
+}
+
 public enum SyncTextRecordKind: String, Codable, Sendable {
     case dictation
     case meeting

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -186,7 +186,9 @@ final class AppState {
     var dictationPageSize: Int = 50
     var dictationFromDate: String? = nil
     var dictationToDate: String? = nil
+    var dictationOriginFilter: RecordOriginFilter = .all
     var hasMoreDictations: Bool = true
+    var meetingOriginFilter: RecordOriginFilter = .all
 
     // Search
     var searchQuery: String = ""

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -115,13 +115,17 @@ struct DictationsView: View {
                 .padding(.bottom, MuesliTheme.spacing12)
             }
 
+            dictationFilterBar
+                .padding(.horizontal, MuesliTheme.spacing24)
+                .padding(.bottom, MuesliTheme.spacing12)
+
             if appState.dictationRows.isEmpty {
                 Spacer()
                 VStack(spacing: MuesliTheme.spacing12) {
                     Image(systemName: "mic.badge.plus")
                         .font(.system(size: 40, weight: .thin))
                         .foregroundStyle(MuesliTheme.textTertiary)
-                    Text("No dictations yet")
+                    Text(emptyStateTitle)
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textSecondary)
                     Text(emptyStateInstruction)
@@ -132,20 +136,13 @@ struct DictationsView: View {
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
-                        ForEach(Array(groupedDictations.enumerated()), id: \.element.header) { index, group in
+                        ForEach(groupedDictations, id: \.header) { group in
                             VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                                 HStack {
                                     Text(group.header)
                                         .font(.system(size: 12, weight: .semibold))
                                         .foregroundStyle(MuesliTheme.textTertiary)
                                         .padding(.leading, MuesliTheme.spacing4)
-
-                                    Spacer()
-
-                                    // Filter button on the first group header
-                                    if index == 0 {
-                                        dateFilterButton
-                                    }
                                 }
 
                                 VStack(spacing: 1) {
@@ -455,9 +452,31 @@ struct DictationsView: View {
     }
 
     private var emptyStateInstruction: String {
-        appState.config.resolvedOnboardingUseCase.includesVoiceNotes
+        if appState.dictationOriginFilter != .all || selectedFilter != .all {
+            return "Try another source or time range"
+        }
+        return appState.config.resolvedOnboardingUseCase.includesVoiceNotes
             ? "Click Record Voice Note to capture your first note"
             : "Hold \(appState.config.dictationHotkey.label) to start dictating"
+    }
+
+    private var emptyStateTitle: String {
+        switch appState.dictationOriginFilter {
+        case .all: return "No dictations yet"
+        case .thisMac: return "No dictations from this Mac"
+        case .fromIPhone: return "No dictations from iPhone"
+        }
+    }
+
+    private var dictationFilterBar: some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            RecordOriginPicker(selection: Binding(
+                get: { appState.dictationOriginFilter },
+                set: { controller.filterDictations(origin: $0) }
+            ))
+            Spacer(minLength: 0)
+            dateFilterButton
+        }
     }
 
     private var voiceNoteButton: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -46,7 +46,7 @@ struct DictationsView: View {
     @State private var bridgePromptSeen = false
     @State private var isBridgeQRCodePresented = false
 
-    private var groupedDictations: [(header: String, records: [DictationRecord])] {
+    private var groupedDictations: [(id: Date, header: String, records: [DictationRecord])] {
         let calendar = Calendar.current
         let now = Date()
         let today = calendar.startOfDay(for: now)
@@ -89,7 +89,7 @@ struct DictationsView: View {
             groups.append((key: key, header: currentHeader, records: currentRecords))
         }
 
-        return groups.map { (header: $0.header, records: $0.records) }
+        return groups.map { (id: $0.key, header: $0.header, records: $0.records) }
     }
 
     var body: some View {
@@ -136,7 +136,7 @@ struct DictationsView: View {
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
-                        ForEach(groupedDictations, id: \.header) { group in
+                        ForEach(groupedDictations, id: \.id) { group in
                             VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                                 HStack {
                                     Text(group.header)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -19,6 +19,26 @@ enum DictationFilter: Hashable {
     }
 }
 
+enum ICloudBridgeWorkingCopy {
+    static func title(isActivationPending: Bool) -> String {
+        isActivationPending
+            ? "Setting up private iCloud sync"
+            : "Syncing with private iCloud"
+    }
+
+    static func subtitle(isActivationPending: Bool) -> String {
+        isActivationPending
+            ? "Creating the sync channel and pulling your latest text records."
+            : "Checking for new text and uploading local changes."
+    }
+
+    static func buttonHelp(isActivationPending: Bool) -> String {
+        isActivationPending
+            ? "Sync setup is in progress"
+            : "Text sync is in progress"
+    }
+}
+
 struct DictationsView: View {
     let appState: AppState
     let controller: MuesliController
@@ -341,8 +361,12 @@ struct DictationsView: View {
                 return "Synced with \(deviceName) · \(relativeSyncTime(lastSyncedAt))"
             }
             return "Synced with \(deviceName)"
-        case .checkingICloud, .syncing:
+        case .checkingICloud:
             return "Setting up private iCloud sync"
+        case .syncing:
+            return ICloudBridgeWorkingCopy.title(
+                isActivationPending: appState.isICloudBridgeActivationPending
+            )
         case .needsICloud:
             return "Sign in to iCloud to sync"
         case .error:
@@ -362,7 +386,9 @@ struct DictationsView: View {
         case .checkingICloud:
             return "Checking this Mac's iCloud account..."
         case .syncing:
-            return "Creating the sync channel and pulling your latest text records."
+            return ICloudBridgeWorkingCopy.subtitle(
+                isActivationPending: appState.isICloudBridgeActivationPending
+            )
         case .needsICloud, .error:
             return appState.iCloudBridgeMessage ?? "Open iCloud settings, then try again."
         case .notConfigured:
@@ -400,8 +426,12 @@ struct DictationsView: View {
         switch bridgeState {
         case .active:
             return "Sync text with iCloud"
-        case .checkingICloud, .syncing:
+        case .checkingICloud:
             return "Sync setup is in progress"
+        case .syncing:
+            return ICloudBridgeWorkingCopy.buttonHelp(
+                isActivationPending: appState.isICloudBridgeActivationPending
+            )
         default:
             return "Set up private iCloud text sync"
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -57,7 +57,6 @@ enum MeetingBrowserLogic {
     static func filteredMeetings(
         from meetings: [MeetingRecord],
         filter: MeetingBrowserFilter,
-        origin: RecordOriginFilter = .all,
         sort: MeetingBrowserSort,
         now: Date = Date(),
         calendar: Calendar = .current
@@ -65,7 +64,6 @@ enum MeetingBrowserLogic {
         presentation(
             from: meetings,
             filter: filter,
-            origin: origin,
             sort: sort,
             now: now,
             calendar: calendar
@@ -75,7 +73,6 @@ enum MeetingBrowserLogic {
     static func presentation(
         from meetings: [MeetingRecord],
         filter: MeetingBrowserFilter,
-        origin: RecordOriginFilter = .all,
         sort: MeetingBrowserSort,
         now: Date = Date(),
         calendar: Calendar = .current
@@ -88,8 +85,7 @@ enum MeetingBrowserLogic {
             if let followUpToID = meeting.followUpToID {
                 meetingIDsWithFollowUps.insert(followUpToID)
             }
-            if origin.matches(meetingSource: meeting.source),
-               isAfterThreshold(meeting, threshold: threshold) {
+            if isAfterThreshold(meeting, threshold: threshold) {
                 filtered.append(meeting)
             }
         }
@@ -208,7 +204,6 @@ struct MeetingsView: View {
         MeetingBrowserLogic.presentation(
             from: scopedMeetings,
             filter: selectedFilter,
-            origin: appState.meetingOriginFilter,
             sort: selectedSort
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -57,6 +57,7 @@ enum MeetingBrowserLogic {
     static func filteredMeetings(
         from meetings: [MeetingRecord],
         filter: MeetingBrowserFilter,
+        origin: RecordOriginFilter = .all,
         sort: MeetingBrowserSort,
         now: Date = Date(),
         calendar: Calendar = .current
@@ -64,6 +65,7 @@ enum MeetingBrowserLogic {
         presentation(
             from: meetings,
             filter: filter,
+            origin: origin,
             sort: sort,
             now: now,
             calendar: calendar
@@ -73,6 +75,7 @@ enum MeetingBrowserLogic {
     static func presentation(
         from meetings: [MeetingRecord],
         filter: MeetingBrowserFilter,
+        origin: RecordOriginFilter = .all,
         sort: MeetingBrowserSort,
         now: Date = Date(),
         calendar: Calendar = .current
@@ -85,7 +88,8 @@ enum MeetingBrowserLogic {
             if let followUpToID = meeting.followUpToID {
                 meetingIDsWithFollowUps.insert(followUpToID)
             }
-            if isAfterThreshold(meeting, threshold: threshold) {
+            if origin.matches(meetingSource: meeting.source),
+               isAfterThreshold(meeting, threshold: threshold) {
                 filtered.append(meeting)
             }
         }
@@ -204,6 +208,7 @@ struct MeetingsView: View {
         MeetingBrowserLogic.presentation(
             from: scopedMeetings,
             filter: selectedFilter,
+            origin: appState.meetingOriginFilter,
             sort: selectedSort
         )
     }
@@ -569,6 +574,11 @@ struct MeetingsView: View {
             }
 
             browserHeaderMeta(meetingCount: meetingCount)
+
+            RecordOriginPicker(selection: Binding(
+                get: { appState.meetingOriginFilter },
+                set: { controller.filterMeetings(origin: $0) }
+            ))
         }
     }
 
@@ -853,15 +863,11 @@ struct MeetingsView: View {
                 .font(.system(size: 30, weight: .thin))
                 .foregroundStyle(MuesliTheme.textTertiary)
 
-            Text(appState.selectedFolderID == nil ? "No meetings yet" : "No meetings in this folder")
+            Text(emptyStateTitle)
                 .font(MuesliTheme.title3())
                 .foregroundStyle(MuesliTheme.textSecondary)
 
-            Text(
-                appState.selectedFolderID == nil
-                    ? "Start a recording from the menu bar to create your first meeting note."
-                    : "Choose another folder or move a meeting here from the browser."
-            )
+            Text(emptyStateInstruction)
             .font(MuesliTheme.callout())
             .foregroundStyle(MuesliTheme.textTertiary)
             .frame(maxWidth: 320, alignment: .leading)
@@ -874,5 +880,25 @@ struct MeetingsView: View {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerXL)
                 .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
         )
+    }
+
+    private var emptyStateTitle: String {
+        switch appState.meetingOriginFilter {
+        case .thisMac:
+            return "No meetings from this Mac"
+        case .fromIPhone:
+            return "No meetings from iPhone"
+        case .all:
+            return appState.selectedFolderID == nil ? "No meetings yet" : "No meetings in this folder"
+        }
+    }
+
+    private var emptyStateInstruction: String {
+        if appState.meetingOriginFilter != .all || selectedFilter != .all {
+            return "Try another source, time range, or folder."
+        }
+        return appState.selectedFolderID == nil
+            ? "Start a recording from the menu bar to create your first meeting note."
+            : "Choose another folder or move a meeting here from the browser."
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1022,11 +1022,16 @@ final class MuesliController: NSObject {
             limit: appState.dictationPageSize,
             offset: 0,
             fromDate: appState.dictationFromDate,
-            toDate: appState.dictationToDate
+            toDate: appState.dictationToDate,
+            origin: appState.dictationOriginFilter
         )) ?? []
         appState.dictationRows = rows
         appState.hasMoreDictations = rows.count >= appState.dictationPageSize
-        appState.meetingRows = (try? dictationStore.recentMeetings(limit: 200, folderID: appState.selectedFolderID)) ?? []
+        appState.meetingRows = (try? dictationStore.recentMeetings(
+            limit: 200,
+            folderID: appState.selectedFolderID,
+            origin: appState.meetingOriginFilter
+        )) ?? []
         let counts = (try? dictationStore.meetingCounts()) ?? (total: 0, byFolder: [:], directByFolder: [:])
         appState.totalMeetingCount = counts.total
         appState.meetingCountsByFolder = counts.byFolder
@@ -4324,7 +4329,8 @@ final class MuesliController: NSObject {
             limit: appState.dictationPageSize,
             offset: offset,
             fromDate: appState.dictationFromDate,
-            toDate: appState.dictationToDate
+            toDate: appState.dictationToDate,
+            origin: appState.dictationOriginFilter
         )) ?? []
         appState.dictationRows.append(contentsOf: more)
         appState.hasMoreDictations = more.count >= appState.dictationPageSize
@@ -4341,6 +4347,16 @@ final class MuesliController: NSObject {
     func clearDictationFilter() {
         appState.dictationFromDate = nil
         appState.dictationToDate = nil
+        syncAppState()
+    }
+
+    func filterDictations(origin: RecordOriginFilter) {
+        appState.dictationOriginFilter = origin
+        syncAppState()
+    }
+
+    func filterMeetings(origin: RecordOriginFilter) {
+        appState.meetingOriginFilter = origin
         syncAppState()
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1032,7 +1032,8 @@ final class MuesliController: NSObject {
             folderID: appState.selectedFolderID,
             origin: appState.meetingOriginFilter
         )) ?? []
-        let counts = (try? dictationStore.meetingCounts()) ?? (total: 0, byFolder: [:], directByFolder: [:])
+        let counts = (try? dictationStore.meetingCounts(origin: appState.meetingOriginFilter))
+            ?? (total: 0, byFolder: [:], directByFolder: [:])
         appState.totalMeetingCount = counts.total
         appState.meetingCountsByFolder = counts.byFolder
         appState.directMeetingCountsByFolder = counts.directByFolder

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -276,17 +276,33 @@ private final class ICloudSyncCallbackGate<Value>: @unchecked Sendable {
     private var continuation: CheckedContinuation<Value, Error>?
     private var operation: CKOperation?
     private var timeoutWorkItem: DispatchWorkItem?
+    private var isFinished = false
+    private var isCancelled = false
 
-    init(continuation: CheckedContinuation<Value, Error>) {
+    func install(continuation: CheckedContinuation<Value, Error>) -> Bool {
+        lock.lock()
+        if isCancelled {
+            isFinished = true
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return false
+        }
+        guard !isFinished, self.continuation == nil else {
+            lock.unlock()
+            return false
+        }
         self.continuation = continuation
+        lock.unlock()
+        return true
     }
 
     func resolve(_ result: Result<Value, Error>) {
         lock.lock()
-        guard let continuation else {
+        guard !isFinished, let continuation else {
             lock.unlock()
             return
         }
+        isFinished = true
         self.continuation = nil
         operation = nil
         let timeoutWorkItem = self.timeoutWorkItem
@@ -303,8 +319,12 @@ private final class ICloudSyncCallbackGate<Value>: @unchecked Sendable {
         }
 
         lock.lock()
-        guard continuation != nil else {
+        guard !isFinished, continuation != nil else {
+            let shouldCancel = isCancelled
             lock.unlock()
+            if shouldCancel {
+                operation?.cancel()
+            }
             return
         }
         self.operation = operation
@@ -317,12 +337,36 @@ private final class ICloudSyncCallbackGate<Value>: @unchecked Sendable {
         )
     }
 
-    private func timeOut() {
+    func cancel() {
         lock.lock()
-        guard let continuation else {
+        guard !isFinished else {
             lock.unlock()
             return
         }
+        isCancelled = true
+        let continuation = self.continuation
+        let operation = self.operation
+        let timeoutWorkItem = self.timeoutWorkItem
+        self.continuation = nil
+        self.operation = nil
+        self.timeoutWorkItem = nil
+        if continuation != nil {
+            isFinished = true
+        }
+        lock.unlock()
+
+        timeoutWorkItem?.cancel()
+        operation?.cancel()
+        continuation?.resume(throwing: CancellationError())
+    }
+
+    private func timeOut() {
+        lock.lock()
+        guard !isFinished, let continuation else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
         self.continuation = nil
         let operation = self.operation
         self.operation = nil
@@ -341,12 +385,24 @@ enum ICloudSyncCallbackDeadline {
         timeout: TimeInterval = defaultTimeout,
         start: (@escaping (Result<Value, Error>) -> Void) -> CKOperation?
     ) async throws -> Value {
-        try await withCheckedThrowingContinuation { continuation in
-            let gate = ICloudSyncCallbackGate(continuation: continuation)
-            let operation = start { result in
-                gate.resolve(result)
+        let gate = ICloudSyncCallbackGate<Value>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard gate.install(continuation: continuation) else { return }
+                if Task.isCancelled {
+                    gate.cancel()
+                    return
+                }
+                let operation = start { result in
+                    gate.resolve(result)
+                }
+                gate.arm(operation: operation, timeout: timeout)
+                if Task.isCancelled {
+                    gate.cancel()
+                }
             }
-            gate.arm(operation: operation, timeout: timeout)
+        } onCancel: {
+            gate.cancel()
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -263,6 +263,94 @@ private enum ICloudSyncAccountError: LocalizedError {
     }
 }
 
+enum ICloudSyncDeadlineError: LocalizedError, Equatable {
+    case operationTimedOut
+
+    var errorDescription: String? {
+        "iCloud did not respond in time. Your text is safe and will be retried."
+    }
+}
+
+private final class ICloudSyncCallbackGate<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var operation: CKOperation?
+    private var timeoutWorkItem: DispatchWorkItem?
+
+    init(continuation: CheckedContinuation<Value, Error>) {
+        self.continuation = continuation
+    }
+
+    func resolve(_ result: Result<Value, Error>) {
+        lock.lock()
+        guard let continuation else {
+            lock.unlock()
+            return
+        }
+        self.continuation = nil
+        operation = nil
+        let timeoutWorkItem = self.timeoutWorkItem
+        self.timeoutWorkItem = nil
+        lock.unlock()
+
+        timeoutWorkItem?.cancel()
+        continuation.resume(with: result)
+    }
+
+    func arm(operation: CKOperation?, timeout: TimeInterval) {
+        let timeoutWorkItem = DispatchWorkItem { [self] in
+            timeOut()
+        }
+
+        lock.lock()
+        guard continuation != nil else {
+            lock.unlock()
+            return
+        }
+        self.operation = operation
+        self.timeoutWorkItem = timeoutWorkItem
+        lock.unlock()
+
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + timeout,
+            execute: timeoutWorkItem
+        )
+    }
+
+    private func timeOut() {
+        lock.lock()
+        guard let continuation else {
+            lock.unlock()
+            return
+        }
+        self.continuation = nil
+        let operation = self.operation
+        self.operation = nil
+        timeoutWorkItem = nil
+        lock.unlock()
+
+        operation?.cancel()
+        continuation.resume(throwing: ICloudSyncDeadlineError.operationTimedOut)
+    }
+}
+
+enum ICloudSyncCallbackDeadline {
+    static let defaultTimeout: TimeInterval = 60
+
+    static func wait<Value>(
+        timeout: TimeInterval = defaultTimeout,
+        start: (@escaping (Result<Value, Error>) -> Void) -> CKOperation?
+    ) async throws -> Value {
+        try await withCheckedThrowingContinuation { continuation in
+            let gate = ICloudSyncCallbackGate(continuation: continuation)
+            let operation = start { result in
+                gate.resolve(result)
+            }
+            gate.arm(operation: operation, timeout: timeout)
+        }
+    }
+}
+
 final class MuesliICloudSyncEngine {
     private enum Schema {
         static let containerIdentifier = "iCloud.com.mueslihq.muesli"
@@ -458,14 +546,15 @@ final class MuesliICloudSyncEngine {
     }
 
     private func accountStatus() async throws -> CKAccountStatus {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             container.accountStatus { status, error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 } else {
-                    continuation.resume(returning: status)
+                    finish(.success(status))
                 }
             }
+            return nil
         }
     }
 
@@ -673,7 +762,7 @@ final class MuesliICloudSyncEngine {
     }
 
     private func fetchTextRecordsPage(cursor: CKQueryOperation.Cursor?) async throws -> ICloudQueryPage {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             let operation: CKQueryOperation
             if let cursor {
                 operation = CKQueryOperation(cursor: cursor)
@@ -701,12 +790,13 @@ final class MuesliICloudSyncEngine {
                     lock.lock()
                     let pageRecords = records
                     lock.unlock()
-                    continuation.resume(returning: ICloudQueryPage(records: pageRecords, cursor: cursor))
+                    finish(.success(ICloudQueryPage(records: pageRecords, cursor: cursor)))
                 case .failure(let error):
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 }
             }
             database.add(operation)
+            return operation
         }
     }
 
@@ -714,7 +804,7 @@ final class MuesliICloudSyncEngine {
         query: CKQuery,
         cursor: CKQueryOperation.Cursor?
     ) async throws -> ICloudQueryPage {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             let operation: CKQueryOperation
             if let cursor {
                 operation = CKQueryOperation(cursor: cursor)
@@ -741,12 +831,13 @@ final class MuesliICloudSyncEngine {
                     lock.lock()
                     let pageRecords = records
                     lock.unlock()
-                    continuation.resume(returning: ICloudQueryPage(records: pageRecords, cursor: cursor))
+                    finish(.success(ICloudQueryPage(records: pageRecords, cursor: cursor)))
                 case .failure(let error):
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 }
             }
             database.add(operation)
+            return operation
         }
     }
 
@@ -754,7 +845,7 @@ final class MuesliICloudSyncEngine {
         zoneID: CKRecordZone.ID,
         previousServerChangeToken: CKServerChangeToken?
     ) async throws -> ICloudZoneChangesPage {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             let configuration = CKFetchRecordZoneChangesOperation.ZoneConfiguration(
                 previousServerChangeToken: previousServerChangeToken,
                 resultsLimit: nil,
@@ -800,55 +891,58 @@ final class MuesliICloudSyncEngine {
                     lock.unlock()
                     switch pageResult {
                     case .success(let page):
-                        continuation.resume(returning: ICloudZoneChangesPage(
+                        finish(.success(ICloudZoneChangesPage(
                             records: pageRecords,
                             serverChangeToken: page.serverChangeToken,
                             moreComing: page.moreComing
-                        ))
+                        )))
                     case .failure(let error):
-                        continuation.resume(throwing: error)
+                        finish(.failure(error))
                     case .none:
-                        continuation.resume(throwing: CKError(.internalError))
+                        finish(.failure(CKError(.internalError)))
                     }
                 case .failure(let error):
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 }
             }
             database.add(operation)
+            return operation
         }
     }
 
     private func fetchSubscription(id: String) async throws -> CKSubscription {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             database.fetch(withSubscriptionID: id) { subscription, error in
                 if let subscription {
-                    continuation.resume(returning: subscription)
+                    finish(.success(subscription))
                 } else if let error {
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 } else {
-                    continuation.resume(throwing: CKError(.unknownItem))
+                    finish(.failure(CKError(.unknownItem)))
                 }
             }
+            return nil
         }
     }
 
     private func fetchZone(id: CKRecordZone.ID) async throws -> CKRecordZone {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             database.fetch(withRecordZoneID: id) { zone, error in
                 if let zone {
-                    continuation.resume(returning: zone)
+                    finish(.success(zone))
                 } else if let error {
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 } else {
-                    continuation.resume(throwing: CKError(.unknownItem))
+                    finish(.failure(CKError(.unknownItem)))
                 }
             }
+            return nil
         }
     }
 
     private func fetchExistingRecords(recordIDs: [CKRecord.ID]) async throws -> [CKRecord.ID: CKRecord] {
         guard !recordIDs.isEmpty else { return [:] }
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await ICloudSyncCallbackDeadline.wait { finish in
             let operation = CKFetchRecordsOperation(recordIDs: recordIDs)
             let lock = NSLock()
             var fetchedRecords: [CKRecord.ID: CKRecord] = [:]
@@ -874,29 +968,30 @@ final class MuesliICloudSyncEngine {
                 lock.unlock()
 
                 if let firstNonMissingError {
-                    continuation.resume(throwing: firstNonMissingError)
+                    finish(.failure(firstNonMissingError))
                     return
                 }
 
                 switch result {
                 case .success:
-                    continuation.resume(returning: records)
+                    finish(.success(records))
                 case .failure(let error):
                     if Self.containsOnlyUnknownItemErrors(error) {
-                        continuation.resume(returning: records)
+                        finish(.success(records))
                     } else {
-                        continuation.resume(throwing: error)
+                        finish(.failure(error))
                     }
                 }
             }
 
             database.add(operation)
+            return operation
         }
     }
 
     private func save(records: [CKRecord]) async throws -> [CKRecord] {
         guard !records.isEmpty else { return [] }
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await ICloudSyncCallbackDeadline.wait { finish in
             let operation = CKModifyRecordsOperation(recordsToSave: records, recordIDsToDelete: nil)
             operation.savePolicy = .changedKeys
             let lock = NSLock()
@@ -914,12 +1009,13 @@ final class MuesliICloudSyncEngine {
                     lock.lock()
                     let records = savedRecords
                     lock.unlock()
-                    continuation.resume(returning: records)
+                    finish(.success(records))
                 case .failure(let error):
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 }
             }
             database.add(operation)
+            return operation
         }
     }
 
@@ -936,30 +1032,32 @@ final class MuesliICloudSyncEngine {
     }
 
     private func save(subscription: CKSubscription) async throws -> CKSubscription {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             database.save(subscription) { savedSubscription, error in
                 if let savedSubscription {
-                    continuation.resume(returning: savedSubscription)
+                    finish(.success(savedSubscription))
                 } else if let error {
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 } else {
-                    continuation.resume(throwing: CKError(.internalError))
+                    finish(.failure(CKError(.internalError)))
                 }
             }
+            return nil
         }
     }
 
     private func save(zone: CKRecordZone) async throws -> CKRecordZone {
-        try await withCheckedThrowingContinuation { continuation in
+        try await ICloudSyncCallbackDeadline.wait { finish in
             database.save(zone) { savedZone, error in
                 if let savedZone {
-                    continuation.resume(returning: savedZone)
+                    finish(.success(savedZone))
                 } else if let error {
-                    continuation.resume(throwing: error)
+                    finish(.failure(error))
                 } else {
-                    continuation.resume(throwing: CKError(.internalError))
+                    finish(.failure(CKError(.internalError)))
                 }
             }
+            return nil
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SyncOriginDisplay.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SyncOriginDisplay.swift
@@ -17,6 +17,33 @@ enum SyncOriginDisplay {
     }
 }
 
+extension RecordOriginFilter {
+    var label: String {
+        switch self {
+        case .all: return "All"
+        case .thisMac: return "This Mac"
+        case .fromIPhone: return "From iPhone"
+        }
+    }
+}
+
+struct RecordOriginPicker: View {
+    @Binding var selection: RecordOriginFilter
+
+    var body: some View {
+        Picker("Record source", selection: $selection) {
+            ForEach(RecordOriginFilter.allCases, id: \.self) { origin in
+                Text(origin.label).tag(origin)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: 240)
+        .help("Filter by the device where the recording was created")
+        .accessibilityLabel("Record source")
+    }
+}
+
 struct SyncOriginBadge: View {
     let label: String
     var help: String = SyncOriginDisplay.iOSBadgeHelp

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -1048,6 +1048,47 @@ struct DictationStoreTests {
         #expect(try store.textRecordsNeedingSync().isEmpty)
     }
 
+    @Test("recent meetings filter by recording device before limit")
+    func recentMeetingsFilterByOriginBeforeLimit() throws {
+        let store = try makeStore()
+        let startedAt = Date(timeIntervalSince1970: 1_770_000_000)
+
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: "meeting-origin-ios",
+            kind: .meeting,
+            title: "iPhone Meeting",
+            text: "Synced transcript",
+            source: "ios",
+            createdAt: startedAt,
+            updatedAt: startedAt,
+            startedAt: startedAt,
+            endedAt: startedAt.addingTimeInterval(60),
+            durationSeconds: 60,
+            wordCount: 2,
+            cloudChangeTag: "tag-origin-ios"
+        ))
+        for index in 0..<2 {
+            let start = startedAt.addingTimeInterval(Double(100 + index * 100))
+            try store.insertMeeting(
+                title: "Mac Meeting \(index)",
+                calendarEventID: nil,
+                startTime: start,
+                endTime: start.addingTimeInterval(60),
+                rawTranscript: "Local transcript",
+                formattedNotes: "Local notes",
+                micAudioPath: nil,
+                systemAudioPath: nil,
+                source: index == 0 ? .meeting : .audioImport
+            )
+        }
+
+        let iPhoneRows = try store.recentMeetings(limit: 1, origin: .fromIPhone)
+        let macRows = try store.recentMeetings(limit: 10, origin: .thisMac)
+
+        #expect(iPhoneRows.map(\.title) == ["iPhone Meeting"])
+        #expect(macRows.map(\.title) == ["Mac Meeting 1", "Mac Meeting 0"])
+    }
+
     @Test("CloudKit expired change token errors are detected")
     func cloudKitExpiredChangeTokenErrorsAreDetected() {
         #expect(MuesliICloudSyncEngine.isChangeTokenExpired(CKError(.changeTokenExpired)))
@@ -1927,6 +1968,47 @@ struct DictationStoreTests {
         let rows = try store.recentDictations(limit: 2)
 
         #expect(rows.map(\.rawText) == ["Newer Mac row", "Older iOS row"])
+    }
+
+    @Test("recent dictations filter by recording device before pagination")
+    func recentDictationsFilterByOriginBeforePagination() throws {
+        let store = try makeStore()
+        let base = Date(timeIntervalSince1970: 1_770_000_000)
+
+        for index in 0..<3 {
+            let end = base.addingTimeInterval(Double(index * 10))
+            _ = try store.insertDictation(
+                text: "Mac \(index)",
+                durationSeconds: 1,
+                source: index == 0 ? "cua" : "dictation",
+                startedAt: end.addingTimeInterval(-1),
+                endedAt: end
+            )
+        }
+        for index in 0..<2 {
+            let end = base.addingTimeInterval(Double(100 + index * 10))
+            try store.upsertSyncedTextRecord(SyncTextRecord(
+                id: "origin-filter-ios-\(index)",
+                kind: .dictation,
+                text: "iPhone \(index)",
+                source: index == 0 ? " iOS " : "ios",
+                createdAt: end,
+                updatedAt: end,
+                startedAt: end.addingTimeInterval(-1),
+                endedAt: end,
+                durationSeconds: 1,
+                wordCount: 2,
+                cloudChangeTag: "tag-\(index)"
+            ))
+        }
+
+        let firstIPhonePage = try store.recentDictations(limit: 1, origin: .fromIPhone)
+        let secondIPhonePage = try store.recentDictations(limit: 1, offset: 1, origin: .fromIPhone)
+        let macRows = try store.recentDictations(limit: 10, origin: .thisMac)
+
+        #expect(firstIPhonePage.map(\.rawText) == ["iPhone 1"])
+        #expect(secondIPhonePage.map(\.rawText) == ["iPhone 0"])
+        #expect(macRows.map(\.rawText) == ["Mac 2", "Mac 1", "Mac 0"])
     }
 
     @Test("recent dictations treats fromDate as a bound value, not SQL")

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -2523,6 +2523,49 @@ struct DictationStoreTests {
         #expect(counts.directByFolder[child] == 2)
     }
 
+    @Test("meetingCounts applies origin filter to totals and recursive folder badges")
+    func meetingCountsRespectOriginFilter() throws {
+        let store = try makeStore()
+        let now = Date()
+        let parent = try store.createFolder(name: "Parent")
+        let child = try store.createFolder(name: "Child", parentID: parent)
+
+        try store.insertMeeting(
+            title: "Mac Meeting", calendarEventID: nil, startTime: now,
+            endTime: now.addingTimeInterval(60), rawTranscript: "t", formattedNotes: "",
+            micAudioPath: nil, systemAudioPath: nil, source: .meeting
+        )
+        try store.moveMeeting(id: try store.recentMeetings(limit: 1).first!.id, toFolder: parent)
+
+        try store.insertMeeting(
+            title: "iPhone Meeting", calendarEventID: nil, startTime: now.addingTimeInterval(1),
+            endTime: now.addingTimeInterval(61), rawTranscript: "t", formattedNotes: "",
+            micAudioPath: nil, systemAudioPath: nil, source: .iOS
+        )
+        try store.moveMeeting(id: try store.recentMeetings(limit: 1).first!.id, toFolder: child)
+
+        try store.insertMeeting(
+            title: "Imported Meeting", calendarEventID: nil, startTime: now.addingTimeInterval(2),
+            endTime: now.addingTimeInterval(62), rawTranscript: "t", formattedNotes: "",
+            micAudioPath: nil, systemAudioPath: nil, source: .audioImport
+        )
+        try store.moveMeeting(id: try store.recentMeetings(limit: 1).first!.id, toFolder: child)
+
+        let iPhoneCounts = try store.meetingCounts(origin: .fromIPhone)
+        #expect(iPhoneCounts.total == 1)
+        #expect(iPhoneCounts.byFolder[parent] == 1)
+        #expect(iPhoneCounts.byFolder[child] == 1)
+        #expect(iPhoneCounts.directByFolder[parent] == nil)
+        #expect(iPhoneCounts.directByFolder[child] == 1)
+
+        let macCounts = try store.meetingCounts(origin: .thisMac)
+        #expect(macCounts.total == 2)
+        #expect(macCounts.byFolder[parent] == 2)
+        #expect(macCounts.byFolder[child] == 1)
+        #expect(macCounts.directByFolder[parent] == 1)
+        #expect(macCounts.directByFolder[child] == 1)
+    }
+
     @Test("meetingCounts gives stable totals for cyclic folder data")
     func meetingCountsCyclicFoldersAreStable() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/ICloudSyncCallbackDeadlineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ICloudSyncCallbackDeadlineTests.swift
@@ -1,0 +1,47 @@
+import CloudKit
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("iCloud sync callback deadline")
+struct ICloudSyncCallbackDeadlineTests {
+    @Test("returns a callback result before the deadline")
+    func callbackWins() async throws {
+        let value: Int = try await ICloudSyncCallbackDeadline.wait(timeout: 0.1) { finish in
+            finish(.success(42))
+            return nil
+        }
+
+        #expect(value == 42)
+    }
+
+    @Test("times out and cancels an unfinished CloudKit operation")
+    func timeoutCancelsOperation() async {
+        let operation = CKFetchRecordsOperation()
+
+        do {
+            let _: Int = try await ICloudSyncCallbackDeadline.wait(timeout: 0.01) { _ in
+                operation
+            }
+            Issue.record("Expected the CloudKit callback deadline to expire")
+        } catch let error as ICloudSyncDeadlineError {
+            #expect(error == .operationTimedOut)
+            #expect(operation.isCancelled)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}
+
+@Suite("iCloud bridge working copy")
+struct ICloudBridgeWorkingCopyTests {
+    @Test("distinguishes first-time setup from routine sync")
+    func distinguishesSetupFromSync() {
+        #expect(ICloudBridgeWorkingCopy.title(isActivationPending: true) == "Setting up private iCloud sync")
+        #expect(ICloudBridgeWorkingCopy.title(isActivationPending: false) == "Syncing with private iCloud")
+        #expect(ICloudBridgeWorkingCopy.subtitle(isActivationPending: true).contains("Creating the sync channel"))
+        #expect(ICloudBridgeWorkingCopy.subtitle(isActivationPending: false).contains("uploading local changes"))
+        #expect(ICloudBridgeWorkingCopy.buttonHelp(isActivationPending: true) == "Sync setup is in progress")
+        #expect(ICloudBridgeWorkingCopy.buttonHelp(isActivationPending: false) == "Text sync is in progress")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/ICloudSyncCallbackDeadlineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ICloudSyncCallbackDeadlineTests.swift
@@ -3,6 +3,29 @@ import Foundation
 import Testing
 @testable import MuesliNativeApp
 
+private actor ICloudSyncTestSignal {
+    private var pendingSignals = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        if waiters.isEmpty {
+            pendingSignals += 1
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+
+    func wait() async {
+        if pendingSignals > 0 {
+            pendingSignals -= 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}
+
 @Suite("iCloud sync callback deadline")
 struct ICloudSyncCallbackDeadlineTests {
     @Test("returns a callback result before the deadline")
@@ -26,6 +49,57 @@ struct ICloudSyncCallbackDeadlineTests {
             Issue.record("Expected the CloudKit callback deadline to expire")
         } catch let error as ICloudSyncDeadlineError {
             #expect(error == .operationTimedOut)
+            #expect(operation.isCancelled)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("task cancellation cancels an armed CloudKit operation")
+    func taskCancellationCancelsArmedOperation() async {
+        let operation = CKFetchRecordsOperation()
+        let started = ICloudSyncTestSignal()
+        let task = Task<Int, Error> {
+            try await ICloudSyncCallbackDeadline.wait(timeout: 10) { _ in
+                Task { await started.signal() }
+                return operation
+            }
+        }
+
+        await started.wait()
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected task cancellation")
+        } catch is CancellationError {
+            #expect(operation.isCancelled)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("task cancellation before arm cancels the operation when start returns")
+    func taskCancellationBeforeArmCancelsReturnedOperation() async {
+        let operation = CKFetchRecordsOperation()
+        let startEntered = ICloudSyncTestSignal()
+        let allowStartToReturn = DispatchSemaphore(value: 0)
+        let task = Task<Int, Error> {
+            try await ICloudSyncCallbackDeadline.wait(timeout: 10) { _ in
+                Task { await startEntered.signal() }
+                allowStartToReturn.wait()
+                return operation
+            }
+        }
+
+        await startEntered.wait()
+        task.cancel()
+        allowStartToReturn.signal()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected task cancellation")
+        } catch is CancellationError {
             #expect(operation.isCancelled)
         } catch {
             Issue.record("Unexpected error: \(error)")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1273,6 +1273,31 @@ struct MeetingBrowserLogicTests {
         #expect(filtered.map(\.id) == [12, 11, 10])
     }
 
+    @Test("origin filter separates iPhone meetings from local and imported meetings")
+    func originFilterSeparatesDevices() {
+        let meetings = [
+            makeMeeting(id: 20, daysAgo: 1, title: "Local", source: .meeting),
+            makeMeeting(id: 21, daysAgo: 2, title: "iPhone", source: .iOS),
+            makeMeeting(id: 22, daysAgo: 3, title: "Import", source: .audioImport)
+        ]
+
+        let fromIPhone = MeetingBrowserLogic.filteredMeetings(
+            from: meetings,
+            filter: .all,
+            origin: .fromIPhone,
+            sort: .newestFirst
+        )
+        let thisMac = MeetingBrowserLogic.filteredMeetings(
+            from: meetings,
+            filter: .all,
+            origin: .thisMac,
+            sort: .newestFirst
+        )
+
+        #expect(fromIPhone.map(\.id) == [21])
+        #expect(thisMac.map(\.id) == [20, 22])
+    }
+
     @Test("formatStartTime converts UTC ISO timestamps to the requested timezone")
     func formatStartTimeConvertsUTC() {
         let timeZone = TimeZone(identifier: "America/Los_Angeles")!
@@ -1308,13 +1333,28 @@ struct MeetingBrowserLogicTests {
         return formatter.string(from: date)
     }
 
-    private func makeMeeting(id: Int64, daysAgo: Int, title: String) -> MeetingRecord {
+    private func makeMeeting(
+        id: Int64,
+        daysAgo: Int,
+        title: String,
+        source: MeetingSource = .meeting
+    ) -> MeetingRecord {
         let now = Date(timeIntervalSince1970: 1_710_000_000)
         let calendar = Calendar(identifier: .gregorian)
-        return makeMeeting(id: id, rawDate: Self.isoDate(daysAgo: daysAgo, now: now, calendar: calendar), title: title)
+        return makeMeeting(
+            id: id,
+            rawDate: Self.isoDate(daysAgo: daysAgo, now: now, calendar: calendar),
+            title: title,
+            source: source
+        )
     }
 
-    private func makeMeeting(id: Int64, rawDate: String, title: String) -> MeetingRecord {
+    private func makeMeeting(
+        id: Int64,
+        rawDate: String,
+        title: String,
+        source: MeetingSource = .meeting
+    ) -> MeetingRecord {
         MeetingRecord(
             id: id,
             title: title,
@@ -1330,7 +1370,8 @@ struct MeetingBrowserLogicTests {
             selectedTemplateID: MeetingTemplates.autoID,
             selectedTemplateName: "Auto",
             selectedTemplateKind: .auto,
-            selectedTemplatePrompt: ""
+            selectedTemplatePrompt: "",
+            source: source
         )
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -1273,31 +1273,6 @@ struct MeetingBrowserLogicTests {
         #expect(filtered.map(\.id) == [12, 11, 10])
     }
 
-    @Test("origin filter separates iPhone meetings from local and imported meetings")
-    func originFilterSeparatesDevices() {
-        let meetings = [
-            makeMeeting(id: 20, daysAgo: 1, title: "Local", source: .meeting),
-            makeMeeting(id: 21, daysAgo: 2, title: "iPhone", source: .iOS),
-            makeMeeting(id: 22, daysAgo: 3, title: "Import", source: .audioImport)
-        ]
-
-        let fromIPhone = MeetingBrowserLogic.filteredMeetings(
-            from: meetings,
-            filter: .all,
-            origin: .fromIPhone,
-            sort: .newestFirst
-        )
-        let thisMac = MeetingBrowserLogic.filteredMeetings(
-            from: meetings,
-            filter: .all,
-            origin: .thisMac,
-            sort: .newestFirst
-        )
-
-        #expect(fromIPhone.map(\.id) == [21])
-        #expect(thisMac.map(\.id) == [20, 22])
-    }
-
     @Test("formatStartTime converts UTC ISO timestamps to the requested timezone")
     func formatStartTimeConvertsUTC() {
         let timeZone = TimeZone(identifier: "America/Los_Angeles")!
@@ -1333,28 +1308,17 @@ struct MeetingBrowserLogicTests {
         return formatter.string(from: date)
     }
 
-    private func makeMeeting(
-        id: Int64,
-        daysAgo: Int,
-        title: String,
-        source: MeetingSource = .meeting
-    ) -> MeetingRecord {
+    private func makeMeeting(id: Int64, daysAgo: Int, title: String) -> MeetingRecord {
         let now = Date(timeIntervalSince1970: 1_710_000_000)
         let calendar = Calendar(identifier: .gregorian)
         return makeMeeting(
             id: id,
             rawDate: Self.isoDate(daysAgo: daysAgo, now: now, calendar: calendar),
-            title: title,
-            source: source
+            title: title
         )
     }
 
-    private func makeMeeting(
-        id: Int64,
-        rawDate: String,
-        title: String,
-        source: MeetingSource = .meeting
-    ) -> MeetingRecord {
+    private func makeMeeting(id: Int64, rawDate: String, title: String) -> MeetingRecord {
         MeetingRecord(
             id: id,
             title: title,
@@ -1370,8 +1334,7 @@ struct MeetingBrowserLogicTests {
             selectedTemplateID: MeetingTemplates.autoID,
             selectedTemplateName: "Auto",
             selectedTemplateKind: .auto,
-            selectedTemplatePrompt: "",
-            source: source
+            selectedTemplatePrompt: ""
         )
     }
 }


### PR DESCRIPTION
## Summary\n\n- bound CloudKit callback operations with a cancellation-aware deadline so sync setup cannot leave the UI spinning indefinitely\n- propagate caller cancellation into CloudKit operations, including cancellation before operation attachment\n- add reusable All / This Mac / From iPhone source filters to both dictations and meetings\n- apply source filtering in SQLite before pagination, meeting limits, and recursive sidebar counts\n- preserve source selections across navigation and show accurate empty states\n\n## Testing\n\n- swift test --package-path native/MuesliNative --scratch-path /Volumes/MuesliBuildCache/muesli-spm/worktrees/icloud-sync-timeout/test\n- 1,396 tests passed across 138 suites\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added record origin filters (All, This Mac, From iPhone) for recent dictations and recent meetings.
  - Added origin pickers to the dictations and meetings interfaces.
  - Updated meeting/dictation counts to respect the selected origin.
- **Bug Fixes**
  - Made pagination and “load more” consistently apply the selected origin filter.
  - Improved iCloud sync reliability with timeout protection to prevent stalled operations.
- **Tests**
  - Added coverage for origin-based filtering and iCloud callback/deadline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->