### PR TITLE
Dispatch the post-meeting hook for imported audio meetings

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -5252,6 +5252,11 @@ final class MuesliController: NSObject {
             source: .audioImport
         )
         scheduleICloudSyncAfterLocalChange()
+        meetingHookDispatcher.dispatchCompletedMeetingHook(
+            meetingID: meetingID,
+            completedAt: endTime,
+            config: config
+        )
         return meetingID
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -108,6 +108,10 @@ struct MeetingHookIntegrationTests {
         let spy = MeetingHookDispatcherSpy()
         let controller = makeController(store: store, dispatcher: spy)
         let endTime = Date(timeIntervalSince1970: 1_713_961_500)
+        var meetingExistedAtDispatch = false
+        spy.onDispatch = { invocation in
+            meetingExistedAtDispatch = (try? store.meeting(id: invocation.meetingID)) != nil
+        }
 
         let meetingID = try controller.persistImportedAudioMeeting(
             title: "Imported Call Recording",
@@ -128,7 +132,15 @@ struct MeetingHookIntegrationTests {
         #expect(spy.invocations.count == 1)
         #expect(spy.invocations.first?.meetingID == meetingID)
         #expect(spy.invocations.first?.completedAt == endTime)
-        #expect(try store.meeting(id: meetingID) != nil)
+        #expect(meetingExistedAtDispatch)
+
+        let record = try #require(try store.meeting(id: meetingID))
+        #expect(record.title == "Imported Call Recording")
+        #expect(record.startTime == "2024-04-24T12:20:00Z")
+        #expect(record.durationSeconds == 300)
+        #expect(record.rawTranscript == "Speaker 1: Discussed the imported call.")
+        #expect(record.formattedNotes == "## Summary\nImported recording.")
+        #expect(record.source == .audioImport)
     }
 
     private func makeController(store: DictationStore, dispatcher: MeetingHookDispatching) -> MuesliController {
@@ -187,8 +199,11 @@ private final class MeetingHookDispatcherSpy: MeetingHookDispatching {
     }
 
     private(set) var invocations: [Invocation] = []
+    var onDispatch: ((Invocation) -> Void)?
 
     func dispatchCompletedMeetingHook(meetingID: Int64, completedAt: Date, config: AppConfig) {
-        invocations.append(Invocation(meetingID: meetingID, completedAt: completedAt, config: config))
+        let invocation = Invocation(meetingID: meetingID, completedAt: completedAt, config: config)
+        invocations.append(invocation)
+        onDispatch?(invocation)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -102,6 +102,35 @@ struct MeetingHookIntegrationTests {
         #expect(spy.invocations.count == 1)
     }
 
+    @Test("imported audio meeting dispatches one hook event after persistence succeeds")
+    func importedMeetingDispatchesHook() throws {
+        let store = try makeStore()
+        let spy = MeetingHookDispatcherSpy()
+        let controller = makeController(store: store, dispatcher: spy)
+        let endTime = Date(timeIntervalSince1970: 1_713_961_500)
+
+        let meetingID = try controller.persistImportedAudioMeeting(
+            title: "Imported Call Recording",
+            calendarEventID: nil,
+            startTime: endTime.addingTimeInterval(-300),
+            endTime: endTime,
+            rawTranscript: "Speaker 1: Discussed the imported call.",
+            formattedNotes: "## Summary\nImported recording.",
+            micAudioPath: nil,
+            systemAudioPath: nil,
+            savedRecordingPath: nil,
+            selectedTemplateID: nil,
+            selectedTemplateName: nil,
+            selectedTemplateKind: nil,
+            selectedTemplatePrompt: nil
+        )
+
+        #expect(spy.invocations.count == 1)
+        #expect(spy.invocations.first?.meetingID == meetingID)
+        #expect(spy.invocations.first?.completedAt == endTime)
+        #expect(try store.meeting(id: meetingID) != nil)
+    }
+
     private func makeController(store: DictationStore, dispatcher: MeetingHookDispatching) -> MuesliController {
         MuesliController(
             runtime: RuntimePaths(


### PR DESCRIPTION
## Summary
- dispatch the completed-meeting hook after an imported audio meeting is persisted, matching the live-recording path's persist-then-dispatch ordering
- use the import's end time as the hook payload's `completedAt`
- add an integration test covering hook dispatch for imported meetings

## Why
The post-meeting hook (#67) runs after a live meeting is persisted so downstream automations can react without polling `muesli-cli`. Audio file import (#154) landed later and persists meetings through a separate path (`persistImportedAudioMeeting`) that never dispatched the hook, so imported recordings were invisible to hook-based automations even though #154 asked for imports to produce the same output as a live session. This closes that gap.

## Validation
- `swift test --package-path native/MuesliNative --filter MeetingHookIntegrationTests` (the new test fails without the fix, passes with it)
- `swift test --package-path native/MuesliNative` (full suite: 1569 tests in 151 suites, all passing)
- manually verified in a signed dev build: dragged an m4a onto the meetings list, the import persisted, and the configured hook script was dispatched with the new meeting id and exited 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789066198&installation_model_id=422865&pr_number=398&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F398&signature=09689b846219694875d7c8f161d648c0f03dea2dcd175012bc9a19337c951bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None.

### AI assistance

Claude Code drafted the implementation and test. I reviewed the changes, ran the full test suite locally, and manually verified the hook fires end-to-end in a signed dev build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imported audio meetings now trigger completion events with saved meeting details and accurate timing information.

* **Tests**
  * Added coverage to verify imported meetings are saved successfully and trigger exactly one completion event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
