### PR TITLE
Prevent meeting capture from disrupting the default microphone

### DIFF
--- a/Context/handoff-2026-07-17-issue-322-meeting-audio.md
+++ b/Context/handoff-2026-07-17-issue-322-meeting-audio.md
@@ -35,7 +35,8 @@ Those diagnostics were intentionally excluded from PR #327 because some instrume
 
 ## Validation
 
-- 85 focused tests pass across route selection, recorder behavior, meeting candidate resolution, media-session tracking, prompt suppression, and selected-mic hot-plug behavior.
+- Historical local validation on commit `76b1fe8c`: 85 focused tests passed across route selection, recorder behavior, meeting candidate resolution, media-session tracking, prompt suppression, and selected-mic hot-plug behavior.
+- Full GitHub CI passed for that commit in [run 29598233464](https://github.com/Muesli-HQ/muesli/actions/runs/29598233464).
 - Muesli-first then Google Meet: both clients shared the built-in mic and participants heard the user.
 - Google Meet-first then Muesli auto-detection: Muesli used `systemDefaultStreaming`; microphone and system-audio capture remained healthy.
 - Discard while the external meeting remained active: teardown completed normally and the same session did not prompt again after cooldown.

--- a/Context/handoff-2026-07-17-issue-322-meeting-audio.md
+++ b/Context/handoff-2026-07-17-issue-322-meeting-audio.md
@@ -38,9 +38,10 @@ Those diagnostics were intentionally excluded from PR #327 because some instrume
 
 ## Validation
 
-- Historical local validation on commit `76b1fe8c`: 85 focused tests passed across route selection, recorder behavior, meeting candidate resolution, media-session tracking, prompt suppression, and selected-mic hot-plug behavior.
-- Current local validation after the selected-mic cache hardening: 88 tests passed across the same five route, recorder, candidate-resolution, media-session, and prompt-state suites, including deterministic immediate-selection and unavailable-device cache regressions.
-- Full GitHub CI passed for that commit in [run 29598233464](https://github.com/Muesli-HQ/muesli/actions/runs/29598233464).
+- Historical local validation on commit `76b1fe8cbe533738baec37580fefebdf161e1988` from `codex/fix-322-meeting-microphone`: 85 focused tests passed across route selection, recorder behavior, meeting candidate resolution, media-session tracking, prompt suppression, and selected-mic hot-plug behavior.
+- Historical full GitHub CI for `76b1fe8cbe533738baec37580fefebdf161e1988` passed in [run 29598233464](https://github.com/Muesli-HQ/muesli/actions/runs/29598233464). That run predates later PR-tip changes and does not validate the latest implementation.
+- Local validation on commit `7e558ecf6174f4d5521a1964c82dedde17f40990` after the selected-mic cache hardening: 88 tests passed across the same five route, recorder, candidate-resolution, media-session, and prompt-state suites, including deterministic immediate-selection and unavailable-device cache regressions.
+- Full GitHub CI for `7e558ecf6174f4d5521a1964c82dedde17f40990` passed in [run 29608356208](https://github.com/Muesli-HQ/muesli/actions/runs/29608356208).
 - Muesli-first then Google Meet: both clients shared the built-in mic and participants heard the user.
 - Google Meet-first then Muesli auto-detection: Muesli used `systemDefaultStreaming`; microphone and system-audio capture remained healthy.
 - Discard while the external meeting remained active: teardown completed normally and the same session did not prompt again after cooldown.

--- a/Context/handoff-2026-07-17-issue-322-meeting-audio.md
+++ b/Context/handoff-2026-07-17-issue-322-meeting-audio.md
@@ -3,16 +3,17 @@
 ## Published work
 
 - Issue: [#322 — Google Meet Microphone Inconsistency](https://github.com/Muesli-HQ/muesli/issues/322)
-- Draft PR: [#327 — Prevent meeting capture from disrupting the default microphone](https://github.com/Muesli-HQ/muesli/pull/327)
+- PR: [#327 — Prevent meeting capture from disrupting the default microphone](https://github.com/Muesli-HQ/muesli/pull/327)
 - Focused branch: `codex/fix-322-meeting-microphone`
 - Base: `origin/main`
 
-The PR contains four focused commits:
+The PR contains five focused changes:
 
 1. Avoid blocking meeting startup on CoreAudio route refresh.
 2. Use the system-default streaming recorder when the desired meeting mic is already the system default.
 3. Suppress repeated prompts for a meeting session that has already started recording.
 4. Refresh cached routes when the CoreAudio device inventory changes, including selected-mic unplug/reconnect.
+5. Apply cached microphone selections atomically so an immediate meeting start cannot consume the prior device ID while asynchronous route verification is pending.
 
 ## Diagnosis
 
@@ -27,6 +28,8 @@ The deterministic diagnostic harness reproduced the issue shape:
 
 This supports the unnecessary explicit microphone graph and its CoreAudio lifecycle as the cause of the startup-order race. The fix is shared by all supported meeting applications and browsers; it is not Google Meet-specific.
 
+A follow-up review found a narrower cache-ordering race: changing the selected microphone stored its UID immediately but left the prior device ID in the meeting snapshot until the route queue completed another CoreAudio inspection. The controller now caches UID-to-device-ID mappings, applies a cached selection under the same lock as the meeting snapshot, and reconciles every asynchronous refresh against the latest selected UID before committing it.
+
 ## Scope decision
 
 The broader investigation branch is preserved locally as `codex/diagnose-issue-322-meeting-mic` at `223fb511`. It contains the opt-in stress harness and detailed meeting lifecycle diagnostics used to reproduce the failure.
@@ -36,6 +39,7 @@ Those diagnostics were intentionally excluded from PR #327 because some instrume
 ## Validation
 
 - Historical local validation on commit `76b1fe8c`: 85 focused tests passed across route selection, recorder behavior, meeting candidate resolution, media-session tracking, prompt suppression, and selected-mic hot-plug behavior.
+- Current local validation after the selected-mic cache hardening: 88 tests passed across the same five route, recorder, candidate-resolution, media-session, and prompt-state suites, including deterministic immediate-selection and unavailable-device cache regressions.
 - Full GitHub CI passed for that commit in [run 29598233464](https://github.com/Muesli-HQ/muesli/actions/runs/29598233464).
 - Muesli-first then Google Meet: both clients shared the built-in mic and participants heard the user.
 - Google Meet-first then Muesli auto-detection: Muesli used `systemDefaultStreaming`; microphone and system-audio capture remained healthy.
@@ -46,6 +50,6 @@ Earlier full-suite runs were noisy under combined system load, with independentl
 
 ## Follow-up
 
-- Let PR #327 CI and review complete before marking it ready.
+- Let CI and review rerun on the latest PR #327 commit before merging.
 - If #322-like behavior returns, use the preserved diagnostic branch to collect a trace, but do not merge its release-time instrumentation without removing the callback/startup overhead.
 - Repeat both startup orders with a non-default external microphone before release if hardware is available; the explicit route is intentionally retained for that case.

--- a/Context/handoff-2026-07-17-issue-322-meeting-audio.md
+++ b/Context/handoff-2026-07-17-issue-322-meeting-audio.md
@@ -1,0 +1,50 @@
+# Issue #322 meeting microphone handoff
+
+## Published work
+
+- Issue: [#322 — Google Meet Microphone Inconsistency](https://github.com/Muesli-HQ/muesli/issues/322)
+- Draft PR: [#327 — Prevent meeting capture from disrupting the default microphone](https://github.com/Muesli-HQ/muesli/pull/327)
+- Focused branch: `codex/fix-322-meeting-microphone`
+- Base: `origin/main`
+
+The PR contains four focused commits:
+
+1. Avoid blocking meeting startup on CoreAudio route refresh.
+2. Use the system-default streaming recorder when the desired meeting mic is already the system default.
+3. Suppress repeated prompts for a meeting session that has already started recording.
+4. Refresh cached routes when the CoreAudio device inventory changes, including selected-mic unplug/reconnect.
+
+## Diagnosis
+
+Muesli represented the built-in/default microphone as an explicit meeting-device preference. This selected the app-scoped `AudioQueue` recorder even when the same physical microphone was already the macOS default used by the meeting client.
+
+The deterministic diagnostic harness reproduced the issue shape:
+
+- system-audio process tap started successfully
+- microphone `AudioQueueStart` blocked for about 15 seconds
+- start returned `kAudioQueueErr_CannotStart` (`-66681`)
+- failed-queue cleanup blocked for about another 30 seconds
+
+This supports the unnecessary explicit microphone graph and its CoreAudio lifecycle as the cause of the startup-order race. The fix is shared by all supported meeting applications and browsers; it is not Google Meet-specific.
+
+## Scope decision
+
+The broader investigation branch is preserved locally as `codex/diagnose-issue-322-meeting-mic` at `223fb511`. It contains the opt-in stress harness and detailed meeting lifecycle diagnostics used to reproduce the failure.
+
+Those diagnostics were intentionally excluded from PR #327 because some instrumentation still performed release-time callback bookkeeping and an additional `AudioQueueGetProperty` in the timing-sensitive startup path. The focused PR also excludes the unrelated speculative-dictation experiment and its revert history.
+
+## Validation
+
+- 85 focused tests pass across route selection, recorder behavior, meeting candidate resolution, media-session tracking, prompt suppression, and selected-mic hot-plug behavior.
+- Muesli-first then Google Meet: both clients shared the built-in mic and participants heard the user.
+- Google Meet-first then Muesli auto-detection: Muesli used `systemDefaultStreaming`; microphone and system-audio capture remained healthy.
+- Discard while the external meeting remained active: teardown completed normally and the same session did not prompt again after cooldown.
+- Chrome, Muesli, and CoreAudio were not restarted between the relevant live lifecycle transitions.
+
+Earlier full-suite runs were noisy under combined system load, with independently passing flakes in streaming VAD, Nemotron timeout, and clipboard tests. PR CI is the source of truth for the complete suite.
+
+## Follow-up
+
+- Let PR #327 CI and review complete before marking it ready.
+- If #322-like behavior returns, use the preserved diagnostic branch to collect a trace, but do not merge its release-time instrumentation without removing the callback/startup overhead.
+- Repeat both startup orders with a non-default external microphone before release if hardware is available; the explicit route is intentionally retained for that case.

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -153,6 +153,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         var builtInInputDeviceID: AudioObjectID?
         var defaultInputDeviceID: AudioObjectID?
         var selectedInputDeviceID: AudioObjectID?
+        var inputDeviceNamesByID: [AudioObjectID: String] = [:]
 
         var systemDefaultInputIsBuiltIn: Bool {
             guard let defaultInputDeviceID, let builtInInputDeviceID else { return false }
@@ -252,7 +253,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     func refreshRouteCache(notifyEvenIfPreferredUnchanged: Bool) {
         queue.async { [weak self] in
             guard let self else { return }
-            let next = self.makeRouteSnapshot()
+            let next = self.makeRouteSnapshot(refreshingDeviceNames: true)
             let previousPreferredInputDeviceID = self.lock.withLock { () -> AudioObjectID? in
                 let previous = self.snapshot
                 self.snapshot = next
@@ -302,9 +303,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
             selectedInputDeviceUID: selectedInputDeviceUID,
             selectedInputDeviceResolved: selectedInputDeviceUID == nil || current.selectedInputDeviceID != nil,
             preferredInputDeviceID: preferredInputDeviceID,
-            preferredInputDeviceName: nil,
+            preferredInputDeviceName: preferredInputDeviceID.flatMap { current.inputDeviceNamesByID[$0] },
             defaultInputDeviceID: current.defaultInputDeviceID,
-            defaultInputDeviceName: nil,
+            defaultInputDeviceName: current.defaultInputDeviceID.flatMap { current.inputDeviceNamesByID[$0] },
             builtInInputDeviceID: current.builtInInputDeviceID,
             systemDefaultInputIsBuiltIn: current.systemDefaultInputIsBuiltIn
         )
@@ -381,17 +382,27 @@ final class DictationAudioRouteController: DictationAudioRouting {
         return desiredInputDeviceID
     }
 
-    private func makeRouteSnapshot() -> RouteSnapshot {
+    private func makeRouteSnapshot(refreshingDeviceNames: Bool = false) -> RouteSnapshot {
         let outputClassification = currentOutputRouteClassification()
         let selectedInputDeviceUID = lock.withLock { selectedInputDeviceUIDStorage }
+        let cachedInputDeviceNames = lock.withLock { snapshot.inputDeviceNamesByID }
+        let inputDevices = refreshingDeviceNames ? inspector.availableInputDevices() : nil
+        let selectedInputDeviceID = selectedInputDeviceUID.flatMap { uid in
+            if let inputDevices {
+                return inputDevices.first(where: { $0.uid == uid })?.deviceID
+            }
+            return inspector.inputDeviceID(matchingUID: uid)
+        }
+        let inputDeviceNamesByID = inputDevices.map { devices in
+            Dictionary(uniqueKeysWithValues: devices.map { ($0.deviceID, $0.name) })
+        } ?? cachedInputDeviceNames
         return RouteSnapshot(
             outputRouteKind: outputClassification.kind,
             outputIsAmbiguousBluetooth: outputClassification.isAmbiguousBluetooth,
             builtInInputDeviceID: inspector.builtInInputDeviceID(),
             defaultInputDeviceID: inspector.defaultInputDeviceID(),
-            selectedInputDeviceID: selectedInputDeviceUID.flatMap {
-                inspector.inputDeviceID(matchingUID: $0)
-            }
+            selectedInputDeviceID: selectedInputDeviceID,
+            inputDeviceNamesByID: inputDeviceNamesByID
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -358,10 +358,16 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     private static func preferredMeetingInputDeviceID(for snapshot: RouteSnapshot) -> AudioObjectID? {
-        if let selectedInputDeviceID = snapshot.selectedInputDeviceID {
-            return selectedInputDeviceID
+        let desiredInputDeviceID = snapshot.selectedInputDeviceID ?? snapshot.builtInInputDeviceID
+
+        // A nil meeting preference means "use the system-default recorder".
+        // Avoid forcing the same physical device through the app-scoped
+        // AudioQueue path: opening that second explicit input context can
+        // disrupt a meeting client's already-running microphone graph.
+        guard desiredInputDeviceID != snapshot.defaultInputDeviceID else {
+            return nil
         }
-        return snapshot.builtInInputDeviceID
+        return desiredInputDeviceID
     }
 
     private func makeRouteSnapshot() -> RouteSnapshot {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -394,7 +394,10 @@ final class DictationAudioRouteController: DictationAudioRouting {
             return inspector.inputDeviceID(matchingUID: uid)
         }
         let inputDeviceNamesByID = inputDevices.map { devices in
-            Dictionary(uniqueKeysWithValues: devices.map { ($0.deviceID, $0.name) })
+            Dictionary(
+                devices.map { ($0.deviceID, $0.name) },
+                uniquingKeysWith: { first, _ in first }
+            )
         } ?? cachedInputDeviceNames
         return RouteSnapshot(
             outputRouteKind: outputClassification.kind,

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -168,6 +168,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private var selectedInputDeviceUIDStorage: String?
     private var defaultOutputListener: AudioObjectPropertyListenerBlock?
     private var defaultInputListener: AudioObjectPropertyListenerBlock?
+    private var deviceInventoryListener: AudioObjectPropertyListenerBlock?
     private var onPreferredInputDeviceChangedStorage: ((AudioObjectID?) -> Void)?
     var selectedInputDeviceUID: String? {
         get {
@@ -209,6 +210,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         if observesDefaultOutputChanges {
             installDefaultOutputListener()
             installDefaultInputListener()
+            installDeviceInventoryListener()
         }
         refreshRouteCache()
     }
@@ -230,6 +232,15 @@ final class DictationAudioRouteController: DictationAudioRouting {
                 &address,
                 queue,
                 defaultInputListener
+            )
+        }
+        if let deviceInventoryListener {
+            var address = Self.deviceInventoryAddress()
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                queue,
+                deviceInventoryListener
             )
         }
     }
@@ -423,6 +434,25 @@ final class DictationAudioRouteController: DictationAudioRouting {
         }
     }
 
+    private func installDeviceInventoryListener() {
+        var address = Self.deviceInventoryAddress()
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            // A selected non-default microphone can disappear or return without
+            // changing either system-default device. Refresh its UID resolution
+            // so meeting startup never consumes a stale AudioObjectID.
+            self?.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            queue,
+            listener
+        )
+        if status == noErr {
+            deviceInventoryListener = listener
+        }
+    }
+
     private static func defaultOutputDeviceAddress() -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultOutputDevice,
@@ -434,6 +464,14 @@ final class DictationAudioRouteController: DictationAudioRouting {
     private static func defaultInputDeviceAddress() -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+
+    private static func deviceInventoryAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -266,12 +266,10 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     func preferredInputDeviceIDForMeeting() -> AudioObjectID? {
-        syncOnRouteQueue {
-            let next = makeRouteSnapshot()
-            lock.withLock {
-                snapshot = next
-            }
-        }
+        // Meeting startup runs on the main actor. CoreAudio property reads can
+        // block indefinitely while the HAL is unhealthy, so never wait for a
+        // fresh route read here. Default-device listeners keep this snapshot
+        // warm on the dedicated route queue.
         return Self.preferredMeetingInputDeviceID(for: lock.withLock { snapshot })
     }
 
@@ -280,31 +278,22 @@ final class DictationAudioRouteController: DictationAudioRouting {
     }
 
     func meetingInputRouteSnapshot() -> MeetingMicRouteDiagnosticsSnapshot {
-        syncOnRouteQueue {
-            let next = makeRouteSnapshot()
-            lock.withLock {
-                snapshot = next
-            }
-        }
+        // This method is called from meeting startup on the main actor. Reading
+        // the lock-protected cache is intentionally the only work performed
+        // here: both queue.sync and inspector calls can wedge behind CoreAudio
+        // and freeze the prompt, status item, and recording controls.
         let current = lock.withLock { snapshot }
         let preferredInputDeviceID = Self.preferredMeetingInputDeviceID(for: current)
         let selectedInputDeviceUID = lock.withLock { selectedInputDeviceUIDStorage }
-        let devices = inspector.availableInputDevices()
-        let preferredDevice = preferredInputDeviceID.flatMap { id in
-            devices.first(where: { $0.deviceID == id })
-        }
-        let defaultInputDevice = current.defaultInputDeviceID.flatMap { id in
-            devices.first(where: { $0.deviceID == id })
-        }
         return MeetingMicRouteDiagnosticsSnapshot(
             outputRouteKind: current.outputRouteKind.description,
             outputIsAmbiguousBluetooth: current.outputIsAmbiguousBluetooth,
             selectedInputDeviceUID: selectedInputDeviceUID,
             selectedInputDeviceResolved: selectedInputDeviceUID == nil || current.selectedInputDeviceID != nil,
             preferredInputDeviceID: preferredInputDeviceID,
-            preferredInputDeviceName: preferredDevice?.name,
+            preferredInputDeviceName: nil,
             defaultInputDeviceID: current.defaultInputDeviceID,
-            defaultInputDeviceName: defaultInputDevice?.name,
+            defaultInputDeviceName: nil,
             builtInInputDeviceID: current.builtInInputDeviceID,
             systemDefaultInputIsBuiltIn: current.systemDefaultInputIsBuiltIn
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioRouteController.swift
@@ -154,6 +154,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
         var defaultInputDeviceID: AudioObjectID?
         var selectedInputDeviceID: AudioObjectID?
         var inputDeviceNamesByID: [AudioObjectID: String] = [:]
+        var inputDeviceIDsByUID: [String: AudioObjectID] = [:]
 
         var systemDefaultInputIsBuiltIn: Bool {
             guard let defaultInputDeviceID, let builtInInputDeviceID else { return false }
@@ -177,7 +178,15 @@ final class DictationAudioRouteController: DictationAudioRouting {
         }
         set {
             let normalized = newValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            lock.withLock { selectedInputDeviceUIDStorage = normalized?.isEmpty == false ? normalized : nil }
+            let selectedInputDeviceUID = normalized?.isEmpty == false ? normalized : nil
+            lock.withLock {
+                // Meeting startup only reads this cache, so apply a known
+                // selection before its asynchronous CoreAudio verification.
+                selectedInputDeviceUIDStorage = selectedInputDeviceUID
+                snapshot.selectedInputDeviceID = selectedInputDeviceUID.flatMap {
+                    snapshot.inputDeviceIDsByUID[$0]
+                }
+            }
             refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
         }
     }
@@ -254,12 +263,9 @@ final class DictationAudioRouteController: DictationAudioRouting {
         queue.async { [weak self] in
             guard let self else { return }
             let next = self.makeRouteSnapshot(refreshingDeviceNames: true)
-            let previousPreferredInputDeviceID = self.lock.withLock { () -> AudioObjectID? in
-                let previous = self.snapshot
-                self.snapshot = next
-                return Self.preferredInputDeviceID(for: previous)
-            }
-            let preferredInputDeviceID = Self.preferredInputDeviceID(for: next)
+            let routeChange = self.replaceRouteSnapshot(next)
+            let previousPreferredInputDeviceID = routeChange.previousPreferredInputDeviceID
+            let preferredInputDeviceID = routeChange.preferredInputDeviceID
             if notifyEvenIfPreferredUnchanged || previousPreferredInputDeviceID != preferredInputDeviceID {
                 let handler = self.onPreferredInputDeviceChanged
                 handler?(preferredInputDeviceID)
@@ -270,9 +276,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     func preferredInputDeviceIDForDictation() -> AudioObjectID? {
         syncOnRouteQueue {
             let next = makeRouteSnapshot()
-            lock.withLock {
-                snapshot = next
-            }
+            replaceRouteSnapshot(next)
         }
         return Self.preferredInputDeviceID(for: lock.withLock { snapshot })
     }
@@ -294,9 +298,12 @@ final class DictationAudioRouteController: DictationAudioRouting {
         // the lock-protected cache is intentionally the only work performed
         // here: both queue.sync and inspector calls can wedge behind CoreAudio
         // and freeze the prompt, status item, and recording controls.
-        let current = lock.withLock { snapshot }
+        let cachedRoute = lock.withLock {
+            (snapshot: snapshot, selectedInputDeviceUID: selectedInputDeviceUIDStorage)
+        }
+        let current = cachedRoute.snapshot
         let preferredInputDeviceID = Self.preferredMeetingInputDeviceID(for: current)
-        let selectedInputDeviceUID = lock.withLock { selectedInputDeviceUIDStorage }
+        let selectedInputDeviceUID = cachedRoute.selectedInputDeviceUID
         return MeetingMicRouteDiagnosticsSnapshot(
             outputRouteKind: current.outputRouteKind.description,
             outputIsAmbiguousBluetooth: current.outputIsAmbiguousBluetooth,
@@ -341,9 +348,7 @@ final class DictationAudioRouteController: DictationAudioRouting {
     func refreshRouteAfterDictationSession() {
         syncOnRouteQueue {
             let current = makeRouteSnapshot()
-            lock.withLock {
-                snapshot = current
-            }
+            replaceRouteSnapshot(current)
         }
     }
 
@@ -384,29 +389,67 @@ final class DictationAudioRouteController: DictationAudioRouting {
 
     private func makeRouteSnapshot(refreshingDeviceNames: Bool = false) -> RouteSnapshot {
         let outputClassification = currentOutputRouteClassification()
-        let selectedInputDeviceUID = lock.withLock { selectedInputDeviceUIDStorage }
-        let cachedInputDeviceNames = lock.withLock { snapshot.inputDeviceNamesByID }
-        let inputDevices = refreshingDeviceNames ? inspector.availableInputDevices() : nil
-        let selectedInputDeviceID = selectedInputDeviceUID.flatMap { uid in
-            if let inputDevices {
-                return inputDevices.first(where: { $0.uid == uid })?.deviceID
-            }
-            return inspector.inputDeviceID(matchingUID: uid)
+        let cachedRoute = lock.withLock {
+            (
+                selectedInputDeviceUID: selectedInputDeviceUIDStorage,
+                inputDeviceNamesByID: snapshot.inputDeviceNamesByID,
+                inputDeviceIDsByUID: snapshot.inputDeviceIDsByUID
+            )
         }
+        let inputDevices = refreshingDeviceNames ? inspector.availableInputDevices() : nil
         let inputDeviceNamesByID = inputDevices.map { devices in
             Dictionary(
                 devices.map { ($0.deviceID, $0.name) },
                 uniquingKeysWith: { first, _ in first }
             )
-        } ?? cachedInputDeviceNames
+        } ?? cachedRoute.inputDeviceNamesByID
+        var inputDeviceIDsByUID = inputDevices.map { devices in
+            Dictionary(
+                devices.map { ($0.uid, $0.deviceID) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        } ?? cachedRoute.inputDeviceIDsByUID
+        let selectedInputDeviceID = cachedRoute.selectedInputDeviceUID.flatMap { uid -> AudioObjectID? in
+            if inputDevices != nil {
+                return inputDeviceIDsByUID[uid]
+            }
+            let deviceID = inspector.inputDeviceID(matchingUID: uid)
+            if let deviceID {
+                inputDeviceIDsByUID[uid] = deviceID
+            } else {
+                inputDeviceIDsByUID.removeValue(forKey: uid)
+            }
+            return deviceID
+        }
         return RouteSnapshot(
             outputRouteKind: outputClassification.kind,
             outputIsAmbiguousBluetooth: outputClassification.isAmbiguousBluetooth,
             builtInInputDeviceID: inspector.builtInInputDeviceID(),
             defaultInputDeviceID: inspector.defaultInputDeviceID(),
             selectedInputDeviceID: selectedInputDeviceID,
-            inputDeviceNamesByID: inputDeviceNamesByID
+            inputDeviceNamesByID: inputDeviceNamesByID,
+            inputDeviceIDsByUID: inputDeviceIDsByUID
         )
+    }
+
+    @discardableResult
+    private func replaceRouteSnapshot(
+        _ next: RouteSnapshot
+    ) -> (previousPreferredInputDeviceID: AudioObjectID?, preferredInputDeviceID: AudioObjectID?) {
+        lock.withLock {
+            let previousPreferredInputDeviceID = Self.preferredInputDeviceID(for: snapshot)
+            var reconciled = next
+            // CoreAudio inspection can outlive a selection change. Resolve the
+            // latest UID against the candidate's freshly populated inventory.
+            reconciled.selectedInputDeviceID = selectedInputDeviceUIDStorage.flatMap {
+                reconciled.inputDeviceIDsByUID[$0]
+            }
+            snapshot = reconciled
+            return (
+                previousPreferredInputDeviceID,
+                Self.preferredInputDeviceID(for: reconciled)
+            )
+        }
     }
 
     private func currentOutputRouteClassification() -> AudioRouteClassifier.Classification {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMonitor.swift
@@ -599,6 +599,16 @@ private actor MeetingDetectionService {
             activityCandidate,
             mutedBundleIDs: context.mutedBundleIDs
         ) ? nil : activityCandidate
+        if context.isRecording,
+           let unmutedActivityCandidate {
+            // Manual recordings can begin before the meeting app becomes active.
+            // Consume a media-backed session only after capture has really started,
+            // so failed startups remain retryable and recurring URL-only candidates
+            // are not suppressed for the lifetime of the app.
+            if promptState.markRecordingStarted(unmutedActivityCandidate) {
+                log("recording_session_consumed id=\(unmutedActivityCandidate.id)")
+            }
+        }
         emitActivityUpdate(unmutedActivityCandidate)
         let candidate = isGloballySuppressed(now: now) ? nil : unmutedActivityCandidate
         logCandidateIfChanged(candidate)
@@ -702,6 +712,8 @@ private actor MeetingDetectionService {
             log("prompt_suppressed id=\(candidate.id) reason=auto_dismissed")
         case .userDismissedSuppression:
             log("prompt_suppressed id=\(candidate.id) reason=user_dismissed")
+        case .recordingStartedSuppression:
+            log("prompt_suppressed id=\(candidate.id) reason=recording_started")
         case .calendarNotificationVisible:
             log("prompt_suppressed id=\(candidate.id) reason=calendar_notification_visible")
         case .recording:

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
@@ -34,6 +34,10 @@ struct MeetingPromptDecision: Equatable {
 final class MeetingPromptStateMachine {
     private(set) var visiblePromptID: String?
     private var userDismissedSuppressionIDs: Set<String> = []
+    // Media-session IDs are unique for each continuous call and intentionally
+    // remain consumed for this app process. Evicting them on a timer or count
+    // could re-prompt a long-running meeting; app restart is the cleanup bound,
+    // matching the existing user-dismissed suppression lifetime.
     private var recordingStartedSuppressionIDs: Set<String> = []
     private var autoDismissedSuppressionIDs: [String: Date] = [:]
     private var lastCandidateID: String?

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
@@ -23,6 +23,7 @@ struct MeetingPromptDecision: Equatable {
         case candidatePending
         case autoDismissedSuppression
         case userDismissedSuppression
+        case recordingStartedSuppression
     }
 
     let action: Action
@@ -33,6 +34,7 @@ struct MeetingPromptDecision: Equatable {
 final class MeetingPromptStateMachine {
     private(set) var visiblePromptID: String?
     private var userDismissedSuppressionIDs: Set<String> = []
+    private var recordingStartedSuppressionIDs: Set<String> = []
     private var autoDismissedSuppressionIDs: [String: Date] = [:]
     private var lastCandidateID: String?
     private let candidateStabilityDelay: TimeInterval
@@ -95,6 +97,11 @@ final class MeetingPromptStateMachine {
             return MeetingPromptDecision(action: .none, candidate: candidate, reason: .userDismissedSuppression)
         }
 
+        if recordingStartedSuppressionIDs.contains(candidate.suppressionID) {
+            resetPendingCandidate()
+            return MeetingPromptDecision(action: .none, candidate: candidate, reason: .recordingStartedSuppression)
+        }
+
         if autoDismissedSuppressionIDs.keys.contains(candidate.suppressionID) {
             resetPendingCandidate()
             return MeetingPromptDecision(action: .none, candidate: candidate, reason: .autoDismissedSuppression)
@@ -129,6 +136,21 @@ final class MeetingPromptStateMachine {
         userDismissedSuppressionIDs.insert(candidate.suppressionID)
         autoDismissedSuppressionIDs.removeValue(forKey: candidate.suppressionID)
         resetPendingCandidate()
+    }
+
+    @discardableResult
+    func markRecordingStarted(_ candidate: MeetingCandidate) -> Bool {
+        if visiblePromptID == candidate.id { visiblePromptID = nil }
+        lastCandidateID = candidate.id
+        guard candidate.suppressionID.hasPrefix("meeting-session:") else {
+            resetPendingCandidate()
+            return false
+        }
+        let inserted = recordingStartedSuppressionIDs.insert(candidate.suppressionID).inserted
+        userDismissedSuppressionIDs.remove(candidate.suppressionID)
+        autoDismissedSuppressionIDs.removeValue(forKey: candidate.suppressionID)
+        resetPendingCandidate()
+        return inserted
     }
 
     func markClosed(_ candidate: MeetingCandidate) {

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -39,6 +39,25 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.meetingInputRouteSnapshot().outputRouteKind == "headphone-like")
     }
 
+    @Test("meeting uses system default recorder when built-in mic is already default")
+    func meetingUsesSystemDefaultRecorderForDefaultBuiltInMic() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 82,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.meeting-default-built-in"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == nil)
+        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == nil)
+        #expect(controller.meetingInputRouteSnapshot().defaultInputDeviceID == 82)
+    }
+
     @Test("meeting route snapshot never performs synchronous CoreAudio inspection")
     func meetingRouteSnapshotUsesCacheOnly() {
         let inspector = FakeCoreAudioDeviceInspector(
@@ -59,7 +78,7 @@ struct DictationAudioRouteControllerTests {
 
         let snapshot = controller.meetingInputRouteSnapshot()
 
-        #expect(snapshot.preferredInputDeviceID == 82)
+        #expect(snapshot.preferredInputDeviceID == nil)
         #expect(snapshot.defaultInputDeviceID == 82)
         #expect(inspector.inspectionCallCount == inspectionCountBeforeSnapshot)
     }
@@ -81,8 +100,8 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.preferredInputDeviceIDForDictation() == nil)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
         #expect(controller.systemDefaultInputIsBuiltInForDictation())
-        #expect(controller.preferredInputDeviceIDForMeeting() == 82)
-        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == 82)
+        #expect(controller.preferredInputDeviceIDForMeeting() == nil)
+        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == nil)
     }
 
     @Test("speaker output with non-built-in default input is not warmup-safe")
@@ -177,6 +196,52 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.preferredInputDeviceIDForDictation() == 91)
         #expect(controller.cachedPreferredInputDeviceIDForDictation() == 91)
         #expect(controller.preferredInputDeviceIDForMeeting() == 91)
+    }
+
+    @Test("user selected default microphone uses system default recorder")
+    func userSelectedDefaultMicrophoneUsesSystemDefaultRecorder() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            defaultInputDeviceID: 91,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.selected-default-input")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        controller.selectedInputDeviceUID = "external-mic"
+        routeQueue.sync {}
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == nil)
+        let snapshot = controller.meetingInputRouteSnapshot()
+        #expect(snapshot.preferredInputDeviceID == nil)
+        #expect(snapshot.selectedInputDeviceResolved)
+        #expect(snapshot.defaultInputDeviceID == 91)
+    }
+
+    @Test("meeting keeps explicit built-in routing when another microphone is default")
+    func meetingKeepsExplicitBuiltInRoutingForDifferentDefault() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 91,
+            builtInInputDeviceID: 82
+        )
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: DispatchQueue(label: "test.dictation-audio-route.meeting-nondefault-built-in"),
+            observesDefaultOutputChanges: false
+        )
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == 82)
+        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == 82)
     }
 
     @Test("unavailable selected microphone falls back to automatic route policy")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -253,6 +253,30 @@ struct DictationAudioRouteControllerTests {
         #expect(snapshot.defaultInputDeviceName == "External Mic")
     }
 
+    @Test("meeting route cache tolerates duplicate device IDs")
+    func meetingRouteCacheToleratesDuplicateDeviceIDs() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 91,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "duplicate-mic", name: "Duplicate Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.duplicate-device-ids")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        routeQueue.sync {}
+
+        #expect(controller.meetingInputRouteSnapshot().defaultInputDeviceName == "External Mic")
+    }
+
     @Test("meeting route cache follows selected microphone unplug and reconnect")
     func meetingRouteCacheFollowsSelectedMicrophoneHotPlug() {
         let inspector = FakeCoreAudioDeviceInspector(

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -232,16 +232,25 @@ struct DictationAudioRouteControllerTests {
             defaultOutputDeviceID: 10,
             outputRouteKind: .speakerLike,
             defaultInputDeviceID: 91,
-            builtInInputDeviceID: 82
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
         )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.meeting-nondefault-built-in")
         let controller = DictationAudioRouteController(
             inspector: inspector,
-            queue: DispatchQueue(label: "test.dictation-audio-route.meeting-nondefault-built-in"),
+            queue: routeQueue,
             observesDefaultOutputChanges: false
         )
+        routeQueue.sync {}
 
         #expect(controller.preferredInputDeviceIDForMeeting() == 82)
-        #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == 82)
+        let snapshot = controller.meetingInputRouteSnapshot()
+        #expect(snapshot.preferredInputDeviceID == 82)
+        #expect(snapshot.preferredInputDeviceName == "MacBook Microphone")
+        #expect(snapshot.defaultInputDeviceName == "External Mic")
     }
 
     @Test("meeting route cache follows selected microphone unplug and reconnect")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -248,7 +248,10 @@ struct DictationAudioRouteControllerTests {
         // verification from hiding whether its synchronous cache update works.
         routeQueue.sync {}
         routeQueue.suspend()
-        defer { routeQueue.resume() }
+        defer {
+            routeQueue.resume()
+            routeQueue.sync {}
+        }
         let inspectionCountBeforeSelection = inspector.inspectionCallCount
 
         controller.selectedInputDeviceUID = "external-mic"

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -226,6 +226,48 @@ struct DictationAudioRouteControllerTests {
         #expect(snapshot.defaultInputDeviceID == 91)
     }
 
+    @Test("meeting immediately observes a cached microphone selection")
+    func meetingImmediatelyObservesCachedMicrophoneSelection() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 82,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.immediate-selected-input")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        // Warm the UID-to-device cache, then prevent the setter's asynchronous
+        // verification from hiding whether its synchronous cache update works.
+        routeQueue.sync {}
+        routeQueue.suspend()
+        defer { routeQueue.resume() }
+        let inspectionCountBeforeSelection = inspector.inspectionCallCount
+
+        controller.selectedInputDeviceUID = "external-mic"
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == 91)
+        let externalSnapshot = controller.meetingInputRouteSnapshot()
+        #expect(externalSnapshot.selectedInputDeviceUID == "external-mic")
+        #expect(externalSnapshot.selectedInputDeviceResolved)
+        #expect(externalSnapshot.preferredInputDeviceName == "External Mic")
+
+        controller.selectedInputDeviceUID = "built-in-mic"
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == nil)
+        let builtInSnapshot = controller.meetingInputRouteSnapshot()
+        #expect(builtInSnapshot.selectedInputDeviceUID == "built-in-mic")
+        #expect(builtInSnapshot.selectedInputDeviceResolved)
+        #expect(inspector.inspectionCallCount == inspectionCountBeforeSelection)
+    }
+
     @Test("meeting keeps explicit built-in routing when another microphone is default")
     func meetingKeepsExplicitBuiltInRoutingForDifferentDefault() {
         let inspector = FakeCoreAudioDeviceInspector(
@@ -316,6 +358,36 @@ struct DictationAudioRouteControllerTests {
 
         #expect(controller.preferredInputDeviceIDForMeeting() == 92)
         #expect(controller.meetingInputRouteSnapshot().selectedInputDeviceResolved)
+    }
+
+    @Test("synchronous route refresh clears an unavailable cached microphone")
+    func synchronousRouteRefreshClearsUnavailableCachedMicrophone() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 82,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.cached-input-unavailable")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        controller.selectedInputDeviceUID = "external-mic"
+        routeQueue.sync {}
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == 91)
+
+        inspector.inputDevices.removeAll { $0.uid == "external-mic" }
+
+        #expect(controller.preferredInputDeviceIDForDictation() == nil)
+        #expect(controller.cachedPreferredInputDeviceIDForDictation() == nil)
+        #expect(controller.preferredInputDeviceIDForMeeting() == nil)
+        #expect(!controller.meetingInputRouteSnapshot().selectedInputDeviceResolved)
     }
 
     @Test("unavailable selected microphone falls back to automatic route policy")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -39,6 +39,31 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.meetingInputRouteSnapshot().outputRouteKind == "headphone-like")
     }
 
+    @Test("meeting route snapshot never performs synchronous CoreAudio inspection")
+    func meetingRouteSnapshotUsesCacheOnly() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .headphoneLike,
+            defaultInputDeviceID: 82,
+            builtInInputDeviceID: 82
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.meeting-cache-only")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        // Drain the initialization refresh before measuring the synchronous call.
+        routeQueue.sync {}
+        let inspectionCountBeforeSnapshot = inspector.inspectionCallCount
+
+        let snapshot = controller.meetingInputRouteSnapshot()
+
+        #expect(snapshot.preferredInputDeviceID == 82)
+        #expect(snapshot.defaultInputDeviceID == 82)
+        #expect(inspector.inspectionCallCount == inspectionCountBeforeSnapshot)
+    }
+
     @Test("dictation preserves default input for speaker output")
     func dictationPreservesDefaultInputForSpeakerOutput() {
         let inspector = FakeCoreAudioDeviceInspector(
@@ -228,6 +253,7 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     var outputIsAmbiguousBluetoothValue: Bool
     var builtInInputDeviceIDValue: AudioObjectID?
     var inputDevices: [AudioInputDeviceInfo]
+    private(set) var inspectionCallCount = 0
 
     init(
         defaultOutputDeviceID: AudioObjectID?,
@@ -246,11 +272,13 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     func defaultOutputDeviceID() -> AudioObjectID? {
-        defaultOutputDeviceIDValue
+        inspectionCallCount += 1
+        return defaultOutputDeviceIDValue
     }
 
     func defaultInputDeviceID() -> AudioObjectID? {
-        defaultInputDeviceIDValue
+        inspectionCallCount += 1
+        return defaultInputDeviceIDValue
     }
 
     func setDefaultInputDeviceID(_ deviceID: AudioObjectID) -> Bool {
@@ -258,10 +286,12 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     func availableInputDevices() -> [AudioInputDeviceInfo] {
-        inputDevices.filter { !$0.uid.hasPrefix("CADefaultDeviceAggregate") }
+        inspectionCallCount += 1
+        return inputDevices.filter { !$0.uid.hasPrefix("CADefaultDeviceAggregate") }
     }
 
     func inputDeviceID(matchingUID uid: String) -> AudioObjectID? {
+        inspectionCallCount += 1
         guard !uid.hasPrefix("CADefaultDeviceAggregate") else { return nil }
         return inputDevices.first(where: { $0.uid == uid })?.deviceID
     }
@@ -275,13 +305,15 @@ private final class FakeCoreAudioDeviceInspector: CoreAudioDeviceInspecting {
     }
 
     func outputRouteClassification(for deviceID: AudioObjectID) -> AudioRouteClassifier.Classification {
-        AudioRouteClassifier.Classification(
+        inspectionCallCount += 1
+        return AudioRouteClassifier.Classification(
             kind: outputRouteKindValue,
             isAmbiguousBluetooth: outputIsAmbiguousBluetoothValue
         )
     }
 
     func builtInInputDeviceID() -> AudioObjectID? {
-        builtInInputDeviceIDValue
+        inspectionCallCount += 1
+        return builtInInputDeviceIDValue
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioRouteControllerTests.swift
@@ -244,6 +244,47 @@ struct DictationAudioRouteControllerTests {
         #expect(controller.meetingInputRouteSnapshot().preferredInputDeviceID == 82)
     }
 
+    @Test("meeting route cache follows selected microphone unplug and reconnect")
+    func meetingRouteCacheFollowsSelectedMicrophoneHotPlug() {
+        let inspector = FakeCoreAudioDeviceInspector(
+            defaultOutputDeviceID: 10,
+            outputRouteKind: .speakerLike,
+            defaultInputDeviceID: 82,
+            builtInInputDeviceID: 82,
+            inputDevices: [
+                AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 91, isBuiltIn: false),
+                AudioInputDeviceInfo(uid: "built-in-mic", name: "MacBook Microphone", deviceID: 82, isBuiltIn: true),
+            ]
+        )
+        let routeQueue = DispatchQueue(label: "test.dictation-audio-route.selected-input-hot-plug")
+        let controller = DictationAudioRouteController(
+            inspector: inspector,
+            queue: routeQueue,
+            observesDefaultOutputChanges: false
+        )
+        controller.selectedInputDeviceUID = "external-mic"
+        routeQueue.sync {}
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == 91)
+        #expect(controller.meetingInputRouteSnapshot().selectedInputDeviceResolved)
+
+        inspector.inputDevices.removeAll { $0.uid == "external-mic" }
+        controller.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+        routeQueue.sync {}
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == nil)
+        #expect(!controller.meetingInputRouteSnapshot().selectedInputDeviceResolved)
+
+        inspector.inputDevices.append(
+            AudioInputDeviceInfo(uid: "external-mic", name: "External Mic", deviceID: 92, isBuiltIn: false)
+        )
+        controller.refreshRouteCache(notifyEvenIfPreferredUnchanged: true)
+        routeQueue.sync {}
+
+        #expect(controller.preferredInputDeviceIDForMeeting() == 92)
+        #expect(controller.meetingInputRouteSnapshot().selectedInputDeviceResolved)
+    }
+
     @Test("unavailable selected microphone falls back to automatic route policy")
     func unavailableSelectedMicrophoneFallsBackToAutomaticRoutePolicy() {
         let inspector = FakeCoreAudioDeviceInspector(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
@@ -170,6 +170,83 @@ struct MeetingPromptStateMachineTests {
         #expect(result.candidate?.id == laterSession.id)
     }
 
+    @Test("recording start suppresses the accepted meeting session after recording ends")
+    func recordingStartSuppressesAcceptedMeetingSession() {
+        let machine = immediateMachine()
+        let accepted = candidate(
+            "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1",
+            suppressionID: "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1"
+        )
+        let sameSessionWithUpdatedCandidateID = candidate(
+            "cal:event-123",
+            suppressionID: accepted.suppressionID
+        )
+
+        machine.markShown(accepted)
+        machine.markRecordingStarted(accepted)
+
+        let result = decision(machine, candidate: sameSessionWithUpdatedCandidateID)
+
+        #expect(machine.visiblePromptID == nil)
+        #expect(result.action == .none)
+        #expect(result.reason == .recordingStartedSuppression)
+    }
+
+    @Test("meeting activity discovered during manual recording remains suppressed after recording ends")
+    func activityDiscoveredDuringManualRecordingRemainsSuppressed() {
+        let machine = immediateMachine()
+        let discoveredDuringRecording = candidate(
+            "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1",
+            suppressionID: "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1"
+        )
+
+        machine.markRecordingStarted(discoveredDuringRecording)
+
+        let result = decision(machine, candidate: discoveredDuringRecording)
+
+        #expect(machine.visiblePromptID == nil)
+        #expect(result.action == .none)
+        #expect(result.reason == .recordingStartedSuppression)
+    }
+
+    @Test("recording start does not permanently suppress a URL-only recurring meeting")
+    func recordingStartDoesNotPermanentlySuppressURLOnlyCandidate() {
+        let machine = immediateMachine()
+        let urlOnlyCandidate = candidate(
+            "googleMeet:meet.google.com/abc-defg-hij",
+            suppressionID: "googleMeet:meet.google.com/abc-defg-hij",
+            evidence: [.browserURL, .foregroundApp]
+        )
+
+        let didConsumeSession = machine.markRecordingStarted(urlOnlyCandidate)
+        let result = decision(machine, candidate: urlOnlyCandidate)
+
+        #expect(!didConsumeSession)
+        #expect(result.action == .show)
+        #expect(result.reason == .eligible)
+    }
+
+    @Test("recording start does not suppress a genuinely later meeting session")
+    func recordingStartDoesNotSuppressLaterMeetingSession() {
+        let machine = immediateMachine()
+        let accepted = candidate(
+            "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1",
+            suppressionID: "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:1"
+        )
+        let laterSession = candidate(
+            "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:2",
+            suppressionID: "meeting-session:browser:com.google.Chrome:room:meet.google.com/abc-defg-hij:2"
+        )
+
+        machine.markShown(accepted)
+        machine.markRecordingStarted(accepted)
+
+        let result = decision(machine, candidate: laterSession)
+
+        #expect(result.action == .show)
+        #expect(result.candidate?.suppressionID == laterSession.suppressionID)
+    }
+
     @Test("auto-dismiss suppression survives candidate dropout")
     func autoDismissSuppressionSurvivesCandidateDropout() {
         let machine = immediateMachine()


### PR DESCRIPTION
## Summary

Fixes #322.

Muesli was treating the built-in/default microphone as an explicit device preference for meeting capture. When that microphone was already the macOS system default, Muesli opened an additional app-scoped `AudioQueue` for the same physical input that the meeting client was using.

Depending on startup order, the meeting client could temporarily lose microphone input, or Muesli could continue with system audio while its microphone capture failed. This matches both paths reported in #322.

This PR:

- uses the system-default streaming recorder when Muesli's desired meeting input is already the macOS default
- preserves explicit app-scoped routing when the user genuinely selects a different microphone
- uses the listener-maintained route snapshot during meeting startup instead of synchronously querying CoreAudio on the main actor
- suppresses another auto-detection prompt for the same continuous meeting session after recording has successfully started, while keeping failed starts and later sessions eligible

The routing change applies to all supported meeting applications and browsers, not only Google Meet.

## Diagnosis

During investigation, a deterministic local stress harness reproduced the #322-shaped failure:

- the system-audio process tap started successfully
- microphone `AudioQueueStart` blocked for approximately 15 seconds
- it returned `kAudioQueueErr_CannotStart` (`-66681`)
- failed-queue cleanup blocked for approximately another 30 seconds

This isolated the failure to the unnecessary explicit microphone graph and its CoreAudio lifecycle rather than the meeting-detection signal or system-audio process tap. The diagnostic harness and release-time profiling hooks are intentionally not included in this focused production PR.

## Behavior after this change

| Scenario | Meeting microphone | Muesli capture |
| --- | --- | --- |
| Start Muesli, then join a meeting | remains available | microphone and system audio continue |
| Join a meeting, then accept Muesli's prompt | remains available | microphone and system audio start |
| Select a genuinely different microphone in Muesli | unchanged | explicit device routing remains available |
| Discard while the external meeting continues | unchanged | the same live session is not prompted again |

## Validation

- 88 focused tests pass across audio routing, recorder selection, meeting candidate resolution, media-session tracking, and prompt state, including selected-microphone unplug/reconnect behavior
- live DevA test: start Muesli recording, then open and join Google Meet; both clients shared the built-in microphone and participants could hear the user
- live DevA test: join Google Meet, then accept Muesli's auto-detection prompt; Muesli selected the system-default streaming recorder and both microphone and system audio remained healthy
- live DevA test: discard Muesli's recording while Google Meet remained active; teardown completed normally and the same meeting session did not prompt again after the cooldown

The live lifecycle tests were performed without restarting Chrome, Muesli, or CoreAudio between the relevant transitions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786897924&installation_id=136549638&pr_number=327&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F327&signature=17c2b1554e305a5ebb34cc710e29a56b84ec0a4550e1d1fc6dfe77f23be7796d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting audio startup and routing by avoiding main-actor blocking during CoreAudio route refresh and resolving the system-default recorder correctly.
  * Prevented incorrect/stale microphone selection during device and async refresh races by applying cached choices atomically and reconciling against the latest selection.
  * Enhanced hot-plug (unplug/reconnect) behavior and route-cache resilience.
  * Improved meeting-prompt behavior by suppressing repeated prompts once recording has started, with clearer “recording started” logging.
* **Documentation**
  * Added an Issue `#322` handoff document with validation results and follow-up steps.
* **Tests**
  * Expanded meeting and dictation route-cache, system-default semantics, hot-plug, and prompt-suppression test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->