### PR TITLE
Fix silent LocalVQE→DTLN AEC fallback on source builds (#384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Test CI test shard assignments
         run: ./scripts/test_ci_test_shards.sh
 
+      - name: Test LocalVQE runtime validation
+        run: ./scripts/test_localvqe_runtime_validation.sh
+
   # Release build — validate the app product compiles in release mode
   build_release:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache LocalVQE runtime build
+        uses: actions/cache@v4
+        with:
+          path: |
+            native/MuesliNative/LocalVQE/lib
+            /tmp/LocalVQE
+          key: localvqe-${{ runner.os }}-${{ hashFiles('scripts/build_localvqe.sh') }}
+
       - name: Verify packaged CLI bundle
+        # Builds LocalVQE when missing, then asserts the packaged app includes
+        # a complete LocalVQE runtime + the committed GGUF model.
         run: ./scripts/test_packaged_cli.sh
 
   # Sparkle appcast/update metadata smoke test — catches broken release URLs,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,34 @@ dev app without signing:
 MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
 ```
 
+### Meeting echo cancellation (LocalVQE)
+
+Meeting AEC defaults to LocalVQE. The GGUF model is committed under
+`native/MuesliNative/LocalVQE/models/`, but the shared libraries under
+`native/MuesliNative/LocalVQE/lib/` are gitignored. Build them once before
+packaging if you need the default AEC path (otherwise the app falls back to
+DTLN):
+
+```bash
+./scripts/build_localvqe.sh
+MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
+```
+
+`scripts/build_native_app.sh` refuses signed packaging without a *complete*
+LocalVQE runtime (`liblocalvqe` plus its `libggml*` companions, especially
+`libggml-base`). That includes maintainer `./scripts/dev-test.sh` runs that
+do not set `MUESLI_SKIP_SIGN=1` — the gate is keyed on signing, not
+debug/release. Unsigned packaging (`MUESLI_SKIP_SIGN=1`) prints a loud warning
+and continues; override with `MUESLI_REQUIRE_LOCALVQE=1` (fail) or
+`MUESLI_ALLOW_MISSING_LOCALVQE=1` (silence and continue). To build the runtime
+inline during packaging, set `MUESLI_BUILD_LOCALVQE=1`.
+
+With meeting diagnostics enabled
+(`~/Library/Application Support/MuesliDev/MeetingDiagnostics.enabled`),
+`diagnostics.json` reports `aec.processor` (`localvqe` or `dtln`, or null when
+unloaded) and `aec.frameSize` (`256` for LocalVQE, `512` for DTLN, `0` when
+unloaded).
+
 That installs `/Applications/MuesliDev.app` with bundle ID `com.muesli.dev`
 and stores data under `~/Library/Application Support/MuesliDev/`, so it does
 not touch your production Muesli install or data.
@@ -95,6 +123,11 @@ ID provisioning profiles:
 Those profiles are not committed to the repository. Maintainers pass them with
 `MUESLI_PROVISIONING_PROFILE`; contributors should not need to run these
 release scripts for normal PR validation.
+
+Before packaging a signed release, ensure a *complete* LocalVQE runtime is
+present (`./scripts/build_localvqe.sh`). `build_native_app.sh` fails closed when
+those dylibs are missing or incomplete unless `MUESLI_ALLOW_MISSING_LOCALVQE=1`
+is set.
 
 ## SwiftPM Build Cache
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,18 +35,22 @@ MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
 
 `scripts/build_native_app.sh` refuses signed packaging without a *complete*
 LocalVQE runtime (`liblocalvqe` plus its `libggml*` companions, especially
-`libggml-base`). That includes maintainer `./scripts/dev-test.sh` runs that
-do not set `MUESLI_SKIP_SIGN=1` — the gate is keyed on signing, not
-debug/release. Unsigned packaging (`MUESLI_SKIP_SIGN=1`) prints a loud warning
-and continues; override with `MUESLI_REQUIRE_LOCALVQE=1` (fail) or
-`MUESLI_ALLOW_MISSING_LOCALVQE=1` (silence and continue). To build the runtime
+`libggml-base`, including transitive `otool` deps). That includes maintainer
+`./scripts/dev-test.sh` runs that do not set `MUESLI_SKIP_SIGN=1` — the gate
+is keyed on signing, not debug/release. Unsigned packaging
+(`MUESLI_SKIP_SIGN=1`) prints a loud warning and continues; override with
+`MUESLI_REQUIRE_LOCALVQE=1` (fail) or
+`MUESLI_ALLOW_MISSING_LOCALVQE=1` (unsigned only). To build the runtime
 inline during packaging, set `MUESLI_BUILD_LOCALVQE=1`.
 
-With meeting diagnostics enabled
-(`~/Library/Application Support/MuesliDev/MeetingDiagnostics.enabled`),
-`diagnostics.json` reports `aec.processor` (`localvqe` or `dtln`, or null when
-unloaded) and `aec.frameSize` (`256` for LocalVQE, `512` for DTLN, `0` when
-unloaded).
+To force a specific runtime AEC processor while testing:
+
+```bash
+MUESLI_AEC_PROCESSOR=dtln MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
+MUESLI_AEC_PROCESSOR=localvqe-strict MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh
+```
+
+`localvqe-strict` does not fall back to DTLN when LocalVQE fails to load.
 
 That installs `/Applications/MuesliDev.app` with bundle ID `com.muesli.dev`
 and stores data under `~/Library/Application Support/MuesliDev/`, so it does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,8 +130,9 @@ release scripts for normal PR validation.
 
 Before packaging a signed release, ensure a *complete* LocalVQE runtime is
 present (`./scripts/build_localvqe.sh`). `build_native_app.sh` fails closed when
-those dylibs are missing or incomplete unless `MUESLI_ALLOW_MISSING_LOCALVQE=1`
-is set.
+those dylibs are missing or incomplete. `MUESLI_ALLOW_MISSING_LOCALVQE=1` is
+an unsigned-development override only and cannot bypass signed release
+packaging.
 
 ## SwiftPM Build Cache
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,16 @@ Cohere Transcribe is a 2B parameter model (#1 on Open ASR Leaderboard) running i
 
 Gemma 4 E2B is an experimental multimodal LiteRT-LM backend for direct transcription or on-device transcript cleanup. It is not an ASR-tuned model, so assistant-style outputs are rejected and Parakeet remains the recommended transcription backend. Gemma cannot be selected for ASR and cleanup at the same time.
 
-Meeting echo cancellation uses the bundled LocalVQE `localvqe-v1.2-1.3M-f32.gguf` model by default, so users do not need to download an AEC model before their first meeting transcription. DTLN remains available as the fallback AEC path.
+Meeting echo cancellation uses LocalVQE by default. Release builds ship the
+bundled `localvqe-v1.2-1.3M-f32.gguf` model plus the LocalVQE shared libraries,
+so users do not need to download an AEC model before their first meeting
+transcription. DTLN remains available as the fallback AEC path when LocalVQE
+cannot load.
+
+Source/dev builds need the LocalVQE runtime built once with
+`./scripts/build_localvqe.sh` (the model is committed; the dylibs under
+`native/MuesliNative/LocalVQE/lib/` are not). Without that step, packaging
+warns and the app falls back to DTLN. See `CONTRIBUTING.md`.
 
 Models download on demand from HuggingFace. Manage them from the **Models** tab in the dashboard.
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -155,10 +155,11 @@ final class MeetingNeuralAec {
                 Self.logger.info("LocalVQE preloaded (frameSize=\(localVQE.frameSize, privacy: .public), library=\(localVQE.libraryPath, privacy: .public), model=\(localVQE.modelPath, privacy: .public))")
                 return
             } catch {
-                Self.logger.error("LocalVQE preload failed; falling back to DTLN: \(String(describing: error), privacy: .public)")
                 if selection == .localVQEStrict {
+                    Self.logger.error("LocalVQE preload failed in strict mode (no DTLN fallback): \(String(describing: error), privacy: .public)")
                     return
                 }
+                Self.logger.error("LocalVQE preload failed; falling back to DTLN: \(String(describing: error), privacy: .public)")
             }
         }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -152,14 +152,16 @@ final class MeetingNeuralAec {
                 processor = localVQE
                 frameSize = localVQE.frameSize
                 isLoaded = true
-                Self.logger.info("LocalVQE preloaded (frameSize=\(localVQE.frameSize, privacy: .public), library=\(localVQE.libraryPath, privacy: .public), model=\(localVQE.modelPath, privacy: .public))")
+                let libraryName = URL(fileURLWithPath: localVQE.libraryPath).lastPathComponent
+                let modelName = URL(fileURLWithPath: localVQE.modelPath).lastPathComponent
+                Self.logger.info("LocalVQE preloaded (frameSize=\(localVQE.frameSize, privacy: .public), library=\(libraryName, privacy: .public), model=\(modelName, privacy: .public))")
                 return
             } catch {
                 if selection == .localVQEStrict {
-                    Self.logger.error("LocalVQE preload failed in strict mode (no DTLN fallback): \(String(describing: error), privacy: .public)")
+                    Self.logger.error("LocalVQE preload failed in strict mode (no DTLN fallback): \(String(describing: error), privacy: .private)")
                     return
                 }
-                Self.logger.error("LocalVQE preload failed; falling back to DTLN: \(String(describing: error), privacy: .public)")
+                Self.logger.error("LocalVQE preload failed; falling back to DTLN: \(String(describing: error), privacy: .private)")
             }
         }
 
@@ -170,7 +172,7 @@ final class MeetingNeuralAec {
             isLoaded = true
             Self.logger.info("DTLN-aec model preloaded (frameSize=\(dtln.frameSize, privacy: .public))")
         } catch {
-            Self.logger.error("DTLN-aec preload failed: \(String(describing: error), privacy: .public)")
+            Self.logger.error("DTLN-aec preload failed: \(String(describing: error), privacy: .private)")
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingNeuralAec.swift
@@ -1,5 +1,6 @@
 import DTLNAecCoreML
 import Foundation
+import os
 
 protocol MeetingAecProcessor: AnyObject {
     var name: String { get }
@@ -94,6 +95,8 @@ enum MeetingAecProcessorSelection {
 }
 
 final class MeetingNeuralAec {
+    private static let logger = Logger(subsystem: "com.muesli.native", category: "MeetingAec")
+
     private var processor: MeetingAecProcessor?
     private var isLoaded = false
 
@@ -149,10 +152,10 @@ final class MeetingNeuralAec {
                 processor = localVQE
                 frameSize = localVQE.frameSize
                 isLoaded = true
-                fputs("[meeting-aec] LocalVQE preloaded (\(localVQE.libraryPath), model: \(localVQE.modelPath))\n", stderr)
+                Self.logger.info("LocalVQE preloaded (frameSize=\(localVQE.frameSize, privacy: .public), library=\(localVQE.libraryPath, privacy: .public), model=\(localVQE.modelPath, privacy: .public))")
                 return
             } catch {
-                fputs("[meeting-aec] LocalVQE preload failed: \(error)\n", stderr)
+                Self.logger.error("LocalVQE preload failed; falling back to DTLN: \(String(describing: error), privacy: .public)")
                 if selection == .localVQEStrict {
                     return
                 }
@@ -164,9 +167,9 @@ final class MeetingNeuralAec {
             processor = dtln
             frameSize = dtln.frameSize
             isLoaded = true
-            fputs("[meeting-aec] DTLN-aec model preloaded\n", stderr)
+            Self.logger.info("DTLN-aec model preloaded (frameSize=\(dtln.frameSize, privacy: .public))")
         } catch {
-            fputs("[meeting-aec] DTLN-aec preload failed: \(error)\n", stderr)
+            Self.logger.error("DTLN-aec preload failed: \(String(describing: error), privacy: .public)")
         }
     }
 
@@ -512,6 +515,10 @@ final class MeetingNeuralAec {
     var diagnosticsSnapshot: MeetingAecDiagnosticsSnapshot {
         MeetingAecDiagnosticsSnapshot(
             ready: isReady,
+            processor: processor?.name,
+            // 0 means unloaded — do not advertise LocalVQE's 256-sample default
+            // before preload selects a processor.
+            frameSize: processor?.frameSize ?? 0,
             processedFrames: processedFrames,
             fullReferenceFrames: fullReferenceFrames,
             partialReferenceFrames: partialReferenceFrames,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
@@ -88,6 +88,43 @@ struct MeetingAecDiagnosticsSnapshot: Codable {
     let delaySkipHistory: [MeetingAecDelaySkip]
 }
 
+extension MeetingAecDiagnosticsSnapshot {
+    private enum CodingKeys: String, CodingKey {
+        case ready
+        case processor
+        case frameSize
+        case processedFrames
+        case fullReferenceFrames
+        case partialReferenceFrames
+        case missingReferenceFrames
+        case systemSamplesReceived
+        case micSamplesReceived
+        case bufferedSystemSamples
+        case bufferedMicSamples
+        case currentDelayMs
+        case delayHistory
+        case delaySkipHistory
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ready = try container.decode(Bool.self, forKey: .ready)
+        processor = try container.decodeIfPresent(String.self, forKey: .processor)
+        frameSize = try container.decodeIfPresent(Int.self, forKey: .frameSize) ?? 0
+        processedFrames = try container.decode(Int.self, forKey: .processedFrames)
+        fullReferenceFrames = try container.decode(Int.self, forKey: .fullReferenceFrames)
+        partialReferenceFrames = try container.decode(Int.self, forKey: .partialReferenceFrames)
+        missingReferenceFrames = try container.decode(Int.self, forKey: .missingReferenceFrames)
+        systemSamplesReceived = try container.decode(Int.self, forKey: .systemSamplesReceived)
+        micSamplesReceived = try container.decode(Int.self, forKey: .micSamplesReceived)
+        bufferedSystemSamples = try container.decode(Int.self, forKey: .bufferedSystemSamples)
+        bufferedMicSamples = try container.decode(Int.self, forKey: .bufferedMicSamples)
+        currentDelayMs = try container.decode(Int.self, forKey: .currentDelayMs)
+        delayHistory = try container.decode([MeetingAecDelayObservation].self, forKey: .delayHistory)
+        delaySkipHistory = try container.decode([MeetingAecDelaySkip].self, forKey: .delaySkipHistory)
+    }
+}
+
 struct MeetingAecDelayObservation: Codable {
     let delayMs: Int
     let appliedDelayMs: Int

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSessionDiagnostics.swift
@@ -71,6 +71,10 @@ protocol SystemAudioDiagnosticsProviding {
 
 struct MeetingAecDiagnosticsSnapshot: Codable {
     let ready: Bool
+    /// Active AEC backend name (`localvqe`, `dtln`, or nil when unloaded).
+    let processor: String?
+    /// Model hop/frame size in samples (LocalVQE=256, DTLN=512, 0=unloaded).
+    let frameSize: Int
     let processedFrames: Int
     let fullReferenceFrames: Int
     let partialReferenceFrames: Int

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
@@ -210,6 +210,23 @@ struct MeetingNeuralAecTests {
         #expect(processor.processedFrameCount == 2)
     }
 
+    @Test("diagnostics report active processor and frame size")
+    func diagnosticsReportActiveProcessorAndFrameSize() {
+        let localVQE = MeetingNeuralAec(preloadedProcessor: PassthroughAecProcessor(name: "localvqe", frameSize: 256))
+        #expect(localVQE.diagnosticsSnapshot.processor == "localvqe")
+        #expect(localVQE.diagnosticsSnapshot.frameSize == 256)
+        #expect(localVQE.diagnosticsSnapshot.ready)
+
+        let dtln = MeetingNeuralAec(preloadedProcessor: PassthroughAecProcessor(name: "dtln", frameSize: 512))
+        #expect(dtln.diagnosticsSnapshot.processor == "dtln")
+        #expect(dtln.diagnosticsSnapshot.frameSize == 512)
+
+        let unloaded = MeetingNeuralAec()
+        #expect(unloaded.diagnosticsSnapshot.processor == nil)
+        #expect(unloaded.diagnosticsSnapshot.frameSize == 0)
+        #expect(unloaded.diagnosticsSnapshot.ready == false)
+    }
+
     @Test("delay estimator reports missing mic candidate windows")
     func delayEstimatorReportsMissingMicCandidateWindows() throws {
         let estimator = MeetingAecDelayEstimator()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingNeuralAecTests.swift
@@ -227,6 +227,46 @@ struct MeetingNeuralAecTests {
         #expect(unloaded.diagnosticsSnapshot.ready == false)
     }
 
+    @Test("diagnostics decode legacy payload without processor metadata")
+    func diagnosticsDecodeLegacyPayloadWithoutProcessorMetadata() throws {
+        let legacyPayload = Data("""
+        {
+          "ready": true,
+          "processedFrames": 12,
+          "fullReferenceFrames": 10,
+          "partialReferenceFrames": 1,
+          "missingReferenceFrames": 1,
+          "systemSamplesReceived": 4096,
+          "micSamplesReceived": 4096,
+          "bufferedSystemSamples": 256,
+          "bufferedMicSamples": 0,
+          "currentDelayMs": 0,
+          "delayHistory": [],
+          "delaySkipHistory": []
+        }
+        """.utf8)
+
+        let snapshot = try JSONDecoder().decode(MeetingAecDiagnosticsSnapshot.self, from: legacyPayload)
+
+        #expect(snapshot.processor == nil)
+        #expect(snapshot.frameSize == 0)
+        #expect(snapshot.processedFrames == 12)
+    }
+
+    @Test("diagnostics processor metadata round trips")
+    func diagnosticsProcessorMetadataRoundTrips() throws {
+        let original = MeetingNeuralAec(
+            preloadedProcessor: PassthroughAecProcessor(name: "localvqe", frameSize: 256)
+        ).diagnosticsSnapshot
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MeetingAecDiagnosticsSnapshot.self, from: encoded)
+
+        #expect(decoded.processor == "localvqe")
+        #expect(decoded.frameSize == 256)
+        #expect(decoded.ready)
+    }
+
     @Test("delay estimator reports missing mic candidate windows")
     func delayEstimatorReportsMissingMicCandidateWindows() throws {
         let estimator = MeetingAecDelayEstimator()

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT/scripts/muesli_spm_cache.sh"
+source "$ROOT/scripts/localvqe_runtime.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
 DIST_DIR="$ROOT/dist-native"
 INSTALL_DIR="${MUESLI_INSTALL_DIR:-/Applications}"
@@ -149,75 +150,22 @@ ALLOW_MISSING_LOCALVQE="${MUESLI_ALLOW_MISSING_LOCALVQE:-0}"
 REQUIRE_LOCALVQE="${MUESLI_REQUIRE_LOCALVQE:-0}"
 BUILD_LOCALVQE="${MUESLI_BUILD_LOCALVQE:-0}"
 
-collect_localvqe_runtime() {
-  local dir="$1"
-  local -a found=()
-  if [[ -d "$dir" ]]; then
-    while IFS= read -r dylib; do
-      found+=("$dylib")
-    done < <(find "$dir" -maxdepth 1 \( -name "liblocalvqe*.dylib" -o -name "libggml*.dylib" -o -name "libggml*.so" \) \( -type f -o -type l \) | sort)
-  fi
-  printf '%s\n' "${found[@]+"${found[@]}"}"
-}
-
 # Reject partial LocalVQE installs (e.g. liblocalvqe present but libggml-base
 # missing). Otherwise packaging would "succeed" and the app would still fall
 # back to DTLN at runtime when dlopen fails.
-localvqe_runtime_is_complete() {
-  local dir="$1"
-  local primary=""
-  local name
-  for name in liblocalvqe.dylib liblocalvqe.0.1.0.dylib liblocalvqe.0.dylib liblocalvqe_shared.dylib; do
-    if [[ -e "$dir/$name" ]]; then
-      primary="$dir/$name"
-      break
-    fi
-  done
-  if [[ -z "$primary" ]]; then
-    echo "LocalVQE primary library missing in $dir" >&2
-    return 1
-  fi
-
-  # libggml-base is a transitive dependency of the libggml umbrella shared
-  # library. Require it unconditionally so a one-level otool walk of only
-  # liblocalvqe cannot accept liblocalvqe+libggml without libggml-base.
-  if ! find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .; then
-    echo "LocalVQE runtime incomplete: libggml-base*.dylib missing in $dir" >&2
-    return 1
-  fi
-
-  if command -v otool >/dev/null 2>&1; then
-    local lib dep base
-    # Walk every present LocalVQE/ggml dylib so transitive deps of libggml
-    # (libggml-base, libggml-cpu, …) are validated, not just direct deps of
-    # the primary liblocalvqe dylib.
-    while IFS= read -r lib; do
-      [[ -n "$lib" ]] || continue
-      while IFS= read -r dep; do
-        [[ -n "$dep" ]] || continue
-        base="$(basename "$dep")"
-        case "$base" in
-          liblocalvqe*|libggml*)
-            if [[ ! -e "$dir/$base" ]]; then
-              echo "LocalVQE runtime incomplete: $base missing (required by $(basename "$lib"))" >&2
-              return 1
-            fi
-            ;;
-        esac
-      done < <(otool -L "$lib" 2>/dev/null | awk '/^\t/ {print $1}')
-    done < <(find "$dir" -maxdepth 1 \( -name 'liblocalvqe*.dylib' -o -name 'libggml*.dylib' \) \( -type f -o -type l \) | sort)
-  fi
-  return 0
-}
-
 refresh_localvqe_runtime_files() {
+  local collected=""
   LOCALVQE_RUNTIME_FILES=()
+  if ! collected="$(muesli_collect_localvqe_runtime "$LOCALVQE_LIB_DIR")"; then
+    echo "Unable to inspect LocalVQE runtime in $LOCALVQE_LIB_DIR" >&2
+    return 1
+  fi
   while IFS= read -r dylib; do
     [[ -n "$dylib" ]] || continue
     LOCALVQE_RUNTIME_FILES+=("$dylib")
-  done < <(collect_localvqe_runtime "$LOCALVQE_LIB_DIR")
+  done <<< "$collected"
 
-  if [[ ${#LOCALVQE_RUNTIME_FILES[@]} -gt 0 ]] && ! localvqe_runtime_is_complete "$LOCALVQE_LIB_DIR"; then
+  if [[ ${#LOCALVQE_RUNTIME_FILES[@]} -gt 0 ]] && ! muesli_localvqe_runtime_is_complete "$LOCALVQE_LIB_DIR"; then
     echo "Ignoring incomplete LocalVQE runtime in $LOCALVQE_LIB_DIR" >&2
     LOCALVQE_RUNTIME_FILES=()
   fi

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -141,14 +141,117 @@ for bundle in "$BIN_DIR"/*.bundle; do
   ditto "$bundle" "$STAGED_APP_DIR/Contents/Resources/$(basename "$bundle")"
 done
 
-# Bundle optional LocalVQE runtime if it has been built for local AEC testing.
+# Bundle LocalVQE runtime (default meeting AEC). The .gguf model is committed;
+# the shared libraries under LocalVQE/lib/ are gitignored and produced by
+# scripts/build_localvqe.sh. Without them the app silently falls back to DTLN.
 LOCALVQE_LIB_DIR="${MUESLI_LOCALVQE_LIB_DIR:-$ROOT/native/MuesliNative/LocalVQE/lib}"
-if [[ -d "$LOCALVQE_LIB_DIR" ]]; then
-  find "$LOCALVQE_LIB_DIR" -maxdepth 1 \( -name "liblocalvqe*.dylib" -o -name "libggml*.dylib" -o -name "libggml*.so" \) \( -type f -o -type l \) | while read -r dylib; do
+ALLOW_MISSING_LOCALVQE="${MUESLI_ALLOW_MISSING_LOCALVQE:-0}"
+REQUIRE_LOCALVQE="${MUESLI_REQUIRE_LOCALVQE:-0}"
+BUILD_LOCALVQE="${MUESLI_BUILD_LOCALVQE:-0}"
+
+collect_localvqe_runtime() {
+  local dir="$1"
+  local -a found=()
+  if [[ -d "$dir" ]]; then
+    while IFS= read -r dylib; do
+      found+=("$dylib")
+    done < <(find "$dir" -maxdepth 1 \( -name "liblocalvqe*.dylib" -o -name "libggml*.dylib" -o -name "libggml*.so" \) \( -type f -o -type l \) | sort)
+  fi
+  printf '%s\n' "${found[@]+"${found[@]}"}"
+}
+
+# Reject partial LocalVQE installs (e.g. liblocalvqe present but libggml-base
+# missing). Otherwise packaging would "succeed" and the app would still fall
+# back to DTLN at runtime when dlopen fails.
+localvqe_runtime_is_complete() {
+  local dir="$1"
+  local primary=""
+  local name
+  for name in liblocalvqe.dylib liblocalvqe.0.1.0.dylib liblocalvqe.0.dylib liblocalvqe_shared.dylib; do
+    if [[ -e "$dir/$name" ]]; then
+      primary="$dir/$name"
+      break
+    fi
+  done
+  if [[ -z "$primary" ]]; then
+    echo "LocalVQE primary library missing in $dir" >&2
+    return 1
+  fi
+
+  if command -v otool >/dev/null 2>&1; then
+    local dep base
+    while IFS= read -r dep; do
+      [[ -n "$dep" ]] || continue
+      base="$(basename "$dep")"
+      case "$base" in
+        liblocalvqe*|libggml*)
+          if [[ ! -e "$dir/$base" ]]; then
+            echo "LocalVQE runtime incomplete: $base missing (required by $(basename "$primary"))" >&2
+            return 1
+          fi
+          ;;
+      esac
+    done < <(otool -L "$primary" 2>/dev/null | awk '/^\t/ {print $1}')
+  elif ! find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .; then
+    # Fallback when otool is unavailable (non-macOS harnesses).
+    echo "LocalVQE runtime incomplete: libggml-base*.dylib missing in $dir" >&2
+    return 1
+  fi
+  return 0
+}
+
+refresh_localvqe_runtime_files() {
+  LOCALVQE_RUNTIME_FILES=()
+  while IFS= read -r dylib; do
+    [[ -n "$dylib" ]] || continue
+    LOCALVQE_RUNTIME_FILES+=("$dylib")
+  done < <(collect_localvqe_runtime "$LOCALVQE_LIB_DIR")
+
+  if [[ ${#LOCALVQE_RUNTIME_FILES[@]} -gt 0 ]] && ! localvqe_runtime_is_complete "$LOCALVQE_LIB_DIR"; then
+    echo "Ignoring incomplete LocalVQE runtime in $LOCALVQE_LIB_DIR" >&2
+    LOCALVQE_RUNTIME_FILES=()
+  fi
+}
+
+refresh_localvqe_runtime_files
+
+if [[ ${#LOCALVQE_RUNTIME_FILES[@]} -eq 0 && "$BUILD_LOCALVQE" == "1" ]]; then
+  echo "LocalVQE runtime missing/incomplete; building via scripts/build_localvqe.sh (MUESLI_BUILD_LOCALVQE=1)..."
+  "$ROOT/scripts/build_localvqe.sh"
+  refresh_localvqe_runtime_files
+fi
+
+if [[ ${#LOCALVQE_RUNTIME_FILES[@]} -eq 0 ]]; then
+  cat >&2 <<EOF
+WARNING: Complete LocalVQE runtime not found in $LOCALVQE_LIB_DIR
+         Meeting echo cancellation will fall back to DTLN instead of the
+         documented LocalVQE default. A usable runtime needs liblocalvqe
+         plus its libggml* companions (especially libggml-base).
+
+  Build the runtime once with:
+    ./scripts/build_localvqe.sh
+
+  Or re-run this build with:
+    MUESLI_BUILD_LOCALVQE=1 $0 $*
+EOF
+  if [[ "$ALLOW_MISSING_LOCALVQE" == "1" ]]; then
+    echo "Continuing without LocalVQE (MUESLI_ALLOW_MISSING_LOCALVQE=1)." >&2
+  elif [[ "$REQUIRE_LOCALVQE" == "1" || "$SKIP_SIGN" != "1" ]]; then
+    # Intentionally keyed on signing, not BUILD_CONFIG: signed packaging
+    # (release scripts and maintainer ./scripts/dev-test.sh without
+    # MUESLI_SKIP_SIGN=1) must not silently ship a DTLN-only bundle.
+    echo "ERROR: refusing to package without a complete LocalVQE runtime. Set MUESLI_ALLOW_MISSING_LOCALVQE=1 to override." >&2
+    exit 1
+  else
+    echo "Continuing without LocalVQE for unsigned packaging (MUESLI_SKIP_SIGN=1). Set MUESLI_REQUIRE_LOCALVQE=1 to fail instead." >&2
+  fi
+else
+  for dylib in "${LOCALVQE_RUNTIME_FILES[@]}"; do
     target="$STAGED_APP_DIR/Contents/MacOS/$(basename "$dylib")"
     cp -RL "$dylib" "$target"
     thin_macho_to_bundle_arch "$target"
   done
+  echo "Bundled LocalVQE runtime (${#LOCALVQE_RUNTIME_FILES[@]} files) from $LOCALVQE_LIB_DIR"
 fi
 LOCALVQE_MODEL_PATH="${MUESLI_LOCALVQE_MODEL_PATH:-$ROOT/native/MuesliNative/LocalVQE/models/localvqe-v1.2-1.3M-f32.gguf}"
 if [[ -f "$LOCALVQE_MODEL_PATH" ]]; then

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -178,24 +178,34 @@ localvqe_runtime_is_complete() {
     return 1
   fi
 
-  if command -v otool >/dev/null 2>&1; then
-    local dep base
-    while IFS= read -r dep; do
-      [[ -n "$dep" ]] || continue
-      base="$(basename "$dep")"
-      case "$base" in
-        liblocalvqe*|libggml*)
-          if [[ ! -e "$dir/$base" ]]; then
-            echo "LocalVQE runtime incomplete: $base missing (required by $(basename "$primary"))" >&2
-            return 1
-          fi
-          ;;
-      esac
-    done < <(otool -L "$primary" 2>/dev/null | awk '/^\t/ {print $1}')
-  elif ! find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .; then
-    # Fallback when otool is unavailable (non-macOS harnesses).
+  # libggml-base is a transitive dependency of the libggml umbrella shared
+  # library. Require it unconditionally so a one-level otool walk of only
+  # liblocalvqe cannot accept liblocalvqe+libggml without libggml-base.
+  if ! find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .; then
     echo "LocalVQE runtime incomplete: libggml-base*.dylib missing in $dir" >&2
     return 1
+  fi
+
+  if command -v otool >/dev/null 2>&1; then
+    local lib dep base
+    # Walk every present LocalVQE/ggml dylib so transitive deps of libggml
+    # (libggml-base, libggml-cpu, …) are validated, not just direct deps of
+    # the primary liblocalvqe dylib.
+    while IFS= read -r lib; do
+      [[ -n "$lib" ]] || continue
+      while IFS= read -r dep; do
+        [[ -n "$dep" ]] || continue
+        base="$(basename "$dep")"
+        case "$base" in
+          liblocalvqe*|libggml*)
+            if [[ ! -e "$dir/$base" ]]; then
+              echo "LocalVQE runtime incomplete: $base missing (required by $(basename "$lib"))" >&2
+              return 1
+            fi
+            ;;
+        esac
+      done < <(otool -L "$lib" 2>/dev/null | awk '/^\t/ {print $1}')
+    done < <(find "$dir" -maxdepth 1 \( -name 'liblocalvqe*.dylib' -o -name 'libggml*.dylib' \) \( -type f -o -type l \) | sort)
   fi
   return 0
 }
@@ -234,13 +244,16 @@ WARNING: Complete LocalVQE runtime not found in $LOCALVQE_LIB_DIR
   Or re-run this build with:
     MUESLI_BUILD_LOCALVQE=1 $0 $*
 EOF
-  if [[ "$ALLOW_MISSING_LOCALVQE" == "1" ]]; then
-    echo "Continuing without LocalVQE (MUESLI_ALLOW_MISSING_LOCALVQE=1)." >&2
+  if [[ "$ALLOW_MISSING_LOCALVQE" == "1" && "$SKIP_SIGN" == "1" && "$REQUIRE_LOCALVQE" != "1" ]]; then
+    echo "Continuing without LocalVQE (MUESLI_ALLOW_MISSING_LOCALVQE=1, unsigned packaging)." >&2
+  elif [[ "$ALLOW_MISSING_LOCALVQE" == "1" ]]; then
+    echo "ERROR: MUESLI_ALLOW_MISSING_LOCALVQE=1 cannot override signed packaging or MUESLI_REQUIRE_LOCALVQE=1." >&2
+    exit 1
   elif [[ "$REQUIRE_LOCALVQE" == "1" || "$SKIP_SIGN" != "1" ]]; then
     # Intentionally keyed on signing, not BUILD_CONFIG: signed packaging
     # (release scripts and maintainer ./scripts/dev-test.sh without
     # MUESLI_SKIP_SIGN=1) must not silently ship a DTLN-only bundle.
-    echo "ERROR: refusing to package without a complete LocalVQE runtime. Set MUESLI_ALLOW_MISSING_LOCALVQE=1 to override." >&2
+    echo "ERROR: refusing to package without a complete LocalVQE runtime. Set MUESLI_ALLOW_MISSING_LOCALVQE=1 with MUESLI_SKIP_SIGN=1 to override for unsigned builds." >&2
     exit 1
   else
     echo "Continuing without LocalVQE for unsigned packaging (MUESLI_SKIP_SIGN=1). Set MUESLI_REQUIRE_LOCALVQE=1 to fail instead." >&2

--- a/scripts/localvqe_runtime.sh
+++ b/scripts/localvqe_runtime.sh
@@ -25,6 +25,7 @@ muesli_collect_localvqe_runtime() {
 
 muesli_localvqe_runtime_is_complete() {
   local dir="$1"
+  local ggml_umbrella=""
   local primary=""
   local name
   local runtime_listing=""
@@ -51,6 +52,20 @@ muesli_localvqe_runtime_is_complete() {
   done
   if [[ -z "$primary" ]]; then
     echo "LocalVQE primary library missing in $dir" >&2
+    return 1
+  fi
+
+  for library in "${runtime_files[@]}"; do
+    name="$(basename "$library")"
+    case "$name" in
+      libggml.dylib|libggml.[0-9]*.dylib)
+        ggml_umbrella="$library"
+        break
+        ;;
+    esac
+  done
+  if [[ -z "$ggml_umbrella" ]]; then
+    echo "LocalVQE runtime incomplete: libggml umbrella dylib missing in $dir" >&2
     return 1
   fi
 

--- a/scripts/localvqe_runtime.sh
+++ b/scripts/localvqe_runtime.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Shared LocalVQE runtime discovery and completeness validation.
+# This file is sourced by packaging and smoke-test scripts.
+
+[[ -n "${_MUESLI_LOCALVQE_RUNTIME_LOADED:-}" ]] && return 0
+_MUESLI_LOCALVQE_RUNTIME_LOADED=1
+
+muesli_collect_localvqe_runtime() {
+  local dir="$1"
+  local listing=""
+  local -a found=()
+  if [[ -d "$dir" ]]; then
+    if ! listing="$(find "$dir" -maxdepth 1 \( -name "liblocalvqe*.dylib" -o -name "libggml*.dylib" -o -name "libggml*.so" \) \( -type f -o -type l \))"; then
+      echo "Could not enumerate LocalVQE runtime in $dir" >&2
+      return 1
+    fi
+    while IFS= read -r library; do
+      [[ -n "$library" ]] || continue
+      found+=("$library")
+    done <<< "$listing"
+  fi
+  printf '%s\n' "${found[@]+"${found[@]}"}" | sort
+}
+
+muesli_localvqe_runtime_is_complete() {
+  local dir="$1"
+  local primary=""
+  local name
+  local runtime_listing=""
+  local -a runtime_files=()
+
+  if ! runtime_listing="$(muesli_collect_localvqe_runtime "$dir")"; then
+    return 1
+  fi
+  while IFS= read -r library; do
+    [[ -n "$library" ]] || continue
+    runtime_files+=("$library")
+  done <<< "$runtime_listing"
+
+  if [[ ${#runtime_files[@]} -eq 0 ]]; then
+    echo "LocalVQE runtime files missing in $dir" >&2
+    return 1
+  fi
+
+  for name in liblocalvqe.dylib liblocalvqe.0.1.0.dylib liblocalvqe.0.dylib liblocalvqe_shared.dylib; do
+    if [[ -e "$dir/$name" ]]; then
+      primary="$dir/$name"
+      break
+    fi
+  done
+  if [[ -z "$primary" ]]; then
+    echo "LocalVQE primary library missing in $dir" >&2
+    return 1
+  fi
+
+  # libggml-base is a transitive dependency of the libggml umbrella shared
+  # library. Require it unconditionally so a one-level dependency walk of only
+  # liblocalvqe cannot accept liblocalvqe+libggml without libggml-base.
+  if ! find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .; then
+    echo "LocalVQE runtime incomplete: libggml-base*.dylib missing in $dir" >&2
+    return 1
+  fi
+
+  if command -v otool >/dev/null 2>&1; then
+    local library inspection line dependency base
+    # Inspect every collected runtime library, including dynamically loaded
+    # ggml backend modules. A library that otool cannot read must fail closed;
+    # treating its dependencies as an empty list would permit a broken bundle.
+    for library in "${runtime_files[@]}"; do
+      if ! inspection="$(otool -L "$library" 2>/dev/null)"; then
+        echo "LocalVQE runtime incomplete: otool could not inspect $(basename "$library")" >&2
+        return 1
+      fi
+      if [[ -z "$inspection" ]]; then
+        echo "LocalVQE runtime incomplete: otool returned no metadata for $(basename "$library")" >&2
+        return 1
+      fi
+
+      while IFS= read -r line; do
+        [[ "$line" == [[:space:]]* ]] || continue
+        dependency="${line#"${line%%[![:space:]]*}"}"
+        dependency="${dependency%% *}"
+        [[ -n "$dependency" ]] || continue
+        base="$(basename "$dependency")"
+        case "$base" in
+          liblocalvqe*|libggml*)
+            if [[ ! -e "$dir/$base" ]]; then
+              echo "LocalVQE runtime incomplete: $base missing (required by $(basename "$library"))" >&2
+              return 1
+            fi
+            ;;
+        esac
+      done <<< "$inspection"
+    done
+  fi
+  return 0
+}

--- a/scripts/test_localvqe_runtime_validation.sh
+++ b/scripts/test_localvqe_runtime_validation.sh
@@ -8,7 +8,8 @@ TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 RUNTIME_DIR="$TEST_ROOT/runtime"
 FAKE_BIN="$TEST_ROOT/bin"
-mkdir -p "$RUNTIME_DIR" "$FAKE_BIN"
+NO_OTOOL_BIN="$TEST_ROOT/no-otool-bin"
+mkdir -p "$RUNTIME_DIR" "$FAKE_BIN" "$NO_OTOOL_BIN"
 
 cat > "$FAKE_BIN/otool" <<'FAKE_OTOOL'
 #!/usr/bin/env bash
@@ -40,6 +41,9 @@ printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current versi
 FAKE_OTOOL
 chmod +x "$FAKE_BIN/otool"
 export PATH="$FAKE_BIN:$PATH"
+for tool in basename find grep sort; do
+  ln -s "$(command -v "$tool")" "$NO_OTOOL_BIN/$tool"
+done
 
 touch \
   "$RUNTIME_DIR/liblocalvqe.dylib" \
@@ -64,6 +68,10 @@ expect_incomplete() {
 }
 
 expect_complete "complete dependency closure"
+
+rm "$RUNTIME_DIR/libggml.dylib"
+PATH="$NO_OTOOL_BIN" expect_incomplete "missing libggml umbrella without otool"
+touch "$RUNTIME_DIR/libggml.dylib"
 
 export FAKE_OTOOL_FAIL_BASENAME="libggml.dylib"
 expect_incomplete "unreadable dylib"

--- a/scripts/test_localvqe_runtime_validation.sh
+++ b/scripts/test_localvqe_runtime_validation.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/localvqe_runtime.sh"
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+RUNTIME_DIR="$TEST_ROOT/runtime"
+FAKE_BIN="$TEST_ROOT/bin"
+mkdir -p "$RUNTIME_DIR" "$FAKE_BIN"
+
+cat > "$FAKE_BIN/otool" <<'FAKE_OTOOL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:-}" == "-L" && -n "${2:-}" ]] || exit 2
+library="$2"
+name="$(basename "$library")"
+if [[ "$name" == "${FAKE_OTOOL_FAIL_BASENAME:-}" ]]; then
+  exit 1
+fi
+if [[ "$name" == "${FAKE_OTOOL_EMPTY_BASENAME:-}" ]]; then
+  exit 0
+fi
+
+printf '%s:\n' "$library"
+case "$name" in
+  liblocalvqe*)
+    printf '\t@rpath/libggml.dylib (compatibility version 0.0.0, current version 0.0.0)\n'
+    ;;
+  libggml.dylib)
+    printf '\t@rpath/libggml-base.dylib (compatibility version 0.0.0, current version 0.0.0)\n'
+    ;;
+esac
+if [[ -n "${FAKE_OTOOL_MISSING_DEP:-}" ]]; then
+  printf '\t@rpath/%s (compatibility version 0.0.0, current version 0.0.0)\n' "$FAKE_OTOOL_MISSING_DEP"
+fi
+printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n'
+FAKE_OTOOL
+chmod +x "$FAKE_BIN/otool"
+export PATH="$FAKE_BIN:$PATH"
+
+touch \
+  "$RUNTIME_DIR/liblocalvqe.dylib" \
+  "$RUNTIME_DIR/libggml.dylib" \
+  "$RUNTIME_DIR/libggml-base.dylib" \
+  "$RUNTIME_DIR/libggml-cpu-apple_m4.so"
+
+expect_complete() {
+  local name="$1"
+  if ! muesli_localvqe_runtime_is_complete "$RUNTIME_DIR"; then
+    echo "FAIL: $name should accept the runtime" >&2
+    exit 1
+  fi
+}
+
+expect_incomplete() {
+  local name="$1"
+  if muesli_localvqe_runtime_is_complete "$RUNTIME_DIR" >/dev/null 2>&1; then
+    echo "FAIL: $name should reject the runtime" >&2
+    exit 1
+  fi
+}
+
+expect_complete "complete dependency closure"
+
+export FAKE_OTOOL_FAIL_BASENAME="libggml.dylib"
+expect_incomplete "unreadable dylib"
+unset FAKE_OTOOL_FAIL_BASENAME
+
+export FAKE_OTOOL_EMPTY_BASENAME="libggml.dylib"
+expect_incomplete "empty otool metadata"
+unset FAKE_OTOOL_EMPTY_BASENAME
+
+export FAKE_OTOOL_FAIL_BASENAME="libggml-cpu-apple_m4.so"
+expect_incomplete "unreadable backend module"
+unset FAKE_OTOOL_FAIL_BASENAME
+
+rm "$RUNTIME_DIR/libggml-base.dylib"
+expect_incomplete "missing required libggml-base"
+touch "$RUNTIME_DIR/libggml-base.dylib"
+
+export FAKE_OTOOL_MISSING_DEP="libggml-missing.dylib"
+expect_incomplete "missing inspected dependency"
+unset FAKE_OTOOL_MISSING_DEP
+
+echo "LocalVQE runtime validation tests passed."

--- a/scripts/test_packaged_cli.sh
+++ b/scripts/test_packaged_cli.sh
@@ -16,10 +16,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
+LOCALVQE_LIB_DIR="${MUESLI_LOCALVQE_LIB_DIR:-$ROOT/native/MuesliNative/LocalVQE/lib}"
+localvqe_runtime_ready() {
+  local dir="$1"
+  [[ -e "$dir/liblocalvqe.dylib" || -e "$dir/liblocalvqe.0.1.0.dylib" || -e "$dir/liblocalvqe.0.dylib" ]] || return 1
+  find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .
+}
+
+if ! localvqe_runtime_ready "$LOCALVQE_LIB_DIR"; then
+  echo "Building LocalVQE runtime for packaging smoke test..."
+  "$ROOT/scripts/build_localvqe.sh"
+fi
+
 echo "Building isolated app bundle in $INSTALL_ROOT"
 MUESLI_INSTALL_DIR="$INSTALL_ROOT" \
 MUESLI_APP_BUNDLE_NAME="$APP_BUNDLE_NAME" \
 MUESLI_SKIP_SIGN=1 \
+MUESLI_REQUIRE_LOCALVQE=1 \
 "$ROOT/scripts/build_native_app.sh" "$BUILD_CONFIG"
 
 if [[ ! -d "$APP_PATH" ]]; then
@@ -34,6 +47,19 @@ fi
 
 if [[ ! -x "$CLI_BIN" ]]; then
   echo "Missing CLI executable at $CLI_BIN" >&2
+  exit 1
+fi
+
+MACOS_DIR="$APP_PATH/Contents/MacOS"
+if ! localvqe_runtime_ready "$MACOS_DIR"; then
+  echo "Packaged app is missing a complete LocalVQE runtime under Contents/MacOS." >&2
+  echo "Expected liblocalvqe*.dylib and libggml-base*.dylib." >&2
+  ls -la "$MACOS_DIR" >&2 || true
+  exit 1
+fi
+
+if [[ ! -f "$APP_PATH/Contents/Resources/Models/localvqe/localvqe-v1.2-1.3M-f32.gguf" ]]; then
+  echo "Packaged app is missing the LocalVQE model under Contents/Resources/Models/localvqe/." >&2
   exit 1
 fi
 
@@ -56,3 +82,4 @@ echo "Packaged CLI smoke test passed."
 echo "Verified:"
 echo "  - $APP_BIN"
 echo "  - $CLI_BIN"
+echo "  - LocalVQE runtime + model bundled"

--- a/scripts/test_packaged_cli.sh
+++ b/scripts/test_packaged_cli.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/localvqe_runtime.sh"
 BUILD_CONFIG="${1:-debug}"
 INSTALL_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/muesli-packaging-test.XXXXXX")"
 APP_BUNDLE_NAME="MuesliPackagingTest.app"
@@ -17,13 +18,7 @@ cleanup() {
 trap cleanup EXIT
 
 LOCALVQE_LIB_DIR="${MUESLI_LOCALVQE_LIB_DIR:-$ROOT/native/MuesliNative/LocalVQE/lib}"
-localvqe_runtime_ready() {
-  local dir="$1"
-  [[ -e "$dir/liblocalvqe.dylib" || -e "$dir/liblocalvqe.0.1.0.dylib" || -e "$dir/liblocalvqe.0.dylib" || -e "$dir/liblocalvqe_shared.dylib" ]] || return 1
-  find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .
-}
-
-if ! localvqe_runtime_ready "$LOCALVQE_LIB_DIR"; then
+if ! muesli_localvqe_runtime_is_complete "$LOCALVQE_LIB_DIR"; then
   echo "Building LocalVQE runtime for packaging smoke test..."
   "$ROOT/scripts/build_localvqe.sh"
 fi
@@ -51,7 +46,7 @@ if [[ ! -x "$CLI_BIN" ]]; then
 fi
 
 MACOS_DIR="$APP_PATH/Contents/MacOS"
-if ! localvqe_runtime_ready "$MACOS_DIR"; then
+if ! muesli_localvqe_runtime_is_complete "$MACOS_DIR"; then
   echo "Packaged app is missing a complete LocalVQE runtime under Contents/MacOS." >&2
   echo "Expected liblocalvqe*.dylib and libggml-base*.dylib." >&2
   ls -la "$MACOS_DIR" >&2 || true

--- a/scripts/test_packaged_cli.sh
+++ b/scripts/test_packaged_cli.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 LOCALVQE_LIB_DIR="${MUESLI_LOCALVQE_LIB_DIR:-$ROOT/native/MuesliNative/LocalVQE/lib}"
 localvqe_runtime_ready() {
   local dir="$1"
-  [[ -e "$dir/liblocalvqe.dylib" || -e "$dir/liblocalvqe.0.1.0.dylib" || -e "$dir/liblocalvqe.0.dylib" ]] || return 1
+  [[ -e "$dir/liblocalvqe.dylib" || -e "$dir/liblocalvqe.0.1.0.dylib" || -e "$dir/liblocalvqe.0.dylib" || -e "$dir/liblocalvqe_shared.dylib" ]] || return 1
   find "$dir" -maxdepth 1 -name 'libggml-base*.dylib' \( -type f -o -type l \) 2>/dev/null | grep -q .
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verifies and fixes [#384](https://github.com/Muesli-HQ/muesli/issues/384): source builds silently used DTLN for meeting AEC because the LocalVQE runtime is gitignored, never built by packaging/CI, and load failure only logged to stderr.

### Fix

- **Packaging:** Fail closed for signed packaging without a *complete* LocalVQE runtime. Completeness requires `liblocalvqe` + `libggml-base`, and walks `otool -L` on every present LocalVQE/ggml dylib (transitive deps). Gate is keyed on `MUESLI_SKIP_SIGN`. `MUESLI_ALLOW_MISSING_LOCALVQE=1` only works for unsigned packaging.
- **Visibility:** diagnostics include `aec.processor` + `aec.frameSize` (`0` when unloaded); preload uses `os.Logger`.
- **Docs / CI:** document `build_localvqe.sh`; cache + assert complete runtime in `cli-smoke`.

### Review follow-ups

- Greptile/Claude (post-`129ab436`): transitive ggml gap fixed in `3dc3487a` (require `libggml-base` + walk all present dylibs).
- CodeRabbit: restricted allow-missing override; smoke accepts `liblocalvqe_shared`; strict-mode log clarified; `MUESLI_AEC_PROCESSOR` documented.

Fixes #384
## Validation

- `./scripts/test_localvqe_runtime_validation.sh`
- Real LocalVQE runtime validation against the PR build and `/Applications/MuesliDevA.app`
- Focused `MeetingNeuralAecTests`: 17 tests passed
- Full Swift suite: 1,526 tests across 149 suites passed
- Packaged CLI smoke test, including the LocalVQE runtime and model assertions
- `bash -n` and `git diff --check`

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

- [LocalVQE](https://github.com/localai-org/LocalVQE) runtime built from pinned commit `134aa7fd73d6a61dcab24c4f0c70bc49a38c0494`; Apache-2.0. No third-party source or binary is committed by this PR.

### AI assistance

- Cursor Agent authored the initial implementation and early review follow-ups.
- OpenAI Codex verified the runtime in a local meeting, addressed later review findings, and ran the focused, packaging, and full-suite validation listed above. The resulting changes were reviewed before being pushed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-003b90ea-0d5d-42de-84f6-7edcc86ac65c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-003b90ea-0d5d-42de-84f6-7edcc86ac65c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788723414&installation_model_id=422865&pr_number=386&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F386&signature=6d7b0d56aec40c343fd97c186e76f4d2aa94223e2a1b33e3750536c226c4c850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release packages now bundle the LocalVQE runtime and echo-cancellation model.
  * Source builds can automatically build the LocalVQE runtime.
  * Audio diagnostics display the active processor and model frame size.
  * Runtime preload and fallback logging is clearer.

* **Bug Fixes**
  * Packaging validates required runtime libraries and rejects incomplete runtimes.
  * Signed releases enforce runtime requirements while supporting documented fallback behavior.
  * Diagnostics remain compatible with older saved data.

* **Documentation**
  * Added LocalVQE setup, packaging, signing, fallback, and diagnostics guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
