### PR TITLE
Publish MuesliPreprod 0.8.0-preprod.2 appcast

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,14 +6,14 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
-            <title>0.8.0-preprod.1</title>
-            <pubDate>Tue, 14 Jul 2026 11:09:19 -0700</pubDate>
+            <title>0.8.0-preprod.2</title>
+            <pubDate>Tue, 14 Jul 2026 13:36:16 -0700</pubDate>
             <description><![CDATA[
-<h2>MuesliPreprod 0.8.0-preprod.1</h2>
+<h2>MuesliPreprod 0.8.0-preprod.2</h2>
 <p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
 <h3>Install</h3>
 <ul>
-<li>Download <code>MuesliPreprod-0.8.0-preprod.1.dmg</code></li>
+<li>Download <code>MuesliPreprod-0.8.0-preprod.2.dmg</code></li>
 <li>Open the DMG and drag MuesliPreprod to Applications</li>
 <li>Launch MuesliPreprod from Applications</li>
 </ul>
@@ -25,6 +25,15 @@
 <li>Does not update the production appcast, public download page, or Homebrew tap.</li>
 </ul>
 ]]></description>
+            <sparkle:version>8000002</sparkle:version>
+            <sparkle:shortVersionString>0.8.0-preprod.2</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.0-preprod.2/MuesliPreprod-0.8.0-preprod.2.dmg" length="94561043" type="application/octet-stream" sparkle:edSignature="PEQFKQNfLcKGRnRDIl4mNSltifJVAH1BLOnpeP3vS9WkA71PbqWYpy6777FW49rH1GprVWMFpJedlQP7hyiICA=="/>
+        </item>
+        <item>
+            <title>0.8.0-preprod.1</title>
+            <pubDate>Tue, 14 Jul 2026 11:09:19 -0700</pubDate>
             <sparkle:version>8000001</sparkle:version>
             <sparkle:shortVersionString>0.8.0-preprod.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>


### PR DESCRIPTION
## Summary
- publish the signed Sparkle appcast entry for MuesliPreprod 0.8.0-preprod.2
- point the enclosure at the verified Muesli-HQ GitHub prerelease DMG
- retain 0.8.0-preprod.1 as the previous update entry

## Verification
- 1,399 tests passed across 138 suites
- app and DMG notarized, stapled, and accepted by Gatekeeper
- local and hosted DMG SHA-256 matched: 996c065d11c7d4081621527a7f0143f9f3eaae23925d34d226d015fa01d44b68
- Sparkle EdDSA signature, release notes, bundle metadata, feed URL, and update flow verified

## Scope
- preprod appcast only
- stable appcast, public download page, Homebrew, and production release remain unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786653692&installation_id=136549638&pr_number=319&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F319&signature=67c2bea17001bf0ac4d3d31be35a3e03307cdde2d2253d506a63d29193ea2ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-production appcast to reference version 0.8.0-preprod.2.
  * Refreshed release dates, download links, package metadata, file size, and signing information.
  * Preserved the previous pre-production release as the next historical entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->