### PR TITLE
fix: keep auto-stop armed when a finished meeting is resumed

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingResumePolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingResumePolicy.swift
@@ -31,4 +31,22 @@ enum MeetingResumePolicy {
     static func hasNewTranscriptContent(prior: String, new: String) -> Bool {
         combinedResumeTranscript(prior: prior, new: new) != prior
     }
+
+    /// The start origin a resumed meeting should be re-armed with.
+    ///
+    /// Resume reopens the *same* meeting row, so it should keep behaving like the
+    /// meeting it is. Hardcoding `.manual` here silently discarded auto-stop:
+    /// a recording armed from a detection prompt or a calendar event became
+    /// unstoppable the moment the user resumed it, and ran until stopped by hand.
+    ///
+    /// `recordedOrigin` is nil when the original start is not known — the meeting
+    /// was started in an earlier app session, so nothing in memory records how it
+    /// began. Falling back to `.manual` there preserves the previous behaviour for
+    /// exactly the case where inheriting is not possible, and never re-arms a
+    /// recording against a meeting this process never observed starting.
+    static func resumedStartOrigin(
+        recordedOrigin: MeetingRecordingStartOrigin?
+    ) -> MeetingRecordingStartOrigin {
+        recordedOrigin ?? .manual
+    }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -431,6 +431,12 @@ final class MuesliController: NSObject {
     /// Present only while a resume is in flight; consumed at stop to merge old + new
     /// transcript, and cleared on success or restored-on-failure.
     private var pendingResumePriorTranscript: [Int64: String] = [:]
+    /// How each meeting recorded in this app session was started, keyed by meeting id.
+    /// Resuming a finished meeting reads this so the reopened recording keeps the
+    /// auto-stop behaviour it was armed with instead of degrading to `.manual`.
+    /// In-memory only: meetings started before the current launch are absent, and
+    /// `MeetingResumePolicy.resumedStartOrigin` falls back to `.manual` for those.
+    private var meetingStartOrigins: [Int64: MeetingRecordingStartOrigin] = [:]
     private var iCloudSyncTask: Task<Void, Never>?
     private var ckSyncEngine: MuesliCKSyncEngine?
     private var ckSyncEngineCancellationTask: Task<Void, Never>?
@@ -4845,6 +4851,7 @@ final class MuesliController: NSObject {
             )
             activeMeetingID = meetingID
             activeMeetingAudioWarning = nil
+            meetingStartOrigins[meetingID] = startOrigin
             syncAppState()
             if openDocument {
                 showMeetingDocument(id: meetingID)
@@ -5016,12 +5023,18 @@ final class MuesliController: NSObject {
         activeMeetingAudioWarning = nil
         syncAppState()
 
+        // Resume reopens the same row, so it inherits how that meeting was
+        // started rather than degrading to `.manual` and losing auto-stop.
+        let resumedOrigin = MeetingResumePolicy.resumedStartOrigin(
+            recordedOrigin: meetingStartOrigins[meetingID]
+        )
+        meetingStartOrigins[meetingID] = resumedOrigin
         armMeetingAutoStop(
-            source: MeetingRecordingStartOrigin.manual.signalLossSource(
+            source: resumedOrigin.signalLossSource(
                 explicitSource: nil,
                 recentSource: recentMeetingAutoStopSource()
             ),
-            response: MeetingRecordingStartOrigin.manual.signalLossResponse
+            response: resumedOrigin.signalLossResponse
         )
         isStartingMeetingRecording = true
         cancelDictationAudioSessionForMeetingRecordingIfNeeded()

--- a/native/MuesliNative/Tests/MuesliTests/MeetingResumePolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingResumePolicyTests.swift
@@ -94,4 +94,50 @@ struct MeetingResumePolicyTests {
         #expect(overridden.durationSeconds == 45)
         #expect(overridden.rawTranscript == "z")
     }
+
+    @Test("a resumed meeting inherits the origin it was started with")
+    func resumeInheritsRecordedOrigin() {
+        for origin in [
+            MeetingRecordingStartOrigin.detectedPrompt,
+            .calendarAutoRecord,
+            .scheduledMeetingPrompt,
+            .joinAndRecord,
+            .manual,
+        ] {
+            #expect(MeetingResumePolicy.resumedStartOrigin(recordedOrigin: origin) == origin)
+        }
+    }
+
+    @Test("resuming an auto-armed meeting keeps auto-stop armed")
+    func resumeKeepsAutoStopArmed() {
+        // The defect this guards: resume hardcoded `.manual`, so a recording armed
+        // from a detection prompt came back unstoppable and ran until stopped by hand.
+        for origin in [
+            MeetingRecordingStartOrigin.detectedPrompt,
+            .calendarAutoRecord,
+            .scheduledMeetingPrompt,
+            .joinAndRecord,
+        ] {
+            let resumed = MeetingResumePolicy.resumedStartOrigin(recordedOrigin: origin)
+            #expect(resumed.enablesMeetingAutoStop)
+            #expect(resumed.signalLossResponse == .autoStopAfterWarning)
+        }
+    }
+
+    @Test("resuming a manually started meeting stays manual")
+    func resumeManualStaysManual() {
+        let resumed = MeetingResumePolicy.resumedStartOrigin(recordedOrigin: .manual)
+
+        #expect(!resumed.enablesMeetingAutoStop)
+        #expect(resumed.signalLossResponse == .none)
+    }
+
+    @Test("an unknown origin falls back to manual so resume never arms blind")
+    func resumeUnknownOriginFallsBackToManual() {
+        // Meetings started before this app launch have no recorded origin.
+        let resumed = MeetingResumePolicy.resumedStartOrigin(recordedOrigin: nil)
+
+        #expect(resumed == .manual)
+        #expect(!resumed.enablesMeetingAutoStop)
+    }
 }


### PR DESCRIPTION
## Summary

`resumeFinishedMeeting` armed the auto-stop tracker with a hardcoded
`MeetingRecordingStartOrigin.manual`. That origin has
`enablesMeetingAutoStop == false`, so `signalLossSource` returns `nil` and
`signalLossResponse` is `.none` — resuming silently discarded auto-stop.

A recording armed from a detection prompt, calendar auto-record, scheduled
prompt, or Join & Record therefore came back unstoppable and ran until stopped
by hand.

Observed in a live session on 2026-08-08:

```
10:13:48  Zoom call ends — audio process drops to in=0 out=0
10:14:22  auto-stop fires correctly, meeting finalised (387s, status 'completed')
10:14:35  Resume clicked — status forced back to 'recording'
10:14:36  mic reacquired; recording continues for a further ~15 minutes
```

Auto-stop was working. Resume dropped it.

A second reproduction on 2026-08-10, this time with per-process CoreAudio
sampling running throughout, so the call's own state is recorded rather than
inferred. Recording started from a "Join & Record" notification:

```
22:01:03  Zoom   in=0 out=0 -> in=1 out=1   call joined
22:04:31  Muesli in=0       -> in=1         recording starts
22:05:55  Muesli in=1       -> in=0         torn down 84s in, while Zoom held in=1 out=1
22:06:01  Muesli in=0       -> in=1         resumed by hand, call still live
23:07:42  Zoom   in=1 out=1 -> in=0 out=0   call actually ends
23:20:09  ...                               recording finally stopped, 12.5 min later
```

Meeting row: 4534s, 17800 words, `meeting_status 'completed'`.

Zoom held `in=1 out=1` continuously from 22:01:03 to 23:07:42 — not one
transition. The teardown at 84s happened while the call was plainly still
there, and the 12.5 minutes at the end were recorded into an empty room.

This is the resume-during-a-live-call case, which is the one this PR fixes: at
22:06:01 the call was still running, so `recentMeetingAutoStopSource()` would
have found a candidate inside its 15s window and re-armed. Whether the
re-armed recording then survived to 23:07:42 is a separate question that
belongs to #375 — the source would be candidate-derived, so it depends on the
dedicated-app arm holding across session rotation. The two changes compose;
neither alone covers this timeline.

Resume reopens the *same* meeting row, so it now inherits the origin that row
was started with. `MeetingResumePolicy.resumedStartOrigin` makes the decision
explicit and testable; `MuesliController` records each start origin against its
meeting id and reads it back on resume.

### Scope — what this does and does not fix

Restoring the origin selects the intended *response*, but arming also needs a
*source*. `armMeetingAutoStop` sets the response to `.none` when the source is
nil, and `MeetingAutoStopTracker.isArmed` is `source != nil`. So the two resume
cases differ:

- **Resume while the call is still live** — the common case, where the user
  resumes because they disagreed with the stop. `handleMeetingActivityCandidate`
  keeps repopulating `latestMeetingActivityCandidate` while unarmed and not
  recording, so `recentMeetingAutoStopSource()` finds a source inside its 15s
  window and auto-stop re-arms. **This PR fixes this case.**
- **Resume after the call has ended** — no candidate is observed, the source is
  nil, and the recording stays unarmed until stopped by hand. **This PR does not
  change this case.**

The 2026-08-08 incident above was the second case: the call ended at 10:13:48
and resume happened at 10:14:35, after it was over. This PR would not have
prevented that recording. Credit to Greptile's review for catching that the
original description of this PR overstated its reach.

Closing the second case needs a mechanism that does not exist yet — auto-stop
has no source to track when no call is in progress, so it would mean stopping on
the *absence* of a candidate after a grace window rather than on the
disappearance of a known one. That is a behaviour change with its own failure
modes and belongs in #391, not smuggled into this PR.

A second limitation: the origin record is in-memory, so a meeting started before
the current app launch has no known origin and falls back to `.manual`. Resume
is deliberately age-independent, so this gap is not rare.

## Validation

- `swift test --package-path native/MuesliNative` — 1546 tests in 150 suites,
  passing. One run flagged `ConfigStore`
  ("saved config uses owner-only file permissions"); it passes in isolation both
  with and without this change and did not recur on re-run, so it looks like
  parallel-execution interference rather than a regression from this change.
- Mutation-verified: forcing `resumedStartOrigin` back to `.manual` fails
  "resuming an auto-armed meeting keeps auto-stop armed" and
  "a resumed meeting inherits the origin it was started with", while the manual
  and unknown-origin negative controls keep passing.
- `MeetingResumePolicyTests` is already assigned to a real CI shard
  (`scripts/run_ci_test_shard.sh`), so the new tests run in required CI.

Not covered by tests: the wiring in `resumeFinishedMeeting` itself.
`MuesliController` is a large `@MainActor` class with no existing unit-test
seam, so the tests cover the policy decision rather than the call site. The call
site was verified by reading the diff, not by an automated test.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

Claude Code (Anthropic) was used materially: it diagnosed the defect from live
CoreAudio process sampling and the local meeting database, wrote the change and
its tests, and ran the test suite and mutation check. The change and the test
results were reviewed before submission.

