### PR TITLE
Add GPT-5.6 Sol, Terra, and Luna model support

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ChatGPTResponsesClient.swift
@@ -22,16 +22,11 @@ enum ChatGPTResponsesClient {
         logCategory: String
     ) async throws -> String {
         let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
-        let body: [String: Any] = [
-            "model": model,
-            "store": false,
-            "stream": true,
-            "instructions": systemPrompt,
-            "input": [[
-                "role": "user",
-                "content": [["type": "input_text", "text": userPrompt]],
-            ] as [String: Any]],
-        ]
+        let body = requestBody(
+            systemPrompt: systemPrompt,
+            userPrompt: userPrompt,
+            model: model
+        )
 
         var request = URLRequest(url: whamURL)
         request.timeoutInterval = requestTimeout
@@ -70,6 +65,27 @@ enum ChatGPTResponsesClient {
         let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
         fputs("[\(logCategory)] ChatGPT WHAM: collected \(trimmed.count) chars\n", stderr)
         return trimmed
+    }
+
+    static func requestBody(
+        systemPrompt: String,
+        userPrompt: String,
+        model: String
+    ) -> [String: Any] {
+        var body: [String: Any] = [
+            "model": model,
+            "store": false,
+            "stream": true,
+            "instructions": systemPrompt,
+            "input": [[
+                "role": "user",
+                "content": [["type": "input_text", "text": userPrompt]],
+            ] as [String: Any]],
+        ]
+        if let effort = SummaryModelPreset.reasoningEffort(for: model) {
+            body["reasoning"] = ["effort": effort]
+        }
+        return body
     }
 
     static func applyStreamPayload(_ payload: [String: Any], deltaText: inout String, finalText: inout String) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ComputerUsePlannerClient.swift
@@ -25,7 +25,7 @@ enum ComputerUsePlannerError: LocalizedError, Equatable {
 
 enum ComputerUsePlannerClient {
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
-    static let defaultModel = "gpt-5.5"
+    static let defaultModel = "gpt-5.6-sol"
 
     static var instructions: String {
         """
@@ -100,27 +100,12 @@ enum ComputerUsePlannerClient {
         model: String
     ) async throws -> ComputerUsePlannerResponse {
         let (token, accountId) = try await ChatGPTAuthManager.shared.validAccessToken()
-        var content: [[String: Any]] = [
-            ["type": "input_text", "text": userPrompt],
-        ]
-        if let imageDataURL {
-            content.append(["type": "input_image", "image_url": imageDataURL])
-        }
-        let body: [String: Any] = [
-            "model": model,
-            "store": false,
-            "stream": true,
-            "instructions": systemPrompt,
-            "tools": ComputerUseToolRegistry.nativeToolDefinitions(),
-            "tool_choice": "required",
-            "parallel_tool_calls": false,
-            "input": [
-                [
-                    "role": "user",
-                    "content": content,
-                ] as [String: Any],
-            ],
-        ]
+        let body = requestBody(
+            systemPrompt: systemPrompt,
+            userPrompt: userPrompt,
+            imageDataURL: imageDataURL,
+            model: model
+        )
 
         var urlRequest = URLRequest(url: whamURL)
         urlRequest.httpMethod = "POST"
@@ -186,6 +171,39 @@ enum ComputerUsePlannerClient {
                 ? "The model did not return a native tool call."
                 : "The model returned text instead of a native tool call: \(String(trimmedText.prefix(800)))"
         )
+    }
+
+    static func requestBody(
+        systemPrompt: String,
+        userPrompt: String,
+        imageDataURL: String?,
+        model: String
+    ) -> [String: Any] {
+        var content: [[String: Any]] = [
+            ["type": "input_text", "text": userPrompt],
+        ]
+        if let imageDataURL {
+            content.append(["type": "input_image", "image_url": imageDataURL])
+        }
+        var body: [String: Any] = [
+            "model": model,
+            "store": false,
+            "stream": true,
+            "instructions": systemPrompt,
+            "tools": ComputerUseToolRegistry.nativeToolDefinitions(),
+            "tool_choice": "required",
+            "parallel_tool_calls": false,
+            "input": [
+                [
+                    "role": "user",
+                    "content": content,
+                ] as [String: Any],
+            ],
+        ]
+        if let effort = SummaryModelPreset.reasoningEffort(for: model) {
+            body["reasoning"] = ["effort": effort]
+        }
+        return body
     }
 
     private static func nativeToolCall(in value: Any, depth: Int = 0) -> (name: String, arguments: String)? {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -485,13 +485,14 @@ enum MeetingSummaryClient {
             visualContext: visualContext,
             previousMeetingNotes: previousMeetingNotes
         )
+        let model = config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel
         let body: [String: Any] = [
-            "model": config.openAIModel.isEmpty ? defaultOpenAIModel : config.openAIModel,
+            "model": model,
             "input": [
                 ["role": "system", "content": instructions],
                 ["role": "user", "content": userPrompt],
             ],
-            "reasoning": ["effort": "low"],
+            "reasoning": ["effort": SummaryModelPreset.reasoningEffort(for: model) ?? "low"],
             "text": ["verbosity": "low"],
             "max_output_tokens": defaultSummaryMaxOutputTokens,
         ]
@@ -1187,6 +1188,9 @@ enum MeetingSummaryClient {
         if let maxTokens {
             // OpenAI newer models require max_completion_tokens; OpenRouter uses max_tokens
             body[isOpenAI ? "max_completion_tokens" : "max_tokens"] = maxTokens
+        }
+        if isOpenAI, let effort = SummaryModelPreset.reasoningEffort(for: model) {
+            body["reasoning_effort"] = effort
         }
 
         var request = URLRequest(url: url)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -341,7 +341,9 @@ struct SummaryModelPreset {
 
     static let openAIModels: [SummaryModelPreset] = [
         SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini (default)"),
-        SummaryModelPreset(id: "gpt-5.5", label: "GPT-5.5"),
+        SummaryModelPreset(id: "gpt-5.6-sol", label: "GPT-5.6 Sol"),
+        SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra"),
+        SummaryModelPreset(id: "gpt-5.6-luna", label: "GPT-5.6 Luna"),
         SummaryModelPreset(id: "chat-latest", label: "Chat Latest (Instant)"),
         SummaryModelPreset(id: "gpt-5.4-nano", label: "GPT-5.4 Nano"),
         SummaryModelPreset(id: "gpt-5.4", label: "GPT-5.4"),
@@ -352,7 +354,16 @@ struct SummaryModelPreset {
 
     static let chatGPTModels: [SummaryModelPreset] = [
         SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini (default)"),
-        SummaryModelPreset(id: "gpt-5.5", label: "GPT-5.5"),
+        SummaryModelPreset(id: "gpt-5.6-sol", label: "GPT-5.6 Sol"),
+        SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra"),
+        SummaryModelPreset(id: "gpt-5.6-luna", label: "GPT-5.6 Luna"),
+    ]
+
+    static let chatGPTTranscriptCleanupModels: [SummaryModelPreset] = [
+        SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra (default)"),
+        SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini"),
+        SummaryModelPreset(id: "gpt-5.6-sol", label: "GPT-5.6 Sol"),
+        SummaryModelPreset(id: "gpt-5.6-luna", label: "GPT-5.6 Luna"),
     ]
 
     private static let unsupportedChatGPTModelIDs: Set<String> = [
@@ -361,7 +372,9 @@ struct SummaryModelPreset {
     ]
 
     static let computerUsePlannerModels: [SummaryModelPreset] = [
-        SummaryModelPreset(id: "gpt-5.5", label: "GPT-5.5 (default)"),
+        SummaryModelPreset(id: "gpt-5.6-sol", label: "GPT-5.6 Sol (default)"),
+        SummaryModelPreset(id: "gpt-5.6-terra", label: "GPT-5.6 Terra"),
+        SummaryModelPreset(id: "gpt-5.6-luna", label: "GPT-5.6 Luna"),
         SummaryModelPreset(id: "gpt-5.4", label: "GPT-5.4"),
         SummaryModelPreset(id: "gpt-5.4-mini", label: "GPT-5.4 Mini"),
         SummaryModelPreset(id: "gpt-5.2", label: "GPT-5.2"),
@@ -384,6 +397,21 @@ struct SummaryModelPreset {
     static func supportedChatGPTModel(_ model: String) -> String {
         let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
         return unsupportedChatGPTModelIDs.contains(trimmed) ? "" : trimmed
+    }
+
+    static func reasoningEffort(for model: String) -> String? {
+        switch model.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna":
+            return "high"
+        default:
+            return nil
+        }
+    }
+
+    static func migratedFromGPT55(_ model: String) -> String {
+        model.trimmingCharacters(in: .whitespacesAndNewlines) == "gpt-5.5"
+            ? "gpt-5.6-sol"
+            : model
     }
 }
 
@@ -1241,7 +1269,9 @@ struct AppConfig: Codable {
         meetingRecordingHotkey = (try? c.decode(HotkeyConfig.self, forKey: .meetingRecordingHotkey)) ?? defaults.meetingRecordingHotkey
         enableMeetingRecordingHotkey = (try? c.decode(Bool.self, forKey: .enableMeetingRecordingHotkey)) ?? defaults.enableMeetingRecordingHotkey
         enableComputerUsePlanner = (try? c.decode(Bool.self, forKey: .enableComputerUsePlanner)) ?? defaults.enableComputerUsePlanner
-        computerUsePlannerModel = (try? c.decode(String.self, forKey: .computerUsePlannerModel)) ?? defaults.computerUsePlannerModel
+        computerUsePlannerModel = SummaryModelPreset.migratedFromGPT55(
+            (try? c.decode(String.self, forKey: .computerUsePlannerModel)) ?? defaults.computerUsePlannerModel
+        )
         computerUseTimeoutSeconds = (try? c.decode(Int.self, forKey: .computerUseTimeoutSeconds)) ?? defaults.computerUseTimeoutSeconds
         sttBackend = (try? c.decode(String.self, forKey: .sttBackend)) ?? defaults.sttBackend
         sttModel = (try? c.decode(String.self, forKey: .sttModel)) ?? defaults.sttModel
@@ -1305,10 +1335,14 @@ struct AppConfig: Codable {
         indicatorOrigin = try? c.decode(CGPointCodable.self, forKey: .indicatorOrigin)
         openAIAPIKey = (try? c.decode(String.self, forKey: .openAIAPIKey)) ?? defaults.openAIAPIKey
         openRouterAPIKey = (try? c.decode(String.self, forKey: .openRouterAPIKey)) ?? defaults.openRouterAPIKey
-        openAIModel = (try? c.decode(String.self, forKey: .openAIModel)) ?? defaults.openAIModel
+        openAIModel = SummaryModelPreset.migratedFromGPT55(
+            (try? c.decode(String.self, forKey: .openAIModel)) ?? defaults.openAIModel
+        )
         openRouterModel = (try? c.decode(String.self, forKey: .openRouterModel)) ?? defaults.openRouterModel
         chatGPTModel = SummaryModelPreset.supportedChatGPTModel(
-            (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
+            SummaryModelPreset.migratedFromGPT55(
+                (try? c.decode(String.self, forKey: .chatGPTModel)) ?? defaults.chatGPTModel
+            )
         )
         meetingSummaryRetryCount = MeetingSummaryRetryPolicy.clampedRetryCount(
             (try? c.decode(Int.self, forKey: .meetingSummaryRetryCount)) ?? defaults.meetingSummaryRetryCount
@@ -1363,9 +1397,13 @@ struct AppConfig: Codable {
             .backend
         activePostProcessorId = (try? c.decode(String.self, forKey: .activePostProcessorId)) ?? defaults.activePostProcessorId
         postProcessorChatGPTModel = SummaryModelPreset.supportedChatGPTModel(
-            (try? c.decode(String.self, forKey: .postProcessorChatGPTModel)) ?? defaults.postProcessorChatGPTModel
+            SummaryModelPreset.migratedFromGPT55(
+                (try? c.decode(String.self, forKey: .postProcessorChatGPTModel)) ?? defaults.postProcessorChatGPTModel
+            )
         )
-        postProcessorOpenAIModel = (try? c.decode(String.self, forKey: .postProcessorOpenAIModel)) ?? defaults.postProcessorOpenAIModel
+        postProcessorOpenAIModel = SummaryModelPreset.migratedFromGPT55(
+            (try? c.decode(String.self, forKey: .postProcessorOpenAIModel)) ?? defaults.postProcessorOpenAIModel
+        )
         postProcessorOpenRouterModel = (try? c.decode(String.self, forKey: .postProcessorOpenRouterModel)) ?? defaults.postProcessorOpenRouterModel
         postProcessorOllamaModel = (try? c.decode(String.self, forKey: .postProcessorOllamaModel)) ?? defaults.postProcessorOllamaModel
         postProcessorLMStudioModel = (try? c.decode(String.self, forKey: .postProcessorLMStudioModel)) ?? defaults.postProcessorLMStudioModel

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -913,7 +913,7 @@ struct SettingsView: View {
             settingsRow("Cleanup model", controlWidth: meetingControlWidth) {
                 settingsModelMenu(
                     currentModel: appState.config.postProcessorChatGPTModel,
-                    presets: SummaryModelPreset.chatGPTModels
+                    presets: SummaryModelPreset.chatGPTTranscriptCleanupModels
                 ) { controller.updatePostProcessorModel($0, for: backend) }
             }
         case .some(.openAI):

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptCleanupClient.swift
@@ -40,7 +40,7 @@ enum TranscriptCleanupClient {
         }
         switch backend.llmBackend {
         case .some(.chatGPT):
-            return SummaryModelPreset.chatGPTModels.first?.id ?? "gpt-5.4-mini"
+            return SummaryModelPreset.chatGPTTranscriptCleanupModels.first?.id ?? "gpt-5.6-terra"
         case .some(.openAI):
             return SummaryModelPreset.openAIModels.first?.id ?? "gpt-5.4-mini"
         case .some(.openRouter):
@@ -263,12 +263,15 @@ enum TranscriptCleanupClient {
         guard !apiKey.isEmpty else {
             throw TranscriptCleanupError.missingConfiguration("OpenAI API key is not configured.")
         }
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "model": model,
             "instructions": systemPrompt,
             "input": userPrompt,
             "max_output_tokens": defaultMaxOutputTokens,
         ]
+        if let effort = SummaryModelPreset.reasoningEffort(for: model) {
+            body["reasoning"] = ["effort": effort]
+        }
         var request = URLRequest(url: openAIResponsesURL)
         request.timeoutInterval = requestTimeout
         request.httpMethod = "POST"

--- a/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ComputerUsePlannerTests.swift
@@ -385,10 +385,38 @@ struct ComputerUsePlannerModelTests {
         config.chatGPTModel = "gpt-5.4-mini"
 
         #expect(ComputerUsePlannerClient.plannerModel(for: config) == ComputerUsePlannerClient.defaultModel)
+        #expect(ComputerUsePlannerClient.defaultModel == "gpt-5.6-sol")
 
         config.computerUsePlannerModel = "gpt-5.4"
 
         #expect(ComputerUsePlannerClient.plannerModel(for: config) == "gpt-5.4")
+    }
+
+    @Test("uses fixed High reasoning for every GPT-5.6 planner tier")
+    func usesHighReasoningForGPT56Family() {
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            let body = ComputerUsePlannerClient.requestBody(
+                systemPrompt: "System",
+                userPrompt: "User",
+                imageDataURL: nil,
+                model: model
+            )
+            let reasoning = body["reasoning"] as? [String: String]
+
+            #expect(reasoning?["effort"] == "high")
+        }
+    }
+
+    @Test("keeps GPT-5.4 Mini available without changing its reasoning behavior")
+    func preservesGPT54MiniReasoning() {
+        let body = ComputerUsePlannerClient.requestBody(
+            systemPrompt: "System",
+            userPrompt: "User",
+            imageDataURL: nil,
+            model: "gpt-5.4-mini"
+        )
+
+        #expect(body["reasoning"] == nil)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -94,6 +94,31 @@ struct MeetingSummaryClientTests {
         #expect(prompt.contains("- User typed decision"))
     }
 
+    @Test("ChatGPT WHAM requests fix GPT-5.6 reasoning to High")
+    func chatGPTWHAMRequestUsesHighReasoningForGPT56() {
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            let body = ChatGPTResponsesClient.requestBody(
+                systemPrompt: "System",
+                userPrompt: "User",
+                model: model
+            )
+            let reasoning = body["reasoning"] as? [String: String]
+
+            #expect(reasoning?["effort"] == "high")
+        }
+    }
+
+    @Test("ChatGPT WHAM requests preserve GPT-5.4 Mini reasoning behavior")
+    func chatGPTWHAMRequestPreservesGPT54MiniReasoning() {
+        let body = ChatGPTResponsesClient.requestBody(
+            systemPrompt: "System",
+            userPrompt: "User",
+            model: "gpt-5.4-mini"
+        )
+
+        #expect(body["reasoning"] == nil)
+    }
+
     @Test("ChatGPT WHAM parser reads top-level output text")
     func chatGPTWHAMParserReadsTopLevelOutputText() {
         let payload: [String: Any] = [

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -384,7 +384,10 @@ struct SummaryModelPresetTests {
     func openAIModels() {
         #expect(!SummaryModelPreset.openAIModels.isEmpty)
         #expect(SummaryModelPreset.openAIModels.first?.id == "gpt-5.4-mini")
-        #expect(SummaryModelPreset.openAIModels.contains { $0.id == "gpt-5.5" })
+        #expect(SummaryModelPreset.openAIModels.contains { $0.id == "gpt-5.6-sol" })
+        #expect(SummaryModelPreset.openAIModels.contains { $0.id == "gpt-5.6-terra" })
+        #expect(SummaryModelPreset.openAIModels.contains { $0.id == "gpt-5.6-luna" })
+        #expect(!SummaryModelPreset.openAIModels.contains { $0.id == "gpt-5.5" })
         #expect(SummaryModelPreset.openAIModels.contains { $0.id == "chat-latest" })
         for preset in SummaryModelPreset.openAIModels {
             #expect(!preset.id.isEmpty)
@@ -396,7 +399,10 @@ struct SummaryModelPresetTests {
     func chatGPTModels() {
         #expect(!SummaryModelPreset.chatGPTModels.isEmpty)
         #expect(SummaryModelPreset.chatGPTModels.first?.id == "gpt-5.4-mini")
-        #expect(SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.5" })
+        #expect(SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.6-sol" })
+        #expect(SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.6-terra" })
+        #expect(SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.6-luna" })
+        #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.5" })
         #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.4-nano" })
         #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "chat-latest" })
         #expect(!SummaryModelPreset.chatGPTModels.contains { $0.id == "gpt-5.4" })
@@ -408,6 +414,23 @@ struct SummaryModelPresetTests {
         }
     }
 
+    @Test("ChatGPT transcript cleanup uses GPT-5.6 Terra by default")
+    func chatGPTTranscriptCleanupModels() {
+        let presets = SummaryModelPreset.chatGPTTranscriptCleanupModels
+        #expect(presets.first?.id == "gpt-5.6-terra")
+        #expect(presets.first?.label.contains("default") == true)
+        #expect(Set(presets.map(\.id)) == Set([
+            "gpt-5.4-mini",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        ]))
+
+        let backend = TranscriptCleanupBackendOption.hosted(.chatGPT)
+        #expect(TranscriptCleanupClient.defaultModel(for: backend) == "gpt-5.6-terra")
+        #expect(TranscriptCleanupClient.configuredModel(for: backend, config: AppConfig()) == "gpt-5.6-terra")
+    }
+
     @Test("OpenRouter presets have valid model IDs")
     func openRouterModels() {
         #expect(!SummaryModelPreset.openRouterModels.isEmpty)
@@ -417,14 +440,26 @@ struct SummaryModelPresetTests {
         }
     }
 
-    @Test("Computer use planner presets include GPT-5.5 default")
+    @Test("Computer use planner presets use GPT-5.6 Sol by default")
     func computerUsePlannerModels() {
-        #expect(SummaryModelPreset.computerUsePlannerModels.first?.id == "gpt-5.5")
+        #expect(SummaryModelPreset.computerUsePlannerModels.first?.id == "gpt-5.6-sol")
+        #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.6-terra" })
+        #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.6-luna" })
         #expect(SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.4-mini" })
+        #expect(!SummaryModelPreset.computerUsePlannerModels.contains { $0.id == "gpt-5.5" })
         for preset in SummaryModelPreset.computerUsePlannerModels {
             #expect(!preset.id.isEmpty)
             #expect(!preset.label.isEmpty)
         }
+    }
+
+    @Test("GPT-5.6 family uses fixed High reasoning")
+    func gpt56ReasoningEffort() {
+        #expect(SummaryModelPreset.reasoningEffort(for: "gpt-5.6-sol") == "high")
+        #expect(SummaryModelPreset.reasoningEffort(for: "gpt-5.6-terra") == "high")
+        #expect(SummaryModelPreset.reasoningEffort(for: "gpt-5.6-luna") == "high")
+        #expect(SummaryModelPreset.reasoningEffort(for: "gpt-5.4-mini") == nil)
+        #expect(SummaryModelPreset.reasoningEffort(for: "gpt-5.5") == nil)
     }
 
     @Test("model menu includes custom configured model")
@@ -1194,6 +1229,26 @@ struct AppConfigTests {
 
         #expect(config.chatGPTModel.isEmpty)
         #expect(config.postProcessorChatGPTModel.isEmpty)
+    }
+
+    @Test("stored GPT-5.5 selections migrate to GPT-5.6 Sol")
+    func storedGPT55SelectionsMigrateToSol() throws {
+        let json = """
+        {
+          "computer_use_planner_model": "gpt-5.5",
+          "openai_model": "gpt-5.5",
+          "chatgpt_model": "gpt-5.5",
+          "post_processor_openai_model": "gpt-5.5",
+          "post_processor_chatgpt_model": "gpt-5.5"
+        }
+        """
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.computerUsePlannerModel == "gpt-5.6-sol")
+        #expect(config.openAIModel == "gpt-5.6-sol")
+        #expect(config.chatGPTModel == "gpt-5.6-sol")
+        #expect(config.postProcessorOpenAIModel == "gpt-5.6-sol")
+        #expect(config.postProcessorChatGPTModel == "gpt-5.6-sol")
     }
 
     @Test("legacy completed onboarding enables meetings when use case is missing")


### PR DESCRIPTION
## Summary

- replace GPT-5.5 presets with GPT-5.6 Sol, Terra, and Luna across ChatGPT, OpenAI, and computer-use model selectors
- keep GPT-5.4 Mini available across dictation cleanup, meetings, and computer use
- fix reasoning effort to `high` for all three GPT-5.6 variants on ChatGPT WHAM and OpenAI request paths
- migrate stored GPT-5.5 selections to GPT-5.6 Sol
- set GPT-5.6 Terra as the default specifically for ChatGPT dictation cleanup while preserving the existing meeting-summary default and GPT-5.6 Sol CUA default
- add request-encoding, model-catalog, reasoning, and migration coverage

## Why Terra for dictation cleanup

A live rotating-order benchmark used the same representative noisy transcript for seven measured requests per model through the ChatGPT WHAM streaming path. Median end-to-end cloud cleanup latency was 2.10s for GPT-5.4 Mini, 4.04s for Terra, 6.17s for Sol, and 8.18s for Luna. Terra preserved the intended deletion cue in 5/7 runs, compared with 3/7 for Luna; Sol consistently over-deleted and Mini consistently under-deleted on this sample.

This benchmark covers cloud cleanup only, not Parakeet transcription or paste latency.

## User impact

Users can select the GPT-5.6 family in supported model menus. New or unset ChatGPT dictation-cleanup selections resolve to Terra; explicit existing selections remain intact. GPT-5.4 Mini remains available as the fastest option.

## Validation

- focused `SummaryModelPresetTests`: 9 tests passed
- full SwiftPM suite: 1,439 tests across 140 suites passed
- `MuesliDevA` debug build, install, deep-signature verification, and launch succeeded
- `git diff --check` passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787878941&installation_model_id=422865&pr_number=348&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F348&signature=d6740d3ffc00f8935ffd5ce711993315dd8f77dbb2b6376c807ac5299cadce7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.6 Sol, Terra, and Luna model options across supported AI features.
  * Added automatic migration of saved GPT-5.5 selections to GPT-5.6 Sol.
  * Added model-specific reasoning settings, including high reasoning for GPT-5.6 models.
  * Updated transcript cleanup options with dedicated model presets.

* **Bug Fixes**
  * Ensured reasoning settings are applied consistently across summaries, cleanup, and computer-use requests.

* **Tests**
  * Expanded coverage for model availability, migration, and reasoning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->