### PR TITLE
Add Apple Contacts participants to meeting records

### DIFF
--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -54,6 +54,8 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedLibrary("sqlite3"),
+                .linkedFramework("Contacts"),
+                .linkedFramework("ContactsUI"),
             ]
         ),
         .executableTarget(

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -4,6 +4,7 @@ import SQLite3
 public enum DictationStoreError: Error, LocalizedError {
     case dictationNotFound(id: Int64)
     case meetingNotFound(id: Int64)
+    case invalidContactIdentifier
 
     public var errorDescription: String? {
         switch self {
@@ -11,6 +12,8 @@ public enum DictationStoreError: Error, LocalizedError {
             return "Dictation \(id) no longer exists."
         case .meetingNotFound(let id):
             return "Meeting \(id) no longer exists."
+        case .invalidContactIdentifier:
+            return "That contact could not be identified."
         }
     }
 }
@@ -23,6 +26,32 @@ public struct MeetingThreadNavigation: Equatable, Sendable {
 
 public final class DictationStore {
     public static let defaultTombstoneRetentionInterval: TimeInterval = 30 * 24 * 60 * 60
+
+    /// Domain of the `NSError`s this store raises for raw SQLite faults. The error
+    /// code is the SQLite result code, which is what makes `isTransientLockFailure`
+    /// possible without callers hardcoding the domain string.
+    public static let errorDomain = "MuesliDB"
+
+    /// Reports whether an error raised by this store is lock contention that a retry
+    /// could clear, as opposed to a deterministic fault such as corruption or a
+    /// missing database file.
+    ///
+    /// Every connection sets `sqlite3_busy_timeout`, so a surfaced `SQLITE_BUSY` or
+    /// `SQLITE_LOCKED` already means a writer held the database past that window —
+    /// which a caller that can afford to wait longer may still ride out. Anything
+    /// else will fail identically on the next attempt.
+    public static func isTransientLockFailure(_ error: Error) -> Bool {
+        let error = error as NSError
+        guard error.domain == errorDomain else { return false }
+        // Mask to the primary result code so an extended code (SQLITE_BUSY_SNAPSHOT
+        // and friends, which share the low byte) is not misread as unrecoverable.
+        switch Int32(truncatingIfNeeded: error.code) & 0xFF {
+        case SQLITE_BUSY, SQLITE_LOCKED:
+            return true
+        default:
+            return false
+        }
+    }
 
     private static let iso8601Formatter = ISO8601DateFormatter()
     private static let iso8601FormatterLock = NSLock()
@@ -120,6 +149,20 @@ public final class DictationStore {
         );
         CREATE INDEX IF NOT EXISTS idx_meetings_start_time ON meetings(start_time DESC);
         CREATE UNIQUE INDEX IF NOT EXISTS idx_meetings_calendar_event_id ON meetings(calendar_event_id) WHERE calendar_event_id IS NOT NULL;
+
+        -- Meeting participants are deliberately device-local: they are not carried
+        -- by MuesliICloudSyncEngine and this table has no sync bookkeeping columns.
+        -- Propagating removals across devices needs tombstones, so syncing them
+        -- belongs in a dedicated change rather than a partial retrofit here.
+        CREATE TABLE IF NOT EXISTS meeting_participants (
+            meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+            contact_identifier TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            insertion_order INTEGER NOT NULL,
+            PRIMARY KEY (meeting_id, contact_identifier)
+        );
+        CREATE INDEX IF NOT EXISTS idx_meeting_participants_order
+            ON meeting_participants(meeting_id, insertion_order);
 
         CREATE TABLE IF NOT EXISTS meeting_transcript_checkpoints (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -765,6 +808,180 @@ public final class DictationStore {
             throw lastError(db)
         }
         return sqlite3_last_insert_rowid(db)
+    }
+
+    public func listMeetingParticipants(meetingID: Int64) throws -> [MeetingParticipant] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT meeting_id, contact_identifier, display_name, insertion_order
+        FROM meeting_participants
+        WHERE meeting_id = ?
+        ORDER BY insertion_order, contact_identifier
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+
+        var participants: [MeetingParticipant] = []
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                participants.append(MeetingParticipant(
+                    meetingID: sqlite3_column_int64(statement, 0),
+                    contactIdentifier: stringColumn(statement, index: 1),
+                    displayName: stringColumn(statement, index: 2),
+                    insertionOrder: Int(sqlite3_column_int64(statement, 3))
+                ))
+            case SQLITE_DONE:
+                return participants
+            default:
+                // Returning the rows gathered so far would hand callers a silently
+                // short participant list. Throwing also lets a SQLITE_BUSY read reach
+                // the auto-exporter's isTransientLockFailure retry instead of baking a
+                // missing "People" line into the exported file.
+                throw lastError(db)
+            }
+        }
+    }
+
+    @discardableResult
+    public func attachMeetingParticipant(
+        meetingID: Int64,
+        contactIdentifier: String,
+        displayName: String
+    ) throws -> Bool {
+        guard !contactIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DictationStoreError.invalidContactIdentifier
+        }
+
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        try exec("BEGIN IMMEDIATE", db: db)
+
+        do {
+            var meetingStatement: OpaquePointer?
+            guard sqlite3_prepare_v2(
+                db,
+                "SELECT 1 FROM meetings WHERE id = ? AND deleted_at IS NULL LIMIT 1",
+                -1,
+                &meetingStatement,
+                nil
+            ) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_int64(meetingStatement, 1, meetingID)
+            let meetingStep = sqlite3_step(meetingStatement)
+            sqlite3_finalize(meetingStatement)
+            switch meetingStep {
+            case SQLITE_ROW:
+                break
+            case SQLITE_DONE:
+                throw DictationStoreError.meetingNotFound(id: meetingID)
+            default:
+                // Never collapse a genuine SQLite fault (SQLITE_BUSY, SQLITE_CORRUPT)
+                // into "meeting not found" — that reaches the user as a claim their
+                // meeting no longer exists while it is visibly on screen.
+                throw lastError(db)
+            }
+
+            // Determine newness explicitly: the upsert below reports a row change for
+            // both an insert and a display-name refresh, so sqlite3_changes() cannot
+            // distinguish them.
+            var existingStatement: OpaquePointer?
+            guard sqlite3_prepare_v2(
+                db,
+                """
+                SELECT 1 FROM meeting_participants
+                WHERE meeting_id = ? AND contact_identifier = ?
+                LIMIT 1
+                """,
+                -1,
+                &existingStatement,
+                nil
+            ) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_int64(existingStatement, 1, meetingID)
+            sqlite3_bind_text(existingStatement, 2, (contactIdentifier as NSString).utf8String, -1, nil)
+            let existingStep = sqlite3_step(existingStatement)
+            sqlite3_finalize(existingStatement)
+            let alreadyAttached: Bool
+            switch existingStep {
+            case SQLITE_ROW:
+                alreadyAttached = true
+            case SQLITE_DONE:
+                alreadyAttached = false
+            default:
+                throw lastError(db)
+            }
+
+            // Refresh the stored snapshot on re-add so a contact renamed in
+            // Contacts.app has a recovery path. Scoping the conflict clause to the
+            // primary key keeps real constraint violations throwing.
+            let sql = """
+            INSERT INTO meeting_participants
+                (meeting_id, contact_identifier, display_name, insertion_order)
+            VALUES (
+                ?,
+                ?,
+                ?,
+                COALESCE(
+                    (SELECT MAX(insertion_order) + 1
+                     FROM meeting_participants
+                     WHERE meeting_id = ?),
+                    0
+                )
+            )
+            ON CONFLICT(meeting_id, contact_identifier)
+            DO UPDATE SET display_name = excluded.display_name
+            """
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_int64(statement, 1, meetingID)
+            sqlite3_bind_text(statement, 2, (contactIdentifier as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 3, (displayName as NSString).utf8String, -1, nil)
+            sqlite3_bind_int64(statement, 4, meetingID)
+            guard sqlite3_step(statement) == SQLITE_DONE else {
+                sqlite3_finalize(statement)
+                throw lastError(db)
+            }
+            sqlite3_finalize(statement)
+            try exec("COMMIT", db: db)
+            return !alreadyAttached
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    public func removeMeetingParticipant(
+        meetingID: Int64,
+        contactIdentifier: String
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        DELETE FROM meeting_participants
+        WHERE meeting_id = ? AND contact_identifier = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        sqlite3_bind_text(statement, 2, (contactIdentifier as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
     }
 
     @discardableResult
@@ -1501,6 +1718,7 @@ public final class DictationStore {
         do {
             try deleteResumeSnapshot(meetingID: id, db: db)
             try deleteLiveTranscriptCheckpoints(meetingID: id, db: db)
+            try deleteMeetingParticipants(meetingID: id, db: db)
             let sql = """
             UPDATE meetings
             SET title = 'Deleted Meeting',
@@ -1614,27 +1832,35 @@ public final class DictationStore {
     public func clearMeetings() throws {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
-        try exec("DELETE FROM meeting_resume_snapshots", db: db)
-        try exec("DELETE FROM meeting_transcript_checkpoints", db: db)
-        try exec(
-            """
-            UPDATE meetings
-            SET title = 'Deleted Meeting',
-                raw_transcript = '',
-                formatted_notes = NULL,
-                manual_notes = '',
-                mic_audio_path = NULL,
-                system_audio_path = NULL,
-                saved_recording_path = NULL,
-                word_count = 0,
-                duration_seconds = 0,
-                deleted_at = strftime('%s','now'),
-                updated_at = strftime('%s','now'),
-                sync_dirty = 1
-            WHERE deleted_at IS NULL
-            """,
-            db: db
-        )
+        try exec("BEGIN IMMEDIATE", db: db)
+        do {
+            try exec("DELETE FROM meeting_resume_snapshots", db: db)
+            try exec("DELETE FROM meeting_transcript_checkpoints", db: db)
+            try exec("DELETE FROM meeting_participants", db: db)
+            try exec(
+                """
+                UPDATE meetings
+                SET title = 'Deleted Meeting',
+                    raw_transcript = '',
+                    formatted_notes = NULL,
+                    manual_notes = '',
+                    mic_audio_path = NULL,
+                    system_audio_path = NULL,
+                    saved_recording_path = NULL,
+                    word_count = 0,
+                    duration_seconds = 0,
+                    deleted_at = strftime('%s','now'),
+                    updated_at = strftime('%s','now'),
+                    sync_dirty = 1
+                WHERE deleted_at IS NULL
+                """,
+                db: db
+            )
+            try exec("COMMIT", db: db)
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
     }
 
     public func updateMeeting(id: Int64, title: String, formattedNotes: String) throws {
@@ -2305,6 +2531,19 @@ public final class DictationStore {
 
     private func deleteLiveTranscriptCheckpoints(meetingID: Int64, db: OpaquePointer?) throws {
         let sql = "DELETE FROM meeting_transcript_checkpoints WHERE meeting_id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    private func deleteMeetingParticipants(meetingID: Int64, db: OpaquePointer?) throws {
+        let sql = "DELETE FROM meeting_participants WHERE meeting_id = ?"
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
             throw lastError(db)
@@ -3632,7 +3871,7 @@ public final class DictationStore {
 
     private func lastError(_ db: OpaquePointer?) -> NSError {
         NSError(
-            domain: "MuesliDB",
+            domain: Self.errorDomain,
             code: Int(sqlite3_errcode(db)),
             userInfo: [NSLocalizedDescriptionKey: String(cString: sqlite3_errmsg(db))]
         )

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -367,6 +367,29 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
     }
 }
 
+public struct MeetingParticipant: Identifiable, Equatable, Sendable {
+    public let meetingID: Int64
+    public let contactIdentifier: String
+    public let displayName: String
+    public let insertionOrder: Int
+
+    public var id: String {
+        "\(meetingID):\(contactIdentifier)"
+    }
+
+    public init(
+        meetingID: Int64,
+        contactIdentifier: String,
+        displayName: String,
+        insertionOrder: Int
+    ) {
+        self.meetingID = meetingID
+        self.contactIdentifier = contactIdentifier
+        self.displayName = displayName
+        self.insertionOrder = insertionOrder
+    }
+}
+
 public struct MeetingFolder: Identifiable, Codable, Sendable {
     public let id: Int64
     public var name: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactIdentity.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactIdentity.swift
@@ -1,0 +1,76 @@
+import Contacts
+import Foundation
+
+enum MeetingContactIdentity {
+    static func displayName(for contact: CNContact) -> String {
+        let nameDescriptor = CNContactFormatter.descriptorForRequiredKeys(for: .fullName)
+        let fullName = contact.areKeysAvailable([nameDescriptor])
+            ? CNContactFormatter.string(from: contact, style: .fullName)
+            : nil
+        let nickname = contact.isKeyAvailable(CNContactNicknameKey) ? contact.nickname : nil
+        let organization = contact.isKeyAvailable(CNContactOrganizationNameKey) ? contact.organizationName : nil
+        let email = contact.isKeyAvailable(CNContactEmailAddressesKey)
+            ? contact.emailAddresses.first?.value as String?
+            : nil
+        let phone = contact.isKeyAvailable(CNContactPhoneNumbersKey)
+            ? contact.phoneNumbers.first?.value.stringValue
+            : nil
+        let candidates = [fullName, nickname, organization, email, phone]
+        for candidate in candidates {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return "Unnamed contact"
+    }
+}
+
+struct NewMeetingContactDraft: Equatable {
+    var givenName = ""
+    var familyName = ""
+    var emailAddress = ""
+    var phoneNumber = ""
+
+    var normalizedGivenName: String {
+        givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedFamilyName: String {
+        familyName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedEmailAddress: String {
+        emailAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedPhoneNumber: String {
+        phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var canSave: Bool {
+        !normalizedEmailAddress.isEmpty || !normalizedPhoneNumber.isEmpty
+    }
+
+    func makeContact() -> CNMutableContact? {
+        guard canSave else { return nil }
+
+        let contact = CNMutableContact()
+        contact.givenName = normalizedGivenName
+        contact.familyName = normalizedFamilyName
+        if !normalizedEmailAddress.isEmpty {
+            contact.emailAddresses = [
+                CNLabeledValue(label: CNLabelWork, value: normalizedEmailAddress as NSString),
+            ]
+        }
+        if !normalizedPhoneNumber.isEmpty {
+            contact.phoneNumbers = [
+                CNLabeledValue(
+                    label: CNLabelPhoneNumberMobile,
+                    value: CNPhoneNumber(stringValue: normalizedPhoneNumber)
+                ),
+            ]
+        }
+        return contact
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactPicker.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactPicker.swift
@@ -1,0 +1,90 @@
+import AppKit
+import Contacts
+import ContactsUI
+import SwiftUI
+
+struct MeetingContactPicker: NSViewRepresentable {
+    @Binding var isPresented: Bool
+    let onSelect: (CNContact) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.parent = self
+        guard isPresented else { return }
+        context.coordinator.presentIfNeeded(relativeTo: nsView)
+    }
+
+    final class Coordinator: NSObject, CNContactPickerDelegate {
+        var parent: MeetingContactPicker
+        private var picker: CNContactPicker?
+
+        init(parent: MeetingContactPicker) {
+            self.parent = parent
+        }
+
+        func presentIfNeeded(relativeTo view: NSView) {
+            // A live picker owns the presentation state. `updateNSView` re-runs on any
+            // SwiftUI re-render, so clearing the binding here would dismiss the popover
+            // the user is still using.
+            guard picker == nil else { return }
+
+            // No window means no anchor, so bail out without leaving `isPresented` stuck
+            // true. It is already true here, so a stale flag would make every later click
+            // a no-op change — no updateNSView, no presentation, and a dead button.
+            guard view.window != nil else {
+                resetPresentation()
+                return
+            }
+
+            // Deliberately no `displayedKeys`: per CNContactPicker.h, providing keys
+            // switches the picker to selecting values rather than whole contacts.
+            // Thin key sets are handled by MeetingContactStore.resolveDisplayName.
+            let picker = CNContactPicker()
+            picker.delegate = self
+            self.picker = picker
+
+            // Present after the current SwiftUI update pass. Showing the popover
+            // inline reads uncommitted layout for the anchor rect, and a synchronous
+            // delegate callback would mutate state during view update.
+            DispatchQueue.main.async { [weak self, weak view] in
+                guard let self, let view, view.window != nil else {
+                    self?.picker = nil
+                    self?.resetPresentation()
+                    return
+                }
+                guard self.picker === picker else { return }
+                picker.showRelative(to: view.bounds, of: view, preferredEdge: .maxY)
+            }
+        }
+
+        func contactPicker(_ picker: CNContactPicker, didSelect contact: CNContact) {
+            parent.onSelect(contact)
+            finish()
+        }
+
+        func contactPickerDidClose(_ picker: CNContactPicker) {
+            finish()
+        }
+
+        private func finish() {
+            picker = nil
+            resetPresentation()
+        }
+
+        /// Always deferred: `presentIfNeeded` runs inside `updateNSView`, and clearing
+        /// the binding synchronously there mutates state during a view update.
+        private func resetPresentation() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.parent.isPresented else { return }
+                self.parent.isPresented = false
+            }
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactStore.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactStore.swift
@@ -1,0 +1,206 @@
+import Contacts
+import Foundation
+
+struct SavedMeetingContact: Equatable, Sendable {
+    let identifier: String
+    let displayName: String
+}
+
+enum MeetingContactStoreError: LocalizedError, Equatable {
+    case missingEmailOrPhone
+    case accessDenied
+    case duplicateContact(displayName: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingEmailOrPhone:
+            return "Add an email address or phone number before saving this contact."
+        case .accessDenied:
+            return "\(AppIdentity.displayName) does not have permission to add contacts. "
+                + "Enable Contacts access in System Settings."
+        case .duplicateContact(let displayName):
+            return "\(displayName) is already in your Contacts. "
+                + "Use \"Add person\" to attach them to this meeting."
+        }
+    }
+}
+
+/// Seam over the parts of `CNContactStore` this feature uses, so the save flow can
+/// be exercised in tests without touching the machine's real address book.
+protocol MeetingContactWriting {
+    func requestContactsAccess() async throws -> Bool
+    func fetchContacts(matching predicate: NSPredicate, keysToFetch keys: [CNKeyDescriptor]) throws -> [CNContact]
+    func saveContact(_ request: CNSaveRequest) throws
+}
+
+extension CNContactStore: MeetingContactWriting {
+    func requestContactsAccess() async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            requestAccess(for: .contacts) { granted, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    func fetchContacts(matching predicate: NSPredicate, keysToFetch keys: [CNKeyDescriptor]) throws -> [CNContact] {
+        try unifiedContacts(matching: predicate, keysToFetch: keys)
+    }
+
+    func saveContact(_ request: CNSaveRequest) throws {
+        try execute(request)
+    }
+}
+
+struct MeetingContactStore {
+    /// Every key `MeetingContactIdentity.displayName(for:)` can fall back to. Fetching
+    /// only the name would silently degrade an email-or-phone-only contact — the exact
+    /// shape this app's own contact form allows — to "Unnamed contact".
+    private static let displayNameKeys: [CNKeyDescriptor] = [
+        CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+        CNContactNicknameKey as CNKeyDescriptor,
+        CNContactOrganizationNameKey as CNKeyDescriptor,
+        CNContactEmailAddressesKey as CNKeyDescriptor,
+        CNContactPhoneNumbersKey as CNKeyDescriptor,
+    ]
+
+    private let store: any MeetingContactWriting
+    private let authorizationStatus: () -> CNAuthorizationStatus
+
+    init(
+        store: any MeetingContactWriting = CNContactStore(),
+        authorizationStatus: @escaping () -> CNAuthorizationStatus = {
+            CNContactStore.authorizationStatus(for: .contacts)
+        }
+    ) {
+        self.store = store
+        self.authorizationStatus = authorizationStatus
+    }
+
+    func save(_ draft: NewMeetingContactDraft) async throws -> SavedMeetingContact {
+        guard let contact = draft.makeContact() else {
+            throw MeetingContactStoreError.missingEmailOrPhone
+        }
+        guard try await requestAccess() else {
+            throw MeetingContactStoreError.accessDenied
+        }
+
+        if let existing = try await findExistingContact(for: draft) {
+            throw MeetingContactStoreError.duplicateContact(
+                displayName: MeetingContactIdentity.displayName(for: existing)
+            )
+        }
+
+        let request = CNSaveRequest()
+        request.add(contact, toContainerWithIdentifier: nil)
+
+        // CNContactStore is documented thread-safe, and `execute` is a synchronous
+        // XPC round-trip to contactsd. Running it on the main actor freezes the UI
+        // whenever contactsd is slow (large address book, first iCloud sync).
+        try await performOffMainActor { store in
+            try store.saveContact(request)
+        }
+
+        return SavedMeetingContact(
+            identifier: contact.identifier,
+            displayName: MeetingContactIdentity.displayName(for: contact)
+        )
+    }
+
+    /// Derives a display name for a picker-vended contact.
+    ///
+    /// `CNContactPicker` is an out-of-process remote view service, so the contact it
+    /// hands back only carries the keys that service fetched. When the name keys are
+    /// missing, `MeetingContactIdentity` would silently degrade to "Unnamed contact",
+    /// so re-fetch by identifier instead. Note `displayedKeys` cannot be used to force
+    /// the key set: per CNContactPicker.h, providing keys switches the picker to
+    /// selecting *values* rather than contacts.
+    ///
+    /// The re-fetch is deliberately skipped unless access is already granted — a
+    /// permission prompt must never fire merely to render a name.
+    func resolveDisplayName(for contact: CNContact) async -> String {
+        let nameDescriptor = CNContactFormatter.descriptorForRequiredKeys(for: .fullName)
+        if contact.areKeysAvailable([nameDescriptor]) {
+            return MeetingContactIdentity.displayName(for: contact)
+        }
+        guard authorizationStatus() == .authorized,
+              !contact.identifier.isEmpty else {
+            return MeetingContactIdentity.displayName(for: contact)
+        }
+
+        let identifier = contact.identifier
+        let keys = Self.displayNameKeys
+        let refetched = try? await performOffMainActor { store -> CNContact? in
+            try store.fetchContacts(
+                matching: CNContact.predicateForContacts(withIdentifiers: [identifier]),
+                keysToFetch: keys
+            ).first
+        }
+        guard let refetched else {
+            return MeetingContactIdentity.displayName(for: contact)
+        }
+        return MeetingContactIdentity.displayName(for: refetched)
+    }
+
+    /// Avoids writing a second copy of somebody already in the user's address book.
+    /// A failed lookup is not fatal — worst case the user gets the duplicate they
+    /// would have got anyway, which beats blocking the save on a transient error.
+    private func findExistingContact(for draft: NewMeetingContactDraft) async throws -> CNContact? {
+        var predicates: [NSPredicate] = []
+        if !draft.normalizedEmailAddress.isEmpty {
+            predicates.append(CNContact.predicateForContacts(matchingEmailAddress: draft.normalizedEmailAddress))
+        }
+        if !draft.normalizedPhoneNumber.isEmpty {
+            predicates.append(CNContact.predicateForContacts(
+                matching: CNPhoneNumber(stringValue: draft.normalizedPhoneNumber)
+            ))
+        }
+        guard !predicates.isEmpty else { return nil }
+
+        let keys = Self.displayNameKeys
+        return try? await performOffMainActor { store -> CNContact? in
+            for predicate in predicates {
+                if let match = try store.fetchContacts(matching: predicate, keysToFetch: keys).first {
+                    return match
+                }
+            }
+            return nil
+        }
+    }
+
+    private func performOffMainActor<T>(
+        _ work: @escaping (any MeetingContactWriting) throws -> T
+    ) async throws -> T {
+        let store = self.store
+        return try await Task.detached(priority: .userInitiated) {
+            try work(store)
+        }.value
+    }
+
+    private func requestAccess() async throws -> Bool {
+        if isAccessDenied {
+            throw MeetingContactStoreError.accessDenied
+        }
+
+        do {
+            return try await store.requestContactsAccess()
+        } catch {
+            if isAccessDenied {
+                throw MeetingContactStoreError.accessDenied
+            }
+            throw error
+        }
+    }
+
+    private var isAccessDenied: Bool {
+        switch authorizationStatus() {
+        case .denied, .restricted:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -222,6 +222,11 @@ struct MeetingDetailView: View {
                     folderPill(for: meeting)
 
                     threadBreadcrumb
+
+                    MeetingParticipantsView(
+                        meetingID: meeting.id,
+                        controller: controller
+                    )
                 }
 
                 Spacer(minLength: MuesliTheme.spacing16)
@@ -835,18 +840,32 @@ struct MeetingDetailView: View {
         .help(label)
     }
 
+    /// Export is best-effort on participants: a lookup failure should never block
+    /// exporting the meeting itself.
+    private func exportParticipants(for meeting: MeetingRecord) -> [MeetingParticipant] {
+        (try? controller.meetingParticipants(meetingID: meeting.id)) ?? []
+    }
+
     @ViewBuilder
     private func exportMenu(for meeting: MeetingRecord) -> some View {
         let currentContent: MeetingExportContent = documentMode == .transcript ? .transcript : .notes
         let currentLabel = documentMode == .transcript ? "Export Transcript" : "Export Notes"
         Menu {
             Button {
-                MeetingExporter.export(meeting: meeting, content: currentContent)
+                MeetingExporter.export(
+                    meeting: meeting,
+                    content: currentContent,
+                    participants: exportParticipants(for: meeting)
+                )
             } label: {
                 Label(currentLabel, systemImage: documentMode == .transcript ? "text.quote" : "doc.text")
             }
             Button {
-                MeetingExporter.export(meeting: meeting, content: .fullMeeting)
+                MeetingExporter.export(
+                    meeting: meeting,
+                    content: .fullMeeting,
+                    participants: exportParticipants(for: meeting)
+                )
             } label: {
                 Label("Export Full Meeting", systemImage: "doc.on.doc")
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingExporter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingExporter.swift
@@ -51,9 +51,13 @@ struct MeetingExporter {
     static let mdType = UTType(filenameExtension: "md") ?? .plainText
     static let pdfType = UTType.pdf
 
-    static func export(meeting: MeetingRecord, content: MeetingExportContent) {
+    static func export(
+        meeting: MeetingRecord,
+        content: MeetingExportContent,
+        participants: [MeetingParticipant] = []
+    ) {
         DispatchQueue.main.async {
-            let markdown = buildMarkdown(meeting: meeting, content: content)
+            let markdown = buildMarkdown(meeting: meeting, content: content, participants: participants)
             let filename = suggestedFilename(meeting: meeting, content: content)
 
             let panel = NSSavePanel()
@@ -81,7 +85,11 @@ struct MeetingExporter {
 
     // MARK: - Markdown composition
 
-    static func buildMarkdown(meeting: MeetingRecord, content: MeetingExportContent) -> String {
+    static func buildMarkdown(
+        meeting: MeetingRecord,
+        content: MeetingExportContent,
+        participants: [MeetingParticipant] = []
+    ) -> String {
         var parts: [String] = []
 
         parts.append("# \(meeting.title)")
@@ -91,6 +99,9 @@ struct MeetingExporter {
         parts.append("**Words:** \(meeting.wordCount)")
         if let name = meeting.selectedTemplateName, !name.isEmpty {
             parts.append("**Template:** \(name)")
+        }
+        if !participants.isEmpty {
+            parts.append("**People:** \(participants.map(\.displayName).joined(separator: ", "))")
         }
         parts.append("")
         parts.append("---")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMarkdownAutoExporter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMarkdownAutoExporter.swift
@@ -7,7 +7,17 @@ import os
 /// user-configured folder. Mirrors the meeting-hook dispatch pattern by
 /// dispatching export work away from the meeting persistence path.
 protocol MeetingMarkdownAutoExporting {
-    func exportIfConfigured(meeting: MeetingRecord, config: AppConfig)
+    /// Participants arrive as a provider rather than a materialized list. This type
+    /// owns no database handle, so the caller supplies the read — but running it here
+    /// rather than at the call site keeps a SQLite query off the main-actor meeting
+    /// persistence path, and lets `resolveParticipants` retry lock contention before
+    /// committing to a one-shot artifact that would otherwise silently lose its
+    /// People line.
+    func exportIfConfigured(
+        meeting: MeetingRecord,
+        loadParticipants: @escaping @Sendable () throws -> [MeetingParticipant],
+        config: AppConfig
+    )
     func recordMeetingLookupFailure(meetingID: Int64, error: Error?)
 }
 
@@ -33,10 +43,14 @@ final class MeetingMarkdownAutoExporter: MeetingMarkdownAutoExporting {
         supportDirectory.appendingPathComponent("meeting-markdown-export.log")
     }
 
-    func exportIfConfigured(meeting: MeetingRecord, config: AppConfig) {
+    func exportIfConfigured(
+        meeting: MeetingRecord,
+        loadParticipants: @escaping @Sendable () throws -> [MeetingParticipant],
+        config: AppConfig
+    ) {
         guard config.autoExportMarkdownEnabled else { return }
         Task.detached(priority: .utility) { [self] in
-            await performExport(meeting: meeting, config: config)
+            await performExport(meeting: meeting, loadParticipants: loadParticipants, config: config)
         }
     }
 
@@ -48,10 +62,66 @@ final class MeetingMarkdownAutoExporter: MeetingMarkdownAutoExporting {
         }
     }
 
+    /// Records that participants could not be loaded for an export that still went
+    /// ahead without them. Deliberately logs only the meeting id, the attempt count,
+    /// and the error, never participant names.
+    func recordParticipantLookupFailure(meetingID: Int64, error: Error, attempts: Int = 1) {
+        writeLog(
+            "export incomplete: could not load participants id=\(meetingID) attempts=\(attempts) "
+                + "error=\(error.localizedDescription); exported without the People line"
+        )
+    }
+
+    // MARK: - Participants
+
+    /// Backoff between participant lookup attempts. Sized to outlast a transcript
+    /// checkpoint flush — which can still be draining when a meeting ends — without
+    /// holding a background export for a noticeable stretch.
+    private static let participantRetryDelays: [Duration] = [
+        .milliseconds(200),
+        .milliseconds(600),
+        .milliseconds(1500),
+    ]
+
+    /// Resolves the participant snapshot for an export, retrying lock contention.
+    ///
+    /// An automatic export is written exactly once and never revisited, so a single
+    /// `SQLITE_BUSY` read would cost that file its People line permanently. Retrying
+    /// is what actually repairs that case; the log below is only for the residue that
+    /// no retry can fix. A deterministic fault gives up on the first attempt rather
+    /// than stalling the export behind three pointless sleeps.
+    private func resolveParticipants(
+        meetingID: Int64,
+        load: @Sendable () throws -> [MeetingParticipant]
+    ) async -> [MeetingParticipant] {
+        var attempt = 0
+        while true {
+            do {
+                return try load()
+            } catch {
+                guard attempt < Self.participantRetryDelays.count,
+                      DictationStore.isTransientLockFailure(error) else {
+                    recordParticipantLookupFailure(
+                        meetingID: meetingID,
+                        error: error,
+                        attempts: attempt + 1
+                    )
+                    return []
+                }
+                try? await Task.sleep(for: Self.participantRetryDelays[attempt])
+                attempt += 1
+            }
+        }
+    }
+
     /// Builds the export payloads and writes them to disk. Returns the written URLs on
     /// success (exposed for testing); logs and returns nil on any failure.
     @discardableResult
-    func performExport(meeting: MeetingRecord, config: AppConfig) async -> [URL]? {
+    func performExport(
+        meeting: MeetingRecord,
+        loadParticipants: @Sendable () throws -> [MeetingParticipant] = { [] },
+        config: AppConfig
+    ) async -> [URL]? {
         let trimmedFolder = config.autoExportMarkdownFolderPath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedFolder.isEmpty else {
             writeLog("skipped: auto-export enabled but no destination folder configured")
@@ -70,9 +140,17 @@ final class MeetingMarkdownAutoExporter: MeetingMarkdownAutoExporting {
             return nil
         }
 
+        // Deliberately after the destination checks above: an export that is going to
+        // be skipped should not touch the database at all.
+        let participants = await resolveParticipants(meetingID: meeting.id, load: loadParticipants)
+
         let content = config.resolvedAutoExportMarkdownContent
         let fileFormat = config.resolvedAutoExportFileFormat
-        let markdown = MeetingExporter.buildMarkdown(meeting: meeting, content: content)
+        let markdown = MeetingExporter.buildMarkdown(
+            meeting: meeting,
+            content: content,
+            participants: participants
+        )
         var writtenURLs: [URL] = []
 
         if fileFormat.includesMarkdown {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
@@ -1,0 +1,180 @@
+import AppKit
+import Contacts
+import MuesliCore
+import SwiftUI
+
+struct MeetingParticipantsView: View {
+    let meetingID: Int64
+    let controller: MuesliController
+
+    @State private var participants: [MeetingParticipant] = []
+    @State private var isContactPickerPresented = false
+    @State private var isNewContactPresented = false
+    @State private var errorMessage: String?
+    @State private var statusMessage: String?
+    @State private var statusDismissTask: Task<Void, Never>?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+            Text("People")
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .padding(.top, 5)
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                WordFlowLayout(spacing: MuesliTheme.spacing8) {
+                    ForEach(participants) { participant in
+                        participantChip(participant)
+                    }
+
+                    Button {
+                        isContactPickerPresented = true
+                    } label: {
+                        Label("Add person", systemImage: "person.badge.plus")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help("Attach someone from Contacts to this meeting")
+                    .background {
+                        MeetingContactPicker(isPresented: $isContactPickerPresented) { contact in
+                            attach(contact)
+                        }
+                    }
+
+                    Button("New Contact…") {
+                        isNewContactPresented = true
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .help("Create a new contact in Apple Contacts and attach them")
+                }
+
+                if let statusMessage {
+                    Text(statusMessage)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .transition(.opacity)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("People in this meeting")
+        .task(id: meetingID) {
+            reload()
+        }
+        .onDisappear {
+            statusDismissTask?.cancel()
+        }
+        .sheet(isPresented: $isNewContactPresented) {
+            NewMeetingContactView { contact in
+                attach(
+                    contactIdentifier: contact.identifier,
+                    displayName: contact.displayName
+                )
+            }
+        }
+        .alert("Couldn't Update People", isPresented: errorBinding) {
+            Button("OK", role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "The meeting's people could not be updated.")
+        }
+    }
+
+    private func participantChip(_ participant: MeetingParticipant) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "person.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text(participant.displayName)
+                .lineLimit(1)
+            Button {
+                remove(participant)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .padding(3)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(participant.displayName)")
+        }
+        .font(MuesliTheme.caption())
+        .foregroundStyle(MuesliTheme.textSecondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(Capsule())
+        .overlay {
+            Capsule()
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { presented in
+                if !presented {
+                    errorMessage = nil
+                }
+            }
+        )
+    }
+
+    private func reload() {
+        do {
+            participants = try controller.meetingParticipants(meetingID: meetingID)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Resolves the picker-vended contact's name before storing it — the picker may
+    /// hand back a contact without the name keys fetched.
+    private func attach(_ contact: CNContact) {
+        Task { @MainActor in
+            let displayName = await MeetingContactStore().resolveDisplayName(for: contact)
+            attach(contactIdentifier: contact.identifier, displayName: displayName)
+        }
+    }
+
+    private func attach(contactIdentifier: String, displayName: String) {
+        do {
+            let added = try controller.attachMeetingParticipant(
+                meetingID: meetingID,
+                contactIdentifier: contactIdentifier,
+                displayName: displayName
+            )
+            reload()
+            if !added {
+                showStatus("\(displayName) is already on this meeting.")
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func remove(_ participant: MeetingParticipant) {
+        do {
+            try controller.removeMeetingParticipant(
+                meetingID: meetingID,
+                contactIdentifier: participant.contactIdentifier
+            )
+            reload()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func showStatus(_ message: String) {
+        statusDismissTask?.cancel()
+        statusMessage = message
+        statusDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            statusMessage = nil
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4036,6 +4036,33 @@ final class MuesliController: NSObject {
 
     // MARK: - Meeting Editing
 
+    func meetingParticipants(meetingID: Int64) throws -> [MeetingParticipant] {
+        try dictationStore.listMeetingParticipants(meetingID: meetingID)
+    }
+
+    @discardableResult
+    func attachMeetingParticipant(
+        meetingID: Int64,
+        contactIdentifier: String,
+        displayName: String
+    ) throws -> Bool {
+        try dictationStore.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: contactIdentifier,
+            displayName: displayName
+        )
+    }
+
+    func removeMeetingParticipant(
+        meetingID: Int64,
+        contactIdentifier: String
+    ) throws {
+        try dictationStore.removeMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: contactIdentifier
+        )
+    }
+
     private func notesContextForResummary(_ meeting: MeetingRecord) -> String? {
         Self.notesContextForResummary(meeting)
     }
@@ -6064,7 +6091,21 @@ final class MuesliController: NSObject {
         if config.autoExportMarkdownEnabled {
             do {
                 if let record = try dictationStore.meeting(id: persistenceResult.meetingID) {
-                    meetingMarkdownAutoExporter.exportIfConfigured(meeting: record, config: config)
+                    // Hand the exporter a provider rather than a list. This method runs
+                    // on the main actor, and the exporter retries the read on lock
+                    // contention, so the query belongs in its background task. A fresh
+                    // store is built from the database URL there because `DictationStore`
+                    // is not `Sendable` — the same pattern `insightsSnapshot` uses.
+                    let databaseURL = dictationStore.resolvedDatabaseURL
+                    let meetingID = persistenceResult.meetingID
+                    meetingMarkdownAutoExporter.exportIfConfigured(
+                        meeting: record,
+                        loadParticipants: {
+                            try DictationStore(databaseURL: databaseURL)
+                                .listMeetingParticipants(meetingID: meetingID)
+                        },
+                        config: config
+                    )
                 } else {
                     meetingMarkdownAutoExporter.recordMeetingLookupFailure(
                         meetingID: persistenceResult.meetingID,

--- a/native/MuesliNative/Sources/MuesliNativeApp/NewMeetingContactView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/NewMeetingContactView.swift
@@ -1,0 +1,115 @@
+import AppKit
+import SwiftUI
+
+struct NewMeetingContactView: View {
+    let onCreated: (SavedMeetingContact) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft = NewMeetingContactDraft()
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var isAccessDenied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            Text("New Contact")
+                .font(MuesliTheme.title2())
+
+            Text("Add an email address or phone number so this person can be saved to Apple Contacts.")
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+
+            Grid(alignment: .leading, horizontalSpacing: MuesliTheme.spacing12, verticalSpacing: MuesliTheme.spacing12) {
+                contactField("First name", text: $draft.givenName)
+                contactField("Last name", text: $draft.familyName)
+                contactField("Email", text: $draft.emailAddress)
+                contactField("Phone", text: $draft.phoneNumber)
+            }
+
+            HStack {
+                if isSaving {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Saving to Contacts…")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Save Contact") {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(!draft.canSave || isSaving)
+            }
+        }
+        .padding(MuesliTheme.spacing24)
+        .frame(width: 440)
+        .alert("Couldn't Save Contact", isPresented: errorBinding) {
+            if isAccessDenied {
+                Button("Open System Settings") {
+                    openContactsPrivacyPane()
+                    errorMessage = nil
+                }
+            }
+            Button("OK", role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "The contact could not be saved.")
+        }
+    }
+
+    private func openContactsPrivacyPane() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func contactField(_ label: String, text: Binding<String>) -> some View {
+        GridRow {
+            Text(label)
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 80, alignment: .trailing)
+            TextField(label, text: text)
+                .textFieldStyle(.roundedBorder)
+                .frame(minWidth: 280)
+        }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { presented in
+                if !presented {
+                    errorMessage = nil
+                }
+            }
+        )
+    }
+
+    private func save() {
+        guard draft.canSave, !isSaving else { return }
+        isSaving = true
+        Task { @MainActor in
+            defer { isSaving = false }
+            do {
+                let saved = try await MeetingContactStore().save(draft)
+                // Dismiss before handing the contact back: `onCreated` can surface an
+                // error on the presenting view, and SwiftUI drops a presentation
+                // requested while another is being torn down.
+                dismiss()
+                onCreated(saved)
+            } catch {
+                isAccessDenied = (error as? MeetingContactStoreError) == .accessDenied
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -2863,4 +2863,39 @@ struct DictationStoreTests {
         #expect(lower.count == 1)
         #expect(mixed.count == 1)
     }
+
+    // MARK: - Transient failure classification
+
+    @Test("lock contention is classified as transient", arguments: [SQLITE_BUSY, SQLITE_LOCKED])
+    func lockContentionIsTransient(code: Int32) {
+        #expect(DictationStore.isTransientLockFailure(storeError(code: code)))
+    }
+
+    @Test(
+        "extended lock result codes are classified as transient",
+        arguments: [SQLITE_BUSY | (2 << 8), SQLITE_LOCKED | (1 << 8)]
+    )
+    func extendedLockCodesAreTransient(code: Int32) {
+        #expect(DictationStore.isTransientLockFailure(storeError(code: code)))
+    }
+
+    @Test(
+        "deterministic faults are not classified as transient",
+        arguments: [SQLITE_CORRUPT, SQLITE_CANTOPEN, SQLITE_READONLY, SQLITE_ERROR]
+    )
+    func deterministicFaultsAreNotTransient(code: Int32) {
+        #expect(DictationStore.isTransientLockFailure(storeError(code: code)) == false)
+    }
+
+    @Test("a foreign error that happens to share a SQLite code is not transient")
+    func foreignErrorIsNotTransient() {
+        let foreign = NSError(domain: NSPOSIXErrorDomain, code: Int(SQLITE_BUSY))
+
+        #expect(DictationStore.isTransientLockFailure(foreign) == false)
+        #expect(DictationStore.isTransientLockFailure(DictationStoreError.meetingNotFound(id: 1)) == false)
+    }
+
+    private func storeError(code: Int32) -> NSError {
+        NSError(domain: DictationStore.errorDomain, code: Int(code))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingContactIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingContactIdentityTests.swift
@@ -1,0 +1,147 @@
+import Contacts
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting contact identity")
+struct MeetingContactIdentityTests {
+    @Test("uses a conventional full name")
+    func fullName() {
+        let contact = CNMutableContact()
+        contact.givenName = "Alice"
+        contact.familyName = "Example"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Alice Example")
+    }
+
+    @Test("falls back to nickname")
+    func nickname() {
+        let contact = CNMutableContact()
+        contact.nickname = "Ace"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Ace")
+    }
+
+    @Test("falls back to organization")
+    func organization() {
+        let contact = CNMutableContact()
+        contact.organizationName = "Example Industries Ltd."
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Example Industries Ltd.")
+    }
+
+    @Test("falls back to email")
+    func email() {
+        let contact = CNMutableContact()
+        contact.emailAddresses = [
+            CNLabeledValue(label: CNLabelWork, value: "alice@example.test" as NSString),
+        ]
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "alice@example.test")
+    }
+
+    @Test("falls back to phone")
+    func phone() {
+        let contact = CNMutableContact()
+        contact.phoneNumbers = [
+            CNLabeledValue(label: CNLabelPhoneNumberMobile, value: CNPhoneNumber(stringValue: "+1 555 0100")),
+        ]
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "+1 555 0100")
+    }
+
+    @Test("falls back to an unnamed label")
+    func unnamed() {
+        #expect(MeetingContactIdentity.displayName(for: CNMutableContact()) == "Unnamed contact")
+    }
+
+    @Test("prefers the strongest available identity")
+    func precedenceChain() {
+        let contact = CNMutableContact()
+        contact.givenName = "Alice"
+        contact.familyName = "Example"
+        contact.nickname = "Ace"
+        contact.organizationName = "Example Industries Ltd."
+        contact.emailAddresses = [
+            CNLabeledValue(label: CNLabelWork, value: "alice@example.test" as NSString),
+        ]
+        contact.phoneNumbers = [
+            CNLabeledValue(label: CNLabelPhoneNumberMobile, value: CNPhoneNumber(stringValue: "+1 555 0100")),
+        ]
+
+        // Peel the candidates off one at a time; each step pins the next rung down.
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Alice Example")
+        contact.givenName = ""
+        contact.familyName = ""
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Ace")
+        contact.nickname = ""
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Example Industries Ltd.")
+        contact.organizationName = ""
+        #expect(MeetingContactIdentity.displayName(for: contact) == "alice@example.test")
+        contact.emailAddresses = []
+        #expect(MeetingContactIdentity.displayName(for: contact) == "+1 555 0100")
+    }
+
+    @Test("treats whitespace-only values as absent")
+    func whitespaceOnlyNameFallsThrough() {
+        let contact = CNMutableContact()
+        contact.givenName = "   "
+        contact.familyName = "\n"
+        contact.nickname = "Fallback"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Fallback")
+    }
+
+    @Test("handles a single-name contact")
+    func singleName() {
+        let contact = CNMutableContact()
+        contact.givenName = "Nova"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Nova")
+    }
+
+    @Test("draft normalizes values before building a contact")
+    func makeContactNormalizes() {
+        #expect(NewMeetingContactDraft(
+            givenName: "A",
+            familyName: "B",
+            emailAddress: " ",
+            phoneNumber: " "
+        ).makeContact() == nil)
+
+        let contact = NewMeetingContactDraft(
+            givenName: "  Dana ",
+            familyName: " Sample ",
+            emailAddress: " dana@example.test ",
+            phoneNumber: ""
+        ).makeContact()
+
+        #expect(contact?.givenName == "Dana")
+        #expect(contact?.familyName == "Sample")
+        #expect(contact?.emailAddresses.first?.value as String? == "dana@example.test")
+        #expect(contact?.emailAddresses.first?.label == CNLabelWork)
+        // A blank phone must not produce an empty labeled value.
+        #expect(contact?.phoneNumbers.isEmpty == true)
+    }
+
+    @Test("new contacts require a normalized email or phone")
+    func newContactValidation() {
+        #expect(!NewMeetingContactDraft(
+            givenName: "Name",
+            familyName: "Only",
+            emailAddress: "  ",
+            phoneNumber: "\n"
+        ).canSave)
+        #expect(NewMeetingContactDraft(
+            givenName: "Email",
+            familyName: "Contact",
+            emailAddress: " person@example.test ",
+            phoneNumber: ""
+        ).canSave)
+        #expect(NewMeetingContactDraft(
+            givenName: "Phone",
+            familyName: "Contact",
+            emailAddress: "",
+            phoneNumber: " +1 555 0101 "
+        ).canSave)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingContactStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingContactStoreTests.swift
@@ -1,0 +1,173 @@
+import Contacts
+import Testing
+@testable import MuesliNativeApp
+
+/// Stand-in for `CNContactStore` so the save flow can be exercised without touching
+/// the machine's real address book or its TCC state.
+private final class FakeContactWriter: MeetingContactWriting, @unchecked Sendable {
+    var accessGranted = true
+    var accessError: Error?
+    var matches: [CNContact] = []
+    var fetchError: Error?
+    var saveError: Error?
+    private(set) var savedRequestCount = 0
+    private(set) var lastRequestedKeys: [CNKeyDescriptor] = []
+
+    func requestContactsAccess() async throws -> Bool {
+        if let accessError {
+            throw accessError
+        }
+        return accessGranted
+    }
+
+    func fetchContacts(matching predicate: NSPredicate, keysToFetch keys: [CNKeyDescriptor]) throws -> [CNContact] {
+        lastRequestedKeys = keys
+        if let fetchError {
+            throw fetchError
+        }
+        return matches
+    }
+
+    func saveContact(_ request: CNSaveRequest) throws {
+        if let saveError {
+            throw saveError
+        }
+        savedRequestCount += 1
+    }
+}
+
+private func makeDraft(
+    givenName: String = "Dana",
+    familyName: String = "Sample",
+    emailAddress: String = "dana@example.test",
+    phoneNumber: String = ""
+) -> NewMeetingContactDraft {
+    NewMeetingContactDraft(
+        givenName: givenName,
+        familyName: familyName,
+        emailAddress: emailAddress,
+        phoneNumber: phoneNumber
+    )
+}
+
+@Suite("Meeting contact store")
+struct MeetingContactStoreTests {
+    @Test("saves a contact and reports its derived name")
+    func savesContact() async throws {
+        let writer = FakeContactWriter()
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .authorized })
+
+        let saved = try await store.save(makeDraft())
+
+        #expect(saved.displayName == "Dana Sample")
+        #expect(!saved.identifier.isEmpty)
+        #expect(writer.savedRequestCount == 1)
+    }
+
+    @Test("rejects a draft with neither email nor phone")
+    func rejectsIncompleteDraft() async {
+        let writer = FakeContactWriter()
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .authorized })
+
+        await #expect(throws: MeetingContactStoreError.missingEmailOrPhone) {
+            try await store.save(makeDraft(emailAddress: "  ", phoneNumber: " "))
+        }
+        #expect(writer.savedRequestCount == 0)
+    }
+
+    @Test("surfaces denied access without attempting a write")
+    func deniedAuthorizationIsReported() async {
+        let writer = FakeContactWriter()
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .denied })
+
+        await #expect(throws: MeetingContactStoreError.accessDenied) {
+            try await store.save(makeDraft())
+        }
+        #expect(writer.savedRequestCount == 0)
+    }
+
+    @Test("treats a refused prompt as denied access")
+    func refusedPromptIsReported() async {
+        let writer = FakeContactWriter()
+        writer.accessGranted = false
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .notDetermined })
+
+        await #expect(throws: MeetingContactStoreError.accessDenied) {
+            try await store.save(makeDraft())
+        }
+        #expect(writer.savedRequestCount == 0)
+    }
+
+    @Test("refuses to duplicate somebody already in Contacts")
+    func duplicateContactIsRejected() async {
+        let existing = CNMutableContact()
+        existing.givenName = "Dana"
+        existing.familyName = "Sample"
+
+        let writer = FakeContactWriter()
+        writer.matches = [existing]
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .authorized })
+
+        await #expect(throws: MeetingContactStoreError.duplicateContact(displayName: "Dana Sample")) {
+            try await store.save(makeDraft())
+        }
+        #expect(writer.savedRequestCount == 0)
+    }
+
+    @Test("names a nameless duplicate by its email instead of \"Unnamed contact\"")
+    func duplicateWithoutNameIsIdentifiable() async {
+        // Email-or-phone-only contacts are exactly what this app's own form creates, so
+        // the lookup must fetch every key `displayName(for:)` falls back to. Fetching
+        // only the name would leave the user with "Unnamed contact is already in your
+        // Contacts" and no way to tell who that is.
+        let existing = CNMutableContact()
+        existing.emailAddresses = [CNLabeledValue(label: CNLabelWork, value: "dana@example.test")]
+
+        let writer = FakeContactWriter()
+        writer.matches = [existing]
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .authorized })
+
+        await #expect(throws: MeetingContactStoreError.duplicateContact(displayName: "dana@example.test")) {
+            try await store.save(makeDraft(givenName: "", familyName: ""))
+        }
+
+        let requestedKeys = writer.lastRequestedKeys.compactMap { $0 as? String }
+        #expect(requestedKeys.contains(CNContactNicknameKey))
+        #expect(requestedKeys.contains(CNContactOrganizationNameKey))
+        #expect(requestedKeys.contains(CNContactEmailAddressesKey))
+        #expect(requestedKeys.contains(CNContactPhoneNumbersKey))
+    }
+
+    @Test("a failed duplicate lookup does not block the save")
+    func duplicateLookupFailureIsNotFatal() async throws {
+        let writer = FakeContactWriter()
+        writer.fetchError = CocoaError(.fileReadUnknown)
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .authorized })
+
+        _ = try await store.save(makeDraft())
+
+        #expect(writer.savedRequestCount == 1)
+    }
+
+    @Test("uses the contact as-is when its name keys are already available")
+    func resolveDisplayNameUsesAvailableKeys() async {
+        let contact = CNMutableContact()
+        contact.givenName = "Alice"
+        contact.familyName = "Example"
+
+        let writer = FakeContactWriter()
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .authorized })
+
+        #expect(await store.resolveDisplayName(for: contact) == "Alice Example")
+    }
+
+    @Test("never re-fetches a name while access is undetermined")
+    func resolveDisplayNameDoesNotPromptWhenUndetermined() async {
+        // A permission prompt must never fire merely to render a participant's name,
+        // so an unauthorized store falls back rather than reaching for the address book.
+        let writer = FakeContactWriter()
+        let store = MeetingContactStore(store: writer, authorizationStatus: { .notDetermined })
+
+        #expect(await store.resolveDisplayName(for: CNMutableContact()) == "Unnamed contact")
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMarkdownAutoExporterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMarkdownAutoExporterTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Testing
 import MuesliCore
 @testable import MuesliNativeApp
@@ -15,7 +16,7 @@ struct MeetingMarkdownAutoExporterTests {
         config.autoExportMarkdownEnabled = false
         config.autoExportMarkdownFolderPath = destination.path
 
-        exporter.exportIfConfigured(meeting: makeMeeting(), config: config)
+        exporter.exportIfConfigured(meeting: makeMeeting(), loadParticipants: { [] }, config: config)
 
         #expect(FileManager.default.fileExists(atPath: exporter.logURL.path) == false)
         #expect(try FileManager.default.contentsOfDirectory(atPath: destination.path).isEmpty)
@@ -70,6 +71,149 @@ struct MeetingMarkdownAutoExporterTests {
         #expect(contents.contains("# Weekly Standup"))
         #expect(contents.contains("## Key Points"))
         #expect(contents.contains("Ship export feature"))
+    }
+
+    @Test("attached participants appear in the automatic export")
+    func writesParticipants() async throws {
+        let support = makeTemporaryDirectory()
+        let destination = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+        var config = AppConfig()
+        config.autoExportMarkdownEnabled = true
+        config.autoExportMarkdownFolderPath = destination.path
+
+        let url = try #require(await exporter.performExport(
+            meeting: makeMeeting(),
+            loadParticipants: { Self.sampleParticipants },
+            config: config
+        )?.first)
+
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("**People:** Alice Example, Bob Example"))
+    }
+
+    @Test("exportIfConfigured carries participants through the production path")
+    func exportIfConfiguredWritesParticipants() async throws {
+        let support = makeTemporaryDirectory()
+        let destination = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+        var config = AppConfig()
+        config.autoExportMarkdownEnabled = true
+        config.autoExportMarkdownFolderPath = destination.path
+
+        exporter.exportIfConfigured(
+            meeting: makeMeeting(),
+            loadParticipants: { Self.sampleParticipants },
+            config: config
+        )
+
+        let url = try #require(await waitForFirstFile(in: destination))
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("**People:** Alice Example, Bob Example"))
+    }
+
+    @Test("a locked database is retried until the People line survives")
+    func retriesTransientParticipantLookupFailure() async throws {
+        let support = makeTemporaryDirectory()
+        let destination = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+        var config = AppConfig()
+        config.autoExportMarkdownEnabled = true
+        config.autoExportMarkdownFolderPath = destination.path
+
+        let recorder = LookupRecorder()
+        let url = try #require(await exporter.performExport(
+            meeting: makeMeeting(),
+            loadParticipants: {
+                guard recorder.recordAttempt() >= 3 else { throw Self.lockedDatabaseError }
+                return Self.sampleParticipants
+            },
+            config: config
+        )?.first)
+        exporter.waitForPendingLogWrites()
+
+        #expect(recorder.attempts == 3)
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("**People:** Alice Example, Bob Example"))
+        let log = try String(contentsOf: exporter.logURL, encoding: .utf8)
+        #expect(log.contains("could not load participants") == false)
+    }
+
+    @Test("a deterministic lookup failure is not retried")
+    func deterministicParticipantLookupFailureIsNotRetried() async throws {
+        let support = makeTemporaryDirectory()
+        let destination = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+        var config = AppConfig()
+        config.autoExportMarkdownEnabled = true
+        config.autoExportMarkdownFolderPath = destination.path
+
+        let recorder = LookupRecorder()
+        let url = try #require(await exporter.performExport(
+            meeting: makeMeeting(),
+            loadParticipants: {
+                _ = recorder.recordAttempt()
+                throw DictationStoreError.meetingNotFound(id: 1)
+            },
+            config: config
+        )?.first)
+        exporter.waitForPendingLogWrites()
+
+        #expect(recorder.attempts == 1)
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("**People:**") == false)
+        let log = try String(contentsOf: exporter.logURL, encoding: .utf8)
+        #expect(log.contains("could not load participants id=1 attempts=1"))
+    }
+
+    @Test("an export still lands when every retry is exhausted")
+    func exhaustedParticipantRetriesStillExport() async throws {
+        let support = makeTemporaryDirectory()
+        let destination = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+        var config = AppConfig()
+        config.autoExportMarkdownEnabled = true
+        config.autoExportMarkdownFolderPath = destination.path
+
+        let recorder = LookupRecorder()
+        let url = try #require(await exporter.performExport(
+            meeting: makeMeeting(),
+            loadParticipants: {
+                _ = recorder.recordAttempt()
+                throw Self.lockedDatabaseError
+            },
+            config: config
+        )?.first)
+        exporter.waitForPendingLogWrites()
+
+        #expect(recorder.attempts == 4)
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents.contains("# Weekly Standup"))
+        #expect(contents.contains("**People:**") == false)
+        let log = try String(contentsOf: exporter.logURL, encoding: .utf8)
+        #expect(log.contains("could not load participants id=1 attempts=4"))
+    }
+
+    @Test("a skipped export never touches the database")
+    func skippedExportDoesNotLoadParticipants() async throws {
+        let support = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+        var config = AppConfig()
+        config.autoExportMarkdownEnabled = true
+        config.autoExportMarkdownFolderPath = "relative/notes"
+
+        let recorder = LookupRecorder()
+        let result = await exporter.performExport(
+            meeting: makeMeeting(),
+            loadParticipants: {
+                _ = recorder.recordAttempt()
+                return []
+            },
+            config: config
+        )
+
+        #expect(result == nil)
+        #expect(recorder.attempts == 0)
     }
 
     @Test("filename includes date prefix and -notes suffix")
@@ -161,6 +305,22 @@ struct MeetingMarkdownAutoExporterTests {
         #expect(log.contains("persisted meeting not found id=42"))
     }
 
+    @Test("participant lookup failures are written to export log")
+    func participantLookupFailureWritesLog() throws {
+        let support = makeTemporaryDirectory()
+        let exporter = MeetingMarkdownAutoExporter(supportDirectory: support)
+
+        exporter.recordParticipantLookupFailure(
+            meetingID: 42,
+            error: DictationStoreError.meetingNotFound(id: 42)
+        )
+        exporter.waitForPendingLogWrites()
+
+        let log = try String(contentsOf: exporter.logURL, encoding: .utf8)
+        #expect(log.contains("could not load participants id=42"))
+        #expect(log.contains("exported without the People line"))
+    }
+
     @Test("creates destination folder when missing")
     func createsMissingFolder() async throws {
         let support = makeTemporaryDirectory()
@@ -215,6 +375,66 @@ struct MeetingMarkdownAutoExporterTests {
     }
 
     // MARK: - Helpers
+
+    /// Counts participant-provider invocations. The provider is `@Sendable` and runs
+    /// on the exporter's task, so the counter needs its own synchronization.
+    private final class LookupRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        var attempts: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+
+        @discardableResult
+        func recordAttempt() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            count += 1
+            return count
+        }
+    }
+
+    /// Shaped exactly like the error `DictationStore` raises for lock contention, so
+    /// the retry path is exercised through the real classification rather than a
+    /// test-only hook.
+    private static let lockedDatabaseError = NSError(
+        domain: DictationStore.errorDomain,
+        code: Int(SQLITE_BUSY),
+        userInfo: [NSLocalizedDescriptionKey: "database is locked"]
+    )
+
+    private static let sampleParticipants = [
+        MeetingParticipant(
+            meetingID: 1,
+            contactIdentifier: "contact-a",
+            displayName: "Alice Example",
+            insertionOrder: 0
+        ),
+        MeetingParticipant(
+            meetingID: 1,
+            contactIdentifier: "contact-b",
+            displayName: "Bob Example",
+            insertionOrder: 1
+        ),
+    ]
+
+    /// `exportIfConfigured` hands the work to a detached task, so the file appears
+    /// asynchronously. Polls instead of sleeping a fixed interval.
+    private func waitForFirstFile(in folder: URL, timeout: Duration = .seconds(10)) async -> URL? {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            let contents = (try? FileManager.default.contentsOfDirectory(
+                at: folder,
+                includingPropertiesForKeys: nil
+            )) ?? []
+            if let first = contents.first { return first }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        return nil
+    }
 
     private func makeMeeting(
         title: String = "Weekly Standup",

--- a/native/MuesliNative/Tests/MuesliTests/MeetingParticipantStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingParticipantStoreTests.swift
@@ -1,0 +1,509 @@
+import Foundation
+import MuesliCore
+import SQLite3
+import Testing
+
+@Suite("Meeting participants", .serialized)
+struct MeetingParticipantStoreTests {
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-participants-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    private func makeMeeting(in store: DictationStore, title: String = "Participants") throws -> Int64 {
+        let start = Date(timeIntervalSince1970: 1_775_000_000)
+        return try store.insertMeeting(
+            title: title,
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(60),
+            rawTranscript: "",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+    }
+
+    private func makePreParticipantStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-pre-participants-\(UUID().uuidString).db")
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK else {
+            throw sqliteError("failed to open pre-participant database")
+        }
+        defer { sqlite3_close(database) }
+
+        let sql = """
+        CREATE TABLE meetings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            calendar_event_id TEXT,
+            start_time TEXT NOT NULL,
+            end_time TEXT,
+            duration_seconds REAL,
+            raw_transcript TEXT,
+            formatted_notes TEXT,
+            mic_audio_path TEXT,
+            system_audio_path TEXT,
+            word_count INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'meeting',
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw sqliteError("failed to create pre-participant meeting schema")
+        }
+        return DictationStore(databaseURL: url)
+    }
+
+    private func makeStepFaultStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-participant-step-fault-\(UUID().uuidString).db")
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK else {
+            throw sqliteError("failed to open step-fault database")
+        }
+        defer { sqlite3_close(database) }
+
+        // Adding the generated column after insertion lets one row succeed before
+        // the next row faults, without relying on a timing-sensitive lock race.
+        let sql = """
+        CREATE TABLE meeting_participants (
+            meeting_id INTEGER NOT NULL,
+            contact_identifier TEXT NOT NULL,
+            source_value INTEGER NOT NULL,
+            insertion_order INTEGER NOT NULL
+        );
+        INSERT INTO meeting_participants
+            (meeting_id, contact_identifier, source_value, insertion_order)
+        VALUES
+            (42, 'first', 1, 0),
+            (42, 'fault', -9223372036854775808, 1);
+        ALTER TABLE meeting_participants
+            ADD COLUMN display_name TEXT GENERATED ALWAYS AS (abs(source_value)) VIRTUAL;
+        CREATE INDEX idx_meeting_participants_order
+            ON meeting_participants(meeting_id, insertion_order, contact_identifier);
+        """
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw sqliteError("failed to create step-fault participant schema")
+        }
+        return DictationStore(databaseURL: url)
+    }
+
+    /// Inserts a meeting row using only the pre-participant column set, so the row
+    /// looks exactly like one already sitting in a shipped user database.
+    private func insertLegacyMeeting(into store: DictationStore, title: String) throws -> Int64 {
+        var database: OpaquePointer?
+        guard sqlite3_open(store.databasePath().path, &database) == SQLITE_OK else {
+            throw sqliteError("failed to reopen pre-participant database")
+        }
+        defer { sqlite3_close(database) }
+
+        let sql = """
+        INSERT INTO meetings (title, start_time, raw_transcript, formatted_notes)
+        VALUES (?, '2026-01-01T00:00:00Z', 'legacy transcript', 'legacy notes')
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw sqliteError("failed to prepare legacy meeting insert")
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (title as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw sqliteError("failed to insert legacy meeting")
+        }
+        return sqlite3_last_insert_rowid(database)
+    }
+
+    private func sqliteError(_ message: String) -> NSError {
+        NSError(
+            domain: "MeetingParticipantStoreTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+
+    @Test("participant migration upgrades an existing database idempotently")
+    func migrationIsIdempotent() throws {
+        let store = try makePreParticipantStore()
+
+        try store.migrateIfNeeded()
+        try store.migrateIfNeeded()
+
+        var database: OpaquePointer?
+        #expect(sqlite3_open(store.databasePath().path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        #expect(sqlite3_prepare_v2(
+            database,
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'meeting_participants'",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK)
+        #expect(sqlite3_step(statement) == SQLITE_ROW)
+        #expect(sqlite3_column_int(statement, 0) == 1)
+        sqlite3_finalize(statement)
+
+        statement = nil
+        #expect(sqlite3_prepare_v2(
+            database,
+            "PRAGMA table_info(meeting_participants)",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK)
+        // Sort by the pk ordinal rather than relying on declaration order, otherwise
+        // PRIMARY KEY (contact_identifier, meeting_id) would produce the same array.
+        var primaryKeyColumns: [(ordinal: Int32, name: String)] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let ordinal = sqlite3_column_int(statement, 5)
+            if ordinal > 0, let name = sqlite3_column_text(statement, 1) {
+                primaryKeyColumns.append((ordinal, String(cString: name)))
+            }
+        }
+        #expect(primaryKeyColumns.sorted { $0.ordinal < $1.ordinal }.map(\.name) == [
+            "meeting_id",
+            "contact_identifier",
+        ])
+        sqlite3_finalize(statement)
+
+        statement = nil
+        #expect(sqlite3_prepare_v2(
+            database,
+            "PRAGMA foreign_key_list(meeting_participants)",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK)
+        var cascadesToMeetings = false
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let table = sqlite3_column_text(statement, 2).map(String.init(cString:)) ?? ""
+            let onDelete = sqlite3_column_text(statement, 6).map(String.init(cString:)) ?? ""
+            if table == "meetings", onDelete == "CASCADE" {
+                cascadesToMeetings = true
+            }
+        }
+        #expect(cascadesToMeetings)
+        sqlite3_finalize(statement)
+
+        statement = nil
+        #expect(sqlite3_prepare_v2(
+            database,
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_meeting_participants_order'",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK)
+        #expect(sqlite3_step(statement) == SQLITE_ROW)
+        #expect(sqlite3_column_int(statement, 0) == 1)
+        sqlite3_finalize(statement)
+    }
+
+    @Test("a migrated database keeps its meetings and accepts participants")
+    func migrationPreservesDataAndEnablesParticipants() throws {
+        let store = try makePreParticipantStore()
+        let legacyID = try insertLegacyMeeting(into: store, title: "Legacy Standup")
+
+        try store.migrateIfNeeded()
+
+        // The pre-existing row survives the migration intact.
+        let migrated = try store.meeting(id: legacyID)
+        #expect(migrated?.title == "Legacy Standup")
+        #expect(migrated?.rawTranscript == "legacy transcript")
+
+        // And the upgraded database actually works, rather than merely having the
+        // right shape. This exercises columns added by ALTER TABLE during migration
+        // (notably meetings.deleted_at, which attachMeetingParticipant depends on).
+        #expect(try store.attachMeetingParticipant(
+            meetingID: legacyID,
+            contactIdentifier: "legacy-contact",
+            displayName: "Legacy Person"
+        ))
+        #expect(try store.listMeetingParticipants(meetingID: legacyID).map(\.displayName) == ["Legacy Person"])
+    }
+
+    @Test("participant listing throws instead of returning rows before a step fault")
+    func participantListingThrowsOnStepFault() throws {
+        let store = try makeStepFaultStore()
+
+        do {
+            let participants = try store.listMeetingParticipants(meetingID: 42)
+            Issue.record("Expected a SQLite step fault, got \(participants.count) participants")
+        } catch {
+            let error = error as NSError
+            #expect(error.domain == DictationStore.errorDomain)
+            #expect(error.code == Int(SQLITE_ERROR))
+        }
+    }
+
+    @Test("participants attach, list, and remove in insertion order")
+    func attachListAndRemove() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        #expect(try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "contact-b",
+            displayName: "Bob Example"
+        ))
+        #expect(try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "contact-a",
+            displayName: "Alice Example"
+        ))
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID) == [
+            MeetingParticipant(
+                meetingID: meetingID,
+                contactIdentifier: "contact-b",
+                displayName: "Bob Example",
+                insertionOrder: 0
+            ),
+            MeetingParticipant(
+                meetingID: meetingID,
+                contactIdentifier: "contact-a",
+                displayName: "Alice Example",
+                insertionOrder: 1
+            ),
+        ])
+
+        try store.removeMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "contact-b"
+        )
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.contactIdentifier) == [
+            "contact-a",
+        ])
+    }
+
+    @Test("attaching the same contact twice deduplicates but refreshes the name")
+    func duplicateSelectionRefreshesDisplayName() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        #expect(try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "same-contact",
+            displayName: "Original Snapshot"
+        ))
+        // Returns false because no new participant was added, but the stored snapshot
+        // is refreshed so a contact renamed in Contacts.app has a recovery path.
+        #expect(try !store.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "same-contact",
+            displayName: "Changed Snapshot"
+        ))
+
+        let participants = try store.listMeetingParticipants(meetingID: meetingID)
+        #expect(participants.count == 1)
+        #expect(participants.first?.displayName == "Changed Snapshot")
+        #expect(participants.first?.insertionOrder == 0)
+    }
+
+    @Test("re-adding does not reshuffle existing participants")
+    func refreshPreservesOrdering() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "first", displayName: "First"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "second", displayName: "Second"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "first", displayName: "First Renamed"
+        )
+
+        let participants = try store.listMeetingParticipants(meetingID: meetingID)
+        #expect(participants.map(\.contactIdentifier) == ["first", "second"])
+        #expect(participants.map(\.displayName) == ["First Renamed", "Second"])
+        #expect(participants.map(\.insertionOrder) == [0, 1])
+    }
+
+    @Test("participants are scoped to their own meeting")
+    func participantsAreScopedPerMeeting() throws {
+        let store = try makeStore()
+        let first = try makeMeeting(in: store, title: "First")
+        let second = try makeMeeting(in: store, title: "Second")
+
+        _ = try store.attachMeetingParticipant(
+            meetingID: first, contactIdentifier: "shared", displayName: "Shared Person"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: second, contactIdentifier: "shared", displayName: "Shared Person"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: second, contactIdentifier: "second-only", displayName: "Second Only"
+        )
+
+        // Insertion order restarts per meeting rather than running globally.
+        #expect(try store.listMeetingParticipants(meetingID: first).map(\.insertionOrder) == [0])
+        #expect(try store.listMeetingParticipants(meetingID: second).map(\.insertionOrder) == [0, 1])
+
+        // Removing from one meeting must not touch the other.
+        try store.removeMeetingParticipant(meetingID: first, contactIdentifier: "shared")
+        #expect(try store.listMeetingParticipants(meetingID: first).isEmpty)
+        #expect(try store.listMeetingParticipants(meetingID: second).map(\.contactIdentifier) == [
+            "shared",
+            "second-only",
+        ])
+
+        // Nor may deleting one meeting wipe another meeting's participants.
+        try store.deleteMeeting(id: first)
+        #expect(try store.listMeetingParticipants(meetingID: second).count == 2)
+    }
+
+    @Test("re-adding a removed participant appends to the end")
+    func reAddedParticipantGoesLast() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "a", displayName: "A"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "b", displayName: "B"
+        )
+        try store.removeMeetingParticipant(meetingID: meetingID, contactIdentifier: "a")
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "a", displayName: "A"
+        )
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.contactIdentifier) == ["b", "a"])
+
+        // Emptying the meeting resets numbering rather than leaving a permanent gap.
+        try store.removeMeetingParticipant(meetingID: meetingID, contactIdentifier: "a")
+        try store.removeMeetingParticipant(meetingID: meetingID, contactIdentifier: "b")
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "c", displayName: "C"
+        )
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).first?.insertionOrder == 0)
+    }
+
+    @Test("blank contact identifiers are rejected")
+    func blankIdentifierIsRejected() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        #expect(throws: DictationStoreError.self) {
+            try store.attachMeetingParticipant(
+                meetingID: meetingID, contactIdentifier: "   ", displayName: "Blank"
+            )
+        }
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).isEmpty)
+    }
+
+    @Test("display names round-trip unusual text")
+    func displayNamesRoundTrip() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+        let longName = String(repeating: "é", count: 2_000)
+
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "emoji", displayName: "Alice 🧮 Example-Sample"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "long", displayName: longName
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "empty", displayName: ""
+        )
+
+        let names = try store.listMeetingParticipants(meetingID: meetingID).map(\.displayName)
+        #expect(names == ["Alice 🧮 Example-Sample", longName, ""])
+    }
+
+    @Test("removing a contact that was never attached is a no-op")
+    func removingUnattachedContactIsNoOp() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID, contactIdentifier: "kept", displayName: "Kept"
+        )
+
+        try store.removeMeetingParticipant(meetingID: meetingID, contactIdentifier: "never-attached")
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.contactIdentifier) == ["kept"])
+    }
+
+    @Test("deleting a meeting removes its participant associations")
+    func deletionRemovesParticipants() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "delete-contact",
+            displayName: "Delete Me"
+        )
+
+        try store.deleteMeeting(id: meetingID)
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).isEmpty)
+        #expect(throws: DictationStoreError.self) {
+            try store.attachMeetingParticipant(
+                meetingID: meetingID,
+                contactIdentifier: "late-contact",
+                displayName: "Too Late"
+            )
+        }
+    }
+
+    @Test("physically deleting a meeting cascades to participants")
+    func physicalDeletionCascades() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+        _ = try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            contactIdentifier: "cascade-contact",
+            displayName: "Cascade"
+        )
+
+        var database: OpaquePointer?
+        #expect(sqlite3_open(store.databasePath().path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+        #expect(sqlite3_exec(database, "PRAGMA foreign_keys=ON", nil, nil, nil) == SQLITE_OK)
+
+        var statement: OpaquePointer?
+        #expect(sqlite3_prepare_v2(
+            database,
+            "DELETE FROM meetings WHERE id = ?",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK)
+        sqlite3_bind_int64(statement, 1, meetingID)
+        #expect(sqlite3_step(statement) == SQLITE_DONE)
+        sqlite3_finalize(statement)
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).isEmpty)
+    }
+
+    @Test("clearing meetings removes all participant associations")
+    func clearingRemovesParticipants() throws {
+        let store = try makeStore()
+        let firstID = try makeMeeting(in: store, title: "First")
+        let secondID = try makeMeeting(in: store, title: "Second")
+        _ = try store.attachMeetingParticipant(
+            meetingID: firstID,
+            contactIdentifier: "first-contact",
+            displayName: "First"
+        )
+        _ = try store.attachMeetingParticipant(
+            meetingID: secondID,
+            contactIdentifier: "second-contact",
+            displayName: "Second"
+        )
+
+        try store.clearMeetings()
+
+        #expect(try store.listMeetingParticipants(meetingID: firstID).isEmpty)
+        #expect(try store.listMeetingParticipants(meetingID: secondID).isEmpty)
+    }
+}

--- a/scripts/Muesli.entitlements
+++ b/scripts/Muesli.entitlements
@@ -8,6 +8,8 @@
     <false/>
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
     <key>com.apple.developer.icloud-container-identifiers</key>

--- a/scripts/MuesliLocalOnly.entitlements
+++ b/scripts/MuesliLocalOnly.entitlements
@@ -8,6 +8,8 @@
     <false/>
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
 </dict>

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -221,6 +221,8 @@ cat > "$STAGED_APP_DIR/Contents/Info.plist" <<PLIST
   <string>$APP_DISPLAY_NAME captures screen content for meeting context.</string>
   <key>NSCalendarsFullAccessUsageDescription</key>
   <string>$APP_DISPLAY_NAME reads calendar events to help with meeting recordings.</string>
+  <key>NSContactsUsageDescription</key>
+  <string>$APP_DISPLAY_NAME uses Contacts to attach people to meeting notes and save new contacts you create.</string>
   <key>SUFeedURL</key>
   <string>$SPARKLE_FEED_URL</string>
   <key>SUPublicEDKey</key>

--- a/scripts/ci_unsharded_test_suites.txt
+++ b/scripts/ci_unsharded_test_suites.txt
@@ -46,7 +46,6 @@ MeetingChunkTimingTrackerTests
 MeetingExporterTests
 MeetingHookIntegrationTests
 MeetingHookRunnerTests
-MeetingMarkdownAutoExporterTests
 MeetingMediaSessionTrackerTests
 MeetingMediaSignalFilterTests
 MeetingMicHealthTrackerTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -19,6 +19,7 @@ case "${shard}" in
     filters=(
       ConfigStoreTests
       DictationStoreTests
+      MeetingParticipantStoreTests
       MuesliCLITests
       ChatGPTAuthTests
       ChatGPTTokenStorageTests
@@ -66,7 +67,10 @@ case "${shard}" in
       AudioGraphExceptionBridgeTests
       DiagnosticIncidentTests
       DictationAudioRouteControllerTests
+      MeetingContactIdentityTests
+      MeetingContactStoreTests
       MeetingDetectorTests
+      MeetingMarkdownAutoExporterTests
       MeetingRecordingWriterTests
       MeetingResumePolicyTests
       MeetingStreamingPartialSessionTests


### PR DESCRIPTION
## Summary

Closes #347.

Attach people from Apple Contacts to a meeting, create new contacts inline, and carry the resulting list into meeting exports.

- add a `meeting_participants` table with a composite primary key and `ON DELETE CASCADE`, created through the existing `CREATE TABLE IF NOT EXISTS` migration path
- add a People section to the meeting detail view backed by `CNContactPicker`, plus an inline "New Contact…" sheet that writes to Apple Contacts
- persist display names as a snapshot so they survive a Contacts permission revocation, and refresh them on re-add so a renamed contact has a recovery path
- request Contacts access only at the point of use, never at launch or during onboarding
- include participants in Markdown and PDF exports
- add `NSContactsUsageDescription` and the `personal-information.addressbook` entitlement

## Privacy and permissions

Contacts access is requested from exactly one place — the Save Contact button in the new-contact sheet. Nothing in `MuesliController`, the app delegate, or onboarding touches Contacts, so the deferred-monitor rule in `CLAUDE.md` is preserved. Attaching an existing person goes through the out-of-process picker and needs no grant at all; the all-or-nothing grant is only needed to *write* a new contact.

Every `CNContact` property read is guarded by `isKeyAvailable` / `areKeysAvailable`, using `CNContactFormatter.descriptorForRequiredKeys(for:)` rather than a hand-rolled key list. Touching an unfetched key raises an Objective-C exception that Swift cannot catch.

`CNContactPicker` is a remote view service, so the contact it vends carries only the keys that service fetched. `displayedKeys` cannot be used to force a key set — per `CNContactPicker.h`, providing keys switches the picker to selecting *values* instead of contacts. Instead, `MeetingContactStore.resolveDisplayName` re-fetches by identifier when the name keys are absent, and only when access is already `.authorized`, so a permission prompt never fires merely to render a name.

No contact data reaches logs, exports beyond the participant list, or the summarization backends. `MeetingParticipant` is deliberately not `Codable`.

## Design decisions

**Participants are device-local.** They are not carried by `MuesliICloudSyncEngine`, and the table has no sync bookkeeping columns. Propagating removals across devices needs tombstones, so syncing them belongs in a dedicated change rather than a partial retrofit. This is now stated in a comment on the table rather than left implicit.

**Names are a refreshable snapshot.** Storing the name means a participant still renders after Contacts access is revoked, or when a `CNContact.identifier` no longer resolves after a restore or re-sync. Re-adding the same person upserts the name so a rename in Contacts.app has a recovery path without remove-and-re-add.

**A SQLite fault is never reported as a missing meeting.** The meeting-existence probe branches on the step result, so `SQLITE_BUSY` — live during meeting transcript checkpointing — surfaces the real error instead of claiming the meeting no longer exists while it is visibly on screen.

## Validation

Verified locally:

- `MuesliCore` and `MuesliCLI` build clean
- the upsert was exercised directly against SQLite: re-adding refreshes the name without reordering or duplicating, insertion order restarts per meeting, and deleting one meeting cascades only to its own participants
- all changed Swift files parse clean
- `git diff --check` clean


Test coverage added alongside the feature:

- participants are scoped per meeting, covering the `WHERE meeting_id = ?` clauses that guard against cross-record data loss
- a migrated pre-participant database keeps its meetings and then actually accepts participants, rather than only being introspected for shape
- the display-name precedence chain, whitespace-only names, single-name contacts, and the unnamed fallback
- the save flow through a `MeetingContactWriting` fake: denied access, a refused prompt, duplicate rejection, and a non-fatal duplicate-lookup failure
- Unicode, very long, and empty display names round-tripping through SQLite

Test fixtures use only reserved identifiers: the RFC 6761 `.test` TLD and the reserved `555-01xx` number block, with placeholder names matching the existing `Alice`/`Bob` convention in `DictationStoreTests`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787870553&installation_model_id=422865&pr_number=346&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F346&signature=f4a2774e2cb5939b4abc69eaac4d3cbad91b9703bf5255448d509be8a928c36f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add meeting participants from macOS Contacts (picker) or create a new contact, with validation, duplicate detection, and saved display names.
  * View and manage participants per meeting (ordered insertion, attach/remove).
  * Include attached participants in exported meeting markdown under a “People” section.
* **Bug Fixes**
  * Improve meeting cleanup by fully removing participant associations when deleting or clearing meetings.
* **Tests**
  * Expanded coverage for contact identity/drafting, Contacts save flow, participant persistence/migration/CRUD, and participant-aware markdown auto-export behavior.
* **Chores**
  * Updated macOS Contacts permission messaging and address book entitlements for meeting contacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
