### PR TITLE
Keep dictation capture graph persistent; eliminate idle route-change churn

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppScopedDictationRecorder.swift
@@ -280,9 +280,12 @@ final class AppScopedDictationRecorder: DictationAudioRecording {
         lifecycleGeneration &+= 1
         lock.unlock()
         return recorderQueue.sync {
-            let url = recorder.stop()
-            recorder.cancel()
-            return url
+            // Stop IO and finalize the WAV, but keep the prepared capture
+            // graph alive: AudioQueueInputRecorder.stop() retains the queue,
+            // so the next start() is AudioQueueStart on the existing graph
+            // instead of a full rebuild. The graph is only torn down on
+            // cancel() (proven failure / explicit invalidation).
+            recorder.stop()
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -260,7 +260,8 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         emitLatency("audio_queue_prepare_end")
     }
 
-    private func applyPreferredInputDeviceID(_ deviceID: AudioObjectID, to queue: AudioQueueRef) throws {        emitLatency("audio_queue_device_uid_lookup_begin")
+    private func applyPreferredInputDeviceID(_ deviceID: AudioObjectID, to queue: AudioQueueRef) throws {
+        emitLatency("audio_queue_device_uid_lookup_begin")
         guard var deviceUID = Self.deviceUID(for: deviceID) as CFString? else {
             throw Self.runtimeError(code: 6, message: "Could not resolve device UID for \(deviceID)")
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -186,6 +186,12 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     }
 
     private func prepareLocked() throws {
+        // Reuse is safe for the default route too: a queue prepared without an
+        // explicit device reports kAudioQueueProperty_CurrentDevice =
+        // "AQDefaultDevice", i.e. it follows the system default input at start
+        // time. Explicit-device queues are bound to a fixed UID; if that device
+        // disappears, AudioQueueStart fails and the caller's failure path
+        // disposes + rebuilds. Neither case needs eager rebuild here.
         if isPrepared, preparedInputDeviceID == preferredInputDeviceID {
             emitLatency("audio_queue_prepare_reused")
             return
@@ -254,8 +260,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         emitLatency("audio_queue_prepare_end")
     }
 
-    private func applyPreferredInputDeviceID(_ deviceID: AudioObjectID, to queue: AudioQueueRef) throws {
-        emitLatency("audio_queue_device_uid_lookup_begin")
+    private func applyPreferredInputDeviceID(_ deviceID: AudioObjectID, to queue: AudioQueueRef) throws {        emitLatency("audio_queue_device_uid_lookup_begin")
         guard var deviceUID = Self.deviceUID(for: deviceID) as CFString? else {
             throw Self.runtimeError(code: 6, message: "Could not resolve device UID for \(deviceID)")
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAudioSessionManager.swift
@@ -449,17 +449,29 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
         routeSnapshot = makeRouteSnapshot(refreshInput: false)
         emitLatency("route_refresh:\(intent.debugName) \(routeSnapshot.debugDescription)")
+        if intent == .idlePrewarm(.routeChange) {
+            // Persistent-graph policy: route changes are telemetry-only. The
+            // warm capture graph is bound to a fixed input device and is
+            // indifferent to output-route churn, so there is nothing to
+            // rebuild here. Rebuilds happen only at start() after a proven
+            // failure or a device-selection change.
+            emitLatency("route_refresh_ignored:\(intent.debugName)")
+            return
+        }
         guard stateStorage == .idle, !externalSessionActive else { return }
-        if let skipReason = idleWarmupSkipReason(route: routeSnapshot, canWarmUp: canWarmUp) {
-            recorder.keepsAudioGraphWarm = false
-            recorder.coolDown()
+        if let skipReason = idleWarmupSkipReason(
+            route: routeSnapshot,
+            canWarmUp: canWarmUp
+        ) {
             emitLatency("warmup_skipped:\(intent.debugName):\(skipReason)")
             fputs("[dictation-session] warmup skipped intent=\(intent.debugName) reason=\(skipReason) \(routeSnapshot.debugDescription)\n", stderr)
             return
         }
         recorder.keepsAudioGraphWarm = true
-        recorder.coolDown()
         do {
+            // No coolDown before warming: warmUp() is idempotent per bound
+            // device, so an already-warm graph is reused. Disposal stays
+            // reserved for proven failure / explicit cancellation paths.
             emitLatency("engine_prepare_begin:warmup:\(intent.debugName)")
             try recorder.warmUp(preferredInputDeviceID: routeSnapshot.preferredInputDeviceID)
             emitLatency("engine_prepare_end:warmup:\(intent.debugName)")
@@ -470,7 +482,10 @@ final class DictationAudioSessionManager: @unchecked Sendable {
         }
     }
 
-    private func idleWarmupSkipReason(route: RouteSnapshot, canWarmUp: Bool) -> String? {
+    private func idleWarmupSkipReason(
+        route: RouteSnapshot,
+        canWarmUp: Bool
+    ) -> String? {
         guard canWarmUp else { return "not_allowed" }
         switch route.routeKind {
         case .speakerLike:

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -121,11 +121,9 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         lifecycleQueue.sync {
             lock.lock()
             let activeRecorder = activeRecorderLocked()
-            let inactiveRecorder = inactiveRecorderLocked()
             lock.unlock()
-            let url = activeRecorder.stop()
-            inactiveRecorder.cancel()
-            return url
+            // Keep both slot graphs warm across dictations; only IO stops.
+            return activeRecorder.stop()
         }
     }
 
@@ -184,17 +182,17 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
     private func selectRecorder(preferredInputDeviceID: AudioObjectID?) -> DictationAudioRecording {
         lock.lock()
         let nextKind: ActiveRecorderKind = preferredInputDeviceID == nil ? .systemDefault : .appScoped
-        let inactiveRecorderToCancel = nextKind == activeRecorderKindStorage ? nil : activeRecorderLocked()
         preferredInputDeviceIDStorage = preferredInputDeviceID
         activeRecorderKindStorage = nextKind
         let selectedRecorder = activeRecorderLocked()
         let keepsAudioGraphWarm = keepsAudioGraphWarmStorage
         lock.unlock()
 
+        // The previously active slot is intentionally left warm: its prepared
+        // graph stays valid for its bound device and costs nothing while idle.
         selectedRecorder.preferredInputDeviceID = preferredInputDeviceID
         selectedRecorder.keepsAudioGraphWarm = keepsAudioGraphWarm
         emitRecorderSelection(kind: nextKind, recorder: selectedRecorder, preferredInputDeviceID: preferredInputDeviceID)
-        inactiveRecorderToCancel?.cancel()
         return selectedRecorder
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RouteAwareDictationRecorder.swift
@@ -213,25 +213,12 @@ final class RouteAwareDictationRecorder: DictationAudioRecording {
         recorder(for: activeRecorderKindStorage)
     }
 
-    private func inactiveRecorderLocked() -> DictationAudioRecording {
-        inactiveRecorder(for: activeRecorderKindStorage)
-    }
-
     private func recorder(for kind: ActiveRecorderKind) -> DictationAudioRecording {
         switch kind {
         case .systemDefault:
             return systemDefaultRecorder
         case .appScoped:
             return appScopedRecorder
-        }
-    }
-
-    private func inactiveRecorder(for kind: ActiveRecorderKind) -> DictationAudioRecording {
-        switch kind {
-        case .systemDefault:
-            return appScopedRecorder
-        case .appScoped:
-            return systemDefaultRecorder
         }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppScopedDictationRecorderTests.swift
@@ -124,8 +124,8 @@ struct AppScopedDictationRecorderTests {
         #expect(streamingRecorder.preparedInputDeviceIDs == [82, 82])
     }
 
-    @Test("stop tears down child recorder graph after finalizing recording")
-    func stopTearsDownChildRecorderGraphAfterFinalizingRecording() throws {
+    @Test("stop finalizes recording and keeps the child graph warm")
+    func stopKeepsChildRecorderGraphWarm() throws {
         let streamingRecorder = FakeStreamingRecorder()
         let recorder = AppScopedDictationRecorder(
             recorder: streamingRecorder,
@@ -137,7 +137,7 @@ struct AppScopedDictationRecorderTests {
 
         #expect(streamingRecorder.startCalls == 1)
         #expect(streamingRecorder.stopCalls == 1)
-        #expect(streamingRecorder.cancelCalls == 1)
+        #expect(streamingRecorder.cancelCalls == 0)
     }
 
     @Test("cool down clears explicit preparation so next arm re-warms")

--- a/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAudioSessionManagerTests.swift
@@ -24,7 +24,7 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .speakerLike)
         harness.recorder.warmUpDelay = 0.2
 
-        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.startup), canWarmUp: true)
         let startedAt = Date()
         harness.manager.arm(source: "hotkey")
         let elapsed = Date().timeIntervalSince(startedAt)
@@ -277,18 +277,38 @@ struct DictationAudioSessionManagerTests {
         })
     }
 
-    @Test("speaker route refresh warms graph without opening mic")
-    func speakerRouteRefreshWarmsGraphWithoutOpeningMic() {
+    @Test("speaker startup refresh warms graph without opening mic")
+    func speakerStartupRefreshWarmsGraphWithoutOpeningMic() {
+        let harness = Harness(routeKind: .speakerLike)
+
+        harness.manager.refreshRoute(intent: .idlePrewarm(.startup), canWarmUp: true)
+        harness.wait()
+
+        #expect(harness.route.refreshCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
+        #expect(harness.recorder.warmUpCalls == 1)
+        #expect(harness.recorder.startCalls == 0)
+        #expect(harness.recorder.activateCalls == 0)
+    }
+
+    @Test("route change refresh does not touch the audio graph")
+    func routeChangeRefreshDoesNotTouchAudioGraph() {
         let harness = Harness(routeKind: .speakerLike)
 
         harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 1)
-        #expect(harness.recorder.warmUpCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
+        #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)
+        #expect(harness.events.contains { event in
+            if case .latency(let name, _) = event {
+                return name == "route_refresh_ignored:idle_routeChange"
+            }
+            return false
+        })
     }
 
     @Test("speaker route skips idle warmup when default input is not built in")
@@ -296,18 +316,18 @@ struct DictationAudioSessionManagerTests {
         let harness = Harness(routeKind: .speakerLike)
         harness.route.systemDefaultInputIsBuiltIn = false
 
-        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.startup), canWarmUp: true)
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)
         #expect(!harness.recorder.keepsAudioGraphWarm)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "warmup_skipped:idle_routeChange:risky_default_input"
+                return name == "warmup_skipped:idle_startup:risky_default_input"
             }
             return false
         })
@@ -356,18 +376,18 @@ struct DictationAudioSessionManagerTests {
     func headphoneRouteRefreshSkipsIdleMicWarmup() {
         let harness = Harness(routeKind: .headphoneLike, preferredInputDeviceID: 82)
 
-        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.startup), canWarmUp: true)
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)
         #expect(!harness.recorder.keepsAudioGraphWarm)
         #expect(harness.events.contains { event in
             if case .latency(let name, _) = event {
-                return name == "warmup_skipped:idle_routeChange:risky_route"
+                return name == "warmup_skipped:idle_startup:risky_route"
             }
             return false
         })
