### PR TITLE
Fix CUA audio routing and background meeting starts

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -323,8 +323,9 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     func stop() {
+        let requestedSessionID = detachSessionHint()
         queue.async { [self] in
-            let sessionID = self.stateStorage.sessionID
+            let sessionID = self.stateStorage.sessionID ?? requestedSessionID
             guard sessionID != nil else {
                 self.restoreSessionAudioState(completion: nil)
                 return
@@ -335,7 +336,6 @@ final class DictationAudioSessionManager: @unchecked Sendable {
             self.activeRecorderRunID = nil
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
-            self.clearSessionHint(sessionID)
             self.emit(.stopped(sessionID, wavURL: wavURL))
             self.restoreSessionAudioState {
                 self.emit(.audioRestored(sessionID))
@@ -344,16 +344,15 @@ final class DictationAudioSessionManager: @unchecked Sendable {
     }
 
     func cancel(reason: String) {
+        let requestedSessionID = detachSessionHint(clearExternalSession: true)
         queue.async { [self] in
-            let sessionID = self.stateStorage.sessionID
+            let sessionID = self.stateStorage.sessionID ?? requestedSessionID
             self.recorder.keepsAudioGraphWarm = false
             self.recorder.cancel()
             self.activeRecorderRunID = nil
             self.recorder.preferredInputDeviceID = nil
             self.stateStorage = .idle
             self.externalSessionActive = false
-            self.clearSessionHint(sessionID)
-            self.setExternalSessionHint(false)
             self.restoreSessionAudioState()
             self.emitLatency("cancelled:\(reason)")
             self.emit(.cancelled(sessionID, reason: reason))
@@ -409,6 +408,17 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         sessionHintLock.withLock {
             guard self.sessionHint == sessionID || sessionID == nil else { return }
             self.sessionHint = nil
+        }
+    }
+
+    private func detachSessionHint(clearExternalSession: Bool = false) -> UUID? {
+        sessionHintLock.withLock {
+            let detachedSessionID = sessionHint
+            sessionHint = nil
+            if clearExternalSession {
+                externalSessionHint = false
+            }
+            return detachedSessionID
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStartPresentation.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStartPresentation.swift
@@ -1,0 +1,12 @@
+enum MeetingStartPresentation: Equatable {
+    case foregroundNotes
+    case backgroundPill
+
+    var opensMeetingDocument: Bool {
+        self == .foregroundNotes
+    }
+
+    var presentsHistoryWindow: Bool {
+        self == .foregroundNotes
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -251,6 +251,8 @@ final class MuesliController: NSObject {
     private static let pendingDictionaryCorrectionAccessibilityRequestedAtKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestedAt"
     private static let pendingDictionaryCorrectionAccessibilityRequestProcessIDKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestProcessID"
     private static let dictionaryCorrectionAccessibilityIntentTimeout: TimeInterval = 24 * 60 * 60
+    private static let computerUsePreparationLeaseDuration: TimeInterval = 2
+    private static let computerUseRecordingLeaseDuration: TimeInterval = 60
 
     private let runtime: RuntimePaths
     private let configStore: ConfigStore
@@ -262,7 +264,7 @@ final class MuesliController: NSObject {
     private let hotkeyMonitor = HotkeyMonitor()
     private let computerUseHotkeyMonitor = HotkeyMonitor()
     private let meetingRecordingHotkeyMonitor = HotkeyMonitor()
-    private let computerUseRecorder = MicrophoneRecorder()
+    private let computerUseRecorder = RouteAwareDictationRecorder()
     private let dictationRecorder = RouteAwareDictationRecorder()
     private let dictationCorrectionMonitor = DictationCorrectionMonitor()
     private let dictionarySuggestionPrompt = DictionarySuggestionPromptController()
@@ -273,6 +275,11 @@ final class MuesliController: NSObject {
     private let dictationAudioRoutingController: DictationAudioRouting
     private lazy var dictationAudioSessionManager = DictationAudioSessionManager(
         recorder: dictationRecorder,
+        duckingController: audioDuckingController,
+        routingController: dictationAudioRoutingController
+    )
+    private lazy var computerUseAudioSessionManager = DictationAudioSessionManager(
+        recorder: computerUseRecorder,
         duckingController: audioDuckingController,
         routingController: dictationAudioRoutingController
     )
@@ -347,8 +354,14 @@ final class MuesliController: NSObject {
     private var pendingDictationStopSessionID: UUID?
     private var pendingReleaseSoundSessionID: UUID?
     private var pendingPreparingIndicatorWorkItem: DispatchWorkItem?
+    private var activeComputerUseAudioSessionID: UUID?
     private var computerUseCommandStartedAt: Date?
+    private var pendingComputerUseStopStartedAt: Date?
+    private var pendingComputerUseStopSessionID: UUID?
+    private var computerUsePreparationLeaseWorkItem: DispatchWorkItem?
+    private var computerUseRecordingLeaseWorkItem: DispatchWorkItem?
     private var computerUseCommandTask: Task<Void, Never>?
+    private var computerUseCommandTaskID: UUID?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
     private var computerUseLastFloatingStatusAt = Date.distantPast
     private var computerUseLastFloatingStatus = ""
@@ -465,6 +478,11 @@ final class MuesliController: NSObject {
         dictationAudioSessionManager.onEvent = { [weak self] event in
             Task { @MainActor [weak self] in
                 self?.handleDictationAudioSessionEvent(event)
+            }
+        }
+        computerUseAudioSessionManager.onEvent = { [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.handleComputerUseAudioSessionEvent(event)
             }
         }
         dictationAudioRoutingController.onPreferredInputDeviceChanged = { [weak self] _ in
@@ -774,6 +792,11 @@ final class MuesliController: NSObject {
         meetingRecordingHotkeyMonitor.stop()
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
+        computerUseCommandTaskID = nil
+        cancelComputerUseAudioLeases()
+        activeComputerUseAudioSessionID = nil
+        pendingComputerUseStopSessionID = nil
+        pendingComputerUseStopStartedAt = nil
         calendarMonitor.stop()
         calendarCheckTimer?.invalidate()
         calendarCheckTimer = nil
@@ -798,7 +821,7 @@ final class MuesliController: NSObject {
         activeMeetingAudioWarning = nil
         endMeetingActivity()
         dictationAudioSessionManager.cancel(reason: "shutdown")
-        computerUseRecorder.cancel()
+        computerUseAudioSessionManager.cancel(reason: "shutdown")
         Task {
             await transcriptionCoordinator.shutdown()
         }
@@ -2713,7 +2736,7 @@ final class MuesliController: NSObject {
                 startMeetingRecording(
                     title: event.title,
                     calendarOccurrence: event.resolvedCalendarOccurrence,
-                    openDocument: true,
+                    openDocument: false,
                     endDate: event.endDate,
                     autoStopSource: event.meetingURL.flatMap { MeetingAutoStopSource(meetingURL: $0) },
                     startOrigin: .calendarAutoRecord
@@ -2800,11 +2823,12 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(
+                self.startMeetingRecordingFromEntryPoint(
                     title: title,
                     calendarOccurrence: calendarOccurrence,
                     endDate: endDate,
                     autoStopSource: autoStopSource,
+                    presentation: .backgroundPill,
                     startOrigin: .scheduledMeetingPrompt
                 )
             },
@@ -2815,7 +2839,8 @@ final class MuesliController: NSObject {
                     title: title,
                     meetingURL: meetingURL!,
                     endDate: endDate,
-                    calendarOccurrence: calendarOccurrence
+                    calendarOccurrence: calendarOccurrence,
+                    presentation: .backgroundPill
                 )
             } : nil,
             onJoinOnly: meetingURL != nil ? { [weak self] in
@@ -4613,7 +4638,7 @@ final class MuesliController: NSObject {
             stopMeetingRecording()
         } else {
             let wasMeetingRecording = isMeetingRecording()
-            startForegroundMeetingRecording()
+            startMeetingRecordingFromEntryPoint()
             if !isMeetingRecording() && !isStartingMeetingRecording && !wasMeetingRecording {
                 meetingRecordingHotkeyMonitor.cancelToggleMode()
             }
@@ -4654,7 +4679,7 @@ final class MuesliController: NSObject {
 
     @objc func startMeetingFromCalendarMenuItem(_ sender: NSMenuItem) {
         if let payload = sender.representedObject as? CalendarMenuMeetingPayload {
-            startForegroundMeetingRecording(
+            startMeetingRecordingFromEntryPoint(
                 title: payload.title,
                 calendarOccurrence: payload.calendarOccurrence,
                 endDate: payload.endDate,
@@ -4665,21 +4690,24 @@ final class MuesliController: NSObject {
         }
 
         guard let title = sender.representedObject as? String else { return }
-        startForegroundMeetingRecording(title: title)
+        startMeetingRecordingFromEntryPoint(title: title)
     }
 
     @discardableResult
-    func startForegroundMeetingRecording(
+    func startMeetingRecordingFromEntryPoint(
         title: String = "Meeting",
         calendarEventID: String? = nil,
         calendarOccurrence: CalendarOccurrenceReference? = nil,
         endDate: Date? = nil,
         autoStopSource: MeetingAutoStopSource? = nil,
+        presentation: MeetingStartPresentation = .foregroundNotes,
         startOrigin: MeetingRecordingStartOrigin = .manual
     ) -> Bool {
         guard ensureBasicDictationPermissionsBeforeDashboard() else { return false }
         if isMeetingRecording() {
-            presentHistoryWindow(tab: .meetings)
+            if presentation.presentsHistoryWindow {
+                presentHistoryWindow(tab: .meetings)
+            }
             return false
         }
         guard !isStartingMeetingRecording else { return false }
@@ -4687,13 +4715,15 @@ final class MuesliController: NSObject {
             title: title,
             calendarEventID: calendarEventID,
             calendarOccurrence: calendarOccurrence,
-            openDocument: true,
+            openDocument: presentation.opensMeetingDocument,
             endDate: endDate,
             autoStopSource: autoStopSource,
             startOrigin: startOrigin
         )
         guard didStart else { return false }
-        presentHistoryWindow(tab: .meetings)
+        if presentation.presentsHistoryWindow {
+            presentHistoryWindow(tab: .meetings)
+        }
         return true
     }
 
@@ -4826,7 +4856,7 @@ final class MuesliController: NSObject {
     }
 
     func startQuickNoteMeeting() {
-        startForegroundMeetingRecording(title: "Meeting")
+        startMeetingRecordingFromEntryPoint(title: "Meeting")
     }
 
     /// Whether a finished meeting can be resumed right now (used to gate the UI control too).
@@ -5417,14 +5447,16 @@ final class MuesliController: NSObject {
         title: String,
         meetingURL: URL,
         endDate: Date?,
-        calendarOccurrence: CalendarOccurrenceReference? = nil
+        calendarOccurrence: CalendarOccurrenceReference? = nil,
+        presentation: MeetingStartPresentation = .foregroundNotes
     ) {
         NSWorkspace.shared.open(meetingURL)
-        startForegroundMeetingRecording(
+        startMeetingRecordingFromEntryPoint(
             title: title,
             calendarOccurrence: calendarOccurrence,
             endDate: endDate,
             autoStopSource: MeetingAutoStopSource(meetingURL: meetingURL),
+            presentation: presentation,
             startOrigin: .joinAndRecord
         )
     }
@@ -6856,9 +6888,10 @@ final class MuesliController: NSObject {
             platform: MeetingPlatform(candidate.platform),
             onStartRecording: { [weak self] in
                 guard let self else { return }
-                if self.startForegroundMeetingRecording(
+                if self.startMeetingRecordingFromEntryPoint(
                     title: title,
                     autoStopSource: MeetingAutoStopSource(candidate: candidate),
+                    presentation: .backgroundPill,
                     startOrigin: .detectedPrompt
                 ) {
                     self.meetingMonitor.markRecordingStarted(candidate)
@@ -6924,40 +6957,30 @@ final class MuesliController: NSObject {
         fputs("[cua] prepare\n", stderr)
         meetingMonitor.suppressWhileActive()
         meetingMonitor.refreshState()
-        computerUseRecorder.preferredInputDeviceID = nil
         setState(.preparing)
-        do {
-            try computerUseRecorder.prepare()
-        } catch {
-            fputs("[cua] recorder prepare failed: \(error)\n", stderr)
-            computerUseRecorder.cancel()
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
-        }
+        computerUseAudioSessionManager.arm(source: "computer_use_hotkey_prepare")
+        activeComputerUseAudioSessionID = computerUseAudioSessionManager.currentSessionID
+        scheduleComputerUsePreparationLease(for: activeComputerUseAudioSessionID)
     }
 
     private func handleComputerUseStart() {
         guard canStartComputerUseCommand else { return }
         fputs("[cua] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
-        computerUseRecorder.preferredInputDeviceID = nil
-        do {
-            try computerUseRecorder.start()
-            computerUseCommandStartedAt = Date()
-            indicator.powerProvider = { [weak self] in
-                self?.computerUseRecorder.currentPower() ?? -160
-            }
-            setState(.recording)
-            SoundController.playDictationStart(enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode)
-        } catch {
-            fputs("[cua] recorder start failed: \(error)\n", stderr)
-            computerUseRecorder.cancel()
-            computerUseCommandStartedAt = nil
-            setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
+        computerUsePreparationLeaseWorkItem?.cancel()
+        computerUsePreparationLeaseWorkItem = nil
+        computerUseCommandStartedAt = Date()
+        indicator.powerProvider = { [weak self] in
+            self?.computerUseAudioSessionManager.currentPower() ?? -160
         }
+        setState(.preparing)
+        computerUseAudioSessionManager.beginRecording(
+            mode: "computer_use",
+            duckingEnabled: false,
+            mediaPauseEnabled: false
+        )
+        activeComputerUseAudioSessionID = computerUseAudioSessionManager.currentSessionID
+        scheduleComputerUseRecordingLease(for: activeComputerUseAudioSessionID)
     }
 
     private func handleComputerUseToggleStart() {
@@ -6980,23 +7003,91 @@ final class MuesliController: NSObject {
         fputs("[cua] cancel\n", stderr)
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
-        computerUseRecorder.cancel()
+        computerUseCommandTaskID = nil
+        cancelComputerUseAudioLeases()
+        computerUseAudioSessionManager.cancel(reason: "computer_use_cancel")
+        activeComputerUseAudioSessionID = nil
         computerUseCommandStartedAt = nil
+        pendingComputerUseStopSessionID = nil
+        pendingComputerUseStopStartedAt = nil
         indicator.isToggleDictation = false
+        computerUseHotkeyMonitor.cancelToggleMode()
+        indicator.hideComputerUseCursor()
+        resetComputerUseFloatingStatus()
         setState(.idle)
         meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
     }
 
     private func handleComputerUseStop() {
         fputs("[cua] stop\n", stderr)
+        guard pendingComputerUseStopSessionID == nil else {
+            fputs("[cua] stop already pending\n", stderr)
+            return
+        }
+        guard let sessionID = activeComputerUseAudioSessionID,
+              computerUseAudioSessionManager.currentSessionID == sessionID else {
+            fputs("[cua] stop without owned audio session\n", stderr)
+            return
+        }
         indicator.isToggleDictation = false
         let startedAt = computerUseCommandStartedAt ?? Date()
         computerUseCommandStartedAt = nil
+        cancelComputerUseAudioLeases()
+        activeComputerUseAudioSessionID = nil
+        pendingComputerUseStopSessionID = sessionID
+        pendingComputerUseStopStartedAt = startedAt
+        computerUseAudioSessionManager.stop()
+    }
 
-        guard let wavURL = computerUseRecorder.stop() else {
+    private func scheduleComputerUsePreparationLease(for sessionID: UUID?) {
+        computerUsePreparationLeaseWorkItem?.cancel()
+        guard let sessionID else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.activeComputerUseAudioSessionID == sessionID,
+                  self.computerUseCommandStartedAt == nil else { return }
+            fputs("[cua] preparation lease expired; releasing microphone\n", stderr)
+            self.handleComputerUseCancel()
+        }
+        computerUsePreparationLeaseWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.computerUsePreparationLeaseDuration,
+            execute: workItem
+        )
+    }
+
+    private func scheduleComputerUseRecordingLease(for sessionID: UUID?) {
+        computerUseRecordingLeaseWorkItem?.cancel()
+        guard let sessionID else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.activeComputerUseAudioSessionID == sessionID,
+                  self.computerUseCommandStartedAt != nil else { return }
+            fputs("[cua] recording lease expired; releasing microphone\n", stderr)
+            self.handleComputerUseCancel()
+            self.indicator.showWarning("CUA recording timed out", icon: "!")
+        }
+        computerUseRecordingLeaseWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.computerUseRecordingLeaseDuration,
+            execute: workItem
+        )
+    }
+
+    private func cancelComputerUseAudioLeases() {
+        computerUsePreparationLeaseWorkItem?.cancel()
+        computerUsePreparationLeaseWorkItem = nil
+        computerUseRecordingLeaseWorkItem?.cancel()
+        computerUseRecordingLeaseWorkItem = nil
+    }
+
+    private func finishComputerUseAudioStop(wavURL: URL?, startedAt: Date) {
+        guard let wavURL else {
             fputs("[cua] stop without wav\n", stderr)
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
             return
         }
         let duration = max(Date().timeIntervalSince(startedAt), 0)
@@ -7005,11 +7096,15 @@ final class MuesliController: NSObject {
             try? FileManager.default.removeItem(at: wavURL)
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
             return
         }
 
         indicator.setTranscribingTitle("Parsing command", config: config)
         setState(.transcribing)
+        computerUseCommandTask?.cancel()
+        let taskID = UUID()
+        computerUseCommandTaskID = taskID
         let task = Task { [weak self] in
             guard let self else { return }
             defer {
@@ -7029,6 +7124,7 @@ final class MuesliController: NSObject {
                 try Task.checkCancellation()
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 await MainActor.run {
+                    guard self.computerUseCommandTaskID == taskID else { return }
                     TelemetryDeck.signal("computer_use.command_parsed", parameters: [
                         "planner_enabled": self.config.enableComputerUsePlanner ? "true" : "false",
                     ])
@@ -7036,12 +7132,19 @@ final class MuesliController: NSObject {
                 guard !text.isEmpty else {
                     fputs("[cua] empty transcript, skipping planner\n", stderr)
                     await MainActor.run {
+                        guard self.computerUseCommandTaskID == taskID else { return }
                         self.computerUseCommandTask = nil
+                        self.computerUseCommandTaskID = nil
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
+                        self.meetingMonitor.refreshState()
                     }
                     return
                 }
+                guard await MainActor.run(body: {
+                    self.computerUseCommandTaskID == taskID
+                }) else { return }
+                try Task.checkCancellation()
                 let commandEndedAt = Date()
                 let dictationID = try? self.dictationStore.insertDictation(
                     text: text,
@@ -7050,28 +7153,40 @@ final class MuesliController: NSObject {
                     startedAt: startedAt,
                     endedAt: commandEndedAt
                 )
+                guard await MainActor.run(body: {
+                    self.computerUseCommandTaskID == taskID
+                }) else { return }
                 await MainActor.run {
                     self.scheduleICloudSyncAfterLocalChange()
                 }
-                await self.handleComputerUseCommand(transcript: text, dictationID: dictationID)
+                await self.handleComputerUseCommand(
+                    transcript: text,
+                    dictationID: dictationID,
+                    taskID: taskID
+                )
             } catch is CancellationError {
                 fputs("[cua] command parsing cancelled\n", stderr)
                 await MainActor.run {
+                    guard self.computerUseCommandTaskID == taskID else { return }
                     self.computerUseCommandTask = nil
+                    self.computerUseCommandTaskID = nil
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
+                    self.meetingMonitor.refreshState()
                 }
             } catch {
                 fputs("[cua] transcription failed: \(error)\n", stderr)
                 await MainActor.run {
+                    guard self.computerUseCommandTaskID == taskID else { return }
                     self.computerUseCommandTask = nil
+                    self.computerUseCommandTaskID = nil
                     self.setState(.idle)
                     self.indicator.showWarning("CUA command failed", icon: "!")
                     self.meetingMonitor.resumeAfterCooldown()
+                    self.meetingMonitor.refreshState()
                 }
             }
         }
-        computerUseCommandTask?.cancel()
         computerUseCommandTask = task
     }
 
@@ -7080,6 +7195,8 @@ final class MuesliController: NSObject {
             && !isDictationTestMode
             && dictationStartedAt == nil
             && computerUseCommandStartedAt == nil
+            && pendingComputerUseStopSessionID == nil
+            && computerUseCommandTask == nil
             && !isNemotron35Streaming
             && dictationState == .idle
     }
@@ -7089,36 +7206,49 @@ final class MuesliController: NSObject {
             && !isDictationTestMode
             && dictationStartedAt == nil
             && computerUseCommandStartedAt == nil
+            && pendingComputerUseStopSessionID == nil
+            && computerUseCommandTask == nil
             && !isNemotron35Streaming
             && (dictationState == .idle || dictationState == .preparing)
     }
 
     @MainActor
-    private func handleComputerUseCommand(transcript: String, dictationID: Int64?) async {
+    private func handleComputerUseCommand(
+        transcript: String,
+        dictationID: Int64?,
+        taskID: UUID
+    ) async {
+        guard computerUseCommandTaskID == taskID else { return }
         resetComputerUseFloatingStatus()
         presentComputerUseTranscript(transcript)
         setState(.transcribing)
         let runtime = ComputerUsePlannerRuntime(config: config) { [weak self] status in
-            guard let self else { return }
+            guard let self, self.computerUseCommandTaskID == taskID else { return }
             self.presentComputerUseFloatingStatus(status)
         }
 
         let result = await runtime.run(command: transcript)
+        guard computerUseCommandTaskID == taskID else { return }
         indicator.hideComputerUseCursor()
         if result.status == .cancelled {
             computerUseCommandTask = nil
+            computerUseCommandTaskID = nil
             setState(.idle)
             meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
             TelemetryDeck.signal("computer_use.command_finished", parameters: [
                 "status": "\(result.status)",
             ])
             return
         }
         persistComputerUseTrace(result, dictationID: dictationID)
-        computerUseCommandTask = nil
         await waitForComputerUseFloatingStatusDwell()
+        guard computerUseCommandTaskID == taskID else { return }
+        computerUseCommandTask = nil
+        computerUseCommandTaskID = nil
         presentComputerUseRuntimeResult(result)
         meetingMonitor.resumeAfterCooldown()
+        meetingMonitor.refreshState()
         TelemetryDeck.signal("computer_use.command_finished", parameters: [
             "status": "\(result.status)",
         ])
@@ -7462,6 +7592,68 @@ final class MuesliController: NSObject {
 
     private var shouldPlayDictationLifecycleSounds: Bool {
         config.soundEnabled && !dictationAudioRoutingController.isDefaultOutputHeadphoneLike()
+    }
+
+    private func handleComputerUseAudioSessionEvent(_ event: DictationAudioSessionEvent) {
+        switch event {
+        case .armed(let sessionID, _):
+            guard activeComputerUseAudioSessionID == sessionID else { break }
+            break
+        case .acquiringAudio(let sessionID):
+            guard activeComputerUseAudioSessionID == sessionID else { break }
+            setState(.preparing)
+        case .streamActive(let sessionID, _):
+            guard activeComputerUseAudioSessionID == sessionID,
+                  computerUseCommandStartedAt != nil else { break }
+            setState(.recording)
+            SoundController.playDictationStart(
+                enabled: shouldPlayDictationLifecycleSounds && !isDictationTestMode
+            )
+        case .speechDetected(let sessionID, _):
+            guard activeComputerUseAudioSessionID == sessionID else { break }
+            break
+        case .noAudioTimeout(let sessionID, _):
+            guard activeComputerUseAudioSessionID == sessionID else { break }
+            statusBarController?.setStatus("Mic waiting for speech")
+        case .stopped(let eventSessionID, let wavURL):
+            guard pendingComputerUseStopSessionID == eventSessionID else {
+                fputs("[cua] ignoring stale stopped event\n", stderr)
+                if let wavURL {
+                    try? FileManager.default.removeItem(at: wavURL)
+                }
+                break
+            }
+            guard computerUseAudioSessionManager.currentSessionID == nil else {
+                fputs("[cua] ignoring stopped event while a new session is active\n", stderr)
+                if let wavURL {
+                    try? FileManager.default.removeItem(at: wavURL)
+                }
+                break
+            }
+            let startedAt = pendingComputerUseStopStartedAt ?? Date()
+            pendingComputerUseStopSessionID = nil
+            pendingComputerUseStopStartedAt = nil
+            finishComputerUseAudioStop(wavURL: wavURL, startedAt: startedAt)
+        case .audioRestored, .cancelled:
+            break
+        case .failed(let sessionID, let error):
+            guard let sessionID,
+                  activeComputerUseAudioSessionID == sessionID
+                    || pendingComputerUseStopSessionID == sessionID else { break }
+            fputs("[cua] recorder start failed: \(error)\n", stderr)
+            cancelComputerUseAudioLeases()
+            activeComputerUseAudioSessionID = nil
+            computerUseCommandStartedAt = nil
+            pendingComputerUseStopSessionID = nil
+            pendingComputerUseStopStartedAt = nil
+            indicator.isToggleDictation = false
+            computerUseHotkeyMonitor.cancelToggleMode()
+            setState(.idle)
+            meetingMonitor.resumeAfterCooldown()
+            meetingMonitor.refreshState()
+        case .latency(let event, _):
+            fputs("[cua-audio] \(event)\n", stderr)
+        }
     }
 
     private func handleDictationAudioSessionEvent(_ event: DictationAudioSessionEvent) {
@@ -7922,8 +8114,18 @@ final class MuesliController: NSObject {
     }
 
     private func cancelDictationAudioSessionForMeetingRecordingIfNeeded() {
-        guard dictationAudioSessionManager.hasActiveSession || isNemotron35Streaming else { return }
+        let hasComputerUseActivity = computerUseAudioSessionManager.hasActiveSession
+            || computerUseCommandStartedAt != nil
+            || pendingComputerUseStopSessionID != nil
+            || computerUseCommandTask != nil
+        guard dictationAudioSessionManager.hasActiveSession
+            || isNemotron35Streaming
+            || hasComputerUseActivity else { return }
         fputs("[muesli-native] cancelling dictation audio session because meeting is active\n", stderr)
+
+        if hasComputerUseActivity {
+            handleComputerUseCancel()
+        }
 
         if isNemotron35Streaming {
             isNemotron35Streaming = false
@@ -7935,7 +8137,7 @@ final class MuesliController: NSObject {
             previousStreamText = ""
             indicator.setToggleDictation(false, config: config)
             dictationAudioSessionManager.endExternalSession(reason: "meeting-active")
-        } else {
+        } else if dictationAudioSessionManager.hasActiveSession {
             dictationAudioSessionManager.cancel(reason: "meeting-active")
         }
 
@@ -8306,11 +8508,12 @@ final class MuesliController: NSObject {
             onStartRecording: { [weak self] in
                 guard let self else { return }
                 self.isShowingCalendarNotification = false
-                self.startForegroundMeetingRecording(
+                self.startMeetingRecordingFromEntryPoint(
                     title: title,
                     calendarOccurrence: calendarOccurrence,
                     endDate: calendarEndDate,
                     autoStopSource: autoStopSource,
+                    presentation: .backgroundPill,
                     startOrigin: .scheduledMeetingPrompt
                 )
             },
@@ -8321,7 +8524,8 @@ final class MuesliController: NSObject {
                     title: title,
                     meetingURL: meetingURL!,
                     endDate: calendarEndDate,
-                    calendarOccurrence: calendarOccurrence
+                    calendarOccurrence: calendarOccurrence,
+                    presentation: .backgroundPill
                 )
             } : nil,
             onJoinOnly: meetingURL != nil ? { [weak self] in

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -279,9 +279,6 @@ final class MuesliController: NSObject {
     private static let pendingDictionaryCorrectionAccessibilityRequestedAtKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestedAt"
     private static let pendingDictionaryCorrectionAccessibilityRequestProcessIDKey = "dictionaryCorrectionPrompts.pendingAccessibilityRequestProcessID"
     private static let dictionaryCorrectionAccessibilityIntentTimeout: TimeInterval = 24 * 60 * 60
-    private static let computerUsePreparationLeaseDuration: TimeInterval = 2
-    private static let computerUseRecordingLeaseDuration: TimeInterval = 60
-
     private let runtime: RuntimePaths
     private let configStore: ConfigStore
     private let dictationStore: DictationStore
@@ -386,8 +383,6 @@ final class MuesliController: NSObject {
     private var computerUseCommandStartedAt: Date?
     private var pendingComputerUseStopStartedAt: Date?
     private var pendingComputerUseStopSessionID: UUID?
-    private var computerUsePreparationLeaseWorkItem: DispatchWorkItem?
-    private var computerUseRecordingLeaseWorkItem: DispatchWorkItem?
     private var computerUseCommandTask: Task<Void, Never>?
     private var computerUseCommandTaskID: UUID?
     private var computerUseFloatingStatusWorkItem: DispatchWorkItem?
@@ -821,7 +816,6 @@ final class MuesliController: NSObject {
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
         computerUseCommandTaskID = nil
-        cancelComputerUseAudioLeases()
         activeComputerUseAudioSessionID = nil
         pendingComputerUseStopSessionID = nil
         pendingComputerUseStopStartedAt = nil
@@ -6988,15 +6982,12 @@ final class MuesliController: NSObject {
         setState(.preparing)
         computerUseAudioSessionManager.arm(source: "computer_use_hotkey_prepare")
         activeComputerUseAudioSessionID = computerUseAudioSessionManager.currentSessionID
-        scheduleComputerUsePreparationLease(for: activeComputerUseAudioSessionID)
     }
 
     private func handleComputerUseStart() {
         guard canStartComputerUseCommand else { return }
         fputs("[cua] recording start\n", stderr)
         meetingMonitor.suppressWhileActive()
-        computerUsePreparationLeaseWorkItem?.cancel()
-        computerUsePreparationLeaseWorkItem = nil
         computerUseCommandStartedAt = Date()
         indicator.powerProvider = { [weak self] in
             self?.computerUseAudioSessionManager.currentPower() ?? -160
@@ -7008,7 +6999,6 @@ final class MuesliController: NSObject {
             mediaPauseEnabled: false
         )
         activeComputerUseAudioSessionID = computerUseAudioSessionManager.currentSessionID
-        scheduleComputerUseRecordingLease(for: activeComputerUseAudioSessionID)
     }
 
     private func handleComputerUseToggleStart() {
@@ -7037,7 +7027,6 @@ final class MuesliController: NSObject {
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
         computerUseCommandTaskID = nil
-        cancelComputerUseAudioLeases()
         computerUseAudioSessionManager.cancel(reason: "computer_use_cancel")
         activeComputerUseAudioSessionID = nil
         computerUseCommandStartedAt = nil
@@ -7066,53 +7055,10 @@ final class MuesliController: NSObject {
         indicator.isToggleDictation = false
         let startedAt = computerUseCommandStartedAt ?? Date()
         computerUseCommandStartedAt = nil
-        cancelComputerUseAudioLeases()
         activeComputerUseAudioSessionID = nil
         pendingComputerUseStopSessionID = sessionID
         pendingComputerUseStopStartedAt = startedAt
         computerUseAudioSessionManager.stop()
-    }
-
-    private func scheduleComputerUsePreparationLease(for sessionID: UUID?) {
-        computerUsePreparationLeaseWorkItem?.cancel()
-        guard let sessionID else { return }
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self,
-                  self.activeComputerUseAudioSessionID == sessionID,
-                  self.computerUseCommandStartedAt == nil else { return }
-            fputs("[cua] preparation lease expired; releasing microphone\n", stderr)
-            self.handleComputerUseCancel()
-        }
-        computerUsePreparationLeaseWorkItem = workItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + Self.computerUsePreparationLeaseDuration,
-            execute: workItem
-        )
-    }
-
-    private func scheduleComputerUseRecordingLease(for sessionID: UUID?) {
-        computerUseRecordingLeaseWorkItem?.cancel()
-        guard let sessionID else { return }
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self,
-                  self.activeComputerUseAudioSessionID == sessionID,
-                  self.computerUseCommandStartedAt != nil else { return }
-            fputs("[cua] recording lease expired; releasing microphone\n", stderr)
-            self.handleComputerUseCancel()
-            self.indicator.showWarning("CUA recording timed out", icon: "!")
-        }
-        computerUseRecordingLeaseWorkItem = workItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + Self.computerUseRecordingLeaseDuration,
-            execute: workItem
-        )
-    }
-
-    private func cancelComputerUseAudioLeases() {
-        computerUsePreparationLeaseWorkItem?.cancel()
-        computerUsePreparationLeaseWorkItem = nil
-        computerUseRecordingLeaseWorkItem?.cancel()
-        computerUseRecordingLeaseWorkItem = nil
     }
 
     private func finishComputerUseAudioStop(wavURL: URL?, startedAt: Date) {
@@ -7708,7 +7654,6 @@ final class MuesliController: NSObject {
                   activeComputerUseAudioSessionID == sessionID
                     || pendingComputerUseStopSessionID == sessionID else { break }
             fputs("[cua] recorder start failed: \(error)\n", stderr)
-            cancelComputerUseAudioLeases()
             activeComputerUseAudioSessionID = nil
             computerUseCommandStartedAt = nil
             pendingComputerUseStopSessionID = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -52,6 +52,34 @@ private enum DictationAudioRouteTiming {
     static let stabilizationDelay: TimeInterval = 1.0
 }
 
+enum InteractiveAudioSessionOwner {
+    case dictation
+    case computerUse
+}
+
+struct InteractiveAudioSessionOwnership: Equatable {
+    let dictationIsActive: Bool
+    let computerUseIsActive: Bool
+
+    func canStart(_ owner: InteractiveAudioSessionOwner) -> Bool {
+        switch owner {
+        case .dictation:
+            return !computerUseIsActive
+        case .computerUse:
+            return !dictationIsActive
+        }
+    }
+
+    func shouldIgnoreCleanup(for owner: InteractiveAudioSessionOwner) -> Bool {
+        switch owner {
+        case .dictation:
+            return !dictationIsActive && computerUseIsActive
+        case .computerUse:
+            return !computerUseIsActive && dictationIsActive
+        }
+    }
+}
+
 struct MeetingResummarizationPlan: Equatable {
     let promptTitle: String
     let persistedTitle: String
@@ -7001,6 +7029,11 @@ final class MuesliController: NSObject {
 
     private func handleComputerUseCancel() {
         fputs("[cua] cancel\n", stderr)
+        guard !interactiveAudioSessionOwnership.shouldIgnoreCleanup(for: .computerUse) else {
+            fputs("[cua] ignoring cleanup while dictation owns interactive audio\n", stderr)
+            computerUseHotkeyMonitor.cancelToggleMode()
+            return
+        }
         computerUseCommandTask?.cancel()
         computerUseCommandTask = nil
         computerUseCommandTaskID = nil
@@ -7198,6 +7231,7 @@ final class MuesliController: NSObject {
             && pendingComputerUseStopSessionID == nil
             && computerUseCommandTask == nil
             && !isNemotron35Streaming
+            && interactiveAudioSessionOwnership.canStart(.computerUse)
             && dictationState == .idle
     }
 
@@ -7209,7 +7243,38 @@ final class MuesliController: NSObject {
             && pendingComputerUseStopSessionID == nil
             && computerUseCommandTask == nil
             && !isNemotron35Streaming
+            && interactiveAudioSessionOwnership.canStart(.computerUse)
             && (dictationState == .idle || dictationState == .preparing)
+    }
+
+    private var interactiveAudioSessionOwnership: InteractiveAudioSessionOwnership {
+        let computerUseIsActive = computerUseAudioSessionManager.hasActiveSession
+            || computerUseCommandStartedAt != nil
+            || pendingComputerUseStopSessionID != nil
+            || computerUseCommandTask != nil
+        let dictationIsActive = dictationAudioSessionManager.hasActiveSession
+            || dictationStartedAt != nil
+            || pendingDictationStopSessionID != nil
+            || isNemotron35Streaming
+            || (!computerUseIsActive && dictationState != .idle)
+        return InteractiveAudioSessionOwnership(
+            dictationIsActive: dictationIsActive,
+            computerUseIsActive: computerUseIsActive
+        )
+    }
+
+    private func shouldRejectDictationForComputerUseActivity() -> Bool {
+        guard !interactiveAudioSessionOwnership.canStart(.dictation) else { return false }
+        fputs("[muesli-native] ignoring dictation start while computer use owns interactive audio\n", stderr)
+        hotkeyMonitor.cancelToggleMode()
+        return true
+    }
+
+    private func shouldIgnoreDictationCleanupForComputerUseActivity() -> Bool {
+        guard interactiveAudioSessionOwnership.shouldIgnoreCleanup(for: .dictation) else { return false }
+        fputs("[muesli-native] ignoring dictation cleanup while computer use owns interactive audio\n", stderr)
+        hotkeyMonitor.cancelToggleMode()
+        return true
     }
 
     @MainActor
@@ -7469,6 +7534,7 @@ final class MuesliController: NSObject {
     }
 
     private func handlePrepare() {
+        if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
@@ -7489,6 +7555,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleArm() {
+        if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
@@ -7835,6 +7902,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleStart() {
+        if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
@@ -7982,6 +8050,7 @@ final class MuesliController: NSObject {
 
     private func handleCancel() {
         if isMeetingRecording() { return }
+        if shouldIgnoreDictationCleanupForComputerUseActivity() { return }
         fputs("[muesli-native] cancel\n", stderr)
         resetDictationOutputMode()
 
@@ -8009,6 +8078,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
+        if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
         if isMeetingRecording() { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
@@ -8074,6 +8144,7 @@ final class MuesliController: NSObject {
             cancelDictationAudioSessionForMeetingRecordingIfNeeded()
             return
         }
+        if shouldIgnoreDictationCleanupForComputerUseActivity() { return }
         fputs("[muesli-native] stop\n", stderr)
         let startedAt = dictationStartedAt ?? Date()
         dictationStartedAt = nil
@@ -8114,10 +8185,7 @@ final class MuesliController: NSObject {
     }
 
     private func cancelDictationAudioSessionForMeetingRecordingIfNeeded() {
-        let hasComputerUseActivity = computerUseAudioSessionManager.hasActiveSession
-            || computerUseCommandStartedAt != nil
-            || pendingComputerUseStopSessionID != nil
-            || computerUseCommandTask != nil
+        let hasComputerUseActivity = interactiveAudioSessionOwnership.computerUseIsActive
         guard dictationAudioSessionManager.hasActiveSession
             || isNemotron35Streaming
             || hasComputerUseActivity else { return }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -606,6 +606,33 @@ struct DictationAudioSessionManagerTests {
         #expect(harness.recorder.cancelCalls == 1)
         #expect(!harness.recorder.keepsAudioGraphWarm)
     }
+
+    @Test("cancel detaches ownership before queued teardown so immediate rearm gets a new session")
+    func cancelThenImmediateRearmGetsNewSession() {
+        let harness = Harness(routeKind: .speakerLike)
+        harness.managerQueue.suspend()
+
+        harness.manager.arm(source: "first")
+        let firstSessionID = harness.manager.currentSessionID
+        harness.manager.cancel(reason: "replace")
+
+        #expect(firstSessionID != nil)
+        #expect(harness.manager.currentSessionID == nil)
+
+        harness.manager.arm(source: "second")
+        let secondSessionID = harness.manager.currentSessionID
+
+        #expect(secondSessionID != nil)
+        #expect(secondSessionID != firstSessionID)
+
+        harness.managerQueue.resume()
+        harness.wait()
+
+        #expect(harness.manager.currentSessionID == secondSessionID)
+        if let secondSessionID {
+            #expect(harness.manager.currentState == .armed(secondSessionID))
+        }
+    }
 }
 
 private final class Harness {

--- a/native/MuesliNative/Tests/MuesliTests/InteractiveAudioSessionOwnershipTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InteractiveAudioSessionOwnershipTests.swift
@@ -12,6 +12,8 @@ struct InteractiveAudioSessionOwnershipTests {
 
         #expect(ownership.canStart(.dictation))
         #expect(ownership.canStart(.computerUse))
+        #expect(!ownership.shouldIgnoreCleanup(for: .dictation))
+        #expect(!ownership.shouldIgnoreCleanup(for: .computerUse))
     }
 
     @Test("dictation ownership rejects computer use start and cleanup")
@@ -21,6 +23,7 @@ struct InteractiveAudioSessionOwnershipTests {
             computerUseIsActive: false
         )
 
+        #expect(ownership.canStart(.dictation))
         #expect(!ownership.canStart(.computerUse))
         #expect(ownership.shouldIgnoreCleanup(for: .computerUse))
         #expect(!ownership.shouldIgnoreCleanup(for: .dictation))
@@ -34,6 +37,7 @@ struct InteractiveAudioSessionOwnershipTests {
         )
 
         #expect(!ownership.canStart(.dictation))
+        #expect(ownership.canStart(.computerUse))
         #expect(ownership.shouldIgnoreCleanup(for: .dictation))
         #expect(!ownership.shouldIgnoreCleanup(for: .computerUse))
     }

--- a/native/MuesliNative/Tests/MuesliTests/InteractiveAudioSessionOwnershipTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/InteractiveAudioSessionOwnershipTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Interactive audio session ownership")
+struct InteractiveAudioSessionOwnershipTests {
+    @Test("idle ownership allows either feature to start")
+    func idleAllowsEitherOwner() {
+        let ownership = InteractiveAudioSessionOwnership(
+            dictationIsActive: false,
+            computerUseIsActive: false
+        )
+
+        #expect(ownership.canStart(.dictation))
+        #expect(ownership.canStart(.computerUse))
+    }
+
+    @Test("dictation ownership rejects computer use start and cleanup")
+    func dictationWinsOverComputerUse() {
+        let ownership = InteractiveAudioSessionOwnership(
+            dictationIsActive: true,
+            computerUseIsActive: false
+        )
+
+        #expect(!ownership.canStart(.computerUse))
+        #expect(ownership.shouldIgnoreCleanup(for: .computerUse))
+        #expect(!ownership.shouldIgnoreCleanup(for: .dictation))
+    }
+
+    @Test("computer use ownership rejects dictation start and cleanup")
+    func computerUseWinsOverDictation() {
+        let ownership = InteractiveAudioSessionOwnership(
+            dictationIsActive: false,
+            computerUseIsActive: true
+        )
+
+        #expect(!ownership.canStart(.dictation))
+        #expect(ownership.shouldIgnoreCleanup(for: .dictation))
+        #expect(!ownership.shouldIgnoreCleanup(for: .computerUse))
+    }
+
+    @Test("an existing overlap still permits both owners to clean up")
+    func existingOverlapCanCleanUp() {
+        let ownership = InteractiveAudioSessionOwnership(
+            dictationIsActive: true,
+            computerUseIsActive: true
+        )
+
+        #expect(!ownership.canStart(.dictation))
+        #expect(!ownership.canStart(.computerUse))
+        #expect(!ownership.shouldIgnoreCleanup(for: .dictation))
+        #expect(!ownership.shouldIgnoreCleanup(for: .computerUse))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -65,6 +65,22 @@ struct MeetingsNavigationTests {
         #expect(appState.selectedMeeting == nil)
     }
 
+    @Test("foreground meeting starts open and present notes")
+    func foregroundMeetingStartPresentation() {
+        let presentation = MeetingStartPresentation.foregroundNotes
+
+        #expect(presentation.opensMeetingDocument)
+        #expect(presentation.presentsHistoryWindow)
+    }
+
+    @Test("background meeting starts only transition the recording pill")
+    func backgroundMeetingStartPresentation() {
+        let presentation = MeetingStartPresentation.backgroundPill
+
+        #expect(!presentation.opensMeetingDocument)
+        #expect(!presentation.presentsHistoryWindow)
+    }
+
     @Test("each dashboard statistic opens insights with its originating section")
     func dashboardStatisticsOpenInsights() {
         let controller = makeController()

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -58,6 +58,7 @@ case "${shard}" in
       BackendOptionTests
       SummaryModelPresetTests
       HotkeyMonitorTests
+      InteractiveAudioSessionOwnershipTests
       DictationStateTests
       HotkeyConfigTests
       DictationStateIdleTests


### PR DESCRIPTION
## Summary

- route CUA recording through the shared route-aware dictation audio session lifecycle
- reuse dictation's normal hotkey start, cancel, stop, and no-audio cleanup behavior for CUA without CUA-only recording limits
- prevent stale CUA audio and planner work from overriding a new session or meeting recording
- enforce first-session-wins ownership between dictation and CUA, including rejected cleanup callbacks
- start detected, notified, and calendar-auto-recorded meetings in the background while preserving Notes focus for manual starts

## Why

CUA had its own raw microphone recorder, bypassing the app-scoped input routing and lifecycle protections used by dictation. Separately, meeting starts initiated by detection or notifications opened Notes and stole focus even though those entry points should be silent.

The two independently configured hotkey monitors also needed explicit audio-session ownership so a toggle-mode command could not start or clean up while the other feature owned the shared microphone route.

## Validation

- full Swift package suite: 1,473 tests across 144 suites passed
- focused interactive-audio ownership and hotkey-monitor suites passed
- focused audio-session and meeting-navigation suites passed
- built and installed as MuesliDevA using the reusable SwiftPM cache
- locally verified CUA routing and microphone release
- locally verified background meeting starts do not steal focus
- locally verified manual meeting starts still open Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible meeting recording presentation options, including foreground notes and a background recording pill.
  * Calendar and detection prompts can now start meetings in the background.
  * Auto-recorded calendar meetings remain in the background instead of opening the meeting document automatically.

* **Bug Fixes**
  * Improved Computer Use recording reliability by preventing stale audio and transcription activity from affecting newer sessions.
  * Meeting cancellation now releases recording control immediately, allowing a new session to start without delay.
  * Prevented competing dictation and Computer Use sessions from interfering with each other.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
