### PR TITLE
Migrate macOS CloudKit text sync to CKSyncEngine

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -2784,29 +2784,48 @@ public final class DictationStore {
     /// CKSyncEngine may restore pending changes from its serialized state after an
     /// app restart, so the record provider cannot rely on an in-memory upload cache.
     public func textRecordForSync(recordName: String) throws -> SyncTextRecord? {
+        try textRecordsForSync(recordNames: [recordName])[recordName]
+    }
+
+    /// Returns local snapshots for a batch of CloudKit record names using one
+    /// database connection and one record-name migration pass.
+    public func textRecordsForSync(recordNames: [String]) throws -> [String: SyncTextRecord] {
+        let recordNames = Array(Set(recordNames.filter { !$0.isEmpty }))
+        guard !recordNames.isEmpty else { return [:] }
+
         let db = try openDatabase()
         defer { sqlite3_close(db) }
         try ensureCloudRecordNames(db: db)
+
+        let placeholders = Array(repeating: "?", count: recordNames.count).joined(separator: ", ")
+        var records: [String: SyncTextRecord] = [:]
 
         let dictationSQL = """
         SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
                duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
                cloud_system_fields
         FROM dictations
-        WHERE cloud_record_name = ?
-        LIMIT 1
+        WHERE cloud_record_name IN (\(placeholders))
         """
         var dictationStatement: OpaquePointer?
         guard sqlite3_prepare_v2(db, dictationSQL, -1, &dictationStatement, nil) == SQLITE_OK else {
             throw lastError(db)
         }
-        sqlite3_bind_text(dictationStatement, 1, (recordName as NSString).utf8String, -1, nil)
-        if sqlite3_step(dictationStatement) == SQLITE_ROW {
-            let record = makeSyncDictationRecord(dictationStatement)
-            sqlite3_finalize(dictationStatement)
-            return record
+        defer { sqlite3_finalize(dictationStatement) }
+        for (index, recordName) in recordNames.enumerated() {
+            sqlite3_bind_text(
+                dictationStatement,
+                Int32(index + 1),
+                (recordName as NSString).utf8String,
+                -1,
+                nil
+            )
         }
-        sqlite3_finalize(dictationStatement)
+        while sqlite3_step(dictationStatement) == SQLITE_ROW {
+            if let record = makeSyncDictationRecord(dictationStatement) {
+                records[record.id] = record
+            }
+        }
 
         let meetingSQL = """
         SELECT m.cloud_record_name, m.title, m.raw_transcript, m.formatted_notes, m.manual_notes,
@@ -2816,17 +2835,28 @@ public final class DictationStore {
                m.cloud_system_fields
         FROM meetings AS m
         LEFT JOIN meetings AS predecessor ON predecessor.id = m.follow_up_to_id
-        WHERE m.cloud_record_name = ?
-        LIMIT 1
+        WHERE m.cloud_record_name IN (\(placeholders))
         """
         var meetingStatement: OpaquePointer?
         guard sqlite3_prepare_v2(db, meetingSQL, -1, &meetingStatement, nil) == SQLITE_OK else {
             throw lastError(db)
         }
         defer { sqlite3_finalize(meetingStatement) }
-        sqlite3_bind_text(meetingStatement, 1, (recordName as NSString).utf8String, -1, nil)
-        guard sqlite3_step(meetingStatement) == SQLITE_ROW else { return nil }
-        return makeSyncMeetingRecord(meetingStatement)
+        for (index, recordName) in recordNames.enumerated() {
+            sqlite3_bind_text(
+                meetingStatement,
+                Int32(index + 1),
+                (recordName as NSString).utf8String,
+                -1,
+                nil
+            )
+        }
+        while sqlite3_step(meetingStatement) == SQLITE_ROW {
+            if let record = makeSyncMeetingRecord(meetingStatement) {
+                records[record.id] = record
+            }
+        }
+        return records
     }
 
     public func cloudSyncStateData(forKey key: String) throws -> Data? {

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -71,6 +71,7 @@ public final class DictationStore {
             deleted_at REAL,
             cloud_record_name TEXT,
             cloud_change_tag TEXT,
+            cloud_system_fields BLOB,
             last_synced_at REAL,
             sync_dirty INTEGER NOT NULL DEFAULT 1,
             created_at TEXT DEFAULT (datetime('now'))
@@ -116,6 +117,7 @@ public final class DictationStore {
             deleted_at REAL,
             cloud_record_name TEXT,
             cloud_change_tag TEXT,
+            cloud_system_fields BLOB,
             cloud_transcript_record_name TEXT,
             last_synced_at REAL,
             sync_dirty INTEGER NOT NULL DEFAULT 1,
@@ -138,6 +140,12 @@ public final class DictationStore {
         );
         CREATE INDEX IF NOT EXISTS idx_meeting_transcript_checkpoints_meeting
             ON meeting_transcript_checkpoints(meeting_id, start_seconds, id);
+
+        CREATE TABLE IF NOT EXISTS cloud_sync_state (
+            key TEXT PRIMARY KEY,
+            value BLOB NOT NULL,
+            updated_at REAL NOT NULL
+        );
 
         CREATE TABLE IF NOT EXISTS meeting_resume_snapshots (
             meeting_id INTEGER PRIMARY KEY REFERENCES meetings(id) ON DELETE CASCADE,
@@ -199,12 +207,14 @@ public final class DictationStore {
             "ALTER TABLE dictations ADD COLUMN deleted_at REAL",
             "ALTER TABLE dictations ADD COLUMN cloud_record_name TEXT",
             "ALTER TABLE dictations ADD COLUMN cloud_change_tag TEXT",
+            "ALTER TABLE dictations ADD COLUMN cloud_system_fields BLOB",
             "ALTER TABLE dictations ADD COLUMN last_synced_at REAL",
             "ALTER TABLE dictations ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1",
             "ALTER TABLE meetings ADD COLUMN updated_at REAL NOT NULL DEFAULT 0",
             "ALTER TABLE meetings ADD COLUMN deleted_at REAL",
             "ALTER TABLE meetings ADD COLUMN cloud_record_name TEXT",
             "ALTER TABLE meetings ADD COLUMN cloud_change_tag TEXT",
+            "ALTER TABLE meetings ADD COLUMN cloud_system_fields BLOB",
             "ALTER TABLE meetings ADD COLUMN cloud_transcript_record_name TEXT",
             "ALTER TABLE meetings ADD COLUMN last_synced_at REAL",
             "ALTER TABLE meetings ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1",
@@ -2769,6 +2779,108 @@ public final class DictationStore {
         return Array((dictations + meetings).prefix(boundedLimit))
     }
 
+    /// Returns the current local snapshot for a CloudKit record name.
+    ///
+    /// CKSyncEngine may restore pending changes from its serialized state after an
+    /// app restart, so the record provider cannot rely on an in-memory upload cache.
+    public func textRecordForSync(recordName: String) throws -> SyncTextRecord? {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        try ensureCloudRecordNames(db: db)
+
+        let dictationSQL = """
+        SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
+               duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
+               cloud_system_fields
+        FROM dictations
+        WHERE cloud_record_name = ?
+        LIMIT 1
+        """
+        var dictationStatement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, dictationSQL, -1, &dictationStatement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        sqlite3_bind_text(dictationStatement, 1, (recordName as NSString).utf8String, -1, nil)
+        if sqlite3_step(dictationStatement) == SQLITE_ROW {
+            let record = makeSyncDictationRecord(dictationStatement)
+            sqlite3_finalize(dictationStatement)
+            return record
+        }
+        sqlite3_finalize(dictationStatement)
+
+        let meetingSQL = """
+        SELECT m.cloud_record_name, m.title, m.raw_transcript, m.formatted_notes, m.manual_notes,
+               m.start_time, m.duration_seconds, m.word_count, m.source, m.meeting_status,
+               m.updated_at, m.deleted_at, m.cloud_change_tag,
+               COALESCE(m.follow_up_to_record_name, predecessor.cloud_record_name),
+               m.cloud_system_fields
+        FROM meetings AS m
+        LEFT JOIN meetings AS predecessor ON predecessor.id = m.follow_up_to_id
+        WHERE m.cloud_record_name = ?
+        LIMIT 1
+        """
+        var meetingStatement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, meetingSQL, -1, &meetingStatement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(meetingStatement) }
+        sqlite3_bind_text(meetingStatement, 1, (recordName as NSString).utf8String, -1, nil)
+        guard sqlite3_step(meetingStatement) == SQLITE_ROW else { return nil }
+        return makeSyncMeetingRecord(meetingStatement)
+    }
+
+    public func cloudSyncStateData(forKey key: String) throws -> Data? {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "SELECT value FROM cloud_sync_state WHERE key = ? LIMIT 1"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (key as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        guard let bytes = sqlite3_column_blob(statement, 0) else { return Data() }
+        return Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, 0)))
+    }
+
+    public func saveCloudSyncStateData(_ data: Data, forKey key: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = """
+        INSERT INTO cloud_sync_state (key, value, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (key as NSString).utf8String, -1, nil)
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        _ = data.withUnsafeBytes {
+            sqlite3_bind_blob(statement, 2, $0.baseAddress, Int32(data.count), transient)
+        }
+        sqlite3_bind_double(statement, 3, Date().timeIntervalSince1970)
+        guard sqlite3_step(statement) == SQLITE_DONE else { throw lastError(db) }
+    }
+
+    public func clearCloudSyncStateData(forKey key: String) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let sql = "DELETE FROM cloud_sync_state WHERE key = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, (key as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else { throw lastError(db) }
+    }
+
     private func dirtyDictationTextRecords(
         limit: Int,
         offset: Int,
@@ -2778,7 +2890,8 @@ public final class DictationStore {
         var records: [SyncTextRecord] = []
         let dictationSQL = """
         SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
-               duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag
+               duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
+               cloud_system_fields
         FROM dictations
         WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL
         ORDER BY updated_at DESC, id DESC
@@ -2810,7 +2923,8 @@ public final class DictationStore {
         SELECT m.cloud_record_name, m.title, m.raw_transcript, m.formatted_notes, m.manual_notes,
                m.start_time, m.duration_seconds, m.word_count, m.source, m.meeting_status,
                m.updated_at, m.deleted_at, m.cloud_change_tag,
-               COALESCE(m.follow_up_to_record_name, predecessor.cloud_record_name)
+               COALESCE(m.follow_up_to_record_name, predecessor.cloud_record_name),
+               m.cloud_system_fields
         FROM meetings AS m
         LEFT JOIN meetings AS predecessor ON predecessor.id = m.follow_up_to_id
         WHERE m.sync_dirty = 1 AND m.cloud_record_name IS NOT NULL
@@ -2882,7 +2996,8 @@ public final class DictationStore {
         var records: [SyncTextRecord] = []
         let dictationSQL = """
         SELECT cloud_record_name, raw_text, app_context, timestamp, started_at, ended_at,
-               duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag
+               duration_seconds, word_count, source, updated_at, deleted_at, cloud_change_tag,
+               cloud_system_fields
         FROM dictations
         WHERE cloud_record_name IS NOT NULL
         ORDER BY updated_at DESC, id DESC
@@ -2913,7 +3028,8 @@ public final class DictationStore {
         SELECT m.cloud_record_name, m.title, m.raw_transcript, m.formatted_notes, m.manual_notes,
                m.start_time, m.duration_seconds, m.word_count, m.source, m.meeting_status,
                m.updated_at, m.deleted_at, m.cloud_change_tag,
-               COALESCE(m.follow_up_to_record_name, predecessor.cloud_record_name)
+               COALESCE(m.follow_up_to_record_name, predecessor.cloud_record_name),
+               m.cloud_system_fields
         FROM meetings AS m
         LEFT JOIN meetings AS predecessor ON predecessor.id = m.follow_up_to_id
         WHERE m.cloud_record_name IS NOT NULL
@@ -3014,6 +3130,7 @@ public final class DictationStore {
         kind: SyncTextRecordKind,
         recordName: String,
         changeTag: String?,
+        systemFields: Data? = nil,
         recordUpdatedAt: Date,
         syncedAt: Date = Date()
     ) throws -> Bool {
@@ -3022,7 +3139,7 @@ public final class DictationStore {
         let table = kind == .dictation ? "dictations" : "meetings"
         let sql = """
         UPDATE \(table)
-        SET cloud_change_tag = ?, last_synced_at = ?, sync_dirty = 0
+        SET cloud_change_tag = ?, cloud_system_fields = ?, last_synced_at = ?, sync_dirty = 0
         WHERE cloud_record_name = ? AND updated_at <= ?
         """
         var statement: OpaquePointer?
@@ -3031,13 +3148,79 @@ public final class DictationStore {
         }
         defer { sqlite3_finalize(statement) }
         bindOptionalText(changeTag, at: 1, statement: statement)
-        sqlite3_bind_double(statement, 2, syncedAt.timeIntervalSince1970)
-        sqlite3_bind_text(statement, 3, (recordName as NSString).utf8String, -1, nil)
-        sqlite3_bind_double(statement, 4, recordUpdatedAt.timeIntervalSince1970)
+        bindOptionalBlob(systemFields, at: 2, statement: statement)
+        sqlite3_bind_double(statement, 3, syncedAt.timeIntervalSince1970)
+        sqlite3_bind_text(statement, 4, (recordName as NSString).utf8String, -1, nil)
+        sqlite3_bind_double(statement, 5, recordUpdatedAt.timeIntervalSince1970)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
         return sqlite3_changes(db) > 0
+    }
+
+    /// Refreshes CKRecord identity/version metadata without touching local text,
+    /// timestamps, or the durable dirty flag. This is used when a fetched server
+    /// record loses last-write-wins to a newer local edit.
+    public func updateTextRecordCloudMetadata(
+        kind: SyncTextRecordKind,
+        recordName: String,
+        changeTag: String?,
+        systemFields: Data?
+    ) throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        let table = kind == .dictation ? "dictations" : "meetings"
+        let sql = """
+        UPDATE \(table)
+        SET cloud_change_tag = ?, cloud_system_fields = ?
+        WHERE cloud_record_name = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        bindOptionalText(changeTag, at: 1, statement: statement)
+        bindOptionalBlob(systemFields, at: 2, statement: statement)
+        sqlite3_bind_text(statement, 3, (recordName as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else { throw lastError(db) }
+    }
+
+    /// Drops account-scoped CKRecord metadata while preserving every local row.
+    /// Stable record names and dirty flags let the new account safely reconcile.
+    public func resetTextRecordCloudMetadataForAccountChange() throws {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        try exec("BEGIN IMMEDIATE TRANSACTION", db: db)
+        do {
+            try exec(
+                """
+                UPDATE dictations
+                SET cloud_change_tag = NULL,
+                    cloud_system_fields = NULL,
+                    last_synced_at = NULL,
+                    sync_dirty = 1
+                WHERE cloud_record_name IS NOT NULL
+                """,
+                db: db
+            )
+            try exec(
+                """
+                UPDATE meetings
+                SET cloud_change_tag = NULL,
+                    cloud_system_fields = NULL,
+                    last_synced_at = NULL,
+                    sync_dirty = 1
+                WHERE cloud_record_name IS NOT NULL
+                  AND meeting_status NOT IN ('recording', 'processing')
+                """,
+                db: db
+            )
+            try exec("COMMIT", db: db)
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
     }
 
     public func databasePath() -> URL {
@@ -3318,7 +3501,8 @@ public final class DictationStore {
             durationSeconds: sqlite3_column_double(statement, 6),
             wordCount: Int(sqlite3_column_int(statement, 7)),
             isDeleted: sqlite3_column_type(statement, 10) != SQLITE_NULL,
-            cloudChangeTag: optionalStringColumn(statement, index: 11)
+            cloudChangeTag: optionalStringColumn(statement, index: 11),
+            cloudSystemFields: optionalDataColumn(statement, index: 12)
         )
     }
 
@@ -3350,6 +3534,7 @@ public final class DictationStore {
             wordCount: Int(sqlite3_column_int(statement, 7)),
             isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL,
             cloudChangeTag: optionalStringColumn(statement, index: 12),
+            cloudSystemFields: optionalDataColumn(statement, index: 14),
             followUpToRecordName: optionalStringColumn(statement, index: 13)
         )
     }
@@ -3479,9 +3664,9 @@ public final class DictationStore {
         INSERT INTO dictations (
             timestamp, duration_seconds, raw_text, app_context, word_count, source,
             started_at, ended_at, updated_at, deleted_at, cloud_record_name,
-            cloud_change_tag, last_synced_at, sync_dirty
+            cloud_change_tag, cloud_system_fields, last_synced_at, sync_dirty
         )
-        VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+        VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
         ON CONFLICT(cloud_record_name) DO UPDATE SET
             timestamp = excluded.timestamp,
             duration_seconds = excluded.duration_seconds,
@@ -3493,6 +3678,7 @@ public final class DictationStore {
             updated_at = excluded.updated_at,
             deleted_at = excluded.deleted_at,
             cloud_change_tag = excluded.cloud_change_tag,
+            cloud_system_fields = excluded.cloud_system_fields,
             last_synced_at = excluded.last_synced_at,
             sync_dirty = 0
         WHERE excluded.updated_at > dictations.updated_at
@@ -3516,7 +3702,8 @@ public final class DictationStore {
         bindOptionalDouble(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, at: 9, statement: statement)
         sqlite3_bind_text(statement, 10, (record.id as NSString).utf8String, -1, nil)
         bindOptionalText(record.cloudChangeTag, at: 11, statement: statement)
-        sqlite3_bind_double(statement, 12, Date().timeIntervalSince1970)
+        bindOptionalBlob(record.cloudSystemFields, at: 12, statement: statement)
+        sqlite3_bind_double(statement, 13, Date().timeIntervalSince1970)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
@@ -3538,11 +3725,11 @@ public final class DictationStore {
             raw_transcript, formatted_notes, mic_audio_path, system_audio_path,
             saved_recording_path, meeting_status, manual_notes, word_count, source,
             follow_up_to_id, follow_up_to_record_name, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
-            last_synced_at, sync_dirty
+            cloud_system_fields, last_synced_at, sync_dirty
         )
         VALUES (?, NULL, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, ?,
                 (SELECT id FROM meetings WHERE cloud_record_name = ? AND deleted_at IS NULL LIMIT 1),
-                ?, ?, ?, ?, ?, ?, 0)
+                ?, ?, ?, ?, ?, ?, ?, 0)
         ON CONFLICT(cloud_record_name) DO UPDATE SET
             title = excluded.title,
             start_time = excluded.start_time,
@@ -3559,6 +3746,7 @@ public final class DictationStore {
             updated_at = excluded.updated_at,
             deleted_at = excluded.deleted_at,
             cloud_change_tag = excluded.cloud_change_tag,
+            cloud_system_fields = excluded.cloud_system_fields,
             last_synced_at = excluded.last_synced_at,
             sync_dirty = 0
         WHERE excluded.updated_at > meetings.updated_at
@@ -3588,7 +3776,8 @@ public final class DictationStore {
         bindOptionalDouble(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, at: 14, statement: statement)
         sqlite3_bind_text(statement, 15, (record.id as NSString).utf8String, -1, nil)
         bindOptionalText(record.cloudChangeTag, at: 16, statement: statement)
-        sqlite3_bind_double(statement, 17, Date().timeIntervalSince1970)
+        bindOptionalBlob(record.cloudSystemFields, at: 17, statement: statement)
+        sqlite3_bind_double(statement, 18, Date().timeIntervalSince1970)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
         }
@@ -3754,11 +3943,29 @@ public final class DictationStore {
         return value.isEmpty ? nil : value
     }
 
+    private func optionalDataColumn(_ statement: OpaquePointer?, index: Int32) -> Data? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL else { return nil }
+        let count = Int(sqlite3_column_bytes(statement, index))
+        guard count > 0, let bytes = sqlite3_column_blob(statement, index) else { return Data() }
+        return Data(bytes: bytes, count: count)
+    }
+
     private func bindOptionalText(_ value: String?, at index: Int32, statement: OpaquePointer?) {
         if let value {
             sqlite3_bind_text(statement, index, (value as NSString).utf8String, -1, nil)
         } else {
             sqlite3_bind_null(statement, index)
+        }
+    }
+
+    private func bindOptionalBlob(_ value: Data?, at index: Int32, statement: OpaquePointer?) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        _ = value.withUnsafeBytes {
+            sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(value.count), transient)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -65,6 +65,9 @@ public struct SyncTextRecord: Identifiable, Codable, Sendable, Equatable {
     public var wordCount: Int
     public var isDeleted: Bool
     public var cloudChangeTag: String?
+    /// Opaque CKRecord identity and version metadata. MuesliCore stores the bytes
+    /// without importing CloudKit; platform sync clients encode and decode them.
+    public var cloudSystemFields: Data?
     public var followUpToRecordName: String?
 
     public init(
@@ -87,6 +90,7 @@ public struct SyncTextRecord: Identifiable, Codable, Sendable, Equatable {
         wordCount: Int,
         isDeleted: Bool = false,
         cloudChangeTag: String? = nil,
+        cloudSystemFields: Data? = nil,
         followUpToRecordName: String? = nil
     ) {
         self.id = id
@@ -108,6 +112,7 @@ public struct SyncTextRecord: Identifiable, Codable, Sendable, Equatable {
         self.wordCount = wordCount
         self.isDeleted = isDeleted
         self.cloudChangeTag = cloudChangeTag
+        self.cloudSystemFields = cloudSystemFields
         self.followUpToRecordName = followUpToRecordName
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -8,6 +8,7 @@ import MuesliCore
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var controller: MuesliController?
+    private var terminationTask: Task<Void, Never>?
     private(set) var updaterController: SPUStandardUpdaterController?
     private let sparkleUpdateDelegate = SparkleUpdateDelegate()
 
@@ -55,10 +56,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func applicationWillTerminate(_ notification: Notification) {
-        controller?.shutdown()
-    }
-
     func application(
         _ application: NSApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
@@ -78,10 +75,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if terminationTask != nil {
+            return .terminateLater
+        }
         if controller?.shouldTerminateApplication() == false {
             return .terminateCancel
         }
-        return .terminateNow
+        guard let controller else { return .terminateNow }
+
+        terminationTask = Task { @MainActor [weak self] in
+            await controller.shutdown()
+            self?.terminationTask = nil
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 
     private static var hasConfiguredSparkleFeed: Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
@@ -228,6 +228,16 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     func makeRecordBatch(
         pendingChanges: [CKSyncEngine.PendingRecordZoneChange]
     ) -> MuesliCKSyncRecordBatch {
+        makeRecordBatch(
+            pendingChanges: pendingChanges,
+            loadRecords: { try store.textRecordsForSync(recordNames: $0) }
+        )
+    }
+
+    func makeRecordBatch(
+        pendingChanges: [CKSyncEngine.PendingRecordZoneChange],
+        loadRecords: ([String]) throws -> [String: SyncTextRecord]
+    ) -> MuesliCKSyncRecordBatch {
         var recordsToSave: [CKRecord] = []
         var staleChanges: [CKSyncEngine.PendingRecordZoneChange] = []
         let relevantChanges: [(CKSyncEngine.PendingRecordZoneChange, CKRecord.ID)] =
@@ -238,9 +248,18 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 }
                 return (change, recordID)
             }
-        let localRecords = (try? store.textRecordsForSync(
-            recordNames: relevantChanges.map { $0.1.recordName }
-        )) ?? [:]
+        let localRecords: [String: SyncTextRecord]
+        do {
+            localRecords = try loadRecords(relevantChanges.map { $0.1.recordName })
+        } catch {
+            // A transient SQLite read failure must not turn durable pending saves into
+            // stale changes. Keep the outbox intact so CKSyncEngine can retry later.
+            fputs(
+                "[muesli-native] CKSyncEngine local batch read failed: \(String(describing: type(of: error)))\n",
+                stderr
+            )
+            return MuesliCKSyncRecordBatch(recordsToSave: [], staleChanges: [])
+        }
 
         for (change, recordID) in relevantChanges {
             guard let localRecord = localRecords[recordID.recordName] else {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
@@ -80,11 +80,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         uploaded = ICloudSyncKindCounts()
         downloaded = ICloudSyncKindCounts()
 
-        let syncZoneWasRecreated = try await prepare(
+        let (_, syncEngine) = try await prepareEngine(
             forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
         )
-
-        let syncEngine = try makeEngineIfNeeded()
         try await MuesliCKSyncCycle.run(
             maximumUploadBatches: Self.maximumUploadBatchesPerSync,
             fetch: {
@@ -109,13 +107,21 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             uploaded: uploaded,
             downloaded: downloaded,
             hasPendingUploads: try store.hasTextRecordsNeedingSync(),
-            syncZoneWasRecreated: syncZoneWasRecreated,
             syncedAt: Date()
         )
     }
 
     @discardableResult
     func prepare(forceBridgeDeviceRefresh: Bool = false) async throws -> Bool {
+        let (syncZoneWasRecreated, _) = try await prepareEngine(
+            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+        )
+        return syncZoneWasRecreated
+    }
+
+    private func prepareEngine(
+        forceBridgeDeviceRefresh: Bool
+    ) async throws -> (syncZoneWasRecreated: Bool, engine: CKSyncEngine) {
         let preflight: MuesliICloudSyncEngine
         if let existing = self.preflight {
             preflight = existing
@@ -133,8 +139,8 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             engine = nil
         }
 
-        _ = try makeEngineIfNeeded()
-        return syncZoneWasRecreated
+        let syncEngine = try makeEngineIfNeeded()
+        return (syncZoneWasRecreated, syncEngine)
     }
 
     func cancel() async {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
@@ -46,7 +46,7 @@ struct MuesliCKSyncRecordBatch: Sendable {
 /// rediscover dirty rows and add their stable record IDs to CKSyncEngine state,
 /// so a crash between a local edit and state serialization cannot lose work.
 actor MuesliCKSyncEngine: CKSyncEngineDelegate {
-    private static var stateKey: String {
+    static var stateKey: String {
         "cksyncengine.private.MuesliSyncZone.\(MuesliICloudSyncEngine.cloudKitEnvironmentKeyComponent).v1"
     }
     private static let subscriptionID = "muesli-cksyncengine-private-v1"
@@ -135,8 +135,10 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
         )
         if syncZoneWasRecreated {
-            try store.clearCloudSyncStateData(forKey: Self.stateKey)
+            let engineToCancel = engine
             engine = nil
+            await engineToCancel?.cancelOperations()
+            try store.clearCloudSyncStateData(forKey: Self.stateKey)
         }
 
         let syncEngine = try makeEngineIfNeeded()
@@ -144,7 +146,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     }
 
     func cancel() async {
-        await engine?.cancelOperations()
+        let engineToCancel = engine
+        engine = nil
+        await engineToCancel?.cancelOperations()
     }
 
     private func makeEngineIfNeeded() throws -> CKSyncEngine {
@@ -226,13 +230,20 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     ) -> MuesliCKSyncRecordBatch {
         var recordsToSave: [CKRecord] = []
         var staleChanges: [CKSyncEngine.PendingRecordZoneChange] = []
-
-        for change in pendingChanges {
-            guard case .saveRecord(let recordID) = change,
-                  recordID.zoneID == MuesliICloudSyncEngine.Schema.syncZoneID else {
-                continue
+        let relevantChanges: [(CKSyncEngine.PendingRecordZoneChange, CKRecord.ID)] =
+            pendingChanges.compactMap { change in
+                guard case .saveRecord(let recordID) = change,
+                      recordID.zoneID == MuesliICloudSyncEngine.Schema.syncZoneID else {
+                    return nil
+                }
+                return (change, recordID)
             }
-            guard let localRecord = try? store.textRecordForSync(recordName: recordID.recordName) else {
+        let localRecords = (try? store.textRecordsForSync(
+            recordNames: relevantChanges.map { $0.1.recordName }
+        )) ?? [:]
+
+        for (change, recordID) in relevantChanges {
+            guard let localRecord = localRecords[recordID.recordName] else {
                 staleChanges.append(change)
                 continue
             }
@@ -276,9 +287,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 conflictBaseRecords.removeAll()
                 switch change.changeType {
                 case .signIn, .switchAccounts:
-                    try handleAccountChange(requiresMetadataReset: true)
+                    try await handleAccountChange(requiresMetadataReset: true)
                 case .signOut:
-                    try handleAccountChange(requiresMetadataReset: false)
+                    try await handleAccountChange(requiresMetadataReset: false)
                 @unknown default:
                     break
                 }
@@ -380,7 +391,11 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         }
     }
 
-    func handleAccountChange(requiresMetadataReset: Bool) throws {
+    func handleAccountChange(requiresMetadataReset: Bool) async throws {
+        let engineToCancel = engine
+        engine = nil
+        await engineToCancel?.cancelOperations()
+        try store.clearCloudSyncStateData(forKey: Self.stateKey)
         conflictBaseRecords.removeAll()
         if requiresMetadataReset {
             try store.resetTextRecordCloudMetadataForAccountChange()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
@@ -1,0 +1,383 @@
+import CloudKit
+import Foundation
+import MuesliCore
+
+protocol MuesliCKSyncPendingState: AnyObject, Sendable {
+    var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange] { get }
+    func add(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange])
+    func remove(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange])
+}
+
+extension CKSyncEngine.State: MuesliCKSyncPendingState {}
+
+enum MuesliCKSyncCycle {
+    static func run(
+        maximumUploadBatches: Int,
+        fetch: () async throws -> Void,
+        registerNextBatch: () async throws -> Int,
+        uploadedCount: () async -> Int,
+        send: () async throws -> Void
+    ) async throws {
+        try await fetch()
+
+        for _ in 0..<max(maximumUploadBatches, 0) {
+            let registered = try await registerNextBatch()
+            guard registered > 0 else { break }
+            let uploadedBeforeSend = await uploadedCount()
+            try await send()
+            guard await uploadedCount() > uploadedBeforeSend else { break }
+        }
+    }
+}
+
+struct MuesliCKSyncFailedRecordSave: Sendable {
+    let record: CKRecord
+    let error: CKError
+}
+
+struct MuesliCKSyncRecordBatch: Sendable {
+    let recordsToSave: [CKRecord]
+    let staleChanges: [CKSyncEngine.PendingRecordZoneChange]
+}
+
+/// Owns the single CKSyncEngine instance for Muesli's private text-record zone.
+///
+/// SQLite's `sync_dirty` flags remain the durable outbox. Before every send we
+/// rediscover dirty rows and add their stable record IDs to CKSyncEngine state,
+/// so a crash between a local edit and state serialization cannot lose work.
+actor MuesliCKSyncEngine: CKSyncEngineDelegate {
+    private static var stateKey: String {
+        "cksyncengine.private.MuesliSyncZone.\(MuesliICloudSyncEngine.cloudKitEnvironmentKeyComponent).v1"
+    }
+    private static let subscriptionID = "muesli-cksyncengine-private-v1"
+    private static let uploadBatchSize = 200
+    private static let maximumUploadBatchesPerSync = 50
+
+    private let store: DictationStore
+    private var container: CKContainer?
+    private var preflight: MuesliICloudSyncEngine?
+    private var engine: CKSyncEngine?
+    private var conflictBaseRecords: [CKRecord.ID: CKRecord] = [:]
+    private var uploaded = ICloudSyncKindCounts()
+    private var downloaded = ICloudSyncKindCounts()
+
+    nonisolated static func isSyncNotification(_ userInfo: [AnyHashable: Any]) -> Bool {
+        guard let notification = CKNotification(fromRemoteNotificationDictionary: userInfo) else {
+            return false
+        }
+        return notification.subscriptionID == subscriptionID
+    }
+
+    init(
+        store: DictationStore,
+        container: CKContainer? = nil
+    ) {
+        self.store = store
+        self.container = container
+    }
+
+    func sync(forceBridgeDeviceRefresh: Bool = false) async throws -> ICloudSyncResult {
+        uploaded = ICloudSyncKindCounts()
+        downloaded = ICloudSyncKindCounts()
+
+        let syncZoneWasRecreated = try await prepare(
+            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+        )
+
+        let syncEngine = try makeEngineIfNeeded()
+        try await MuesliCKSyncCycle.run(
+            maximumUploadBatches: Self.maximumUploadBatchesPerSync,
+            fetch: {
+                let options = CKSyncEngine.FetchChangesOptions(
+                    scope: .zoneIDs([MuesliICloudSyncEngine.Schema.syncZoneID])
+                )
+                try await syncEngine.fetchChanges(options)
+            },
+            registerNextBatch: {
+                try self.registerNextDirtyBatch(state: syncEngine.state)
+            },
+            uploadedCount: { self.uploaded.total },
+            send: {
+                let options = CKSyncEngine.SendChangesOptions(
+                    scope: .zoneIDs([MuesliICloudSyncEngine.Schema.syncZoneID])
+                )
+                try await syncEngine.sendChanges(options)
+            }
+        )
+
+        return ICloudSyncResult(
+            uploaded: uploaded,
+            downloaded: downloaded,
+            hasPendingUploads: try store.hasTextRecordsNeedingSync(),
+            syncZoneWasRecreated: syncZoneWasRecreated,
+            syncedAt: Date()
+        )
+    }
+
+    @discardableResult
+    func prepare(forceBridgeDeviceRefresh: Bool = false) async throws -> Bool {
+        let preflight: MuesliICloudSyncEngine
+        if let existing = self.preflight {
+            preflight = existing
+        } else {
+            let created = MuesliICloudSyncEngine(container: resolvedContainer())
+            self.preflight = created
+            preflight = created
+        }
+        let syncZoneWasRecreated = try await preflight.prepareForCKSyncEngine(
+            store: store,
+            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+        )
+        if syncZoneWasRecreated {
+            try store.clearCloudSyncStateData(forKey: Self.stateKey)
+            engine = nil
+        }
+
+        _ = try makeEngineIfNeeded()
+        return syncZoneWasRecreated
+    }
+
+    func cancel() async {
+        await engine?.cancelOperations()
+    }
+
+    private func makeEngineIfNeeded() throws -> CKSyncEngine {
+        if let engine { return engine }
+
+        let serialization: CKSyncEngine.State.Serialization?
+        if let data = try store.cloudSyncStateData(forKey: Self.stateKey) {
+            do {
+                serialization = try PropertyListDecoder().decode(
+                    CKSyncEngine.State.Serialization.self,
+                    from: data
+                )
+            } catch {
+                // A corrupt engine cursor is recoverable: starting with nil causes a
+                // complete private-database replay, while local rows remain intact.
+                try store.clearCloudSyncStateData(forKey: Self.stateKey)
+                serialization = nil
+            }
+        } else {
+            serialization = nil
+        }
+
+        var configuration = CKSyncEngine.Configuration(
+            database: resolvedContainer().privateCloudDatabase,
+            stateSerialization: serialization,
+            delegate: self
+        )
+        configuration.automaticallySync = true
+        configuration.subscriptionID = Self.subscriptionID
+        let created = CKSyncEngine(configuration)
+        engine = created
+        return created
+    }
+
+    private func resolvedContainer() -> CKContainer {
+        if let container { return container }
+        let created = CKContainer(identifier: MuesliICloudSyncEngine.Schema.containerIdentifier)
+        container = created
+        return created
+    }
+
+    func registerNextDirtyBatch(state: any MuesliCKSyncPendingState) throws -> Int {
+        let dirtyRecords = try store.textRecordsNeedingSync(limit: Self.uploadBatchSize)
+        guard !dirtyRecords.isEmpty else { return 0 }
+
+        let alreadyPending = Set(state.pendingRecordZoneChanges.compactMap { change -> CKRecord.ID? in
+            guard case .saveRecord(let recordID) = change else { return nil }
+            return recordID
+        })
+        let additions = dirtyRecords.compactMap { record -> CKSyncEngine.PendingRecordZoneChange? in
+            let recordID = CKRecord.ID(
+                recordName: record.id,
+                zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+            )
+            guard !alreadyPending.contains(recordID) else { return nil }
+            return .saveRecord(recordID)
+        }
+        state.add(pendingRecordZoneChanges: additions)
+        return dirtyRecords.count
+    }
+
+    func nextRecordZoneChangeBatch(
+        _ context: CKSyncEngine.SendChangesContext,
+        syncEngine: CKSyncEngine
+    ) async -> CKSyncEngine.RecordZoneChangeBatch? {
+        let pending = syncEngine.state.pendingRecordZoneChanges.filter {
+            context.options.scope.contains($0)
+        }
+        let batch = makeRecordBatch(pendingChanges: pending)
+        if !batch.staleChanges.isEmpty {
+            syncEngine.state.remove(pendingRecordZoneChanges: batch.staleChanges)
+        }
+        guard !batch.recordsToSave.isEmpty else { return nil }
+        return CKSyncEngine.RecordZoneChangeBatch(recordsToSave: batch.recordsToSave)
+    }
+
+    func makeRecordBatch(
+        pendingChanges: [CKSyncEngine.PendingRecordZoneChange]
+    ) -> MuesliCKSyncRecordBatch {
+        var recordsToSave: [CKRecord] = []
+        var staleChanges: [CKSyncEngine.PendingRecordZoneChange] = []
+
+        for change in pendingChanges {
+            guard case .saveRecord(let recordID) = change,
+                  recordID.zoneID == MuesliICloudSyncEngine.Schema.syncZoneID else {
+                continue
+            }
+            guard let localRecord = try? store.textRecordForSync(recordName: recordID.recordName) else {
+                staleChanges.append(change)
+                continue
+            }
+            let cloudRecord = MuesliICloudSyncEngine.syncZoneCloudRecord(
+                from: localRecord,
+                baseRecord: conflictBaseRecords[recordID]
+            )
+            recordsToSave.append(cloudRecord)
+        }
+        return MuesliCKSyncRecordBatch(
+            recordsToSave: recordsToSave,
+            staleChanges: staleChanges
+        )
+    }
+
+    func handleEvent(_ event: CKSyncEngine.Event, syncEngine: CKSyncEngine) async {
+        do {
+            switch event {
+            case .stateUpdate(let update):
+                let data = try PropertyListEncoder().encode(update.stateSerialization)
+                try store.saveCloudSyncStateData(data, forKey: Self.stateKey)
+
+            case .fetchedRecordZoneChanges(let changes):
+                try handleFetchedRecords(
+                    changes.modifications.map(\.record),
+                    state: syncEngine.state
+                )
+                // Muesli represents deletion as a saved tombstone. Hard-deletion
+                // notifications are intentionally ignored for this record contract.
+
+            case .sentRecordZoneChanges(let changes):
+                try handleSentRecordChanges(
+                    savedRecords: changes.savedRecords,
+                    failedRecordSaves: changes.failedRecordSaves.map {
+                        MuesliCKSyncFailedRecordSave(record: $0.record, error: $0.error)
+                    },
+                    state: syncEngine.state
+                )
+
+            case .accountChange(let change):
+                conflictBaseRecords.removeAll()
+                switch change.changeType {
+                case .signIn, .switchAccounts:
+                    try handleAccountChange(requiresMetadataReset: true)
+                case .signOut:
+                    try handleAccountChange(requiresMetadataReset: false)
+                @unknown default:
+                    break
+                }
+
+            case .fetchedDatabaseChanges,
+                 .sentDatabaseChanges,
+                 .willFetchChanges,
+                 .willFetchRecordZoneChanges,
+                 .didFetchRecordZoneChanges,
+                 .didFetchChanges,
+                 .willSendChanges,
+                 .didSendChanges:
+                break
+
+            @unknown default:
+                break
+            }
+        } catch {
+            // Delegate callbacks cannot throw. Emit only the failure category; no
+            // record identifiers or user-authored fields enter diagnostics.
+            fputs("[muesli-native] CKSyncEngine event failed: \(String(describing: type(of: error)))\n", stderr)
+        }
+    }
+
+    func handleFetchedRecords(
+        _ cloudRecords: [CKRecord],
+        state: any MuesliCKSyncPendingState
+    ) throws {
+        let records = cloudRecords
+            .filter {
+                $0.recordID.zoneID == MuesliICloudSyncEngine.Schema.syncZoneID
+                    && $0.recordType == MuesliICloudSyncEngine.Schema.textRecordType
+            }
+            .compactMap(MuesliICloudSyncEngine.syncTextRecord(from:))
+        let appliedRecordIDs = Set(try store.upsertSyncedTextRecords(records).map(\.id))
+        for record in records {
+            if !appliedRecordIDs.contains(record.id) {
+                try store.updateTextRecordCloudMetadata(
+                    kind: record.kind,
+                    recordName: record.id,
+                    changeTag: record.cloudChangeTag,
+                    systemFields: record.cloudSystemFields
+                )
+                continue
+            }
+            downloaded.increment(record.kind)
+            state.remove(pendingRecordZoneChanges: [
+                .saveRecord(CKRecord.ID(
+                    recordName: record.id,
+                    zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+                )),
+            ])
+        }
+    }
+
+    func handleSentRecordChanges(
+        savedRecords: [CKRecord],
+        failedRecordSaves: [MuesliCKSyncFailedRecordSave],
+        state: any MuesliCKSyncPendingState
+    ) throws {
+        for savedRecord in savedRecords {
+            guard let syncRecord = MuesliICloudSyncEngine.syncTextRecord(from: savedRecord) else { continue }
+            if try store.markTextRecordSynced(
+                kind: syncRecord.kind,
+                recordName: syncRecord.id,
+                changeTag: savedRecord.recordChangeTag,
+                systemFields: MuesliICloudSyncEngine.encodedSystemFields(for: savedRecord),
+                recordUpdatedAt: syncRecord.updatedAt
+            ) {
+                uploaded.increment(syncRecord.kind)
+            }
+            state.remove(pendingRecordZoneChanges: [.saveRecord(savedRecord.recordID)])
+            conflictBaseRecords[savedRecord.recordID] = nil
+        }
+
+        for failure in failedRecordSaves {
+            let recordID = failure.record.recordID
+            guard recordID.zoneID == MuesliICloudSyncEngine.Schema.syncZoneID else { continue }
+            let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(recordID)
+
+            if failure.error.code == .serverRecordChanged,
+               let serverRecord = failure.error.serverRecord,
+               let remote = MuesliICloudSyncEngine.syncTextRecord(from: serverRecord),
+               let local = try store.textRecordForSync(recordName: recordID.recordName) {
+                // The serverRecordChanged error itself proves the saved version is
+                // stale, so last-write-wins depends only on Muesli's updatedAt field.
+                if remote.updatedAt > local.updatedAt {
+                    _ = try store.upsertSyncedTextRecord(remote)
+                    state.remove(pendingRecordZoneChanges: [pending])
+                } else {
+                    conflictBaseRecords[recordID] = serverRecord
+                    state.add(pendingRecordZoneChanges: [pending])
+                }
+            } else {
+                // CKSyncEngine decides scheduling/backoff; the durable outbox makes
+                // the save discoverable again even if this pending change is dropped.
+                state.add(pendingRecordZoneChanges: [pending])
+            }
+        }
+    }
+
+    func handleAccountChange(requiresMetadataReset: Bool) throws {
+        conflictBaseRecords.removeAll()
+        if requiresMetadataReset {
+            try store.resetTextRecordCloudMetadataForAccountChange()
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -432,6 +432,7 @@ final class MuesliController: NSObject {
     /// transcript, and cleared on success or restored-on-failure.
     private var pendingResumePriorTranscript: [Int64: String] = [:]
     private var iCloudSyncTask: Task<Void, Never>?
+    private lazy var ckSyncEngine = MuesliCKSyncEngine(store: dictationStore)
     private var iCloudSyncGeneration = 0
     private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var iCloudSubscriptionTask: Task<Void, Never>?
@@ -1598,7 +1599,8 @@ final class MuesliController: NSObject {
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = Task { [weak self] in
             do {
-                try await MuesliICloudSyncEngine().ensureTextRecordSubscription()
+                guard let syncEngine = self?.ckSyncEngine else { return }
+                try await syncEngine.prepare()
                 await MainActor.run {
                     guard let self, self.iCloudSyncGeneration == generation else { return }
                     self.iCloudSubscriptionTask = nil
@@ -1641,7 +1643,8 @@ final class MuesliController: NSObject {
 
     func handleICloudRemoteNotification(userInfo: [AnyHashable: Any]) {
         guard config.iCloudSyncEnabled,
-              MuesliICloudSyncEngine.isTextRecordSubscriptionNotification(userInfo) else {
+              (MuesliICloudSyncEngine.isTextRecordSubscriptionNotification(userInfo)
+                  || MuesliCKSyncEngine.isSyncNotification(userInfo)) else {
             return
         }
         scheduleICloudSync(delay: 0.2, userInitiated: false)
@@ -1689,13 +1692,17 @@ final class MuesliController: NSObject {
         }
         iCloudSubscriptionTask = Task { [weak self] in
             do {
-                try await MuesliICloudSyncEngine().ensureTextRecordSubscription()
+                guard let syncEngine = self?.ckSyncEngine else { return }
+                try await syncEngine.prepare()
                 await MainActor.run {
                     self?.hasEnsuredICloudSubscription = true
                     self?.iCloudSubscriptionTask = nil
                 }
             } catch {
-                fputs("[muesli-native] failed to ensure iCloud sync subscription: \(error)\n", stderr)
+                fputs(
+                    "[muesli-native] failed to prepare CKSyncEngine: \(String(describing: type(of: error)))\n",
+                    stderr
+                )
                 await MainActor.run {
                     self?.iCloudSubscriptionTask = nil
                 }
@@ -1790,14 +1797,17 @@ final class MuesliController: NSObject {
                     bridgeDiscoveryTriggered: bridgeDiscoveryTriggeredAtStart,
                     hasKnownCompanionDevice: hasKnownCompanionDeviceAtStart
                 )
-                let result = try await MuesliICloudSyncEngine().sync(
-                    store: store,
+                guard let syncEngine = self?.ckSyncEngine else { return }
+                let result = try await syncEngine.sync(
                     forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
                 )
                 do {
                     _ = try store.purgeSoftDeletedTextRecords()
                 } catch {
-                    fputs("[muesli-native] failed to purge old iCloud tombstones: \(error)\n", stderr)
+                    fputs(
+                        "[muesli-native] failed to purge old iCloud tombstones: \(String(describing: type(of: error)))\n",
+                        stderr
+                    )
                 }
                 await MainActor.run {
                     guard let self, self.iCloudSyncGeneration == generation else { return }
@@ -1823,10 +1833,6 @@ final class MuesliController: NSObject {
                         self.bridgeActivationPending = false
                         self.appState.isICloudBridgeActivationPending = false
                         TelemetryDeck.signal("bridge_enable_completed", parameters: ["platform": "macos"])
-                    }
-                    if result.syncZoneWasRecreated {
-                        self.resetICloudSubscriptionState()
-                        self.ensureICloudSubscription()
                     }
                     self.refreshUI()
                     let shouldRunBridgeDiscoveryFollowUp = self.bridgeDiscoveryFollowUpPending

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -811,6 +811,9 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
+        Task { [ckSyncEngine] in
+            await ckSyncEngine.cancel()
+        }
         hotkeyMonitor.stop()
         computerUseHotkeyMonitor.stop()
         meetingRecordingHotkeyMonitor.stop()
@@ -1899,6 +1902,9 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
+        Task { [ckSyncEngine] in
+            await ckSyncEngine.cancel()
+        }
         resetICloudSubscriptionState()
         resetBridgeDiscoveryRuntimeState()
         appState.iCloudSyncStatus = "iCloud sync is off."
@@ -1912,6 +1918,9 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
+        Task { [ckSyncEngine] in
+            await ckSyncEngine.cancel()
+        }
         resetICloudSubscriptionState()
         resetBridgeDiscoveryRuntimeState()
         appState.iCloudSyncStatus = "iCloud sync is unavailable in this local-only build."

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -433,6 +433,8 @@ final class MuesliController: NSObject {
     private var pendingResumePriorTranscript: [Int64: String] = [:]
     private var iCloudSyncTask: Task<Void, Never>?
     private var ckSyncEngine: MuesliCKSyncEngine?
+    private var ckSyncEngineCancellationTask: Task<Void, Never>?
+    private var ckSyncEngineCancellationGeneration = 0
     private var iCloudSyncGeneration = 0
     private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var iCloudSubscriptionTask: Task<Void, Never>?
@@ -789,7 +791,7 @@ final class MuesliController: NSObject {
         }
     }
 
-    func shutdown() {
+    func shutdown() async {
         if let workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(workspaceObserver)
             self.workspaceObserver = nil
@@ -811,7 +813,7 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
-        cancelCKSyncEngine()
+        let syncEngineCancellationTask = retireCKSyncEngine()
         hotkeyMonitor.stop()
         computerUseHotkeyMonitor.stop()
         meetingRecordingHotkeyMonitor.stop()
@@ -846,9 +848,8 @@ final class MuesliController: NSObject {
         endMeetingActivity()
         dictationAudioSessionManager.cancel(reason: "shutdown")
         computerUseAudioSessionManager.cancel(reason: "shutdown")
-        Task {
-            await transcriptionCoordinator.shutdown()
-        }
+        await syncEngineCancellationTask?.value
+        await transcriptionCoordinator.shutdown()
         indicator.close()
         CoreAudioSystemRecorder.cleanupStaleDevices()
     }
@@ -1901,14 +1902,23 @@ final class MuesliController: NSObject {
         return created
     }
 
-    private func cancelCKSyncEngine() {
-        // Detach first so a rapid re-enable gets a new actor. The asynchronous
-        // cancellation below can then only tear down the retired engine instance.
-        guard let retiredEngine = ckSyncEngine else { return }
-        ckSyncEngine = nil
-        Task {
-            await retiredEngine.cancel()
+    private func retireCKSyncEngine() -> Task<Void, Never>? {
+        guard let retiredEngine = ckSyncEngine else {
+            return ckSyncEngineCancellationTask
         }
+        ckSyncEngine = nil
+        let previousCancellationTask = ckSyncEngineCancellationTask
+        ckSyncEngineCancellationGeneration += 1
+        let cancellationGeneration = ckSyncEngineCancellationGeneration
+        let cancellationTask = Task { [weak self] in
+            await previousCancellationTask?.value
+            await retiredEngine.cancel()
+            guard let self,
+                  self.ckSyncEngineCancellationGeneration == cancellationGeneration else { return }
+            self.ckSyncEngineCancellationTask = nil
+        }
+        ckSyncEngineCancellationTask = cancellationTask
+        return cancellationTask
     }
 
     private func disableICloudSyncRuntimeState() {
@@ -1917,12 +1927,21 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
-        cancelCKSyncEngine()
+        let generation = iCloudSyncGeneration
+        let cancellationTask = retireCKSyncEngine()
         resetICloudSubscriptionState()
         resetBridgeDiscoveryRuntimeState()
-        appState.iCloudSyncStatus = "iCloud sync is off."
-        appState.iCloudBridgeState = .notConfigured
+        appState.iCloudSyncStatus = "Turning off iCloud sync..."
+        appState.iCloudBridgeState = .syncing
         appState.iCloudBridgeMessage = nil
+        Task { [weak self] in
+            await cancellationTask?.value
+            guard let self,
+                  self.iCloudSyncGeneration == generation,
+                  self.ckSyncEngine == nil else { return }
+            self.appState.iCloudSyncStatus = "iCloud sync is off."
+            self.appState.iCloudBridgeState = .notConfigured
+        }
     }
 
     private func disableICloudSyncForUnavailableEntitlement() {
@@ -1931,12 +1950,21 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
-        cancelCKSyncEngine()
+        let generation = iCloudSyncGeneration
+        let cancellationTask = retireCKSyncEngine()
         resetICloudSubscriptionState()
         resetBridgeDiscoveryRuntimeState()
-        appState.iCloudSyncStatus = "iCloud sync is unavailable in this local-only build."
-        appState.iCloudBridgeState = .notConfigured
+        appState.iCloudSyncStatus = "Stopping unavailable iCloud sync..."
+        appState.iCloudBridgeState = .syncing
         appState.iCloudBridgeMessage = nil
+        Task { [weak self] in
+            await cancellationTask?.value
+            guard let self,
+                  self.iCloudSyncGeneration == generation,
+                  self.ckSyncEngine == nil else { return }
+            self.appState.iCloudSyncStatus = "iCloud sync is unavailable in this local-only build."
+            self.appState.iCloudBridgeState = .notConfigured
+        }
     }
 
     private func resetBridgeDiscoveryRuntimeState() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -432,7 +432,7 @@ final class MuesliController: NSObject {
     /// transcript, and cleared on success or restored-on-failure.
     private var pendingResumePriorTranscript: [Int64: String] = [:]
     private var iCloudSyncTask: Task<Void, Never>?
-    private lazy var ckSyncEngine = MuesliCKSyncEngine(store: dictationStore)
+    private var ckSyncEngine: MuesliCKSyncEngine?
     private var iCloudSyncGeneration = 0
     private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var iCloudSubscriptionTask: Task<Void, Never>?
@@ -811,9 +811,7 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
-        Task { [ckSyncEngine] in
-            await ckSyncEngine.cancel()
-        }
+        cancelCKSyncEngine()
         hotkeyMonitor.stop()
         computerUseHotkeyMonitor.stop()
         meetingRecordingHotkeyMonitor.stop()
@@ -1599,10 +1597,10 @@ final class MuesliController: NSObject {
 
         iCloudSyncGeneration += 1
         let generation = iCloudSyncGeneration
+        let syncEngine = resolvedCKSyncEngine()
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = Task { [weak self] in
             do {
-                guard let syncEngine = self?.ckSyncEngine else { return }
                 try await syncEngine.prepare()
                 await MainActor.run {
                     guard let self, self.iCloudSyncGeneration == generation else { return }
@@ -1693,9 +1691,9 @@ final class MuesliController: NSObject {
               iCloudSubscriptionTask == nil else {
             return
         }
+        let syncEngine = resolvedCKSyncEngine()
         iCloudSubscriptionTask = Task { [weak self] in
             do {
-                guard let syncEngine = self?.ckSyncEngine else { return }
                 try await syncEngine.prepare()
                 await MainActor.run {
                     self?.hasEnsuredICloudSubscription = true
@@ -1788,6 +1786,7 @@ final class MuesliController: NSObject {
         let store = dictationStore
         iCloudSyncGeneration += 1
         let generation = iCloudSyncGeneration
+        let syncEngine = resolvedCKSyncEngine()
         let bridgeActivationPendingAtStart = bridgeActivationPending
         let bridgeDiscoveryTriggeredAtStart = bridgeDiscoveryPending
         bridgeDiscoveryPending = false
@@ -1800,7 +1799,6 @@ final class MuesliController: NSObject {
                     bridgeDiscoveryTriggered: bridgeDiscoveryTriggeredAtStart,
                     hasKnownCompanionDevice: hasKnownCompanionDeviceAtStart
                 )
-                guard let syncEngine = self?.ckSyncEngine else { return }
                 let result = try await syncEngine.sync(
                     forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
                 )
@@ -1896,15 +1894,30 @@ final class MuesliController: NSObject {
         refreshICloudBridgeStateForConfig()
     }
 
+    private func resolvedCKSyncEngine() -> MuesliCKSyncEngine {
+        if let ckSyncEngine { return ckSyncEngine }
+        let created = MuesliCKSyncEngine(store: dictationStore)
+        ckSyncEngine = created
+        return created
+    }
+
+    private func cancelCKSyncEngine() {
+        // Detach first so a rapid re-enable gets a new actor. The asynchronous
+        // cancellation below can then only tear down the retired engine instance.
+        guard let retiredEngine = ckSyncEngine else { return }
+        ckSyncEngine = nil
+        Task {
+            await retiredEngine.cancel()
+        }
+    }
+
     private func disableICloudSyncRuntimeState() {
         cancelActiveICloudSyncTask()
         iCloudSyncDebounceTask?.cancel()
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
-        Task { [ckSyncEngine] in
-            await ckSyncEngine.cancel()
-        }
+        cancelCKSyncEngine()
         resetICloudSubscriptionState()
         resetBridgeDiscoveryRuntimeState()
         appState.iCloudSyncStatus = "iCloud sync is off."
@@ -1918,9 +1931,7 @@ final class MuesliController: NSObject {
         iCloudSyncDebounceTask = nil
         iCloudSubscriptionTask?.cancel()
         iCloudSubscriptionTask = nil
-        Task { [ckSyncEngine] in
-            await ckSyncEngine.cancel()
-        }
+        cancelCKSyncEngine()
         resetICloudSubscriptionState()
         resetBridgeDiscoveryRuntimeState()
         appState.iCloudSyncStatus = "iCloud sync is unavailable in this local-only build."

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -25,7 +25,6 @@ struct ICloudSyncResult: Equatable {
     let uploaded: ICloudSyncKindCounts
     let downloaded: ICloudSyncKindCounts
     let hasPendingUploads: Bool
-    let syncZoneWasRecreated: Bool
     let syncedAt: Date
 }
 
@@ -480,7 +479,7 @@ final class MuesliICloudSyncEngine {
         forceBridgeDeviceRefresh: Bool = false
     ) async throws -> ICloudSyncResult {
         try await verifyAccountAvailable()
-        let syncZoneWasRecreated = try await ensureSyncZone()
+        _ = try await ensureSyncZone()
         await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
         try await migrateDefaultZoneIfNeeded(store: store)
 
@@ -500,7 +499,6 @@ final class MuesliICloudSyncEngine {
             uploaded: uploadResult.uploaded,
             downloaded: downloaded,
             hasPendingUploads: uploadResult.hasPendingUploads,
-            syncZoneWasRecreated: syncZoneWasRecreated,
             syncedAt: Date()
         )
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -408,7 +408,7 @@ enum ICloudSyncCallbackDeadline {
 }
 
 final class MuesliICloudSyncEngine {
-    private enum Schema {
+    enum Schema {
         static let containerIdentifier = "iCloud.com.mueslihq.muesli"
         static let syncZoneName = "MuesliSyncZone"
         static let textRecordType = "MuesliTextRecord"
@@ -447,6 +447,21 @@ final class MuesliICloudSyncEngine {
             return container == Schema.containerIdentifier
         }
         return false
+    }
+
+    static var cloudKitEnvironmentKeyComponent: String {
+        guard
+            let task = SecTaskCreateFromSelf(nil),
+            let value = SecTaskCopyValueForEntitlement(
+                task,
+                "com.apple.developer.icloud-container-environment" as CFString,
+                nil
+            ) as? String
+        else {
+            return "unspecified"
+        }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? "unspecified" : normalized
     }
 
     init(
@@ -488,6 +503,21 @@ final class MuesliICloudSyncEngine {
             syncZoneWasRecreated: syncZoneWasRecreated,
             syncedAt: Date()
         )
+    }
+
+    /// Transitional preflight retained while text-record orchestration moves to
+    /// CKSyncEngine. Bridge discovery and the one-time legacy default-zone import
+    /// still use their existing CloudKit operations, but no token-based custom-zone
+    /// fetch or dirty-record upload is performed here.
+    func prepareForCKSyncEngine(
+        store: DictationStore,
+        forceBridgeDeviceRefresh: Bool = false
+    ) async throws -> Bool {
+        try await verifyAccountAvailable()
+        let syncZoneWasRecreated = try await ensureSyncZone()
+        await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
+        try await migrateDefaultZoneIfNeeded(store: store)
+        return syncZoneWasRecreated
     }
 
     func ensureTextRecordSubscription() async throws {
@@ -562,7 +592,10 @@ final class MuesliICloudSyncEngine {
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
             MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
-            fputs("Failed to refresh iCloud bridge device identity: \(error)\n", stderr)
+            fputs(
+                "Failed to refresh iCloud bridge device identity: \(String(describing: type(of: error)))\n",
+                stderr
+            )
             MuesliBridgeDeviceIdentity.markRefreshFailed(defaults: defaults)
         }
     }
@@ -745,6 +778,7 @@ final class MuesliICloudSyncEngine {
                     kind: kind,
                     recordName: recordName,
                     changeTag: savedRecord.recordChangeTag,
+                    systemFields: Self.encodedSystemFields(for: savedRecord),
                     recordUpdatedAt: dirtyRecord.updatedAt
                 ) {
                     markedRecordCount += 1
@@ -1119,7 +1153,8 @@ final class MuesliICloudSyncEngine {
 
     static func syncZoneCloudRecord(from record: SyncTextRecord, baseRecord: CKRecord? = nil) -> CKRecord {
         let recordID = CKRecord.ID(recordName: record.id, zoneID: Schema.syncZoneID)
-        let cloud = baseRecord ?? CKRecord(recordType: Schema.textRecordType, recordID: recordID)
+        let persistedRecord = record.cloudSystemFields.flatMap(Self.record(fromSystemFields:))
+        let cloud = baseRecord ?? persistedRecord ?? CKRecord(recordType: Schema.textRecordType, recordID: recordID)
         cloud["kind"] = record.kind.rawValue as NSString
         cloud["source"] = record.source as NSString?
         cloud["localSource"] = record.localSource as NSString?
@@ -1159,7 +1194,7 @@ final class MuesliICloudSyncEngine {
         fetchedChangeTag != local.cloudChangeTag && remote.updatedAt > local.updatedAt
     }
 
-    private static func syncTextRecord(from record: CKRecord) -> SyncTextRecord? {
+    static func syncTextRecord(from record: CKRecord) -> SyncTextRecord? {
         guard let kind = kind(from: record),
               let createdAt = record["createdAt"] as? Date,
               let updatedAt = record["updatedAt"] as? Date else {
@@ -1189,8 +1224,27 @@ final class MuesliICloudSyncEngine {
             wordCount: (record["wordCount"] as? NSNumber)?.intValue ?? 0,
             isDeleted: isDeleted,
             cloudChangeTag: record.recordChangeTag,
+            cloudSystemFields: encodedSystemFields(for: record),
             followUpToRecordName: record["followUpToRecordName"] as? String
         )
+    }
+
+    static func encodedSystemFields(for record: CKRecord) -> Data? {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+        record.encodeSystemFields(with: archiver)
+        archiver.finishEncoding()
+        return archiver.encodedData
+    }
+
+    static func record(fromSystemFields data: Data) -> CKRecord? {
+        do {
+            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+            unarchiver.requiresSecureCoding = true
+            defer { unarchiver.finishDecoding() }
+            return CKRecord(coder: unarchiver)
+        } catch {
+            return nil
+        }
     }
 
     private static func kind(from record: CKRecord) -> SyncTextRecordKind? {

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -136,6 +136,77 @@ struct DictationStoreTests {
         try store.migrateIfNeeded() // idempotent
     }
 
+    @Test("CloudKit engine state persists independently by key")
+    func cloudSyncEngineStatePersistence() throws {
+        let store = try makeStore()
+        let first = Data([0x00, 0x01, 0xFE, 0xFF])
+        let second = Data("replacement-state".utf8)
+
+        #expect(try store.cloudSyncStateData(forKey: "production-private") == nil)
+        try store.saveCloudSyncStateData(first, forKey: "production-private")
+        try store.saveCloudSyncStateData(Data("other".utf8), forKey: "development-private")
+        #expect(try store.cloudSyncStateData(forKey: "production-private") == first)
+
+        try store.saveCloudSyncStateData(second, forKey: "production-private")
+        #expect(try store.cloudSyncStateData(forKey: "production-private") == second)
+        #expect(try store.cloudSyncStateData(forKey: "development-private") == Data("other".utf8))
+
+        try store.clearCloudSyncStateData(forKey: "production-private")
+        #expect(try store.cloudSyncStateData(forKey: "production-private") == nil)
+        #expect(try store.cloudSyncStateData(forKey: "development-private") == Data("other".utf8))
+    }
+
+    @Test("CloudKit system fields survive local edits and account reset")
+    func cloudSystemFieldsLifecycle() throws {
+        let store = try makeStore()
+        let endedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        _ = try store.insertDictation(
+            text: "Original local text",
+            durationSeconds: 2,
+            startedAt: endedAt.addingTimeInterval(-2),
+            endedAt: endedAt
+        )
+        let outbound = try #require(try store.textRecordsNeedingSync().first)
+        let firstSystemFields = Data([0x01, 0x02, 0x03])
+        #expect(try store.markTextRecordSynced(
+            kind: outbound.kind,
+            recordName: outbound.id,
+            changeTag: "server-v1",
+            systemFields: firstSystemFields,
+            recordUpdatedAt: outbound.updatedAt
+        ))
+
+        let synced = try #require(try store.textRecordForSync(recordName: outbound.id))
+        #expect(synced.cloudChangeTag == "server-v1")
+        #expect(synced.cloudSystemFields == firstSystemFields)
+
+        let localEditAt = endedAt.addingTimeInterval(60)
+        try setDictationDirtyText(
+            recordName: outbound.id,
+            text: "Newer local text",
+            updatedAt: localEditAt,
+            store: store
+        )
+        let newerSystemFields = Data([0x04, 0x05])
+        try store.updateTextRecordCloudMetadata(
+            kind: .dictation,
+            recordName: outbound.id,
+            changeTag: "server-v2",
+            systemFields: newerSystemFields
+        )
+        let dirty = try #require(try store.textRecordsNeedingSync().first { $0.id == outbound.id })
+        #expect(dirty.text == "Newer local text")
+        #expect(dirty.updatedAt == localEditAt)
+        #expect(dirty.cloudChangeTag == "server-v2")
+        #expect(dirty.cloudSystemFields == newerSystemFields)
+
+        try store.resetTextRecordCloudMetadataForAccountChange()
+        let reset = try #require(try store.textRecordsNeedingSync().first { $0.id == outbound.id })
+        #expect(reset.text == "Newer local text")
+        #expect(reset.cloudChangeTag == nil)
+        #expect(reset.cloudSystemFields == nil)
+    }
+
     @Test("migration replaces calendar event uniqueness with occurrence lookup")
     func migrationReplacesCalendarEventUniqueness() throws {
         let store = try makeLegacyStore()
@@ -1171,6 +1242,38 @@ struct DictationStoreTests {
         #expect(cloud.recordID == recordID)
         #expect(cloud["text"] as? String == "Local dirty text")
         #expect(cloud["updatedAt"] as? Date == updatedAt)
+    }
+
+    @Test("sync cloud record restores persisted CKRecord system fields")
+    func syncCloudRecordRestoresPersistedSystemFields() throws {
+        let updatedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let recordID = CKRecord.ID(
+            recordName: "dictation-persisted-system-fields",
+            zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+        )
+        let original = CKRecord(
+            recordType: MuesliICloudSyncEngine.Schema.textRecordType,
+            recordID: recordID
+        )
+        let systemFields = try #require(MuesliICloudSyncEngine.encodedSystemFields(for: original))
+
+        let cloud = MuesliICloudSyncEngine.syncZoneCloudRecord(
+            from: SyncTextRecord(
+                id: recordID.recordName,
+                kind: .dictation,
+                text: "Updated local text",
+                source: "macos",
+                createdAt: updatedAt.addingTimeInterval(-60),
+                updatedAt: updatedAt,
+                durationSeconds: 2,
+                wordCount: 3,
+                cloudSystemFields: systemFields
+            )
+        )
+
+        #expect(cloud.recordID == recordID)
+        #expect(cloud.recordType == MuesliICloudSyncEngine.Schema.textRecordType)
+        #expect(cloud["text"] as? String == "Updated local text")
     }
 
     @Test("dirty upload resolution applies newer fetched remote")

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -207,6 +207,40 @@ struct DictationStoreTests {
         #expect(reset.cloudSystemFields == nil)
     }
 
+    @Test("CloudKit batch lookup returns dictations and meetings")
+    func cloudTextRecordBatchLookup() throws {
+        let store = try makeStore()
+        let endedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        _ = try store.insertDictation(
+            text: "Batch dictation",
+            durationSeconds: 2,
+            startedAt: endedAt.addingTimeInterval(-2),
+            endedAt: endedAt
+        )
+        try store.insertMeeting(
+            title: "Batch meeting",
+            calendarEventID: nil,
+            startTime: endedAt.addingTimeInterval(-60),
+            endTime: endedAt,
+            rawTranscript: "Meeting transcript",
+            formattedNotes: "Meeting notes",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+
+        let dirtyRecords = try store.textRecordsNeedingSync(limit: 10)
+        let dictation = try #require(dirtyRecords.first { $0.kind == .dictation })
+        let meeting = try #require(dirtyRecords.first { $0.kind == .meeting })
+        let records = try store.textRecordsForSync(
+            recordNames: [dictation.id, meeting.id, "missing-record", dictation.id]
+        )
+
+        #expect(records.count == 2)
+        #expect(records[dictation.id]?.text == "Batch dictation")
+        #expect(records[meeting.id]?.text == "Meeting transcript")
+        #expect(records["missing-record"] == nil)
+    }
+
     @Test("migration replaces calendar event uniqueness with occurrence lookup")
     func migrationReplacesCalendarEventUniqueness() throws {
         let store = try makeLegacyStore()

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -150,6 +150,26 @@ struct MuesliCKSyncEngineTests {
         #expect(batch.staleChanges == [pending])
     }
 
+    @Test("local batch read failure preserves pending saves for retry")
+    func localBatchReadFailurePreservesPendingSave() async throws {
+        struct TestReadError: Error {}
+
+        let store = try makeStore()
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(CKRecord.ID(
+            recordName: "pending-local-row",
+            zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+        ))
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        let batch = await coordinator.makeRecordBatch(
+            pendingChanges: [pending],
+            loadRecords: { _ in throw TestReadError() }
+        )
+
+        #expect(batch.recordsToSave.isEmpty)
+        #expect(batch.staleChanges.isEmpty)
+    }
+
     @Test("newer fetched server record replaces local row and pending save")
     func newerFetchedRecordWins() async throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -349,6 +349,10 @@ struct MuesliCKSyncEngineTests {
             recordUpdatedAt: local.updatedAt
         ))
         let coordinator = MuesliCKSyncEngine(store: store)
+        try store.saveCloudSyncStateData(
+            Data("account-one-state".utf8),
+            forKey: MuesliCKSyncEngine.stateKey
+        )
 
         try await coordinator.handleAccountChange(requiresMetadataReset: true)
 
@@ -356,5 +360,6 @@ struct MuesliCKSyncEngineTests {
         #expect(reset.text == "Keep this local text")
         #expect(reset.cloudChangeTag == nil)
         #expect(reset.cloudSystemFields == nil)
+        #expect(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.stateKey) == nil)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -1,0 +1,360 @@
+import CloudKit
+import Foundation
+import MuesliCore
+import Testing
+@testable import MuesliNativeApp
+
+private final class TestCKSyncPendingState: MuesliCKSyncPendingState, @unchecked Sendable {
+    private(set) var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange]
+
+    init(_ changes: [CKSyncEngine.PendingRecordZoneChange] = []) {
+        self.pendingRecordZoneChanges = changes
+    }
+
+    func add(pendingRecordZoneChanges changes: [CKSyncEngine.PendingRecordZoneChange]) {
+        for change in changes where !pendingRecordZoneChanges.contains(change) {
+            pendingRecordZoneChanges.append(change)
+        }
+    }
+
+    func remove(pendingRecordZoneChanges changes: [CKSyncEngine.PendingRecordZoneChange]) {
+        pendingRecordZoneChanges.removeAll { changes.contains($0) }
+    }
+}
+
+private actor TestCKSyncCycleLog {
+    private(set) var events: [String] = []
+    private(set) var uploaded = 0
+    private var registrationResults: [Int]
+
+    init(registrationResults: [Int]) {
+        self.registrationResults = registrationResults
+    }
+
+    func append(_ event: String) {
+        events.append(event)
+    }
+
+    func register() -> Int {
+        events.append("register")
+        return registrationResults.isEmpty ? 0 : registrationResults.removeFirst()
+    }
+
+    func send(makesProgress: Bool) {
+        events.append("send")
+        if makesProgress { uploaded += 1 }
+    }
+}
+
+@Suite("Muesli CKSyncEngine", .serialized)
+struct MuesliCKSyncEngineTests {
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-cksyncengine-test-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    private func makeCloudRecord(
+        from record: SyncTextRecord,
+        updatedAt: Date,
+        text: String
+    ) -> CKRecord {
+        let cloud = MuesliICloudSyncEngine.syncZoneCloudRecord(from: SyncTextRecord(
+            id: record.id,
+            kind: record.kind,
+            title: record.title,
+            text: text,
+            source: record.source,
+            localSource: record.localSource,
+            meetingStatus: record.meetingStatus,
+            createdAt: record.createdAt,
+            updatedAt: updatedAt,
+            startedAt: record.startedAt,
+            endedAt: record.endedAt,
+            durationSeconds: record.durationSeconds,
+            wordCount: DictationStore.countWords(in: text),
+            isDeleted: record.isDeleted
+        ))
+        return cloud
+    }
+
+    @Test("sync cycle fetches before registering and sending")
+    func fetchBeforeSendOrdering() async throws {
+        let log = TestCKSyncCycleLog(registrationResults: [1, 0])
+
+        try await MuesliCKSyncCycle.run(
+            maximumUploadBatches: 5,
+            fetch: { await log.append("fetch") },
+            registerNextBatch: { await log.register() },
+            uploadedCount: { await log.uploaded },
+            send: { await log.send(makesProgress: true) }
+        )
+
+        #expect(await log.events == ["fetch", "register", "send", "register"])
+    }
+
+    @Test("sync cycle stops immediately when a send makes no progress")
+    func noProgressStopsRetryLoop() async throws {
+        let log = TestCKSyncCycleLog(registrationResults: [1, 1, 1])
+
+        try await MuesliCKSyncCycle.run(
+            maximumUploadBatches: 5,
+            fetch: { await log.append("fetch") },
+            registerNextBatch: { await log.register() },
+            uploadedCount: { await log.uploaded },
+            send: { await log.send(makesProgress: false) }
+        )
+
+        #expect(await log.events == ["fetch", "register", "send"])
+    }
+
+    @Test("restored pending save rebuilds its CKRecord from SQLite")
+    func restoredPendingChangeUsesDurableOutbox() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Durable pending text",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let dirty = try #require(try store.textRecordsNeedingSync().first)
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(CKRecord.ID(
+            recordName: dirty.id,
+            zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+        ))
+        let state = TestCKSyncPendingState([pending])
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        #expect(try await coordinator.registerNextDirtyBatch(state: state) == 1)
+        #expect(state.pendingRecordZoneChanges == [pending])
+
+        let batch = await coordinator.makeRecordBatch(pendingChanges: state.pendingRecordZoneChanges)
+        #expect(batch.recordsToSave.count == 1)
+        #expect(batch.recordsToSave.first?["text"] as? String == "Durable pending text")
+        #expect(batch.staleChanges.isEmpty)
+    }
+
+    @Test("restored pending save for a missing local row is discarded")
+    func staleRestoredPendingChangeIsDiscarded() async throws {
+        let store = try makeStore()
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(CKRecord.ID(
+            recordName: "missing-local-row",
+            zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+        ))
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        let batch = await coordinator.makeRecordBatch(pendingChanges: [pending])
+        #expect(batch.recordsToSave.isEmpty)
+        #expect(batch.staleChanges == [pending])
+    }
+
+    @Test("newer fetched server record replaces local row and pending save")
+    func newerFetchedRecordWins() async throws {
+        let store = try makeStore()
+        let endedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        _ = try store.insertDictation(
+            text: "Older local text",
+            durationSeconds: 2,
+            startedAt: endedAt.addingTimeInterval(-2),
+            endedAt: endedAt
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        let cloud = makeCloudRecord(
+            from: local,
+            updatedAt: local.updatedAt.addingTimeInterval(60),
+            text: "Newer server text"
+        )
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(cloud.recordID)
+        let state = TestCKSyncPendingState([pending])
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleFetchedRecords([cloud], state: state)
+
+        let resolved = try #require(try store.textRecordForSync(recordName: local.id))
+        #expect(resolved.text == "Newer server text")
+        #expect(try store.hasTextRecordsNeedingSync() == false)
+        #expect(state.pendingRecordZoneChanges.isEmpty)
+    }
+
+    @Test("older fetched server record hydrates metadata but preserves local dirty edit")
+    func newerLocalEditWinsFetchedRecord() async throws {
+        let store = try makeStore()
+        let endedAt = Date(timeIntervalSince1970: 1_770_000_000)
+        _ = try store.insertDictation(
+            text: "Newer local text",
+            durationSeconds: 2,
+            startedAt: endedAt.addingTimeInterval(-2),
+            endedAt: endedAt
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        let cloud = makeCloudRecord(
+            from: local,
+            updatedAt: local.updatedAt.addingTimeInterval(-60),
+            text: "Older server text"
+        )
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(cloud.recordID)
+        let state = TestCKSyncPendingState([pending])
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleFetchedRecords([cloud], state: state)
+
+        let resolved = try #require(try store.textRecordsNeedingSync().first { $0.id == local.id })
+        #expect(resolved.text == "Newer local text")
+        #expect(resolved.cloudSystemFields != nil)
+        #expect(state.pendingRecordZoneChanges == [pending])
+    }
+
+    @Test("saved record clears the durable outbox and pending state")
+    func savedRecordCompletesUpload() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Saved text",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        let saved = makeCloudRecord(from: local, updatedAt: local.updatedAt, text: local.text)
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(saved.recordID)
+        let state = TestCKSyncPendingState([pending])
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleSentRecordChanges(
+            savedRecords: [saved],
+            failedRecordSaves: [],
+            state: state
+        )
+
+        #expect(try store.hasTextRecordsNeedingSync() == false)
+        #expect(try store.textRecordForSync(recordName: local.id)?.cloudSystemFields != nil)
+    }
+
+    @Test("local winner of server conflict retries using the server CKRecord")
+    func localConflictWinnerUsesServerBase() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Newer local text",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        let server = makeCloudRecord(
+            from: local,
+            updatedAt: local.updatedAt.addingTimeInterval(-60),
+            text: "Older server text"
+        )
+        let client = makeCloudRecord(from: local, updatedAt: local.updatedAt, text: local.text)
+        let error = CKError(.serverRecordChanged, userInfo: [
+            CKRecordChangedErrorServerRecordKey: server,
+            CKRecordChangedErrorClientRecordKey: client,
+        ])
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(client.recordID)
+        let state = TestCKSyncPendingState()
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleSentRecordChanges(
+            savedRecords: [],
+            failedRecordSaves: [MuesliCKSyncFailedRecordSave(record: client, error: error)],
+            state: state
+        )
+        let batch = await coordinator.makeRecordBatch(pendingChanges: state.pendingRecordZoneChanges)
+
+        #expect(state.pendingRecordZoneChanges == [pending])
+        #expect(batch.recordsToSave.count == 1)
+        #expect(batch.recordsToSave.first === server)
+        #expect(batch.recordsToSave.first?["text"] as? String == "Newer local text")
+    }
+
+    @Test("server winner of a conflict replaces local row and removes pending save")
+    func serverConflictWinnerAppliesLocally() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Older local text",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        let server = makeCloudRecord(
+            from: local,
+            updatedAt: local.updatedAt.addingTimeInterval(60),
+            text: "Newer server text"
+        )
+        let client = makeCloudRecord(from: local, updatedAt: local.updatedAt, text: local.text)
+        let error = CKError(.serverRecordChanged, userInfo: [
+            CKRecordChangedErrorServerRecordKey: server,
+            CKRecordChangedErrorClientRecordKey: client,
+        ])
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(client.recordID)
+        let state = TestCKSyncPendingState([pending])
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleSentRecordChanges(
+            savedRecords: [],
+            failedRecordSaves: [MuesliCKSyncFailedRecordSave(record: client, error: error)],
+            state: state
+        )
+
+        let resolved = try #require(try store.textRecordForSync(recordName: local.id))
+        #expect(resolved.text == "Newer server text")
+        #expect(try store.hasTextRecordsNeedingSync() == false)
+        #expect(state.pendingRecordZoneChanges.isEmpty)
+    }
+
+    @Test("transient failed save remains pending and durable")
+    func transientFailureRemainsPending() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Retry this text",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        let client = makeCloudRecord(from: local, updatedAt: local.updatedAt, text: local.text)
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(client.recordID)
+        let state = TestCKSyncPendingState()
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleSentRecordChanges(
+            savedRecords: [],
+            failedRecordSaves: [
+                MuesliCKSyncFailedRecordSave(record: client, error: CKError(.networkUnavailable)),
+            ],
+            state: state
+        )
+
+        #expect(state.pendingRecordZoneChanges == [pending])
+        #expect(try store.hasTextRecordsNeedingSync())
+    }
+
+    @Test("account switch clears only CloudKit metadata and preserves local text")
+    func accountSwitchPreservesLocalData() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Keep this local text",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        #expect(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "account-one-tag",
+            systemFields: Data([0x01, 0x02]),
+            recordUpdatedAt: local.updatedAt
+        ))
+        let coordinator = MuesliCKSyncEngine(store: store)
+
+        try await coordinator.handleAccountChange(requiresMetadataReset: true)
+
+        let reset = try #require(try store.textRecordsNeedingSync().first { $0.id == local.id })
+        #expect(reset.text == "Keep this local text")
+        #expect(reset.cloudChangeTag == nil)
+        #expect(reset.cloudSystemFields == nil)
+    }
+}

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -363,10 +363,14 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
       [[ -n "$ICLOUD_CONTAINER_ENVIRONMENT" ]] || return 0
       /usr/libexec/PlistBuddy -c "Print :Entitlements:$key" "$PROFILE_PLIST" >/dev/null 2>&1 || return 0
       value="$(printf '%s' "$ICLOUD_CONTAINER_ENVIRONMENT" | tr '[:upper:]' '[:lower:]')"
-      if [[ "$value" != "development" && "$value" != "production" ]]; then
-        echo "ERROR: unsupported iCloud container environment '$value'. Expected development or production." >&2
-        exit 1
-      fi
+      case "$value" in
+        development) value="Development" ;;
+        production) value="Production" ;;
+        *)
+          echo "ERROR: unsupported iCloud container environment '$value'. Expected development or production." >&2
+          exit 1
+          ;;
+      esac
       /usr/libexec/PlistBuddy -c "Delete :$key" "$TEMP_ENTITLEMENTS" >/dev/null 2>&1 || true
       /usr/libexec/PlistBuddy -c "Add :$key string $value" "$TEMP_ENTITLEMENTS"
       echo "Using iCloud entitlement: $key=$value"
@@ -375,7 +379,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
     copy_profile_string_entitlement "application-identifier"
     copy_profile_string_entitlement "com.apple.developer.team-identifier"
     # Do not copy this profile entitlement by default: Apple profiles may store
-    # it as an array, while CloudKit expects a single lowercase runtime value.
+    # it as an array, while the signed app requires one case-sensitive value.
     copy_explicit_icloud_container_environment_entitlement "com.apple.developer.icloud-container-environment"
     if [[ -n "$APS_ENVIRONMENT" ]]; then
       if ! /usr/libexec/PlistBuddy -c "Set :com.apple.developer.aps-environment $APS_ENVIRONMENT" "$TEMP_ENTITLEMENTS" 2>/dev/null; then

--- a/scripts/dev-production-sync-soak.sh
+++ b/scripts/dev-production-sync-soak.sh
@@ -195,8 +195,8 @@ run_ios_to_mac() {
   deadline=$(( started_epoch + TIMEOUT_SECONDS ))
   printf 'WAIT iOS -> macOS | create one new TestFlight voice note within %ss.\n' "$TIMEOUT_SECONDS"
 
+  reactivate_muesli_dev
   while (( $(date +%s) <= deadline )); do
-    reactivate_muesli_dev
     count="$(sqlite3 -readonly "$DATABASE_PATH" "SELECT COUNT(*) FROM dictations WHERE id>$baseline AND lower(trim(COALESCE(source, '')))='ios' AND deleted_at IS NULL;")"
     if [[ "$count" =~ ^[0-9]+$ ]] && (( count > 0 )); then
       finished_epoch="$(date +%s)"

--- a/scripts/dev-production-sync-soak.sh
+++ b/scripts/dev-production-sync-soak.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local-only Production CloudKit smoke/soak harness for the maintainer's
+# MuesliDev lane. This script is not bundled into Muesli.app.
+
+APP_PATH="/Applications/MuesliDev.app"
+SUPPORT_DIR="$HOME/Library/Application Support/MuesliDev"
+DATABASE_PATH="$SUPPORT_DIR/muesli.db"
+RESULTS_PATH="$SUPPORT_DIR/sync-soak-results.jsonl"
+DIRECTION="both"
+COUNT=1
+INTERVAL_SECONDS=30
+TIMEOUT_SECONDS=120
+CHECK_ONLY=0
+
+usage() {
+  cat <<'EOF'
+Run a privacy-preserving Production CloudKit sync soak from MuesliDev.
+
+Usage:
+  ./scripts/dev-production-sync-soak.sh [options]
+
+Options:
+  --direction mac-to-ios|ios-to-mac|both
+                                  Test the selected direction (default: both).
+  --count N                       Mac probes to emit, from 1 to 20 (default: 1).
+  --interval SECONDS              Delay between Mac probes (default: 30).
+  --timeout SECONDS               Per-probe / iPhone wait timeout (default: 120).
+  --check                         Validate the dev lane without writing records.
+  --help                          Show this help.
+
+The mac-to-ios leg inserts a timestamped synthetic dictation into MuesliDev and
+waits until CKSyncEngine records a successful Production save. Confirm the
+printed marker appears in the TestFlight app.
+
+The ios-to-mac leg records an aggregate baseline and waits for any new iOS-origin
+dictation. Create one TestFlight voice note after the prompt; its contents are
+never printed or written to the soak results.
+EOF
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --direction)
+      [[ $# -ge 2 ]] || fail "--direction requires a value."
+      DIRECTION="$2"
+      shift 2
+      ;;
+    --count)
+      [[ $# -ge 2 ]] || fail "--count requires a value."
+      COUNT="$2"
+      shift 2
+      ;;
+    --interval)
+      [[ $# -ge 2 ]] || fail "--interval requires a value."
+      INTERVAL_SECONDS="$2"
+      shift 2
+      ;;
+    --timeout)
+      [[ $# -ge 2 ]] || fail "--timeout requires a value."
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --check)
+      CHECK_ONLY=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument '$1'. Run with --help for usage."
+      ;;
+  esac
+done
+
+case "$DIRECTION" in
+  mac-to-ios|ios-to-mac|both) ;;
+  *) fail "unsupported direction '$DIRECTION'." ;;
+esac
+is_positive_integer "$COUNT" || fail "--count must be a positive integer."
+(( COUNT <= 20 )) || fail "--count is capped at 20 to prevent accidental CloudKit spam."
+is_positive_integer "$INTERVAL_SECONDS" || fail "--interval must be a positive integer."
+is_positive_integer "$TIMEOUT_SECONDS" || fail "--timeout must be a positive integer."
+
+[[ "$APP_PATH" == "/Applications/MuesliDev.app" ]] || fail "unexpected app path."
+[[ "$SUPPORT_DIR" == "$HOME/Library/Application Support/MuesliDev" ]] || fail "unexpected support directory."
+[[ -d "$APP_PATH" ]] || fail "MuesliDev is not installed at $APP_PATH."
+[[ -f "$DATABASE_PATH" ]] || fail "MuesliDev database is missing at $DATABASE_PATH."
+command -v sqlite3 >/dev/null || fail "sqlite3 is required."
+command -v codesign >/dev/null || fail "codesign is required."
+
+BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/Contents/Info.plist" 2>/dev/null || true)"
+[[ "$BUNDLE_ID" == "com.muesli.dev" ]] || fail "refusing to run for bundle ID '$BUNDLE_ID'."
+
+ENTITLEMENTS_PLIST="$(mktemp "${TMPDIR:-/tmp}/muesli-sync-soak-entitlements.XXXXXX")"
+cleanup() {
+  rm -f "$ENTITLEMENTS_PLIST"
+}
+trap cleanup EXIT
+codesign -d --entitlements :- "$APP_PATH" > "$ENTITLEMENTS_PLIST" 2>/dev/null \
+  || fail "could not read MuesliDev entitlements."
+ICLOUD_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.icloud-container-environment' "$ENTITLEMENTS_PLIST" 2>/dev/null || true)"
+[[ "$ICLOUD_ENVIRONMENT" == "Production" ]] \
+  || fail "refusing to run without the exact Production CloudKit entitlement."
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  printf 'PASS preflight | bundle=%s | CloudKit=%s | data=MuesliDev\n' "$BUNDLE_ID" "$ICLOUD_ENVIRONMENT"
+  exit 0
+fi
+
+mkdir -p "$SUPPORT_DIR"
+
+json_result() {
+  local status="$1"
+  local direction="$2"
+  local started_at="$3"
+  local finished_at="$4"
+  local latency_ms="$5"
+  printf '{"status":"%s","direction":"%s","startedAt":"%s","finishedAt":"%s","latencyMs":%s}\n' \
+    "$status" "$direction" "$started_at" "$finished_at" "$latency_ms" >> "$RESULTS_PATH"
+}
+
+reactivate_muesli_dev() {
+  open -a "$APP_PATH" >/dev/null
+}
+
+wait_for_mac_probe_upload() {
+  local row_id="$1"
+  local started_epoch="$2"
+  local deadline=$(( started_epoch + TIMEOUT_SECONDS ))
+  while (( $(date +%s) <= deadline )); do
+    local saved
+    saved="$(sqlite3 -readonly "$DATABASE_PATH" "SELECT COUNT(*) FROM dictations WHERE id=$row_id AND sync_dirty=0 AND cloud_system_fields IS NOT NULL AND deleted_at IS NULL;")"
+    if [[ "$saved" == "1" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+run_mac_to_ios() {
+  local index
+  for (( index=1; index<=COUNT; index++ )); do
+    local started_epoch started_iso marker escaped_marker row_id finished_epoch finished_iso latency_ms
+    started_epoch="$(date +%s)"
+    started_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    marker="MUESLI_SYNC_TEST_MAC_${started_epoch}_${index}"
+    escaped_marker="${marker//\'/\'\'}"
+
+    sqlite3 "$DATABASE_PATH" "BEGIN IMMEDIATE; INSERT INTO dictations (timestamp, duration_seconds, raw_text, app_context, word_count, source, started_at, ended_at, updated_at, sync_dirty) VALUES ('$started_iso', 0, '$escaped_marker', 'muesli_sync_probe', 1, 'sync_probe', '$started_iso', '$started_iso', $started_epoch, 1); SELECT last_insert_rowid(); COMMIT;" > "${ENTITLEMENTS_PLIST}.row"
+    row_id="$(sed -n '1p' "${ENTITLEMENTS_PLIST}.row")"
+    rm -f "${ENTITLEMENTS_PLIST}.row"
+    [[ "$row_id" =~ ^[0-9]+$ ]] || fail "failed to create the local synthetic probe."
+
+    reactivate_muesli_dev
+    if wait_for_mac_probe_upload "$row_id" "$started_epoch"; then
+      finished_epoch="$(date +%s)"
+      finished_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      latency_ms=$(( (finished_epoch - started_epoch) * 1000 ))
+      json_result "pass" "mac-to-production" "$started_iso" "$finished_iso" "$latency_ms"
+      printf 'PASS macOS -> Production | %s | %ss | marker=%s\n' "$finished_iso" "$(( latency_ms / 1000 ))" "$marker"
+      printf '     Confirm this marker appears in the TestFlight app.\n'
+    else
+      finished_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      json_result "timeout" "mac-to-production" "$started_iso" "$finished_iso" "$(( TIMEOUT_SECONDS * 1000 ))"
+      printf 'TIMEOUT macOS -> Production | %s | marker=%s\n' "$finished_iso" "$marker" >&2
+      return 1
+    fi
+
+    if (( index < COUNT )); then
+      sleep "$INTERVAL_SECONDS"
+    fi
+  done
+}
+
+run_ios_to_mac() {
+  local baseline started_epoch started_iso deadline count finished_epoch finished_iso latency_ms
+  baseline="$(sqlite3 -readonly "$DATABASE_PATH" "SELECT COALESCE(MAX(id), 0) FROM dictations WHERE lower(trim(COALESCE(source, '')))='ios';")"
+  [[ "$baseline" =~ ^[0-9]+$ ]] || fail "could not establish the iOS-origin baseline."
+  started_epoch="$(date +%s)"
+  started_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  deadline=$(( started_epoch + TIMEOUT_SECONDS ))
+  printf 'WAIT iOS -> macOS | create one new TestFlight voice note within %ss.\n' "$TIMEOUT_SECONDS"
+
+  while (( $(date +%s) <= deadline )); do
+    reactivate_muesli_dev
+    count="$(sqlite3 -readonly "$DATABASE_PATH" "SELECT COUNT(*) FROM dictations WHERE id>$baseline AND lower(trim(COALESCE(source, '')))='ios' AND deleted_at IS NULL;")"
+    if [[ "$count" =~ ^[0-9]+$ ]] && (( count > 0 )); then
+      finished_epoch="$(date +%s)"
+      finished_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      latency_ms=$(( (finished_epoch - started_epoch) * 1000 ))
+      json_result "pass" "ios-to-mac" "$started_iso" "$finished_iso" "$latency_ms"
+      printf 'PASS iOS -> macOS | %s | %ss | received=%s\n' "$finished_iso" "$(( latency_ms / 1000 ))" "$count"
+      return 0
+    fi
+    sleep 3
+  done
+
+  finished_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  json_result "timeout" "ios-to-mac" "$started_iso" "$finished_iso" "$(( TIMEOUT_SECONDS * 1000 ))"
+  printf 'TIMEOUT iOS -> macOS | %s\n' "$finished_iso" >&2
+  return 1
+}
+
+case "$DIRECTION" in
+  mac-to-ios)
+    run_mac_to_ios
+    ;;
+  ios-to-mac)
+    run_ios_to_mac
+    ;;
+  both)
+    run_mac_to_ios
+    run_ios_to_mac
+    ;;
+esac
+
+printf 'Results: %s\n' "$RESULTS_PATH"

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -19,6 +19,7 @@ case "${shard}" in
     filters=(
       ConfigStoreTests
       DictationStoreTests
+      MuesliCKSyncEngineTests
       MuesliCLITests
       ChatGPTAuthTests
       ChatGPTTokenStorageTests


### PR DESCRIPTION
## Summary

- replace the macOS custom-zone fetch/upload loop with one actor-owned `CKSyncEngine`
- persist CKSyncEngine serialization and opaque CKRecord system fields in SQLite
- retain `sync_dirty` as the durable outbox so local writes cannot be lost between engine-state updates
- fetch before sending, preserve last-write-wins reconciliation, and reset only account-scoped CloudKit metadata on account changes
- explicitly stop automatic CloudKit work when sync is disabled, the app shuts down, the zone is recreated, or the account changes
- batch upload record hydration through one SQLite connection and one record-name migration pass
- keep the legacy default-zone migration, bridge discovery, and old subscription wake-up as transitional compatibility paths
- fix the local signing script to emit Apple's case-sensitive `Development` / `Production` CloudKit entitlement values
- add a repository-local, privacy-preserving Production soak harness hard-gated to `com.muesli.dev`

## Why

The hand-written Production sync path could strand large histories and stale change tokens even though Development sync appeared healthy. CKSyncEngine provides durable cursor/pending-change handling and scheduling while the SQLite outbox continues to protect local-first writes.

## Privacy and data safety

- no note contents, titles, filenames, record IDs, account IDs, device names, or tokens are logged by the new diagnostics
- disabling sync and app/account teardown explicitly cancel and discard the automatically scheduling engine
- account changes preserve every local text row and clear only CloudKit identity/version metadata
- the soak harness is not bundled into the shipped app; it refuses to run outside `/Applications/MuesliDev.app`, bundle ID `com.muesli.dev`, the MuesliDev support directory, and an exact `Production` entitlement
- active recording rows remain excluded until completion

## Validation

- complete SwiftPM suite: **1,537 tests across 150 suites passed**
- focused CKSyncEngine suite after review fixes: **12 tests passed**
- focused DictationStore suite after review fixes: **119 tests passed**
- exact local core CI shard after final review fixes: **288 tests across 19 suites passed**
- focused meeting recorder suite: **19 tests passed**, including the previously flaky CI case
- bridge compatibility suites: **20 tests passed**
- full Production-entitled MuesliDev build passed deep signature verification and launched successfully
- aggregate-only Production replay drained **2,762 actionable dirty records to zero**
- user-confirmed MuesliDev -> TestFlight and TestFlight -> MuesliDev round trips
- first automated MuesliDev Production probe completed in **4 seconds**
- the final fresh CI cycle passed on the review-fix commit, including release build, CLI smoke test, and all test shards
- `git diff --check`, `bash -n`, and soak-harness Production preflight passed

## Rollout notes

- the iOS app continues to use the compatible existing record schema/manual implementation for now
- retain the legacy manual implementation as transitional code until the macOS soak and subsequent iOS CKSyncEngine migration are stable
- the next worktree should port the same serialized-state/system-fields/outbox contract and reciprocal dev soak emitter to iOS

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex materially assisted with implementation, testing, Production sync diagnosis, and PR preparation. Greptile, Claude, and CodeRabbit supplied automated review feedback. The maintainer reviewed the changes and manually validated Production-entitled macOS/TestFlight round trips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable iCloud synchronization for dictations and meetings, including conflict handling and recovery.
  * Preserved cloud metadata across syncs, local edits, migrations, and account changes.
  * Added support for restoring interrupted syncs and tracking pending uploads.
  * Added production CloudKit sync testing tools.

* **Bug Fixes**
  * Improved shutdown and reactivation behavior when iCloud is disabled or unavailable.
  * Corrected CloudKit environment entitlement handling.

* **Tests**
  * Expanded coverage for sync, conflicts, account changes, recovery, and metadata persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->