### PR TITLE
Fix crash in dictation correction monitor on non-finite AX geometry

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -1264,14 +1264,30 @@ final class DictationCorrectionMonitor {
         let position = cgPointAttribute(kAXPositionAttribute, from: element)
         let size = cgSizeAttribute(kAXSizeAttribute, from: element)
 
+        return elementVisitKey(
+            processID: pid,
+            role: role,
+            position: position,
+            size: size,
+            fallbackHash: CFHash(element)
+        )
+    }
+
+    nonisolated static func elementVisitKey(
+        processID: pid_t,
+        role: String,
+        position: CGPoint?,
+        size: CGSize?,
+        fallbackHash: CFHashCode
+    ) -> String {
         if let position, let size,
            let px = Int(exactly: position.x.rounded(.towardZero)),
            let py = Int(exactly: position.y.rounded(.towardZero)),
            let sw = Int(exactly: size.width.rounded(.towardZero)),
            let sh = Int(exactly: size.height.rounded(.towardZero)) {
-            return "\(pid)|\(role)|\(px)|\(py)|\(sw)|\(sh)"
+            return "\(processID)|\(role)|\(px)|\(py)|\(sw)|\(sh)"
         }
-        return "\(pid)|\(role)|\(CFHash(element))"
+        return "\(processID)|\(role)|\(fallbackHash)"
     }
 
     nonisolated private static func axElementAttribute(_ attribute: String, from element: AXUIElement) -> AXUIElement? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -1265,9 +1265,11 @@ final class DictationCorrectionMonitor {
         let size = cgSizeAttribute(kAXSizeAttribute, from: element)
 
         if let position, let size,
-           position.x.isFinite, position.y.isFinite,
-           size.width.isFinite, size.height.isFinite {
-            return "\(pid)|\(role)|\(Int(position.x))|\(Int(position.y))|\(Int(size.width))|\(Int(size.height))"
+           let px = Int(exactly: position.x.rounded(.towardZero)),
+           let py = Int(exactly: position.y.rounded(.towardZero)),
+           let sw = Int(exactly: size.width.rounded(.towardZero)),
+           let sh = Int(exactly: size.height.rounded(.towardZero)) {
+            return "\(pid)|\(role)|\(px)|\(py)|\(sw)|\(sh)"
         }
         return "\(pid)|\(role)|\(CFHash(element))"
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationCorrectionMonitor.swift
@@ -1264,7 +1264,9 @@ final class DictationCorrectionMonitor {
         let position = cgPointAttribute(kAXPositionAttribute, from: element)
         let size = cgSizeAttribute(kAXSizeAttribute, from: element)
 
-        if let position, let size {
+        if let position, let size,
+           position.x.isFinite, position.y.isFinite,
+           size.width.isFinite, size.height.isFinite {
             return "\(pid)|\(role)|\(Int(position.x))|\(Int(position.y))|\(Int(size.width))|\(Int(size.height))"
         }
         return "\(pid)|\(role)|\(CFHash(element))"

--- a/native/MuesliNative/Tests/MuesliTests/DictationCorrectionMonitorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationCorrectionMonitorTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Dictionary correction monitor")
+struct DictationCorrectionMonitorTests {
+    private let processID: pid_t = 42
+    private let role = "AXTextArea"
+    private let fallbackHash: CFHashCode = 9_001
+
+    @Test("visit key preserves truncation toward zero for finite geometry")
+    func visitKeyPreservesTruncationTowardZero() {
+        let key = DictationCorrectionMonitor.elementVisitKey(
+            processID: processID,
+            role: role,
+            position: CGPoint(x: 12.9, y: -3.7),
+            size: CGSize(width: 640.8, height: -20.2),
+            fallbackHash: fallbackHash
+        )
+
+        #expect(key == "42|AXTextArea|12|-3|640|-20")
+    }
+
+    @Test("visit key accepts negative offscreen coordinates")
+    func visitKeyAcceptsNegativeOffscreenCoordinates() {
+        let key = DictationCorrectionMonitor.elementVisitKey(
+            processID: processID,
+            role: role,
+            position: CGPoint(x: -12_345.75, y: -6_789.25),
+            size: CGSize(width: 1_024, height: 768),
+            fallbackHash: fallbackHash
+        )
+
+        #expect(key == "42|AXTextArea|-12345|-6789|1024|768")
+    }
+
+    @Test("visit key falls back when geometry is missing")
+    func visitKeyFallsBackWhenGeometryIsMissing() {
+        let expected = "42|AXTextArea|9001"
+
+        #expect(DictationCorrectionMonitor.elementVisitKey(
+            processID: processID,
+            role: role,
+            position: nil,
+            size: CGSize(width: 100, height: 50),
+            fallbackHash: fallbackHash
+        ) == expected)
+
+        #expect(DictationCorrectionMonitor.elementVisitKey(
+            processID: processID,
+            role: role,
+            position: CGPoint(x: 10, y: 20),
+            size: nil,
+            fallbackHash: fallbackHash
+        ) == expected)
+    }
+
+    @Test("visit key falls back for every invalid geometry component")
+    func visitKeyFallsBackForEveryInvalidGeometryComponent() {
+        let invalidValues: [CGFloat] = [
+            .nan,
+            .infinity,
+            -.infinity,
+            .greatestFiniteMagnitude,
+        ]
+        let expected = "42|AXTextArea|9001"
+
+        for invalidValue in invalidValues {
+            let geometries: [(CGPoint, CGSize)] = [
+                (CGPoint(x: invalidValue, y: 20), CGSize(width: 100, height: 50)),
+                (CGPoint(x: 10, y: invalidValue), CGSize(width: 100, height: 50)),
+                (CGPoint(x: 10, y: 20), CGSize(width: invalidValue, height: 50)),
+                (CGPoint(x: 10, y: 20), CGSize(width: 100, height: invalidValue)),
+            ]
+
+            for (position, size) in geometries {
+                #expect(DictationCorrectionMonitor.elementVisitKey(
+                    processID: processID,
+                    role: role,
+                    position: position,
+                    size: size,
+                    fallbackHash: fallbackHash
+                ) == expected)
+            }
+        }
+    }
+}

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -58,6 +58,7 @@ case "${shard}" in
       DictationStateTests
       HotkeyConfigTests
       DictationStateIdleTests
