### PR TITLE
Refine v0.8 feature discovery and diagnostic reporting

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -90,13 +90,7 @@ struct AboutView: View {
 
                     Divider().background(MuesliTheme.surfaceBorder)
 
-                    HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
-                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                            Text("Automatic issue reporting prompts")
-                                .font(MuesliTheme.body())
-                                .foregroundStyle(MuesliTheme.textPrimary)
-                        }
-                        Spacer(minLength: MuesliTheme.spacing16)
+                    aboutRow("Automatic issue reporting prompts") {
                         Toggle("Auto reporting", isOn: Binding(
                             get: { appState.config.enableAutomaticDiagnosticIssuePrompts },
                             set: onSetAutomaticDiagnosticIssuePrompts
@@ -106,7 +100,6 @@ struct AboutView: View {
                         .help("Suggest an anonymized GitHub issue after an app error")
                         .accessibilityLabel("Automatic issue reporting prompts")
                     }
-                    .padding(.vertical, MuesliTheme.spacing8)
                 }
 
                 // MARK: - Data

--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -4,6 +4,7 @@ import MuesliCore
 struct AboutView: View {
     let appState: AppState
     let onOpenManualDiagnosticReport: () -> Void
+    let onSetAutomaticDiagnosticIssuePrompts: (Bool) -> Void
 
     private let githubURL = "https://github.com/Muesli-HQ/muesli"
     private let donateURL = "https://buymeacoffee.com/phequals7"
@@ -86,6 +87,26 @@ struct AboutView: View {
                             onOpenManualDiagnosticReport()
                         }
                     }
+
+                    Divider().background(MuesliTheme.surfaceBorder)
+
+                    HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
+                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                            Text("Automatic issue reporting prompts")
+                                .font(MuesliTheme.body())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                        }
+                        Spacer(minLength: MuesliTheme.spacing16)
+                        Toggle("Auto reporting", isOn: Binding(
+                            get: { appState.config.enableAutomaticDiagnosticIssuePrompts },
+                            set: onSetAutomaticDiagnosticIssuePrompts
+                        ))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .help("Suggest an anonymized GitHub issue after an app error")
+                        .accessibilityLabel("Automatic issue reporting prompts")
+                    }
+                    .padding(.vertical, MuesliTheme.spacing8)
                 }
 
                 // MARK: - Data

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -150,7 +150,8 @@ struct DashboardRootView: View {
             case .about:
                 AboutView(
                     appState: appState,
-                    onOpenManualDiagnosticReport: { controller.openManualDiagnosticReport() }
+                    onOpenManualDiagnosticReport: { controller.openManualDiagnosticReport() },
+                    onSetAutomaticDiagnosticIssuePrompts: { controller.setAutomaticDiagnosticIssuePrompts($0) }
                 )
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DiagnosticIncidentReporter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DiagnosticIncidentReporter.swift
@@ -9,6 +9,7 @@ final class DiagnosticIncidentReporter {
     private let defaults: UserDefaults
     private let appState: AppState
     private let telemetrySink: TelemetrySink
+    private let automaticPromptEnabled: @MainActor () -> Bool
     private let onPrompt: PromptHandler
     private let calendar: Calendar
 
@@ -17,12 +18,14 @@ final class DiagnosticIncidentReporter {
         defaults: UserDefaults = .standard,
         calendar: Calendar = .current,
         telemetrySink: @escaping TelemetrySink = DiagnosticIncidentReporter.sendTelemetry,
+        automaticPromptEnabled: @escaping @MainActor () -> Bool = { false },
         onPrompt: @escaping PromptHandler = { _ in }
     ) {
         self.appState = appState
         self.defaults = defaults
         self.calendar = calendar
         self.telemetrySink = telemetrySink
+        self.automaticPromptEnabled = automaticPromptEnabled
         self.onPrompt = onPrompt
     }
 
@@ -43,7 +46,7 @@ final class DiagnosticIncidentReporter {
             error: error
         )
         telemetrySink(incident)
-        if promptUser, shouldPrompt(for: incident) {
+        if promptUser, automaticPromptEnabled(), shouldPrompt(for: incident) {
             markPrompted(for: incident)
             onPrompt(incident)
             appState.pendingDiagnosticIncident = incident

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -66,6 +66,7 @@ struct DictionaryView: View {
                 .font(MuesliTheme.caption())
                 .foregroundStyle(MuesliTheme.textSecondary)
                 .help("Briefly reads focused app text after dictation to detect corrections.")
+                .featureTourTarget(.dictionarySuggestions)
                 Button {
                     isAdding = true
                     newWord = ""

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -36,6 +36,7 @@ struct MarketingVersion: Comparable, Equatable {
 
 enum FeatureTourTarget: String, Hashable {
     case insightsEntry
+    case dictionarySuggestions
     case meetingsSidebar
     case liveCaptionsSetting
     case cloudCleanupSetting
@@ -48,7 +49,7 @@ enum FeatureTourTarget: String, Hashable {
             return .streaming
         case .experimentalModels:
             return .dictation
-        case .insightsEntry, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
+        case .insightsEntry, .dictionarySuggestions, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
             return nil
         }
     }
@@ -95,6 +96,14 @@ enum FeatureTourCatalog {
                 message: "Select any stat card to explore private word, meeting, pace, streak, and daily activity trends calculated from your local history.",
                 systemImage: "chart.bar.xaxis",
                 target: .insightsEntry
+            ),
+            FeatureTourStep(
+                id: "dictionary-suggestions",
+                eyebrow: "SMARTER DICTIONARY",
+                title: "Turn corrections into custom words",
+                message: "Dictionary suggestions stay off by default. Turn them on to let Muesli notice corrections after dictation and offer a one-click way to remember names, brands, and domain terms.",
+                systemImage: "text.book.closed.fill",
+                target: .dictionarySuggestions
             ),
             FeatureTourStep(
                 id: "meeting-workspace",

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -86,7 +86,7 @@ struct FeatureTourCalloutLayout {
             return [.trailing, .leading, .below, .above]
         case .insightsEntry, .liveCaptionsSetting:
             return [.below, .above, .trailing, .leading]
-        case .cloudCleanupSetting, .streamingModels, .experimentalModels:
+        case .dictionarySuggestions, .cloudCleanupSetting, .streamingModels, .experimentalModels:
             return [.above, .below, .trailing, .leading]
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
@@ -452,7 +452,6 @@ private struct InsightsLoadingStatus: View {
                 }
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(InsightsPalette.secondaryText)
-                .animation(reduceMotion ? nil : .easeInOut(duration: 0.28), value: messageIndex)
             }
             Spacer()
             Image(systemName: "lock.shield.fill")

--- a/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
@@ -311,6 +311,7 @@ struct InsightsView: View {
 
     private var loadingState: some View {
         VStack(spacing: 18) {
+            InsightsLoadingStatus()
             ForEach(0..<4, id: \.self) { index in
                 RoundedRectangle(cornerRadius: 14)
                     .fill(MuesliTheme.backgroundRaised)
@@ -419,6 +420,61 @@ struct InsightsView: View {
     private func format(_ value: Int) -> String { value.formatted(.number.notation(.compactName)) }
 
     private func dayCount(_ value: Int) -> String { "\(value) \(value == 1 ? "day" : "days")" }
+}
+
+enum InsightsLoadingCopy {
+    static let messages = [
+        "Calculating your private activity history",
+        "Insights are computed on this Mac and never uploaded",
+        "Your transcripts and statistics stay under your control",
+        "Hybrid AI works best when you choose what stays local",
+    ]
+}
+
+private struct InsightsLoadingStatus: View {
+    @State private var messageIndex = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack(spacing: 14) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(MuesliTheme.accent)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Building your Insights")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                ZStack(alignment: .leading) {
+                    Text(InsightsLoadingCopy.messages[messageIndex])
+                        .id(messageIndex)
+                        .transition(.opacity)
+                }
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(InsightsPalette.secondaryText)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.28), value: messageIndex)
+            }
+            Spacer()
+            Image(systemName: "lock.shield.fill")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(MuesliTheme.accent.opacity(0.8))
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(MuesliTheme.surfaceBorder))
+        .task {
+            guard !reduceMotion else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_200_000_000)
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeInOut(duration: 0.28)) {
+                    messageIndex = (messageIndex + 1) % InsightsLoadingCopy.messages.count
+                }
+            }
+        }
+    }
 }
 
 struct InsightsInitialScrollGate {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1057,6 +1057,7 @@ struct AppConfig: Codable {
     var dictionarySuggestions: [DictionarySuggestion] = []
     var dismissedDictionarySuggestionKeys: [String] = []
     var enableDictionaryCorrectionPrompts: Bool = false
+    var enableAutomaticDiagnosticIssuePrompts: Bool = false
     var folderOrder: [Int64] = []
     var soundEnabled: Bool = true
     var pauseMediaDuringDictation: Bool = false
@@ -1173,6 +1174,7 @@ struct AppConfig: Codable {
         case dictionarySuggestions = "dictionary_suggestions"
         case dismissedDictionarySuggestionKeys = "dismissed_dictionary_suggestion_keys"
         case enableDictionaryCorrectionPrompts = "enable_dictionary_correction_prompts"
+        case enableAutomaticDiagnosticIssuePrompts = "enable_automatic_diagnostic_issue_prompts"
         case folderOrder = "folder_order"
         case soundEnabled = "sound_enabled"
         case pauseMediaDuringDictation = "pause_media_during_dictation"
@@ -1335,6 +1337,7 @@ struct AppConfig: Codable {
         dictionarySuggestions = (try? c.decode([DictionarySuggestion].self, forKey: .dictionarySuggestions)) ?? defaults.dictionarySuggestions
         dismissedDictionarySuggestionKeys = (try? c.decode([String].self, forKey: .dismissedDictionarySuggestionKeys)) ?? defaults.dismissedDictionarySuggestionKeys
         enableDictionaryCorrectionPrompts = (try? c.decode(Bool.self, forKey: .enableDictionaryCorrectionPrompts)) ?? defaults.enableDictionaryCorrectionPrompts
+        enableAutomaticDiagnosticIssuePrompts = (try? c.decode(Bool.self, forKey: .enableAutomaticDiagnosticIssuePrompts)) ?? defaults.enableAutomaticDiagnosticIssuePrompts
         folderOrder = (try? c.decode([Int64].self, forKey: .folderOrder)) ?? defaults.folderOrder
         soundEnabled = (try? c.decode(Bool.self, forKey: .soundEnabled)) ?? defaults.soundEnabled
         pauseMediaDuringDictation = (try? c.decode(Bool.self, forKey: .pauseMediaDuringDictation)) ?? defaults.pauseMediaDuringDictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5719,7 +5719,9 @@ final class MuesliController: NSObject {
 
     func setAutomaticDiagnosticIssuePrompts(_ enabled: Bool) {
         updateConfig { $0.enableAutomaticDiagnosticIssuePrompts = enabled }
-        if !enabled, appState.pendingDiagnosticIncident?.kind != .manualReport {
+        if !enabled,
+           let pending = appState.pendingDiagnosticIncident,
+           pending.kind != .manualReport {
             diagnosticIncidentReporter.dismissCurrentPrompt()
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -281,6 +281,9 @@ final class MuesliController: NSObject {
     )
     private lazy var diagnosticIncidentReporter = DiagnosticIncidentReporter(
         appState: appState,
+        automaticPromptEnabled: { [weak self] in
+            self?.config.enableAutomaticDiagnosticIssuePrompts ?? false
+        },
         onPrompt: { [weak self] _ in
             self?.presentHistoryWindow(tab: .about)
         }
@@ -957,6 +960,8 @@ final class MuesliController: NSObject {
         switch step.target {
         case .insightsEntry:
             appState.selectedTab = .dictations
+        case .dictionarySuggestions:
+            appState.selectedTab = .dictionary
         case .meetingsSidebar:
             appState.selectedTab = .meetings
             appState.meetingsNavigationState = .browser
@@ -5710,6 +5715,13 @@ final class MuesliController: NSObject {
 
     func openManualDiagnosticReport() {
         diagnosticIncidentReporter.recordManualReport()
+    }
+
+    func setAutomaticDiagnosticIssuePrompts(_ enabled: Bool) {
+        updateConfig { $0.enableAutomaticDiagnosticIssuePrompts = enabled }
+        if !enabled, appState.pendingDiagnosticIncident?.kind != .manualReport {
+            diagnosticIncidentReporter.dismissCurrentPrompt()
+        }
     }
 
     func dismissDiagnosticIncidentPrompt() {

--- a/native/MuesliNative/Tests/MuesliTests/DiagnosticIncidentTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DiagnosticIncidentTests.swift
@@ -231,6 +231,7 @@ struct DiagnosticIncidentReporterTests {
             appState: appState,
             defaults: defaults,
             telemetrySink: { sent.append($0) },
+            automaticPromptEnabled: { true },
             onPrompt: { prompted.append($0) }
         )
 
@@ -260,6 +261,7 @@ struct DiagnosticIncidentReporterTests {
             appState: appState,
             defaults: defaults,
             telemetrySink: { sent.append($0) },
+            automaticPromptEnabled: { true },
             onPrompt: { restartedPrompted.append($0) }
         )
         let third = restartedReporter.record(
@@ -271,5 +273,29 @@ struct DiagnosticIncidentReporterTests {
         #expect(sent.map(\.id) == [first.id, second.id, third.id])
         #expect(restartedPrompted.isEmpty)
         #expect(appState.pendingDiagnosticIncident == nil)
+    }
+
+    @Test("default-off automatic reporting still records telemetry")
+    func defaultOffStillRecordsTelemetry() {
+        let appState = AppState()
+        var sent: [DiagnosticIncident] = []
+        var prompted: [DiagnosticIncident] = []
+        let reporter = DiagnosticIncidentReporter(
+            appState: appState,
+            telemetrySink: { sent.append($0) },
+            onPrompt: { prompted.append($0) }
+        )
+
+        let incident = reporter.record(
+            kind: .dictationTranscriptionFailed,
+            stage: .standardDictationTranscribe
+        )
+
+        #expect(sent.map(\.id) == [incident.id])
+        #expect(prompted.isEmpty)
+        #expect(appState.pendingDiagnosticIncident == nil)
+
+        reporter.recordManualReport()
+        #expect(appState.pendingDiagnosticIncident?.kind == .manualReport)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -127,13 +127,16 @@ struct FeatureTourTests {
     @Test("0.8 catalog points each walkthrough step at a unique product location")
     func catalogShape() {
         #expect(tour.version == "0.8.0")
-        #expect(tour.steps.count == 5)
+        #expect(tour.steps.count == 6)
         #expect(Set(tour.steps.map(\.id)).count == tour.steps.count)
         #expect(Set(tour.steps.map(\.target)).count == tour.steps.count)
 
         let authenticatedTour = FeatureTourCatalog.latest(includeCloudCleanup: true)
-        #expect(authenticatedTour.steps.count == 6)
+        #expect(authenticatedTour.steps.count == 7)
         #expect(authenticatedTour.steps.contains { $0.target == .cloudCleanupSetting })
+
+        let dictionaryStep = tour.steps.first { $0.target == .dictionarySuggestions }
+        #expect(dictionaryStep?.message.contains("off by default") == true)
 
         let streamingStep = tour.steps.first { $0.target == .streamingModels }
         #expect(streamingStep?.message.contains("Nemotron 3.5") == true)

--- a/native/MuesliNative/Tests/MuesliTests/InsightsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InsightsTests.swift
@@ -299,6 +299,14 @@ struct InsightsTests {
         #expect(smallest == 13)
     }
 
+    @Test("loading copy explains local processing without overpromising")
+    func loadingCopyExplainsPrivacy() {
+        #expect(InsightsLoadingCopy.messages.count == 4)
+        #expect(Set(InsightsLoadingCopy.messages).count == 4)
+        #expect(InsightsLoadingCopy.messages.contains { $0.contains("computed on this Mac") })
+        #expect(InsightsLoadingCopy.messages.contains { $0.contains("choose what stays local") })
+    }
+
     @Test("activity heatmap marks the visible starting month and later month boundaries")
     func activityHeatmapMonthMarkers() {
         var calendar = Calendar(identifier: .gregorian)

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -816,6 +816,7 @@ struct AppConfigTests {
         config.enableScreenContext = true
         config.enableDictationOCRContext = true
         config.enableLiveStreamingPartials = true
+        config.enableAutomaticDiagnosticIssuePrompts = true
         config.meetingLiveCaptionBackend = MeetingLiveCaptionBackend.nemotron35.rawValue
         config.showMeetingTranscriptOnIndicatorHover = false
         config.contributionPromptNextWordCount = 31_000
@@ -890,6 +891,7 @@ struct AppConfigTests {
         #expect(decoded.enableScreenContext == true)
         #expect(decoded.enableDictationOCRContext == true)
         #expect(decoded.enableLiveStreamingPartials == true)
+        #expect(decoded.enableAutomaticDiagnosticIssuePrompts == true)
         #expect(decoded.resolvedMeetingLiveCaptionBackend == .nemotron35)
         #expect(decoded.showMeetingTranscriptOnIndicatorHover == false)
         #expect(decoded.contributionPromptNextWordCount == 31_000)
@@ -900,6 +902,13 @@ struct AppConfigTests {
         #expect(decoded.contributionLinkedInClicked == false)
         #expect(decoded.upcomingMeetingsDayCount == UpcomingMeetingsWindow.today.dayCount)
         #expect(decoded.hiddenCalendarEventSourceHints == config.hiddenCalendarEventSourceHints)
+    }
+
+    @Test("Automatic diagnostic issue prompts default off when absent")
+    func automaticDiagnosticIssuePromptsDefaultOffWhenAbsent() throws {
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+
+        #expect(decoded.enableAutomaticDiagnosticIssuePrompts == false)
     }
 
     @Test("JSON coding keys use snake_case")


### PR DESCRIPTION
## Summary
- add Dictionary suggestions to the reusable v0.8 feature walkthrough
- show rotating privacy-focused progress copy while local Insights are computed
- default automatic diagnostic GitHub issue prompts off and expose an opt-in toggle in About
- continue emitting error diagnostics to TelemetryDeck and preserve manual Report a Problem

## Verification
- swift test --package-path native/MuesliNative --scratch-path /Volumes/MuesliBuildCache/muesli-spm/worktrees/v080-release-refinements/test
- 1,399 tests passed across 138 suites
- built and locally verified in isolated MuesliDevA using the eSSD cache

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786650768&installation_id=136549638&pr_number=318&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F318&signature=7d8d36c3a2db54804e29eee33d6cf6892fee1929b4534a5889c154429b65331f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings toggle for “automatic issue reporting prompts” (default off) in the About/Support area.
  * Extended feature tour with a dictionary suggestions step and matching callout behavior.
  * Updated Insights loading to show a progress-based status with privacy-focused rotating copy (respects Reduce Motion).
* **Bug Fixes**
  * When automatic prompts are disabled, pending automatic prompts are dismissed while manual reports are preserved; telemetry continues to be recorded.
* **Tests**
  * Added/updated tests for the new prompt setting, feature tour steps, Insights loading copy, and configuration defaults/round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->