### PR TITLE
Publish MuesliPreprod 0.8.1-preprod.1 appcast

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,6 +6,32 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
+            <title>0.8.1-preprod.1</title>
+            <pubDate>Sat, 01 Aug 2026 12:06:08 +0530</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.8.1-preprod.1</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.8.1-preprod.1.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>8001001</sparkle:version>
+            <sparkle:shortVersionString>0.8.1-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.1-preprod.1/MuesliPreprod-0.8.1-preprod.1.dmg" length="94740278" type="application/octet-stream" sparkle:edSignature="rrmXPXvwS9ZiYp36FXOLCHmZgAKU4qgnxCIZBSAKBUt+dwNX7e/x8b9ZuPRxpG5eWmff+LpvnJwSPjG0xqhICQ=="/>
+        </item>
+        <item>
             <title>0.8.0-preprod.2</title>
             <pubDate>Tue, 14 Jul 2026 13:36:16 -0700</pubDate>
             <description><![CDATA[
@@ -39,32 +65,6 @@
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.0-preprod.1/MuesliPreprod-0.8.0-preprod.1.dmg" length="94557093" type="application/octet-stream" sparkle:edSignature="qiixTLEWcRXDNTLNaCeMsPf+z3YIWilnCltXhcf63jHsxj23Vej3BmKivO4lSwQSDo/T8X7gPgFvGGXxMBFSCw=="/>
-        </item>
-        <item>
-            <title>0.7.1-preprod.1</title>
-            <pubDate>Fri, 26 Jun 2026 01:24:05 -0700</pubDate>
-            <description><![CDATA[
-<h2>MuesliPreprod 0.7.1-preprod.1</h2>
-<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
-<h3>Install</h3>
-<ul>
-<li>Download <code>MuesliPreprod-0.7.1-preprod.1.dmg</code></li>
-<li>Open the DMG and drag MuesliPreprod to Applications</li>
-<li>Launch MuesliPreprod from Applications</li>
-</ul>
-<h3>Notes</h3>
-<ul>
-<li>Installs alongside production Muesli.</li>
-<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
-<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
-<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
-</ul>
-]]></description>
-            <sparkle:version>7001001</sparkle:version>
-            <sparkle:shortVersionString>0.7.1-preprod.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.7.1-preprod.1/MuesliPreprod-0.7.1-preprod.1.dmg" length="70083841" type="application/octet-stream" sparkle:edSignature="GAgPwgF8sUXhKczie0Ph0iZd4lKqCxSky+7buvLsrR98mSewVyRnnUOlBHzegMu3rK5k8H05/8YwP0ghqwLXBA=="/>
         </item>
         <item>
             <title>0.7.0-preprod.1</title>


### PR DESCRIPTION
## Summary

- publish the preprod Sparkle appcast entry for `0.8.1-preprod.1`
- point the feed at the signed and notarized GitHub prerelease DMG
- preserve the previous `0.8.0-preprod.2` entry so installed preprod builds can update in place

## Release

- tag: `v0.8.1-preprod.1`
- Sparkle build: `8001001`
- prerelease: https://github.com/Muesli-HQ/muesli/releases/tag/v0.8.1-preprod.1
- asset: `MuesliPreprod-0.8.1-preprod.1.dmg` (`94,740,278` bytes)
- SHA-256: `435e9ffd7d3488fd477f87f06fc03764a2411ba899062e20720fb2586d7245e4`

## Validation

- full Swift package suite passed: 1,473 tests across 144 suites
- app and DMG notarization accepted by Apple
- app and DMG staples validated
- Gatekeeper accepted the local DMG and the app inside it
- hosted DMG SHA-256 matched the local artifact
- Sparkle EdDSA signature and installer helper validated
- `verify_update_flow.sh` passed for build `8001001`
- embedded profile matches `com.muesli.preprod` with production CloudKit/APNs entitlements
- bundle/feed metadata verified as `MuesliPreprod`, `0.8.1-preprod.1`, and `appcast-preprod.xml`

## Scope

The production appcast, public download page, stable release, and Homebrew tap are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788160033&installation_model_id=422865&pr_number=364&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F364&signature=2a09021d967833dfb4d44d1e60dd7de68bfb959200e91de8eadd122938c1c11e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pre-production release feed for version 0.8.1-preprod.1.
  * Retained recent pre-production releases and removed the outdated 0.7.1-preprod.1 entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->