### PR TITLE
Add Hebrew (ivrit.ai) transcription model with custom HF repo support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Local-first macOS app for **dictation** and **meeting transcription** on Apple S
 - **Meeting transcription:** Captures mic (You) + system audio (Others) → VAD-driven chunking → speaker diarization → AI-powered meeting notes
 - **Meeting export:** Export notes or transcript as PDF (paginated US Letter) or Markdown via `MeetingExporter.swift`
 - **Screen context:** Accessibility API captures app name + text around cursor for dictation context-awareness (opt-in, off by default)
-- **11 ASR models:** Parakeet v3/v2, Whisper Tiny/Small/Medium/Large Turbo, Cohere Transcribe, Nemotron 3.5 Multilingual, SenseVoice Small, Qwen3 ASR, Indic ASR
+- **12 ASR models:** Parakeet v3/v2, Whisper Tiny/Small/Medium/Large Turbo, Hebrew (ivrit.ai), Cohere Transcribe, Nemotron 3.5 Multilingual, SenseVoice Small, Qwen3 ASR, Indic ASR
 - **3 summarization backends:** OpenAI API key, OpenRouter API key, ChatGPT OAuth (subscription-based)
 - **Camera-based meeting detection:** Requires mic + camera + recognized meeting app (camera alone won't trigger)
 - **Join & Record:** Extract meeting URLs from calendar events (Zoom, Meet, Teams, Webex, Chime, FaceTime), split button with "Join & Record" / "Join Only" / "Record Only", platform icons in notifications

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -9,6 +9,15 @@ struct BackendOption: Equatable {
     let sizeLabel: String
     let description: String
     let recommended: Bool
+    /// Hugging Face repo to download WhisperKit models from. `nil` uses
+    /// WhisperKit's default (argmaxinc/whisperkit-coreml). Lets Muesli offer
+    /// community fine-tunes (e.g. ivrit.ai Hebrew) that live outside the
+    /// argmax repo.
+    var repo: String? = nil
+    /// Force this transcription language instead of Whisper auto-detect.
+    /// Fine-tunes like ivrit.ai degrade language detection during training,
+    /// so their model cards require pinning the language explicitly.
+    var forcedLanguage: String? = nil
 
     static let parakeetMultilingual = BackendOption(
         backend: "fluidaudio",
@@ -64,6 +73,17 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
+    static let whisperHebrewIvrit = BackendOption(
+        backend: "whisper",
+        model: "ivrit-ai_whisper-large-v3-turbo",
+        label: "Hebrew (ivrit.ai)",
+        sizeLabel: "~1.6 GB",
+        description: "Whisper Large v3 Turbo fine-tuned for Hebrew by ivrit.ai. Best local Hebrew accuracy, handles mixed Hebrew/English meetings. Language is pinned to Hebrew.",
+        recommended: false,
+        repo: "rontw4/whisperkit-coreml-hebrew",
+        forcedLanguage: "he"
+    )
+
     static let nemotron35Multilingual = BackendOption(
         backend: "nemotron35",
         model: "FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML",
@@ -117,7 +137,7 @@ struct BackendOption: Equatable {
     ]
 
     static let whisperFamily: [BackendOption] = [
-        .whisperTinyEnglish, .whisperSmall, .whisperMedium, .whisperLargeTurbo,
+        .whisperTinyEnglish, .whisperSmall, .whisperMedium, .whisperLargeTurbo, .whisperHebrewIvrit,
     ]
 
     static let qwen3Asr = BackendOption(
@@ -194,7 +214,7 @@ struct BackendOption: Equatable {
         let fm = FileManager.default
         switch backend {
         case "whisper":
-            return WhisperKitTranscriber.isModelDownloaded(model)
+            return WhisperKitTranscriber.isModelDownloaded(model, repo: repo)
         case "fluidaudio":
             let supportDir = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent("Library/Application Support/FluidAudio/Models")

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1338,7 +1338,7 @@ struct ModelsView: View {
         let fm = FileManager.default
         switch option.backend {
         case "whisper":
-            WhisperKitTranscriber.deleteModel(option.model)
+            WhisperKitTranscriber.deleteModel(option.model, repo: option.repo)
         case "nemotron35":
             let path = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/muesli/models/nemotron35-multilingual-2240ms")
@@ -1418,7 +1418,7 @@ struct ModelsView: View {
     private func isModelDownloaded(_ option: BackendOption, fm: FileManager) -> Bool {
         switch option.backend {
         case "whisper":
-            return WhisperKitTranscriber.isModelDownloaded(option.model)
+            return WhisperKitTranscriber.isModelDownloaded(option.model, repo: option.repo)
         case "nemotron35":
             let path = fm.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/muesli/models/nemotron35-multilingual-2240ms/encoder.mlmodelc/coremldata.bin")

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -240,7 +240,12 @@ actor TranscriptionCoordinator {
             let version: AsrModelVersion = backend.model.contains("v2") ? .v2 : .v3
             try await fluidTranscriber.loadModels(version: version, progress: progress)
         case "whisper":
-            try await whisperTranscriber.loadModel(modelName: backend.model, progress: progress)
+            try await whisperTranscriber.loadModel(
+                modelName: backend.model,
+                repo: backend.repo,
+                language: backend.forcedLanguage,
+                progress: progress
+            )
             // Warmup ANE/GPU so first dictation doesn't pay CoreML compilation cost
             fputs("[muesli-native] WhisperKit warmup: running silent audio for CoreML compilation...\n", stderr)
             progress?(0.9, "Warming up model...")

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -6,6 +6,7 @@ import MuesliCore
 actor WhisperKitTranscriber {
     private var whisperKit: WhisperKit?
     private var loadedModel: String?
+    private var loadedLanguage: String?
 
     enum TranscriberError: Error, LocalizedError {
         case notLoaded
@@ -20,19 +21,34 @@ actor WhisperKitTranscriber {
     }
 
     /// Load a WhisperKit CoreML model. Downloads from HuggingFace if not cached.
-    func loadModel(modelName: String, progress: ((Double, String?) -> Void)? = nil) async throws {
-        if loadedModel == modelName, whisperKit != nil { return }
+    /// `repo` selects the Hugging Face repo (nil = WhisperKit's default
+    /// argmaxinc/whisperkit-coreml); community fine-tunes such as the ivrit.ai
+    /// Hebrew model live in their own repos. `language` is remembered so
+    /// transcription can pin it (fine-tunes often require an explicit language).
+    func loadModel(
+        modelName: String,
+        repo: String? = nil,
+        language: String? = nil,
+        progress: ((Double, String?) -> Void)? = nil
+    ) async throws {
+        if loadedModel == modelName, whisperKit != nil {
+            loadedLanguage = language
+            return
+        }
 
         fputs("[whisperkit] loading model: \(modelName)...\n", stderr)
         let modelFolder: URL?
 
-        if Self.isModelDownloaded(modelName) {
+        if Self.isModelDownloaded(modelName, repo: repo) {
             modelFolder = nil
         } else {
             let estimatedTotalBytes = Self.estimatedDownloadBytes(for: modelName)
             let totalText = Self.formatMegabytes(estimatedTotalBytes)
             progress?(0.02, "0 MB of \(totalText)")
-            modelFolder = try await WhisperKit.download(variant: modelName) { downloadProgress in
+            modelFolder = try await WhisperKit.download(
+                variant: modelName,
+                from: repo ?? "argmaxinc/whisperkit-coreml"
+            ) { downloadProgress in
                 let fraction = min(max(downloadProgress.fractionCompleted, 0), 1)
                 let estimatedBytes = Int64(Double(estimatedTotalBytes) * fraction)
                 let completedText = Self.formatMegabytes(estimatedBytes)
@@ -49,7 +65,8 @@ actor WhisperKitTranscriber {
 
         let config = WhisperKitConfig(
             model: modelFolder == nil ? modelName : nil,
-            modelFolder: modelFolder?.path,
+            modelRepo: repo,
+            modelFolder: modelFolder?.path ?? Self.cachedModelFolder(modelName, repo: repo),
             computeOptions: ModelComputeOptions(
                 audioEncoderCompute: .cpuAndNeuralEngine,
                 textDecoderCompute: .cpuAndNeuralEngine
@@ -58,6 +75,7 @@ actor WhisperKitTranscriber {
 
         whisperKit = try await WhisperKit(config)
         loadedModel = modelName
+        loadedLanguage = language
         fputs("[whisperkit] model ready: \(modelName)\n", stderr)
     }
 
@@ -71,6 +89,8 @@ actor WhisperKitTranscriber {
             return 1_500 * 1_000_000
         case "large-v3-v20240930_626MB":
             return 626 * 1_000_000
+        case "ivrit-ai_whisper-large-v3-turbo":
+            return 1_620 * 1_000_000
         default:
             return 250 * 1_000_000
         }
@@ -92,7 +112,13 @@ actor WhisperKitTranscriber {
         guard let whisperKit else { throw TranscriberError.notLoaded }
 
         let start = CFAbsoluteTimeGetCurrent()
-        let results = try await whisperKit.transcribe(audioPath: wavURL.path)
+        let results: [TranscriptionResult]
+        if let language = loadedLanguage {
+            let options = DecodingOptions(task: .transcribe, language: language)
+            results = try await whisperKit.transcribe(audioPath: wavURL.path, decodeOptions: options)
+        } else {
+            results = try await whisperKit.transcribe(audioPath: wavURL.path)
+        }
         let elapsed = CFAbsoluteTimeGetCurrent() - start
 
         let text = results.map(\.text).joined(separator: " ")
@@ -114,26 +140,39 @@ actor WhisperKitTranscriber {
     func shutdown() {
         whisperKit = nil
         loadedModel = nil
+        loadedLanguage = nil
     }
 
     // MARK: - Model Storage
 
-    /// WhisperKit stores models under ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/.
-    /// Each model variant is a direct subdirectory (e.g. openai_whisper-small.en/).
-    static func isModelDownloaded(_ modelName: String) -> Bool {
-        let fm = FileManager.default
-        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        let modelDir = fm.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
-        return fm.fileExists(atPath: modelDir.path)
+    /// WhisperKit stores models under ~/Documents/huggingface/models/<repo>/.
+    /// For the default argmax repo, each variant is prefixed with
+    /// "openai_whisper-" (e.g. openai_whisper-small.en/); custom repos use the
+    /// variant name as the directory as-is.
+    static func modelDirectory(_ modelName: String, repo: String? = nil) -> URL {
+        let repoPath = repo ?? "argmaxinc/whisperkit-coreml"
+        let fullName: String
+        if repo == nil {
+            fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
+        } else {
+            fullName = modelName
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models/\(repoPath)/\(fullName)")
+    }
+
+    private static func cachedModelFolder(_ modelName: String, repo: String?) -> String? {
+        guard repo != nil else { return nil }
+        return modelDirectory(modelName, repo: repo).path
+    }
+
+    /// Check if this model's files exist on disk.
+    static func isModelDownloaded(_ modelName: String, repo: String? = nil) -> Bool {
+        FileManager.default.fileExists(atPath: modelDirectory(modelName, repo: repo).path)
     }
 
     /// Delete cached model files for a WhisperKit model variant.
-    static func deleteModel(_ modelName: String) {
-        let fm = FileManager.default
-        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        let modelDir = fm.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
-        try? fm.removeItem(at: modelDir)
+    static func deleteModel(_ modelName: String, repo: String? = nil) {
+        try? FileManager.default.removeItem(at: modelDirectory(modelName, repo: repo))
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -6,6 +6,7 @@ import MuesliCore
 actor WhisperKitTranscriber {
     private var whisperKit: WhisperKit?
     private var loadedModel: String?
+    private var loadedRepo: String?
     private var loadedLanguage: String?
 
     enum TranscriberError: Error, LocalizedError {
@@ -31,7 +32,7 @@ actor WhisperKitTranscriber {
         language: String? = nil,
         progress: ((Double, String?) -> Void)? = nil
     ) async throws {
-        if loadedModel == modelName, whisperKit != nil {
+        if loadedModel == modelName, loadedRepo == repo, whisperKit != nil {
             loadedLanguage = language
             return
         }
@@ -75,6 +76,7 @@ actor WhisperKitTranscriber {
 
         whisperKit = try await WhisperKit(config)
         loadedModel = modelName
+        loadedRepo = repo
         loadedLanguage = language
         fputs("[whisperkit] model ready: \(modelName)\n", stderr)
     }
@@ -140,6 +142,7 @@ actor WhisperKitTranscriber {
     func shutdown() {
         whisperKit = nil
         loadedModel = nil
+        loadedRepo = nil
         loadedLanguage = nil
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -23,6 +23,37 @@ struct WhisperKitTranscriberTests {
             #expect(!option.model.hasSuffix(".bin"), "\(option.label) should not use .bin suffix")
         }
     }
+
+    @Test("hebrew ivrit model pins repo and language")
+    func hebrewIvritOption() {
+        let option = BackendOption.whisperHebrewIvrit
+        #expect(option.backend == "whisper")
+        #expect(option.repo == "rontw4/whisperkit-coreml-hebrew")
+        #expect(option.forcedLanguage == "he")
+        #expect(BackendOption.whisperFamily.contains(option))
+        #expect(BackendOption.all.contains(option))
+    }
+
+    @Test("stock whisper models keep default repo and auto language")
+    func stockWhisperOptionsUseDefaults() {
+        for option in [BackendOption.whisperTinyEnglish, .whisperSmall, .whisperMedium, .whisperLargeTurbo] {
+            #expect(option.repo == nil, "\(option.label) should use the default argmax repo")
+            #expect(option.forcedLanguage == nil, "\(option.label) should auto-detect language")
+        }
+    }
+
+    @Test("model directory honors custom repo")
+    func modelDirectoryCustomRepo() {
+        let defaultDir = WhisperKitTranscriber.modelDirectory("small.en")
+        #expect(defaultDir.path.contains("argmaxinc/whisperkit-coreml/openai_whisper-small.en"))
+
+        let hebrewDir = WhisperKitTranscriber.modelDirectory(
+            "ivrit-ai_whisper-large-v3-turbo",
+            repo: "rontw4/whisperkit-coreml-hebrew"
+        )
+        #expect(hebrewDir.path.contains("rontw4/whisperkit-coreml-hebrew/ivrit-ai_whisper-large-v3-turbo"))
+        #expect(!hebrewDir.path.contains("openai_whisper-"), "custom repo variants keep their name as-is")
+    }
 }
 
 @Suite("FluidAudioTranscriber")


### PR DESCRIPTION
## What

Adds a Hebrew transcription model to the Whisper family: **Hebrew (ivrit.ai)**, the [ivrit-ai/whisper-large-v3-turbo](https://huggingface.co/ivrit-ai/whisper-large-v3-turbo) fine-tune converted to WhisperKit CoreML format ([rontw4/whisperkit-coreml-hebrew](https://huggingface.co/rontw4/whisperkit-coreml-hebrew), ~1.6 GB fp16).

To support it, `BackendOption` gains two optional fields that any future community fine-tune can reuse:

- `repo`: Hugging Face repo for WhisperKit downloads. `nil` keeps today's behavior (argmaxinc/whisperkit-coreml). WhisperKit's `download(variant:from:)` already accepts this; Muesli just never passed it.
- `forcedLanguage`: pins `DecodingOptions.language` instead of auto-detect. The ivrit.ai model card states language detection was degraded during training and Hebrew must be set explicitly.

## Why

Parakeet v3 and the stock Whisper models produce unusable transcripts for Hebrew meetings. Example from a real 14-minute Hebrew meeting transcribed with Parakeet v3: the summary contains hallucinated fragments like "any hole to config my story". The same audio through the ivrit.ai fine-tune produces clean Hebrew including correctly-preserved English tech terms mid-sentence (verified with the same weights via faster-whisper, RTF ~0.19 on CPU; the CoreML/ANE path is faster).

Hebrew is a reasonable test case for the general "community fine-tune" mechanism: ivrit.ai models top the [Hebrew transcription leaderboard](https://huggingface.co/spaces/ivrit-ai/hebrew-transcription-leaderboard) and have no argmax-repo equivalent.

## Changes

- `Models.swift`: `BackendOption.repo` / `forcedLanguage` (both optional, default nil), new `whisperHebrewIvrit` option in `whisperFamily`, `isDownloaded` passes repo.
- `WhisperCppBackend.swift` (`WhisperKitTranscriber`): `loadModel` takes `repo:`/`language:`; download uses `from:` repo; model storage paths honor the repo directory (custom-repo variants keep their name as-is, argmax variants keep the `openai_whisper-` prefix logic); `transcribe` passes `DecodingOptions(task: .transcribe, language:)` when a language is pinned; `isModelDownloaded`/`deleteModel` take repo.
- `TranscriptionRuntime.swift` / `ModelsView.swift`: pass the new fields through.
- `BackendTests.swift`: new tests for the Hebrew option, default-repo invariants for stock models, and repo-aware model directory resolution.

Not in scope: a generic "add custom HF repo" UI. The plumbing now exists, so that can be a follow-up if there is demand.

## Testing

- `swift test --package-path native/MuesliNative --filter 'WhisperKitTranscriberTests|BackendOptionTests|BackendCoverageTests'` passes (34 tests, 4 suites, all passed).
- Verified the rontw4/whisperkit-coreml-hebrew repo layout matches WhisperKit's downloader expectations (single `ivrit-ai_whisper-large-v3-turbo/` folder with AudioEncoder/TextDecoder/MelSpectrogram `.mlmodelc` + tokenizer files).
- Real-audio validation of the underlying weights on a 14-minute Hebrew meeting (mixed Hebrew/English), output verified by a native speaker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787038059&installation_id=136549638&pr_number=331&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F331&signature=aa9c22a4ba6521496e83e6992b4ccad82eb2aefdd683430800feb475462fb8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hebrew (Ivrit) transcription support via a dedicated Whisper option.
  * Added support for Whisper models hosted in custom repositories.
  * Added optional forced-language pinning for more consistent transcription.
  * Updated Whisper model loading, download/caching, and availability/removal logic to respect the selected repository and language.

* **Tests**
  * Added tests covering Hebrew/Ivrit configuration and correct custom-repo model directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->