### PR TITLE
Unify resumable ASR downloads and promote Qwen3 ASR

### DIFF
--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -660,16 +660,20 @@ actor FluidAudioCLITranscriber: AudioTranscribing {
         let plan = asrModelVersion == .v2
             ? ManagedASRModelPlans.parakeetV2()
             : ManagedASRModelPlans.parakeetV3()
-        let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(plan) { fraction, message in
-            progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+        let manager = try await ManagedASRModelDownloader.loadValidated(
+            plan,
+            progress: { fraction, message in
+                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+            }
+        ) { modelDirectory in
+            progress("preparing model")
+            let models = try await AsrModels.load(from: modelDirectory, version: asrModelVersion)
+            let manager = AsrManager(config: .default)
+            try await manager.loadModels(models)
+            return manager
         }
-        progress("preparing model")
-        let models = try await AsrModels.load(from: modelDirectory, version: asrModelVersion)
-        let manager = AsrManager(config: .default)
-        try await manager.loadModels(models)
         asrManager = manager
         loadedModel = model
-        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress("model ready")
     }
 }
@@ -685,15 +689,16 @@ actor SenseVoiceCLITranscriber: AudioTranscribing {
         if manager == nil {
             progress("loading sensevoice")
             let plan = ManagedASRModelPlans.senseVoice()
-            let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
-                plan
-            ) { fraction, message in
-                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+            manager = try await ManagedASRModelDownloader.loadValidated(
+                plan,
+                progress: { fraction, message in
+                    progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+                }
+            ) { modelDirectory in
+                progress("preparing model")
+                let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
+                return SenseVoiceManager(models: models)
             }
-            progress("preparing model")
-            let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
-            manager = SenseVoiceManager(models: models)
-            try? plan.recordValidatedLegacyInstallationIfNeeded()
             progress("model ready")
         }
         guard let manager else {
@@ -723,16 +728,17 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
         if manager == nil {
             progress("loading qwen3-asr")
             let plan = ManagedASRModelPlans.qwen3ASRInt8()
-            let modelDir = try await ManagedASRModelDownloader.downloadIfNeeded(
-                plan
-            ) { fraction, message in
-                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+            manager = try await ManagedASRModelDownloader.loadValidated(
+                plan,
+                progress: { fraction, message in
+                    progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+                }
+            ) { modelDir in
+                progress("preparing model")
+                let mgr = Qwen3AsrManager()
+                try await mgr.loadModels(from: modelDir)
+                return mgr
             }
-            progress("preparing model")
-            let mgr = Qwen3AsrManager()
-            try await mgr.loadModels(from: modelDir)
-            manager = mgr
-            try? plan.recordValidatedLegacyInstallationIfNeeded()
             progress("model ready")
         }
         guard let manager else {
@@ -819,22 +825,22 @@ actor WhisperCLITranscriber: AudioTranscribing {
         progress("loading \(modelName)")
 
         let plan = ManagedASRModelPlans.whisperKit(modelName: modelName)
-        let modelFolder = try await ManagedASRModelDownloader.downloadIfNeeded(
-            plan
-        ) { fraction, message in
-            progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+        whisperKit = try await ManagedASRModelDownloader.loadValidated(
+            plan,
+            progress: { fraction, message in
+                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
+            }
+        ) { modelFolder in
+            progress("preparing model")
+            return try await WhisperKit(WhisperKitConfig(
+                modelFolder: modelFolder.path,
+                computeOptions: ModelComputeOptions(
+                    audioEncoderCompute: .cpuAndNeuralEngine,
+                    textDecoderCompute: .cpuAndNeuralEngine
+                )
+            ))
         }
-        progress("preparing model")
-
-        whisperKit = try await WhisperKit(WhisperKitConfig(
-            modelFolder: modelFolder.path,
-            computeOptions: ModelComputeOptions(
-                audioEncoderCompute: .cpuAndNeuralEngine,
-                textDecoderCompute: .cpuAndNeuralEngine
-            )
-        ))
         loadedModel = modelName
-        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress("model ready")
     }
 }
@@ -890,23 +896,21 @@ actor StreamingEouCLITranscriber: AudioTranscribing {
     private func loadedManager(progress: @escaping (String) -> Void) async throws -> StreamingEouAsrManager {
         if let manager { return manager }
         let plan = ManagedASRModelPlans.parakeetRealtimeEOU320()
-        if !plan.isAvailableLocally() {
-            progress("downloading parakeet-eou-320ms (~430 MB)")
-            _ = try await ManagedASRModelDownloader.downloadIfNeeded(plan) { fraction, message in
+        if !plan.isAvailableLocally() { progress("downloading parakeet-eou-320ms (~430 MB)") }
+        progress("loading parakeet-eou-320ms")
+        let newManager = try await ManagedASRModelDownloader.loadValidated(
+            plan,
+            progress: { fraction, message in
                 progress(message ?? "model \(Int((fraction * 100).rounded()))%")
             }
+        ) { directory in
+            let candidate = StreamingEouAsrManager(chunkSize: Self.chunkSize)
+            try await candidate.loadModels(from: directory)
+            return candidate
         }
-        progress("loading parakeet-eou-320ms")
-        let newManager = StreamingEouAsrManager(chunkSize: Self.chunkSize)
-        try await newManager.loadModels(from: Self.modelDirectory())
         manager = newManager
-        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress("model ready")
         return newManager
-    }
-
-    private static func modelDirectory() -> URL {
-        ManagedASRModelPlans.parakeetRealtimeEOU320().cacheDirectory
     }
 
     private static func makeBuffer(samples: [Float]) -> AVAudioPCMBuffer? {

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -669,6 +669,7 @@ actor FluidAudioCLITranscriber: AudioTranscribing {
         try await manager.loadModels(models)
         asrManager = manager
         loadedModel = model
+        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress("model ready")
     }
 }
@@ -683,14 +684,16 @@ actor SenseVoiceCLITranscriber: AudioTranscribing {
     func transcribe(wavURL: URL, model: TranscribeModel, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
         if manager == nil {
             progress("loading sensevoice")
+            let plan = ManagedASRModelPlans.senseVoice()
             let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
-                ManagedASRModelPlans.senseVoice()
+                plan
             ) { fraction, message in
                 progress(message ?? "model \(Int((fraction * 100).rounded()))%")
             }
             progress("preparing model")
             let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
             manager = SenseVoiceManager(models: models)
+            try? plan.recordValidatedLegacyInstallationIfNeeded()
             progress("model ready")
         }
         guard let manager else {
@@ -719,8 +722,9 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
     private func transcribeOnSupportedOS(wavURL: URL, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
         if manager == nil {
             progress("loading qwen3-asr")
+            let plan = ManagedASRModelPlans.qwen3ASRInt8()
             let modelDir = try await ManagedASRModelDownloader.downloadIfNeeded(
-                ManagedASRModelPlans.qwen3ASRInt8()
+                plan
             ) { fraction, message in
                 progress(message ?? "model \(Int((fraction * 100).rounded()))%")
             }
@@ -728,6 +732,7 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
             let mgr = Qwen3AsrManager()
             try await mgr.loadModels(from: modelDir)
             manager = mgr
+            try? plan.recordValidatedLegacyInstallationIfNeeded()
             progress("model ready")
         }
         guard let manager else {
@@ -813,8 +818,9 @@ actor WhisperCLITranscriber: AudioTranscribing {
         if loadedModel == modelName, whisperKit != nil { return }
         progress("loading \(modelName)")
 
+        let plan = ManagedASRModelPlans.whisperKit(modelName: modelName)
         let modelFolder = try await ManagedASRModelDownloader.downloadIfNeeded(
-            ManagedASRModelPlans.whisperKit(modelName: modelName)
+            plan
         ) { fraction, message in
             progress(message ?? "model \(Int((fraction * 100).rounded()))%")
         }
@@ -828,6 +834,7 @@ actor WhisperCLITranscriber: AudioTranscribing {
             )
         ))
         loadedModel = modelName
+        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress("model ready")
     }
 }
@@ -883,7 +890,7 @@ actor StreamingEouCLITranscriber: AudioTranscribing {
     private func loadedManager(progress: @escaping (String) -> Void) async throws -> StreamingEouAsrManager {
         if let manager { return manager }
         let plan = ManagedASRModelPlans.parakeetRealtimeEOU320()
-        if !plan.isComplete() {
+        if !plan.isAvailableLocally() {
             progress("downloading parakeet-eou-320ms (~430 MB)")
             _ = try await ManagedASRModelDownloader.downloadIfNeeded(plan) { fraction, message in
                 progress(message ?? "model \(Int((fraction * 100).rounded()))%")
@@ -893,6 +900,7 @@ actor StreamingEouCLITranscriber: AudioTranscribing {
         let newManager = StreamingEouAsrManager(chunkSize: Self.chunkSize)
         try await newManager.loadModels(from: Self.modelDirectory())
         manager = newManager
+        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress("model ready")
         return newManager
     }

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -657,10 +657,14 @@ actor FluidAudioCLITranscriber: AudioTranscribing {
             )
         }
         progress("loading \(model.rawValue)")
-        let models = try await AsrModels.downloadAndLoad(version: asrModelVersion) { downloadProgress in
-            let percent = Int((downloadProgress.fractionCompleted * 100).rounded())
-            progress("model \(percent)%")
+        let plan = asrModelVersion == .v2
+            ? ManagedASRModelPlans.parakeetV2()
+            : ManagedASRModelPlans.parakeetV3()
+        let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(plan) { fraction, message in
+            progress(message ?? "model \(Int((fraction * 100).rounded()))%")
         }
+        progress("preparing model")
+        let models = try await AsrModels.load(from: modelDirectory, version: asrModelVersion)
         let manager = AsrManager(config: .default)
         try await manager.loadModels(models)
         asrManager = manager
@@ -674,19 +678,17 @@ actor FluidAudioCLITranscriber: AudioTranscribing {
 /// default model cache. `int8` matches the precision the app selects by default.
 actor SenseVoiceCLITranscriber: AudioTranscribing {
     private var manager: SenseVoiceManager?
-    static let cacheRelativePath = "Library/Application Support/FluidAudio/Models/sensevoice-small-coreml"
     private static let precision: SenseVoiceEncoderPrecision = .int8
 
     func transcribe(wavURL: URL, model: TranscribeModel, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
         if manager == nil {
             progress("loading sensevoice")
-            let modelDirectory = try await Self.downloadRequiredModels { fraction, message in
-                if let message {
-                    progress(message)
-                } else {
-                    progress("model \(Int((fraction * 100).rounded()))%")
-                }
+            let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
+                ManagedASRModelPlans.senseVoice()
+            ) { fraction, message in
+                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
             }
+            progress("preparing model")
             let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
             manager = SenseVoiceManager(models: models)
             progress("model ready")
@@ -698,81 +700,6 @@ actor SenseVoiceCLITranscriber: AudioTranscribing {
         let text = try await manager.transcribe(audioURL: wavURL)
         progress("transcription complete in \(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s")
         return HeadlessTranscription(text: text, durationSeconds: nil)
-    }
-
-    private static func cacheDirectory(fileManager: FileManager = .default) -> URL {
-        fileManager.homeDirectoryForCurrentUser.appendingPathComponent(cacheRelativePath)
-    }
-
-    private static func downloadRequiredModels(progress: ((Double, String?) -> Void)? = nil) async throws -> URL {
-        let directory = cacheDirectory()
-        if requiredModelsExist(at: directory) {
-            return directory
-        }
-
-        let fileManager = FileManager.default
-        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        try await downloadSubdirectory(
-            ModelNames.SenseVoice.preprocessorFile,
-            to: directory,
-            progressRange: 0.0...0.2,
-            message: "Downloading SenseVoice preprocessor...",
-            progress: progress
-        )
-        try await downloadSubdirectory(
-            ModelNames.SenseVoice.encoderInt8File,
-            to: directory,
-            progressRange: 0.2...0.9,
-            message: "Downloading SenseVoice INT8 encoder...",
-            progress: progress
-        )
-        try await downloadVocabulary(to: directory, progress: progress)
-        return directory
-    }
-
-    private static func downloadSubdirectory(
-        _ subdirectory: String,
-        to directory: URL,
-        progressRange: ClosedRange<Double>,
-        message: String,
-        progress: ((Double, String?) -> Void)?
-    ) async throws {
-        try await DownloadUtils.downloadSubdirectory(
-            .senseVoiceSmall,
-            subdirectory: subdirectory,
-            to: directory,
-            progressHandler: { downloadProgress in
-                let span = progressRange.upperBound - progressRange.lowerBound
-                let fraction = progressRange.lowerBound + span * downloadProgress.fractionCompleted
-                progress?(min(max(fraction, 0.0), 1.0), message)
-            }
-        )
-    }
-
-    private static func downloadVocabulary(to directory: URL, progress: ((Double, String?) -> Void)?) async throws {
-        let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
-        if FileManager.default.fileExists(atPath: vocabularyURL.path) {
-            progress?(0.95, "SenseVoice vocabulary ready...")
-            return
-        }
-
-        progress?(0.9, "Downloading SenseVoice vocabulary...")
-        let remoteURL = try ModelRegistry.resolveModel(
-            Repo.senseVoiceSmall.remotePath,
-            ModelNames.SenseVoice.vocabularyFile
-        )
-        let data = try await DownloadUtils.fetchHuggingFaceFile(
-            from: remoteURL,
-            description: "SenseVoice vocabulary"
-        )
-        try data.write(to: vocabularyURL, options: .atomic)
-        progress?(0.95, "SenseVoice vocabulary ready...")
-    }
-
-    private static func requiredModelsExist(at directory: URL, fileManager: FileManager = .default) -> Bool {
-        let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
-        return SenseVoiceModels.modelsExist(at: directory, precision: precision)
-            && fileManager.fileExists(atPath: vocabularyURL.path)
     }
 }
 
@@ -792,10 +719,12 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
     private func transcribeOnSupportedOS(wavURL: URL, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
         if manager == nil {
             progress("loading qwen3-asr")
-            let modelDir = try await Qwen3AsrModels.download(variant: .int8) { downloadProgress in
-                let percent = Int((downloadProgress.fractionCompleted * 100).rounded())
-                progress("model \(percent)%")
+            let modelDir = try await ManagedASRModelDownloader.downloadIfNeeded(
+                ManagedASRModelPlans.qwen3ASRInt8()
+            ) { fraction, message in
+                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
             }
+            progress("preparing model")
             let mgr = Qwen3AsrManager()
             try await mgr.loadModels(from: modelDir)
             manager = mgr
@@ -884,19 +813,15 @@ actor WhisperCLITranscriber: AudioTranscribing {
         if loadedModel == modelName, whisperKit != nil { return }
         progress("loading \(modelName)")
 
-        let modelFolder: URL?
-        if Self.isModelDownloaded(modelName) {
-            modelFolder = nil
-        } else {
-            modelFolder = try await WhisperKit.download(variant: modelName) { update in
-                let percent = Int((update.fractionCompleted * 100).rounded())
-                progress("model \(percent)%")
-            }
+        let modelFolder = try await ManagedASRModelDownloader.downloadIfNeeded(
+            ManagedASRModelPlans.whisperKit(modelName: modelName)
+        ) { fraction, message in
+            progress(message ?? "model \(Int((fraction * 100).rounded()))%")
         }
+        progress("preparing model")
 
         whisperKit = try await WhisperKit(WhisperKitConfig(
-            model: modelFolder == nil ? modelName : nil,
-            modelFolder: modelFolder?.path,
+            modelFolder: modelFolder.path,
             computeOptions: ModelComputeOptions(
                 audioEncoderCompute: .cpuAndNeuralEngine,
                 textDecoderCompute: .cpuAndNeuralEngine
@@ -904,13 +829,6 @@ actor WhisperCLITranscriber: AudioTranscribing {
         ))
         loadedModel = modelName
         progress("model ready")
-    }
-
-    private static func isModelDownloaded(_ modelName: String) -> Bool {
-        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        let directory = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
-        return FileManager.default.fileExists(atPath: directory.path)
     }
 }
 
@@ -925,7 +843,6 @@ actor WhisperCLITranscriber: AudioTranscribing {
 /// does not need. If a user already downloaded the model via the app's live
 /// captions setting, this reuses that same download.
 actor StreamingEouCLITranscriber: AudioTranscribing {
-    private static let repo = Repo.parakeetEou320
     private static let chunkSize = StreamingChunkSize.ms320
 
     private var manager: StreamingEouAsrManager?
@@ -965,11 +882,11 @@ actor StreamingEouCLITranscriber: AudioTranscribing {
 
     private func loadedManager(progress: @escaping (String) -> Void) async throws -> StreamingEouAsrManager {
         if let manager { return manager }
-        if !Self.isDownloaded() {
+        let plan = ManagedASRModelPlans.parakeetRealtimeEOU320()
+        if !plan.isComplete() {
             progress("downloading parakeet-eou-320ms (~430 MB)")
-            try await DownloadUtils.downloadRepo(Self.repo, to: Self.cacheRoot()) { update in
-                let percent = Int((update.fractionCompleted * 100).rounded())
-                progress("model \(percent)%")
+            _ = try await ManagedASRModelDownloader.downloadIfNeeded(plan) { fraction, message in
+                progress(message ?? "model \(Int((fraction * 100).rounded()))%")
             }
         }
         progress("loading parakeet-eou-320ms")
@@ -980,20 +897,8 @@ actor StreamingEouCLITranscriber: AudioTranscribing {
         return newManager
     }
 
-    private static func cacheRoot() -> URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/FluidAudio/Models", isDirectory: true)
-    }
-
     private static func modelDirectory() -> URL {
-        cacheRoot().appendingPathComponent(repo.folderName, isDirectory: true)
-    }
-
-    private static func isDownloaded() -> Bool {
-        let directory = modelDirectory()
-        return ModelNames.ParakeetEOU.requiredModels.allSatisfy {
-            FileManager.default.fileExists(atPath: directory.appendingPathComponent($0).path)
-        }
+        ManagedASRModelPlans.parakeetRealtimeEOU320().cacheDirectory
     }
 
     private static func makeBuffer(samples: [Float]) -> AVAudioPCMBuffer? {

--- a/native/MuesliNative/Sources/MuesliCore/HuggingFaceModelManifestResolver.swift
+++ b/native/MuesliNative/Sources/MuesliCore/HuggingFaceModelManifestResolver.swift
@@ -159,9 +159,13 @@ public final class HuggingFaceModelManifestResolver: @unchecked Sendable {
             }
             let page = try JSONDecoder().decode([TreeEntry].self, from: data)
             entries.append(contentsOf: page.filter { $0.type == "file" })
-            guard let link = http.value(forHTTPHeaderField: "Link"),
-                  let pageURL = Self.nextLink(in: link)
-            else { break }
+            guard let link = http.value(forHTTPHeaderField: "Link") else { break }
+            guard link.contains("rel=\"next\"") else { break }
+            guard let pageURL = Self.nextLink(in: link, relativeTo: nextURL),
+                  Self.isTrustedPaginationURL(pageURL, relativeTo: nextURL)
+            else {
+                throw HuggingFaceModelManifestError.invalidResponse(nextURL.absoluteString)
+            }
             nextURL = pageURL
         }
         return entries
@@ -174,7 +178,8 @@ public final class HuggingFaceModelManifestResolver: @unchecked Sendable {
             do {
                 var request = URLRequest(url: url)
                 request.timeoutInterval = 60
-                if let token = Self.huggingFaceToken {
+                if let token = Self.huggingFaceToken,
+                   Self.isTrustedHuggingFaceURL(url) {
                     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
                 }
                 let result = try await session.data(for: request)
@@ -235,14 +240,27 @@ public final class HuggingFaceModelManifestResolver: @unchecked Sendable {
         return components.url
     }
 
-    private static func nextLink(in header: String) -> URL? {
+    private static func nextLink(in header: String, relativeTo baseURL: URL) -> URL? {
         for component in header.split(separator: ",") where component.contains("rel=\"next\"") {
             guard let opening = component.firstIndex(of: "<"),
                   let closing = component[component.index(after: opening)...].firstIndex(of: ">")
             else { continue }
-            return URL(string: String(component[component.index(after: opening)..<closing]))
+            return URL(
+                string: String(component[component.index(after: opening)..<closing]),
+                relativeTo: baseURL
+            )?.absoluteURL
         }
         return nil
+    }
+
+    private static func isTrustedPaginationURL(_ candidate: URL, relativeTo current: URL) -> Bool {
+        candidate.scheme?.lowercased() == "https"
+            && candidate.host?.caseInsensitiveCompare(current.host ?? "") == .orderedSame
+    }
+
+    private static func isTrustedHuggingFaceURL(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "https"
+            && url.host?.caseInsensitiveCompare("huggingface.co") == .orderedSame
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliCore/HuggingFaceModelManifestResolver.swift
+++ b/native/MuesliNative/Sources/MuesliCore/HuggingFaceModelManifestResolver.swift
@@ -1,0 +1,262 @@
+import CryptoKit
+import Foundation
+
+/// Selects a complete Hugging Face directory or a subset of its top-level artifacts.
+public struct HuggingFaceModelSelection: Hashable, Sendable {
+    /// Directory inside the repository. `nil` selects the repository root.
+    public let remoteDirectory: String?
+    /// Files or directories relative to `remoteDirectory`. An empty set selects everything.
+    public let includedPaths: Set<String>
+    /// Optional directory prepended to the local manifest paths.
+    public let destinationDirectory: String?
+    /// Whether the Hugging Face tree API should return descendants.
+    public let recursive: Bool
+
+    public init(
+        remoteDirectory: String? = nil,
+        includedPaths: Set<String> = [],
+        destinationDirectory: String? = nil,
+        recursive: Bool = true
+    ) {
+        self.remoteDirectory = Self.normalized(remoteDirectory)
+        self.includedPaths = Set(includedPaths.compactMap(Self.normalized))
+        self.destinationDirectory = Self.normalized(destinationDirectory)
+        self.recursive = recursive
+    }
+
+    private static func normalized(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let value = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return value.isEmpty ? nil : value
+    }
+}
+
+/// Errors reported while converting Hugging Face repository metadata into a manifest.
+public enum HuggingFaceModelManifestError: Error, LocalizedError, Sendable {
+    case invalidRepository(String)
+    case invalidResponse(String)
+    case invalidHTTPStatus(Int, String)
+    case emptySelection(String)
+    case conflictingDestination(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRepository(let repository):
+            return "Invalid Hugging Face repository: \(repository)"
+        case .invalidResponse(let path):
+            return "Hugging Face returned invalid model metadata for \(path)"
+        case .invalidHTTPStatus(let status, let path):
+            return "Hugging Face returned HTTP \(status) while listing \(path)"
+        case .emptySelection(let path):
+            return "No downloadable files were found for \(path)"
+        case .conflictingDestination(let path):
+            return "More than one Hugging Face file maps to \(path)"
+        }
+    }
+}
+
+/// Resolves repository trees into manifests consumed by `ModelDownloadCoordinator`.
+public final class HuggingFaceModelManifestResolver: @unchecked Sendable {
+    public static let shared = HuggingFaceModelManifestResolver()
+
+    private let session: URLSession
+
+    public init(configuration: URLSessionConfiguration = .default) {
+        let configuration = configuration.copy() as? URLSessionConfiguration ?? configuration
+        configuration.timeoutIntervalForRequest = max(configuration.timeoutIntervalForRequest, 60)
+        configuration.timeoutIntervalForResource = max(configuration.timeoutIntervalForResource, 180)
+        session = URLSession(configuration: configuration)
+    }
+
+    public func resolve(
+        modelID: String,
+        repository: String,
+        revision: String = "main",
+        selections: [HuggingFaceModelSelection],
+        maximumConcurrency: Int = 2
+    ) async throws -> ModelDownloadManifest {
+        guard repository.split(separator: "/").count == 2 else {
+            throw HuggingFaceModelManifestError.invalidRepository(repository)
+        }
+
+        var filesByDestination: [String: (file: ModelDownloadFile, fingerprint: String)] = [:]
+        for selection in selections {
+            let entries = try await listFiles(
+                repository: repository,
+                revision: revision,
+                selection: selection
+            )
+            var matchedCount = 0
+            for entry in entries where selection.includes(entry.path) {
+                guard let relativeRemotePath = selection.relativePath(for: entry.path) else { continue }
+                let relativePath = [selection.destinationDirectory, relativeRemotePath]
+                    .compactMap { $0 }
+                    .joined(separator: "/")
+                guard !relativePath.isEmpty else { continue }
+                guard let remoteURL = Self.resolveURL(
+                    repository: repository,
+                    revision: revision,
+                    path: entry.path
+                ) else {
+                    throw HuggingFaceModelManifestError.invalidResponse(entry.path)
+                }
+                let file = ModelDownloadFile(
+                    relativePath: relativePath,
+                    remoteURL: remoteURL,
+                    expectedByteCount: entry.size,
+                    sha256: nil
+                )
+                let fingerprint = "\(entry.path):\(entry.oid ?? ""): \(entry.size ?? -1)"
+                if let existing = filesByDestination[relativePath], existing.file.remoteURL != remoteURL {
+                    throw HuggingFaceModelManifestError.conflictingDestination(relativePath)
+                }
+                filesByDestination[relativePath] = (file, fingerprint)
+                matchedCount += 1
+            }
+            guard matchedCount > 0 else {
+                throw HuggingFaceModelManifestError.emptySelection(
+                    [repository, selection.remoteDirectory].compactMap { $0 }.joined(separator: "/")
+                )
+            }
+        }
+
+        let sorted = filesByDestination.sorted { $0.key < $1.key }
+        let revisionMaterial = sorted.map { $0.value.fingerprint }.joined(separator: "|")
+        let digest = SHA256.hash(data: Data(revisionMaterial.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return ModelDownloadManifest(
+            id: modelID,
+            version: "\(revision)-\(digest)",
+            files: sorted.map { $0.value.file },
+            maximumConcurrency: maximumConcurrency
+        )
+    }
+
+    private func listFiles(
+        repository: String,
+        revision: String,
+        selection: HuggingFaceModelSelection
+    ) async throws -> [TreeEntry] {
+        guard var nextURL = Self.treeURL(
+            repository: repository,
+            revision: revision,
+            directory: selection.remoteDirectory,
+            recursive: selection.recursive
+        ) else {
+            throw HuggingFaceModelManifestError.invalidRepository(repository)
+        }
+
+        var entries: [TreeEntry] = []
+        var visited = Set<URL>()
+        while visited.insert(nextURL).inserted {
+            let (data, response) = try await fetch(nextURL)
+            guard let http = response as? HTTPURLResponse else {
+                throw HuggingFaceModelManifestError.invalidResponse(nextURL.absoluteString)
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                throw HuggingFaceModelManifestError.invalidHTTPStatus(http.statusCode, nextURL.absoluteString)
+            }
+            let page = try JSONDecoder().decode([TreeEntry].self, from: data)
+            entries.append(contentsOf: page.filter { $0.type == "file" })
+            guard let link = http.value(forHTTPHeaderField: "Link"),
+                  let pageURL = Self.nextLink(in: link)
+            else { break }
+            nextURL = pageURL
+        }
+        return entries
+    }
+
+    private func fetch(_ url: URL) async throws -> (Data, URLResponse) {
+        var lastError: Error?
+        for attempt in 0..<3 {
+            try Task.checkCancellation()
+            do {
+                var request = URLRequest(url: url)
+                request.timeoutInterval = 60
+                if let token = Self.huggingFaceToken {
+                    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                }
+                let result = try await session.data(for: request)
+                if let http = result.1 as? HTTPURLResponse,
+                   (http.statusCode == 429 || (500..<600).contains(http.statusCode)),
+                   attempt < 2 {
+                    try await Task.sleep(nanoseconds: UInt64(1 << attempt) * 1_000_000_000)
+                    continue
+                }
+                return result
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                lastError = error
+                guard attempt < 2 else { throw error }
+                try await Task.sleep(nanoseconds: UInt64(1 << attempt) * 1_000_000_000)
+            }
+        }
+        throw lastError ?? HuggingFaceModelManifestError.invalidResponse(url.absoluteString)
+    }
+
+    private struct TreeEntry: Decodable {
+        let type: String
+        let path: String
+        let size: Int64?
+        let oid: String?
+    }
+
+    private static var huggingFaceToken: String? {
+        ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? ProcessInfo.processInfo.environment["HUGGING_FACE_HUB_TOKEN"]
+            ?? ProcessInfo.processInfo.environment["HUGGINGFACEHUB_API_TOKEN"]
+    }
+
+    private static func treeURL(
+        repository: String,
+        revision: String,
+        directory: String?,
+        recursive: Bool
+    ) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/api/models/\(repository)/tree/\(revision)"
+        if let directory { components.path += "/\(directory)" }
+        components.queryItems = [
+            URLQueryItem(name: "recursive", value: recursive ? "true" : "false"),
+            URLQueryItem(name: "limit", value: "100"),
+        ]
+        return components.url
+    }
+
+    private static func resolveURL(repository: String, revision: String, path: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(repository)/resolve/\(revision)/\(path)"
+        return components.url
+    }
+
+    private static func nextLink(in header: String) -> URL? {
+        for component in header.split(separator: ",") where component.contains("rel=\"next\"") {
+            guard let opening = component.firstIndex(of: "<"),
+                  let closing = component[component.index(after: opening)...].firstIndex(of: ">")
+            else { continue }
+            return URL(string: String(component[component.index(after: opening)..<closing]))
+        }
+        return nil
+    }
+}
+
+private extension HuggingFaceModelSelection {
+    func includes(_ repositoryPath: String) -> Bool {
+        guard let relative = relativePath(for: repositoryPath) else { return false }
+        guard !includedPaths.isEmpty else { return true }
+        return includedPaths.contains { relative == $0 || relative.hasPrefix($0 + "/") }
+    }
+
+    func relativePath(for repositoryPath: String) -> String? {
+        guard let remoteDirectory else { return repositoryPath }
+        let prefix = remoteDirectory + "/"
+        guard repositoryPath.hasPrefix(prefix) else { return nil }
+        return String(repositoryPath.dropFirst(prefix.count))
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -71,6 +71,12 @@ public struct ManagedASRModelPlan: Sendable {
         isComplete(fileManager: fileManager) || isLegacyInstallation(fileManager: fileManager)
     }
 
+    /// Whether this cache predates managed completion markers and still needs
+    /// one successful runtime load before it can be trusted as complete.
+    public func requiresRuntimeValidation(fileManager: FileManager = .default) -> Bool {
+        isLegacyInstallation(fileManager: fileManager)
+    }
+
     /// Records a successful, fully validated coordinator install. The marker
     /// carries every manifest file so readiness cannot be inferred from an
     /// early sentinel while sibling weights are still partial or missing.
@@ -363,6 +369,61 @@ public enum ManagedASRModelDownloader {
                 resolver: resolver,
                 coordinator: coordinator
             )
+        }
+    }
+
+    /// Loads a managed model and validates markerless legacy caches through the
+    /// real runtime. A legacy cache that cannot load is removed and downloaded
+    /// once from scratch; a successful legacy load is promoted to a strict,
+    /// size-aware managed installation without requiring network access.
+    public static func loadValidated<T>(
+        _ plan: ManagedASRModelPlan,
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil,
+        resolver: HuggingFaceModelManifestResolver = .shared,
+        coordinator: ModelDownloadCoordinator = .shared,
+        load: (URL) async throws -> T
+    ) async throws -> T {
+        let requiresRuntimeValidation = plan.requiresRuntimeValidation()
+        let directory = try await downloadIfNeeded(
+            plan,
+            progress: progress,
+            progressSnapshot: progressSnapshot,
+            resolver: resolver,
+            coordinator: coordinator
+        )
+
+        do {
+            let value = try await load(directory)
+            try? plan.recordValidatedLegacyInstallationIfNeeded()
+            return value
+        } catch {
+            let validationError = error
+            guard requiresRuntimeValidation, !(error is CancellationError) else { throw error }
+            try Task.checkCancellation()
+
+            let deletionToken = await beginDeletion(
+                modelID: plan.modelID,
+                coordinator: coordinator
+            )
+            let shouldRepair = plan.requiresRuntimeValidation()
+            do {
+                if shouldRepair { try plan.delete() }
+            } catch {
+                await endDeletion(deletionToken)
+                throw error
+            }
+            await endDeletion(deletionToken)
+            guard shouldRepair else { throw validationError }
+
+            let repairedDirectory = try await downloadIfNeeded(
+                plan,
+                progress: progress,
+                progressSnapshot: progressSnapshot,
+                resolver: resolver,
+                coordinator: coordinator
+            )
+            return try await load(repairedDirectory)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -2,6 +2,20 @@ import Foundation
 
 /// A third-party ASR model whose transport is owned by Muesli.
 public struct ManagedASRModelPlan: Sendable {
+    private struct CompletionMarker: Codable {
+        struct File: Codable {
+            let relativePath: String
+            let expectedByteCount: Int64?
+        }
+
+        let modelID: String
+        let revision: String
+        let manifestVersion: String
+        let files: [File]
+    }
+
+    private static let completionMarkerName = ".muesli-managed-model-complete.json"
+
     public let modelID: String
     public let repository: String
     public let revision: String
@@ -30,16 +44,57 @@ public struct ManagedASRModelPlan: Sendable {
     }
 
     public func isComplete(fileManager: FileManager = .default) -> Bool {
-        !requiredArtifactAlternatives.isEmpty && requiredArtifactAlternatives.allSatisfy { alternatives in
+        guard !requiredArtifactAlternatives.isEmpty,
+              requiredArtifactAlternatives.allSatisfy({ alternatives in
             alternatives.contains { relativePath in
                 fileManager.fileExists(atPath: cacheDirectory.appendingPathComponent(relativePath).path)
             }
+        }),
+              let data = try? Data(contentsOf: completionMarkerURL),
+              let marker = try? JSONDecoder().decode(CompletionMarker.self, from: data),
+              marker.modelID == modelID,
+              marker.revision == revision,
+              !marker.files.isEmpty
+        else { return false }
+
+        return marker.files.allSatisfy { file in
+            let url = cacheDirectory.appendingPathComponent(file.relativePath)
+            guard fileManager.fileExists(atPath: url.path) else { return false }
+            guard let expectedByteCount = file.expectedByteCount else { return true }
+            let size = (try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.int64Value
+            return size == expectedByteCount
         }
+    }
+
+    /// Records a successful, fully validated coordinator install. The marker
+    /// carries every manifest file so readiness cannot be inferred from an
+    /// early sentinel while sibling weights are still partial or missing.
+    public func recordSuccessfulInstallation(
+        _ manifest: ModelDownloadManifest,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        let marker = CompletionMarker(
+            modelID: modelID,
+            revision: revision,
+            manifestVersion: manifest.version,
+            files: manifest.files.map {
+                CompletionMarker.File(
+                    relativePath: $0.relativePath,
+                    expectedByteCount: $0.expectedByteCount
+                )
+            }
+        )
+        try JSONEncoder().encode(marker).write(to: completionMarkerURL, options: .atomic)
     }
 
     public func delete(fileManager: FileManager = .default) throws {
         guard fileManager.fileExists(atPath: cacheDirectory.path) else { return }
         try fileManager.removeItem(at: cacheDirectory)
+    }
+
+    private var completionMarkerURL: URL {
+        cacheDirectory.appendingPathComponent(Self.completionMarkerName)
     }
 }
 
@@ -229,6 +284,7 @@ public enum ManagedASRModelDownloader {
             }
             progressSnapshot?(snapshot)
         }
+        try plan.recordSuccessfulInstallation(manifest)
         guard plan.isComplete() else {
             throw HuggingFaceModelManifestError.emptySelection(plan.repository)
         }

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -15,6 +15,8 @@ public struct ManagedASRModelPlan: Sendable {
     }
 
     private static let completionMarkerName = ".muesli-managed-model-complete.json"
+    private static let downloadStateName = ".muesli-download-state.json"
+    private static let legacyManifestVersion = "legacy-local-v1"
 
     public let modelID: String
     public let repository: String
@@ -44,12 +46,7 @@ public struct ManagedASRModelPlan: Sendable {
     }
 
     public func isComplete(fileManager: FileManager = .default) -> Bool {
-        guard !requiredArtifactAlternatives.isEmpty,
-              requiredArtifactAlternatives.allSatisfy({ alternatives in
-            alternatives.contains { relativePath in
-                fileManager.fileExists(atPath: cacheDirectory.appendingPathComponent(relativePath).path)
-            }
-        }),
+        guard requiredArtifactsExist(fileManager: fileManager),
               let data = try? Data(contentsOf: completionMarkerURL),
               let marker = try? JSONDecoder().decode(CompletionMarker.self, from: data),
               marker.modelID == modelID,
@@ -64,6 +61,14 @@ public struct ManagedASRModelPlan: Sendable {
             let size = (try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?.int64Value
             return size == expectedByteCount
         }
+    }
+
+    /// True for either a marker-validated managed download or a complete cache
+    /// created by a Muesli version that predates managed completion markers.
+    /// Legacy recognition is refused when resumable state or partial files are
+    /// present, so interrupted managed downloads cannot masquerade as installs.
+    public func isAvailableLocally(fileManager: FileManager = .default) -> Bool {
+        isComplete(fileManager: fileManager) || isLegacyInstallation(fileManager: fileManager)
     }
 
     /// Records a successful, fully validated coordinator install. The marker
@@ -88,6 +93,27 @@ public struct ManagedASRModelPlan: Sendable {
         try JSONEncoder().encode(marker).write(to: completionMarkerURL, options: .atomic)
     }
 
+    /// Backfills a completion marker after a legacy cache has successfully
+    /// loaded through its runtime. This deliberately runs after validation: a
+    /// file-presence check alone must never certify a partially installed model.
+    public func recordValidatedLegacyInstallationIfNeeded(
+        fileManager: FileManager = .default
+    ) throws {
+        guard !isComplete(fileManager: fileManager),
+              isLegacyInstallation(fileManager: fileManager)
+        else { return }
+
+        let files = try selectedLocalFiles(fileManager: fileManager)
+        guard !files.isEmpty else { return }
+        let marker = CompletionMarker(
+            modelID: modelID,
+            revision: revision,
+            manifestVersion: Self.legacyManifestVersion,
+            files: files
+        )
+        try JSONEncoder().encode(marker).write(to: completionMarkerURL, options: .atomic)
+    }
+
     public func delete(fileManager: FileManager = .default) throws {
         guard fileManager.fileExists(atPath: cacheDirectory.path) else { return }
         try fileManager.removeItem(at: cacheDirectory)
@@ -95,6 +121,73 @@ public struct ManagedASRModelPlan: Sendable {
 
     private var completionMarkerURL: URL {
         cacheDirectory.appendingPathComponent(Self.completionMarkerName)
+    }
+
+    private func requiredArtifactsExist(fileManager: FileManager) -> Bool {
+        !requiredArtifactAlternatives.isEmpty
+            && requiredArtifactAlternatives.allSatisfy { alternatives in
+                alternatives.contains { relativePath in
+                    fileManager.fileExists(
+                        atPath: cacheDirectory.appendingPathComponent(relativePath).path
+                    )
+                }
+            }
+    }
+
+    private func isLegacyInstallation(fileManager: FileManager) -> Bool {
+        guard requiredArtifactsExist(fileManager: fileManager),
+              !fileManager.fileExists(atPath: completionMarkerURL.path),
+              !fileManager.fileExists(
+                atPath: cacheDirectory.appendingPathComponent(Self.downloadStateName).path
+              )
+        else { return false }
+
+        guard let enumerator = fileManager.enumerator(
+            at: cacheDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return false }
+        for case let url as URL in enumerator where url.pathExtension == "part" {
+            return false
+        }
+        return true
+    }
+
+    private func selectedLocalFiles(fileManager: FileManager) throws -> [CompletionMarker.File] {
+        guard let enumerator = fileManager.enumerator(
+            at: cacheDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        let rootPath = cacheDirectory.standardizedFileURL.path
+        var files: [CompletionMarker.File] = []
+        for case let url as URL in enumerator {
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard values.isRegularFile == true else { continue }
+            let path = url.standardizedFileURL.path
+            guard path.hasPrefix(rootPath + "/") else { continue }
+            let relativePath = String(path.dropFirst(rootPath.count + 1))
+            guard isSelected(relativePath: relativePath) else { continue }
+            files.append(CompletionMarker.File(
+                relativePath: relativePath,
+                expectedByteCount: values.fileSize.map(Int64.init)
+            ))
+        }
+        return files.sorted { $0.relativePath < $1.relativePath }
+    }
+
+    private func isSelected(relativePath: String) -> Bool {
+        selections.contains { selection in
+            let destination = selection.destinationDirectory.map { $0 + "/" } ?? ""
+            if selection.includedPaths.isEmpty {
+                return destination.isEmpty || relativePath.hasPrefix(destination)
+            }
+            return selection.includedPaths.contains { includedPath in
+                let selectedPath = destination + includedPath
+                return relativePath == selectedPath || relativePath.hasPrefix(selectedPath + "/")
+            }
+        }
     }
 }
 
@@ -204,15 +297,16 @@ public enum ManagedASRModelPlans {
         let requiredModels = [
             "MelSpectrogram.mlmodelc", "AudioEncoder.mlmodelc", "TextDecoder.mlmodelc",
         ]
+        let requiredFiles = requiredModels + ["config.json", "generation_config.json"]
         return ManagedASRModelPlan(
             modelID: modelName,
             repository: "argmaxinc/whisperkit-coreml",
             cacheDirectory: directory,
             selections: [HuggingFaceModelSelection(
                 remoteDirectory: fullName,
-                includedPaths: Set(requiredModels + ["config.json", "generation_config.json"])
+                includedPaths: Set(requiredFiles)
             )],
-            requiredArtifactAlternatives: completenessRequirements(for: requiredModels)
+            requiredArtifactAlternatives: completenessRequirements(for: requiredFiles)
         )
     }
 
@@ -235,17 +329,22 @@ public enum ManagedASRModelPlans {
     }
 
     private static func completenessRequirements(for paths: [String]) -> [[String]] {
-        paths.map { path in
+        paths.flatMap { path in
             if path.hasSuffix(".mlmodelc") {
-                return [path + "/coremldata.bin"]
+                return [
+                    [path + "/coremldata.bin"],
+                    [path + "/weights/weight.bin"],
+                ]
             }
-            return [path]
+            return [[path]]
         }
     }
 }
 
 /// Bridges Hugging Face discovery to the resumable coordinator and legacy scalar UI callbacks.
 public enum ManagedASRModelDownloader {
+    private static let operations = ManagedASRModelOperations()
+
     @discardableResult
     public static func downloadIfNeeded(
         _ plan: ManagedASRModelPlan,
@@ -254,21 +353,65 @@ public enum ManagedASRModelDownloader {
         resolver: HuggingFaceModelManifestResolver = .shared,
         coordinator: ModelDownloadCoordinator = .shared
     ) async throws -> URL {
-        if plan.isComplete() { return plan.cacheDirectory }
+        try await operations.run(modelID: plan.modelID) {
+            if plan.isAvailableLocally() { return plan.cacheDirectory }
+
+            return try await performDownload(
+                plan,
+                progress: progress,
+                progressSnapshot: progressSnapshot,
+                resolver: resolver,
+                coordinator: coordinator
+            )
+        }
+    }
+
+    /// Cancels manifest discovery and transfer for a model without blocking a
+    /// later resume.
+    public static func cancel(
+        modelID: String,
+        coordinator: ModelDownloadCoordinator = .shared
+    ) async {
+        await operations.cancel(modelID: modelID)
+        await coordinator.cancel(modelID: modelID)
+    }
+
+    /// Cancels and awaits manifest discovery plus any registered transfer.
+    public static func cancelAndWait(
+        modelID: String,
+        coordinator: ModelDownloadCoordinator = .shared
+    ) async {
+        await operations.cancelAndWait(modelID: modelID)
+        await coordinator.cancelAndWait(modelID: modelID)
+    }
+
+    /// Blocks new operations for a model while callers remove its cache.
+    public static func beginDeletion(
+        modelID: String,
+        coordinator: ModelDownloadCoordinator = .shared
+    ) async -> ManagedASRModelDeletionToken {
+        let token = await operations.beginDeletion(modelID: modelID)
+        await coordinator.cancelAndWait(modelID: modelID)
+        return token
+    }
+
+    public static func endDeletion(_ token: ManagedASRModelDeletionToken) async {
+        await operations.endDeletion(token)
+    }
+
+    private static func performDownload(
+        _ plan: ManagedASRModelPlan,
+        progress: ((Double, String?) -> Void)?,
+        progressSnapshot: ModelDownloadProgressHandler?,
+        resolver: HuggingFaceModelManifestResolver,
+        coordinator: ModelDownloadCoordinator
+    ) async throws -> URL {
+        try Task.checkCancellation()
 
         let scalarProgress = ManagedASRScalarProgressRelay(progress)
         scalarProgress.call(0.01, "Finding model files...")
-        progressSnapshot?(ModelDownloadProgress(
+        progressSnapshot?(ModelDownloadProgress.preparing(
             modelID: plan.modelID,
-            phase: .downloading,
-            currentFile: nil,
-            completedBytes: 0,
-            totalBytes: nil,
-            currentFileCompletedBytes: 0,
-            currentFileTotalBytes: nil,
-            bytesPerSecond: 0,
-            estimatedSecondsRemaining: nil,
-            retryCount: 0,
             message: "Finding model files..."
         ))
         let manifest = try await resolver.resolve(
@@ -289,6 +432,62 @@ public enum ManagedASRModelDownloader {
             throw HuggingFaceModelManifestError.emptySelection(plan.repository)
         }
         return plan.cacheDirectory
+    }
+}
+
+public struct ManagedASRModelDeletionToken: Sendable {
+    fileprivate let modelID: String
+    fileprivate let id: UUID
+}
+
+private actor ManagedASRModelOperations {
+    private struct Operation {
+        let id: UUID
+        let task: Task<URL, Error>
+    }
+
+    private var operations: [String: [UUID: Operation]] = [:]
+    private var deletionTokens: [String: UUID] = [:]
+
+    func run(
+        modelID: String,
+        operation: @escaping @Sendable () async throws -> URL
+    ) async throws -> URL {
+        guard deletionTokens[modelID] == nil else { throw CancellationError() }
+        let id = UUID()
+        let task = Task { try await operation() }
+        operations[modelID, default: [:]][id] = Operation(id: id, task: task)
+        defer { operations[modelID]?[id] = nil }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    func cancel(modelID: String) {
+        guard let active = operations[modelID]?.values else { return }
+        for operation in active {
+            operation.task.cancel()
+        }
+    }
+
+    func cancelAndWait(modelID: String) async {
+        let active = operations[modelID].map { Array($0.values) } ?? []
+        for operation in active { operation.task.cancel() }
+        for operation in active { _ = try? await operation.task.value }
+    }
+
+    func beginDeletion(modelID: String) async -> ManagedASRModelDeletionToken {
+        let token = ManagedASRModelDeletionToken(modelID: modelID, id: UUID())
+        deletionTokens[modelID] = token.id
+        await cancelAndWait(modelID: modelID)
+        return token
+    }
+
+    func endDeletion(_ token: ManagedASRModelDeletionToken) {
+        guard deletionTokens[token.modelID] == token.id else { return }
+        deletionTokens[token.modelID] = nil
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+/// A third-party ASR model whose transport is owned by Muesli.
+public struct ManagedASRModelPlan: Sendable {
+    public let modelID: String
+    public let repository: String
+    public let revision: String
+    public let cacheDirectory: URL
+    public let selections: [HuggingFaceModelSelection]
+    /// Every inner group is an either/or requirement; every group must be satisfied.
+    public let requiredArtifactAlternatives: [[String]]
+    public let maximumConcurrency: Int
+
+    public init(
+        modelID: String,
+        repository: String,
+        revision: String = "main",
+        cacheDirectory: URL,
+        selections: [HuggingFaceModelSelection],
+        requiredArtifactAlternatives: [[String]],
+        maximumConcurrency: Int = 2
+    ) {
+        self.modelID = modelID
+        self.repository = repository
+        self.revision = revision
+        self.cacheDirectory = cacheDirectory
+        self.selections = selections
+        self.requiredArtifactAlternatives = requiredArtifactAlternatives
+        self.maximumConcurrency = maximumConcurrency
+    }
+
+    public func isComplete(fileManager: FileManager = .default) -> Bool {
+        !requiredArtifactAlternatives.isEmpty && requiredArtifactAlternatives.allSatisfy { alternatives in
+            alternatives.contains { relativePath in
+                fileManager.fileExists(atPath: cacheDirectory.appendingPathComponent(relativePath).path)
+            }
+        }
+    }
+
+    public func delete(fileManager: FileManager = .default) throws {
+        guard fileManager.fileExists(atPath: cacheDirectory.path) else { return }
+        try fileManager.removeItem(at: cacheDirectory)
+    }
+}
+
+/// Canonical cache layouts and artifact sets shared by the app and CLI.
+public enum ManagedASRModelPlans {
+    private static let fluidAudioRootRelativePath = "Library/Application Support/FluidAudio/Models"
+
+    public static func fluidAudioModelsRoot(fileManager: FileManager = .default) -> URL {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(fluidAudioRootRelativePath, isDirectory: true)
+    }
+
+    public static func parakeetV2(modelsRoot: URL? = nil) -> ManagedASRModelPlan {
+        let required = [
+            "Preprocessor.mlmodelc", "Encoder.mlmodelc", "Decoder.mlmodelc",
+            "JointDecision.mlmodelc", "parakeet_vocab.json",
+        ]
+        return fluidAudioPlan(
+            modelID: "FluidInference/parakeet-tdt-0.6b-v2-coreml",
+            repository: "FluidInference/parakeet-tdt-0.6b-v2-coreml",
+            directoryName: "parakeet-tdt-0.6b-v2",
+            required: required,
+            modelsRoot: modelsRoot
+        )
+    }
+
+    public static func parakeetV3(modelsRoot: URL? = nil) -> ManagedASRModelPlan {
+        let required = [
+            "Preprocessor.mlmodelc", "Encoder.mlmodelc", "Decoder.mlmodelc",
+            "JointDecisionv3.mlmodelc", "parakeet_vocab.json",
+        ]
+        return fluidAudioPlan(
+            modelID: "FluidInference/parakeet-tdt-0.6b-v3-coreml",
+            repository: "FluidInference/parakeet-tdt-0.6b-v3-coreml",
+            directoryName: "parakeet-tdt-0.6b-v3",
+            required: required,
+            modelsRoot: modelsRoot
+        )
+    }
+
+    public static func senseVoice(modelsRoot: URL? = nil) -> ManagedASRModelPlan {
+        let required = [
+            "SenseVoicePreprocessor.mlmodelc", "SenseVoiceSmall_int8.mlmodelc", "vocab.json",
+        ]
+        return fluidAudioPlan(
+            modelID: "FluidInference/sensevoice-small-coreml",
+            repository: "FluidInference/sensevoice-small-coreml",
+            directoryName: "sensevoice-small-coreml",
+            required: required,
+            modelsRoot: modelsRoot
+        )
+    }
+
+    public static func qwen3ASRInt8(modelsRoot: URL? = nil) -> ManagedASRModelPlan {
+        let required = [
+            "qwen3_asr_audio_encoder_v2.mlmodelc",
+            "qwen3_asr_decoder_stateful.mlmodelc",
+            "qwen3_asr_embeddings.bin",
+            "vocab.json",
+        ]
+        let directory = (modelsRoot ?? fluidAudioModelsRoot())
+            .appendingPathComponent("qwen3-asr-0.6b/int8", isDirectory: true)
+        return ManagedASRModelPlan(
+            modelID: "FluidInference/qwen3-asr-0.6b-coreml",
+            repository: "FluidInference/qwen3-asr-0.6b-coreml",
+            cacheDirectory: directory,
+            selections: [
+                HuggingFaceModelSelection(
+                    remoteDirectory: "int8",
+                    includedPaths: Set(required),
+                    recursive: true
+                )
+            ],
+            requiredArtifactAlternatives: completenessRequirements(for: required)
+        )
+    }
+
+    public static func parakeetRealtimeEOU320(modelsRoot: URL? = nil) -> ManagedASRModelPlan {
+        let required = [
+            "streaming_encoder.mlmodelc", "decoder.mlmodelc", "joint_decision.mlmodelc", "vocab.json",
+        ]
+        let directory = (modelsRoot ?? fluidAudioModelsRoot())
+            .appendingPathComponent("parakeet-eou-streaming/320ms", isDirectory: true)
+        return ManagedASRModelPlan(
+            modelID: "FluidInference/parakeet-realtime-eou-120m-coreml/320ms",
+            repository: "FluidInference/parakeet-realtime-eou-120m-coreml",
+            cacheDirectory: directory,
+            selections: [
+                HuggingFaceModelSelection(
+                    remoteDirectory: "320ms",
+                    includedPaths: Set(required),
+                    recursive: true
+                )
+            ],
+            requiredArtifactAlternatives: completenessRequirements(for: required)
+        )
+    }
+
+    public static func whisperKit(
+        modelName: String,
+        downloadRoot: URL? = nil
+    ) -> ManagedASRModelPlan {
+        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
+        let root = downloadRoot ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml", isDirectory: true)
+        let directory = root.appendingPathComponent(fullName, isDirectory: true)
+        let requiredModels = [
+            "MelSpectrogram.mlmodelc", "AudioEncoder.mlmodelc", "TextDecoder.mlmodelc",
+        ]
+        return ManagedASRModelPlan(
+            modelID: modelName,
+            repository: "argmaxinc/whisperkit-coreml",
+            cacheDirectory: directory,
+            selections: [HuggingFaceModelSelection(
+                remoteDirectory: fullName,
+                includedPaths: Set(requiredModels + ["config.json", "generation_config.json"])
+            )],
+            requiredArtifactAlternatives: completenessRequirements(for: requiredModels)
+        )
+    }
+
+    private static func fluidAudioPlan(
+        modelID: String,
+        repository: String,
+        directoryName: String,
+        required: [String],
+        modelsRoot: URL?
+    ) -> ManagedASRModelPlan {
+        let directory = (modelsRoot ?? fluidAudioModelsRoot())
+            .appendingPathComponent(directoryName, isDirectory: true)
+        return ManagedASRModelPlan(
+            modelID: modelID,
+            repository: repository,
+            cacheDirectory: directory,
+            selections: [HuggingFaceModelSelection(includedPaths: Set(required))],
+            requiredArtifactAlternatives: completenessRequirements(for: required)
+        )
+    }
+
+    private static func completenessRequirements(for paths: [String]) -> [[String]] {
+        paths.map { path in
+            if path.hasSuffix(".mlmodelc") {
+                return [path + "/coremldata.bin"]
+            }
+            return [path]
+        }
+    }
+}
+
+/// Bridges Hugging Face discovery to the resumable coordinator and legacy scalar UI callbacks.
+public enum ManagedASRModelDownloader {
+    @discardableResult
+    public static func downloadIfNeeded(
+        _ plan: ManagedASRModelPlan,
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil,
+        resolver: HuggingFaceModelManifestResolver = .shared,
+        coordinator: ModelDownloadCoordinator = .shared
+    ) async throws -> URL {
+        if plan.isComplete() { return plan.cacheDirectory }
+
+        let scalarProgress = ManagedASRScalarProgressRelay(progress)
+        scalarProgress.call(0.01, "Finding model files...")
+        progressSnapshot?(ModelDownloadProgress(
+            modelID: plan.modelID,
+            phase: .downloading,
+            currentFile: nil,
+            completedBytes: 0,
+            totalBytes: nil,
+            currentFileCompletedBytes: 0,
+            currentFileTotalBytes: nil,
+            bytesPerSecond: 0,
+            estimatedSecondsRemaining: nil,
+            retryCount: 0,
+            message: "Finding model files..."
+        ))
+        let manifest = try await resolver.resolve(
+            modelID: plan.modelID,
+            repository: plan.repository,
+            revision: plan.revision,
+            selections: plan.selections,
+            maximumConcurrency: plan.maximumConcurrency
+        )
+        try await coordinator.download(manifest, to: plan.cacheDirectory) { snapshot in
+            if let fraction = snapshot.fractionCompleted {
+                scalarProgress.call(fraction, snapshot.message)
+            }
+            progressSnapshot?(snapshot)
+        }
+        guard plan.isComplete() else {
+            throw HuggingFaceModelManifestError.emptySelection(plan.repository)
+        }
+        return plan.cacheDirectory
+    }
+}
+
+private final class ManagedASRScalarProgressRelay: @unchecked Sendable {
+    private let handler: ((Double, String?) -> Void)?
+
+    init(_ handler: ((Double, String?) -> Void)?) {
+        self.handler = handler
+    }
+
+    func call(_ fraction: Double, _ message: String?) {
+        handler?(fraction, message)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/ModelDownloadCoordinator.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ModelDownloadCoordinator.swift
@@ -296,6 +296,20 @@ public actor ModelDownloadCoordinator {
         }
     }
 
+    /// Cancels active transfers for a model and waits until their file writes
+    /// have fully unwound. Use this before deleting a model destination.
+    public func cancelAndWait(modelID: String) async {
+        let tasks = inFlight.compactMap { key, task in
+            key.modelID == modelID ? task : nil
+        }
+        for task in tasks {
+            task.cancel()
+        }
+        for task in tasks {
+            _ = try? await task.value
+        }
+    }
+
     /// Downloads, validates, and atomically installs every file in a manifest.
     ///
     /// Requests with the same model, canonical destination, and manifest contents

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -52,8 +52,8 @@ enum ModelsCategory: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .dictation: return "Dictation"
-        case .streaming: return "Streaming"
-        case .postProcessing: return "Post-processing"
+        case .streaming: return "Live Meetings"
+        case .postProcessing: return "Cleanup"
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -139,7 +139,7 @@ enum FeatureTourCatalog {
                 id: "streaming-models",
                 eyebrow: "LIVE MODEL OPTIONS",
                 title: "Choose your live transcription engine",
-                message: "The Streaming tab groups Nemotron 3.5 for live and final meeting transcripts with Parakeet Realtime for low-latency live preview.",
+                message: "The Live Meetings tab offers Nemotron 3.5 when you want one live and saved meeting transcript, or Parakeet Live Captions when a fast English preview matters most.",
                 systemImage: "waveform.badge.mic",
                 target: .streamingModels
             ),
@@ -147,7 +147,7 @@ enum FeatureTourCatalog {
                 id: "experimental-models",
                 eyebrow: "EXPERIMENTAL MODELS",
                 title: "Try new local dictation backends",
-                message: "Expand Experimental to evaluate SenseVoice, Qwen3 ASR, Indic ASR, and Gemma 4 without mixing them into the default model choices.",
+                message: "Expand Experimental to try SenseVoice, Indic ASR, and Gemma 4. These early models can help with specific languages or evaluation, but may be less consistent.",
                 systemImage: "cpu",
                 target: .experimentalModels
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
@@ -46,6 +46,7 @@ actor FluidAudioTranscriber {
         try await manager.loadModels(models)
         self.asrManager = manager
         self.loadedVersion = version
+        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress?(1, nil)
         progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[fluidaudio] models ready\n", stderr)
@@ -61,5 +62,22 @@ actor FluidAudioTranscriber {
     func shutdown() {
         asrManager = nil
         loadedVersion = nil
+    }
+
+    func shutdown(ifLoadedVersion version: AsrModelVersion) {
+        guard FluidAudioUnloadPolicy.shouldUnload(
+            loadedVersion: loadedVersion,
+            deletingVersion: version
+        ) else { return }
+        shutdown()
+    }
+}
+
+enum FluidAudioUnloadPolicy {
+    static func shouldUnload(
+        loadedVersion: AsrModelVersion?,
+        deletingVersion: AsrModelVersion
+    ) -> Bool {
+        loadedVersion == deletingVersion
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
@@ -21,50 +21,34 @@ actor FluidAudioTranscriber {
 
     /// Downloads models (if needed) and initializes the ASR manager.
     /// - Parameter version: .v3 for multilingual (25 langs), .v2 for English-only
-    func loadModels(version: AsrModelVersion = .v3, progress: ((Double, String?) -> Void)? = nil) async throws {
+    func loadModels(
+        version: AsrModelVersion = .v3,
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
+    ) async throws {
         if loadedVersion == version, asrManager != nil { return }
 
         fputs("[fluidaudio] downloading/loading models (version: \(version))...\n", stderr)
-        let estimatedTotalBytes: Int64 = 450 * 1_000_000
-        let rateEstimator = DownloadRateEstimator()
-        let totalText = Self.formatMegabytes(estimatedTotalBytes)
-        let models = try await AsrModels.downloadAndLoad(version: version) { downloadProgress in
-            let fraction = downloadProgress.fractionCompleted
-            let estimatedDownloadFraction = min(max(fraction / 0.5, 0), 1)
-            let estimatedBytes = Int64(Double(estimatedTotalBytes) * estimatedDownloadFraction)
-            let bytesPerSecond = rateEstimator.bytesPerSecond(for: estimatedBytes)
-            let status: String
-            switch downloadProgress.phase {
-            case .listing:
-                status = "0 MB of \(totalText)"
-            case .downloading(_, _):
-                let completedText = Self.formatMegabytes(estimatedBytes)
-                if bytesPerSecond > 0 {
-                    let rateText = Self.formatMegabytes(Int64(bytesPerSecond))
-                    status = "\(completedText) of \(totalText) • \(rateText)/s"
-                } else {
-                    status = "\(completedText) of \(totalText)"
-                }
-            case .compiling(_):
-                status = "Compiling model..."
-            }
-            DispatchQueue.main.async {
-                progress?(fraction, status)
-            }
-        }
+        let plan = version == .v2 ? ManagedASRModelPlans.parakeetV2() : ManagedASRModelPlans.parakeetV3()
+        let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            progress: progress,
+            progressSnapshot: progressSnapshot
+        )
+        let preparing = ModelDownloadProgress.preparing(
+            modelID: plan.modelID,
+            message: "Loading Parakeet into Core ML..."
+        )
+        progress?(0.95, preparing.message)
+        progressSnapshot?(preparing)
+        let models = try await AsrModels.load(from: modelDirectory, version: version)
         let manager = AsrManager(config: .default)
         try await manager.loadModels(models)
         self.asrManager = manager
         self.loadedVersion = version
+        progress?(1, nil)
+        progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[fluidaudio] models ready\n", stderr)
-    }
-
-    private static func formatMegabytes(_ bytes: Int64) -> String {
-        let megabytes = Double(bytes) / 1_000_000
-        if megabytes >= 100 {
-            return "\(Int(megabytes.rounded())) MB"
-        }
-        return String(format: "%.1f MB", megabytes)
     }
 
     /// Transcribe a WAV file URL directly.
@@ -77,20 +61,5 @@ actor FluidAudioTranscriber {
     func shutdown() {
         asrManager = nil
         loadedVersion = nil
-    }
-}
-
-private final class DownloadRateEstimator {
-    private var downloadStartedAt: Date?
-
-    func bytesPerSecond(for estimatedBytes: Int64) -> Double {
-        guard estimatedBytes > 0 else { return 0 }
-        let now = Date()
-        if downloadStartedAt == nil {
-            downloadStartedAt = now
-            return 0
-        }
-        let elapsed = max(now.timeIntervalSince(downloadStartedAt ?? now), 1.0)
-        return Double(estimatedBytes) / elapsed
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FluidAudioBackend.swift
@@ -30,23 +30,28 @@ actor FluidAudioTranscriber {
 
         fputs("[fluidaudio] downloading/loading models (version: \(version))...\n", stderr)
         let plan = version == .v2 ? ManagedASRModelPlans.parakeetV2() : ManagedASRModelPlans.parakeetV3()
-        let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
+        let manager = try await ManagedASRModelDownloader.loadValidated(
             plan,
             progress: progress,
             progressSnapshot: progressSnapshot
-        )
+        ) { modelDirectory in
+            let preparing = ModelDownloadProgress.preparing(
+                modelID: plan.modelID,
+                message: "Loading Parakeet into Core ML..."
+            )
+            progress?(0.95, preparing.message)
+            progressSnapshot?(preparing)
+            let models = try await AsrModels.load(from: modelDirectory, version: version)
+            let manager = AsrManager(config: .default)
+            try await manager.loadModels(models)
+            return manager
+        }
+        self.asrManager = manager
+        self.loadedVersion = version
         let preparing = ModelDownloadProgress.preparing(
             modelID: plan.modelID,
             message: "Loading Parakeet into Core ML..."
         )
-        progress?(0.95, preparing.message)
-        progressSnapshot?(preparing)
-        let models = try await AsrModels.load(from: modelDirectory, version: version)
-        let manager = AsrManager(config: .default)
-        try await manager.loadModels(models)
-        self.asrManager = manager
-        self.loadedVersion = version
-        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress?(1, nil)
         progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[fluidaudio] models ready\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -1,12 +1,14 @@
 import AVFoundation
 import FluidAudio
 import Foundation
+import MuesliCore
 import os
 
 enum MeetingLiveCaptionModelStore {
     static let repo = Repo.parakeetEou320
+    static let modelID = "FluidInference/parakeet-realtime-eou-120m-coreml/320ms"
     static let sizeLabel = "~430 MB"
-    static let label = "Parakeet Realtime EOU"
+    static let label = "Parakeet Live Captions"
 
     static func cacheRoot(fileManager: FileManager = .default) -> URL {
         fileManager.homeDirectoryForCurrentUser
@@ -26,24 +28,25 @@ enum MeetingLiveCaptionModelStore {
     }
 
     static func isDownloaded(in cacheRoot: URL, fileManager: FileManager = .default) -> Bool {
-        let directory = modelDirectory(in: cacheRoot)
-        return ModelNames.ParakeetEOU.requiredModels.allSatisfy {
-            fileManager.fileExists(atPath: directory.appendingPathComponent($0).path)
-        }
+        ManagedASRModelPlans.parakeetRealtimeEOU320(modelsRoot: cacheRoot)
+            .isComplete(fileManager: fileManager)
     }
 
     static func download(
-        progress: (@Sendable (Double) -> Void)? = nil
+        progress: (@Sendable (Double) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
     ) async throws {
-        try await DownloadUtils.downloadRepo(repo, to: cacheRoot()) { update in
-            progress?(update.fractionCompleted)
-        }
+        _ = try await ManagedASRModelDownloader.downloadIfNeeded(
+            ManagedASRModelPlans.parakeetRealtimeEOU320(),
+            progress: { fraction, _ in progress?(fraction) },
+            progressSnapshot: progressSnapshot
+        )
     }
 
     static func delete(fileManager: FileManager = .default) throws {
-        let directory = modelDirectory(fileManager: fileManager)
-        guard fileManager.fileExists(atPath: directory.path) else { return }
-        try fileManager.removeItem(at: directory)
+        try ManagedASRModelPlans.parakeetRealtimeEOU320(
+            modelsRoot: cacheRoot(fileManager: fileManager)
+        ).delete(fileManager: fileManager)
     }
 
     static func makeEngine(label: String) async throws -> MeetingStreamingPartialEngine {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -50,11 +50,12 @@ enum MeetingLiveCaptionModelStore {
     }
 
     static func makeEngine(label: String) async throws -> MeetingStreamingPartialEngine {
-        let engine = ParakeetEOUMeetingPartialEngine(label: label)
-        try await engine.loadModels(from: modelDirectory())
-        try? ManagedASRModelPlans.parakeetRealtimeEOU320()
-            .recordValidatedLegacyInstallationIfNeeded()
-        return engine
+        let plan = ManagedASRModelPlans.parakeetRealtimeEOU320()
+        return try await ManagedASRModelDownloader.loadValidated(plan) { directory in
+            let engine = ParakeetEOUMeetingPartialEngine(label: label)
+            try await engine.loadModels(from: directory)
+            return engine
+        }
     }
 
     static func makeEngines(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingStreamingPartialSession.swift
@@ -29,7 +29,7 @@ enum MeetingLiveCaptionModelStore {
 
     static func isDownloaded(in cacheRoot: URL, fileManager: FileManager = .default) -> Bool {
         ManagedASRModelPlans.parakeetRealtimeEOU320(modelsRoot: cacheRoot)
-            .isComplete(fileManager: fileManager)
+            .isAvailableLocally(fileManager: fileManager)
     }
 
     static func download(
@@ -52,6 +52,8 @@ enum MeetingLiveCaptionModelStore {
     static func makeEngine(label: String) async throws -> MeetingStreamingPartialEngine {
         let engine = ParakeetEOUMeetingPartialEngine(label: label)
         try await engine.loadModels(from: modelDirectory())
+        try? ManagedASRModelPlans.parakeetRealtimeEOU320()
+            .recordValidatedLegacyInstallationIfNeeded()
         return engine
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -206,10 +206,7 @@ struct BackendOption: Equatable {
             }
             return false
         case "qwen":
-            let supportDir = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/FluidAudio/Models/qwen3-asr-0.6b-coreml")
-            return fm.fileExists(atPath: supportDir.appendingPathComponent("int8/vocab.json").path)
-                || fm.fileExists(atPath: supportDir.appendingPathComponent("f32/vocab.json").path)
+            return Qwen3AsrModelStore.isModelDownloaded(fileManager: fm)
         case "nemotron35":
             return Nemotron35ModelStore.isModelDownloaded(fileManager: fm)
         case "cohere":

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -199,7 +199,7 @@ struct BackendOption: Equatable {
             let plan = model.contains("v2")
                 ? ManagedASRModelPlans.parakeetV2()
                 : ManagedASRModelPlans.parakeetV3()
-            return plan.isComplete(fileManager: fm)
+            return plan.isAvailableLocally(fileManager: fm)
         case "qwen":
             return Qwen3AsrModelStore.isModelDownloaded(fileManager: fm)
         case "nemotron35":
@@ -209,7 +209,7 @@ struct BackendOption: Equatable {
         case "indicasr":
             return IndicASRModelStore.isAvailableLocally()
         case "sensevoice":
-            return SenseVoiceTranscriber.isModelDownloaded()
+            return SenseVoiceTranscriber.isModelDownloaded(fileManager: fm)
         case "gemma4-litert":
             return Gemma4LiteRTModelStore.isAvailableLocally()
         default:

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -15,7 +15,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/parakeet-tdt-0.6b-v3-coreml",
         label: "Parakeet v3",
         sizeLabel: "~450 MB",
-        description: "Fast everyday transcription with an excellent balance of speed and accuracy. Supports 25 languages.",
+        description: "The best default for everyday dictation: quick enough to feel responsive, reliable in normal rooms, and able to follow 25 languages.",
         recommended: true
     )
 
@@ -24,7 +24,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/parakeet-tdt-0.6b-v2-coreml",
         label: "Parakeet v2",
         sizeLabel: "~450 MB",
-        description: "Fast English transcription with a strong balance of speed and accuracy.",
+        description: "A quick, dependable English-only option. Choose it if you mainly dictate in English and prefer the older Parakeet model.",
         recommended: false
     )
 
@@ -33,7 +33,7 @@ struct BackendOption: Equatable {
         model: "small.en",
         label: "Whisper Small",
         sizeLabel: "~250 MB",
-        description: "Fast, English-optimized. Runs on Apple Neural Engine via CoreML.",
+        description: "A dependable English Whisper option for everyday notes. It is more forgiving than Tiny while keeping the download modest.",
         recommended: false
     )
 
@@ -42,7 +42,7 @@ struct BackendOption: Equatable {
         model: "tiny.en",
         label: "Whisper Tiny English",
         sizeLabel: "~153 MB",
-        description: "Smallest English WhisperKit CoreML model. Quickest local setup.",
+        description: "The quickest Whisper download and lightest option for occasional English notes. It gives up some accuracy on accents, noise, and longer speech.",
         recommended: false
     )
 
@@ -51,7 +51,7 @@ struct BackendOption: Equatable {
         model: "medium.en",
         label: "Whisper Medium",
         sizeLabel: "~1.5 GB",
-        description: "Better accuracy, English-only. Runs on Apple Neural Engine via CoreML.",
+        description: "More careful English transcription for accents or difficult audio, at the cost of a much larger download and slower results.",
         recommended: false
     )
 
@@ -60,7 +60,7 @@ struct BackendOption: Equatable {
         model: "large-v3-v20240930_626MB",
         label: "Whisper Large Turbo",
         sizeLabel: "~626 MB",
-        description: "Highest accuracy, multilingual. Quantized CoreML for faster inference.",
+        description: "Whisper's strongest multilingual option. Better for mixed languages and difficult audio, with a larger download and more processing time than Small.",
         recommended: false
     )
 
@@ -69,7 +69,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML",
         label: "Nemotron 3.5 Multilingual",
         sizeLabel: "~665 MB",
-        description: "NVIDIA Nemotron 3.5 streaming RNNT via FluidInference. Multilingual incl. Hindi, Chinese, Japanese + 100+ locales (auto-detect). Native punctuation. Hold-to-talk or double-tap handsfree (live text). For meetings, one continuous transcript is used live and as the final raw transcript. Append-only with no corrections.",
+        description: "Live text appears as you speak in more than 100 locales, including Hindi, Chinese, and Japanese, with language auto-detection and punctuation. It works for hold-to-talk, hands-free dictation, and meetings, but it only appends words—it does not go back to correct earlier text.",
         recommended: false
     )
 
@@ -78,7 +78,7 @@ struct BackendOption: Equatable {
         model: "phequals/cohere-transcribe-coreml-mixed-precision",
         label: "Cohere Transcribe",
         sizeLabel: "~3.8 GB",
-        description: "Best accuracy for difficult audio and accents. Choose it when getting every word right matters more than speed. It is larger and slower than Parakeet, supports 14 languages, and gives you the final transcript when you stop. Works best in a quiet environment.",
+        description: "The most deliberate option for difficult accents and tricky audio. It supports 14 languages and can be more accurate than faster models, but the download is large and you only see the result after you stop speaking.",
         recommended: false
     )
 
@@ -87,7 +87,7 @@ struct BackendOption: Equatable {
         model: "phequals/indic-conformer-600m-multilingual-coreml-rnnt",
         label: "Indic ASR",
         sizeLabel: "~618 MB",
-        description: "Experimental AI4Bharat IndicConformer RNNT CoreML backend for seven Indian languages. Requires explicit language selection.",
+        description: "Built specifically for seven Indian languages. Choose your language before recording; it can help where general multilingual models struggle, but results still vary enough to keep it experimental.",
         recommended: false
     )
 
@@ -96,7 +96,7 @@ struct BackendOption: Equatable {
         model: "FluidInference/sensevoice-small-coreml",
         label: "SenseVoice Small",
         sizeLabel: SenseVoiceTranscriber.downloadedModelSizeLabel,
-        description: "FunASR SenseVoiceSmall via FluidAudio. INT8 CoreML/ANE on macOS 14+, 50+ languages. Non-autoregressive with built-in punctuation.",
+        description: "A compact option covering more than 50 languages, with punctuation included in the result. Quality varies by language and accent, so try it with your own voice before relying on it.",
         recommended: false
     )
 
@@ -105,7 +105,7 @@ struct BackendOption: Equatable {
         model: Gemma4LiteRTModelStore.repoID,
         label: "Gemma 4 E2B",
         sizeLabel: "~2.6 GB",
-        description: "Experimental Gemma 4 LiteRT-LM evaluation backend. Downloads managed local weights, requires macOS 15+, and is not production ASR until an ASR-tuned Gemma artifact is available; chat-style outputs fail closed.",
+        description: "A research preview, not a dependable dictation model yet. It is large, slow to get ready, requires macOS 15 or later, and may produce an answer instead of a faithful transcript.",
         recommended: false
     )
 
@@ -125,12 +125,12 @@ struct BackendOption: Equatable {
         model: "FluidInference/qwen3-asr-0.6b-coreml",
         label: "Qwen3 ASR",
         sizeLabel: "~1.3 GB",
-        description: "Multilingual, 52 languages. Slower than Parakeet (~2-3s). First use takes ~30s to warm up.",
+        description: "Strong multilingual transcription across 52 languages when accuracy matters more than instant results. Expect a short 2–3 second wait compared with Parakeet, and about 30 seconds of one-time preparation the first time it runs.",
         recommended: false
     )
 
     static let experimental: [BackendOption] = [
-        .senseVoiceSmall, .qwen3Asr, .indicASR, .gemma4E2BLiteRT,
+        .senseVoiceSmall, .indicASR, .gemma4E2BLiteRT,
     ]
 
     /// Native streaming backends used by low-latency product surfaces.
@@ -141,7 +141,7 @@ struct BackendOption: Equatable {
     ]
 
     /// Models available for download and use.
-    static let all: [BackendOption] = parakeetFamily + whisperFamily + [.cohereTranscribe] + streaming + experimental
+    static let all: [BackendOption] = parakeetFamily + [.qwen3Asr] + whisperFamily + [.cohereTranscribe] + streaming + experimental
 
     /// Curated first-run choices shown in onboarding's "Other models" section.
     /// This is a deliberate hand-picked list, not a derived rule. Experimental models
@@ -196,15 +196,10 @@ struct BackendOption: Equatable {
         case "whisper":
             return WhisperKitTranscriber.isModelDownloaded(model)
         case "fluidaudio":
-            let supportDir = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/FluidAudio/Models")
-            if model.contains("parakeet") {
-                let version = model.contains("v2") ? "v2" : "v3"
-                if let contents = try? fm.contentsOfDirectory(at: supportDir, includingPropertiesForKeys: nil) {
-                    return contents.contains { $0.lastPathComponent.contains("parakeet") && $0.lastPathComponent.contains(version) }
-                }
-            }
-            return false
+            let plan = model.contains("v2")
+                ? ManagedASRModelPlans.parakeetV2()
+                : ManagedASRModelPlans.parakeetV3()
+            return plan.isComplete(fileManager: fm)
         case "qwen":
             return Qwen3AsrModelStore.isModelDownloaded(fileManager: fm)
         case "nemotron35":
@@ -586,9 +581,9 @@ struct PostProcessorOption: Identifiable, Equatable {
     // HF repo must be public (or token-gated) before distributing alpha builds.
     static let finetunedV2 = PostProcessorOption(
         id: "qwen3-postproc-v2",
-        label: "Post-Proc v2 (Finetuned)",
+        label: "Muesli Cleanup (Legacy)",
         sizeLabel: "~390 MB",
-        description: "Fine-tuned on Muesli dictation data. Best for filler removal, deletion cues, and spoken list formatting.",
+        description: "An earlier cleanup model for Muesli dictation. It handles filler words, corrections, and spoken lists, but is less consistent than the current model.",
         downloadURL: URL(string: "https://huggingface.co/phequals/qwen3-postproc-v2/resolve/main/qwen3-postproc-v2-q4_k_m.gguf")!,
         filename: "qwen3-postproc-v2-q4_k_m.gguf"
     )
@@ -596,9 +591,9 @@ struct PostProcessorOption: Identifiable, Equatable {
     // Vanilla Qwen3.5-0.8B. Stable for basic cleanup; does not reliably convert spoken list cues.
     static let qwen35_0_8b = PostProcessorOption(
         id: "qwen35-0.8b",
-        label: "Qwen3.5 0.8B",
+        label: "Qwen Basic Cleanup",
         sizeLabel: "~533 MB",
-        description: "Vanilla Qwen3.5-0.8B. Good for typo correction and filler removal. Spoken list formatting is unreliable.",
+        description: "A general-purpose option for typos and filler words. It may miss “scratch that” edits and spoken list formatting.",
         downloadURL: URL(string: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf")!,
         filename: "Qwen3.5-0.8B-Q4_K_M.gguf"
     )
@@ -606,9 +601,9 @@ struct PostProcessorOption: Identifiable, Equatable {
     // Fine-tuned Qwen3.5-0.8B v3 trained on Muesli dictation correction data.
     static let finetunedV3 = PostProcessorOption(
         id: "qwen35-postproc-v3",
-        label: "Post-Proc v3 (Finetuned)",
+        label: "Muesli Cleanup",
         sizeLabel: "~505 MB",
-        description: "Fine-tuned Qwen3.5-0.8B on Muesli dictation data. Improved over v2 on filler removal, deletion cues, and spoken list formatting.",
+        description: "The best overall choice for everyday dictation. It removes filler words, follows “scratch that,” and turns spoken list cues into clean formatting.",
         downloadURL: URL(string: "https://huggingface.co/phequals/qwen35-postproc-v3-gguf/resolve/main/qwen35-postproc-v3-Q4_K_M.gguf")!,
         filename: "qwen35-postproc-v3-Q4_K_M.gguf"
     )

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1,5 +1,6 @@
-import SwiftUI
+import FluidAudio
 import MuesliCore
+import SwiftUI
 
 struct ModelDownloadGenerationState: Equatable {
     private(set) var current: UUID?
@@ -342,7 +343,7 @@ struct ModelsView: View {
                                 liveCaptionDownloadGeneration.contains(cancellationGeneration)
                             }
                             guard shouldCancel else { return }
-                            await ModelDownloadCoordinator.shared.cancelAndWait(
+                            await ManagedASRModelDownloader.cancelAndWait(
                                 modelID: MeetingLiveCaptionModelStore.modelID
                             )
                             _ = await task?.value
@@ -1541,7 +1542,7 @@ struct ModelsView: View {
             }
             guard shouldCancel else { return }
 
-            await ModelDownloadCoordinator.shared.cancel(modelID: modelID)
+            await ManagedASRModelDownloader.cancel(modelID: modelID)
             _ = await task?.value
 
             await MainActor.run {
@@ -1592,13 +1593,18 @@ struct ModelsView: View {
         // Stop any transfer before removing files so a late write cannot recreate
         // part of the model after the deletion has completed.
         Task {
+            let deletionToken = await ManagedASRModelDownloader.beginDeletion(
+                modelID: option.model
+            )
             do {
-                await ModelDownloadCoordinator.shared.cancelAndWait(modelID: option.model)
                 _ = await task?.value
                 let shouldDelete = await MainActor.run {
                     downloadGenerations[option.model] == deletionGeneration
                 }
-                guard shouldDelete else { return }
+                guard shouldDelete else {
+                    await ManagedASRModelDownloader.endDeletion(deletionToken)
+                    return
+                }
                 try await deleteModelFiles(option)
                 await MainActor.run {
                     _ = downloadedModels.remove(option.model)
@@ -1609,6 +1615,7 @@ struct ModelsView: View {
             } catch {
                 fputs("[muesli-native] model delete failed for \(option.backend)/\(option.model): \(error)\n", stderr)
             }
+            await ManagedASRModelDownloader.endDeletion(deletionToken)
         }
     }
 
@@ -1631,8 +1638,11 @@ struct ModelsView: View {
             await controller.transcriptionCoordinator.unloadGemma4LiteRTTranscriber()
             try Gemma4LiteRTModelStore.deleteModelFiles(fileManager: fm)
         case "fluidaudio":
-            await controller.transcriptionCoordinator.unloadFluidAudioTranscriber()
-            let plan = option.model.contains("v2")
+            let version: AsrModelVersion = option.model.contains("v2") ? .v2 : .v3
+            await controller.transcriptionCoordinator.unloadFluidAudioTranscriber(
+                ifLoadedVersion: version
+            )
+            let plan = version == .v2
                 ? ManagedASRModelPlans.parakeetV2()
                 : ManagedASRModelPlans.parakeetV3()
             try plan.delete(fileManager: fm)
@@ -1694,7 +1704,7 @@ struct ModelsView: View {
             let plan = option.model.contains("v2")
                 ? ManagedASRModelPlans.parakeetV2()
                 : ManagedASRModelPlans.parakeetV3()
-            return plan.isComplete(fileManager: fm)
+            return plan.isAvailableLocally(fileManager: fm)
         case "qwen":
             return Qwen3AsrModelStore.isModelDownloaded(fileManager: fm)
         case "cohere":
@@ -1702,7 +1712,7 @@ struct ModelsView: View {
         case "indicasr":
             return IndicASRModelStore.isAvailableLocally()
         case "sensevoice":
-            return SenseVoiceTranscriber.isModelDownloaded()
+            return SenseVoiceTranscriber.isModelDownloaded(fileManager: fm)
         case "gemma4-litert":
             return Gemma4LiteRTModelStore.isAvailableLocally(fileManager: fm)
         default:

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -48,7 +48,7 @@ struct ModelsView: View {
                         .font(MuesliTheme.title1())
                         .foregroundStyle(MuesliTheme.textPrimary)
 
-                    Text("Download and manage models for dictation, streaming, and post-processing.")
+                    Text("Choose the transcription and cleanup models that fit how you speak and work.")
                         .font(MuesliTheme.body())
                         .foregroundStyle(MuesliTheme.textSecondary)
 
@@ -129,7 +129,7 @@ struct ModelsView: View {
                 deleteLiveCaptionModel()
             }
         } message: {
-            Text("Live meetings will fall back to committed VAD-chunk captions until this model is downloaded again.")
+            Text("Live meetings will fall back to standard chunk-by-chunk captions until this model is downloaded again.")
         }
     }
 
@@ -146,16 +146,18 @@ struct ModelsView: View {
         case .dictation:
             familyCard(
                 title: "Parakeet Family",
-                subtitle: "Fast, responsive transcription with an excellent balance of speed and accuracy.",
+                subtitle: "The most responsive choices for everyday dictation, with multilingual and English-only options.",
                 defaultBadge: "Default: v3",
                 logo: "nvidia-logo",
                 selection: $selectedParakeetModel,
                 options: BackendOption.parakeetFamily
             )
 
+            modelCard(option: .qwen3Asr, logo: "qwen-logo")
+
             familyCard(
                 title: "Whisper",
-                subtitle: "OpenAI Whisper variants. Runs on Apple Neural Engine via CoreML.",
+                subtitle: "Dependable alternatives when you prefer Whisper's transcription style or need broader multilingual coverage.",
                 defaultBadge: "Default: Small",
                 logo: "openai-logo",
                 selection: $selectedWhisperModel,
@@ -218,11 +220,11 @@ struct ModelsView: View {
     private var streamingSection: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                Text("STREAMING")
+                Text("LIVE MEETINGS")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(MuesliTheme.textTertiary)
 
-                Text("Choose one live meeting transcript model. Nemotron is live + final; Parakeet is live preview only.")
+                Text("Choose how words appear while a meeting is in progress. Nemotron also creates the saved transcript; Parakeet prioritizes a faster English preview.")
                     .font(MuesliTheme.caption())
                     .foregroundStyle(MuesliTheme.textSecondary)
             }
@@ -271,7 +273,7 @@ struct ModelsView: View {
                             .foregroundStyle(MuesliTheme.textTertiary)
                     }
 
-                    Text("Low-latency English preview while a meeting is in progress. A separate meeting model creates the final transcript.")
+                    Text("Fast English captions while a meeting is in progress. They are a provisional preview; your regular meeting model creates the transcript you keep.")
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }
@@ -298,22 +300,30 @@ struct ModelsView: View {
             }
 
             if isDownloadingLiveCaptionModel {
-                VStack(alignment: .leading, spacing: 4) {
-                    ProgressView(value: liveCaptionDownloadProgress)
-                        .tint(MuesliTheme.accent)
-                    Text("\(Int(liveCaptionDownloadProgress * 100))% downloading...")
-                        .font(.system(size: 11))
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                }
+                downloadProgressView(
+                    for: MeetingLiveCaptionModelStore.modelID,
+                    fallbackProgress: liveCaptionDownloadProgress
+                )
             }
 
             HStack(spacing: MuesliTheme.spacing8) {
                 if isDownloadingLiveCaptionModel {
                     Button("Cancel") {
                         liveCaptionDownloadTask?.cancel()
+                        Task {
+                            await ModelDownloadCoordinator.shared.cancel(
+                                modelID: MeetingLiveCaptionModelStore.modelID
+                            )
+                        }
                         liveCaptionDownloadTask = nil
                         isDownloadingLiveCaptionModel = false
                         liveCaptionDownloadProgress = 0
+                        if let snapshot = downloadSnapshots[MeetingLiveCaptionModelStore.modelID] {
+                            downloadSnapshots[MeetingLiveCaptionModelStore.modelID] = snapshot.replacing(
+                                phase: .paused,
+                                message: "Paused — select Download to resume"
+                            )
+                        }
                     }
                     .buttonStyle(.plain)
                     .font(.system(size: 12, weight: .medium))
@@ -372,11 +382,19 @@ struct ModelsView: View {
         guard !isDownloadingLiveCaptionModel else { return }
         isDownloadingLiveCaptionModel = true
         liveCaptionDownloadProgress = 0
+        downloadSnapshots.removeValue(forKey: MeetingLiveCaptionModelStore.modelID)
         liveCaptionDownloadTask = Task {
             do {
                 try await MeetingLiveCaptionModelStore.download { progress in
                     Task { @MainActor in
                         liveCaptionDownloadProgress = progress
+                    }
+                } progressSnapshot: { snapshot in
+                    Task { @MainActor in
+                        downloadSnapshots[MeetingLiveCaptionModelStore.modelID] = snapshot
+                        if let fraction = snapshot.fractionCompleted {
+                            liveCaptionDownloadProgress = fraction
+                        }
                     }
                 }
                 guard !Task.isCancelled else { return }
@@ -389,6 +407,9 @@ struct ModelsView: View {
             isDownloadingLiveCaptionModel = false
             liveCaptionDownloadProgress = 0
             liveCaptionDownloadTask = nil
+            if isLiveCaptionModelDownloaded {
+                downloadSnapshots.removeValue(forKey: MeetingLiveCaptionModelStore.modelID)
+            }
         }
     }
 
@@ -421,7 +442,7 @@ struct ModelsView: View {
                                 .foregroundStyle(MuesliTheme.textSecondary)
                         }
 
-                        Text("SenseVoice, Qwen, Indic ASR, and Gemma 4 evaluation backends. Hidden by default because these are still slower and less polished.")
+                        Text("Early models for specific languages and evaluation. Expect less consistent transcripts, and try them with your own voice before relying on them.")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(MuesliTheme.textPrimary)
                             .opacity(0.8)
@@ -429,7 +450,7 @@ struct ModelsView: View {
 
                     Spacer()
 
-                    Text("IYKYK")
+                    Text("Early access")
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(MuesliTheme.textTertiary)
                         .padding(.horizontal, 8)
@@ -495,13 +516,13 @@ struct ModelsView: View {
     private var postProcessorSection: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                Text("POST-PROCESSING")
+                Text("CLEANUP")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(MuesliTheme.textTertiary)
                     .textCase(.uppercase)
                     .padding(.leading, 2)
 
-                Text("Optional LLM cleanup layer applied after transcription. Removes filler words, formats spoken lists, and corrects common dictation errors.")
+                Text("Optional cleanup after transcription. Use it to remove filler words, follow spoken corrections, format lists, and fix obvious dictation errors.")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .padding(.leading, 2)
@@ -531,7 +552,7 @@ struct ModelsView: View {
             onSetActive: {
                 controller.selectPostProcessorBackend(.gemma4LiteRT)
             },
-            description: "On-device Gemma cleanup for filler removal, formatting, and transcript correction. Shares one download with the experimental Gemma dictation backend.",
+            description: "An experimental local option for filler removal, formatting, and obvious transcript errors. It uses the same download as Gemma 4 dictation.",
             activeLabel: "Cleanup Active",
             downloadedLabel: isCompatible ? "Downloaded" : "Used for Dictation",
             actionTitle: "Use for Cleanup",
@@ -1131,7 +1152,7 @@ struct ModelsView: View {
                             .font(MuesliTheme.headline())
                             .foregroundStyle(MuesliTheme.textTertiary)
 
-                        Text("Experimental")
+                        Text("Coming soon")
                             .font(.system(size: 10, weight: .semibold))
                             .foregroundStyle(MuesliTheme.textTertiary)
                             .padding(.horizontal, 6)
@@ -1551,17 +1572,10 @@ struct ModelsView: View {
             await controller.transcriptionCoordinator.unloadGemma4LiteRTTranscriber()
             try Gemma4LiteRTModelStore.deleteModelFiles(fileManager: fm)
         case "fluidaudio":
-            // FluidAudio models are in ~/Library/Application Support/FluidAudio/Models/
-            let supportDir = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/FluidAudio/Models")
-            if option.model.contains("parakeet") {
-                let version = option.model.contains("v2") ? "v2" : "v3"
-                if let contents = try? fm.contentsOfDirectory(at: supportDir, includingPropertiesForKeys: nil) {
-                    for dir in contents where dir.lastPathComponent.contains("parakeet") && dir.lastPathComponent.contains(version) {
-                        try removeItemIfPresent(at: dir, fileManager: fm)
-                    }
-                }
-            }
+            let plan = option.model.contains("v2")
+                ? ManagedASRModelPlans.parakeetV2()
+                : ManagedASRModelPlans.parakeetV3()
+            try plan.delete(fileManager: fm)
         case "qwen":
             try Qwen3AsrModelStore.deleteModelFiles(fileManager: fm)
         default:
@@ -1616,16 +1630,10 @@ struct ModelsView: View {
         case "nemotron35":
             return Nemotron35ModelStore.isModelDownloaded(fileManager: fm)
         case "fluidaudio":
-            // Check FluidAudio's cache
-            let supportDir = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/FluidAudio/Models")
-            if option.model.contains("parakeet") {
-                let version = option.model.contains("v2") ? "v2" : "v3"
-                if let contents = try? fm.contentsOfDirectory(at: supportDir, includingPropertiesForKeys: nil) {
-                    return contents.contains { $0.lastPathComponent.contains("parakeet") && $0.lastPathComponent.contains(version) }
-                }
-            }
-            return false
+            let plan = option.model.contains("v2")
+                ? ManagedASRModelPlans.parakeetV2()
+                : ManagedASRModelPlans.parakeetV3()
+            return plan.isComplete(fileManager: fm)
         case "qwen":
             return Qwen3AsrModelStore.isModelDownloaded(fileManager: fm)
         case "cohere":

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1,6 +1,27 @@
 import SwiftUI
 import MuesliCore
 
+struct ModelDownloadGenerationState: Equatable {
+    private(set) var current: UUID?
+
+    mutating func begin() -> UUID {
+        let generation = UUID()
+        current = generation
+        return generation
+    }
+
+    func contains(_ generation: UUID) -> Bool {
+        current == generation
+    }
+
+    @discardableResult
+    mutating func clear(_ generation: UUID) -> Bool {
+        guard current == generation else { return false }
+        current = nil
+        return true
+    }
+}
+
 struct ModelsView: View {
     let appState: AppState
     let controller: MuesliController
@@ -19,8 +40,10 @@ struct ModelsView: View {
     @State private var showExperimental: Bool
     @State private var isLiveCaptionModelDownloaded = false
     @State private var isDownloadingLiveCaptionModel = false
+    @State private var isCancellingLiveCaptionModelDownload = false
     @State private var liveCaptionDownloadProgress = 0.0
     @State private var liveCaptionDownloadTask: Task<Void, Never>?
+    @State private var liveCaptionDownloadGeneration = ModelDownloadGenerationState()
     @State private var showDeleteLiveCaptionModelConfirmation = false
 
     // Post-processor state
@@ -308,15 +331,29 @@ struct ModelsView: View {
 
             HStack(spacing: MuesliTheme.spacing8) {
                 if isDownloadingLiveCaptionModel {
-                    Button("Cancel") {
-                        liveCaptionDownloadTask?.cancel()
+                    Button(isCancellingLiveCaptionModelDownload ? "Pausing…" : "Cancel") {
+                        guard !isCancellingLiveCaptionModelDownload else { return }
+                        let task = liveCaptionDownloadTask
+                        task?.cancel()
+                        let cancellationGeneration = liveCaptionDownloadGeneration.begin()
+                        isCancellingLiveCaptionModelDownload = true
                         Task {
-                            await ModelDownloadCoordinator.shared.cancel(
+                            let shouldCancel = await MainActor.run {
+                                liveCaptionDownloadGeneration.contains(cancellationGeneration)
+                            }
+                            guard shouldCancel else { return }
+                            await ModelDownloadCoordinator.shared.cancelAndWait(
                                 modelID: MeetingLiveCaptionModelStore.modelID
                             )
+                            _ = await task?.value
+                            await MainActor.run {
+                                guard liveCaptionDownloadGeneration.clear(cancellationGeneration) else { return }
+                                liveCaptionDownloadTask = nil
+                                isDownloadingLiveCaptionModel = false
+                                isCancellingLiveCaptionModelDownload = false
+                                liveCaptionDownloadProgress = 0
+                            }
                         }
-                        liveCaptionDownloadTask = nil
-                        isDownloadingLiveCaptionModel = false
                         liveCaptionDownloadProgress = 0
                         if let snapshot = downloadSnapshots[MeetingLiveCaptionModelStore.modelID] {
                             downloadSnapshots[MeetingLiveCaptionModelStore.modelID] = snapshot.replacing(
@@ -325,6 +362,7 @@ struct ModelsView: View {
                             )
                         }
                     }
+                    .disabled(isCancellingLiveCaptionModelDownload)
                     .buttonStyle(.plain)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(MuesliTheme.textSecondary)
@@ -380,31 +418,39 @@ struct ModelsView: View {
 
     private func startLiveCaptionModelDownload() {
         guard !isDownloadingLiveCaptionModel else { return }
+        isCancellingLiveCaptionModelDownload = false
         isDownloadingLiveCaptionModel = true
         liveCaptionDownloadProgress = 0
         downloadSnapshots.removeValue(forKey: MeetingLiveCaptionModelStore.modelID)
+        let generation = liveCaptionDownloadGeneration.begin()
         liveCaptionDownloadTask = Task {
             do {
                 try await MeetingLiveCaptionModelStore.download { progress in
                     Task { @MainActor in
+                        guard liveCaptionDownloadGeneration.contains(generation) else { return }
                         liveCaptionDownloadProgress = progress
                     }
                 } progressSnapshot: { snapshot in
                     Task { @MainActor in
+                        guard liveCaptionDownloadGeneration.contains(generation) else { return }
                         downloadSnapshots[MeetingLiveCaptionModelStore.modelID] = snapshot
                         if let fraction = snapshot.fractionCompleted {
                             liveCaptionDownloadProgress = fraction
                         }
                     }
                 }
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled,
+                      liveCaptionDownloadGeneration.contains(generation)
+                else { return }
                 isLiveCaptionModelDownloaded = true
             } catch is CancellationError {
                 // Cancellation is an expected user action.
             } catch {
                 fputs("[muesli-native] live caption model download failed: \(error)\n", stderr)
             }
+            guard liveCaptionDownloadGeneration.clear(generation) else { return }
             isDownloadingLiveCaptionModel = false
+            isCancellingLiveCaptionModelDownload = false
             liveCaptionDownloadProgress = 0
             liveCaptionDownloadTask = nil
             if isLiveCaptionModelDownloaded {
@@ -1537,9 +1583,22 @@ struct ModelsView: View {
                 .first ?? .parakeetMultilingual
             controller.selectBackend(fallback)
         }
-        // Remove cached model files
+        let task = downloadTasks[option.model]
+        task?.cancel()
+        let deletionGeneration = UUID()
+        downloadGenerations[option.model] = deletionGeneration
+        downloadTasks.removeValue(forKey: option.model)
+
+        // Stop any transfer before removing files so a late write cannot recreate
+        // part of the model after the deletion has completed.
         Task {
             do {
+                await ModelDownloadCoordinator.shared.cancelAndWait(modelID: option.model)
+                _ = await task?.value
+                let shouldDelete = await MainActor.run {
+                    downloadGenerations[option.model] == deletionGeneration
+                }
+                guard shouldDelete else { return }
                 try await deleteModelFiles(option)
                 await MainActor.run {
                     _ = downloadedModels.remove(option.model)
@@ -1572,11 +1631,13 @@ struct ModelsView: View {
             await controller.transcriptionCoordinator.unloadGemma4LiteRTTranscriber()
             try Gemma4LiteRTModelStore.deleteModelFiles(fileManager: fm)
         case "fluidaudio":
+            await controller.transcriptionCoordinator.unloadFluidAudioTranscriber()
             let plan = option.model.contains("v2")
                 ? ManagedASRModelPlans.parakeetV2()
                 : ManagedASRModelPlans.parakeetV3()
             try plan.delete(fileManager: fm)
         case "qwen":
+            await controller.transcriptionCoordinator.unloadQwen3Transcriber()
             try Qwen3AsrModelStore.deleteModelFiles(fileManager: fm)
         default:
             break

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -1563,9 +1563,7 @@ struct ModelsView: View {
                 }
             }
         case "qwen":
-            let path = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/FluidAudio/Models/qwen3-asr-0.6b-coreml")
-            try removeItemIfPresent(at: path, fileManager: fm)
+            try Qwen3AsrModelStore.deleteModelFiles(fileManager: fm)
         default:
             break
         }
@@ -1629,10 +1627,7 @@ struct ModelsView: View {
             }
             return false
         case "qwen":
-            let supportDir = fm.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/FluidAudio/Models/qwen3-asr-0.6b-coreml")
-            return fm.fileExists(atPath: supportDir.appendingPathComponent("int8/vocab.json").path)
-                || fm.fileExists(atPath: supportDir.appendingPathComponent("f32/vocab.json").path)
+            return Qwen3AsrModelStore.isModelDownloaded(fileManager: fm)
         case "cohere":
             return CohereTranscribeModelStore.isAvailableLocally()
         case "indicasr":

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -1904,7 +1904,7 @@ struct OnboardingView: View {
     private func cancelModelDownload(for backend: BackendOption?) {
         guard let backend else { return }
         Task {
-            await ModelDownloadCoordinator.shared.cancel(modelID: backend.model)
+            await ManagedASRModelDownloader.cancel(modelID: backend.model)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -6,11 +6,11 @@ import MuesliCore
 ///
 /// FluidAudio's `Repo.folderName` strips the `-coreml` suffix for Qwen, so the
 /// on-disk cache is `qwen3-asr-0.6b/{int8,f32}` rather than
-/// `qwen3-asr-0.6b-coreml/...` (see GitHub issue #380). Prefer FluidAudio's own
-/// cache helpers when available so this stays aligned with upstream.
+/// `qwen3-asr-0.6b-coreml/...` (see GitHub issue #380). Readiness follows the
+/// managed runtime plan; the legacy name is retained only for cleanup.
 enum Qwen3AsrModelStore {
-    /// Current FluidAudio cache directory name, plus the older `-coreml` name in
-    /// case a manual install or older tooling used the HuggingFace repo slug.
+    /// Current FluidAudio cache directory name, plus the older `-coreml` name
+    /// retained so model deletion also cleans up manual or legacy installs.
     static let cacheDirectoryNames = [
         "qwen3-asr-0.6b",
         "qwen3-asr-0.6b-coreml",
@@ -22,30 +22,17 @@ enum Qwen3AsrModelStore {
     }
 
     static func isModelDownloaded(fileManager: FileManager = .default) -> Bool {
-        if ManagedASRModelPlans.qwen3ASRInt8(
-            modelsRoot: modelsRoot(fileManager: fileManager)
-        ).isComplete(fileManager: fileManager) {
-            return true
-        }
-        if #available(macOS 15, *) {
-            if Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .int8)) {
-                return true
-            }
-        }
-
-        return hasInt8VocabMarker(in: modelsRoot(fileManager: fileManager), fileManager: fileManager)
+        isModelDownloaded(in: modelsRoot(fileManager: fileManager), fileManager: fileManager)
     }
 
-    /// Marker used by Models-tab recognition when FluidAudio's macOS 15 helpers
-    /// are unavailable or point at a different layout.
-    static func hasInt8VocabMarker(in modelsRoot: URL, fileManager: FileManager = .default) -> Bool {
-        for name in cacheDirectoryNames {
-            let directory = modelsRoot.appendingPathComponent(name, isDirectory: true)
-            if fileManager.fileExists(atPath: directory.appendingPathComponent("int8/vocab.json").path) {
-                return true
-            }
-        }
-        return false
+    /// Readiness deliberately uses the same managed directory and completeness
+    /// contract as runtime loading so the Models tab cannot hide a required download.
+    static func isModelDownloaded(
+        in modelsRoot: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: modelsRoot)
+            .isComplete(fileManager: fileManager)
     }
 
     static func deleteModelFiles(fileManager: FileManager = .default) throws {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -1,6 +1,62 @@
 import FluidAudio
 import Foundation
 
+/// Resolves Qwen3 ASR cache paths used by FluidAudio.
+///
+/// FluidAudio's `Repo.folderName` strips the `-coreml` suffix for Qwen, so the
+/// on-disk cache is `qwen3-asr-0.6b/{int8,f32}` rather than
+/// `qwen3-asr-0.6b-coreml/...` (see GitHub issue #380). Prefer FluidAudio's own
+/// cache helpers when available so this stays aligned with upstream.
+enum Qwen3AsrModelStore {
+    /// Current FluidAudio cache directory name, plus the older `-coreml` name in
+    /// case a manual install or older tooling used the HuggingFace repo slug.
+    static let cacheDirectoryNames = [
+        "qwen3-asr-0.6b",
+        "qwen3-asr-0.6b-coreml",
+    ]
+
+    static func modelsRoot(fileManager: FileManager = .default) -> URL {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/FluidAudio/Models", isDirectory: true)
+    }
+
+    static func isModelDownloaded(fileManager: FileManager = .default) -> Bool {
+        if #available(macOS 15, *) {
+            if Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .int8))
+                || Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .f32)) {
+                return true
+            }
+        }
+
+        return hasVocabMarker(in: modelsRoot(fileManager: fileManager), fileManager: fileManager)
+    }
+
+    /// Marker used by Models-tab recognition when FluidAudio's macOS 15 helpers
+    /// are unavailable or point at a different layout.
+    static func hasVocabMarker(in modelsRoot: URL, fileManager: FileManager = .default) -> Bool {
+        for name in cacheDirectoryNames {
+            let directory = modelsRoot.appendingPathComponent(name, isDirectory: true)
+            if fileManager.fileExists(atPath: directory.appendingPathComponent("int8/vocab.json").path)
+                || fileManager.fileExists(atPath: directory.appendingPathComponent("f32/vocab.json").path) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func deleteModelFiles(fileManager: FileManager = .default) throws {
+        try deleteModelFiles(from: modelsRoot(fileManager: fileManager), fileManager: fileManager)
+    }
+
+    static func deleteModelFiles(from modelsRoot: URL, fileManager: FileManager = .default) throws {
+        for name in cacheDirectoryNames {
+            let directory = modelsRoot.appendingPathComponent(name, isDirectory: true)
+            guard fileManager.fileExists(atPath: directory.path) else { continue }
+            try fileManager.removeItem(at: directory)
+        }
+    }
+}
+
 /// Native Swift transcription backend using FluidAudio's Qwen3 ASR model
 /// running on Apple's Neural Engine (ANE) via CoreML.
 /// Requires macOS 15+ due to CoreML stateful decoder support.

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -1,5 +1,6 @@
 import FluidAudio
 import Foundation
+import MuesliCore
 
 /// Resolves Qwen3 ASR cache paths used by FluidAudio.
 ///
@@ -21,6 +22,11 @@ enum Qwen3AsrModelStore {
     }
 
     static func isModelDownloaded(fileManager: FileManager = .default) -> Bool {
+        if ManagedASRModelPlans.qwen3ASRInt8(
+            modelsRoot: modelsRoot(fileManager: fileManager)
+        ).isComplete(fileManager: fileManager) {
+            return true
+        }
         if #available(macOS 15, *) {
             if Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .int8))
                 || Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .f32)) {
@@ -76,16 +82,25 @@ actor Qwen3AsrTranscriber {
     }
 
     /// Downloads models (if needed) and initializes the Qwen3 ASR manager.
-    func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+    func loadModels(
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
+    ) async throws {
         if manager != nil { return }
 
         fputs("[qwen3-asr] downloading/loading models...\n", stderr)
-        let modelDir = try await Qwen3AsrModels.download(variant: .int8) { downloadProgress in
-            let fraction = downloadProgress.fractionCompleted
-            DispatchQueue.main.async {
-                progress?(fraction, "Downloading Qwen3 ASR...")
-            }
-        }
+        let plan = ManagedASRModelPlans.qwen3ASRInt8()
+        let modelDir = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            progress: progress,
+            progressSnapshot: progressSnapshot
+        )
+        let preparing = ModelDownloadProgress.preparing(
+            modelID: plan.modelID,
+            message: "Loading Qwen3 ASR into Core ML..."
+        )
+        progress?(0.95, preparing.message)
+        progressSnapshot?(preparing)
         let mgr = Qwen3AsrManager()
         try await mgr.loadModels(from: modelDir)
         self.manager = mgr
@@ -95,6 +110,8 @@ actor Qwen3AsrTranscriber {
         // This moves the ~30s compilation cost from first dictation to preload time.
         let warmupSamples = [Float](repeating: 0, count: 16000) // 1 second of silence
         _ = try? await mgr.transcribe(audioSamples: warmupSamples)
+        progress?(1, nil)
+        progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[qwen3-asr] warmup complete, ready\n", stderr)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -28,22 +28,20 @@ enum Qwen3AsrModelStore {
             return true
         }
         if #available(macOS 15, *) {
-            if Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .int8))
-                || Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .f32)) {
+            if Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory(variant: .int8)) {
                 return true
             }
         }
 
-        return hasVocabMarker(in: modelsRoot(fileManager: fileManager), fileManager: fileManager)
+        return hasInt8VocabMarker(in: modelsRoot(fileManager: fileManager), fileManager: fileManager)
     }
 
     /// Marker used by Models-tab recognition when FluidAudio's macOS 15 helpers
     /// are unavailable or point at a different layout.
-    static func hasVocabMarker(in modelsRoot: URL, fileManager: FileManager = .default) -> Bool {
+    static func hasInt8VocabMarker(in modelsRoot: URL, fileManager: FileManager = .default) -> Bool {
         for name in cacheDirectoryNames {
             let directory = modelsRoot.appendingPathComponent(name, isDirectory: true)
-            if fileManager.fileExists(atPath: directory.appendingPathComponent("int8/vocab.json").path)
-                || fileManager.fileExists(atPath: directory.appendingPathComponent("f32/vocab.json").path) {
+            if fileManager.fileExists(atPath: directory.appendingPathComponent("int8/vocab.json").path) {
                 return true
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -32,7 +32,7 @@ enum Qwen3AsrModelStore {
         fileManager: FileManager = .default
     ) -> Bool {
         ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: modelsRoot)
-            .isComplete(fileManager: fileManager)
+            .isAvailableLocally(fileManager: fileManager)
     }
 
     static func deleteModelFiles(fileManager: FileManager = .default) throws {
@@ -103,6 +103,7 @@ actor Qwen3AsrTranscriber {
         do {
             _ = try await mgr.transcribe(audioSamples: warmupSamples)
             try Qwen3AsrWarmupReadiness.validate(isCurrent: manager === mgr)
+            try? plan.recordValidatedLegacyInstallationIfNeeded()
         } catch {
             if manager === mgr { manager = nil }
             throw error

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -81,33 +81,39 @@ actor Qwen3AsrTranscriber {
 
         fputs("[qwen3-asr] downloading/loading models...\n", stderr)
         let plan = ManagedASRModelPlans.qwen3ASRInt8()
-        let modelDir = try await ManagedASRModelDownloader.downloadIfNeeded(
+        let mgr = try await ManagedASRModelDownloader.loadValidated(
             plan,
             progress: progress,
             progressSnapshot: progressSnapshot
-        )
+        ) { modelDir in
+            let preparing = ModelDownloadProgress.preparing(
+                modelID: plan.modelID,
+                message: "Loading Qwen3 ASR into Core ML..."
+            )
+            progress?(0.95, preparing.message)
+            progressSnapshot?(preparing)
+            let candidate = Qwen3AsrManager()
+            try await candidate.loadModels(from: modelDir)
+            self.manager = candidate
+            fputs("[qwen3-asr] models loaded, running warmup inference...\n", stderr)
+
+            // Warmup: run a tiny dummy audio through the pipeline to trigger CoreML compilation.
+            // This moves the ~30s compilation cost from first dictation to preload time.
+            let warmupSamples = [Float](repeating: 0, count: 16000) // 1 second of silence
+            do {
+                _ = try await candidate.transcribe(audioSamples: warmupSamples)
+                try Qwen3AsrWarmupReadiness.validate(isCurrent: manager === candidate)
+                return candidate
+            } catch {
+                if manager === candidate { manager = nil }
+                throw error
+            }
+        }
+        self.manager = mgr
         let preparing = ModelDownloadProgress.preparing(
             modelID: plan.modelID,
             message: "Loading Qwen3 ASR into Core ML..."
         )
-        progress?(0.95, preparing.message)
-        progressSnapshot?(preparing)
-        let mgr = Qwen3AsrManager()
-        try await mgr.loadModels(from: modelDir)
-        self.manager = mgr
-        fputs("[qwen3-asr] models loaded, running warmup inference...\n", stderr)
-
-        // Warmup: run a tiny dummy audio through the pipeline to trigger CoreML compilation.
-        // This moves the ~30s compilation cost from first dictation to preload time.
-        let warmupSamples = [Float](repeating: 0, count: 16000) // 1 second of silence
-        do {
-            _ = try await mgr.transcribe(audioSamples: warmupSamples)
-            try Qwen3AsrWarmupReadiness.validate(isCurrent: manager === mgr)
-            try? plan.recordValidatedLegacyInstallationIfNeeded()
-        } catch {
-            if manager === mgr { manager = nil }
-            throw error
-        }
         progress?(1, nil)
         progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[qwen3-asr] warmup complete, ready\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -48,6 +48,12 @@ enum Qwen3AsrModelStore {
     }
 }
 
+enum Qwen3AsrWarmupReadiness {
+    static func validate(isCancelled: Bool = Task.isCancelled, isCurrent: Bool) throws {
+        guard !isCancelled, isCurrent else { throw CancellationError() }
+    }
+}
+
 /// Native Swift transcription backend using FluidAudio's Qwen3 ASR model
 /// running on Apple's Neural Engine (ANE) via CoreML.
 /// Requires macOS 15+ due to CoreML stateful decoder support.
@@ -94,7 +100,13 @@ actor Qwen3AsrTranscriber {
         // Warmup: run a tiny dummy audio through the pipeline to trigger CoreML compilation.
         // This moves the ~30s compilation cost from first dictation to preload time.
         let warmupSamples = [Float](repeating: 0, count: 16000) // 1 second of silence
-        _ = try? await mgr.transcribe(audioSamples: warmupSamples)
+        do {
+            _ = try await mgr.transcribe(audioSamples: warmupSamples)
+            try Qwen3AsrWarmupReadiness.validate(isCurrent: manager === mgr)
+        } catch {
+            if manager === mgr { manager = nil }
+            throw error
+        }
         progress?(1, nil)
         progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[qwen3-asr] warmup complete, ready\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -52,6 +52,7 @@ actor SenseVoiceTranscriber {
         let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
         self.manager = SenseVoiceManager(models: models)
         await warmupIfNeeded(progress: progress)
+        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress?(1.0, nil)
         progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[sensevoice] models ready\n", stderr)
@@ -79,20 +80,16 @@ actor SenseVoiceTranscriber {
         ).cacheDirectory
     }
 
-    static func isModelDownloaded() -> Bool {
-        requiredModelsExist(at: cacheDirectory())
+    static func isModelDownloaded(fileManager: FileManager = .default) -> Bool {
+        ManagedASRModelPlans.senseVoice(
+            modelsRoot: ManagedASRModelPlans.fluidAudioModelsRoot(fileManager: fileManager)
+        ).isAvailableLocally(fileManager: fileManager)
     }
 
     static func deleteModelFiles(fileManager: FileManager = .default) {
         try? ManagedASRModelPlans.senseVoice(
             modelsRoot: ManagedASRModelPlans.fluidAudioModelsRoot(fileManager: fileManager)
         ).delete(fileManager: fileManager)
-    }
-
-    private static func requiredModelsExist(at directory: URL, fileManager: FileManager = .default) -> Bool {
-        let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
-        return SenseVoiceModels.modelsExist(at: directory, precision: precision)
-            && fileManager.fileExists(atPath: vocabularyURL.path)
     }
 
     private func warmupIfNeeded(progress: ((Double, String?) -> Void)?) async {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -38,21 +38,26 @@ actor SenseVoiceTranscriber {
 
         fputs("[sensevoice] downloading/loading models...\n", stderr)
         let plan = ManagedASRModelPlans.senseVoice()
-        let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
+        let loadedManager = try await ManagedASRModelDownloader.loadValidated(
             plan,
             progress: progress,
             progressSnapshot: progressSnapshot
-        )
+        ) { modelDirectory in
+            let preparing = ModelDownloadProgress.preparing(
+                modelID: plan.modelID,
+                message: "Loading SenseVoice into Core ML..."
+            )
+            progressSnapshot?(preparing)
+            progress?(0.95, "Loading SenseVoice...")
+            let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
+            return SenseVoiceManager(models: models)
+        }
         let preparing = ModelDownloadProgress.preparing(
             modelID: plan.modelID,
             message: "Loading SenseVoice into Core ML..."
         )
-        progressSnapshot?(preparing)
-        progress?(0.95, "Loading SenseVoice...")
-        let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
-        self.manager = SenseVoiceManager(models: models)
+        self.manager = loadedManager
         await warmupIfNeeded(progress: progress)
-        try? plan.recordValidatedLegacyInstallationIfNeeded()
         progress?(1.0, nil)
         progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[sensevoice] models ready\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SenseVoiceBackend.swift
@@ -1,5 +1,6 @@
 import FluidAudio
 import Foundation
+import MuesliCore
 
 /// Native Swift transcription backend for FunASR's SenseVoiceSmall via FluidAudio.
 actor SenseVoiceTranscriber {
@@ -20,7 +21,10 @@ actor SenseVoiceTranscriber {
     }
 
     /// Downloads models if needed and initializes the SenseVoice manager.
-    func loadModels(progress: ((Double, String?) -> Void)? = nil) async throws {
+    func loadModels(
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
+    ) async throws {
         // Actor isolation makes this check-and-set race-free. Waiters retry after
         // a failed load so a transient download error does not poison the actor.
         while isLoading {
@@ -33,12 +37,23 @@ actor SenseVoiceTranscriber {
         defer { isLoading = false }
 
         fputs("[sensevoice] downloading/loading models...\n", stderr)
-        let modelDirectory = try await Self.downloadRequiredModels(progress: progress)
+        let plan = ManagedASRModelPlans.senseVoice()
+        let modelDirectory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            progress: progress,
+            progressSnapshot: progressSnapshot
+        )
+        let preparing = ModelDownloadProgress.preparing(
+            modelID: plan.modelID,
+            message: "Loading SenseVoice into Core ML..."
+        )
+        progressSnapshot?(preparing)
         progress?(0.95, "Loading SenseVoice...")
         let models = try SenseVoiceModels.load(from: modelDirectory, precision: Self.precision)
         self.manager = SenseVoiceManager(models: models)
         await warmupIfNeeded(progress: progress)
         progress?(1.0, nil)
+        progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[sensevoice] models ready\n", stderr)
     }
 
@@ -59,8 +74,9 @@ actor SenseVoiceTranscriber {
     static let downloadedModelSizeLabel = "~240 MB"
 
     static func cacheDirectory(fileManager: FileManager = .default) -> URL {
-        fileManager.homeDirectoryForCurrentUser
-            .appendingPathComponent(cacheRelativePath)
+        ManagedASRModelPlans.senseVoice(
+            modelsRoot: ManagedASRModelPlans.fluidAudioModelsRoot(fileManager: fileManager)
+        ).cacheDirectory
     }
 
     static func isModelDownloaded() -> Bool {
@@ -68,77 +84,9 @@ actor SenseVoiceTranscriber {
     }
 
     static func deleteModelFiles(fileManager: FileManager = .default) {
-        try? fileManager.removeItem(at: cacheDirectory(fileManager: fileManager))
-    }
-
-    private static func downloadRequiredModels(progress: ((Double, String?) -> Void)?) async throws -> URL {
-        let directory = cacheDirectory()
-        if requiredModelsExist(at: directory) {
-            return directory
-        }
-
-        // FluidAudio 0.15.x downloads every SenseVoice encoder precision via SenseVoiceManager.load.
-        // Muesli only needs the INT8 ANE encoder, so fetch that subset and then use FluidAudio's loader.
-        let fm = FileManager.default
-        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
-
-        try await downloadSubdirectory(
-            ModelNames.SenseVoice.preprocessorFile,
-            to: directory,
-            progressRange: 0.0...0.2,
-            message: "Downloading SenseVoice preprocessor...",
-            progress: progress
-        )
-        try await downloadSubdirectory(
-            ModelNames.SenseVoice.encoderInt8File,
-            to: directory,
-            progressRange: 0.2...0.9,
-            message: "Downloading SenseVoice INT8 encoder...",
-            progress: progress
-        )
-        try await downloadVocabulary(to: directory, progress: progress)
-
-        return directory
-    }
-
-    private static func downloadSubdirectory(
-        _ subdirectory: String,
-        to directory: URL,
-        progressRange: ClosedRange<Double>,
-        message: String,
-        progress: ((Double, String?) -> Void)?
-    ) async throws {
-        try await DownloadUtils.downloadSubdirectory(
-            .senseVoiceSmall,
-            subdirectory: subdirectory,
-            to: directory,
-            progressHandler: { downloadProgress in
-                let span = progressRange.upperBound - progressRange.lowerBound
-                let fraction = progressRange.lowerBound + span * downloadProgress.fractionCompleted
-                progress?(min(max(fraction, 0.0), 1.0), message)
-            }
-        )
-    }
-
-    private static func downloadVocabulary(to directory: URL, progress: ((Double, String?) -> Void)?) async throws {
-        let vocabularyURL = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
-        if FileManager.default.fileExists(atPath: vocabularyURL.path) {
-            progress?(0.95, "SenseVoice vocabulary ready...")
-            return
-        }
-
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        progress?(0.9, "Downloading SenseVoice vocabulary...")
-        let remoteURL = try ModelRegistry.resolveModel(
-            Repo.senseVoiceSmall.remotePath,
-            ModelNames.SenseVoice.vocabularyFile
-        )
-        let data = try await DownloadUtils.fetchHuggingFaceFile(
-            from: remoteURL,
-            description: "SenseVoice vocabulary"
-        )
-        try data.write(to: vocabularyURL, options: .atomic)
-        progress?(0.95, "SenseVoice vocabulary ready...")
+        try? ManagedASRModelPlans.senseVoice(
+            modelsRoot: ManagedASRModelPlans.fluidAudioModelsRoot(fileManager: fileManager)
+        ).delete(fileManager: fileManager)
     }
 
     private static func requiredModelsExist(at directory: URL, fileManager: FileManager = .default) -> Bool {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -123,6 +123,17 @@ actor TranscriptionCoordinator {
         }
     }
 
+    func unloadFluidAudioTranscriber() async {
+        await fluidTranscriber.shutdown()
+    }
+
+    func unloadQwen3Transcriber() async {
+        if #available(macOS 15, *), let transcriber = _qwen3Transcriber as? Qwen3AsrTranscriber {
+            await transcriber.shutdown()
+            _qwen3Transcriber = nil
+        }
+    }
+
     @available(macOS 15, *)
     private var qwen3Transcriber: Qwen3AsrTranscriber {
         if _qwen3Transcriber == nil {
@@ -303,10 +314,16 @@ actor TranscriptionCoordinator {
             )
             // Warmup ANE/GPU so first dictation doesn't pay CoreML compilation cost
             fputs("[muesli-native] WhisperKit warmup: running silent audio for CoreML compilation...\n", stderr)
-            progress?(0.9, "Warming up model...")
+            let warming = ModelDownloadProgress.preparing(
+                modelID: backend.model,
+                message: "Warming up model..."
+            )
+            progress?(0.9, warming.message)
+            progressSnapshot?(warming)
             try await whisperTranscriber.warmup()
             fputs("[muesli-native] WhisperKit warmup complete\n", stderr)
             progress?(1.0, nil)
+            progressSnapshot?(warming.replacing(phase: .ready, message: "Model ready"))
         case "nemotron35":
             if #available(macOS 15, *) {
                 let transcriber = try await getLoadedNemotron35Transcriber(progress: progress, progressSnapshot: progressSnapshot)

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -123,8 +123,8 @@ actor TranscriptionCoordinator {
         }
     }
 
-    func unloadFluidAudioTranscriber() async {
-        await fluidTranscriber.shutdown()
+    func unloadFluidAudioTranscriber(ifLoadedVersion version: AsrModelVersion) async {
+        await fluidTranscriber.shutdown(ifLoadedVersion: version)
     }
 
     func unloadQwen3Transcriber() async {

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -290,9 +290,17 @@ actor TranscriptionCoordinator {
         switch backend.backend {
         case "fluidaudio":
             let version: AsrModelVersion = backend.model.contains("v2") ? .v2 : .v3
-            try await fluidTranscriber.loadModels(version: version, progress: progress)
+            try await fluidTranscriber.loadModels(
+                version: version,
+                progress: progress,
+                progressSnapshot: progressSnapshot
+            )
         case "whisper":
-            try await whisperTranscriber.loadModel(modelName: backend.model, progress: progress)
+            try await whisperTranscriber.loadModel(
+                modelName: backend.model,
+                progress: progress,
+                progressSnapshot: progressSnapshot
+            )
             // Warmup ANE/GPU so first dictation doesn't pay CoreML compilation cost
             fputs("[muesli-native] WhisperKit warmup: running silent audio for CoreML compilation...\n", stderr)
             progress?(0.9, "Warming up model...")
@@ -315,7 +323,10 @@ actor TranscriptionCoordinator {
             }
         case "qwen":
             if #available(macOS 15, *) {
-                try await qwen3Transcriber.loadModels(progress: progress)
+                try await qwen3Transcriber.loadModels(
+                    progress: progress,
+                    progressSnapshot: progressSnapshot
+                )
             } else {
                 throw NSError(domain: "MuesliTranscriptionRuntime", code: 2, userInfo: [
                     NSLocalizedDescriptionKey: "Qwen3 ASR requires macOS 15 or later.",
@@ -338,7 +349,10 @@ actor TranscriptionCoordinator {
                 ])
             }
         case "sensevoice":
-            try await senseVoiceTranscriber.loadModels(progress: progress)
+            try await senseVoiceTranscriber.loadModels(
+                progress: progress,
+                progressSnapshot: progressSnapshot
+            )
         case "gemma4-litert":
             if #available(macOS 15, *) {
                 try await gemma4LiteRTTranscriber.prepare(progress: progress, progressSnapshot: progressSnapshot)

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -51,6 +51,7 @@ actor WhisperKitTranscriber {
 
         whisperKit = try await WhisperKit(config)
         loadedModel = modelName
+        try? plan.recordValidatedLegacyInstallationIfNeeded()
         fputs("[whisperkit] model loaded: \(modelName)\n", stderr)
     }
 
@@ -88,7 +89,7 @@ actor WhisperKitTranscriber {
     /// WhisperKit stores models under ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/.
     /// Each model variant is a direct subdirectory (e.g. openai_whisper-small.en/).
     static func isModelDownloaded(_ modelName: String) -> Bool {
-        ManagedASRModelPlans.whisperKit(modelName: modelName).isComplete()
+        ManagedASRModelPlans.whisperKit(modelName: modelName).isAvailableLocally()
     }
 
     /// Delete cached model files for a WhisperKit model variant.

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -29,29 +29,30 @@ actor WhisperKitTranscriber {
 
         fputs("[whisperkit] loading model: \(modelName)...\n", stderr)
         let plan = ManagedASRModelPlans.whisperKit(modelName: modelName)
-        let modelFolder = try await ManagedASRModelDownloader.downloadIfNeeded(
+        let loadedWhisperKit = try await ManagedASRModelDownloader.loadValidated(
             plan,
             progress: progress,
             progressSnapshot: progressSnapshot
-        )
-        let preparing = ModelDownloadProgress.preparing(
-            modelID: plan.modelID,
-            message: "Loading WhisperKit into Core ML..."
-        )
-        progress?(0.95, preparing.message)
-        progressSnapshot?(preparing)
-
-        let config = WhisperKitConfig(
-            modelFolder: modelFolder.path,
-            computeOptions: ModelComputeOptions(
-                audioEncoderCompute: .cpuAndNeuralEngine,
-                textDecoderCompute: .cpuAndNeuralEngine
+        ) { modelFolder in
+            let preparing = ModelDownloadProgress.preparing(
+                modelID: plan.modelID,
+                message: "Loading WhisperKit into Core ML..."
             )
-        )
+            progress?(0.95, preparing.message)
+            progressSnapshot?(preparing)
 
-        whisperKit = try await WhisperKit(config)
+            let config = WhisperKitConfig(
+                modelFolder: modelFolder.path,
+                computeOptions: ModelComputeOptions(
+                    audioEncoderCompute: .cpuAndNeuralEngine,
+                    textDecoderCompute: .cpuAndNeuralEngine
+                )
+            )
+            return try await WhisperKit(config)
+        }
+
+        whisperKit = loadedWhisperKit
         loadedModel = modelName
-        try? plan.recordValidatedLegacyInstallationIfNeeded()
         fputs("[whisperkit] model loaded: \(modelName)\n", stderr)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -51,9 +51,7 @@ actor WhisperKitTranscriber {
 
         whisperKit = try await WhisperKit(config)
         loadedModel = modelName
-        progress?(1, nil)
-        progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
-        fputs("[whisperkit] model ready: \(modelName)\n", stderr)
+        fputs("[whisperkit] model loaded: \(modelName)\n", stderr)
     }
 
     /// Transcribe a 16kHz mono WAV file.

--- a/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/WhisperCppBackend.swift
@@ -20,36 +20,29 @@ actor WhisperKitTranscriber {
     }
 
     /// Load a WhisperKit CoreML model. Downloads from HuggingFace if not cached.
-    func loadModel(modelName: String, progress: ((Double, String?) -> Void)? = nil) async throws {
+    func loadModel(
+        modelName: String,
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
+    ) async throws {
         if loadedModel == modelName, whisperKit != nil { return }
 
         fputs("[whisperkit] loading model: \(modelName)...\n", stderr)
-        let modelFolder: URL?
-
-        if Self.isModelDownloaded(modelName) {
-            modelFolder = nil
-        } else {
-            let estimatedTotalBytes = Self.estimatedDownloadBytes(for: modelName)
-            let totalText = Self.formatMegabytes(estimatedTotalBytes)
-            progress?(0.02, "0 MB of \(totalText)")
-            modelFolder = try await WhisperKit.download(variant: modelName) { downloadProgress in
-                let fraction = min(max(downloadProgress.fractionCompleted, 0), 1)
-                let estimatedBytes = Int64(Double(estimatedTotalBytes) * fraction)
-                let completedText = Self.formatMegabytes(estimatedBytes)
-                let throughput = downloadProgress.userInfo[.throughputKey] as? Double ?? 0
-                let status: String
-                if throughput > 0 {
-                    status = "\(completedText) of \(totalText) • \(Self.formatMegabytes(Int64(throughput)))/s"
-                } else {
-                    status = "\(completedText) of \(totalText)"
-                }
-                progress?(max(fraction, 0.02), status)
-            }
-        }
+        let plan = ManagedASRModelPlans.whisperKit(modelName: modelName)
+        let modelFolder = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            progress: progress,
+            progressSnapshot: progressSnapshot
+        )
+        let preparing = ModelDownloadProgress.preparing(
+            modelID: plan.modelID,
+            message: "Loading WhisperKit into Core ML..."
+        )
+        progress?(0.95, preparing.message)
+        progressSnapshot?(preparing)
 
         let config = WhisperKitConfig(
-            model: modelFolder == nil ? modelName : nil,
-            modelFolder: modelFolder?.path,
+            modelFolder: modelFolder.path,
             computeOptions: ModelComputeOptions(
                 audioEncoderCompute: .cpuAndNeuralEngine,
                 textDecoderCompute: .cpuAndNeuralEngine
@@ -58,33 +51,9 @@ actor WhisperKitTranscriber {
 
         whisperKit = try await WhisperKit(config)
         loadedModel = modelName
+        progress?(1, nil)
+        progressSnapshot?(preparing.replacing(phase: .ready, message: "Model ready"))
         fputs("[whisperkit] model ready: \(modelName)\n", stderr)
-    }
-
-    private static func estimatedDownloadBytes(for modelName: String) -> Int64 {
-        switch modelName {
-        case "tiny.en":
-            return 153 * 1_000_000
-        case "small.en":
-            return 250 * 1_000_000
-        case "medium.en":
-            return 1_500 * 1_000_000
-        case "large-v3-v20240930_626MB":
-            return 626 * 1_000_000
-        default:
-            return 250 * 1_000_000
-        }
-    }
-
-    private static func formatMegabytes(_ bytes: Int64) -> String {
-        let megabytes = Double(bytes) / 1_000_000
-        if megabytes >= 1_000 {
-            return String(format: "%.1f GB", megabytes / 1_000)
-        }
-        if megabytes >= 100 {
-            return "\(Int(megabytes.rounded())) MB"
-        }
-        return String(format: "%.1f MB", megabytes)
     }
 
     /// Transcribe a 16kHz mono WAV file.
@@ -121,19 +90,11 @@ actor WhisperKitTranscriber {
     /// WhisperKit stores models under ~/Documents/huggingface/models/argmaxinc/whisperkit-coreml/.
     /// Each model variant is a direct subdirectory (e.g. openai_whisper-small.en/).
     static func isModelDownloaded(_ modelName: String) -> Bool {
-        let fm = FileManager.default
-        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        let modelDir = fm.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
-        return fm.fileExists(atPath: modelDir.path)
+        ManagedASRModelPlans.whisperKit(modelName: modelName).isComplete()
     }
 
     /// Delete cached model files for a WhisperKit model variant.
     static func deleteModel(_ modelName: String) {
-        let fm = FileManager.default
-        let fullName = modelName.hasPrefix("openai_whisper-") ? modelName : "openai_whisper-\(modelName)"
-        let modelDir = fm.homeDirectoryForCurrentUser
-            .appendingPathComponent("Documents/huggingface/models/argmaxinc/whisperkit-coreml/\(fullName)")
-        try? fm.removeItem(at: modelDir)
+        try? ManagedASRModelPlans.whisperKit(modelName: modelName).delete()
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -79,24 +79,23 @@ struct SenseVoiceTranscriberTests {
         #expect(SenseVoiceTranscriber.cacheDirectory().path.hasSuffix(SenseVoiceTranscriber.cacheRelativePath))
     }
 
-    @Test("sensevoice metadata reflects INT8 download footprint")
-    func senseVoiceInt8DownloadMetadata() {
+    @Test("sensevoice metadata reflects its download footprint")
+    func senseVoiceDownloadMetadata() {
         #expect(SenseVoiceTranscriber.downloadedModelSizeLabel == "~240 MB")
         #expect(BackendOption.senseVoiceSmall.sizeLabel == SenseVoiceTranscriber.downloadedModelSizeLabel)
-        #expect(BackendOption.senseVoiceSmall.description.contains("INT8"))
+        #expect(BackendOption.senseVoiceSmall.description.contains("50 languages"))
     }
 }
 
 @Suite("Gemma4LiteRTTranscriber")
 struct Gemma4LiteRTTranscriberTests {
 
-    @Test("gemma4 model uses managed LiteRT-LM metadata")
+    @Test("gemma4 model uses managed download metadata")
     func gemma4Model() {
         #expect(BackendOption.gemma4E2BLiteRT.backend == "gemma4-litert")
         #expect(BackendOption.gemma4E2BLiteRT.model == Gemma4LiteRTModelStore.repoID)
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("managed local weights"))
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("ASR-tuned Gemma artifact"))
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("chat-style outputs fail closed"))
+        #expect(BackendOption.gemma4E2BLiteRT.description.contains("research preview"))
+        #expect(BackendOption.gemma4E2BLiteRT.description.contains("faithful transcript"))
         #expect(Gemma4LiteRTModelStore.downloadURL.absoluteString.contains(Gemma4LiteRTModelStore.repoID))
         #expect(Gemma4LiteRTModelStore.downloadURL.absoluteString.contains(Gemma4LiteRTModelStore.modelFilename))
     }

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -140,7 +140,7 @@ struct FeatureTourTests {
 
         let streamingStep = tour.steps.first { $0.target == .streamingModels }
         #expect(streamingStep?.message.contains("Nemotron 3.5") == true)
-        #expect(streamingStep?.message.contains("Parakeet Realtime") == true)
+        #expect(streamingStep?.message.contains("Parakeet Live Captions") == true)
         #expect(streamingStep?.target.modelsCategory == .streaming)
 
         let experimentalStep = tour.steps.last

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -41,23 +41,35 @@ struct MeetingStreamingPartialSessionTests {
             if artifact.hasSuffix(".mlmodelc") {
                 try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
                 try Data([0x01]).write(to: url.appendingPathComponent("coremldata.bin"))
+                let weight = url.appendingPathComponent("weights/weight.bin")
+                try FileManager.default.createDirectory(
+                    at: weight.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try Data([0x01]).write(to: weight)
             } else {
                 try Data("{}".utf8).write(to: url)
             }
         }
 
-        // Presence alone is not proof that a multi-file download finished.
+        let partialState = directory.appendingPathComponent(".muesli-download-state.json")
+        try Data("{}".utf8).write(to: partialState)
         #expect(!MeetingLiveCaptionModelStore.isDownloaded(in: root))
+        try FileManager.default.removeItem(at: partialState)
+        #expect(MeetingLiveCaptionModelStore.isDownloaded(in: root))
+
         let plan = ManagedASRModelPlans.parakeetRealtimeEOU320(modelsRoot: root)
-        let installedFiles = ModelNames.ParakeetEOU.requiredModels.map { artifact in
-            let relativePath = artifact.hasSuffix(".mlmodelc")
-                ? "\(artifact)/coremldata.bin"
-                : artifact
-            return ModelDownloadFile(
-                relativePath: relativePath,
-                remoteURL: URL(string: "https://example.com/model")!,
-                expectedByteCount: artifact.hasSuffix(".mlmodelc") ? 1 : 2
-            )
+        let installedFiles = ModelNames.ParakeetEOU.requiredModels.flatMap { artifact in
+            let relativePaths = artifact.hasSuffix(".mlmodelc")
+                ? ["\(artifact)/coremldata.bin", "\(artifact)/weights/weight.bin"]
+                : [artifact]
+            return relativePaths.map { relativePath in
+                ModelDownloadFile(
+                    relativePath: relativePath,
+                    remoteURL: URL(string: "https://example.com/model")!,
+                    expectedByteCount: artifact.hasSuffix(".mlmodelc") ? 1 : 2
+                )
+            }
         }
         try plan.recordSuccessfulInstallation(ModelDownloadManifest(
             id: plan.modelID,
@@ -65,6 +77,15 @@ struct MeetingStreamingPartialSessionTests {
             files: installedFiles
         ))
         #expect(MeetingLiveCaptionModelStore.isDownloaded(in: root))
+
+        let firstCompiledModel = try #require(
+            ModelNames.ParakeetEOU.requiredModels.first { $0.hasSuffix(".mlmodelc") }
+        )
+        let missingWeight = directory.appendingPathComponent(
+            "\(firstCompiledModel)/weights/weight.bin"
+        )
+        try FileManager.default.removeItem(at: missingWeight)
+        #expect(!MeetingLiveCaptionModelStore.isDownloaded(in: root))
     }
 
     @Test("publishes cumulative Parakeet partials")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -19,6 +19,7 @@ struct MeetingStreamingPartialSessionTests {
             let url = directory.appendingPathComponent(artifact)
             if artifact.hasSuffix(".mlmodelc") {
                 try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+                try Data([0x01]).write(to: url.appendingPathComponent("coremldata.bin"))
             } else {
                 try Data("{}".utf8).write(to: url)
             }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FluidAudio
+import MuesliCore
 import os
 import Testing
 @testable import MuesliNativeApp
@@ -44,6 +45,25 @@ struct MeetingStreamingPartialSessionTests {
                 try Data("{}".utf8).write(to: url)
             }
         }
+
+        // Presence alone is not proof that a multi-file download finished.
+        #expect(!MeetingLiveCaptionModelStore.isDownloaded(in: root))
+        let plan = ManagedASRModelPlans.parakeetRealtimeEOU320(modelsRoot: root)
+        let installedFiles = ModelNames.ParakeetEOU.requiredModels.map { artifact in
+            let relativePath = artifact.hasSuffix(".mlmodelc")
+                ? "\(artifact)/coremldata.bin"
+                : artifact
+            return ModelDownloadFile(
+                relativePath: relativePath,
+                remoteURL: URL(string: "https://example.com/model")!,
+                expectedByteCount: artifact.hasSuffix(".mlmodelc") ? 1 : 2
+            )
+        }
+        try plan.recordSuccessfulInstallation(ModelDownloadManifest(
+            id: plan.modelID,
+            version: "test-install",
+            files: installedFiles
+        ))
         #expect(MeetingLiveCaptionModelStore.isDownloaded(in: root))
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingStreamingPartialSessionTests.swift
@@ -6,6 +6,26 @@ import Testing
 
 @Suite("Meeting streaming partial session")
 struct MeetingStreamingPartialSessionTests {
+    @Test("stale live caption downloads cannot finish after an immediate restart")
+    func liveCaptionDownloadGenerationRejectsStaleCompletion() {
+        var state = ModelDownloadGenerationState()
+        let firstDownload = state.begin()
+        let cancellation = state.begin()
+        let replacementDownload = state.begin()
+
+        #expect(!state.contains(firstDownload))
+        #expect(!state.contains(cancellation))
+        #expect(state.contains(replacementDownload))
+        let clearedFirstDownload = state.clear(firstDownload)
+        let clearedCancellation = state.clear(cancellation)
+        #expect(!clearedFirstDownload)
+        #expect(!clearedCancellation)
+        #expect(state.contains(replacementDownload))
+        let clearedReplacement = state.clear(replacementDownload)
+        #expect(clearedReplacement)
+        #expect(state.current == nil)
+    }
+
     @Test("live caption model is ready only when every EOU artifact exists")
     func modelAvailabilityRequiresEveryArtifact() throws {
         let root = FileManager.default.temporaryDirectory

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -336,7 +336,7 @@ struct ModelDownloadCoordinatorTests {
                 #expect(request.url?.query?.contains("recursive=true") == true)
                 data = firstPage
                 headers = [
-                    "Link": "<https://huggingface.co/api/models/acme/asr/tree/main/int8?cursor=next>; rel=\"next\""
+                    "Link": "</api/models/acme/asr/tree/main/int8?cursor=next>; rel=\"next\""
                 ]
             }
             return ModelDownloadTestURLProtocol.Response(
@@ -367,11 +367,41 @@ struct ModelDownloadCoordinatorTests {
         #expect(manifest.version.hasPrefix("main-"))
     }
 
+    @Test("Hugging Face pagination rejects cross-host next links")
+    func huggingFacePaginationRejectsCrossHostLinks() async throws {
+        let tracker = DownloadTestTracker()
+        let page = try JSONSerialization.data(withJSONObject: [[
+            "type": "file",
+            "path": "int8/Encoder.mlmodelc/coremldata.bin",
+            "size": 7,
+            "oid": "encoder-oid",
+        ]])
+        ModelDownloadTestURLProtocol.install { _ in
+            ModelDownloadTestURLProtocol.Response(
+                data: page,
+                headers: ["Link": "<https://example.com/steal-token>; rel=\"next\""],
+                tracker: tracker
+            )
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        await #expect(throws: HuggingFaceModelManifestError.self) {
+            try await resolver.resolve(
+                modelID: "acme/asr",
+                repository: "acme/asr",
+                selections: [HuggingFaceModelSelection(remoteDirectory: "int8")]
+            )
+        }
+        #expect(tracker.requestCount == 1)
+    }
+
     @Test("managed ASR plans require complete compiled artifacts")
     func managedASRPlanCompleteness() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let plan = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root)
+        #expect(plan.cacheDirectory.standardizedFileURL.path.hasPrefix(root.standardizedFileURL.path + "/"))
 
         try FileManager.default.createDirectory(
             at: plan.cacheDirectory.appendingPathComponent("qwen3_asr_audio_encoder_v2.mlmodelc"),
@@ -816,7 +846,7 @@ struct ModelDownloadCoordinatorTests {
         #expect(tracker.requestCount == 6)
     }
 
-    @Test("cancellation preserves the partial file and does not finalize it")
+    @Test("cancel and wait preserves the partial file and finishes before deletion")
     func cancellationPreservesPartialFile() async throws {
         ModelDownloadTestURLProtocol.install { _ in
             ModelDownloadTestURLProtocol.Response(
@@ -838,7 +868,7 @@ struct ModelDownloadCoordinatorTests {
         )
         let task = Task { try await coordinator.download(manifest, to: directory) }
         try await Task.sleep(for: .milliseconds(60))
-        await coordinator.cancel(modelID: manifest.id)
+        await coordinator.cancelAndWait(modelID: manifest.id)
         do {
             try await task.value
             Issue.record("Cancellation unexpectedly completed")
@@ -849,6 +879,9 @@ struct ModelDownloadCoordinatorTests {
         let partURL = directory.appendingPathComponent("model.bin.part")
         #expect(FileManager.default.fileExists(atPath: partURL.path))
         #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("model.bin").path))
+        try FileManager.default.removeItem(at: partURL)
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(!FileManager.default.fileExists(atPath: partURL.path))
     }
 
     private func makeCoordinator() -> ModelDownloadCoordinator {

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -44,6 +44,12 @@ private final class DownloadResponseSequence: @unchecked Sendable {
         value += 1
         return value
     }
+
+    var current: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
 }
 
 private final class DownloadCompletionFlag: @unchecked Sendable {
@@ -508,6 +514,82 @@ struct ModelDownloadCoordinatorTests {
         #expect(tracker.requestCount == 0)
         #expect(!plan.isComplete())
         #expect(plan.isAvailableLocally())
+    }
+
+    @Test("invalid legacy ASR installs are replaced after runtime validation fails")
+    func invalidLegacyASRInstallIsRepaired() async throws {
+        let tracker = DownloadTestTracker()
+        let tree = try JSONSerialization.data(withJSONObject: [[
+            "type": "file",
+            "path": "model.bin",
+            "size": 4,
+            "oid": "model-oid",
+        ]])
+        ModelDownloadTestURLProtocol.install { request in
+            let data = request.url?.path.contains("/resolve/") == true
+                ? Data("good".utf8)
+                : tree
+            return ModelDownloadTestURLProtocol.Response(data: data, tracker: tracker)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let plan = ManagedASRModelPlan(
+            modelID: "legacy-repair",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]]
+        )
+        try FileManager.default.createDirectory(at: plan.cacheDirectory, withIntermediateDirectories: true)
+        try Data("bad".utf8).write(to: plan.cacheDirectory.appendingPathComponent("model.bin"))
+        #expect(plan.requiresRuntimeValidation())
+
+        let attempts = DownloadResponseSequence()
+        let value = try await ManagedASRModelDownloader.loadValidated(
+            plan,
+            resolver: HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration()),
+            coordinator: makeCoordinator()
+        ) { directory in
+            let data = try Data(contentsOf: directory.appendingPathComponent("model.bin"))
+            guard data == Data("good".utf8) else {
+                _ = attempts.next()
+                throw NSError(domain: "LegacyRuntimeValidation", code: 1)
+            }
+            _ = attempts.next()
+            return String(decoding: data, as: UTF8.self)
+        }
+
+        #expect(value == "good")
+        #expect(attempts.current == 2)
+        #expect(tracker.requestCount == 2)
+        #expect(plan.isComplete())
+    }
+
+    @Test("cancelled legacy validation preserves the offline cache")
+    func cancelledLegacyValidationPreservesCache() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let plan = ManagedASRModelPlan(
+            modelID: "legacy-validation-cancel",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]]
+        )
+        try FileManager.default.createDirectory(at: plan.cacheDirectory, withIntermediateDirectories: true)
+        let modelURL = plan.cacheDirectory.appendingPathComponent("model.bin")
+        try Data("legacy".utf8).write(to: modelURL)
+
+        await #expect(throws: CancellationError.self) {
+            try await ManagedASRModelDownloader.loadValidated(plan) { _ in
+                throw CancellationError()
+            }
+        }
+
+        #expect(FileManager.default.fileExists(atPath: modelURL.path))
+        #expect(plan.requiresRuntimeValidation())
     }
 
     @Test("managed ASR deletion cancels manifest discovery and blocks replacement work")

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -3,7 +3,7 @@ import Testing
 import MuesliCore
 
 private final class DownloadTestTracker: @unchecked Sendable {
-    private let lock = NSLock()
+    private let lock = NSCondition()
     private var active = 0
     private(set) var maximumActive = 0
     private(set) var requestCount = 0
@@ -13,6 +13,7 @@ private final class DownloadTestTracker: @unchecked Sendable {
         active += 1
         requestCount += 1
         maximumActive = max(maximumActive, active)
+        lock.broadcast()
         lock.unlock()
     }
 
@@ -20,6 +21,16 @@ private final class DownloadTestTracker: @unchecked Sendable {
         lock.lock()
         active = max(0, active - 1)
         lock.unlock()
+    }
+
+    func waitUntilRequestStarts(timeout: TimeInterval = 2) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let deadline = Date().addingTimeInterval(timeout)
+        while requestCount == 0 {
+            guard lock.wait(until: deadline) else { return false }
+        }
+        return true
     }
 }
 
@@ -413,6 +424,7 @@ struct ModelDownloadCoordinatorTests {
             "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
             "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
             "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/weights/weight.bin",
             "qwen3_asr_embeddings.bin",
             "vocab.json",
         ] {
@@ -425,25 +437,17 @@ struct ModelDownloadCoordinatorTests {
         }
 
         #expect(!plan.isComplete())
-        let installedPaths = [
-            "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
-            "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
-            "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
-            "qwen3_asr_embeddings.bin",
-            "vocab.json",
-        ]
-        let manifest = ModelDownloadManifest(
-            id: plan.modelID,
-            version: "test-install",
-            files: installedPaths.map { relativePath in
-                ModelDownloadFile(
-                    relativePath: relativePath,
-                    remoteURL: URL(string: "https://example.com/model")!,
-                    expectedByteCount: 1
-                )
-            }
-        )
-        try plan.recordSuccessfulInstallation(manifest)
+        #expect(plan.isAvailableLocally())
+        let partialState = plan.cacheDirectory.appendingPathComponent(".muesli-download-state.json")
+        try Data("{}".utf8).write(to: partialState)
+        #expect(!plan.isAvailableLocally())
+        try FileManager.default.removeItem(at: partialState)
+        let partialFile = plan.cacheDirectory.appendingPathComponent("pending.bin.part")
+        try Data([0x01]).write(to: partialFile)
+        #expect(!plan.isAvailableLocally())
+        try FileManager.default.removeItem(at: partialFile)
+
+        try plan.recordValidatedLegacyInstallationIfNeeded()
         #expect(plan.isComplete())
 
         try FileManager.default.removeItem(
@@ -452,6 +456,7 @@ struct ModelDownloadCoordinatorTests {
             )
         )
         #expect(!plan.isComplete())
+        #expect(!plan.isAvailableLocally())
         #expect(plan.modelID == "FluidInference/qwen3-asr-0.6b-coreml")
         #expect(plan.cacheDirectory.path.hasSuffix("qwen3-asr-0.6b/int8"))
         #expect(plan.selections.count == 1)
@@ -461,7 +466,108 @@ struct ModelDownloadCoordinatorTests {
         let whisper = ManagedASRModelPlans.whisperKit(modelName: "tiny.en", downloadRoot: root)
         #expect(whisper.selections[0].includedPaths.contains("AudioEncoder.mlmodelc"))
         #expect(whisper.selections[0].includedPaths.contains("config.json"))
+        #expect(whisper.selections[0].includedPaths.contains("generation_config.json"))
         #expect(!whisper.selections[0].includedPaths.contains("AudioEncoder.mlpackage"))
+    }
+
+    @Test("legacy ASR installs stay available without manifest discovery")
+    func legacyASRInstallSkipsNetworkResolution() async throws {
+        let tracker = DownloadTestTracker()
+        ModelDownloadTestURLProtocol.install { _ in
+            Issue.record("Legacy installation unexpectedly requested the network")
+            return ModelDownloadTestURLProtocol.Response(tracker: tracker)
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let plan = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root)
+        for relativePath in [
+            "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+            "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/weights/weight.bin",
+            "qwen3_asr_embeddings.bin",
+            "vocab.json",
+        ] {
+            let url = plan.cacheDirectory.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data([0x01]).write(to: url)
+        }
+
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let directory = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            resolver: resolver,
+            coordinator: makeCoordinator()
+        )
+        #expect(directory == plan.cacheDirectory)
+        #expect(tracker.requestCount == 0)
+        #expect(!plan.isComplete())
+        #expect(plan.isAvailableLocally())
+    }
+
+    @Test("managed ASR deletion cancels manifest discovery and blocks replacement work")
+    func managedASRDeletionOwnsManifestDiscovery() async throws {
+        let tracker = DownloadTestTracker()
+        let page = try JSONSerialization.data(withJSONObject: [[
+            "type": "file",
+            "path": "model.bin",
+            "size": 1,
+            "oid": String(repeating: "x", count: 64 * 1024),
+        ]])
+        ModelDownloadTestURLProtocol.install { _ in
+            ModelDownloadTestURLProtocol.Response(
+                data: page,
+                chunkSize: 128,
+                delay: 0.002,
+                tracker: tracker
+            )
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let plan = ManagedASRModelPlan(
+            modelID: "managed-resolve-cancel",
+            repository: "acme/asr",
+            cacheDirectory: root.appendingPathComponent("model", isDirectory: true),
+            selections: [HuggingFaceModelSelection(includedPaths: ["model.bin"])],
+            requiredArtifactAlternatives: [["model.bin"]]
+        )
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let coordinator = makeCoordinator()
+        let task = Task {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                coordinator: coordinator
+            )
+        }
+        #expect(tracker.waitUntilRequestStarts())
+
+        let deletionToken = await ManagedASRModelDownloader.beginDeletion(
+            modelID: plan.modelID,
+            coordinator: coordinator
+        )
+        do {
+            _ = try await task.value
+            Issue.record("Manifest discovery unexpectedly completed after deletion began")
+        } catch {
+            #expect(error is CancellationError || (error as? URLError)?.code == .cancelled)
+        }
+        await #expect(throws: CancellationError.self) {
+            try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                resolver: resolver,
+                coordinator: coordinator
+            )
+        }
+        await ManagedASRModelDownloader.endDeletion(deletionToken)
+        #expect(!FileManager.default.fileExists(atPath: plan.cacheDirectory.path))
     }
 
     @Test("downloads multiple files with bounded concurrency")
@@ -876,11 +982,13 @@ struct ModelDownloadCoordinatorTests {
 
     @Test("cancel and wait preserves the partial file and finishes before deletion")
     func cancellationPreservesPartialFile() async throws {
+        let tracker = DownloadTestTracker()
         ModelDownloadTestURLProtocol.install { _ in
             ModelDownloadTestURLProtocol.Response(
                 data: Data(repeating: 0x43, count: 512 * 1024),
                 chunkSize: 4 * 1024,
-                delay: 0.01
+                delay: 0.01,
+                tracker: tracker
             )
         }
         defer { ModelDownloadTestURLProtocol.uninstall() }
@@ -895,7 +1003,14 @@ struct ModelDownloadCoordinatorTests {
             maximumConcurrency: 1
         )
         let task = Task { try await coordinator.download(manifest, to: directory) }
-        try await Task.sleep(for: .milliseconds(60))
+        #expect(tracker.waitUntilRequestStarts())
+        let partURL = directory.appendingPathComponent("model.bin.part")
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while !FileManager.default.fileExists(atPath: partURL.path),
+              ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(FileManager.default.fileExists(atPath: partURL.path))
         await coordinator.cancelAndWait(modelID: manifest.id)
         do {
             try await task.value
@@ -904,11 +1019,9 @@ struct ModelDownloadCoordinatorTests {
             // Expected.
         }
 
-        let partURL = directory.appendingPathComponent("model.bin.part")
         #expect(FileManager.default.fileExists(atPath: partURL.path))
         #expect(!FileManager.default.fileExists(atPath: directory.appendingPathComponent("model.bin").path))
         try FileManager.default.removeItem(at: partURL)
-        try await Task.sleep(for: .milliseconds(20))
         #expect(!FileManager.default.fileExists(atPath: partURL.path))
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -411,6 +411,7 @@ struct ModelDownloadCoordinatorTests {
 
         for relativePath in [
             "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+            "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
             "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
             "qwen3_asr_embeddings.bin",
             "vocab.json",
@@ -423,7 +424,34 @@ struct ModelDownloadCoordinatorTests {
             try Data([0x01]).write(to: url)
         }
 
+        #expect(!plan.isComplete())
+        let installedPaths = [
+            "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+            "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+            "qwen3_asr_embeddings.bin",
+            "vocab.json",
+        ]
+        let manifest = ModelDownloadManifest(
+            id: plan.modelID,
+            version: "test-install",
+            files: installedPaths.map { relativePath in
+                ModelDownloadFile(
+                    relativePath: relativePath,
+                    remoteURL: URL(string: "https://example.com/model")!,
+                    expectedByteCount: 1
+                )
+            }
+        )
+        try plan.recordSuccessfulInstallation(manifest)
         #expect(plan.isComplete())
+
+        try FileManager.default.removeItem(
+            at: plan.cacheDirectory.appendingPathComponent(
+                "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin"
+            )
+        )
+        #expect(!plan.isComplete())
         #expect(plan.modelID == "FluidInference/qwen3-asr-0.6b-coreml")
         #expect(plan.cacheDirectory.path.hasSuffix("qwen3-asr-0.6b/int8"))
         #expect(plan.selections.count == 1)

--- a/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelDownloadCoordinatorTests.swift
@@ -299,6 +299,113 @@ struct ModelDownloadCoordinatorTests {
         #expect(error.localizedDescription.contains("stalled"))
     }
 
+    @Test("Hugging Face trees become size-aware filtered manifests")
+    func huggingFaceTreeResolution() async throws {
+        let tracker = DownloadTestTracker()
+        let firstPage = try JSONSerialization.data(withJSONObject: [
+            [
+                "type": "file",
+                "path": "int8/Encoder.mlmodelc/coremldata.bin",
+                "size": 7,
+                "oid": "encoder-oid",
+            ],
+            [
+                "type": "file",
+                "path": "int8/ignored.txt",
+                "size": 100,
+                "oid": "ignored-oid",
+            ],
+        ])
+        let secondPage = try JSONSerialization.data(withJSONObject: [[
+            "type": "file",
+            "path": "int8/Decoder.mlmodelc/coremldata.bin",
+            "size": 9,
+            "oid": "decoder-oid",
+        ]])
+        ModelDownloadTestURLProtocol.install { request in
+            let isSecondPage = request.url.flatMap {
+                URLComponents(url: $0, resolvingAgainstBaseURL: false)
+            }?.queryItems?.contains(URLQueryItem(name: "cursor", value: "next")) == true
+            let data: Data
+            let headers: [String: String]
+            if isSecondPage {
+                data = secondPage
+                headers = [:]
+            } else {
+                #expect(request.url?.path.hasSuffix("/tree/main/int8") == true)
+                #expect(request.url?.query?.contains("recursive=true") == true)
+                data = firstPage
+                headers = [
+                    "Link": "<https://huggingface.co/api/models/acme/asr/tree/main/int8?cursor=next>; rel=\"next\""
+                ]
+            }
+            return ModelDownloadTestURLProtocol.Response(
+                data: data,
+                headers: headers,
+                tracker: tracker
+            )
+        }
+        defer { ModelDownloadTestURLProtocol.uninstall() }
+
+        let resolver = HuggingFaceModelManifestResolver(configuration: makeSessionConfiguration())
+        let manifest = try await resolver.resolve(
+            modelID: "acme/asr",
+            repository: "acme/asr",
+            selections: [HuggingFaceModelSelection(
+                remoteDirectory: "int8",
+                includedPaths: ["Encoder.mlmodelc", "Decoder.mlmodelc"]
+            )]
+        )
+
+        #expect(tracker.requestCount == 2)
+        #expect(manifest.files.map(\.relativePath) == [
+            "Decoder.mlmodelc/coremldata.bin",
+            "Encoder.mlmodelc/coremldata.bin",
+        ])
+        #expect(manifest.totalExpectedByteCount == 16)
+        #expect(manifest.files[0].remoteURL.absoluteString.contains("/acme/asr/resolve/main/int8/Decoder.mlmodelc/coremldata.bin"))
+        #expect(manifest.version.hasPrefix("main-"))
+    }
+
+    @Test("managed ASR plans require complete compiled artifacts")
+    func managedASRPlanCompleteness() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let plan = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root)
+
+        try FileManager.default.createDirectory(
+            at: plan.cacheDirectory.appendingPathComponent("qwen3_asr_audio_encoder_v2.mlmodelc"),
+            withIntermediateDirectories: true
+        )
+        #expect(!plan.isComplete())
+
+        for relativePath in [
+            "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+            "qwen3_asr_embeddings.bin",
+            "vocab.json",
+        ] {
+            let url = plan.cacheDirectory.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data([0x01]).write(to: url)
+        }
+
+        #expect(plan.isComplete())
+        #expect(plan.modelID == "FluidInference/qwen3-asr-0.6b-coreml")
+        #expect(plan.cacheDirectory.path.hasSuffix("qwen3-asr-0.6b/int8"))
+        #expect(plan.selections.count == 1)
+        #expect(plan.selections[0].remoteDirectory == "int8")
+        #expect(plan.selections[0].includedPaths.contains("vocab.json"))
+
+        let whisper = ManagedASRModelPlans.whisperKit(modelName: "tiny.en", downloadRoot: root)
+        #expect(whisper.selections[0].includedPaths.contains("AudioEncoder.mlmodelc"))
+        #expect(whisper.selections[0].includedPaths.contains("config.json"))
+        #expect(!whisper.selections[0].includedPaths.contains("AudioEncoder.mlpackage"))
+    }
+
     @Test("downloads multiple files with bounded concurrency")
     func downloadsMultipleFilesWithBoundedConcurrency() async throws {
         let tracker = DownloadTestTracker()
@@ -745,12 +852,16 @@ struct ModelDownloadCoordinatorTests {
     }
 
     private func makeCoordinator() -> ModelDownloadCoordinator {
+        ModelDownloadCoordinator(configuration: makeSessionConfiguration())
+    }
+
+    private func makeSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [ModelDownloadTestURLProtocol.self]
         configuration.waitsForConnectivity = false
         configuration.timeoutIntervalForRequest = 5
         configuration.timeoutIntervalForResource = 30
-        return ModelDownloadCoordinator(configuration: configuration)
+        return configuration
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Accelerate
 import AppKit
 import Foundation
+import FluidAudio
 import MuesliCore
 @testable import MuesliNativeApp
 
@@ -116,7 +117,9 @@ struct BackendOptionTests {
         func installRequiredArtifacts(in directory: URL) throws {
             for relativePath in [
                 "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+                "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
                 "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+                "qwen3_asr_decoder_stateful.mlmodelc/weights/weight.bin",
                 "qwen3_asr_embeddings.bin",
                 "vocab.json",
             ] {
@@ -136,10 +139,12 @@ struct BackendOptionTests {
         let managedDirectory = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root).cacheDirectory
         try installRequiredArtifacts(in: managedDirectory)
         let managedPlan = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root)
-        #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
+        #expect(Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
         let installedPaths = [
             "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+            "qwen3_asr_audio_encoder_v2.mlmodelc/weights/weight.bin",
             "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/weights/weight.bin",
             "qwen3_asr_embeddings.bin",
             "vocab.json",
         ]
@@ -180,6 +185,22 @@ struct BackendOptionTests {
         #expect(throws: CancellationError.self) {
             try Qwen3AsrWarmupReadiness.validate(isCancelled: false, isCurrent: false)
         }
+    }
+
+    @Test("Parakeet deletion unloads only the matching runtime variant")
+    func parakeetDeletionUnloadPolicy() {
+        #expect(FluidAudioUnloadPolicy.shouldUnload(
+            loadedVersion: .v2,
+            deletingVersion: .v2
+        ))
+        #expect(!FluidAudioUnloadPolicy.shouldUnload(
+            loadedVersion: .v3,
+            deletingVersion: .v2
+        ))
+        #expect(!FluidAudioUnloadPolicy.shouldUnload(
+            loadedVersion: nil,
+            deletingVersion: .v3
+        ))
     }
 
     @Test("Cohere uses cohere backend")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -143,7 +143,7 @@ struct BackendOptionTests {
             "qwen3_asr_embeddings.bin",
             "vocab.json",
         ]
-        try managedPlan.recordSuccessfulInstallation(ModelDownloadManifest(
+        let installedManifest = ModelDownloadManifest(
             id: managedPlan.modelID,
             version: "test-install",
             files: installedPaths.map { relativePath in
@@ -153,9 +153,16 @@ struct BackendOptionTests {
                     expectedByteCount: 1
                 )
             }
-        ))
+        )
+        try managedPlan.recordSuccessfulInstallation(installedManifest)
         #expect(Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
 
+        let completionMarker = managedDirectory
+            .appendingPathComponent(".muesli-managed-model-complete.json")
+        try Data("not-json".utf8).write(to: completionMarker)
+        #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
+
+        try managedPlan.recordSuccessfulInstallation(installedManifest)
         try fm.removeItem(at: managedDirectory.appendingPathComponent("vocab.json"))
         #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
 

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -75,6 +75,36 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.gemma4E2BLiteRT))
     }
 
+    @Test("Qwen ASR cache names match FluidAudio folderName strip of -coreml")
+    func qwenAsrCacheDirectoryNamesMatchFluidAudio() {
+        // FluidAudio Repo.folderName default strips "-coreml" from the repo slug,
+        // so downloads land in qwen3-asr-0.6b/{int8,f32} (issue #380).
+        #expect(Qwen3AsrModelStore.cacheDirectoryNames.first == "qwen3-asr-0.6b")
+        #expect(Qwen3AsrModelStore.cacheDirectoryNames.contains("qwen3-asr-0.6b-coreml"))
+    }
+
+    @Test("Qwen ASR vocab marker recognizes FluidAudio stripped cache path")
+    func qwenAsrVocabMarkerRecognizesStrippedCachePath() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("muesli-qwen-asr-path-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        #expect(!Qwen3AsrModelStore.hasVocabMarker(in: root, fileManager: fm))
+
+        let vocab = root
+            .appendingPathComponent("qwen3-asr-0.6b/int8", isDirectory: true)
+            .appendingPathComponent("vocab.json")
+        try fm.createDirectory(at: vocab.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: vocab)
+
+        #expect(Qwen3AsrModelStore.hasVocabMarker(in: root, fileManager: fm))
+
+        try Qwen3AsrModelStore.deleteModelFiles(from: root, fileManager: fm)
+        #expect(!fm.fileExists(atPath: root.appendingPathComponent("qwen3-asr-0.6b").path))
+        #expect(!Qwen3AsrModelStore.hasVocabMarker(in: root, fileManager: fm))
+    }
+
     @Test("Cohere uses cohere backend")
     func cohereBackend() {
         #expect(BackendOption.cohereTranscribe.backend == "cohere")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -135,6 +135,25 @@ struct BackendOptionTests {
 
         let managedDirectory = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root).cacheDirectory
         try installRequiredArtifacts(in: managedDirectory)
+        let managedPlan = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root)
+        #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
+        let installedPaths = [
+            "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+            "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+            "qwen3_asr_embeddings.bin",
+            "vocab.json",
+        ]
+        try managedPlan.recordSuccessfulInstallation(ModelDownloadManifest(
+            id: managedPlan.modelID,
+            version: "test-install",
+            files: installedPaths.map { relativePath in
+                ModelDownloadFile(
+                    relativePath: relativePath,
+                    remoteURL: URL(string: "https://example.com/model")!,
+                    expectedByteCount: 1
+                )
+            }
+        ))
         #expect(Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
 
         try fm.removeItem(at: managedDirectory.appendingPathComponent("vocab.json"))
@@ -143,6 +162,17 @@ struct BackendOptionTests {
         try Qwen3AsrModelStore.deleteModelFiles(from: root, fileManager: fm)
         #expect(!fm.fileExists(atPath: root.appendingPathComponent("qwen3-asr-0.6b").path))
         #expect(!fm.fileExists(atPath: root.appendingPathComponent("qwen3-asr-0.6b-coreml").path))
+    }
+
+    @Test("Qwen ASR warmup publishes readiness only for the current uncancelled load")
+    func qwenAsrWarmupReadinessGate() throws {
+        try Qwen3AsrWarmupReadiness.validate(isCancelled: false, isCurrent: true)
+        #expect(throws: CancellationError.self) {
+            try Qwen3AsrWarmupReadiness.validate(isCancelled: true, isCurrent: true)
+        }
+        #expect(throws: CancellationError.self) {
+            try Qwen3AsrWarmupReadiness.validate(isCancelled: false, isCurrent: false)
+        }
     }
 
     @Test("Cohere uses cohere backend")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -98,7 +98,7 @@ struct BackendOptionTests {
         }
     }
 
-    @Test("Qwen ASR cache names match FluidAudio folderName strip of -coreml")
+    @Test("Qwen ASR cache names preserve current runtime and legacy cleanup paths")
     func qwenAsrCacheDirectoryNamesMatchFluidAudio() {
         // FluidAudio Repo.folderName default strips "-coreml" from the repo slug,
         // so downloads land in qwen3-asr-0.6b/{int8,f32} (issue #380).
@@ -106,43 +106,43 @@ struct BackendOptionTests {
         #expect(Qwen3AsrModelStore.cacheDirectoryNames.contains("qwen3-asr-0.6b-coreml"))
     }
 
-    @Test("Qwen ASR recognizes only the INT8 runtime cache layouts")
-    func qwenAsrVocabMarkerRecognizesInt8CacheLayouts() throws {
+    @Test("Qwen ASR readiness matches the complete managed INT8 runtime directory")
+    func qwenAsrReadinessMatchesManagedRuntimeDirectory() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
             .appendingPathComponent("muesli-qwen-asr-path-\(UUID().uuidString)", isDirectory: true)
         defer { try? fm.removeItem(at: root) }
 
-        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
-
-        for cacheName in Qwen3AsrModelStore.cacheDirectoryNames {
-            let vocab = root
-                .appendingPathComponent(cacheName, isDirectory: true)
-                .appendingPathComponent("int8/vocab.json")
-            try fm.createDirectory(at: vocab.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try Data("{}".utf8).write(to: vocab)
-            #expect(Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
-            try fm.removeItem(at: root.appendingPathComponent(cacheName))
-            #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
+        func installRequiredArtifacts(in directory: URL) throws {
+            for relativePath in [
+                "qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin",
+                "qwen3_asr_decoder_stateful.mlmodelc/coremldata.bin",
+                "qwen3_asr_embeddings.bin",
+                "vocab.json",
+            ] {
+                let url = directory.appendingPathComponent(relativePath)
+                try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try Data([0x01]).write(to: url)
+            }
         }
 
-        let f32Vocab = root
-            .appendingPathComponent("qwen3-asr-0.6b/f32", isDirectory: true)
-            .appendingPathComponent("vocab.json")
-        try fm.createDirectory(at: f32Vocab.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try Data("{}".utf8).write(to: f32Vocab)
-        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
+        #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
 
-        let unsupportedVocab = root
-            .appendingPathComponent("qwen3-asr-unsupported/int8", isDirectory: true)
-            .appendingPathComponent("vocab.json")
-        try fm.createDirectory(at: unsupportedVocab.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try Data("{}".utf8).write(to: unsupportedVocab)
-        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
+        let legacyDirectory = root
+            .appendingPathComponent("qwen3-asr-0.6b-coreml/int8", isDirectory: true)
+        try installRequiredArtifacts(in: legacyDirectory)
+        #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
+
+        let managedDirectory = ManagedASRModelPlans.qwen3ASRInt8(modelsRoot: root).cacheDirectory
+        try installRequiredArtifacts(in: managedDirectory)
+        #expect(Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
+
+        try fm.removeItem(at: managedDirectory.appendingPathComponent("vocab.json"))
+        #expect(!Qwen3AsrModelStore.isModelDownloaded(in: root, fileManager: fm))
 
         try Qwen3AsrModelStore.deleteModelFiles(from: root, fileManager: fm)
         #expect(!fm.fileExists(atPath: root.appendingPathComponent("qwen3-asr-0.6b").path))
-        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
+        #expect(!fm.fileExists(atPath: root.appendingPathComponent("qwen3-asr-0.6b-coreml").path))
     }
 
     @Test("Cohere uses cohere backend")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -106,26 +106,43 @@ struct BackendOptionTests {
         #expect(Qwen3AsrModelStore.cacheDirectoryNames.contains("qwen3-asr-0.6b-coreml"))
     }
 
-    @Test("Qwen ASR vocab marker recognizes FluidAudio stripped cache path")
-    func qwenAsrVocabMarkerRecognizesStrippedCachePath() throws {
+    @Test("Qwen ASR recognizes only the INT8 runtime cache layouts")
+    func qwenAsrVocabMarkerRecognizesInt8CacheLayouts() throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory
             .appendingPathComponent("muesli-qwen-asr-path-\(UUID().uuidString)", isDirectory: true)
         defer { try? fm.removeItem(at: root) }
 
-        #expect(!Qwen3AsrModelStore.hasVocabMarker(in: root, fileManager: fm))
+        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
 
-        let vocab = root
-            .appendingPathComponent("qwen3-asr-0.6b/int8", isDirectory: true)
+        for cacheName in Qwen3AsrModelStore.cacheDirectoryNames {
+            let vocab = root
+                .appendingPathComponent(cacheName, isDirectory: true)
+                .appendingPathComponent("int8/vocab.json")
+            try fm.createDirectory(at: vocab.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: vocab)
+            #expect(Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
+            try fm.removeItem(at: root.appendingPathComponent(cacheName))
+            #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
+        }
+
+        let f32Vocab = root
+            .appendingPathComponent("qwen3-asr-0.6b/f32", isDirectory: true)
             .appendingPathComponent("vocab.json")
-        try fm.createDirectory(at: vocab.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try Data("{}".utf8).write(to: vocab)
+        try fm.createDirectory(at: f32Vocab.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: f32Vocab)
+        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
 
-        #expect(Qwen3AsrModelStore.hasVocabMarker(in: root, fileManager: fm))
+        let unsupportedVocab = root
+            .appendingPathComponent("qwen3-asr-unsupported/int8", isDirectory: true)
+            .appendingPathComponent("vocab.json")
+        try fm.createDirectory(at: unsupportedVocab.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: unsupportedVocab)
+        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
 
         try Qwen3AsrModelStore.deleteModelFiles(from: root, fileManager: fm)
         #expect(!fm.fileExists(atPath: root.appendingPathComponent("qwen3-asr-0.6b").path))
-        #expect(!Qwen3AsrModelStore.hasVocabMarker(in: root, fileManager: fm))
+        #expect(!Qwen3AsrModelStore.hasInt8VocabMarker(in: root, fileManager: fm))
     }
 
     @Test("Cohere uses cohere backend")

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -75,6 +75,29 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.gemma4E2BLiteRT))
     }
 
+    @Test("Qwen ASR is a standard dictation model")
+    func qwenAsrIsNotExperimental() {
+        #expect(BackendOption.all.contains(.qwen3Asr))
+        #expect(!BackendOption.experimental.contains(.qwen3Asr))
+        #expect(BackendOption.qwen3Asr.description.contains("52 languages"))
+        #expect(BackendOption.qwen3Asr.description.contains("2–3 second"))
+    }
+
+    @Test("model descriptions explain usage without implementation jargon")
+    func modelDescriptionsAreProductFacing() {
+        let implementationTerms = ["INT8", "CoreML", "ANE", "RNNT", "FluidAudio", "LiteRT-LM", "quantized", "GGUF"]
+        for option in BackendOption.all {
+            for term in implementationTerms {
+                #expect(!option.description.contains(term), "\(option.label) description exposes \(term)")
+            }
+        }
+        for option in PostProcessorOption.all {
+            for term in implementationTerms {
+                #expect(!option.description.contains(term), "\(option.label) description exposes \(term)")
+            }
+        }
+    }
+
     @Test("Qwen ASR cache names match FluidAudio folderName strip of -coreml")
     func qwenAsrCacheDirectoryNamesMatchFluidAudio() {
         // FluidAudio Repo.folderName default strips "-coreml" from the repo slug,
@@ -172,23 +195,20 @@ struct BackendOptionTests {
         #expect(swapped != expectedColumnMajorTranspose)
     }
 
-    @Test("SenseVoice uses native FluidAudio CoreML model")
+    @Test("SenseVoice uses the native speech model")
     func senseVoiceBackend() {
         #expect(BackendOption.senseVoiceSmall.backend == "sensevoice")
         #expect(BackendOption.senseVoiceSmall.model == "FluidInference/sensevoice-small-coreml")
-        #expect(BackendOption.senseVoiceSmall.description.contains("FluidAudio"))
     }
 
-    @Test("Gemma 4 E2B uses LiteRT-LM as an experimental managed model")
+    @Test("Gemma 4 E2B remains an experimental managed model")
     func gemma4LiteRTBackend() {
         #expect(BackendOption.gemma4E2BLiteRT.backend == "gemma4-litert")
         #expect(BackendOption.gemma4E2BLiteRT.model == Gemma4LiteRTModelStore.repoID)
         #expect(BackendOption.gemma4E2BLiteRT.label == "Gemma 4 E2B")
         #expect(BackendOption.gemma4E2BLiteRT.sizeLabel == "~2.6 GB")
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("LiteRT-LM"))
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("Downloads managed local weights"))
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("ASR-tuned Gemma artifact"))
-        #expect(BackendOption.gemma4E2BLiteRT.description.contains("chat-style outputs fail closed"))
+        #expect(BackendOption.gemma4E2BLiteRT.description.contains("research preview"))
+        #expect(BackendOption.gemma4E2BLiteRT.description.contains("macOS 15"))
         #expect(BackendOption.experimental.contains(.gemma4E2BLiteRT))
         #expect(!BackendOption.onboarding.contains(.gemma4E2BLiteRT))
     }

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -844,16 +844,16 @@ struct Nemotron35StreamStateTests {
 @Suite("Nemotron35 backend metadata")
 struct Nemotron35BackendMetadataTests {
 
-    @Test("nemotron35 description warns about limitations and lists languages")
+    @Test("nemotron35 description explains live usage and limitations")
     func descriptionWarnings() {
         let desc = BackendOption.nemotron35Multilingual.description
         #expect(!BackendOption.nemotron35Multilingual.label.contains("Experimental"))
         #expect(!desc.contains("Experimental"))
-        #expect(desc.contains("Hold-to-talk"))
-        #expect(desc.contains("handsfree"))
-        #expect(desc.contains("Multilingual"))
+        #expect(desc.contains("hold-to-talk"))
+        #expect(desc.contains("hands-free"))
         #expect(desc.contains("Hindi"))
         #expect(desc.contains("punctuation"))
+        #expect(desc.contains("does not go back to correct"))
     }
 
     @Test("nemotron35 backend identifier is nemotron35")


### PR DESCRIPTION
## Summary

- Fix Qwen3 ASR cache recognition from #380 and use the INT8 layout that the runtime actually loads.
- Route FluidAudio and WhisperKit models through the shared resumable Hugging Face downloader, including pause/resume, size-aware progress, validation, and consistent cache recognition.
- Promote Qwen3 ASR to the standard dictation catalog and rewrite model descriptions around real-world speed, language coverage, and limitations.
- Harden download lifecycle behavior from review: trusted pagination URLs, cancel-and-wait deletion, resident manager unloads, live-caption generation safety, and WhisperKit readiness after warmup.

## Validation

- [x] `swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-pr395-review-tests --filter ModelDownloadCoordinatorTests|BackendOptionTests|MeetingStreamingPartialSessionTests` (71 tests)
- [x] `./scripts/test_classify_changed_files.sh`
- [x] `./scripts/test_ci_test_shards.sh`
- [x] `./scripts/verify_update_flow.sh --skip-dmg`
- [x] `./scripts/dev-test.sh --lane B` (signed debug app built, installed, deep signature verified, and launched)
- [x] Maintainer validation: Qwen3 ASR downloads and transcribes successfully, with expected slower completion than Parakeet.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid author-matching `Signed-off-by` trailer under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli MIT License.
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] Third-party runtime model sources are identified below.
- [x] Material AI assistance is disclosed below and the resulting changes were reviewed and tested.

### Third-party materials

Existing runtime model sources used by this integration: `FluidInference/qwen3-asr-0.6b-coreml`, FluidInference Parakeet repositories, and `argmaxinc/whisperkit-coreml` on Hugging Face. This PR adds no vendored model artifacts or new package dependencies; repository-specific licenses and terms continue to apply to runtime downloads.

### AI assistance

OpenAI Codex was used to retrieve project history, inspect and modify the downloader integrations, address automated review findings, and run the validation listed above. The maintainer reviewed product behavior and model copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Qwen3 ASR to dictation and experimental model options.
  - Added managed downloads for transcription and live-caption models.
  - Download progress now shows preparation, file transfer, and readiness states.

- **Bug Fixes**
  - Improved download cancellation, pausing, resuming, deletion, and cleanup.
  - Prevented stale updates after restarting live captions.
  - Improved detection of existing and legacy model files.

- **Documentation**
  - Updated model descriptions, feature-tour text, and category labels, including “Live Meetings” and “Cleanup.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->