### PR TITLE
Use manual notes for summary context and titles

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -701,6 +701,7 @@ final class MeetingSession {
             meetingStart: meetingStart
         )
 
+        let manualNotes = await manualNotesProvider?()
         let generatedTitle: String
         onProgress?(.generatingTitle)
         if let liveTitle = await userEditedLiveTitle() {
@@ -710,7 +711,11 @@ final class MeetingSession {
             calendarEventID: calendarEventID
         ) {
             generatedTitle = calendarTitle
-        } else if let autoTitle = await MeetingSummaryClient.generateTitle(transcript: rawTranscript, config: config),
+        } else if let autoTitle = await MeetingSummaryClient.generateTitle(
+            transcript: rawTranscript,
+            manualNotes: manualNotes,
+            config: config
+        ),
            !autoTitle.isEmpty {
             generatedTitle = autoTitle
             fputs("[meeting] auto-generated title: \(generatedTitle)\n", stderr)
@@ -722,7 +727,6 @@ final class MeetingSession {
         Self.logger.info("visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(self.config.useCoreAudioTap)")
         fputs("[meeting] visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(config.useCoreAudioTap)\n", stderr)
         onProgress?(.summarizingNotes)
-        let manualNotes = await manualNotesProvider?()
         let formattedNotes: String
         do {
             formattedNotes = try await MeetingSummaryClient.summarize(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -701,7 +701,7 @@ final class MeetingSession {
             meetingStart: meetingStart
         )
 
-        let manualNotes = await manualNotesProvider?()
+        let titleManualNotes = await manualNotesProvider?()
         let generatedTitle: String
         onProgress?(.generatingTitle)
         if let liveTitle = await userEditedLiveTitle() {
@@ -713,7 +713,7 @@ final class MeetingSession {
             generatedTitle = calendarTitle
         } else if let autoTitle = await MeetingSummaryClient.generateTitle(
             transcript: rawTranscript,
-            manualNotes: manualNotes,
+            manualNotes: titleManualNotes,
             config: config
         ),
            !autoTitle.isEmpty {
@@ -727,6 +727,7 @@ final class MeetingSession {
         Self.logger.info("visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(self.config.useCoreAudioTap)")
         fputs("[meeting] visual context drained chars=\(visualContext.count) includedInPrompt=\(!visualContext.isEmpty) useOCR=\(config.useCoreAudioTap)\n", stderr)
         onProgress?(.summarizingNotes)
+        let manualNotes = await manualNotesProvider?()
         let formattedNotes: String
         do {
             formattedNotes = try await MeetingSummaryClient.summarize(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -137,7 +137,8 @@ enum MeetingSummaryClient {
     private static let customLLMTitleTimeout: TimeInterval = 120
 
     private static let titleInstructions = """
-    Generate a short, descriptive meeting title (3-7 words) from these transcript excerpts. \
+    Generate a short, descriptive meeting title (3-7 words) from these transcript excerpts and any written notes. \
+    Treat written notes as high-priority context: they may contain the clearest statement of the meeting's topic or outcome. \
     Prefer the main topic and outcome across the whole meeting over opening small talk or setup. \
     Return ONLY the title text, nothing else. No quotes, no prefix, no explanation. \
     Examples: "Q3 Sprint Planning", "Customer Onboarding Review", "Security Audit Discussion"
@@ -316,7 +317,7 @@ enum MeetingSummaryClient {
             notePreservationInstructions = ""
         }
         let manualNoteInstructions = hasManualNotes
-            ? "\n\nProtected written notes may also be provided. These are notes the user typed by hand during the meeting. Use them as high-priority context. Place each written note near the most relevant section of the summary, preserving the user's wording verbatim when possible. Do not rewrite, polish, summarize away, or omit concrete user-written notes. Avoid creating a large standalone Manual Notes appendix unless there is no relevant section for a note."
+            ? "\n\nProtected written notes may also be provided. These are notes the user typed by hand during the meeting. Treat them as first-class meeting context, not only as text to retain: use their concrete details to inform the summary, decisions, action items, risks, and outcomes, including details that are not stated verbatim in the transcript. Place each written note near the most relevant section of the summary, preserving the user's wording verbatim when possible. Do not rewrite, polish, summarize away, or omit concrete user-written notes. Avoid creating a large standalone Manual Notes appendix unless there is no relevant section for a note."
             : ""
         let hasPreviousNotes = !(previousMeetingNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         let followUpInstructions = hasPreviousNotes
@@ -360,7 +361,7 @@ enum MeetingSummaryClient {
 
         let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmedManualNotes.isEmpty {
-            prompt += "Protected written notes typed by the user during the meeting. Preserve these verbatim and place them where they belong in the summary:\n\(trimmedManualNotes)\n\n"
+            prompt += "First-class meeting context from written notes typed by the user during the meeting. Use these notes together with the transcript to identify the meeting's topic, decisions, action items, risks, and outcomes. Preserve the written notes verbatim in the final summary:\n\(trimmedManualNotes)\n\n"
         }
 
         prompt += "Raw transcript:\n\(transcript)"
@@ -1096,9 +1097,13 @@ enum MeetingSummaryClient {
     }
 
     static func generateTitle(transcript: String, config: AppConfig) async -> String? {
+        await generateTitle(transcript: transcript, manualNotes: nil, config: config)
+    }
+
+    static func generateTitle(transcript: String, manualNotes: String?, config: AppConfig) async -> String? {
         let backend = (config.meetingSummaryBackend.isEmpty ? MeetingSummaryBackendOption.chatGPT.backend : config.meetingSummaryBackend).lowercased()
 
-        let excerpt = titleTranscriptExcerpt(from: transcript)
+        let excerpt = titlePrompt(transcript: transcript, manualNotes: manualNotes)
 
         if backend == MeetingSummaryBackendOption.chatGPT.backend {
             return await generateTitleWithChatGPT(transcript: excerpt, config: config)
@@ -1144,6 +1149,20 @@ enum MeetingSummaryClient {
             maxTokens: nil,
             extraHeaders: [:]
         )
+    }
+
+    static func titlePrompt(transcript: String, manualNotes: String? = nil) -> String {
+        let excerpt = titleTranscriptExcerpt(from: transcript)
+        let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedManualNotes.isEmpty else { return excerpt }
+
+        return """
+        Meeting transcript excerpts:
+        \(excerpt)
+
+        Written notes captured by the user during the meeting. Treat these as high-priority context when choosing the main topic and outcome:
+        \(trimmedManualNotes)
+        """
     }
 
     static func titleTranscriptExcerpt(from transcript: String, segmentLength: Int = 900) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSummaryClient.swift
@@ -129,6 +129,7 @@ enum MeetingSummaryClient {
     private static let defaultChatGPTModel = "gpt-5.4-mini"
     private static let defaultOllamaModel = "qwen3.5"
     private static let defaultSummaryMaxOutputTokens = 2500
+    private static let titlePromptCharacterLimit = 6_000
     private static let ollamaSummaryTimeout: TimeInterval = 300
     private static let ollamaTitleTimeout: TimeInterval = 120
     private static let lmStudioSummaryTimeout: TimeInterval = 300
@@ -1156,13 +1157,15 @@ enum MeetingSummaryClient {
         let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmedManualNotes.isEmpty else { return excerpt }
 
-        return """
-        Meeting transcript excerpts:
-        \(excerpt)
+        let transcriptLabel = "Meeting transcript excerpts:\n"
+        let notesLabel = "\n\nWritten notes captured by the user during the meeting. Treat these as high-priority context when choosing the main topic and outcome:\n"
+        let availableNotesCharacters = max(
+            0,
+            titlePromptCharacterLimit - transcriptLabel.count - excerpt.count - notesLabel.count
+        )
+        let boundedManualNotes = String(trimmedManualNotes.prefix(availableNotesCharacters))
 
-        Written notes captured by the user during the meeting. Treat these as high-priority context when choosing the main topic and outcome:
-        \(trimmedManualNotes)
-        """
+        return transcriptLabel + excerpt + notesLabel + boundedManualNotes
     }
 
     static func titleTranscriptExcerpt(from transcript: String, segmentLength: Int = 900) -> String {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -103,8 +103,20 @@ struct MeetingSummaryClientTests {
         )
 
         #expect(prompt.contains("Meeting transcript excerpts:"))
+        #expect(prompt.contains("Transcript body"))
         #expect(prompt.contains("Written notes captured by the user during the meeting"))
         #expect(prompt.contains("Decision: launch the new workflow"))
+    }
+
+    @Test("title prompt bounds oversized written notes")
+    func titlePromptBoundsOversizedWrittenNotes() {
+        let prompt = MeetingSummaryClient.titlePrompt(
+            transcript: "Transcript body",
+            manualNotes: String(repeating: "Decision: launch the new workflow\n", count: 1_000)
+        )
+
+        #expect(prompt.contains("Transcript body"))
+        #expect(prompt.count <= 6_000)
     }
 
     @Test("ChatGPT WHAM requests fix GPT-5.6 reasoning to High")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingSummaryClientTests.swift
@@ -90,8 +90,21 @@ struct MeetingSummaryClientTests {
         )
 
         #expect(prompt.contains("Current generated notes to preserve and reformat:"))
-        #expect(prompt.contains("Protected written notes typed by the user during the meeting"))
+        #expect(prompt.contains("First-class meeting context from written notes typed by the user during the meeting"))
+        #expect(prompt.contains("identify the meeting's topic, decisions, action items, risks, and outcomes"))
         #expect(prompt.contains("- User typed decision"))
+    }
+
+    @Test("title prompt includes written notes as meeting context")
+    func titlePromptIncludesWrittenNotes() {
+        let prompt = MeetingSummaryClient.titlePrompt(
+            transcript: "Transcript body",
+            manualNotes: "Decision: launch the new workflow"
+        )
+
+        #expect(prompt.contains("Meeting transcript excerpts:"))
+        #expect(prompt.contains("Written notes captured by the user during the meeting"))
+        #expect(prompt.contains("Decision: launch the new workflow"))
     }
 
     @Test("ChatGPT WHAM requests fix GPT-5.6 reasoning to High")


### PR DESCRIPTION
## Summary

- Pass the same captured manual-note snapshot into automatic title generation and meeting summarization.
- Treat manual notes as first-class meeting context so their decisions, action items, risks, and outcomes influence the generated summary while remaining preserved verbatim.
- Keep calendar-derived and user-edited titles authoritative.

## Validation

- swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-spm-issue-359 --filter MeetingSummaryClientTests
- swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-spm-issue-359 --filter MeetingSessionTitleTests

Fixes #359

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788067429&installation_model_id=422865&pr_number=360&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F360&signature=3927f28c2681aac1010847bfd8fa0f6770f03648efe97db0e64df59565fc6923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meeting titles and summaries now incorporate user-written notes alongside transcript content.
  * Generated summaries better identify topics, decisions, action items, risks, and outcomes while preserving note wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->