### PR TITLE
feat(dictionary): apply custom words to meetings and streaming dictation

### DIFF
--- a/docs/plans/plan-2026-07-30-dictionary-meeting-streaming-corrections.md
+++ b/docs/plans/plan-2026-07-30-dictionary-meeting-streaming-corrections.md
@@ -1,0 +1,44 @@
+# Plan: Apply dictionary corrections to meetings + streaming dictation
+
+## Context
+
+A full corrections dictionary already exists (`CustomWord` word→replacement pairs with fuzzy Jaro-Winkler matching in `CustomWordMatcher`, `DictionaryView` CRUD UI, auto-suggestion flow) but is applied **only** to standard hold-to-talk dictation (`TranscriptionRuntime.transcribeDictation`). Meeting transcription bypasses it intentionally, and streaming (double-tap Nemotron) dictation also skips it. Goal: one dictionary applied to all future meeting transcripts and dictations.
+
+## Design
+
+Reuse `CustomWordMatcher` + existing `AppConfig.customWords`. Meeting transcripts are built FROM segments (`TranscriptFormatter.merge` consumes `SpeechSegment.text`), so corrections must hit segment text — correcting only `result.text` per chunk would have no effect on the final merged transcript.
+
+`transcribeMeetingChunk` is the WRONG chokepoint: unified-Nemotron meetings source `systemSegments` from `MeetingStreamingPartialSession` and never call it, and repair/fallback passes risk double application (the matcher is not idempotent). Two touch points instead:
+
+1. **Live meetings**: correct the final `micSegments`/`systemSegments` once at finalize, immediately before `TranscriptFormatter.merge` in `MeetingSession` — covers chunked, unified-Nemotron, repair, and fallback paths in one place. Live partials stay uncorrected (out of scope).
+2. **Flat-text paths** (import + retranscribe): add `customWords: [CustomWord] = []` param to `transcribeMeeting` only, applied to `result.text` AND each `segment.text`; pass it only from `AudioFileImportController` and the retranscribe path. `MeetingSession` calls keep the default `[]` → no double application.
+
+Use typed `[CustomWord]` for the new params; leave the untyped `serializedCustomWords()` bridge and the dictation path alone.
+
+## Steps
+
+1. **Helper** — `CustomWordMatcher.swift`: `apply(result: SpeechTranscriptionResult, customWords:) -> SpeechTranscriptionResult` correcting `result.text` + each segment text, preserving timings, early-return on empty words.
+2. **`TranscriptionRuntime.swift`** — `transcribeMeeting` (407): add `customWords: [CustomWord] = []`, wrap return with the helper; update the stale "intentionally skip" comment (413). `transcribeMeetingChunk` untouched.
+3. **`MeetingSession.swift`** — at finalize before `TranscriptFormatter.merge` (~636+): map mic/system segments through the helper using `config.customWords` (session already holds `config`). Grep all `TranscriptFormatter.merge` call sites; cover each.
+4. **`AudioFileImportController.swift:185`** — pass `customWords: config.customWords`.
+5. **`MuesliController.swift:3962`** (retranscribe) — pass `customWords: self.config.customWords`.
+6. **`MuesliController.finishNemotronStreamingStop` (~7953)** — apply `CustomWordMatcher.apply(text:customWords:)` after `FillerWordFilter.apply(finalText)` before `insertDictation`. Note in PR: this corrects the stored history record only; live-typed text was already streamed, retro-backspacing is out of scope (matches existing FillerWordFilter precedent).
+7. Optional: `DictionaryView` copy tweak noting global scope.
+
+## Tests
+
+- Extend `CustomWordMatcherTests.swift` (`dictation-transcription` shard — if a new test class name is used, register it in `run_ci_test_shard.sh`): segment timings preserved, text+segments corrected consistently, empty-words no-op.
+- `TranscriptFormatterTests.swift`: integration test — segments corrected pre-merge appear corrected in the merged string.
+
+## Risks
+
+- Custom-word replacement inside meeting text touches all speakers' words — intended "global dictionary" semantics; note in PR.
+- Phrase entries spanning segment boundaries won't match (matcher is space-tokenized per text) — accept, single words unaffected.
+- Unified-Nemotron partials uncorrected until finalize — documented.
+- Size: ~120-180 LOC incl. tests, ~6 files.
+
+## Verification
+
+1. `swift test --package-path native/MuesliNative` (or `./scripts/run_ci_test_shard.sh dictation-transcription|meetings`)
+2. `scripts/test_ci_test_shards.sh` if test suites added
+3. Build: `MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh`; manual smoke: add a dictionary entry, run a meeting + a double-tap dictation, confirm correction applied in both.

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -186,7 +186,8 @@ enum AudioFileImportController {
             at: wavURL,
             backend: backend,
             cohereLanguage: config.resolvedCohereLanguage,
-            indicASRLanguage: config.resolvedIndicASRLanguage
+            indicASRLanguage: config.resolvedIndicASRLanguage,
+            customWords: config.customWords
         )
         let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !rawTranscript.isEmpty else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/CustomWordMatcher.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CustomWordMatcher.swift
