### PR TITLE
Avoid M1 diarizer GPU aborts on macOS 15.1

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -21,6 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TelemetryDeck.initialize(config: telemetryConfig)
         if runtimeTelemetry.isEnabled {
             TelemetryDeck.signal("app.launched")
+            DiarizerPreloadDiagnostics().reportInterruptedAttemptIfNeeded()
         }
 
         do {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -21,8 +21,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TelemetryDeck.initialize(config: telemetryConfig)
         if runtimeTelemetry.isEnabled {
             TelemetryDeck.signal("app.launched")
-            DiarizerPreloadDiagnostics().reportInterruptedAttemptIfNeeded()
         }
+        // Always drain a pending marker. TelemetryDeck's global privacy gate
+        // suppresses the signal when analytics are disabled.
+        DiarizerPreloadDiagnostics().reportInterruptedAttemptIfNeeded()
 
         do {
             let runtime = try RuntimePaths.resolve()

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioFileImportController.swift
@@ -159,7 +159,8 @@ enum AudioFileImportController {
         try await transcriptionCoordinator.preloadRequired(
             backend: backend,
             enablePostProcessor: false,
-            includeMeetingHelpers: true
+            includeMeetingHelpers: true,
+            meetingHelperTrigger: .audioImport
         )
 
         try Task.checkCancellation()

--- a/native/MuesliNative/Sources/MuesliNativeApp/DiarizerRuntimePolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DiarizerRuntimePolicy.swift
@@ -18,6 +18,10 @@ enum DiarizerComputePolicy: String, Sendable, Equatable {
     }
 }
 
+enum DiarizerPreloadFailure: Error {
+    case operationTimedOut
+}
+
 struct DiarizerRuntimeEnvironment: Sendable {
     let cpuBrand: String?
     let hardwareModel: String?
@@ -37,7 +41,7 @@ struct DiarizerRuntimeEnvironment: Sendable {
 
         var value = [CChar](repeating: 0, count: size)
         guard sysctlbyname(name, &value, &size, nil, 0) == 0 else { return nil }
-        return String(cString: value)
+        return String(validatingCString: value)
     }
 }
 
@@ -135,6 +139,7 @@ enum DiarizerModelCacheState: String, Sendable {
 
 struct DiarizerPreloadContext: Sendable {
     static let telemetrySchemaVersion = "1"
+    // Keep synchronized with the exact FluidAudio pin in Package.swift.
     static let fluidAudioVersion = "0.15.1"
 
     let trigger: DiarizerPreloadTrigger
@@ -266,6 +271,7 @@ struct DiarizerPreloadDiagnostics {
 
     static func failureCategory(for error: Error) -> String {
         if error is CancellationError { return "cancelled" }
+        if error is DiarizerPreloadFailure { return "timeout" }
         if error is URLError { return "network" }
 
         if let diarizerError = error as? DiarizerError {
@@ -291,7 +297,8 @@ struct DiarizerPreloadDiagnostics {
         if nsError.domain.localizedCaseInsensitiveContains("coreml") {
             return "coreml"
         }
-        if nsError.domain == NSCocoaErrorDomain {
+        if nsError.domain == NSCocoaErrorDomain,
+           (NSFileErrorMinimum...NSFileErrorMaximum).contains(nsError.code) {
             return "filesystem"
         }
         return "other"

--- a/native/MuesliNative/Sources/MuesliNativeApp/DiarizerRuntimePolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DiarizerRuntimePolicy.swift
@@ -1,0 +1,299 @@
+import CoreML
+import Darwin
+import FluidAudio
+import Foundation
+import TelemetryDeck
+
+enum DiarizerComputePolicy: String, Sendable, Equatable {
+    case all
+    case cpuAndNeuralEngine = "cpu_and_neural_engine"
+
+    var computeUnits: MLComputeUnits {
+        switch self {
+        case .all:
+            return .all
+        case .cpuAndNeuralEngine:
+            return .cpuAndNeuralEngine
+        }
+    }
+}
+
+struct DiarizerRuntimeEnvironment: Sendable {
+    let cpuBrand: String?
+    let hardwareModel: String?
+    let operatingSystemVersion: OperatingSystemVersion
+
+    static func current(processInfo: ProcessInfo = .processInfo) -> DiarizerRuntimeEnvironment {
+        DiarizerRuntimeEnvironment(
+            cpuBrand: sysctlString("machdep.cpu.brand_string"),
+            hardwareModel: sysctlString("hw.model"),
+            operatingSystemVersion: processInfo.operatingSystemVersion
+        )
+    }
+
+    private static func sysctlString(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 1 else { return nil }
+
+        var value = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &value, &size, nil, 0) == 0 else { return nil }
+        return String(cString: value)
+    }
+}
+
+struct DiarizerRuntimePolicy: Sendable, Equatable {
+    static let defaultCompatibilityRule = "default_v1"
+    static let m1MacOS151CompatibilityRule = "m1_macos_15_1_gpu_avoidance_v1"
+
+    // Fallback identifiers are used only if the CPU brand sysctl is unavailable.
+    // The CPU brand remains the primary signal because it covers M1, M1 Pro, M1 Max,
+    // and M1 Ultra without trying to infer the chip from every Mac product identifier.
+    private static let m1HardwareModels: Set<String> = [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "iMac21,1",
+        "iMac21,2",
+        "Mac13,1",
+        "Mac13,2",
+    ]
+
+    let computePolicy: DiarizerComputePolicy
+    let compatibilityRule: String
+
+    static func resolve(for environment: DiarizerRuntimeEnvironment) -> DiarizerRuntimePolicy {
+        let version = environment.operatingSystemVersion
+        let isMacOS151 = version.majorVersion == 15 && version.minorVersion == 1
+        let isM1Family = environment.cpuBrand.map(isM1CPUBrand)
+            ?? environment.hardwareModel.map(m1HardwareModels.contains)
+            ?? false
+
+        // Issue #344's crash stack enters MPSGraph/Metal while FluidAudio loads
+        // the diarizer on M1 + macOS 15.1.x. Excluding GPU here leaves CoreML free
+        // to use CPU/ANE fallbacks without slowing unaffected hardware and OSes.
+        if isMacOS151, isM1Family {
+            return DiarizerRuntimePolicy(
+                computePolicy: .cpuAndNeuralEngine,
+                compatibilityRule: m1MacOS151CompatibilityRule
+            )
+        }
+
+        return DiarizerRuntimePolicy(
+            computePolicy: .all,
+            compatibilityRule: defaultCompatibilityRule
+        )
+    }
+
+    var modelConfiguration: MLModelConfiguration {
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = computePolicy.computeUnits
+        return configuration
+    }
+
+    private static func isM1CPUBrand(_ value: String) -> Bool {
+        let brand = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return brand == "Apple M1" || brand.hasPrefix("Apple M1 ")
+    }
+}
+
+enum DiarizerPreloadTrigger: String, Sendable {
+    case appLaunch = "app_launch"
+    case audioImport = "audio_import"
+    case backendChange = "backend_change"
+    case meetingStart = "meeting_start"
+    case modelLibrary = "model_library"
+    case onboarding
+    case retranscription
+    case unspecified
+}
+
+enum DiarizerModelCacheState: String, Sendable {
+    case absent
+    case partial
+    case complete
+
+    static func resolve(
+        directory: URL = DiarizerModels.defaultModelsDirectory(),
+        requiredModelNames: Set<String> = DiarizerModels.requiredModelNames,
+        fileManager: FileManager = .default
+    ) -> DiarizerModelCacheState {
+        let presentCount = requiredModelNames.reduce(into: 0) { count, modelName in
+            if fileManager.fileExists(atPath: directory.appendingPathComponent(modelName).path) {
+                count += 1
+            }
+        }
+
+        if presentCount == 0 { return .absent }
+        if presentCount == requiredModelNames.count { return .complete }
+        return .partial
+    }
+}
+
+struct DiarizerPreloadContext: Sendable {
+    static let telemetrySchemaVersion = "1"
+    static let fluidAudioVersion = "0.15.1"
+
+    let trigger: DiarizerPreloadTrigger
+    let policy: DiarizerRuntimePolicy
+    let cacheState: DiarizerModelCacheState
+
+    var telemetryParameters: [String: String] {
+        [
+            "schema_version": Self.telemetrySchemaVersion,
+            "trigger": trigger.rawValue,
+            "compute_policy": policy.computePolicy.rawValue,
+            "compatibility_rule": policy.compatibilityRule,
+            "cache_state": cacheState.rawValue,
+            "model_set": "pyannote_streaming",
+            "fluid_audio_version": Self.fluidAudioVersion,
+        ]
+    }
+}
+
+struct DiarizerPreloadDiagnostics {
+    typealias SignalSink = (_ event: String, _ parameters: [String: String]) -> Void
+
+    private struct PendingAttempt: Codable {
+        let startedAt: TimeInterval
+        let parameters: [String: String]
+    }
+
+    static let pendingAttemptKey = "diarizerPreload.pendingAttempt.v1"
+
+    private let defaults: UserDefaults
+    private let now: () -> Date
+    private let signalSink: SignalSink
+
+    init(
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init,
+        signalSink: @escaping SignalSink = { event, parameters in
+            TelemetryDeck.signal(event, parameters: parameters)
+        }
+    ) {
+        self.defaults = defaults
+        self.now = now
+        self.signalSink = signalSink
+    }
+
+    func reportInterruptedAttemptIfNeeded() {
+        guard let data = defaults.data(forKey: Self.pendingAttemptKey),
+              let pending = try? JSONDecoder().decode(PendingAttempt.self, from: data) else {
+            clearPendingAttempt()
+            return
+        }
+
+        clearPendingAttempt()
+        var parameters = pending.parameters
+        parameters["duration_bucket"] = Self.durationBucket(
+            now().timeIntervalSince1970 - pending.startedAt
+        )
+        signalSink("diarizer.preload.interrupted", parameters)
+    }
+
+    @discardableResult
+    func begin(_ context: DiarizerPreloadContext) -> Date {
+        let startedAt = now()
+        let pending = PendingAttempt(
+            startedAt: startedAt.timeIntervalSince1970,
+            parameters: context.telemetryParameters
+        )
+        if let data = try? JSONEncoder().encode(pending) {
+            defaults.set(data, forKey: Self.pendingAttemptKey)
+            // This marker must outlive an immediate SIGABRT during CoreML loading.
+            // Preloads are rare enough that forcing this tiny preferences write is acceptable.
+            defaults.synchronize()
+        }
+        signalSink("diarizer.preload.started", context.telemetryParameters)
+        return startedAt
+    }
+
+    func ready(_ context: DiarizerPreloadContext, startedAt: Date) {
+        finish(
+            event: "diarizer.preload.ready",
+            context: context,
+            startedAt: startedAt,
+            additionalParameters: [:]
+        )
+    }
+
+    func failed(_ context: DiarizerPreloadContext, startedAt: Date, error: Error) {
+        finish(
+            event: "diarizer.preload.failed",
+            context: context,
+            startedAt: startedAt,
+            additionalParameters: ["failure_category": Self.failureCategory(for: error)]
+        )
+    }
+
+    func skipped(_ context: DiarizerPreloadContext, reason: String) {
+        var parameters = context.telemetryParameters
+        parameters["skip_reason"] = reason
+        signalSink("diarizer.preload.skipped", parameters)
+    }
+
+    private func finish(
+        event: String,
+        context: DiarizerPreloadContext,
+        startedAt: Date,
+        additionalParameters: [String: String]
+    ) {
+        clearPendingAttempt()
+        var parameters = context.telemetryParameters
+        parameters["duration_bucket"] = Self.durationBucket(now().timeIntervalSince(startedAt))
+        parameters.merge(additionalParameters) { _, new in new }
+        signalSink(event, parameters)
+    }
+
+    private func clearPendingAttempt() {
+        defaults.removeObject(forKey: Self.pendingAttemptKey)
+        defaults.synchronize()
+    }
+
+    static func durationBucket(_ duration: TimeInterval) -> String {
+        switch max(0, duration) {
+        case ..<1: return "under_1s"
+        case ..<5: return "1_to_5s"
+        case ..<15: return "5_to_15s"
+        case ..<60: return "15_to_60s"
+        default: return "60s_or_more"
+        }
+    }
+
+    static func failureCategory(for error: Error) -> String {
+        if error is CancellationError { return "cancelled" }
+        if error is URLError { return "network" }
+
+        if let diarizerError = error as? DiarizerError {
+            switch diarizerError {
+            case .modelDownloadFailed:
+                return "model_download"
+            case .modelCompilationFailed:
+                return "model_compilation"
+            case .memoryAllocationFailed:
+                return "memory"
+            case .notInitialized:
+                return "not_initialized"
+            case .embeddingExtractionFailed:
+                return "embedding_extraction"
+            case .invalidAudioData:
+                return "invalid_audio"
+            case .processingFailed, .invalidArrayBounds:
+                return "processing"
+            }
+        }
+
+        let nsError = error as NSError
+        if nsError.domain.localizedCaseInsensitiveContains("coreml") {
+            return "coreml"
+        }
+        if nsError.domain == NSCocoaErrorDomain {
+            return "filesystem"
+        }
+        return "other"
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1228,7 +1228,8 @@ struct ModelsView: View {
             do {
                 try await controller.transcriptionCoordinator.preloadRequired(
                     backend: option,
-                    includeMeetingHelpers: controller.config.resolvedOnboardingUseCase.includesMeetings
+                    includeMeetingHelpers: controller.config.resolvedOnboardingUseCase.includesMeetings,
+                    meetingHelperTrigger: .modelLibrary
                 ) { progress, _ in
                     DispatchQueue.main.async {
                         downloadProgress[option.model] = max(progress, 0.05)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -707,7 +707,8 @@ final class MuesliController: NSObject {
                 await self.preloadOptionalTranscriptionResources(
                     for: dictationBackend,
                     enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
-                    includeMeetingHelpers: includesMeetings
+                    includeMeetingHelpers: includesMeetings,
+                    meetingHelperTrigger: .appLaunch
                 )
                 if includesMeetings, self.selectedMeetingTranscriptionBackend != self.selectedBackend {
                     await self.transcriptionCoordinator.preload(
@@ -2023,7 +2024,8 @@ final class MuesliController: NSObject {
                 await self.preloadOptionalTranscriptionResources(
                     for: option,
                     enablePostProcessor: self.canRunTranscriptCleanup(option: ppOption),
-                    includeMeetingHelpers: self.config.resolvedOnboardingUseCase.includesMeetings
+                    includeMeetingHelpers: self.config.resolvedOnboardingUseCase.includesMeetings,
+                    meetingHelperTrigger: .backendChange
                 )
             }
             await MainActor.run {
@@ -2059,14 +2061,15 @@ final class MuesliController: NSObject {
     private func preloadOptionalTranscriptionResources(
         for backend: BackendOption,
         enablePostProcessor: Bool,
-        includeMeetingHelpers: Bool
+        includeMeetingHelpers: Bool,
+        meetingHelperTrigger: DiarizerPreloadTrigger
     ) async {
         await transcriptionCoordinator.preloadPostProcessorIfNeeded(
             enabled: enablePostProcessor,
             transcriptionBackend: backend
         )
         if includeMeetingHelpers {
-            await transcriptionCoordinator.preloadMeetingHelpers()
+            await transcriptionCoordinator.preloadMeetingHelpers(trigger: meetingHelperTrigger)
         }
     }
 
@@ -3434,6 +3437,7 @@ final class MuesliController: NSObject {
             backend: backend,
             enablePostProcessor: isPostProcessorReady,
             includeMeetingHelpers: onboardingUseCase.includesMeetings,
+            meetingHelperTrigger: .onboarding,
             progress: { value, status in
                 if wasDownloaded,
                    value < 0.85,
@@ -3957,7 +3961,8 @@ final class MuesliController: NSObject {
                 try await self.transcriptionCoordinator.preloadRequired(
                     backend: backend,
                     enablePostProcessor: false,
-                    includeMeetingHelpers: true
+                    includeMeetingHelpers: true,
+                    meetingHelperTrigger: .retranscription
                 )
                 let transcription = try await self.transcriptionCoordinator.transcribeMeeting(
                     at: recordingURL,
@@ -5209,7 +5214,8 @@ final class MuesliController: NSObject {
         try await transcriptionCoordinator.preloadRequired(
             backend: backend,
             enablePostProcessor: false,
-            includeMeetingHelpers: true
+            includeMeetingHelpers: true,
+            meetingHelperTrigger: .meetingStart
         )
         try Task.checkCancellation()
         try checkMeetingStartStillCurrent(meetingID)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -15,6 +15,7 @@ struct SpeechTranscriptionResult: Sendable {
 
 actor TranscriptionCoordinator {
     typealias DiarizerModelLoader = @Sendable (DiarizerRuntimePolicy) async throws -> DiarizerModels
+    typealias VADLoader = @Sendable () async throws -> VadManager
 
     private enum DiarizerLoadWaitOutcome {
         case succeeded
@@ -54,6 +55,7 @@ actor TranscriptionCoordinator {
     private var didDiarizerLoadTimeOut = false
     private var diarizerLoadWaiters: [UUID: DiarizerLoadWaiter] = [:]
     private let diarizerModelLoader: DiarizerModelLoader
+    private let vadLoader: VADLoader
     private let diarizerLoadOperationTimeout: Duration
     private let diarizerDiagnostics: DiarizerPreloadDiagnostics
     private var activeBackend: String?
@@ -62,10 +64,12 @@ actor TranscriptionCoordinator {
         diarizerModelLoader: @escaping DiarizerModelLoader = { policy in
             try await DiarizerModels.download(configuration: policy.modelConfiguration)
         },
+        vadLoader: @escaping VADLoader = { try await VadManager() },
         diarizerLoadOperationTimeout: Duration = TranscriptionCoordinator.defaultDiarizerLoadOperationTimeout,
         diarizerDiagnostics: DiarizerPreloadDiagnostics = DiarizerPreloadDiagnostics()
     ) {
         self.diarizerModelLoader = diarizerModelLoader
+        self.vadLoader = vadLoader
         self.diarizerLoadOperationTimeout = diarizerLoadOperationTimeout
         self.diarizerDiagnostics = diarizerDiagnostics
     }
@@ -277,6 +281,7 @@ actor TranscriptionCoordinator {
         if includeMeetingHelpers {
             await preloadMeetingHelpers(trigger: meetingHelperTrigger)
         }
+        try Task.checkCancellation()
 
         switch backend.backend {
         case "fluidaudio":
@@ -350,7 +355,7 @@ actor TranscriptionCoordinator {
     func preloadMeetingHelpers(trigger: DiarizerPreloadTrigger = .unspecified) async {
         if vadManager == nil {
             do {
-                vadManager = try await VadManager()
+                vadManager = try await vadLoader()
                 fputs("[muesli-native] Silero VAD loaded\n", stderr)
             } catch {
                 fputs("[muesli-native] VAD load failed (non-critical): \(error)\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -14,6 +14,25 @@ struct SpeechTranscriptionResult: Sendable {
 }
 
 actor TranscriptionCoordinator {
+    typealias DiarizerModelLoader = @Sendable (DiarizerRuntimePolicy) async throws -> DiarizerModels
+
+    private enum DiarizerLoadWaitOutcome {
+        case succeeded
+        case failed
+        case cancelled
+        case timedOut
+    }
+
+    private struct DiarizerLoadWaiter {
+        let continuation: CheckedContinuation<DiarizerLoadWaitOutcome, Never>
+        let timeoutTask: Task<Void, Never>
+    }
+
+    // Product flows stop waiting after two minutes and continue without optional
+    // diarization. The shared background load gets a longer cooperative deadline.
+    private static let defaultDiarizerLoadWaitTimeout: Duration = .seconds(120)
+    private static let defaultDiarizerLoadOperationTimeout: Duration = .seconds(300)
+
     static let explicitlyRoutedBackendIdentifiers: Set<String> = [
         "whisper", "nemotron35", "qwen", "cohere", "indicasr", "sensevoice", "gemma4-litert",
     ]
@@ -29,9 +48,27 @@ actor TranscriptionCoordinator {
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
     private var isDiarizerLoadInProgress = false
-    private var diarizerLoadWaiters: [CheckedContinuation<Void, Never>] = []
-    private let diarizerDiagnostics = DiarizerPreloadDiagnostics()
+    private var activeDiarizerLoadID: UUID?
+    private var diarizerLoadTask: Task<Void, Never>?
+    private var diarizerLoadTimeoutTask: Task<Void, Never>?
+    private var didDiarizerLoadTimeOut = false
+    private var diarizerLoadWaiters: [UUID: DiarizerLoadWaiter] = [:]
+    private let diarizerModelLoader: DiarizerModelLoader
+    private let diarizerLoadOperationTimeout: Duration
+    private let diarizerDiagnostics: DiarizerPreloadDiagnostics
     private var activeBackend: String?
+
+    init(
+        diarizerModelLoader: @escaping DiarizerModelLoader = { policy in
+            try await DiarizerModels.download(configuration: policy.modelConfiguration)
+        },
+        diarizerLoadOperationTimeout: Duration = TranscriptionCoordinator.defaultDiarizerLoadOperationTimeout,
+        diarizerDiagnostics: DiarizerPreloadDiagnostics = DiarizerPreloadDiagnostics()
+    ) {
+        self.diarizerModelLoader = diarizerModelLoader
+        self.diarizerLoadOperationTimeout = diarizerLoadOperationTimeout
+        self.diarizerDiagnostics = diarizerDiagnostics
+    }
 
     private var _nemotron35Transcriber: Any?
     /// Selected Nemotron 3.5 language prompt id (101 = auto). Stored so it survives
@@ -320,6 +357,13 @@ actor TranscriptionCoordinator {
             }
         }
 
+        await preloadDiarizer(trigger: trigger)
+    }
+
+    func preloadDiarizer(
+        trigger: DiarizerPreloadTrigger = .unspecified,
+        waitTimeout: Duration = TranscriptionCoordinator.defaultDiarizerLoadWaitTimeout
+    ) async {
         let policy = DiarizerRuntimePolicy.resolve(for: .current())
         let context = DiarizerPreloadContext(
             trigger: trigger,
@@ -332,31 +376,97 @@ actor TranscriptionCoordinator {
             return
         }
 
-        if isDiarizerLoadInProgress {
-            await withCheckedContinuation { continuation in
-                diarizerLoadWaiters.append(continuation)
-            }
-            diarizerDiagnostics.skipped(
-                context,
-                reason: diarizerManager == nil ? "joined_failed_load" : "joined_active_load"
-            )
-            return
+        let startedLoad = !isDiarizerLoadInProgress
+        if startedLoad {
+            startDiarizerLoad(policy: policy, context: context)
         }
 
+        let outcome = await waitForActiveDiarizerLoad(timeout: waitTimeout)
+        let resolvedOutcome: DiarizerLoadWaitOutcome = Task.isCancelled ? .cancelled : outcome
+        switch (startedLoad, resolvedOutcome) {
+        case (true, .succeeded), (true, .failed):
+            // The load lifecycle itself emits the terminal diagnostic.
+            break
+        case (false, .succeeded):
+            diarizerDiagnostics.skipped(context, reason: "joined_load_succeeded")
+        case (false, .failed):
+            diarizerDiagnostics.skipped(context, reason: "joined_load_failed")
+        case (true, .cancelled):
+            diarizerDiagnostics.skipped(context, reason: "load_wait_cancelled")
+        case (false, .cancelled):
+            diarizerDiagnostics.skipped(context, reason: "joined_load_cancelled")
+        case (true, .timedOut):
+            diarizerDiagnostics.skipped(context, reason: "load_wait_timed_out")
+        case (false, .timedOut):
+            diarizerDiagnostics.skipped(context, reason: "joined_load_timed_out")
+        }
+    }
+
+    private func startDiarizerLoad(
+        policy: DiarizerRuntimePolicy,
+        context: DiarizerPreloadContext
+    ) {
         isDiarizerLoadInProgress = true
-        defer {
-            isDiarizerLoadInProgress = false
-            let waiters = diarizerLoadWaiters
-            diarizerLoadWaiters.removeAll()
-            waiters.forEach { $0.resume() }
+        didDiarizerLoadTimeOut = false
+        let loadID = UUID()
+        activeDiarizerLoadID = loadID
+        let startedAt = diarizerDiagnostics.begin(context)
+
+        let loader = diarizerModelLoader
+        diarizerLoadTask = Task { [weak self] in
+            do {
+                let models = try await loader(policy)
+                try Task.checkCancellation()
+                await self?.finishDiarizerLoad(
+                    id: loadID,
+                    result: .success(models),
+                    policy: policy,
+                    context: context,
+                    startedAt: startedAt
+                )
+            } catch {
+                await self?.finishDiarizerLoad(
+                    id: loadID,
+                    result: .failure(error),
+                    policy: policy,
+                    context: context,
+                    startedAt: startedAt
+                )
+            }
         }
 
-        let startedAt = diarizerDiagnostics.begin(context)
-        do {
+        let operationTimeout = diarizerLoadOperationTimeout
+        diarizerLoadTimeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: operationTimeout)
+            } catch {
+                return
+            }
+            await self?.timeoutDiarizerLoad(id: loadID)
+        }
+    }
+
+    private func finishDiarizerLoad(
+        id: UUID,
+        result: Result<DiarizerModels, Error>,
+        policy: DiarizerRuntimePolicy,
+        context: DiarizerPreloadContext,
+        startedAt: Date
+    ) {
+        guard activeDiarizerLoadID == id else { return }
+
+        let didTimeOut = didDiarizerLoadTimeOut
+        diarizerLoadTimeoutTask?.cancel()
+        diarizerLoadTimeoutTask = nil
+        diarizerLoadTask = nil
+        activeDiarizerLoadID = nil
+        isDiarizerLoadInProgress = false
+        didDiarizerLoadTimeOut = false
+
+        let outcome: DiarizerLoadWaitOutcome
+        switch result {
+        case .success(let models):
             let diarizer = DiarizerManager()
-            let models = try await DiarizerModels.download(
-                configuration: policy.modelConfiguration
-            )
             diarizer.initialize(models: models)
             diarizerManager = diarizer
             diarizerDiagnostics.ready(context, startedAt: startedAt)
@@ -364,11 +474,78 @@ actor TranscriptionCoordinator {
                 "[muesli-native] Speaker diarization loaded (compute: \(policy.computePolicy.rawValue))\n",
                 stderr
             )
-        } catch {
-            diarizerDiagnostics.failed(context, startedAt: startedAt, error: error)
-            fputs("[muesli-native] Diarization load failed (non-critical): \(error)\n", stderr)
+            outcome = .succeeded
+        case .failure(let error):
+            let reportedError: Error = didTimeOut ? DiarizerPreloadFailure.operationTimedOut : error
+            diarizerDiagnostics.failed(context, startedAt: startedAt, error: reportedError)
+            fputs("[muesli-native] Diarization load failed (non-critical): \(reportedError)\n", stderr)
+            outcome = .failed
+        }
+
+        resumeAllDiarizerLoadWaiters(with: outcome)
+    }
+
+    private func timeoutDiarizerLoad(id: UUID) {
+        guard activeDiarizerLoadID == id else { return }
+        didDiarizerLoadTimeOut = true
+        diarizerLoadTask?.cancel()
+        // A third-party model load may not observe cancellation while CoreML is
+        // compiling. Release product callers immediately while retaining the
+        // active-load guard so another expensive load cannot start in parallel.
+        resumeAllDiarizerLoadWaiters(with: .timedOut)
+    }
+
+    private func waitForActiveDiarizerLoad(timeout: Duration) async -> DiarizerLoadWaitOutcome {
+        if didDiarizerLoadTimeOut { return .timedOut }
+
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+
+                let timeoutTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                    } catch {
+                        return
+                    }
+                    await self?.resumeDiarizerLoadWaiter(id: waiterID, with: .timedOut)
+                }
+                diarizerLoadWaiters[waiterID] = DiarizerLoadWaiter(
+                    continuation: continuation,
+                    timeoutTask: timeoutTask
+                )
+            }
+        } onCancel: { [weak self] in
+            Task {
+                await self?.resumeDiarizerLoadWaiter(id: waiterID, with: .cancelled)
+            }
         }
     }
+
+    private func resumeDiarizerLoadWaiter(id: UUID, with outcome: DiarizerLoadWaitOutcome) {
+        guard let waiter = diarizerLoadWaiters.removeValue(forKey: id) else { return }
+        waiter.timeoutTask.cancel()
+        waiter.continuation.resume(returning: outcome)
+    }
+
+    private func resumeAllDiarizerLoadWaiters(with outcome: DiarizerLoadWaitOutcome) {
+        let waiters = diarizerLoadWaiters.values
+        diarizerLoadWaiters.removeAll()
+        for waiter in waiters {
+            waiter.timeoutTask.cancel()
+            waiter.continuation.resume(returning: outcome)
+        }
+    }
+
+    #if DEBUG
+    func diarizerPreloadStateForTesting() -> (isActive: Bool, waiterCount: Int) {
+        (isDiarizerLoadInProgress, diarizerLoadWaiters.count)
+    }
+    #endif
 
     func preloadPostProcessorIfNeeded(
         enabled: Bool,

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -28,6 +28,9 @@ actor TranscriptionCoordinator {
     private let senseVoiceTranscriber = SenseVoiceTranscriber()
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
+    private var isDiarizerLoadInProgress = false
+    private var diarizerLoadWaiters: [CheckedContinuation<Void, Never>] = []
+    private let diarizerDiagnostics = DiarizerPreloadDiagnostics()
     private var activeBackend: String?
 
     private var _nemotron35Transcriber: Any?
@@ -209,6 +212,7 @@ actor TranscriptionCoordinator {
         backend: BackendOption,
         enablePostProcessor: Bool = false,
         includeMeetingHelpers: Bool = true,
+        meetingHelperTrigger: DiarizerPreloadTrigger = .unspecified,
         progress: ((Double, String?) -> Void)? = nil
     ) async {
         do {
@@ -216,6 +220,7 @@ actor TranscriptionCoordinator {
                 backend: backend,
                 enablePostProcessor: enablePostProcessor,
                 includeMeetingHelpers: includeMeetingHelpers,
+                meetingHelperTrigger: meetingHelperTrigger,
                 progress: progress
             )
         } catch {
@@ -227,12 +232,13 @@ actor TranscriptionCoordinator {
         backend: BackendOption,
         enablePostProcessor: Bool = false,
         includeMeetingHelpers: Bool = true,
+        meetingHelperTrigger: DiarizerPreloadTrigger = .unspecified,
         progress: ((Double, String?) -> Void)? = nil
     ) async throws {
         activeBackend = backend.backend
 
         if includeMeetingHelpers {
-            await preloadMeetingHelpers()
+            await preloadMeetingHelpers(trigger: meetingHelperTrigger)
         }
 
         switch backend.backend {
@@ -304,7 +310,7 @@ actor TranscriptionCoordinator {
         await preloadPostProcessorIfNeeded(enabled: enablePostProcessor, transcriptionBackend: backend)
     }
 
-    func preloadMeetingHelpers() async {
+    func preloadMeetingHelpers(trigger: DiarizerPreloadTrigger = .unspecified) async {
         if vadManager == nil {
             do {
                 vadManager = try await VadManager()
@@ -314,16 +320,53 @@ actor TranscriptionCoordinator {
             }
         }
 
-        if diarizerManager == nil {
-            do {
-                let diarizer = DiarizerManager()
-                let models = try await DiarizerModels.download()
-                diarizer.initialize(models: models)
-                diarizerManager = diarizer
-                fputs("[muesli-native] Speaker diarization loaded\n", stderr)
-            } catch {
-                fputs("[muesli-native] Diarization load failed (non-critical): \(error)\n", stderr)
+        let policy = DiarizerRuntimePolicy.resolve(for: .current())
+        let context = DiarizerPreloadContext(
+            trigger: trigger,
+            policy: policy,
+            cacheState: .resolve()
+        )
+
+        if diarizerManager != nil {
+            diarizerDiagnostics.skipped(context, reason: "already_loaded")
+            return
+        }
+
+        if isDiarizerLoadInProgress {
+            await withCheckedContinuation { continuation in
+                diarizerLoadWaiters.append(continuation)
             }
+            diarizerDiagnostics.skipped(
+                context,
+                reason: diarizerManager == nil ? "joined_failed_load" : "joined_active_load"
+            )
+            return
+        }
+
+        isDiarizerLoadInProgress = true
+        defer {
+            isDiarizerLoadInProgress = false
+            let waiters = diarizerLoadWaiters
+            diarizerLoadWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        let startedAt = diarizerDiagnostics.begin(context)
+        do {
+            let diarizer = DiarizerManager()
+            let models = try await DiarizerModels.download(
+                configuration: policy.modelConfiguration
+            )
+            diarizer.initialize(models: models)
+            diarizerManager = diarizer
+            diarizerDiagnostics.ready(context, startedAt: startedAt)
+            fputs(
+                "[muesli-native] Speaker diarization loaded (compute: \(policy.computePolicy.rawValue))\n",
+                stderr
+            )
+        } catch {
+            diarizerDiagnostics.failed(context, startedAt: startedAt, error: error)
+            fputs("[muesli-native] Diarization load failed (non-critical): \(error)\n", stderr)
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/DiarizerRuntimePolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DiarizerRuntimePolicyTests.swift
@@ -1,0 +1,233 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Diarizer runtime policy")
+struct DiarizerRuntimePolicyTests {
+    @Test("M1 family on macOS 15.1 avoids GPU compute")
+    func m1OnMacOS151UsesCPUAndNeuralEngine() {
+        for cpuBrand in ["Apple M1", "Apple M1 Pro", "Apple M1 Max", "Apple M1 Ultra"] {
+            let policy = DiarizerRuntimePolicy.resolve(
+                for: environment(cpuBrand: cpuBrand, os: (15, 1, 1))
+            )
+
+            #expect(policy.computePolicy == .cpuAndNeuralEngine)
+            #expect(policy.compatibilityRule == DiarizerRuntimePolicy.m1MacOS151CompatibilityRule)
+        }
+    }
+
+    @Test("hardware model identifies M1 when CPU brand is unavailable")
+    func hardwareModelFallback() {
+        let policy = DiarizerRuntimePolicy.resolve(
+            for: environment(
+                cpuBrand: nil,
+                hardwareModel: "MacBookPro17,1",
+                os: (15, 1, 1)
+            )
+        )
+
+        #expect(policy.computePolicy == .cpuAndNeuralEngine)
+    }
+
+    @Test("M1 on newer macOS keeps the default policy")
+    func m1OnNewerMacOSUsesDefault() {
+        let policy = DiarizerRuntimePolicy.resolve(
+            for: environment(cpuBrand: "Apple M1", os: (15, 2, 0))
+        )
+
+        #expect(policy.computePolicy == .all)
+        #expect(policy.compatibilityRule == DiarizerRuntimePolicy.defaultCompatibilityRule)
+    }
+
+    @Test("newer Apple silicon on macOS 15.1 keeps the default policy")
+    func m2OnMacOS151UsesDefault() {
+        let policy = DiarizerRuntimePolicy.resolve(
+            for: environment(cpuBrand: "Apple M2", os: (15, 1, 1))
+        )
+
+        #expect(policy.computePolicy == .all)
+    }
+
+    @Test("cache state distinguishes absent, partial, and complete models")
+    func cacheState() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiarizerRuntimePolicyTests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let requiredModels: Set<String> = ["segmentation.mlmodelc", "embedding.mlmodelc"]
+
+        #expect(
+            DiarizerModelCacheState.resolve(
+                directory: directory,
+                requiredModelNames: requiredModels
+            ) == .absent
+        )
+
+        try Data().write(to: directory.appendingPathComponent("segmentation.mlmodelc"))
+        #expect(
+            DiarizerModelCacheState.resolve(
+                directory: directory,
+                requiredModelNames: requiredModels
+            ) == .partial
+        )
+
+        try Data().write(to: directory.appendingPathComponent("embedding.mlmodelc"))
+        #expect(
+            DiarizerModelCacheState.resolve(
+                directory: directory,
+                requiredModelNames: requiredModels
+            ) == .complete
+        )
+    }
+
+    private func environment(
+        cpuBrand: String?,
+        hardwareModel: String? = nil,
+        os: (Int, Int, Int)
+    ) -> DiarizerRuntimeEnvironment {
+        DiarizerRuntimeEnvironment(
+            cpuBrand: cpuBrand,
+            hardwareModel: hardwareModel,
+            operatingSystemVersion: OperatingSystemVersion(
+                majorVersion: os.0,
+                minorVersion: os.1,
+                patchVersion: os.2
+            )
+        )
+    }
+}
+
+@Suite("Diarizer preload diagnostics")
+struct DiarizerPreloadDiagnosticsTests {
+    private final class SignalRecorder {
+        var events: [(String, [String: String])] = []
+
+        func record(_ event: String, parameters: [String: String]) {
+            events.append((event, parameters))
+        }
+    }
+
+    @Test("uncleared attempt is reported as interrupted on next launch")
+    func interruptedAttempt() throws {
+        let suiteName = "DiarizerPreloadDiagnosticsTests.interrupted.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = SignalRecorder()
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        let context = makeContext()
+
+        DiarizerPreloadDiagnostics(
+            defaults: defaults,
+            now: { startedAt },
+            signalSink: recorder.record
+        ).begin(context)
+        DiarizerPreloadDiagnostics(
+            defaults: defaults,
+            now: { startedAt.addingTimeInterval(8) },
+            signalSink: recorder.record
+        ).reportInterruptedAttemptIfNeeded()
+
+        #expect(recorder.events.map(\.0) == [
+            "diarizer.preload.started",
+            "diarizer.preload.interrupted",
+        ])
+        #expect(recorder.events.last?.1["duration_bucket"] == "5_to_15s")
+        #expect(recorder.events.last?.1["compute_policy"] == "cpu_and_neural_engine")
+
+        DiarizerPreloadDiagnostics(
+            defaults: defaults,
+            signalSink: recorder.record
+        ).reportInterruptedAttemptIfNeeded()
+        #expect(recorder.events.count == 2)
+    }
+
+    @Test("successful load clears the interruption marker")
+    func readyClearsMarker() throws {
+        let suiteName = "DiarizerPreloadDiagnosticsTests.ready.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = SignalRecorder()
+        let startedAt = Date(timeIntervalSince1970: 2_000)
+        let diagnostics = DiarizerPreloadDiagnostics(
+            defaults: defaults,
+            now: { startedAt.addingTimeInterval(2) },
+            signalSink: recorder.record
+        )
+        let context = makeContext()
+
+        diagnostics.begin(context)
+        diagnostics.ready(context, startedAt: startedAt)
+        diagnostics.reportInterruptedAttemptIfNeeded()
+
+        #expect(recorder.events.map(\.0) == [
+            "diarizer.preload.started",
+            "diarizer.preload.ready",
+        ])
+        #expect(recorder.events.last?.1["duration_bucket"] == "1_to_5s")
+    }
+
+    @Test("failure telemetry is categorical and excludes raw error text")
+    func failureIsCategorical() throws {
+        let suiteName = "DiarizerPreloadDiagnosticsTests.failure.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = SignalRecorder()
+        let diagnostics = DiarizerPreloadDiagnostics(
+            defaults: defaults,
+            signalSink: recorder.record
+        )
+        let context = makeContext()
+        let startedAt = diagnostics.begin(context)
+
+        diagnostics.failed(
+            context,
+            startedAt: startedAt,
+            error: URLError(.notConnectedToInternet)
+        )
+
+        let parameters = try #require(recorder.events.last?.1)
+        #expect(parameters["failure_category"] == "network")
+        #expect(!parameters.keys.contains("error"))
+        #expect(!parameters.values.contains { $0.localizedCaseInsensitiveContains("internet") })
+    }
+
+    @Test("base telemetry uses an explicit privacy-safe allowlist")
+    func telemetryAllowlist() {
+        let parameters = makeContext().telemetryParameters
+
+        #expect(Set(parameters.keys) == [
+            "schema_version",
+            "trigger",
+            "compute_policy",
+            "compatibility_rule",
+            "cache_state",
+            "model_set",
+            "fluid_audio_version",
+        ])
+    }
+
+    @Test(
+        "duration buckets are stable",
+        arguments: [
+            (0.5, "under_1s"),
+            (1.0, "1_to_5s"),
+            (5.0, "5_to_15s"),
+            (15.0, "15_to_60s"),
+            (60.0, "60s_or_more"),
+        ]
+    )
+    func durationBuckets(argument: (TimeInterval, String)) {
+        #expect(DiarizerPreloadDiagnostics.durationBucket(argument.0) == argument.1)
+    }
+
+    private func makeContext() -> DiarizerPreloadContext {
+        DiarizerPreloadContext(
+            trigger: .appLaunch,
+            policy: DiarizerRuntimePolicy(
+                computePolicy: .cpuAndNeuralEngine,
+                compatibilityRule: DiarizerRuntimePolicy.m1MacOS151CompatibilityRule
+            ),
+            cacheState: .complete
+        )
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DiarizerRuntimePolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DiarizerRuntimePolicyTests.swift
@@ -166,6 +166,24 @@ struct DiarizerPreloadDiagnosticsTests {
         #expect(recorder.events.last?.1["duration_bucket"] == "1_to_5s")
     }
 
+    @Test("corrupt pending attempt is discarded without a signal")
+    func corruptPendingAttempt() throws {
+        let suiteName = "DiarizerPreloadDiagnosticsTests.corrupt.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = SignalRecorder()
+        defaults.set(
+            Data("not json".utf8),
+            forKey: DiarizerPreloadDiagnostics.pendingAttemptKey
+        )
+
+        DiarizerPreloadDiagnostics(defaults: defaults, signalSink: recorder.record)
+            .reportInterruptedAttemptIfNeeded()
+
+        #expect(recorder.events.isEmpty)
+        #expect(defaults.data(forKey: DiarizerPreloadDiagnostics.pendingAttemptKey) == nil)
+    }
+
     @Test("failure telemetry is categorical and excludes raw error text")
     func failureIsCategorical() throws {
         let suiteName = "DiarizerPreloadDiagnosticsTests.failure.\(UUID().uuidString)"
@@ -209,6 +227,7 @@ struct DiarizerPreloadDiagnosticsTests {
     @Test(
         "duration buckets are stable",
         arguments: [
+            (-30.0, "under_1s"),
             (0.5, "under_1s"),
             (1.0, "1_to_5s"),
             (5.0, "5_to_15s"),
@@ -220,6 +239,20 @@ struct DiarizerPreloadDiagnosticsTests {
         #expect(DiarizerPreloadDiagnostics.durationBucket(argument.0) == argument.1)
     }
 
+    @Test("only Cocoa file errors are classified as filesystem failures")
+    func cocoaFailureCategories() {
+        let fileError = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoSuchFileError)
+        let validationError = NSError(domain: NSCocoaErrorDomain, code: NSKeyValueValidationError)
+
+        #expect(DiarizerPreloadDiagnostics.failureCategory(for: fileError) == "filesystem")
+        #expect(DiarizerPreloadDiagnostics.failureCategory(for: validationError) == "other")
+        #expect(
+            DiarizerPreloadDiagnostics.failureCategory(
+                for: DiarizerPreloadFailure.operationTimedOut
+            ) == "timeout"
+        )
+    }
+
     private func makeContext() -> DiarizerPreloadContext {
         DiarizerPreloadContext(
             trigger: .appLaunch,
@@ -229,5 +262,153 @@ struct DiarizerPreloadDiagnosticsTests {
             ),
             cacheState: .complete
         )
+    }
+}
+
+@Suite("Diarizer preload coordination")
+struct DiarizerPreloadCoordinationTests {
+    private enum TestLoadError: Error {
+        case failed
+    }
+
+    private actor BlockingLoader {
+        private(set) var attempts = 0
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var isReleased = false
+
+        func waitUntilReleased() async {
+            attempts += 1
+            guard !isReleased else { return }
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func release() {
+            isReleased = true
+            let continuation = continuation
+            self.continuation = nil
+            continuation?.resume()
+        }
+    }
+
+    private final class LockedSignalRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedEvents: [(String, [String: String])] = []
+
+        func record(_ event: String, parameters: [String: String]) {
+            lock.lock()
+            storedEvents.append((event, parameters))
+            lock.unlock()
+        }
+
+        func events() -> [(String, [String: String])] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedEvents
+        }
+    }
+
+    @Test("cancelled joiner returns while the shared preload continues")
+    func cancelledJoinerReturnsPromptly() async throws {
+        let loader = BlockingLoader()
+        let diagnostics = try makeDiagnostics(suffix: "cancelled-joiner")
+        let coordinator = TranscriptionCoordinator(
+            diarizerModelLoader: { _ in
+                await loader.waitUntilReleased()
+                throw TestLoadError.failed
+            },
+            diarizerDiagnostics: diagnostics.value
+        )
+
+        let initiatingCaller = Task {
+            await coordinator.preloadDiarizer(trigger: .appLaunch, waitTimeout: .seconds(5))
+        }
+        #expect(await waitUntil {
+            let state = await coordinator.diarizerPreloadStateForTesting()
+            return await loader.attempts == 1 && state.waiterCount == 1
+        })
+
+        let joinedCaller = Task {
+            await coordinator.preloadDiarizer(trigger: .meetingStart, waitTimeout: .seconds(5))
+        }
+        #expect(await waitUntil {
+            await coordinator.diarizerPreloadStateForTesting().waiterCount == 2
+        })
+
+        joinedCaller.cancel()
+        let cancellationObserved = await waitUntil {
+            let state = await coordinator.diarizerPreloadStateForTesting()
+            return state.isActive && state.waiterCount == 1
+        }
+        #expect(cancellationObserved)
+
+        if !cancellationObserved {
+            await loader.release()
+        }
+        await joinedCaller.value
+        #expect(await loader.attempts == 1)
+
+        await loader.release()
+        await initiatingCaller.value
+        diagnostics.cleanup()
+    }
+
+    @Test("shared preload has an operation deadline")
+    func sharedPreloadHasDeadline() async throws {
+        let loader = BlockingLoader()
+        let diagnostics = try makeDiagnostics(suffix: "operation-timeout")
+        let coordinator = TranscriptionCoordinator(
+            diarizerModelLoader: { _ in
+                await loader.waitUntilReleased()
+                throw TestLoadError.failed
+            },
+            diarizerLoadOperationTimeout: .milliseconds(30),
+            diarizerDiagnostics: diagnostics.value
+        )
+
+        await coordinator.preloadDiarizer(trigger: .meetingStart, waitTimeout: .seconds(2))
+
+        let timedOutState = await coordinator.diarizerPreloadStateForTesting()
+        #expect(timedOutState.isActive)
+        #expect(timedOutState.waiterCount == 0)
+
+        await loader.release()
+        #expect(await waitUntil {
+            !(await coordinator.diarizerPreloadStateForTesting().isActive)
+        })
+        let failedEvent = diagnostics.recorder.events().last { $0.0 == "diarizer.preload.failed" }
+        #expect(failedEvent?.1["failure_category"] == "timeout")
+        diagnostics.cleanup()
+    }
+
+    private func makeDiagnostics(
+        suffix: String
+    ) throws -> (
+        value: DiarizerPreloadDiagnostics,
+        recorder: LockedSignalRecorder,
+        cleanup: () -> Void
+    ) {
+        let suiteName = "DiarizerPreloadCoordinationTests.\(suffix).\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let recorder = LockedSignalRecorder()
+        return (
+            DiarizerPreloadDiagnostics(defaults: defaults, signalSink: recorder.record),
+            recorder,
+            { defaults.removePersistentDomain(forName: suiteName) }
+        )
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: () async -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return await condition()
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/DiarizerRuntimePolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DiarizerRuntimePolicyTests.swift
@@ -382,6 +382,62 @@ struct DiarizerPreloadCoordinationTests {
         diagnostics.cleanup()
     }
 
+    @Test("cancelled joined required preload never enters backend loading")
+    func cancelledRequiredPreloadStopsBeforeBackend() async throws {
+        let loader = BlockingLoader()
+        let diagnostics = try makeDiagnostics(suffix: "cancelled-required-preload")
+        let coordinator = TranscriptionCoordinator(
+            diarizerModelLoader: { _ in
+                await loader.waitUntilReleased()
+                throw TestLoadError.failed
+            },
+            vadLoader: { throw TestLoadError.failed },
+            diarizerDiagnostics: diagnostics.value
+        )
+        let invalidBackend = BackendOption(
+            backend: "must-not-load",
+            model: "none",
+            label: "Test",
+            sizeLabel: "0 MB",
+            description: "Cancellation boundary test",
+            recommended: false
+        )
+
+        let initiatingCaller = Task {
+            await coordinator.preloadDiarizer(trigger: .appLaunch, waitTimeout: .seconds(5))
+        }
+        #expect(await waitUntil {
+            let state = await coordinator.diarizerPreloadStateForTesting()
+            return await loader.attempts == 1 && state.waiterCount == 1
+        })
+
+        let joinedCaller = Task { () -> String in
+            do {
+                try await coordinator.preloadRequired(
+                    backend: invalidBackend,
+                    includeMeetingHelpers: true,
+                    meetingHelperTrigger: .meetingStart
+                )
+                return "completed"
+            } catch is CancellationError {
+                return "cancelled"
+            } catch {
+                return "unexpected_error"
+            }
+        }
+        #expect(await waitUntil {
+            await coordinator.diarizerPreloadStateForTesting().waiterCount == 2
+        })
+
+        joinedCaller.cancel()
+        #expect(await joinedCaller.value == "cancelled")
+        #expect(await coordinator.diarizerPreloadStateForTesting().waiterCount == 1)
+
+        await loader.release()
+        await initiatingCaller.value
+        diagnostics.cleanup()
+    }
+
     private func makeDiagnostics(
         suffix: String
     ) throws -> (

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -51,6 +51,8 @@ case "${shard}" in
       SpeechTranscriptionResultTests
       TranscriptionCoordinatorTests
       TranscriptionEngineArtifactsFilterTests
+      DiarizerRuntimePolicyTests
+      DiarizerPreloadDiagnosticsTests
       PasteControllerTests
       BackendOptionTests
       SummaryModelPresetTests

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -53,6 +53,7 @@ case "${shard}" in
       TranscriptionEngineArtifactsFilterTests
       DiarizerRuntimePolicyTests
       DiarizerPreloadDiagnosticsTests
+      DiarizerPreloadCoordinationTests
       PasteControllerTests
       BackendOptionTests
       SummaryModelPresetTests


### PR DESCRIPTION
## Summary

- route FluidAudio diarizer model loading to CPU + Neural Engine on M1-family Macs running macOS 15.1.x
- preserve FluidAudio's normal `.all` compute policy on every other hardware/OS combination
- coordinate concurrent diarizer preloads with cancellation-aware joins, caller deadlines, and a bounded shared-load timeout
- stop cancelled required preloads before transcription backend loading or warmup begins
- add a privacy-preserving preload telemetry funnel for started, ready, failed, interrupted, skipped, cancelled, and timed-out outcomes

## Root cause and approach

The reporter's full crash stack reaches `TranscriptionCoordinator.preloadMeetingHelpers()` and `DiarizerModels.download()`, then aborts inside CoreML's MPSGraph/Metal path on a `MacBookPro17,1` running macOS 15.1.1. Because this is a `SIGABRT`, Swift cannot catch and classify it as a normal thrown model-loading error.

This change narrowly excludes GPU compute for the affected M1 + macOS 15.1.x cohort by using `.cpuAndNeuralEngine`. It does not treat M1 hardware as generally incapable of diarization and does not globally slow unaffected Macs.

Concurrent callers share one diarizer load. Individual callers can cancel or time out without leaving a continuation suspended, while a separate operation deadline releases all waiters even if FluidAudio does not return cooperatively. Required preloads re-check cancellation before starting the transcription backend.

Before CoreML loading begins, the app persists a small pending-attempt marker. A later launch reports an uncleared marker as `diarizer.preload.interrupted`, which captures aborts without claiming that every interruption was necessarily a crash.

## Telemetry and privacy

The new events are:

- `diarizer.preload.started`
- `diarizer.preload.ready`
- `diarizer.preload.failed`
- `diarizer.preload.interrupted`
- `diarizer.preload.skipped`

Parameters are restricted to an explicit allowlist: schema version, trigger, compute policy, compatibility rule, model-cache state, model set, FluidAudio version, coarse duration bucket, categorical failure, and skip reason. The instrumentation does not send raw errors, file paths, audio, transcripts, meeting/calendar titles, CPU brand strings, or hardware identifiers. TelemetryDeck's standard aggregate OS and device fields remain available for cohort analysis.

## Validation

- focused diarizer policy, telemetry, and preload coordination tests: 15 passed
- full local package run exercised 1,465 tests; one unrelated Streaming VAD timing test failed and then passed with its complete five-test suite on isolated rerun
- GitHub CI: release build, CLI smoke test, and core, meetings, and dictation/transcription test shards passed
- app target compiled and linked during local validation
- physical M1 + macOS 15.1.x reporter confirmation remains the final hardware validation

Intended for the 0.8.1 bug-fix release.

Fixes #344

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098619&installation_model_id=422865&pr_number=361&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F361&signature=456743533d1adabf44eba4b7667a42255be1db644ecb34f83a098a96c3fe221e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved model preloading reliability during startup, downloads, audio imports, and transcription.
  * Optimized diarization performance on supported Mac hardware.
  * Enhanced recovery from interrupted, timed-out, or unavailable model loads.
  * Improved coordination when multiple transcription tasks request the same models.
  * Added clearer, privacy-conscious diagnostics for preload issues.

* **Tests**
  * Expanded coverage for hardware policies, model availability, preload coordination, cancellation, timeouts, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
