### PR TITLE
Update preprod appcast for v0.8.0-preprod.1

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,6 +6,32 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
+            <title>0.8.0-preprod.1</title>
+            <pubDate>Tue, 14 Jul 2026 11:09:19 -0700</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.8.0-preprod.1</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.8.0-preprod.1.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>8000001</sparkle:version>
+            <sparkle:shortVersionString>0.8.0-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.0-preprod.1/MuesliPreprod-0.8.0-preprod.1.dmg" length="94557093" type="application/octet-stream" sparkle:edSignature="qiixTLEWcRXDNTLNaCeMsPf+z3YIWilnCltXhcf63jHsxj23Vej3BmKivO4lSwQSDo/T8X7gPgFvGGXxMBFSCw=="/>
+        </item>
+        <item>
             <title>0.7.1-preprod.1</title>
             <pubDate>Fri, 26 Jun 2026 01:24:05 -0700</pubDate>
             <description><![CDATA[


### PR DESCRIPTION
## Summary
- publish the Sparkle appcast entry for MuesliPreprod 0.8.0-preprod.1
- point to the notarized GitHub prerelease DMG
- include Sparkle build 8000001, release notes, content length, and EdDSA signature

## Release verification
- full suite: 1,396 tests across 138 suites passed
- app and DMG notarization accepted and stapled
- hosted DMG SHA-256 matches local: 8bc4736a03a1f936a54445583cd4493bb2c0a2932a481cb0b2d1a1ed6632dab6
- Gatekeeper accepted the mounted app and DMG
- verify_update_flow.sh --require-notarized passed for build 8000001

This PR intentionally changes only docs/appcast-preprod.xml.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786644836&installation_id=136549638&pr_number=317&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F317&signature=1343e86abaa26f3322339ce381619aa22b94691b3a0dab81ba08a171c635297e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->