### PR TITLE
Add Cloud Agent environment for Linux CI validation

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Muesli",
+  "user": "ubuntu",
+  "install": "./scripts/cloud-agent-install.sh"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,24 @@
 # AGENTS.md
 
+## Cloud Agents (Linux)
+
+Muesli is a native macOS app. Cloud Agents run on Linux and cannot build the Swift app, run `swift test`, or exercise `muesli-cli` without a macOS host.
+
+Use the Linux CI checks that mirror `.github/workflows/ci.yml` on `ubuntu-latest`:
+
+```bash
+./scripts/test_classify_changed_files.sh
+./scripts/test_ci_test_shards.sh
+./scripts/verify_update_flow.sh --skip-dmg
+```
+
+Native builds and the full test suite require macOS 14.2+ with Xcode 16+:
+
+```bash
+./scripts/dev-test.sh
+swift test --package-path native/MuesliNative
+```
+
 ## Build Artifacts and Worktrees
 
 SwiftPM can write build artifacts to `native/MuesliNative/.build` inside the active worktree. That can consume several GB per worktree when multiple feature worktrees are used.

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+required_commands=(bash git curl python3 perl diff)
+missing=()
+for cmd in "${required_commands[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    missing+=("$cmd")
+  fi
+done
+
+if ((${#missing[@]} > 0)); then
+  echo "Missing required commands: ${missing[*]}" >&2
+  exit 1
+fi
+
+chmod +x \
+  "$ROOT/scripts/classify_changed_files.sh" \
+  "$ROOT/scripts/test_classify_changed_files.sh" \
+  "$ROOT/scripts/test_ci_test_shards.sh" \
+  "$ROOT/scripts/run_ci_test_shard.sh" \
+  "$ROOT/scripts/verify_update_flow.sh" \
+  "$ROOT/scripts/cloud-agent-install.sh"
+
+echo "Cloud Agent install complete (Linux CI tooling ready)."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds repository-managed Cloud Agent configuration for Muesli. Cloud Agents run on Linux and cannot build the native macOS app, but they can run the same `ubuntu-latest` CI checks used in `.github/workflows/ci.yml`.

## Changes

- **`.cursor/environment.json`** — defines the Muesli Cloud Agent environment with an idempotent install script
- **`scripts/cloud-agent-install.sh`** — verifies required Linux CI tooling (bash, git, curl, python3, perl, diff) and ensures scripts are executable
- **`AGENTS.md`** — documents Cloud Agent capabilities and limitations vs macOS local development

## Validation

| Check | Result |
| --- | --- |
| Install idempotence | Passed twice |
| Classifier tests | Passed |
| CI shard assignment tests | Passed |
| Sparkle appcast metadata (`verify_update_flow.sh --skip-dmg`) | Passed |
| Fresh Cloud Agent from build `bld-20260807-b8e2c693-c770-4fa4-a794-b656c09b1215` | All checks passed |

## Notes

- Native Swift builds (`./scripts/dev-test.sh`, `swift test`) still require macOS 14.2+ with Xcode 16+
- After merge, trigger a promotable environment build from `main` (builds from feature branches cannot be promoted to active)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb52a140-15a6-4d36-9e71-a72dcd143e61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb52a140-15a6-4d36-9e71-a72dcd143e61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788722375&installation_model_id=422865&pr_number=385&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F385&signature=0fe82897540434c8b7ebfa4c6b7a3a7f38ee41125099f20abc936d282c20d92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined setup support for cloud-based development environments.

- **Documentation**
  - Added guidance for developing and validating the project on Linux.
  - Documented platform requirements for native builds and complete test execution.

- **Chores**
  - Improved environment setup checks and automatically prepares required verification tools.
  - Added a clear success confirmation after setup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->