### PR TITLE
Use stable system-audio aggregate UID with unique-UID fallback

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CoreAudioSystemRecorder.swift
@@ -196,10 +196,33 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         // The tap list must contain dictionaries with UID strings — NOT
         // CATapDescription objects (passing objects crashes CoreAudio).
         let tapUIDString = tapDesc.uuid.uuidString
-        let aggUID = "com.muesli.system-audio-tap-\(UUID().uuidString)"
-        let aggDesc = Self.makeAggregateDeviceDescription(tapUID: tapUIDString, aggregateUID: aggUID)
+        // Stable aggregate UID: one identity across all sessions, so an
+        // unclean stop can never accumulate fresh HAL settings entries.
+        // The daemon enforces UID uniqueness globally, so if a phantom from a
+        // crashed session still holds the stable UID (or another Muesli
+        // instance is recording), creation fails with 'nope' — in that case we
+        // retry once with a single deterministic fallback UID. The fallback is
+        // deliberately NOT a fresh UUID: private aggregate devices are
+        // invisible to every enumeration/lookup API, so no cleanup sweep can
+        // ever find them, and a per-attempt UUID would let repeated crashes in
+        // the collision state accumulate permanent HAL settings entries — the
+        // exact failure this change exists to remove. Bounding identity count
+        // to two caps worst-case permanent leakage at two keys. A refusal on
+        // either UID is a phantom signal, so log it loudly.
+        var aggUID = "com.muesli.system-audio-tap"
+        var aggDesc = Self.makeAggregateDeviceDescription(tapUID: tapUIDString, aggregateUID: aggUID)
 
         status = AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggregateDeviceID)
+        if status != noErr || aggregateDeviceID == kAudioObjectUnknown {
+            fputs("[system-audio] aggregate creation with stable UID failed (status=\(status)); a phantom or concurrent session may hold it — retrying with fallback UID\n", stderr)
+            aggUID = "com.muesli.system-audio-tap-fallback"
+            aggDesc = Self.makeAggregateDeviceDescription(tapUID: tapUIDString, aggregateUID: aggUID)
+            aggregateDeviceID = kAudioObjectUnknown
+            status = AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggregateDeviceID)
+            if status != noErr || aggregateDeviceID == kAudioObjectUnknown {
+                fputs("[system-audio] aggregate creation failed with fallback UID too (status=\(status)); stable+fallback UIDs both held by phantoms or concurrent sessions — restart coreaudiod (sudo killall coreaudiod) or reboot to clear\n", stderr)
+            }
+        }
         guard status == noErr, aggregateDeviceID != kAudioObjectUnknown else {
             AudioHardwareDestroyProcessTap(tapID)
             tapID = kAudioObjectUnknown
@@ -793,19 +816,31 @@ final class CoreAudioSystemRecorder: SystemAudioCapturing, SystemAudioDiagnostic
         resamplerOutputFormat = nil
 
         if let procID = deviceIOProcID, aggregateDeviceID != kAudioObjectUnknown {
-            AudioDeviceStop(aggregateDeviceID, procID)
-            AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
+            let stopStatus = AudioDeviceStop(aggregateDeviceID, procID)
+            let destroyProcStatus = AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
+            if stopStatus != noErr || destroyProcStatus != noErr {
+                fputs("[system-audio] teardown: IO stop/destroy failed on device \(aggregateDeviceID) (stop=\(stopStatus), destroyProc=\(destroyProcStatus))\n", stderr)
+            }
         }
         deviceIOProcID = nil
         deviceIOBlock = nil
 
         if aggregateDeviceID != kAudioObjectUnknown {
-            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            // A failure here previously went silent: we would drop the ID and
+            // lose any chance to retry, leaving the object for the daemon to
+            // reclaim (or not). Log loudly so field diagnostics can see it.
+            let destroyStatus = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            if destroyStatus != noErr {
+                fputs("[system-audio] teardown: FAILED to destroy aggregate device \(aggregateDeviceID) (status=\(destroyStatus))\n", stderr)
+            }
             aggregateDeviceID = kAudioObjectUnknown
         }
 
         if tapID != kAudioObjectUnknown {
-            AudioHardwareDestroyProcessTap(tapID)
+            let destroyTapStatus = AudioHardwareDestroyProcessTap(tapID)
+            if destroyTapStatus != noErr {
+                fputs("[system-audio] teardown: FAILED to destroy process tap \(tapID) (status=\(destroyTapStatus))\n", stderr)
+            }
             tapID = kAudioObjectUnknown
         }
     }


### PR DESCRIPTION
## Why

Every meeting session creates its CoreAudio aggregate device with a freshly generated UUID in its UID (`com.muesli.system-audio-tap-<UUID>`). Local investigation (Context/handoff-2026-08-06-coreaudio-route-investigation.md + Context/handoff-2026-08-08-coreaudio-phantom-stable-uid-prs.md) showed:

- If the process dies inside the aggregate-registration window (~10ms), coreaudiod completes registration server-side and leaves a **phantom aggregate with no owner** (reproduced 3/3 on an aged daemon).
- Each phantom leaves a **permanent HAL settings key**; healthy sessions write-then-delete theirs. Fresh-UUID-per-session means every such accident accumulates forever.
- Phantoms are invisible to all client-side enumeration/lookup APIs, so `cleanupStaleDevices()` (name-based enumeration at launch) **cannot see or remove them** — relaunch is not a reliable workaround for this class, and no sweep-based cleanup is implementable for private devices.

## What changes

- Aggregate UID is now a single stable identity: `com.muesli.system-audio-tap`. Sessions overwrite one settings entry instead of creating a new one; accumulation becomes impossible.
- The daemon enforces UID uniqueness globally (verified: duplicate create fails with `'nope'`). If the stable UID is held — by a phantom from a crashed session or a concurrent instance — we retry once with a **single deterministic fallback UID** (`com.muesli.system-audio-tap-fallback`). The fallback is deliberately bounded: a per-attempt UUID would reintroduce unbounded key accumulation in precisely the collision/crash state this PR targets (Greptile P1 on the first revision), and no cleanup path exists for private devices. Worst case is two permanent keys, ever.
- If both UIDs are held (double-phantom requires two independent mid-registration crashes), recording fails with an actionable log line (restart coreaudiod / reboot) instead of silently degrading into the failure mode being fixed.
- Refusals are logged loudly — a 'nope' on the stable UID is itself a field-detectable phantom signal.
- Teardown paths now **log `OSStatus` failures** (previously discarded silently, losing both visibility and the object ID).

## Validation (local, macOS 26.5.2)

- Stable key written at meeting start and deleted at stop (verified against the live HAL settings store).
- Full pipeline intact: mic + system audio + transcription on the stable-UID build.
- Duplicate-UID creation semantics verified directly against the daemon: safe refusal ('nope'), no corruption.
- Full SwiftPM suite: 1523/1523 passing (one unrelated flake observed once, green on reruns).

## Honest scope note

This is lifecycle hardening against a demonstrated phantom/accumulation defect. It is **not** claimed as the proven root-cause fix for the reported multi-day `coreaudiod` settings loop, which was never reproduced locally; the stable UID strictly bounds its worst-case settings-store impact, and the refusal log lines give us field-detectable phantom signals.

## Contribution Certification

- [x] I certify that this contribution is my original work and I have the right to submit it under the project's license.

## Third-Party Materials

None — no third-party code, libraries, or assets added.

## AI Assistance

This change was developed with AI assistance (OpenAI Codex): failure-mode investigation, harness design, and implementation. All daemon-behavior claims were validated by direct local experiment on macOS 26.5.2 (see Context handoffs referenced above).