@@ -59,6 +59,24 @@ struct CustomWordMatcher {
         return result.joined(separator: " ")
     }
 
+    /// Corrects both the flat text and the per-segment text. Meeting transcripts
+    /// are assembled from segments, so correcting only `text` would not reach
+    /// the stored transcript.
+    static func apply(result: SpeechTranscriptionResult, customWords: [CustomWord]) -> SpeechTranscriptionResult {
+        guard !customWords.isEmpty else { return result }
+        return SpeechTranscriptionResult(
+            text: apply(text: result.text, customWords: customWords),
+            segments: apply(segments: result.segments, customWords: customWords)
+        )
+    }
+
+    static func apply(segments: [SpeechSegment], customWords: [CustomWord]) -> [SpeechSegment] {
+        guard !customWords.isEmpty else { return segments }
+        return segments.map {
+            SpeechSegment(start: $0.start, end: $0.end, text: apply(text: $0.text, customWords: customWords))
+        }
+    }
+
     private struct TokenParts {
         let prefix: String
         let core: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -694,9 +694,13 @@ final class MeetingSession {
         )
         let protectedTranscriptInputs = reconciledTranscriptInputs
 
+        // Dictionary corrections land here, once, rather than per chunk: every
+        // capture path (chunked, unified streaming, repair, fallback) converges
+        // on this merge, and the matcher is not idempotent.
+        let customWords = config.customWords
         let rawTranscript = TranscriptFormatter.merge(
-            micSegments: protectedTranscriptInputs.micSegments,
-            systemSegments: protectedTranscriptInputs.systemSegments,
+            micSegments: CustomWordMatcher.apply(segments: protectedTranscriptInputs.micSegments, customWords: customWords),
+            systemSegments: CustomWordMatcher.apply(segments: protectedTranscriptInputs.systemSegments, customWords: customWords),
             diarizationSegments: protectedTranscriptInputs.diarizationSegments,
             meetingStart: meetingStart
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -3963,7 +3963,8 @@ final class MuesliController: NSObject {
                     at: recordingURL,
                     backend: backend,
                     cohereLanguage: self.config.resolvedCohereLanguage,
-                    indicASRLanguage: self.config.resolvedIndicASRLanguage
+                    indicASRLanguage: self.config.resolvedIndicASRLanguage,
+                    customWords: self.config.customWords
                 )
                 let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !rawTranscript.isEmpty else {
@@ -7965,8 +7966,13 @@ final class MuesliController: NSObject {
         previousStreamText = ""
         let duration = max(Date().timeIntervalSince(startedAt), 0)
         fputs("[muesli-native] Nemotron streaming stop, got \(finalText.count) chars\n", stderr)
-        let cleaned = FillerWordFilter.apply(finalText)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Corrects the stored dictation only: the streamed text was already
+        // typed out, same as the filler filter above it.
+        let cleaned = CustomWordMatcher.apply(
+            text: FillerWordFilter.apply(finalText),
+            customWords: config.customWords
+        )
+        .trimmingCharacters(in: .whitespacesAndNewlines)
 
         if !config.maraudersMapUnlocked { checkMaraudersMapActivation(cleaned) }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -408,10 +408,14 @@ actor TranscriptionCoordinator {
         at url: URL,
         backend: BackendOption,
         cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
-        indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage
+        indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
+        customWords: [CustomWord] = []
     ) async throws -> SpeechTranscriptionResult {
-        // Meetings intentionally skip Qwen/custom-word post-processing. Keep deterministic artifact/filler cleanup only.
-        cleanMeetingTranscript(try await route(url: url, backend: backend, cohereLanguage: cohereLanguage, indicASRLanguage: indicASRLanguage))
+        // Meetings intentionally skip Qwen post-processing. Keep deterministic artifact/filler cleanup only.
+        // Live meetings pass no custom words here: they correct segments once at
+        // finalize instead, so replacements are never applied twice.
+        let result = cleanMeetingTranscript(try await route(url: url, backend: backend, cohereLanguage: cohereLanguage, indicASRLanguage: indicASRLanguage))
+        return CustomWordMatcher.apply(result: result, customWords: customWords)
     }
 
     func transcribeMeetingChunk(

--- a/native/MuesliNative/Tests/MuesliTests/CustomWordMatcherTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/CustomWordMatcherTests.swift
@@ -184,4 +184,46 @@ struct CustomWordMatcherApplyTests {
         let result = CustomWordMatcher.apply(text: "try open, telemetry now", customWords: words)
         #expect(result == "try open, telemetry now")
     }
+
+    @Test("corrects segment text and preserves timings")
+    func correctsSegmentsPreservingTimings() {
+        let words = [CustomWord(word: "jira", replacement: "Jira")]
+        let segments = [
+            SpeechSegment(start: 0.0, end: 1.5, text: "open jira please"),
+            SpeechSegment(start: 1.5, end: 3.0, text: "nothing to change"),
+        ]
+
+        let corrected = CustomWordMatcher.apply(segments: segments, customWords: words)
+
+        #expect(corrected.map(\.text) == ["open Jira please", "nothing to change"])
+        #expect(corrected.map(\.start) == segments.map(\.start))
+        #expect(corrected.map(\.end) == segments.map(\.end))
+    }
+
+    @Test("corrects both flat text and segments of a transcription result")
+    func correctsResultTextAndSegments() {
+        let words = [CustomWord(word: "jira", replacement: "Jira")]
+        let result = SpeechTranscriptionResult(
+            text: "open jira",
+            segments: [SpeechSegment(start: 0.0, end: 1.0, text: "open jira")]
+        )
+
+        let corrected = CustomWordMatcher.apply(result: result, customWords: words)
+
+        #expect(corrected.text == "open Jira")
+        #expect(corrected.segments.first?.text == "open Jira")
+    }
+
+    @Test("no custom words leaves the result untouched")
+    func emptyCustomWordsIsNoOp() {
+        let result = SpeechTranscriptionResult(
+            text: "open jira",
+            segments: [SpeechSegment(start: 0.0, end: 1.0, text: "open jira")]
+        )
+
+        let corrected = CustomWordMatcher.apply(result: result, customWords: [])
+
+        #expect(corrected.text == result.text)
+        #expect(corrected.segments.map(\.text) == result.segments.map(\.text))
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptFormatterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptFormatterTests.swift
@@ -487,6 +487,24 @@ struct TranscriptFormatterTests {
         #expect(lines.allSatisfy { $0.contains("Others:") })
     }
 
+    @Test("dictionary corrections applied to segments reach the merged transcript")
+    func dictionaryCorrectionsSurviveMerge() {
+        let meetingStart = Date(timeIntervalSince1970: 0)
+        let words = [CustomWord(word: "jira", replacement: "Jira")]
+        let mic = [SpeechSegment(start: 0.0, end: 2.0, text: "I filed a jira ticket")]
+        let system = [SpeechSegment(start: 3.0, end: 4.0, text: "which jira project")]
+
+        let result = TranscriptFormatter.merge(
+            micSegments: CustomWordMatcher.apply(segments: mic, customWords: words),
+            systemSegments: CustomWordMatcher.apply(segments: system, customWords: words),
+            meetingStart: meetingStart
+        )
+
+        #expect(result.contains("You: I filed a Jira ticket"))
+        #expect(result.contains("Others: which Jira project"))
+        #expect(!result.contains("jira"))
+    }
+
     // MARK: - Helpers
 
     private func makeDiarSeg(speakerId: String, start: Float, end: Float) -> TimedSpeakerSegment {


### PR DESCRIPTION
## What

The custom-word dictionary was only reaching hold-to-talk dictation. Meeting transcription skipped it deliberately (three code comments said so), and the Nemotron streaming path never picked it up. A correction the user added therefore applied to some of their transcripts and not others. This makes one dictionary apply everywhere.

No new UI: this uses the existing `DictionaryView` entries and `AppConfig.customWords`.

## Approach

Meeting transcripts are assembled from segments by `TranscriptFormatter.merge`, so correcting only the flat `result.text` would never reach the stored transcript. Added `CustomWordMatcher.apply(segments:customWords:)` and a result-level wrapper, then hooked in at two points:

- **Live meetings**: correct the reconciled mic/system segments once, immediately before the merge in `MeetingSession`. Every capture path (chunked, unified Nemotron streaming, repair, fallback) converges there. `transcribeMeetingChunk` looks like the obvious chokepoint but is not: unified-Nemotron meetings source their system segments from `MeetingStreamingPartialSession` and never call it, and the matcher is not idempotent, so a per-chunk pass plus a merge-time pass could double-apply.
- **Flat-text paths**: audio import and re-transcription pass `customWords` to `transcribeMeeting`, which corrects the text and the segments. `MeetingSession`'s own calls keep the default empty list, so nothing is corrected twice.

Streaming dictation corrects the stored history entry alongside the existing `FillerWordFilter`. Text already typed out during streaming is not rewritten, matching the precedent set by the filler filter on that same path.

Known trade-offs, all documented in code comments:
- Corrections apply to every speaker's words in a meeting. That is the intended "global dictionary" semantics.
- Phrase entries spanning a segment boundary won't match, since the matcher tokenizes within one text. Single-word entries (the common case) are unaffected.
- Live partial transcripts stay uncorrected until finalize.

## Testing

`swift test --package-path native/MuesliNative --filter 'CustomWordMatcher|TranscriptFormatter|JaroWinkler'` — 55 tests in 3 suites, passing.

New coverage:
- `CustomWordMatcherTests`: segment text corrected with timings preserved, result text and segments corrected consistently, empty custom words as a no-op.
- `TranscriptFormatterTests`: corrections applied to segments survive into the merged transcript.

No new test suites, so no CI shard registration changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787993765&installation_model_id=422865&pr_number=356&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F356&signature=ccf30157d55a16c137d5e7a687c39cc1e2cd5744acec00d838ebfe557ce354d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom dictionary corrections now apply to meeting transcripts, imported and re-transcribed audio, and streaming dictation.
  * Corrections are preserved across transcript merging while segment timing remains unchanged.

* **Bug Fixes**
  * Fixed inconsistent custom-word corrections between displayed transcript text and stored segments.

* **Tests**
  * Added coverage for corrected segments, merged transcripts, and empty custom dictionaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->