@@ -377,11 +397,11 @@ struct DictationAudioSessionManagerTests {
     func unknownRouteRefreshSkipsIdleMicWarmup() {
         let harness = Harness(routeKind: .unknown)
 
-        harness.manager.refreshRoute(intent: .idlePrewarm(.routeChange), canWarmUp: true)
+        harness.manager.refreshRoute(intent: .idlePrewarm(.startup), canWarmUp: true)
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)
@@ -396,7 +416,7 @@ struct DictationAudioSessionManagerTests {
         harness.wait()
 
         #expect(harness.route.refreshCalls == 1)
-        #expect(harness.recorder.coolDownCalls == 1)
+        #expect(harness.recorder.coolDownCalls == 0)
         #expect(harness.recorder.warmUpCalls == 0)
         #expect(harness.recorder.startCalls == 0)
         #expect(harness.recorder.activateCalls == 0)

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareDictationRecorderTests.swift
@@ -140,8 +140,8 @@ struct RouteAwareDictationRecorderTests {
         ])
     }
 
-    @Test("switching recorder cancels inactive warmed graph")
-    func switchingRecorderCancelsInactiveWarmedGraph() throws {
+    @Test("switching recorder keeps the inactive graph warm")
+    func switchingRecorderKeepsInactiveGraphWarm() throws {
         let system = FakeRouteAwareChildRecorder()
         let appScoped = FakeRouteAwareChildRecorder()
         let recorder = RouteAwareDictationRecorder(systemDefaultRecorder: system, appScopedRecorder: appScoped)
@@ -151,7 +151,7 @@ struct RouteAwareDictationRecorderTests {
 
         #expect(recorder.activeRecorderKindForDebug() == .appScoped)
         #expect(system.warmUpCalls == 1)
-        #expect(system.cancelCalls == 1)
+        #expect(system.cancelCalls == 0)
         #expect(appScoped.activateCalls == 1)
     }
 
@@ -167,8 +167,8 @@ struct RouteAwareDictationRecorderTests {
         #expect(appScoped.coolDownCalls == 1)
     }
 
-    @Test("route switch waits for in-flight app scoped explicit warmup teardown")
-    func routeSwitchWaitsForInFlightAppScopedExplicitWarmupTeardown() throws {
+    @Test("route switch does not tear down in-flight app scoped explicit warmup")
+    func routeSwitchDoesNotTearDownInFlightAppScopedExplicitWarmup() throws {
         let system = FakeRouteAwareChildRecorder()
         let appScopedStreaming = FakeRouteAwareStreamingRecorder()
         let prepareStarted = DispatchSemaphore(value: 0)
@@ -192,14 +192,15 @@ struct RouteAwareDictationRecorderTests {
             routeSwitchReturned.signal()
         }
 
-        #expect(routeSwitchReturned.wait(timeout: .now() + 0.1) == .timedOut)
+        // The switch no longer cancels the outgoing slot's in-flight prepare,
+        // so it returns promptly instead of waiting for teardown.
+        #expect(routeSwitchReturned.wait(timeout: .now() + 0.5) == .success)
         finishPrepare.signal()
-        #expect(routeSwitchReturned.wait(timeout: .now() + 1) == .success)
 
         #expect(recorder.activeRecorderKindForDebug() == .systemDefault)
         #expect(system.warmUpCalls == 1)
         #expect(appScopedStreaming.prepareCalls == 1)
-        #expect(appScopedStreaming.cancelCalls >= 1)
+        #expect(appScopedStreaming.cancelCalls == 0)
     }
 }
 


### PR DESCRIPTION
## Why

Two problems share one root cause — Muesli tore down and rebuilt the dictation capture graph on every audio route change and after every dictation:

1. **Idle coreaudiod churn**: with no meeting/dictation active, each AirPods connect/disconnect caused duplicate AudioQueue teardown/rebuild cycles and daemon CPU bursts (measured up to 175–193% transient, ~2× baseline median in A/B), with all work attributed to an idle Muesli — the only Muesli-owned CoreAudio activity matching field reports of daemon load while idle.
2. **Hotkey latency**: rebuilding the graph on route events and after every dictation put graph construction back into the hot path.

Reference architecture validated on this machine: Other apps keep pre-created daemon-side IO contexts alive indefinitely and only starts/stops IO per dictation (~65ms hotkey→mic, zero work on route notifications, verified via coreaudiod unified logs across dictations and an AirPods case→out transition). Our AudioQueueInputRecorder already had the right two-phase shape — the teardown was policy, not necessity.

## What changes (persistent-graph lifecycle)

- **`AppScopedDictationRecorder.stop()`** no longer cancels the child recorder. `AudioQueueInputRecorder.stop()` already retains the prepared queue, so the next dictation is `AudioQueueStart` on the existing graph — no rebuild.
- **`RouteAwareDictationRecorder`** keeps both slot graphs warm across `stop()` and slot switches (previously cancelled the inactive slot).
- **`DictationAudioSessionManager`** treats idle route-change refreshes as telemetry-only — no coolDown, no re-warm. The capture graph binds to a fixed input device and is indifferent to output-route churn.
- **Default-route reuse is safe without any rebind logic**: a queue prepared without an explicit device reports `kAudioQueueProperty_CurrentDevice = AQDefaultDevice` and follows the system default input at each `AudioQueueStart` — verified empirically (probe: same queue, default input flipped built-in→BlackHole between starts; coreaudiod logs show the restart capturing from BlackHole). Explicit-device queues bind by UID; a disappeared device fails at `AudioQueueStart` and the existing failure path disposes + rebuilds.

**Rebuilds now happen only on proven failure** (start error → existing fallback recorder, no-audio timeout, explicit cancel) **or device-selection change.** Startup warmup and arm-time activation are unchanged.

## Validation

- 60/60 focused dictation tests updated to the new lifecycle contract; full suite 1524/1524 green.
- Live transition matrix on a dev lane (macOS 26.5.2): repeat dictations reuse the warm graph (`audio_queue_prepare_reused`, no `new_input` outside selection changes); AirPods connect with warm graph → zero churn, 32ms start; explicit AirPods-mic selection → one rebuild on selection change (expected), BT HFP start tax ~500-600ms (daemon-side, not graph); AirPods cased with explicit selection → graceful resolve to warm built-in graph, 78ms start; reconnect → one cheap rebuild, then reuse.
- Mic activation now ~32-78ms on built-in routes (parity with Willow's measured ~65ms).

## Contribution Certification

- [x] I certify that this contribution is my original work and I have the right to submit it under the project's license.

## Third-Party Materials

None — no third-party code, libraries, or assets added. (Willow Voice was observed externally via its daemon telemetry as a reference architecture; no code or assets were taken from it.)

## AI Assistance

This change was developed with AI assistance (OpenAI Codex): comparative architecture analysis and implementation. CoreAudio lifecycle claims were validated by direct local experiment on macOS 26.5.2.