+      DictationCorrectionMonitorTests
     )
     ;;
   meetings)


### PR DESCRIPTION
I've had a few crashes in the last version (v0.8.0) when running dictation, the app crashes.
This is my attempt at fixing this based on the app bug report.

## Summary

Fixes a crash (`EXC_BREAKPOINT` / `SIGTRAP`) in `DictationCorrectionMonitor.elementVisitKey` triggered after dictation, while walking the target app's accessibility tree.

The Accessibility framework can return non-finite **or out-of-range** geometry — `NaN`, `±Infinity`, or finite-but-enormous values — for offscreen, placeholder, or degenerate AX nodes. Swift's `Int(_: Double)` initializer traps on all of these.

Every `CGFloat` → `Int` conversion is now guarded with `Int(exactly:)` applied to `.rounded(.towardZero)`, so any element whose geometry can't be represented exactly falls through to the existing `CFHash`-based visit key instead of crashing.

Fixes #323

## Root cause

Crash report registers (x8, x19, x24) all held `0x7ff0000000000000` — IEEE-754 `+Infinity`. The AX tree walker reached an element with infinite geometry and the interpolation `Int(position.x)` trapped.

## Implementation

| Commit | Author | Change |
|---|---|---|
| `49e8ccf8` | @Gui11aum3 | Initial fix — `.isFinite` guards on position/size |
| `c4f8f72a` | @Gui11aum3 | **Operative fix** — `Int(exactly:)` + `.rounded(.towardZero)` |
| `45a06727` | @pHequals7 | Regression coverage — no behavior change |

`c4f8f72a` is the fix that matters. `.isFinite` alone was insufficient: `.greatestFiniteMagnitude` *is* finite but still traps in `Int()`. `Int(exactly:)` closes `NaN`, `±Infinity` and out-of-range in a single construct, while `.rounded(.towardZero)` preserves the original truncation semantics — visit keys stay byte-identical for normal geometry, so tree-walk dedup is unchanged.

`45a06727` extracts the logic into `nonisolated static func elementVisitKey(processID:role:position:size:fallbackHash:)`, taking plain values rather than an opaque `AXUIElement` (which can't be constructed with arbitrary geometry in a unit test), and adds the regression suite. Behavior-preserving.

## Testing

- `swift test --package-path native/MuesliNative` — **1432 tests across 140 suites, all passing**
- `git diff --check` — clean
- New `Dictionary correction monitor` suite (4 tests):
  - truncation toward zero for normal geometry
  - negative / offscreen coordinates
  - fallback when position or size is missing
  - fallback for `NaN`, `+∞`, `−∞`, `.greatestFiniteMagnitude` — independently across x, y, width and height

The `.greatestFiniteMagnitude` case fails on `49e8ccf8` and passes on `c4f8f72a`, so it pins the checked-conversion approach against a future revert to the `.isFinite` form.

### Runtime verification

The patched build was installed as the default `MuesliDev` lane and exercised across repeated cmux dictations — no crash, process survived throughout. Dictionary correction prompts were separately confirmed working in AX-capable apps.

**The original crash was not reproduced.** #323 was reported against cmux `0.64.18` (build 98); verification here ran on cmux `0.64.20` (build 100), with identical macOS (26.5.2 / 25F84) and Muesli (0.8.0). A pre-fix baseline build also did not crash, so there is no before/after demonstration. The guard is validated by regression tests against the trapping condition rather than by reproducing the original fault. Note the reporter observed 8 crashes across two days of ordinary use, so the per-dictation rate is unknown and a single clean baseline run is weak evidence either way.

### Known limitation — not addressed here

Dictionary correction prompts do not appear in cmux, before or after this change. cmux's terminal AX surface exposes only currently-selected text, never full field contents, so the correction monitor has nothing to diff. This is orthogonal to the crash — #323's "expected behavior" wording touches it, but a crash guard was never going to deliver it. Tracking separately as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787320897&installation_model_id=422865&pr_number=335&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F335&signature=9ba03d52236de8bb5d57bc5ff83502373e963a7a6f32fb41594d45eadf0fac14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved dictation correction monitoring by validating accessibility elements’ position and size data before using coordinate-based tracking.
  * When geometry values can’t be safely represented, the system now uses a consistent fallback identifier to keep monitoring reliable.

* **Tests**
  * Added coverage to verify visit-key formatting across valid/negative/offscreen geometry and invalid floating-point values.

* **Chores**
  * Updated CI test sharding so the new dictation-transcription test suite runs in the appropriate shard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
