### PR TITLE
Fix recurring calendar meeting identity

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -33,7 +33,7 @@ public final class DictationStore {
     t.id, t.final_status, t.final_message, t.trace_json, t.created_at
     """
     private static let meetingColumns = """
-    id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source, follow_up_to_id, follow_up_to_record_name
+    id, title, start_time, duration_seconds, raw_transcript, formatted_notes, word_count, folder_id, calendar_event_id, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source, follow_up_to_id, follow_up_to_record_name, calendar_occurrence_key, calendar_source, calendar_id, calendar_series_id, calendar_occurrence_start
     """
 
     public init() {
@@ -91,6 +91,11 @@ public final class DictationStore {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title TEXT NOT NULL,
             calendar_event_id TEXT,
+            calendar_occurrence_key TEXT,
+            calendar_source TEXT,
+            calendar_id TEXT,
+            calendar_series_id TEXT,
+            calendar_occurrence_start REAL,
             start_time TEXT NOT NULL,
             end_time TEXT,
             duration_seconds REAL,
@@ -119,7 +124,7 @@ public final class DictationStore {
             created_at TEXT DEFAULT (datetime('now'))
         );
         CREATE INDEX IF NOT EXISTS idx_meetings_start_time ON meetings(start_time DESC);
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_meetings_calendar_event_id ON meetings(calendar_event_id) WHERE calendar_event_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_meetings_calendar_event_lookup ON meetings(calendar_event_id) WHERE calendar_event_id IS NOT NULL;
 
         CREATE TABLE IF NOT EXISTS meeting_transcript_checkpoints (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -202,10 +207,30 @@ public final class DictationStore {
             "ALTER TABLE meetings ADD COLUMN cloud_change_tag TEXT",
             "ALTER TABLE meetings ADD COLUMN cloud_transcript_record_name TEXT",
             "ALTER TABLE meetings ADD COLUMN last_synced_at REAL",
-            "ALTER TABLE meetings ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1"
+            "ALTER TABLE meetings ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE meetings ADD COLUMN calendar_occurrence_key TEXT",
+            "ALTER TABLE meetings ADD COLUMN calendar_source TEXT",
+            "ALTER TABLE meetings ADD COLUMN calendar_id TEXT",
+            "ALTER TABLE meetings ADD COLUMN calendar_series_id TEXT",
+            "ALTER TABLE meetings ADD COLUMN calendar_occurrence_start REAL"
         ] {
             _ = sqlite3_exec(db, sql, nil, nil, nil)
         }
+        // Calendar metadata is not a meeting identity: one occurrence may be
+        // recorded more than once, and recurring providers may reuse ids.
+        // Replace the legacy uniqueness constraint with lookup-only indexes.
+        try exec(
+            """
+            DROP INDEX IF EXISTS idx_meetings_calendar_event_id;
+            CREATE INDEX IF NOT EXISTS idx_meetings_calendar_event_lookup
+                ON meetings(calendar_event_id)
+                WHERE calendar_event_id IS NOT NULL;
+            CREATE INDEX IF NOT EXISTS idx_meetings_calendar_occurrence_key
+                ON meetings(calendar_occurrence_key)
+                WHERE calendar_occurrence_key IS NOT NULL;
+            """,
+            db: db
+        )
         if sqlite3_exec(db, "ALTER TABLE meeting_folders ADD COLUMN parent_id INTEGER REFERENCES meeting_folders(id)", nil, nil, nil) != SQLITE_OK {
             let msg = String(cString: sqlite3_errmsg(db))
             if !msg.localizedCaseInsensitiveContains("duplicate column") {
@@ -707,6 +732,40 @@ public final class DictationStore {
         return makeMeetingRecord(statement)
     }
 
+    public func meetingByCalendarOccurrence(_ occurrence: CalendarOccurrenceReference) throws -> MeetingRecord? {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT \(Self.meetingColumns)
+        FROM meetings
+        WHERE deleted_at IS NULL
+          AND (
+            calendar_occurrence_key = ?
+            OR (
+              calendar_occurrence_key IS NULL
+              AND calendar_event_id = ?
+              AND ABS(strftime('%s', start_time) - ?) < 1
+            )
+          )
+        ORDER BY id DESC
+        LIMIT 1
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (occurrence.identityKey as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 2, (occurrence.eventID as NSString).utf8String, -1, nil)
+        sqlite3_bind_double(statement, 3, occurrence.originalStartTime.timeIntervalSince1970)
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            return nil
+        }
+        return makeMeetingRecord(statement)
+    }
+
     @discardableResult
     public func insertMeeting(
         title: String,
@@ -722,15 +781,16 @@ public final class DictationStore {
         selectedTemplateName: String? = nil,
         selectedTemplateKind: MeetingTemplateKind? = nil,
         selectedTemplatePrompt: String? = nil,
-        source: MeetingSource = .meeting
+        source: MeetingSource = .meeting,
+        calendarOccurrence: CalendarOccurrenceReference? = nil
     ) throws -> Int64 {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
         let sql = """
         INSERT INTO meetings
-        (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes, mic_audio_path, system_audio_path, saved_recording_path, word_count, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source, updated_at, sync_dirty)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+        (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes, mic_audio_path, system_audio_path, saved_recording_path, word_count, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source, updated_at, sync_dirty, calendar_occurrence_key, calendar_source, calendar_id, calendar_series_id, calendar_occurrence_start)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
@@ -744,7 +804,7 @@ public final class DictationStore {
         let wordCount = Self.countWords(in: rawTranscript)
 
         sqlite3_bind_text(statement, 1, (title as NSString).utf8String, -1, nil)
-        bindOptionalText(calendarEventID, at: 2, statement: statement)
+        bindOptionalText(calendarOccurrence?.eventID ?? calendarEventID, at: 2, statement: statement)
         sqlite3_bind_text(statement, 3, (startString as NSString).utf8String, -1, nil)
         sqlite3_bind_text(statement, 4, (endString as NSString).utf8String, -1, nil)
         sqlite3_bind_double(statement, 5, durationSeconds)
@@ -760,6 +820,15 @@ public final class DictationStore {
         bindOptionalText(selectedTemplatePrompt, at: 15, statement: statement)
         sqlite3_bind_text(statement, 16, (source.rawValue as NSString).utf8String, -1, nil)
         sqlite3_bind_double(statement, 17, Date().timeIntervalSince1970)
+        bindOptionalText(calendarOccurrence?.identityKey, at: 18, statement: statement)
+        bindOptionalText(calendarOccurrence?.provider.rawValue, at: 19, statement: statement)
+        bindOptionalText(calendarOccurrence?.calendarID, at: 20, statement: statement)
+        bindOptionalText(calendarOccurrence?.seriesID, at: 21, statement: statement)
+        if let calendarOccurrence {
+            sqlite3_bind_double(statement, 22, calendarOccurrence.originalStartTime.timeIntervalSince1970)
+        } else {
+            sqlite3_bind_null(statement, 22)
+        }
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
@@ -777,7 +846,8 @@ public final class DictationStore {
         selectedTemplateKind: MeetingTemplateKind? = nil,
         selectedTemplatePrompt: String? = nil,
         folderID: Int64? = nil,
-        followUpToID: Int64? = nil
+        followUpToID: Int64? = nil,
+        calendarOccurrence: CalendarOccurrenceReference? = nil
     ) throws -> Int64 {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
@@ -785,8 +855,8 @@ public final class DictationStore {
 
         let sql = """
         INSERT INTO meetings
-        (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, word_count, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source, updated_at, sync_dirty, folder_id, follow_up_to_id, follow_up_to_record_name)
-        VALUES (?, ?, ?, NULL, 0, '', '', NULL, NULL, NULL, ?, '', 0, ?, ?, ?, ?, 'meeting', ?, 1, ?, ?, ?)
+        (title, calendar_event_id, start_time, end_time, duration_seconds, raw_transcript, formatted_notes, mic_audio_path, system_audio_path, saved_recording_path, meeting_status, manual_notes, word_count, selected_template_id, selected_template_name, selected_template_kind, selected_template_prompt, source, updated_at, sync_dirty, folder_id, follow_up_to_id, follow_up_to_record_name, calendar_occurrence_key, calendar_source, calendar_id, calendar_series_id, calendar_occurrence_start)
+        VALUES (?, ?, ?, NULL, 0, '', '', NULL, NULL, NULL, ?, '', 0, ?, ?, ?, ?, 'meeting', ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
@@ -796,7 +866,7 @@ public final class DictationStore {
 
         let startString = ISO8601DateFormatter().string(from: startTime)
         sqlite3_bind_text(statement, 1, (title as NSString).utf8String, -1, nil)
-        bindOptionalText(calendarEventID, at: 2, statement: statement)
+        bindOptionalText(calendarOccurrence?.eventID ?? calendarEventID, at: 2, statement: statement)
         sqlite3_bind_text(statement, 3, (startString as NSString).utf8String, -1, nil)
         sqlite3_bind_text(statement, 4, (MeetingStatus.recording.rawValue as NSString).utf8String, -1, nil)
         bindOptionalText(selectedTemplateID, at: 5, statement: statement)
@@ -815,6 +885,15 @@ public final class DictationStore {
             sqlite3_bind_null(statement, 11)
         }
         bindOptionalText(followUpRecordName, at: 12, statement: statement)
+        bindOptionalText(calendarOccurrence?.identityKey, at: 13, statement: statement)
+        bindOptionalText(calendarOccurrence?.provider.rawValue, at: 14, statement: statement)
+        bindOptionalText(calendarOccurrence?.calendarID, at: 15, statement: statement)
+        bindOptionalText(calendarOccurrence?.seriesID, at: 16, statement: statement)
+        if let calendarOccurrence {
+            sqlite3_bind_double(statement, 17, calendarOccurrence.originalStartTime.timeIntervalSince1970)
+        } else {
+            sqlite3_bind_null(statement, 17)
+        }
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
@@ -3578,6 +3657,23 @@ public final class DictationStore {
         let source = MeetingSource(rawValue: stringColumn(statement, index: 18)) ?? .meeting
         let followUpToID: Int64? = sqlite3_column_type(statement, 19) == SQLITE_NULL ? nil : sqlite3_column_int64(statement, 19)
         let followUpToRecordName = optionalStringColumn(statement, index: 20)
+        let calendarSource = optionalStringColumn(statement, index: 22)
+            .flatMap(CalendarOccurrenceReference.Provider.init(rawValue:))
+        let calendarOccurrenceStart: Date? = sqlite3_column_type(statement, 25) == SQLITE_NULL
+            ? nil
+            : Date(timeIntervalSince1970: sqlite3_column_double(statement, 25))
+        let calendarOccurrence: CalendarOccurrenceReference?
+        if let calendarSource, let calendarEventID, let calendarOccurrenceStart {
+            calendarOccurrence = CalendarOccurrenceReference(
+                provider: calendarSource,
+                calendarID: optionalStringColumn(statement, index: 23),
+                eventID: calendarEventID,
+                seriesID: optionalStringColumn(statement, index: 24),
+                originalStartTime: calendarOccurrenceStart
+            )
+        } else {
+            calendarOccurrence = nil
+        }
         return MeetingRecord(
             id: sqlite3_column_int64(statement, 0),
             title: stringColumn(statement, index: 1),
@@ -3588,6 +3684,7 @@ public final class DictationStore {
             wordCount: Int(sqlite3_column_int(statement, 6)),
             folderID: folderID,
             calendarEventID: calendarEventID,
+            calendarOccurrence: calendarOccurrence,
             micAudioPath: micAudioPath,
             systemAudioPath: systemAudioPath,
             savedRecordingPath: savedRecordingPath,

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -736,6 +736,9 @@ public final class DictationStore {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
+        let legacyStartPredicate = occurrence.seriesID == nil
+            ? ""
+            : "AND ABS(strftime('%s', start_time) - ?) < 1"
         let sql = """
         SELECT \(Self.meetingColumns)
         FROM meetings
@@ -745,7 +748,7 @@ public final class DictationStore {
             OR (
               calendar_occurrence_key IS NULL
               AND calendar_event_id = ?
-              AND ABS(strftime('%s', start_time) - ?) < 1
+              \(legacyStartPredicate)
             )
           )
         ORDER BY id DESC
@@ -758,7 +761,9 @@ public final class DictationStore {
         defer { sqlite3_finalize(statement) }
         sqlite3_bind_text(statement, 1, (occurrence.identityKey as NSString).utf8String, -1, nil)
         sqlite3_bind_text(statement, 2, (occurrence.eventID as NSString).utf8String, -1, nil)
-        sqlite3_bind_double(statement, 3, occurrence.originalStartTime.timeIntervalSince1970)
+        if occurrence.seriesID != nil {
+            sqlite3_bind_double(statement, 3, occurrence.originalStartTime.timeIntervalSince1970)
+        }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {
             return nil

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -218,6 +218,49 @@ public struct ComputerUseTraceEvent: Identifiable, Codable, Equatable, Sendable 
     }
 }
 
+public struct CalendarOccurrenceReference: Codable, Equatable, Sendable {
+    public enum Provider: String, Codable, Sendable {
+        case eventKit
+        case googleCalendar
+    }
+
+    public let provider: Provider
+    public let calendarID: String?
+    public let eventID: String
+    public let seriesID: String?
+    public let originalStartTime: Date
+
+    public init(
+        provider: Provider,
+        calendarID: String?,
+        eventID: String,
+        seriesID: String? = nil,
+        originalStartTime: Date
+    ) {
+        self.provider = provider
+        self.calendarID = calendarID
+        self.eventID = eventID
+        self.seriesID = seriesID
+        self.originalStartTime = originalStartTime
+    }
+
+    /// Stable identity for one provider occurrence. Recurring instances use
+    /// the series plus their immutable original start; one-off events use the
+    /// provider event id so rescheduling does not create a new occurrence.
+    public var identityKey: String {
+        let calendarComponent = Self.component(calendarID ?? "")
+        if let seriesID {
+            let originalStartMilliseconds = Int64((originalStartTime.timeIntervalSince1970 * 1_000).rounded())
+            return "v1|recurring|\(provider.rawValue)|\(calendarComponent)|\(Self.component(seriesID))|\(originalStartMilliseconds)"
+        }
+        return "v1|single|\(provider.rawValue)|\(calendarComponent)|\(Self.component(eventID))"
+    }
+
+    private static func component(_ value: String) -> String {
+        Data(value.utf8).base64EncodedString()
+    }
+}
+
 public struct MeetingRecord: Identifiable, Codable, Sendable {
     public let id: Int64
     public let title: String
@@ -228,6 +271,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
     public let wordCount: Int
     public let folderID: Int64?
     public let calendarEventID: String?
+    public let calendarOccurrence: CalendarOccurrenceReference?
     public let micAudioPath: String?
     public let systemAudioPath: String?
     public let savedRecordingPath: String?
@@ -255,6 +299,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         wordCount: Int,
         folderID: Int64?,
         calendarEventID: String? = nil,
+        calendarOccurrence: CalendarOccurrenceReference? = nil,
         micAudioPath: String? = nil,
         systemAudioPath: String? = nil,
         savedRecordingPath: String? = nil,
@@ -277,6 +322,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         self.wordCount = wordCount
         self.folderID = folderID
         self.calendarEventID = calendarEventID
+        self.calendarOccurrence = calendarOccurrence
         self.micAudioPath = micAudioPath
         self.systemAudioPath = systemAudioPath
         self.savedRecordingPath = savedRecordingPath
@@ -301,6 +347,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
         case wordCount
         case folderID
         case calendarEventID
+        case calendarOccurrence
         case micAudioPath
         case systemAudioPath
         case savedRecordingPath
@@ -327,6 +374,7 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
             wordCount: try c.decode(Int.self, forKey: .wordCount),
             folderID: try c.decodeIfPresent(Int64.self, forKey: .folderID),
             calendarEventID: try c.decodeIfPresent(String.self, forKey: .calendarEventID),
+            calendarOccurrence: try c.decodeIfPresent(CalendarOccurrenceReference.self, forKey: .calendarOccurrence),
             micAudioPath: try c.decodeIfPresent(String.self, forKey: .micAudioPath),
             systemAudioPath: try c.decodeIfPresent(String.self, forKey: .systemAudioPath),
             savedRecordingPath: try c.decodeIfPresent(String.self, forKey: .savedRecordingPath),

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -7,6 +7,7 @@ struct UpcomingMeetingEvent {
     let id: String
     let title: String
     let startDate: Date
+    var calendarOccurrence: CalendarOccurrenceReference? = nil
     var meetingURL: URL? = nil
 }
 
@@ -111,10 +112,16 @@ final class CalendarMonitor {
             guard !event.isAllDay else { continue }
             guard let startDate = event.startDate, let endDate = event.endDate else { continue }
             if startDate <= now && endDate > now {
+                let eventID = event.eventIdentifier ?? ""
                 return UpcomingMeetingEvent(
-                    id: event.eventIdentifier ?? "",
+                    id: eventID,
                     title: event.title ?? "Meeting",
                     startDate: startDate,
+                    calendarOccurrence: Self.occurrenceReference(
+                        for: event,
+                        eventID: eventID,
+                        startDate: startDate
+                    ),
                     meetingURL: Self.extractMeetingURL(from: event)
                 )
             }
@@ -170,14 +177,20 @@ final class CalendarMonitor {
         let unified: [UnifiedCalendarEvent] = events.compactMap { event in
             guard let startDate = event.startDate, let endDate = event.endDate else { return nil }
             guard !event.isAllDay else { return nil }
+            let eventID = event.eventIdentifier ?? UUID().uuidString
             return UnifiedCalendarEvent(
-                id: event.eventIdentifier ?? UUID().uuidString,
+                id: eventID,
                 title: event.title ?? "Meeting",
                 startDate: startDate,
                 endDate: endDate,
                 isAllDay: false,
                 source: .eventKit,
                 calendarID: event.calendar?.calendarIdentifier,
+                calendarOccurrence: Self.occurrenceReference(
+                    for: event,
+                    eventID: eventID,
+                    startDate: startDate
+                ),
                 meetingURL: Self.extractMeetingURL(from: event)
             )
         }
@@ -185,6 +198,21 @@ final class CalendarMonitor {
             .filter(unified, disabledCalendarIDs: disabledCalendarIDs)
             .filter { $0.endDate > now && $0.startDate < future }
             .sorted { $0.startDate < $1.startDate }
+    }
+
+    private static func occurrenceReference(
+        for event: EKEvent,
+        eventID: String,
+        startDate: Date
+    ) -> CalendarOccurrenceReference {
+        let originalOccurrenceDate = event.occurrenceDate
+        return CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: event.calendar?.calendarIdentifier,
+            eventID: eventID,
+            seriesID: originalOccurrenceDate == nil ? nil : eventID,
+            originalStartTime: originalOccurrenceDate ?? startDate
+        )
     }
 
     /// Enumerate every event calendar EventKit exposes — iCloud, On-My-Mac,

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -200,18 +200,22 @@ final class CalendarMonitor {
             .sorted { $0.startDate < $1.startDate }
     }
 
-    private static func occurrenceReference(
+    static func occurrenceReference(
         for event: EKEvent,
         eventID: String,
         startDate: Date
     ) -> CalendarOccurrenceReference {
-        let originalOccurrenceDate = event.occurrenceDate
+        let isRecurring = event.hasRecurrenceRules || event.isDetached
         return CalendarOccurrenceReference(
             provider: .eventKit,
             calendarID: event.calendar?.calendarIdentifier,
             eventID: eventID,
-            seriesID: originalOccurrenceDate == nil ? nil : eventID,
-            originalStartTime: originalOccurrenceDate ?? startDate
+            seriesID: isRecurring
+                ? (event.calendarItemExternalIdentifier ?? eventID)
+                : nil,
+            originalStartTime: isRecurring
+                ? (event.occurrenceDate ?? startDate)
+                : startDate
         )
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MuesliCore
 
 // MARK: - Shared Calendar Event Model
 
@@ -13,11 +14,30 @@ struct UnifiedCalendarEvent: Identifiable, Equatable {
     /// EventKit: `EKCalendar.calendarIdentifier`. Google: the calendar list `id`.
     /// Optional because legacy events deserialized from older state may not have it.
     var calendarID: String? = nil
+    var calendarOccurrence: CalendarOccurrenceReference? = nil
     var meetingURL: URL? = nil
 
     enum CalendarSource: String {
         case eventKit
         case googleCalendar
+
+        var occurrenceProvider: CalendarOccurrenceReference.Provider {
+            switch self {
+            case .eventKit:
+                return .eventKit
+            case .googleCalendar:
+                return .googleCalendar
+            }
+        }
+    }
+
+    var resolvedCalendarOccurrence: CalendarOccurrenceReference {
+        calendarOccurrence ?? CalendarOccurrenceReference(
+            provider: source.occurrenceProvider,
+            calendarID: calendarID,
+            eventID: id,
+            originalStartTime: startDate
+        )
     }
 
     /// Drop events whose `calendarID` is in `disabledCalendarIDs`. Events with `nil`
@@ -502,6 +522,28 @@ final class GoogleCalendarClient {
             }
             return nil
         }()
+        let recurringEventID = item["recurringEventId"] as? String
+        let originalStartTime: Date = {
+            guard let originalStart = item["originalStartTime"] as? [String: Any] else {
+                return startDate
+            }
+            if let value = originalStart["dateTime"] as? String,
+               let date = isoFormatter.date(from: value) {
+                return date
+            }
+            if let value = originalStart["date"] as? String,
+               let date = dateOnlyFormatter.date(from: value) {
+                return date
+            }
+            return startDate
+        }()
+        let occurrence = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: calendarID,
+            eventID: id,
+            seriesID: recurringEventID,
+            originalStartTime: originalStartTime
+        )
 
         return UnifiedCalendarEvent(
             id: id,
@@ -511,6 +553,7 @@ final class GoogleCalendarClient {
             isAllDay: isAllDay,
             source: .googleCalendar,
             calendarID: calendarID,
+            calendarOccurrence: occurrence,
             meetingURL: meetingURL
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2709,7 +2709,7 @@ final class MuesliController: NSObject {
 
                 startMeetingRecording(
                     title: event.title,
-                    calendarEventID: event.id,
+                    calendarOccurrence: event.resolvedCalendarOccurrence,
                     openDocument: true,
                     endDate: event.endDate,
                     autoStopSource: event.meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) },
@@ -2737,6 +2737,7 @@ final class MuesliController: NSObject {
                 id: event.id,
                 title: event.title,
                 startDate: event.startDate,
+                calendarOccurrence: event.resolvedCalendarOccurrence,
                 meetingURL: event.meetingURL
             )
 
@@ -2762,7 +2763,7 @@ final class MuesliController: NSObject {
                               ) else { return }
                         self.showMeetingStartingNowNotification(
                             title: event.title,
-                            calendarEventID: key,
+                            calendarOccurrence: event.resolvedCalendarOccurrence,
                             meetingURL: event.meetingURL,
                             endDate: event.endDate
                         )
@@ -2775,7 +2776,12 @@ final class MuesliController: NSObject {
     }
 
     /// Show a "Meeting starting now" notification — independent of Marauder's Map.
-    private func showMeetingStartingNowNotification(title: String, calendarEventID: String?, meetingURL: URL?, endDate: Date?) {
+    private func showMeetingStartingNowNotification(
+        title: String,
+        calendarOccurrence: CalendarOccurrenceReference?,
+        meetingURL: URL?,
+        endDate: Date?
+    ) {
         guard ScheduledMeetingNotificationPolicy.shouldShowStartingNowPrompt(meetingURL: meetingURL),
               config.showScheduledMeetingNotifications,
               !isMeetingRecording(),
@@ -2793,7 +2799,7 @@ final class MuesliController: NSObject {
                 self.isShowingCalendarNotification = false
                 self.startForegroundMeetingRecording(
                     title: title,
-                    calendarEventID: calendarEventID,
+                    calendarOccurrence: calendarOccurrence,
                     endDate: endDate,
                     autoStopSource: autoStopSource,
                     startOrigin: .scheduledMeetingPrompt
@@ -2802,7 +2808,12 @@ final class MuesliController: NSObject {
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.joinAndRecord(title: title, meetingURL: meetingURL!, endDate: endDate, calendarEventID: calendarEventID)
+                self.joinAndRecord(
+                    title: title,
+                    meetingURL: meetingURL!,
+                    endDate: endDate,
+                    calendarOccurrence: calendarOccurrence
+                )
             } : nil,
             onJoinOnly: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
@@ -4313,8 +4324,10 @@ final class MuesliController: NSObject {
     }
 
     func createMeetingFromCalendarEvent(_ event: UnifiedCalendarEvent, folderID: Int64?) {
-        // Check ALL folders for existing meeting with this calendar event ID
-        if let existing = try? dictationStore.meetingByCalendarEventID(event.id) {
+        let occurrence = event.resolvedCalendarOccurrence
+        // Calendar placeholders are idempotent per occurrence. Recordings are
+        // intentionally not: users may record the same occurrence more than once.
+        if let existing = try? dictationStore.meetingByCalendarOccurrence(occurrence) {
             if let folderID {
                 try? dictationStore.moveMeeting(id: existing.id, toFolder: folderID)
             }
@@ -4332,7 +4345,8 @@ final class MuesliController: NSObject {
                 rawTranscript: "",
                 formattedNotes: "",
                 micAudioPath: nil,
-                systemAudioPath: nil
+                systemAudioPath: nil,
+                calendarOccurrence: occurrence
             )
             if let folderID {
                 try? dictationStore.moveMeeting(id: meetingID, toFolder: folderID)
@@ -4637,7 +4651,7 @@ final class MuesliController: NSObject {
         if let payload = sender.representedObject as? CalendarMenuMeetingPayload {
             startForegroundMeetingRecording(
                 title: payload.title,
-                calendarEventID: payload.calendarEventID,
+                calendarOccurrence: payload.calendarOccurrence,
                 endDate: payload.endDate,
                 autoStopSource: payload.autoStopSource,
                 startOrigin: .scheduledMeetingPrompt
@@ -4653,6 +4667,7 @@ final class MuesliController: NSObject {
     func startForegroundMeetingRecording(
         title: String = "Meeting",
         calendarEventID: String? = nil,
+        calendarOccurrence: CalendarOccurrenceReference? = nil,
         endDate: Date? = nil,
         autoStopSource: MeetingAutoStopSource? = nil,
         startOrigin: MeetingRecordingStartOrigin = .manual
@@ -4666,6 +4681,7 @@ final class MuesliController: NSObject {
         let didStart = startMeetingRecording(
             title: title,
             calendarEventID: calendarEventID,
+            calendarOccurrence: calendarOccurrence,
             openDocument: true,
             endDate: endDate,
             autoStopSource: autoStopSource,
@@ -4680,6 +4696,7 @@ final class MuesliController: NSObject {
     func startMeetingRecording(
         title: String = "Meeting",
         calendarEventID: String? = nil,
+        calendarOccurrence: CalendarOccurrenceReference? = nil,
         openDocument: Bool = false,
         endDate: Date? = nil,
         autoStopSource: MeetingAutoStopSource? = nil,
@@ -4697,18 +4714,20 @@ final class MuesliController: NSObject {
             return false
         }
         let templateSnapshot = defaultMeetingTemplate()
+        let resolvedCalendarEventID = calendarOccurrence?.eventID ?? calendarEventID
         let meetingID: Int64
         do {
             meetingID = try dictationStore.createLiveMeeting(
                 title: title,
-                calendarEventID: calendarEventID,
+                calendarEventID: resolvedCalendarEventID,
                 startTime: Date(),
                 selectedTemplateID: templateSnapshot.id,
                 selectedTemplateName: templateSnapshot.name,
                 selectedTemplateKind: templateSnapshot.kind,
                 selectedTemplatePrompt: templateSnapshot.prompt,
                 folderID: inheritedFolderID,
-                followUpToID: followUpToID
+                followUpToID: followUpToID,
+                calendarOccurrence: calendarOccurrence
             )
             activeMeetingID = meetingID
             activeMeetingAudioWarning = nil
@@ -4753,7 +4772,7 @@ final class MuesliController: NSObject {
                 try Task.checkCancellation()
                 try await self.startMeetingRecordingWithSystemAudioRecovery(
                     title: title,
-                    calendarEventID: calendarEventID,
+                    calendarEventID: resolvedCalendarEventID,
                     meetingID: meetingID,
                     backend: meetingBackend,
                     templateSnapshot: templateSnapshot,
@@ -5388,11 +5407,16 @@ final class MuesliController: NSObject {
 
     /// Open meeting URL, start recording, schedule end notification, and suppress detection.
     /// Single entry point for "Join & Record" from both notification panel and Coming Up section.
-    func joinAndRecord(title: String, meetingURL: URL, endDate: Date?, calendarEventID: String? = nil) {
+    func joinAndRecord(
+        title: String,
+        meetingURL: URL,
+        endDate: Date?,
+        calendarOccurrence: CalendarOccurrenceReference? = nil
+    ) {
         NSWorkspace.shared.open(meetingURL)
         startForegroundMeetingRecording(
             title: title,
-            calendarEventID: calendarEventID,
+            calendarOccurrence: calendarOccurrence,
             endDate: endDate,
             autoStopSource: MeetingAutoStopSource(meetingURL: meetingURL),
             startOrigin: .joinAndRecord
@@ -8218,7 +8242,7 @@ final class MuesliController: NSObject {
                 // Reuse the same notification method as the timer path
                 self.showMeetingStartingNowNotification(
                     title: event.title,
-                    calendarEventID: event.id,
+                    calendarOccurrence: event.resolvedCalendarOccurrence,
                     meetingURL: event.meetingURL,
                     endDate: event.endDate
                 )
@@ -8243,9 +8267,10 @@ final class MuesliController: NSObject {
     private func handleUpcomingMeeting(_ event: UpcomingMeetingEvent) {
         // Look up end date and meeting URL from unified calendar events
         let calendarEvent = appState.upcomingCalendarEvents
-            .first(where: { $0.id == event.id })
+            .first(where: { $0.id == event.id && $0.startDate == event.startDate })
         let calendarEndDate = calendarEvent?.endDate
         let meetingURL = event.meetingURL ?? calendarEvent?.meetingURL
+        let calendarOccurrence = event.calendarOccurrence ?? calendarEvent?.resolvedCalendarOccurrence
         let autoStopSource = meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
 
         // Show notification panel for calendar events (if not auto-recording)
@@ -8277,7 +8302,7 @@ final class MuesliController: NSObject {
                 self.isShowingCalendarNotification = false
                 self.startForegroundMeetingRecording(
                     title: title,
-                    calendarEventID: event.id,
+                    calendarOccurrence: calendarOccurrence,
                     endDate: calendarEndDate,
                     autoStopSource: autoStopSource,
                     startOrigin: .scheduledMeetingPrompt
@@ -8286,7 +8311,12 @@ final class MuesliController: NSObject {
             onJoinAndRecord: meetingURL != nil ? { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.joinAndRecord(title: title, meetingURL: meetingURL!, endDate: calendarEndDate, calendarEventID: event.id)
+                self.joinAndRecord(
+                    title: title,
+                    meetingURL: meetingURL!,
+                    endDate: calendarEndDate,
+                    calendarOccurrence: calendarOccurrence
+                )
             } : nil,
             onJoinOnly: meetingURL != nil ? { [weak self] in
                 guard let self else { return }

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -4,13 +4,13 @@ import MuesliCore
 
 final class CalendarMenuMeetingPayload: NSObject {
     let title: String
-    let calendarEventID: String
+    let calendarOccurrence: CalendarOccurrenceReference
     let endDate: Date
     let autoStopSource: MeetingAutoStopSource?
 
     init(event: UnifiedCalendarEvent) {
         self.title = event.title
-        self.calendarEventID = event.id
+        self.calendarOccurrence = event.resolvedCalendarOccurrence
         self.endDate = event.endDate
         self.autoStopSource = event.meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) }
     }

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -276,6 +276,42 @@ struct DictationStoreTests {
         #expect(matched.title == "Legacy placeholder")
         #expect(matched.calendarEventID == occurrence.eventID)
         #expect(matched.calendarOccurrence == nil)
+
+        let differentRecurrence = CalendarOccurrenceReference(
+            provider: occurrence.provider,
+            calendarID: occurrence.calendarID,
+            eventID: occurrence.eventID,
+            seriesID: occurrence.seriesID,
+            originalStartTime: originalStart.addingTimeInterval(24 * 60 * 60)
+        )
+        #expect(try store.meetingByCalendarOccurrence(differentRecurrence) == nil)
+    }
+
+    @Test("calendar occurrence lookup finds a rescheduled legacy one-off event")
+    func calendarOccurrenceLookupFindsRescheduledLegacyOneOffEvent() throws {
+        let store = try makeStore()
+        let originalStart = Date(timeIntervalSince1970: 1_775_817_600)
+        try store.insertMeeting(
+            title: "Legacy one-off placeholder",
+            calendarEventID: "legacy-one-off",
+            startTime: originalStart,
+            endTime: originalStart.addingTimeInterval(30 * 60),
+            rawTranscript: "",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        let rescheduledOccurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "work",
+            eventID: "legacy-one-off",
+            originalStartTime: originalStart.addingTimeInterval(24 * 60 * 60)
+        )
+
+        let matched = try #require(try store.meetingByCalendarOccurrence(rescheduledOccurrence))
+        #expect(matched.title == "Legacy one-off placeholder")
+        #expect(matched.calendarEventID == rescheduledOccurrence.eventID)
+        #expect(matched.calendarOccurrence == nil)
     }
 
     @Test("MeetingRecord decodes legacy JSON without a calendar occurrence")

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -136,6 +136,120 @@ struct DictationStoreTests {
         try store.migrateIfNeeded() // idempotent
     }
 
+    @Test("migration replaces calendar event uniqueness with occurrence lookup")
+    func migrationReplacesCalendarEventUniqueness() throws {
+        let store = try makeLegacyStore()
+        var db: OpaquePointer?
+        #expect(sqlite3_open(store.databasePath().path, &db) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            db,
+            "CREATE UNIQUE INDEX idx_meetings_calendar_event_id ON meetings(calendar_event_id) WHERE calendar_event_id IS NOT NULL",
+            nil,
+            nil,
+            nil
+        ) == SQLITE_OK)
+        sqlite3_close(db)
+
+        try store.migrateIfNeeded()
+
+        let originalStart = Date(timeIntervalSince1970: 1_775_817_600)
+        let occurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "calendar",
+            eventID: "reused-event-id",
+            seriesID: "reused-event-id",
+            originalStartTime: originalStart
+        )
+        let firstID = try store.createLiveMeeting(
+            title: "First recording",
+            calendarEventID: occurrence.eventID,
+            startTime: originalStart,
+            calendarOccurrence: occurrence
+        )
+        let secondID = try store.createLiveMeeting(
+            title: "Second recording",
+            calendarEventID: occurrence.eventID,
+            startTime: originalStart.addingTimeInterval(5),
+            calendarOccurrence: occurrence
+        )
+        let sameDayOccurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "calendar",
+            eventID: "reused-event-id",
+            seriesID: "reused-event-id",
+            originalStartTime: originalStart.addingTimeInterval(60 * 60)
+        )
+        let sameDayID = try store.createLiveMeeting(
+            title: "Later occurrence",
+            calendarEventID: sameDayOccurrence.eventID,
+            startTime: originalStart.addingTimeInterval(60 * 60),
+            calendarOccurrence: sameDayOccurrence
+        )
+        let nextDayOccurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "calendar",
+            eventID: "reused-event-id",
+            seriesID: "reused-event-id",
+            originalStartTime: originalStart.addingTimeInterval(24 * 60 * 60)
+        )
+        let nextDayID = try store.createLiveMeeting(
+            title: "Next recurrence",
+            calendarEventID: nextDayOccurrence.eventID,
+            startTime: originalStart.addingTimeInterval(24 * 60 * 60),
+            calendarOccurrence: nextDayOccurrence
+        )
+
+        #expect(firstID != secondID)
+        #expect(Set([firstID, secondID, sameDayID, nextDayID]).count == 4)
+        #expect(try store.recentMeetings(limit: 10).count == 4)
+        #expect(try store.meeting(id: firstID)?.calendarOccurrence == occurrence)
+        #expect(try store.meetingByCalendarOccurrence(occurrence)?.id == secondID)
+        #expect(try store.meetingByCalendarOccurrence(sameDayOccurrence)?.id == sameDayID)
+        #expect(try store.meetingByCalendarOccurrence(nextDayOccurrence)?.id == nextDayID)
+    }
+
+    @Test("calendar occurrence identity distinguishes recurrences and survives moves")
+    func calendarOccurrenceIdentitySemantics() {
+        let originalStart = Date(timeIntervalSince1970: 1_775_817_600)
+        let movedOccurrence = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: "primary",
+            eventID: "instance-after-move",
+            seriesID: "daily-series",
+            originalStartTime: originalStart
+        )
+        let sameOccurrenceBeforeMove = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: "primary",
+            eventID: "instance-before-move",
+            seriesID: "daily-series",
+            originalStartTime: originalStart
+        )
+        let nextOccurrence = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: "primary",
+            eventID: "next-instance",
+            seriesID: "daily-series",
+            originalStartTime: originalStart.addingTimeInterval(24 * 60 * 60)
+        )
+        let movedSingleEvent = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: "primary",
+            eventID: "single-event",
+            originalStartTime: originalStart.addingTimeInterval(60 * 60)
+        )
+        let originalSingleEvent = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: "primary",
+            eventID: "single-event",
+            originalStartTime: originalStart
+        )
+
+        #expect(movedOccurrence.identityKey == sameOccurrenceBeforeMove.identityKey)
+        #expect(movedOccurrence.identityKey != nextOccurrence.identityKey)
+        #expect(movedSingleEvent.identityKey == originalSingleEvent.identityKey)
+    }
+
     @Test("migration adds template columns to legacy meeting schema")
     func migrationAddsTemplateColumns() throws {
         let store = try makeLegacyStore()

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -250,6 +250,86 @@ struct DictationStoreTests {
         #expect(movedSingleEvent.identityKey == originalSingleEvent.identityKey)
     }
 
+    @Test("calendar occurrence lookup finds a legacy placeholder")
+    func calendarOccurrenceLookupFindsLegacyPlaceholder() throws {
+        let store = try makeStore()
+        let originalStart = Date(timeIntervalSince1970: 1_775_817_600)
+        let occurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "work",
+            eventID: "legacy-event",
+            seriesID: "legacy-series",
+            originalStartTime: originalStart
+        )
+        try store.insertMeeting(
+            title: "Legacy placeholder",
+            calendarEventID: occurrence.eventID,
+            startTime: originalStart,
+            endTime: originalStart.addingTimeInterval(30 * 60),
+            rawTranscript: "",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+
+        let matched = try #require(try store.meetingByCalendarOccurrence(occurrence))
+        #expect(matched.title == "Legacy placeholder")
+        #expect(matched.calendarEventID == occurrence.eventID)
+        #expect(matched.calendarOccurrence == nil)
+    }
+
+    @Test("MeetingRecord decodes legacy JSON without a calendar occurrence")
+    func meetingRecordDecodesWithoutCalendarOccurrence() throws {
+        let json = """
+        {
+          "id": 42,
+          "title": "Legacy meeting",
+          "startTime": "2026-04-10T14:00:00Z",
+          "durationSeconds": 1800,
+          "rawTranscript": "",
+          "formattedNotes": "",
+          "wordCount": 0
+        }
+        """
+
+        let record = try JSONDecoder().decode(
+            MeetingRecord.self,
+            from: try #require(json.data(using: .utf8))
+        )
+
+        #expect(record.calendarOccurrence == nil)
+    }
+
+    @Test("MeetingRecord preserves a calendar occurrence through Codable")
+    func meetingRecordCalendarOccurrenceCodableRoundTrip() throws {
+        let occurrence = CalendarOccurrenceReference(
+            provider: .googleCalendar,
+            calendarID: "primary",
+            eventID: "instance",
+            seriesID: "series",
+            originalStartTime: Date(timeIntervalSince1970: 1_775_817_600)
+        )
+        let original = MeetingRecord(
+            id: 42,
+            title: "Daily sync",
+            startTime: "2026-04-10T14:00:00Z",
+            durationSeconds: 1800,
+            rawTranscript: "",
+            formattedNotes: "",
+            wordCount: 0,
+            folderID: nil,
+            calendarEventID: occurrence.eventID,
+            calendarOccurrence: occurrence
+        )
+
+        let decoded = try JSONDecoder().decode(
+            MeetingRecord.self,
+            from: JSONEncoder().encode(original)
+        )
+
+        #expect(decoded.calendarOccurrence == occurrence)
+    }
+
     @Test("migration adds template columns to legacy meeting schema")
     func migrationAddsTemplateColumns() throws {
         let store = try makeLegacyStore()

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import MuesliCore
 @testable import MuesliNativeApp
 
 @Suite("Google Calendar integration")
@@ -309,6 +310,94 @@ struct GoogleCalendarTests {
         ]
         let event = GoogleCalendarClient().parseEvent(item, calendarID: "team@dockstreet.com")
         #expect(event?.calendarID == "team@dockstreet.com")
+    }
+
+    @Test("parsed recurring event keeps its immutable occurrence identity")
+    func parsedRecurringEventCarriesOriginalStartTime() throws {
+        let item: [String: Any] = [
+            "id": "series_20260410T140000Z",
+            "recurringEventId": "series",
+            "summary": "Daily sync",
+            "originalStartTime": ["dateTime": "2026-04-10T14:00:00Z"],
+            "start": ["dateTime": "2026-04-10T15:30:00Z"],
+            "end": ["dateTime": "2026-04-10T16:00:00Z"],
+        ]
+
+        let event = try #require(
+            GoogleCalendarClient().parseEvent(item, calendarID: "team@dockstreet.com")
+        )
+        let occurrence = try #require(event.calendarOccurrence)
+
+        #expect(occurrence.provider == .googleCalendar)
+        #expect(occurrence.calendarID == "team@dockstreet.com")
+        #expect(occurrence.eventID == "series_20260410T140000Z")
+        #expect(occurrence.seriesID == "series")
+        #expect(occurrence.originalStartTime == date("2026-04-10T14:00:00Z"))
+        #expect(event.startDate == date("2026-04-10T15:30:00Z"))
+    }
+
+    @Test("calendar placeholders deduplicate one occurrence but allow the next recurrence")
+    func calendarPlaceholderOccurrenceDeduplication() throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-calendar-occurrence-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: databaseURL)
+        try store.migrateIfNeeded()
+        let controller = MuesliController(
+            runtime: RuntimePaths(
+                repoRoot: FileManager.default.temporaryDirectory,
+                menuIcon: nil,
+                appIcon: nil,
+                bundlePath: nil
+            ),
+            dictationStore: store
+        )
+        let firstStart = date("2026-04-10T14:00:00Z")
+        let firstOccurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "work",
+            eventID: "shared-series-id",
+            seriesID: "shared-series-id",
+            originalStartTime: firstStart
+        )
+        let firstEvent = UnifiedCalendarEvent(
+            id: "shared-series-id",
+            title: "Daily sync",
+            startDate: firstStart,
+            endDate: firstStart.addingTimeInterval(30 * 60),
+            isAllDay: false,
+            source: .eventKit,
+            calendarID: "work",
+            calendarOccurrence: firstOccurrence
+        )
+        controller.createMeetingFromCalendarEvent(firstEvent, folderID: nil)
+        controller.createMeetingFromCalendarEvent(firstEvent, folderID: nil)
+
+        let nextStart = firstStart.addingTimeInterval(24 * 60 * 60)
+        let nextOccurrence = CalendarOccurrenceReference(
+            provider: .eventKit,
+            calendarID: "work",
+            eventID: "shared-series-id",
+            seriesID: "shared-series-id",
+            originalStartTime: nextStart
+        )
+        let nextEvent = UnifiedCalendarEvent(
+            id: "shared-series-id",
+            title: "Daily sync",
+            startDate: nextStart,
+            endDate: nextStart.addingTimeInterval(30 * 60),
+            isAllDay: false,
+            source: .eventKit,
+            calendarID: "work",
+            calendarOccurrence: nextOccurrence
+        )
+        controller.createMeetingFromCalendarEvent(nextEvent, folderID: nil)
+
+        let meetings = try store.recentMeetings(limit: 10)
+        #expect(meetings.count == 2)
+        #expect(Set(meetings.compactMap(\.calendarOccurrence?.identityKey)) == Set([
+            firstOccurrence.identityKey,
+            nextOccurrence.identityKey,
+        ]))
     }
 
     @Test("event sync cache resets when upcoming window changes")

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import EventKit
 import Foundation
 import MuesliCore
 @testable import MuesliNativeApp
@@ -166,6 +167,59 @@ struct GoogleCalendarTests {
     func returnsNilForNonMeetingText() {
         let url = CalendarMonitor.findMeetingURL(in: "Conference room 3B on the second floor")
         #expect(url == nil)
+    }
+
+    // MARK: - EventKit occurrence identity
+
+    @Test("EventKit one-off event identity survives rescheduling")
+    func eventKitOneOffIdentitySurvivesRescheduling() {
+        let eventStore = EKEventStore()
+        let event = EKEvent(eventStore: eventStore)
+        let originalStart = date("2026-04-10T14:00:00Z")
+        event.startDate = originalStart
+        event.endDate = originalStart.addingTimeInterval(30 * 60)
+
+        let originalReference = CalendarMonitor.occurrenceReference(
+            for: event,
+            eventID: "one-off-event",
+            startDate: originalStart
+        )
+
+        let movedStart = originalStart.addingTimeInterval(90 * 60)
+        event.startDate = movedStart
+        event.endDate = movedStart.addingTimeInterval(30 * 60)
+        let movedReference = CalendarMonitor.occurrenceReference(
+            for: event,
+            eventID: "one-off-event",
+            startDate: movedStart
+        )
+
+        #expect(originalReference.seriesID == nil)
+        #expect(movedReference.seriesID == nil)
+        #expect(originalReference.identityKey == movedReference.identityKey)
+    }
+
+    @Test("EventKit recurrence uses the server-stable series identifier")
+    func eventKitRecurrenceUsesExternalSeriesIdentifier() throws {
+        let eventStore = EKEventStore()
+        let event = EKEvent(eventStore: eventStore)
+        let start = date("2026-04-10T14:00:00Z")
+        event.startDate = start
+        event.endDate = start.addingTimeInterval(30 * 60)
+        event.addRecurrenceRule(
+            EKRecurrenceRule(recurrenceWith: .daily, interval: 1, end: nil)
+        )
+
+        let externalIdentifier = try #require(event.calendarItemExternalIdentifier)
+        let reference = CalendarMonitor.occurrenceReference(
+            for: event,
+            eventID: "store-local-event-id",
+            startDate: start
+        )
+
+        #expect(reference.seriesID == externalIdentifier)
+        #expect(reference.seriesID != reference.eventID)
+        #expect(reference.originalStartTime == event.occurrenceDate)
     }
 
     // MARK: - Merge & dedup

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -75,8 +75,8 @@ struct MeetingHookIntegrationTests {
         #expect(try store.meeting(id: persistence.meetingID) != nil)
     }
 
-    @Test("no hook runs when meeting persistence fails")
-    func noHookRunsWhenPersistenceFails() throws {
+    @Test("duplicate calendar metadata does not block persistence or hooks")
+    func duplicateCalendarMetadataDoesNotBlockPersistence() throws {
         let store = try makeStore()
         let spy = MeetingHookDispatcherSpy()
         let controller = makeController(store: store, dispatcher: spy)
@@ -92,13 +92,14 @@ struct MeetingHookIntegrationTests {
             systemAudioPath: nil
         )
 
-        #expect(throws: Error.self) {
-            try controller.persistCompletedMeetingResultAndDispatchHook(
-                makeMeetingResult(calendarEventID: "duplicate-event"),
-                preparedRecordingSave: .none
-            )
-        }
-        #expect(spy.invocations.isEmpty)
+        let persistence = try controller.persistCompletedMeetingResultAndDispatchHook(
+            makeMeetingResult(calendarEventID: "duplicate-event"),
+            preparedRecordingSave: .none
+        )
+
+        #expect(try store.meeting(id: persistence.meetingID) != nil)
+        #expect(try store.recentMeetings(limit: 10).count == 2)
+        #expect(spy.invocations.count == 1)
     }
 
     private func makeController(store: DictationStore, dispatcher: MeetingHookDispatching) -> MuesliController {


### PR DESCRIPTION
## Summary

- model calendar occurrences explicitly for EventKit and Google Calendar
- remove the global uniqueness constraint from `meetings.calendar_event_id`
- keep calendar-created placeholders idempotent through exact occurrence lookup
- carry occurrence identity through automatic recording, notifications, status-bar actions, and Join & Record

## Root cause

Meeting creation treated a provider calendar event ID as the unique identity of a Muesli meeting. Calendar providers can reuse identifiers across recurring occurrences, and users can also legitimately record one occurrence more than once. The resulting SQLite uniqueness violation happened in `createLiveMeeting`, before audio startup, and surfaced as “Meeting failed to start.”

## Fix

Recurring occurrences now use provider, calendar, series ID, and the provider’s immutable original start time. One-off events use provider, calendar, and event ID so rescheduling does not create a new identity.

The database migration preserves existing rows and calendar IDs, drops only the legacy unique index, adds occurrence metadata, and creates non-unique lookup indexes. Recording rows are never rejected because calendar metadata repeats. Explicit occurrence lookup still prevents duplicate calendar placeholders.

This also fixes the delayed “starting now” path, which previously persisted its notification dedup key as the calendar event ID.

## Validation

- Full Swift suite: 1,449 tests across 140 suites
- Legacy 0.8-style schema migration coverage
- repeated recordings of one occurrence
- recurring occurrences sharing a raw event ID on the same and different days
- moved recurring and one-off event identity
- Google `recurringEventId` and `originalStartTime` parsing
- calendar placeholder idempotency and normal meeting persistence/hook dispatch

## Follow-up

- #351 tracks preservation of calendar occurrence identity across CloudKit sync.

Fixes #341

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787938081&installation_model_id=422865&pr_number=350&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F350&signature=6c32357b6cef8018ac0d29c4a3215d7b2dc7ffbae8ef8e87efb4220203958e61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added calendar-occurrence tracking for scheduled and recurring meetings, including stable occurrence identity across EventKit and Google Calendar.
  - Updated recording, joining, notifications, and automatic meeting creation to carry and persist occurrence-specific calendar metadata.

- **Bug Fixes**
  - Improved meeting matching and deduplication to distinguish separate occurrences (including moved/rescheduled cases) rather than treating all occurrences as the same calendar event.
  - Enhanced database migration so legacy data correctly resolves meetings at the occurrence level.

- **Tests**
  - Expanded coverage for occurrence identity semantics, migration behavior, and recurrence parsing/dedup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
