### PR TITLE
feat: optionally require a join link for calendar meeting detection

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -999,6 +999,11 @@ struct AppConfig: Codable {
     var showScheduledMeetingNotifications: Bool = true
     var scheduledMeetingNotificationLeadTime: ScheduledMeetingNotificationLeadTime = .atStart
     var showMeetingDetectionNotification: Bool = true
+    /// Only treat a calendar entry as a meeting when it carries a join link.
+    /// Off by default: link-less entries are still real meetings for people who
+    /// dial in or meet in person. On, it stops reminders and placeholders from
+    /// being detected as meetings at all.
+    var requireCalendarMeetingLink: Bool = false
     var mutedMeetingDetectionAppBundleIDs: [String] = []
     var meetingRecordingSavePolicy: MeetingRecordingSavePolicy = .never
     var meetingRecordingFileFormat: String = MeetingRecordingFileFormat.m4a.rawValue
@@ -1119,6 +1124,7 @@ struct AppConfig: Codable {
         case showScheduledMeetingNotifications = "show_scheduled_meeting_notifications"
         case scheduledMeetingNotificationLeadTime = "scheduled_meeting_notification_lead_time"
         case showMeetingDetectionNotification = "show_meeting_detection_notification"
+        case requireCalendarMeetingLink = "require_calendar_meeting_link"
         case mutedMeetingDetectionAppBundleIDs = "muted_meeting_detection_app_bundle_ids"
         case meetingRecordingSavePolicy = "meeting_recording_save_policy"
         case meetingRecordingFileFormat = "meeting_recording_file_format"
@@ -1257,6 +1263,7 @@ struct AppConfig: Codable {
             (try? c.decode(ScheduledMeetingNotificationLeadTime.self, forKey: .scheduledMeetingNotificationLeadTime))
             ?? defaults.scheduledMeetingNotificationLeadTime
         showMeetingDetectionNotification = decodedShowMeetingDetectionNotification ?? defaults.showMeetingDetectionNotification
+        requireCalendarMeetingLink = (try? c.decode(Bool.self, forKey: .requireCalendarMeetingLink)) ?? defaults.requireCalendarMeetingLink
         mutedMeetingDetectionAppBundleIDs = (try? c.decode([String].self, forKey: .mutedMeetingDetectionAppBundleIDs)) ?? defaults.mutedMeetingDetectionAppBundleIDs
         meetingRecordingSavePolicy = (try? c.decode(MeetingRecordingSavePolicy.self, forKey: .meetingRecordingSavePolicy)) ?? defaults.meetingRecordingSavePolicy
         let decodedMeetingRecordingFileFormat = (try? c.decode(String.self, forKey: .meetingRecordingFileFormat))

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2739,7 +2739,10 @@ final class MuesliController: NSObject {
     }
 
     private func currentOrNearbyCachedCalendarEvent() -> CalendarEventContext? {
-        selectCurrentOrNearbyCachedCalendarEvent(from: appState.upcomingCalendarEvents)
+        selectCurrentOrNearbyCachedCalendarEvent(
+            from: appState.upcomingCalendarEvents,
+            requireMeetingLink: config.requireCalendarMeetingLink
+        )
     }
 
     private func startMeetingFeatureMonitors(includeMaraudersMap: Bool) {
@@ -8662,14 +8665,26 @@ final class MuesliController: NSObject {
     }
 }
 
+/// Picks the calendar event that meeting detection should attribute activity to.
+///
+/// `requireMeetingLink` reflects the `require_calendar_meeting_link` setting.
+/// Detection otherwise accepts any timed entry, so a reminder or a placeholder
+/// is indistinguishable from a real meeting — and once an event is in play,
+/// `MeetingCandidateResolver.resolve` attributes any media activity to it.
+/// Requiring a join link removes that whole class of false attribution, at the
+/// cost of no longer recognising link-less meetings: dial-in, phone, in person.
+/// That trade-off is the user's to make, which is why it is a setting and why
+/// it defaults to off.
 func selectCurrentOrNearbyCachedCalendarEvent(
     from events: [UnifiedCalendarEvent],
+    requireMeetingLink: Bool = false,
     now: Date = Date()
 ) -> CalendarEventContext? {
     let searchEnd = now.addingTimeInterval(5 * 60)
     let candidates = events
         .filter { event in
             !event.isAllDay && event.endDate > now && event.startDate < searchEnd
+                && (!requireMeetingLink || event.meetingURL != nil)
         }
         .sorted { $0.startDate < $1.startDate }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1433,6 +1433,15 @@ struct SettingsView: View {
                     Divider().background(MuesliTheme.surfaceBorder)
                     mutedMeetingDetectionAppsControl
                 }
+
+                Divider().background(MuesliTheme.surfaceBorder)
+
+                settingsRow("Only calendar events with a join link") {
+                    settingsSwitch(isOn: appState.config.requireCalendarMeetingLink) { newValue in
+                        controller.updateConfig { $0.requireCalendarMeetingLink = newValue }
+                    }
+                }
+                settingsDescription("Ignore calendar entries with no meeting link, so reminders and placeholders are not treated as meetings. Turn this off if you have meetings you dial into or attend in person.")
             }
 
             settingsSection("Calendars") {

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -319,6 +319,61 @@ struct GoogleCalendarTests {
         #expect(selected?.title == "Soon call")
     }
 
+    @Test("link-less events are selected by default")
+    func cachedDetectionSelectsLinklessEventByDefault() {
+        // Dial-in and in-person meetings are real meetings; the default must not
+        // stop recognising them.
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "dial-in", title: "Board call", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(from: events, now: now)
+        #expect(selected?.id == "dial-in")
+    }
+
+    @Test("requiring a join link skips events without one")
+    func cachedDetectionSkipsLinklessEventWhenLinkRequired() {
+        // A reminder or placeholder is otherwise indistinguishable from a
+        // meeting, and any media activity gets attributed to it.
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "placeholder", title: "Hold: write review", startDate: date("2026-04-10T09:55:00Z"), endDate: date("2026-04-10T10:20:00Z"), isAllDay: false, source: .eventKit),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(
+            from: events,
+            requireMeetingLink: true,
+            now: now
+        )
+        #expect(selected == nil)
+    }
+
+    @Test("requiring a join link still selects a linked event behind a placeholder")
+    func cachedDetectionPrefersLinkedEventWhenLinkRequired() {
+        let now = date("2026-04-10T10:02:00Z")
+        let events = [
+            UnifiedCalendarEvent(id: "placeholder", title: "Hold: focus time", startDate: date("2026-04-10T09:50:00Z"), endDate: date("2026-04-10T10:30:00Z"), isAllDay: false, source: .eventKit),
+            UnifiedCalendarEvent(
+                id: "real",
+                title: "Weekly sync",
+                startDate: date("2026-04-10T09:58:00Z"),
+                endDate: date("2026-04-10T10:25:00Z"),
+                isAllDay: false,
+                source: .googleCalendar,
+                meetingURL: URL(string: "https://zoom.us/j/1234567890")
+            ),
+        ]
+
+        let selected = selectCurrentOrNearbyCachedCalendarEvent(
+            from: events,
+            requireMeetingLink: true,
+            now: now
+        )
+        // The placeholder starts earlier and would otherwise win the sort.
+        #expect(selected?.id == "real")
+    }
+
     // MARK: - parseCalendarListEntry
 
     @Test("parses a calendarList entry with summary, primary flag, and color")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -817,6 +817,7 @@ struct AppConfigTests {
         config.showScheduledMeetingNotifications = false
         config.scheduledMeetingNotificationLeadTime = .threeMinutes
         config.showMeetingDetectionNotification = false
+        config.requireCalendarMeetingLink = true
         config.mutedMeetingDetectionAppBundleIDs = ["com.google.Chrome", "com.tinyspeck.slackmacgap"]
         config.computerUseHotkey = HotkeyConfig(keyCode: 62, label: "Right Ctrl")
         config.enableComputerUseHotkey = false
@@ -896,6 +897,7 @@ struct AppConfigTests {
         #expect(decoded.showScheduledMeetingNotifications == false)
         #expect(decoded.scheduledMeetingNotificationLeadTime == .threeMinutes)
         #expect(decoded.showMeetingDetectionNotification == false)
+        #expect(decoded.requireCalendarMeetingLink == true)
         #expect(decoded.mutedMeetingDetectionAppBundleIDs == ["com.google.Chrome", "com.tinyspeck.slackmacgap"])
         #expect(decoded.meetingTranscriptionBackend == config.meetingTranscriptionBackend)
         #expect(decoded.indicatorAnchor == config.indicatorAnchor)
@@ -949,6 +951,25 @@ struct AppConfigTests {
         #expect(decoded.enableAutomaticDiagnosticIssuePrompts == false)
     }
 
+    @Test("Requiring a calendar meeting link defaults off when absent")
+    func requireCalendarMeetingLinkDefaultsOffWhenAbsent() throws {
+        // Every existing config on disk predates this key. Defaulting it on
+        // would silently stop detecting dial-in and in-person meetings.
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+
+        #expect(decoded.requireCalendarMeetingLink == false)
+    }
+
+    @Test("Requiring a calendar meeting link falls back to the default on an invalid value")
+    func requireCalendarMeetingLinkFallsBackOnInvalidValue() throws {
+        // config.json is hand-editable, so a wrong-typed value must not fail the
+        // whole decode and reset every other setting.
+        let json = Data(#"{"require_calendar_meeting_link": "yes"}"#.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+
+        #expect(decoded.requireCalendarMeetingLink == false)
+    }
+
     @Test("JSON coding keys use snake_case")
     func snakeCaseKeys() throws {
         var config = AppConfig()
@@ -981,6 +1002,7 @@ struct AppConfigTests {
         #expect(json["meeting_recording_file_format"] != nil)
         #expect(json["show_scheduled_meeting_notifications"] != nil)
         #expect(json["show_meeting_detection_notification"] != nil)
+        #expect(json["require_calendar_meeting_link"] != nil)
         #expect(json["muted_meeting_detection_app_bundle_ids"] != nil)
         #expect(json["custom_meeting_templates"] != nil)
         #expect(json["meeting_hook_enabled"] != nil)


### PR DESCRIPTION
## Summary

Meeting detection accepts any timed, non-all-day calendar entry inside its
window. `selectCurrentOrNearbyCachedCalendarEvent` filters on three things only:

```swift
!event.isAllDay && event.endDate > now && event.startDate < searchEnd
```

So a reminder, a placeholder or a focus block is an ordinary meeting as far as
detection is concerned. That matters because once an event is in play,
`MeetingCandidateResolver.resolve` attributes *any* media activity to it, and its
last calendar fallback returns a bare `cal:<id>` candidate with no meeting app at
all — a dictation tool holding the microphone is enough to produce a candidate
stamped with that event.

`UnifiedCalendarEvent` already carries `meetingURL`; selection simply never
consulted it. The new `require_calendar_meeting_link` setting makes selection
skip events without one, with a toggle in Settings → Meetings.

### Why it is off by default

Link-less entries are still real meetings for anyone who dials in or meets in
person, so narrowing detection for everyone would trade one wrong behaviour for
another. Whether a link-less calendar entry is a meeting depends on how the user
works, which is why this is a setting and not a new default.

### Relationship to #375

#375 fixes the auto-stop half of the same problem: it stops a placeholder event
holding an already-running recording open, by requiring attributed meeting audio
or a room URL before matching on a calendar event. That guard is unconditional
because it is a correctness fix.

This PR is the detection half — whether a link-less entry should be treated as a
meeting at all — and is a genuine preference, so it is opt-in. The two are
independent and can land in either order.

## Validation

- `swift test --package-path native/MuesliNative` — 1546 tests in 150 suites,
  passing.
- Three new tests in `GoogleCalendarTests` (already in the meetings CI shard):
  link-less events are still selected by default; a placeholder is skipped when a
  link is required; and a linked event is still selected when a placeholder
  starts earlier and would otherwise win the sort.

Not covered by tests: the Settings toggle itself, which follows the existing
`settingsRow`/`settingsSwitch` pattern used by the neighbouring detection
controls and has no test precedent in this file.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

Claude Code (Anthropic) was used materially: it traced the calendar selection
path, wrote the change and its tests, and ran the test suite. The change and the
test results were reviewed before submission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953456&installation_model_id=422865&pr_number=394&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F394&signature=80a0c079a43bdcfcc9e6aa58bfbc486fa0f0466286ad93a7a70397772e5f2195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Meeting Notifications setting to require calendar events to include a meeting join link.
  * When enabled, events without join links are excluded from meeting notifications.
  * Events with valid join links are prioritized when selecting nearby calendar events.
  * The setting is saved and restored across app launches.

* **Tests**
  * Added coverage for meeting-link filtering, event selection, and setting persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->