### PR TITLE
Fix false meeting-detection prompts from personal calendar blocks and parked tabs

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingAutoStopPolicy.swift
@@ -17,7 +17,19 @@ enum MeetingRecordingStartOrigin: Equatable {
     }
 
     var signalLossResponse: MeetingSignalLossResponse {
-        enablesMeetingAutoStop ? .autoStopAfterWarning : .none
+        switch self {
+        case .manual:
+            return .none
+        case .detectedPrompt:
+            // The user saw a prompt and clicked Start, so this recording is wanted. Losing the
+            // signal usually means the incidental thing holding the mic went away, not that the
+            // meeting ended — and silently killing it produced ~60s recordings. Warn instead and
+            // let them decide.
+            return .warnOnly
+        case .calendarAutoRecord, .scheduledMeetingPrompt, .joinAndRecord:
+            // Started without the user asking, so ending it unattended is the safer default.
+            return .autoStopAfterWarning
+        }
     }
 
     func signalLossSource(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -426,8 +426,10 @@ final class MeetingCandidateResolver {
             let app = bestCalendarApp(from: snapshot.runningApps)
             // Sole-evidence guard: with no meeting app running, the only thing left is "a
             // calendar event exists and something is using the mic or camera". That is how a
-            // diary block became a meeting prompt. Require the event to actually look joinable.
-            guard app != nil || calendarEvent.isJoinable else { return nil }
+            // diary block became a meeting prompt. Require the event to actually look joinable,
+            // and require the mic specifically — camera alone is not a meeting, which is the
+            // documented rule everywhere else but was not enforced on this branch.
+            guard app != nil || (calendarEvent.isJoinable && hasMicActivity(snapshot)) else { return nil }
             return candidate(
                 id: "cal:\(calendarEvent.id)",
                 platform: app?.platform ?? .unknown,
@@ -631,6 +633,15 @@ final class MeetingCandidateResolver {
 
     private func hasMediaActivity(_ snapshot: MeetingSignalSnapshot) -> Bool {
         snapshot.micActive || snapshot.cameraActive || snapshot.audioInputProcesses.contains { $0.isRunningInput }
+    }
+
+    /// Mic activity from either the device-level flag or per-process attribution.
+    ///
+    /// `micActive` alone is not enough: a call can be visible only as an attributed input
+    /// process. Camera activity is deliberately excluded — "camera alone won't trigger" is the
+    /// documented rule, but the calendar branch was not enforcing it.
+    private func hasMicActivity(_ snapshot: MeetingSignalSnapshot) -> Bool {
+        snapshot.micActive || snapshot.audioInputProcesses.contains { $0.isRunningInput }
     }
 
     private func activeInputProcess(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingCandidateResolver.swift
@@ -180,21 +180,24 @@ enum MeetingURLNormalizer {
             )
         }
 
-        if host.hasSuffix("zoom.us") {
+        if isHost(host, orSubdomainOf: "zoom.us") {
             if let meetingID = zoomMeetingID(from: path) {
                 let identity = "\(host)/j/\(meetingID)"
                 return NormalizedMeetingURL(id: "zoom:\(identity)", url: identity, platform: .zoom)
             }
+            guard !isNonMeetingPath(path) else { return nil }
             let identity = compactIdentity(host: host, path: compactPath)
             return NormalizedMeetingURL(id: "zoom:\(identity)", url: identity, platform: .zoom)
         }
 
-        if host.hasSuffix("teams.microsoft.com") || host == "teams.live.com" {
+        if isHost(host, orSubdomainOf: "teams.microsoft.com") || host == "teams.live.com" {
+            guard !isNonMeetingPath(path) else { return nil }
             let identity = compactIdentity(host: host, path: compactPath)
             return NormalizedMeetingURL(id: "teams:\(identity)", url: identity, platform: .teams)
         }
 
-        if host.hasSuffix("webex.com") {
+        if isHost(host, orSubdomainOf: "webex.com") {
+            guard !isNonMeetingPath(path) else { return nil }
             let identity = compactIdentity(host: host, path: compactPath)
             return NormalizedMeetingURL(id: "webex:\(identity)", url: identity, platform: .webex)
         }
@@ -205,6 +208,47 @@ enum MeetingURLNormalizer {
         }
 
         return nil
+    }
+
+    /// `host` is exactly `domain`, or a subdomain of it.
+    ///
+    /// A plain `hasSuffix` also matches `evilzoom.us` and `notwebex.com`, so any focused page on
+    /// a lookalike domain resolved as a meeting.
+    private static func isHost(_ host: String, orSubdomainOf domain: String) -> Bool {
+        host == domain || host.hasSuffix(".\(domain)")
+    }
+
+    /// Pages on a meeting host that are definitely not a room.
+    ///
+    /// Zoom, Teams and Webex match on host with any path, so a parked `zoom.us/download` tab or
+    /// the Teams web inbox counted as a meeting and prompted the user — repeatedly, since a
+    /// focused URL-only candidate re-arms every `browserAutoDismissCooldown`. Google Meet never
+    /// had this problem because it requires a real room code.
+    ///
+    /// Deliberately a denylist of known-static pages, not an allowlist of join paths: a missing
+    /// entry here costs one stray prompt, whereas an allowlist that misses a real room shape
+    /// would silently stop a meeting being detected at all.
+    ///
+    /// Matched against every path segment, not just the first, so locale-prefixed variants like
+    /// `zoom.us/en-us/download.html` are caught too. Room identifiers are numeric or hashes, so
+    /// an exact match against these words does not collide with one.
+    private static func isNonMeetingPath(_ path: String) -> Bool {
+        let segments = path.split(separator: "/").map { segment -> String in
+            let lowered = segment.lowercased()
+            // Trim a page extension so "download.html" matches "download".
+            guard let dot = lowered.firstIndex(of: "."),
+                  ["html", "htm", "php", "aspx"].contains(String(lowered[lowered.index(after: dot)...]))
+            else { return lowered }
+            return String(lowered[..<dot])
+        }
+        if segments.isEmpty { return true }   // bare host, e.g. the Teams web app inbox
+        let nonMeeting: Set<String> = [
+            "download", "pricing", "signin", "sign-in", "signup", "account", "profile",
+            "meeting", "meetings", "schedule", "support", "docs", "download-center",
+            "contactcenter", "contact", "blog", "home", "myhome", "buy", "billing",
+            "webappng", "v2", "_", "settings", "recording", "recordings",
+        ]
+        return segments.contains { nonMeeting.contains($0) }
     }
 
     private static func isGoogleMeetCode(_ value: String) -> Bool {
@@ -380,6 +424,10 @@ final class MeetingCandidateResolver {
             }
 
             let app = bestCalendarApp(from: snapshot.runningApps)
+            // Sole-evidence guard: with no meeting app running, the only thing left is "a
+            // calendar event exists and something is using the mic or camera". That is how a
+            // diary block became a meeting prompt. Require the event to actually look joinable.
+            guard app != nil || calendarEvent.isJoinable else { return nil }
             return candidate(
                 id: "cal:\(calendarEvent.id)",
                 platform: app?.platform ?? .unknown,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
@@ -28,6 +28,16 @@ struct MeetingSignals {
 struct CalendarEventContext {
     let id: String
     let title: String
+    /// Whether this event looks like a real meeting on its own (has a conference link).
+    /// A link-less diary block can still supply a *title* to a candidate that other evidence
+    /// already justifies, but must not be the sole reason a candidate exists.
+    let isJoinable: Bool
+
+    init(id: String, title: String, isJoinable: Bool = true) {
+        self.id = id
+        self.title = title
+        self.isJoinable = isJoinable
+    }
 }
 
 /// A running application on the system.

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingPromptStateMachine.swift
@@ -43,12 +43,21 @@ final class MeetingPromptStateMachine {
     private var lastCandidateID: String?
     private let candidateStabilityDelay: TimeInterval
     private let browserAutoDismissCooldown: TimeInterval
+    /// How long a calendar-only candidate stays suppressed after the user starts recording it.
+    /// Long enough to outlast a stop then re-detect cycle, short enough that a later occurrence
+    /// of a recurring event still prompts. See markRecordingStarted.
+    private let calendarRestartCooldown: TimeInterval
     private var pendingCandidateID: String?
     private var pendingCandidateFirstSeenAt: Date?
 
-    init(candidateStabilityDelay: TimeInterval = 3, browserAutoDismissCooldown: TimeInterval = 120) {
+    init(
+        candidateStabilityDelay: TimeInterval = 3,
+        browserAutoDismissCooldown: TimeInterval = 120,
+        calendarRestartCooldown: TimeInterval = 15 * 60
+    ) {
         self.candidateStabilityDelay = candidateStabilityDelay
         self.browserAutoDismissCooldown = browserAutoDismissCooldown
+        self.calendarRestartCooldown = calendarRestartCooldown
     }
 
     func evaluate(
@@ -143,9 +152,26 @@ final class MeetingPromptStateMachine {
     }
 
     @discardableResult
-    func markRecordingStarted(_ candidate: MeetingCandidate) -> Bool {
+    func markRecordingStarted(_ candidate: MeetingCandidate, now: Date = Date()) -> Bool {
         if visiblePromptID == candidate.id { visiblePromptID = nil }
         lastCandidateID = candidate.id
+        // Calendar-only candidates keep their raw "cal:<eventID>" id and used to record no
+        // suppression at all, so accepting the prompt suppressed nothing and the identical
+        // event re-prompted as soon as the recording stopped.
+        //
+        // They get an EXPIRING suppression rather than joining the permanent set: unlike a
+        // media-session id, a calendar id is not guaranteed unique per occurrence, so
+        // suppressing it for the life of the process could silently skip tomorrow's instance
+        // of a recurring meeting. The cooldown only has to outlast the stop/re-detect loop.
+        if candidate.suppressionID.hasPrefix("cal:") {
+            let inserted = autoDismissedSuppressionIDs
+                .updateValue(now.addingTimeInterval(calendarRestartCooldown),
+                             forKey: candidate.suppressionID) == nil
+            userDismissedSuppressionIDs.remove(candidate.suppressionID)
+            resetPendingCandidate()
+            return inserted
+        }
+
         guard candidate.suppressionID.hasPrefix("meeting-session:") else {
             resetPendingCandidate()
             return false

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2685,7 +2685,10 @@ final class MuesliController: NSObject {
     }
 
     private func currentOrNearbyCachedCalendarEvent() -> CalendarEventContext? {
-        selectCurrentOrNearbyCachedCalendarEvent(from: appState.upcomingCalendarEvents)
+        selectCurrentOrNearbyCachedCalendarEvent(
+            from: appState.upcomingCalendarEvents,
+            hiddenEventIDs: appState.hiddenCalendarEventIDs
+        )
     }
 
     private func startMeetingFeatureMonitors(includeMaraudersMap: Bool) {
@@ -8608,21 +8611,44 @@ final class MuesliController: NSObject {
     }
 }
 
+/// Calendar context handed to the live meeting detector.
+///
+/// Hidden events are excluded outright — detection used to ignore the user's hide list.
+/// Everything else is still passed through, because a calendar event is useful *enrichment*
+/// (it supplies the meeting title) even when it carries no link. What it must not do is be
+/// sole evidence: the resolver's terminal calendar fallback builds a candidate from an event
+/// plus any mic/camera activity with no meeting app and no URL, which turned diary blocks like
+/// "Gym - Pull Calisthenics" into recording prompts titled after the block. `isJoinable` marks
+/// which events are allowed to carry that fallback on their own, using the same rule the
+/// scheduled-notification path already applies.
 func selectCurrentOrNearbyCachedCalendarEvent(
     from events: [UnifiedCalendarEvent],
+    hiddenEventIDs: Set<String>,
     now: Date = Date()
 ) -> CalendarEventContext? {
     let searchEnd = now.addingTimeInterval(5 * 60)
     let candidates = events
         .filter { event in
-            !event.isAllDay && event.endDate > now && event.startDate < searchEnd
+            !event.isAllDay
+                && !hiddenEventIDs.contains(event.id)
+                && event.endDate > now && event.startDate < searchEnd
         }
         .sorted { $0.startDate < $1.startDate }
 
-    if let active = candidates.first(where: { $0.startDate <= now && $0.endDate > now }) {
-        return CalendarEventContext(id: active.id, title: active.title)
+    func context(_ event: UnifiedCalendarEvent) -> CalendarEventContext {
+        CalendarEventContext(
+            id: event.id,
+            title: event.title,
+            isJoinable: ScheduledMeetingNotificationPolicy.isJoinableMeeting(
+                event,
+                hiddenEventIDs: hiddenEventIDs
+            )
+        )
     }
 
-    return candidates.first(where: { $0.startDate > now })
-        .map { CalendarEventContext(id: $0.id, title: $0.title) }
+    if let active = candidates.first(where: { $0.startDate <= now && $0.endDate > now }) {
+        return context(active)
+    }
+
+    return candidates.first(where: { $0.startDate > now }).map(context)
 }

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -286,10 +286,10 @@ struct GoogleCalendarTests {
     func cachedDetectionIgnoresRecentlyEndedEvents() {
         let now = date("2026-04-10T10:08:00Z")
         let events = [
-            UnifiedCalendarEvent(id: "ended", title: "Already done", startDate: date("2026-04-10T09:50:00Z"), endDate: date("2026-04-10T10:00:00Z"), isAllDay: false, source: .eventKit),
+            UnifiedCalendarEvent(id: "ended", title: "Already done", startDate: date("2026-04-10T09:50:00Z"), endDate: date("2026-04-10T10:00:00Z"), isAllDay: false, source: .eventKit, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
         ]
 
-        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: [], now: now)
         #expect(selected == nil)
     }
 
@@ -297,11 +297,11 @@ struct GoogleCalendarTests {
     func cachedDetectionPrefersActiveEvent() {
         let now = date("2026-04-10T10:02:00Z")
         let events = [
-            UnifiedCalendarEvent(id: "upcoming", title: "Next call", startDate: date("2026-04-10T10:04:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .googleCalendar),
-            UnifiedCalendarEvent(id: "active", title: "Current call", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit),
+            UnifiedCalendarEvent(id: "upcoming", title: "Next call", startDate: date("2026-04-10T10:04:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .googleCalendar, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
+            UnifiedCalendarEvent(id: "active", title: "Current call", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
         ]
 
-        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: [], now: now)
         #expect(selected?.id == "active")
         #expect(selected?.title == "Current call")
     }
@@ -310,13 +310,50 @@ struct GoogleCalendarTests {
     func cachedDetectionSelectsImminentFutureEvent() {
         let now = date("2026-04-10T10:00:00Z")
         let events = [
-            UnifiedCalendarEvent(id: "later", title: "Later call", startDate: date("2026-04-10T10:20:00Z"), endDate: date("2026-04-10T11:00:00Z"), isAllDay: false, source: .eventKit),
-            UnifiedCalendarEvent(id: "soon", title: "Soon call", startDate: date("2026-04-10T10:03:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .googleCalendar),
+            UnifiedCalendarEvent(id: "later", title: "Later call", startDate: date("2026-04-10T10:20:00Z"), endDate: date("2026-04-10T11:00:00Z"), isAllDay: false, source: .eventKit, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
+            UnifiedCalendarEvent(id: "soon", title: "Soon call", startDate: date("2026-04-10T10:03:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .googleCalendar, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
         ]
 
-        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: [], now: now)
         #expect(selected?.id == "soon")
         #expect(selected?.title == "Soon call")
+    }
+
+    @Test("cached meeting detection ignores personal blocks with no meeting link")
+    func cachedDetectionIgnoresLinklessPersonalBlocks() {
+        // Regression: a diary block like "Gym - Pull Calisthenics" used to be handed to the live
+        // detector as if it were a meeting, so personal blocks produced "meeting detected"
+        // prompts titled after them. It is still passed through (it can supply a title), but
+        // must be marked non-joinable so it cannot be sole evidence for a candidate.
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "gym", title: "Gym - Pull Calisthenics", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:45:00Z"), isAllDay: false, source: .eventKit),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: [], now: now)
+        #expect(selected?.id == "gym")
+        #expect(selected?.isJoinable == false)
+    }
+
+    @Test("cached meeting detection marks linked events joinable")
+    func cachedDetectionMarksLinkedEventsJoinable() {
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "standup", title: "Standup", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
+        ]
+
+        #expect(selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: [], now: now)?.isJoinable == true)
+    }
+
+    @Test("cached meeting detection ignores hidden events")
+    func cachedDetectionIgnoresHiddenEvents() {
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "hidden", title: "Standup", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit, meetingURL: URL(string: "https://zoom.us/j/123456789")!),
+        ]
+
+        #expect(selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: [], now: now)?.id == "hidden")
+        #expect(selectCurrentOrNearbyCachedCalendarEvent(from: events, hiddenEventIDs: ["hidden"], now: now) == nil)
     }
 
     // MARK: - parseCalendarListEntry

--- a/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingAutoStopPolicyTests.swift
@@ -170,9 +170,25 @@ struct MeetingAutoStopPolicyTests {
 
         for origin in origins {
             #expect(origin.enablesMeetingAutoStop)
-            #expect(origin.signalLossResponse == .autoStopAfterWarning)
             #expect(origin.signalLossSource(explicitSource: explicitSource, recentSource: recentSource) == explicitSource)
             #expect(origin.signalLossSource(explicitSource: nil, recentSource: recentSource) == recentSource)
+        }
+    }
+
+    @Test("only unattended start origins auto-stop on signal loss")
+    func onlyUnattendedStartOriginsAutoStopOnSignalLoss() {
+        // The user clicked Start on a detected prompt, so that recording is wanted. Losing the
+        // signal usually means the incidental mic holder went away, not that the meeting ended —
+        // silently stopping it produced ~60 second recordings. Warn, do not stop.
+        #expect(MeetingRecordingStartOrigin.detectedPrompt.signalLossResponse == .warnOnly)
+        #expect(MeetingRecordingStartOrigin.manual.signalLossResponse == .none)
+
+        for unattended in [
+            MeetingRecordingStartOrigin.calendarAutoRecord,
+            .scheduledMeetingPrompt,
+            .joinAndRecord,
+        ] {
+            #expect(unattended.signalLossResponse == .autoStopAfterWarning)
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -1022,4 +1022,84 @@ struct MeetingCandidateResolverTests {
         #expect(MeetingURLNormalizer.normalize("https://meet.google.com/landing") == nil)
         #expect(MeetingURLNormalizer.normalize("https://meet.google.com/") == nil)
     }
+
+    @Test("URL normalizer rejects non-room pages on meeting hosts")
+    func urlNormalizerRejectsNonRoomPages() {
+        // A parked tab on any of these used to resolve as a meeting and prompt repeatedly,
+        // because only Google Meet checked the path shape.
+        for parked in [
+            "https://zoom.us/download",
+            "https://zoom.us/pricing",
+            "https://zoom.us/en-us/download.html",     // locale-prefixed, non-first segment
+            "https://us02web.zoom.us/meeting",
+            "https://zoom.us/",                        // bare host
+            "https://teams.microsoft.com/",
+            "https://teams.microsoft.com/v2/",
+            "https://teams.live.com/",
+            "https://acme.webex.com/webappng/sites/acme/dashboard",
+            "https://acme.webex.com/",
+        ] {
+            #expect(MeetingURLNormalizer.normalize(parked) == nil, "expected nil for \(parked)")
+        }
+    }
+
+    @Test("URL normalizer still accepts real rooms on those hosts")
+    func urlNormalizerAcceptsRealRooms() {
+        #expect(MeetingURLNormalizer.normalize("https://us02web.zoom.us/j/123456789")?.platform == .zoom)
+        #expect(MeetingURLNormalizer.normalize("https://zoom.us/my/clinton")?.platform == .zoom)
+        #expect(MeetingURLNormalizer.normalize("https://teams.microsoft.com/l/meetup-join/abc")?.platform == .teams)
+        #expect(MeetingURLNormalizer.normalize("https://acme.webex.com/meet/clinton")?.platform == .webex)
+    }
+
+    @Test("URL normalizer rejects lookalike hosts")
+    func urlNormalizerRejectsLookalikeHosts() {
+        // hasSuffix("zoom.us") also matched evilzoom.us, so any focused page on a lookalike
+        // domain resolved as a meeting.
+        #expect(MeetingURLNormalizer.normalize("https://evilzoom.us/j/123456789") == nil)
+        #expect(MeetingURLNormalizer.normalize("https://notwebex.com/meet/clinton") == nil)
+        #expect(MeetingURLNormalizer.normalize("https://fatteams.microsoft.com/l/meetup-join/abc") == nil)
+        // ...but genuine subdomains still work.
+        #expect(MeetingURLNormalizer.normalize("https://us02web.zoom.us/j/123456789")?.platform == .zoom)
+    }
+
+    @Test("link-less calendar block is not sole evidence for a candidate")
+    func linklessCalendarBlockIsNotSoleEvidence() {
+        // The reported bug: a diary block plus any mic activity, with no meeting app running,
+        // produced a candidate titled after the block.
+        let candidate = resolver().resolve(snapshot(
+            micActive: true,
+            cameraActive: false,
+            calendarEvent: CalendarEventContext(id: "gym", title: "Gym - Pull Calisthenics", isJoinable: false)
+        ))
+
+        #expect(candidate == nil)
+    }
+
+    @Test("link-less calendar block still titles an app-backed candidate")
+    func linklessCalendarBlockStillTitlesAppBackedCandidate() {
+        // Enrichment must survive: a real meeting whose calendar entry has no parsed link
+        // should still be detected and still borrow the event title.
+        let candidate = resolver().resolve(snapshot(
+            micActive: true,
+            cameraActive: false,
+            calendarEvent: CalendarEventContext(id: "evt", title: "Team sync", isJoinable: false),
+            runningApps: [RunningAppInfo(bundleID: "us.zoom.xos", isActive: true)],
+            foregroundBundleID: "us.zoom.xos"
+        ))
+
+        #expect(candidate?.id == "cal:evt")
+        #expect(candidate?.meetingTitle == "Team sync")
+    }
+
+    @Test("joinable calendar event is still sole evidence without an app")
+    func joinableCalendarEventIsSoleEvidence() {
+        let candidate = resolver().resolve(snapshot(
+            micActive: true,
+            cameraActive: false,
+            calendarEvent: CalendarEventContext(id: "evt", title: "Client call", isJoinable: true)
+        ))
+
+        #expect(candidate?.id == "cal:evt")
+        #expect(candidate?.meetingTitle == "Client call")
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingCandidateResolverTests.swift
@@ -1091,6 +1091,19 @@ struct MeetingCandidateResolverTests {
         #expect(candidate?.meetingTitle == "Team sync")
     }
 
+    @Test("camera alone plus a calendar event is not a meeting")
+    func cameraAloneWithCalendarEventIsNotAMeeting() {
+        // "camera alone won't trigger" is the documented rule, but the calendar branch only
+        // required mic OR camera.
+        let candidate = resolver().resolve(snapshot(
+            micActive: false,
+            cameraActive: true,
+            calendarEvent: CalendarEventContext(id: "evt", title: "Client call", isJoinable: true)
+        ))
+
+        #expect(candidate == nil)
+    }
+
     @Test("joinable calendar event is still sole evidence without an app")
     func joinableCalendarEventIsSoleEvidence() {
         let candidate = resolver().resolve(snapshot(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingPromptStateMachineTests.swift
@@ -226,6 +226,40 @@ struct MeetingPromptStateMachineTests {
         #expect(result.reason == .eligible)
     }
 
+    @Test("recording start suppresses a calendar candidate through the stop and re-detect loop")
+    func recordingStartSuppressesCalendarCandidateAfterStop() {
+        // Regression: markRecordingStarted only consumed "meeting-session:" ids, so accepting a
+        // calendar prompt suppressed nothing and the identical event re-prompted seconds after
+        // the recording stopped.
+        let machine = immediateMachine()
+        let cal = candidate("cal:evt-standup", suppressionID: "cal:evt-standup", evidence: [.micActive, .calendarEvent])
+
+        machine.markShown(cal)
+        #expect(machine.markRecordingStarted(cal, now: now))
+
+        // The stop/re-detect loop fires within seconds; it must not re-prompt.
+        let result = decision(machine, candidate: cal, now: now.addingTimeInterval(30))
+        #expect(result.action == .none)
+        #expect(result.reason == .autoDismissedSuppression)
+    }
+
+    @Test("calendar suppression expires so a later occurrence still prompts")
+    func calendarSuppressionExpiresForLaterOccurrence() {
+        // Calendar ids are not guaranteed unique per occurrence, so this suppression must not be
+        // permanent or tomorrow's instance of a recurring meeting would be silently skipped.
+        let machine = MeetingPromptStateMachine(candidateStabilityDelay: 0, calendarRestartCooldown: 60)
+        let cal = candidate("cal:evt-standup", suppressionID: "cal:evt-standup", evidence: [.micActive, .calendarEvent])
+
+        machine.markShown(cal)
+        machine.markRecordingStarted(cal, now: now)
+
+        #expect(decision(machine, candidate: cal, now: now.addingTimeInterval(30)).action == .none)
+
+        let later = decision(machine, candidate: cal, now: now.addingTimeInterval(90))
+        #expect(later.action == .show)
+        #expect(later.reason == .eligible)
+    }
+
     @Test("recording start does not suppress a genuinely later meeting session")
     func recordingStartDoesNotSuppressLaterMeetingSession() {
         let machine = immediateMachine()


### PR DESCRIPTION
## Summary

Fixes a family of false "Meeting detected — start recording?" prompts. On my
machine these fired several times a day, and the recordings they produced were
titled after whatever unrelated calendar block happened to overlap.

**Root cause.** `selectCurrentOrNearbyCachedCalendarEvent`
(`MuesliController.swift`) hands the live detector every non-all-day event.
`MeetingCandidateResolver`'s terminal calendar branch then builds a candidate
from "an event exists + something is using the mic or camera" — no meeting app,
no conference link — and uses the event title. So a personal diary block became
a recording prompt. My session diagnostics folders were literally named
`Gym---Pull-Calisthenics` and `Personal-Project-s-`.

The repo already had the right predicate:
`ScheduledMeetingNotificationPolicy.isJoinableMeeting` requires
`meetingURL != nil`, which is why the scheduled/auto-record paths never had this
problem. Detection just wasn't using it.

Commit 1 — the prompts:

1. Calendar events still flow to the detector (a link-less event is useful
   *enrichment*, it supplies the title), but now carry `isJoinable`. The
   terminal calendar fallback requires either a running meeting app **or** a
   joinable event before it will stand on its own. A real meeting whose calendar
   entry has no parsed link is still detected via the app and still borrows the
   title, so this is narrower than filtering at the producer.
2. Detection ignored the user's hidden-events list entirely. It no longer does.
3. `markRecordingStarted` only recorded suppression for `meeting-session:` ids,
   so accepting a calendar prompt suppressed nothing and the identical event
   re-prompted as soon as recording stopped. Calendar ids now suppress too, but
   with an **expiry** rather than joining the permanent set — unlike a media
   session id they are not guaranteed unique per occurrence, and permanent
   suppression would silently skip tomorrow's instance of a recurring meeting.
4. `MeetingURLNormalizer` matched `zoom.us` / `teams.microsoft.com` /
   `webex.com` on host with **any** path, so `zoom.us/download` or the Teams web
   inbox counted as a room. Combined with `autoDismissExpiry`, a focused tab on
   one of those re-prompted every `browserAutoDismissCooldown`. Now rejects known
   non-room pages, checking every path segment so `zoom.us/en-us/download.html`
   is caught. Deliberately a denylist, not an allowlist of join paths: a missing
   denylist entry costs one stray prompt, a missing allowlist entry would
   silently stop detecting a real meeting.
5. Host matching used `hasSuffix`, so `evilzoom.us` and `notwebex.com` resolved
   as meeting hosts.

Commit 2 — two related defects, **separable if you'd rather not take them**:

- Auto-stop treated `.detectedPrompt` like the unattended origins, so a
  recording the user explicitly started by clicking Start was silently killed
  ~50s after an incidental mic holder went away. That is the two exactly-60.0s
  rows in my database, each followed by an immediate re-prompt. It now warns on
  signal loss and lets the user decide; `.calendarAutoRecord`,
  `.scheduledMeetingPrompt` and `.joinAndRecord` still auto-stop, since nobody
  asked for those. This is the one behaviour-policy judgement call in the PR —
  happy to drop this commit if you disagree.
- The calendar branch required mic **or** camera, so camera activity alone plus
  a calendar event produced a candidate, contradicting the documented "camera
  alone won't trigger" rule. It now requires mic activity, read from either the
  device flag or per-process attribution (`micActive` alone would have rejected
  calls that are only visible as an attributed input process).

## Validation

Apple Silicon (M5), macOS 26.5, Xcode 26.

```
swift test --package-path native/MuesliNative
# ✔ 1536 tests in 149 suites passed

bash ./scripts/run_ci_test_shard.sh meetings
# ✔ 356 tests in 22 suites passed

MUESLI_LOCALVQE_LIB_DIR=... MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh --local-only
# builds, installs and launches MuesliDev cleanly
```

19 tests added across `MeetingCandidateResolverTests`,
`MeetingPromptStateMachineTests`, `MeetingAutoStopPolicyTests` and
`GoogleCalendarTests`, covering: link-less block is not sole evidence; link-less
block still titles an app-backed candidate; joinable event still is sole
evidence; camera-only rejected; parked/locale-prefixed/bare-host URLs rejected;
lookalike hosts rejected; real rooms still accepted; calendar suppression holds
through a stop then expires for a later occurrence.

Four existing tests changed, all deliberate — they pinned the permissive
behaviour being fixed (`calendar fallback does not label Slack/WhatsApp without
attributed audio` fixtures now specify joinability, and
`source-backed start origins can auto-stop after warning` split so
`.detectedPrompt` asserts `.warnOnly`).

Not covered by tests: I have not been able to verify the end-to-end reduction in
prompts over a normal working week yet — that needs real usage. Also note the
detector currently logs nothing durable about *why* it fired (`[meeting-monitor]`
goes to stderr, which `open` discards), so I could not attribute individual
historical prompts to a specific signal; the root cause above is established
from the code paths plus the session diagnostics folder names, not from a live
trace.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None. No new dependencies, models, assets or vendored code — the change is
confined to existing first-party Swift sources and their tests.

### AI assistance

Material AI assistance, disclosed in full.

The investigation and the patch were produced with **Claude Code (Claude Opus
5)**, working from my bug report and my own machine's session diagnostics. It
mapped the detection subsystem, proposed the root cause, and wrote the fixes and
tests. Candidate findings were checked a second time against the source before
anything was changed, and several plausible-sounding ones were discarded as
unsupported.

The resulting diff was then independently reviewed by **OpenAI Codex
(gpt-5.6-sol)**, which raised eight issues; five were adopted — including the
`hasSuffix` host-spoofing bug (#5 above) and the argument that permanent `cal:`
suppression would break recurring meetings, which is why #3 uses an expiry. Two
were rejected as over-engineering for this change, and one ("gate the producer
on `isJoinableMeeting`") was rejected in favour of the narrower per-branch guard
now in the PR, because gating at the producer would have stopped link-less
events supplying titles to genuinely-detected meetings.

All tests above were executed on real hardware, not simulated. I have reviewed
the change and I am accountable for it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788698452&installation_model_id=422865&pr_number=383&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F383&signature=3d64c96bcba278f964af17512b083553c8ea748209ea2e8af5802f39f6d16ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting detection by rejecting invalid or lookalike meeting links.
  * Calendar events without joinable meeting links no longer trigger meeting detection on their own.
  * Hidden calendar events are excluded from meeting suggestions.
  * Added microphone activity checks to improve meeting detection accuracy.
  * Refined recording behavior after signal loss: unattended recordings warn before stopping, while manual and confirmed-prompt recordings remain active.
  * Calendar prompts are temporarily suppressed after recording starts, then resume for later occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->