### PR TITLE
Stabilize initial What's New tour rendering

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -347,6 +347,7 @@ final class MuesliController: NSObject {
     private var preferencesWindowController: PreferencesWindowController?
     private var onboardingWindowController: OnboardingWindowController?
     private let featureTourStore = FeatureTourStore()
+    private var isFeatureTourPresentationQueued = false
     var updaterController: SPUStandardUpdaterController?
     private var busyStatusGeneration = 0
 
@@ -906,17 +907,25 @@ final class MuesliController: NSObject {
     @discardableResult
     private func offerFeatureTour(_ tour: FeatureTour) -> Bool {
         guard !tour.steps.isEmpty,
+              !isFeatureTourPresentationQueued,
               appState.pendingFeatureTourInvitation == nil,
               appState.activeFeatureTour == nil,
               ensureBasicDictationPermissionsBeforeDashboard() else { return false }
 
-        appState.pendingFeatureTourInvitation = tour
-        presentHistoryWindow()
-        TelemetryDeck.signal("feature_walkthrough.invitation_shown", parameters: [
-            "version": tour.version,
-            "step_count": "\(tour.steps.count)",
-            "includes_cloud_cleanup": "\(tour.steps.contains { $0.target == .cloudCleanupSetting })",
-        ])
+        isFeatureTourPresentationQueued = true
+        presentHistoryWindow(whenReady: { [weak self] in
+            guard let self else { return }
+            self.isFeatureTourPresentationQueued = false
+            guard self.appState.pendingFeatureTourInvitation == nil,
+                  self.appState.activeFeatureTour == nil else { return }
+
+            self.appState.pendingFeatureTourInvitation = tour
+            TelemetryDeck.signal("feature_walkthrough.invitation_shown", parameters: [
+                "version": tour.version,
+                "step_count": "\(tour.steps.count)",
+                "includes_cloud_cleanup": "\(tour.steps.contains { $0.target == .cloudCleanupSetting })",
+            ])
+        })
         // The normal startup preload task continues while this invitation and
         // the walkthrough are on screen, so no second backend load is started.
         return true
@@ -946,18 +955,23 @@ final class MuesliController: NSObject {
     @discardableResult
     private func beginFeatureTour(_ tour: FeatureTour, source: String) -> Bool {
         guard !tour.steps.isEmpty,
+              !isFeatureTourPresentationQueued,
               ensureBasicDictationPermissionsBeforeDashboard() else { return false }
 
         appState.pendingFeatureTourInvitation = nil
-        appState.activeFeatureTour = tour
-        appState.featureTourStepIndex = 0
-        navigateToFeatureTourStep(tour.steps[0])
-        presentHistoryWindow()
-        TelemetryDeck.signal("feature_walkthrough.started", parameters: [
-            "version": tour.version,
-            "source": source,
-            "step_count": "\(tour.steps.count)",
-        ])
+        isFeatureTourPresentationQueued = true
+        presentHistoryWindow(whenReady: { [weak self] in
+            guard let self else { return }
+            self.isFeatureTourPresentationQueued = false
+            self.appState.activeFeatureTour = tour
+            self.appState.featureTourStepIndex = 0
+            self.navigateToFeatureTourStep(tour.steps[0])
+            TelemetryDeck.signal("feature_walkthrough.started", parameters: [
+                "version": tour.version,
+                "source": source,
+                "step_count": "\(tour.steps.count)",
+            ])
+        })
         return true
     }
 
@@ -3723,9 +3737,9 @@ final class MuesliController: NSObject {
         presentHistoryWindow()
     }
 
-    private func presentHistoryWindow() {
+    private func presentHistoryWindow(whenReady readyAction: (() -> Void)? = nil) {
         DispatchQueue.main.async { [weak self] in
-            self?.historyWindowController?.show()
+            self?.historyWindowController?.show(whenReady: readyAction)
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -3,12 +3,45 @@ import Foundation
 import SwiftUI
 import MuesliCore
 
+struct DashboardPresentationReadiness<Action> {
+    private(set) var isReady = false
+    private(set) var isInitialLayoutScheduled = false
+    private var queuedActions: [Action] = []
+
+    mutating func enqueue(_ action: Action) -> [Action] {
+        guard !isReady else { return [action] }
+        queuedActions.append(action)
+        return []
+    }
+
+    mutating func requestInitialLayout() -> Bool {
+        guard !isReady, !isInitialLayoutScheduled else { return false }
+        isInitialLayoutScheduled = true
+        return true
+    }
+
+    mutating func completeInitialLayout() -> [Action] {
+        isInitialLayoutScheduled = false
+        isReady = true
+        let actions = queuedActions
+        queuedActions.removeAll()
+        return actions
+    }
+
+    mutating func cancelInitialLayout() {
+        isInitialLayoutScheduled = false
+    }
+}
+
 @MainActor
 final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
+    typealias ReadyAction = () -> Void
+
     private let store: DictationStore
     private let controller: MuesliController
     private var window: NSWindow?
     private var keyMonitor: Any?
+    private var presentationReadiness = DashboardPresentationReadiness<ReadyAction>()
 
     var presentationWindow: NSWindow? {
         window
@@ -19,7 +52,7 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         self.controller = controller
     }
 
-    func show() {
+    func show(whenReady readyAction: ReadyAction? = nil) {
         if window == nil {
             buildWindow()
         }
@@ -28,9 +61,14 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         if !window.isVisible {
             controller.noteWindowOpened()
         }
+
+        if let readyAction {
+            run(presentationReadiness.enqueue(readyAction))
+        }
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
         NSApplication.shared.activate(ignoringOtherApps: true)
+        scheduleInitialOrderedLayoutIfNeeded(for: window)
     }
 
     func reload() {
@@ -83,6 +121,32 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
             }
             self.controller.appState.focusSearchField = true
             return nil
+        }
+    }
+
+    private func scheduleInitialOrderedLayoutIfNeeded(for window: NSWindow) {
+        guard presentationReadiness.requestInitialLayout() else { return }
+
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self else { return }
+            guard let window, self.window === window else {
+                self.presentationReadiness.cancelInitialLayout()
+                return
+            }
+
+            // An ordered AppKit window can report isVisible == false while a
+            // different full-screen Space is active. Its hosting hierarchy is
+            // still ready for layout, and feature UI must not wait on occlusion.
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.contentView?.displayIfNeeded()
+            let actions = self.presentationReadiness.completeInitialLayout()
+            self.run(actions)
+        }
+    }
+
+    private func run(_ actions: [ReadyAction]) {
+        for action in actions {
+            action()
         }
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -70,6 +70,31 @@ struct FeatureTourTests {
         #expect(calloutFrame.maxY <= container.height - 20)
     }
 
+    @Test("dashboard presentation waits for its first ordered layout")
+    func dashboardPresentationReadiness() {
+        var readiness = DashboardPresentationReadiness<String>()
+
+        let queuedBeforeReady = readiness.enqueue("feature tour")
+        let firstLayoutRequest = readiness.requestInitialLayout()
+        let duplicateLayoutRequest = readiness.requestInitialLayout()
+        #expect(queuedBeforeReady == [])
+        #expect(firstLayoutRequest)
+        #expect(!duplicateLayoutRequest)
+
+        readiness.cancelInitialLayout()
+        let retriedLayoutRequest = readiness.requestInitialLayout()
+        #expect(!readiness.isReady)
+        #expect(retriedLayoutRequest)
+
+        let firstLayoutActions = readiness.completeInitialLayout()
+        let readyLayoutRequest = readiness.requestInitialLayout()
+        let immediateActions = readiness.enqueue("future tour")
+        #expect(firstLayoutActions == ["feature tour"])
+        #expect(readiness.isReady)
+        #expect(!readyLayoutRequest)
+        #expect(immediateActions == ["future tour"])
+    }
+
     @Test("existing users without legacy version markers see the first feature tour")
     func legacyUpgrade() {
         #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(


### PR DESCRIPTION
## Summary

- wait for the dashboard hosting hierarchy to complete its first ordered layout before activating feature-tour UI
- route both manual walkthrough starts and automatic invitations through the shared readiness gate
- suppress duplicate presentation attempts while the first dashboard action is queued
- add regression coverage for queued, cancelled/retried, and already-ready presentation states

The first tour step previously activated while a newly created `NSHostingView` was still completing its initial layout. That one-time lifecycle race could vertically invert the callout contents; later steps were normal because the hierarchy was already stable. The fix lives at the shared dashboard presentation boundary, so future tours using the standard presentation path inherit it without step-specific handling.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/worktrees/muesli-2692091307/test --filter FeatureTourTests` — 10 tests passed
- `./scripts/dev-test.sh --lane B --local-only` — signed MuesliDevB build installed; deep signature valid
- fresh installed-process MuesliDevB replay — initial step 1 upright, Next step 2 upright, Back step 1 upright
- `git diff --check`

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex was used to trace the historical feature-tour implementation, diagnose the AppKit/SwiftUI presentation-order race, implement the fix and regression test, and drive local MuesliDevB verification. The resulting changes were reviewed and tested locally as documented above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789149873&installation_model_id=422865&pr_number=401&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F401&signature=e1211f2e2ba0d2b19ea30764a0832e25e1e2e6eafb4a4ac4e8bc55f79833e088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature-tour launches to prevent duplicate presentations.
  * Deferred invitations and start actions until the history dashboard is fully ready.
  * Improved handling of dashboard window layout and stale presentation states.

* **Tests**
  * Added coverage for queued dashboard actions, layout readiness, cancellation, retries, and immediate execution after readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->