### PR TITLE
Fix floating indicator dragging and refresh the Muesli icon

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -1499,13 +1499,59 @@ final class FloatingIndicatorController: NSObject {
         return allowedRect.contains(center)
     }
 
+    static func visibleFrameForCustomIndicator(
+        customPositionCenter: CGPoint?,
+        indicatorFrame: NSRect?,
+        savedPositionCenter: CGPoint?,
+        availableVisibleFrames: [NSRect],
+        fallback: NSRect
+    ) -> NSRect {
+        if let customPositionCenter,
+           let matchingFrame = availableVisibleFrames.first(where: { $0.contains(customPositionCenter) }) {
+            return matchingFrame
+        }
+
+        if let indicatorFrame, !indicatorFrame.isEmpty {
+            let matchingFrame = availableVisibleFrames
+                .compactMap { visibleFrame -> (frame: NSRect, overlap: CGFloat)? in
+                    let intersection = visibleFrame.intersection(indicatorFrame)
+                    guard !intersection.isNull, !intersection.isEmpty else { return nil }
+                    return (visibleFrame, intersection.width * intersection.height)
+                }
+                .max(by: { $0.overlap < $1.overlap })?
+                .frame
+            if let matchingFrame {
+                return matchingFrame
+            }
+        }
+
+        if let savedPositionCenter,
+           let matchingFrame = availableVisibleFrames.first(where: { $0.contains(savedPositionCenter) }) {
+            return matchingFrame
+        }
+
+        return fallback
+    }
+
     private func frameForState(
         _ state: DictationState,
         config: AppConfig,
         customPositionCenter: CGPoint? = nil
     ) -> NSRect {
-        guard let screen = NSScreen.main?.visibleFrame else {
+        guard let mainVisibleFrame = NSScreen.main?.visibleFrame else {
             return NSRect(x: 0, y: 0, width: 64, height: 28)
+        }
+        let screen: NSRect
+        if config.indicatorAnchor == .custom {
+            screen = Self.visibleFrameForCustomIndicator(
+                customPositionCenter: customPositionCenter,
+                indicatorFrame: indicatorScreenFrame,
+                savedPositionCenter: config.indicatorOrigin.map { CGPoint(x: $0.x, y: $0.y) },
+                availableVisibleFrames: NSScreen.screens.map(\.visibleFrame),
+                fallback: mainVisibleFrame
+            )
+        } else {
+            screen = mainVisibleFrame
         }
         let size: NSSize
         switch state {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -61,7 +61,7 @@ private final class HoverIndicatorView: NSView {
     override func mouseDown(with event: NSEvent) {
         didDrag = false
         mouseDownScreenLocation = NSEvent.mouseLocation
-        owner?.collapseForDrag()
+        owner?.pointerInteractionBegan()
         windowOriginAtMouseDown = window?.frame.origin
     }
 
@@ -180,8 +180,16 @@ final class FloatingIndicatorController: NSObject {
         hideMeetingTranscript()
     }
 
+    func pointerInteractionBegan() {
+        isDragging = true
+        hoverExitWorkItem?.cancel()
+    }
+
     func pointerInteractionEnded() {
         isDragging = false
+        if state == .idle, isHovered, !pointerIsInsidePanel() {
+            scheduleHoverExit()
+        }
     }
 
     func handleClick(atX x: CGFloat? = nil) {
@@ -216,42 +224,11 @@ final class FloatingIndicatorController: NSObject {
         }
     }
 
-    func collapseForDrag() {
-        isDragging = true
-        hoverExitWorkItem?.cancel()
-        hideMeetingTranscript()
-        guard state == .idle,
-              !isShowingLoading,
-              let panel,
-              let contentView,
-              let iconLabel,
-              let textLabel else { return }
-        isHovered = false
-
-        let config = configStore.load()
-        let style = styleForState(.idle, config: config)
-        let targetFrame = frameForState(.idle, config: config)
-
-        // Instant resize — no animation
-        panel.setFrame(targetFrame, display: true)
-        contentView.frame = NSRect(origin: .zero, size: targetFrame.size)
-        contentView.layer?.cornerRadius = targetFrame.height / 2
-        contentView.layer?.backgroundColor = style.background.cgColor
-        contentView.layer?.borderColor = style.border.cgColor
-        glassView?.frame = NSRect(origin: .zero, size: targetFrame.size)
-        panel.alphaValue = style.alpha
-
-        iconLabel.stringValue = style.icon
-        iconLabel.textColor = style.iconColor
-        textLabel.isHidden = true
-        textLabel.alphaValue = 0
-        layoutLabels(iconLabel: iconLabel, textLabel: textLabel, in: targetFrame.size, hasTitle: false, animated: false)
-        applyGlassState(.idle, frameSize: targetFrame.size)
-    }
-
     func savePosition() {
         guard let frame = indicatorScreenFrame else { return }
-        let center = CGPoint(x: frame.midX, y: frame.midY)
+        let center = state == .idle
+            ? Self.idlePositionCenter(for: frame)
+            : CGPoint(x: frame.midX, y: frame.midY)
         onPositionSaved?(center)
     }
 
@@ -456,7 +433,20 @@ final class FloatingIndicatorController: NSObject {
         }
 
         let style = styleForState(state, config: config)
-        let targetFrame = frameForState(state, config: config)
+        let customPositionCenter: CGPoint?
+        if previousState == .idle,
+           state != .idle,
+           config.indicatorAnchor == .custom,
+           let currentFrame = indicatorScreenFrame {
+            customPositionCenter = Self.idlePositionCenter(for: currentFrame)
+        } else {
+            customPositionCenter = nil
+        }
+        let targetFrame = frameForState(
+            state,
+            config: config,
+            customPositionCenter: customPositionCenter
+        )
 
         let duration = transitionDuration(
             from: previousState,
@@ -634,7 +624,7 @@ final class FloatingIndicatorController: NSObject {
         let fallback = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
             .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)) ?? NSImage()
         let newImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? fallback
-        newImage.isTemplate = false
+        newImage.isTemplate = true
         micIconView?.image = newImage
     }
 
@@ -1108,12 +1098,48 @@ final class FloatingIndicatorController: NSObject {
             if let mic = micIconView {
                 mic.alphaValue = 1
                 if isHovered {
-                    mic.frame = NSRect(x: 12, y: (frameSize.height - iconSize.height) / 2,
-                                      width: iconSize.width, height: iconSize.height)
+                    mic.frame = NSRect(
+                        x: 14,
+                        y: (frameSize.height - iconSize.height) / 2,
+                        width: iconSize.width,
+                        height: iconSize.height
+                    )
+                    if let textLabel {
+                        let textX: CGFloat = 42
+                        let textHeight: CGFloat = 16
+                        textLabel.frame = NSRect(
+                            x: textX,
+                            y: floor((frameSize.height - textHeight) / 2),
+                            width: max(0, frameSize.width - textX - 14),
+                            height: textHeight
+                        )
+                    }
                 } else {
-                    mic.frame = NSRect(x: (frameSize.width - iconSize.width) / 2,
-                                       y: (frameSize.height - iconSize.height) / 2,
-                                       width: iconSize.width, height: iconSize.height)
+                    let showsHotkey = config.showHotkeyOnFloatingIndicator
+                    let compactIconSize = NSSize(width: 14, height: 14)
+                    let iconX = showsHotkey
+                        ? CGFloat(6)
+                        : floor((frameSize.width - compactIconSize.width) / 2)
+                    mic.frame = NSRect(
+                        x: iconX,
+                        y: floor((frameSize.height - compactIconSize.height) / 2),
+                        width: compactIconSize.width,
+                        height: compactIconSize.height
+                    )
+                    if let textLabel, showsHotkey {
+                        textLabel.stringValue = MenuBarIconRenderer.hotkeyCueLabel(
+                            for: config.dictationHotkey
+                        )
+                        textLabel.font = NSFont.monospacedSystemFont(ofSize: 8, weight: .semibold)
+                        textLabel.textColor = .white.withAlphaComponent(0.78)
+                        textLabel.alignment = .center
+                        textLabel.isHidden = false
+                        textLabel.alphaValue = 1
+                        textLabel.frame = NSRect(x: 21, y: 7, width: 18, height: 13)
+                    } else {
+                        textLabel?.isHidden = true
+                        textLabel?.alphaValue = 0
+                    }
                 }
             }
 
@@ -1380,7 +1406,7 @@ final class FloatingIndicatorController: NSObject {
         let fallbackImage = NSImage(systemSymbolName: "waveform.badge.microphone", accessibilityDescription: nil)?
             .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)) ?? NSImage()
         let idleImage = MenuBarIconRenderer.make(choice: config.menuBarIcon) ?? fallbackImage
-        idleImage.isTemplate = false // we tint manually via contentTintColor
+        idleImage.isTemplate = true
         let micView = NSImageView(image: idleImage)
         micView.contentTintColor = .white
         micView.imageScaling = .scaleProportionallyDown
@@ -1412,6 +1438,25 @@ final class FloatingIndicatorController: NSObject {
 
     static func defaultIndicatorCenter(in visibleFrame: NSRect, idleSize: NSSize = NSSize(width: 44, height: 28)) -> CGPoint {
         anchorCenter(.midTrailing, in: visibleFrame, size: idleSize)
+    }
+
+    static func idlePositionCenter(
+        for frame: NSRect,
+        collapsedSize: NSSize = NSSize(width: 44, height: 28)
+    ) -> CGPoint {
+        CGPoint(x: frame.minX + collapsedSize.width / 2, y: frame.midY)
+    }
+
+    static func customIdleFrame(
+        positionCenter: CGPoint,
+        size: NSSize,
+        in visibleFrame: NSRect,
+        collapsedSize: NSSize = NSSize(width: 44, height: 28)
+    ) -> NSRect {
+        let leftEdge = positionCenter.x - collapsedSize.width / 2
+        let x = min(max(leftEdge, visibleFrame.minX), visibleFrame.maxX - size.width)
+        let y = min(max(positionCenter.y - size.height / 2, visibleFrame.minY), visibleFrame.maxY - size.height)
+        return NSRect(origin: CGPoint(x: x, y: y), size: size)
     }
 
     static func anchorCenter(_ anchor: IndicatorAnchor, in visibleFrame: NSRect, size: NSSize) -> CGPoint {
@@ -1454,14 +1499,20 @@ final class FloatingIndicatorController: NSObject {
         return allowedRect.contains(center)
     }
 
-    private func frameForState(_ state: DictationState, config: AppConfig) -> NSRect {
+    private func frameForState(
+        _ state: DictationState,
+        config: AppConfig,
+        customPositionCenter: CGPoint? = nil
+    ) -> NSRect {
         guard let screen = NSScreen.main?.visibleFrame else {
             return NSRect(x: 0, y: 0, width: 64, height: 28)
         }
         let size: NSSize
         switch state {
         case .idle:
-            size = isHovered ? NSSize(width: 220, height: 36) : NSSize(width: 44, height: 28)
+            size = isHovered
+                ? Self.idleHoverPillSize(hotkeyLabel: config.dictationHotkey.label, screenWidth: screen.width)
+                : NSSize(width: 44, height: 28)
         case .preparing: size = NSSize(width: 76, height: 22)
         case .recording: size = NSSize(width: 76, height: 22)
         case .transcribing:
@@ -1472,12 +1523,30 @@ final class FloatingIndicatorController: NSObject {
             }
         }
 
-        // Use the pill's current on-screen center if it exists, so state
-        // transitions resize around the current position rather than jumping
-        // for custom placement. Preset anchors always resolve from config so
-        // changing the setting snaps immediately to the chosen anchor.
+        // Idle hover expansion uses the saved collapsed position as its anchor,
+        // so the left edge stays fixed instead of resizing around the midpoint.
+        // The expanded pill remains draggable; savePosition converts its frame
+        // back to the canonical collapsed center.
+        if state == .idle, config.indicatorAnchor == .custom {
+            let positionCenter: CGPoint
+            if let saved = config.indicatorOrigin {
+                positionCenter = CGPoint(x: saved.x, y: saved.y)
+            } else if let currentFrame = indicatorScreenFrame, currentFrame.width > 0 {
+                positionCenter = Self.idlePositionCenter(for: currentFrame)
+            } else {
+                positionCenter = Self.defaultIndicatorCenter(in: screen)
+            }
+            return Self.customIdleFrame(positionCenter: positionCenter, size: size, in: screen)
+        }
+
+        // Non-idle custom state transitions continue to resize around the
+        // current on-screen center. Preset anchors always resolve from config.
         let center: CGPoint
-        if config.indicatorAnchor == .custom,
+        if config.indicatorAnchor == .custom, let customPositionCenter {
+            // When dictation starts from the left-anchored hover pill, keep the
+            // compact icon position rather than jumping to the hover midpoint.
+            center = customPositionCenter
+        } else if config.indicatorAnchor == .custom,
            let currentFrame = indicatorScreenFrame,
            currentFrame.width > 0 {
             center = CGPoint(x: currentFrame.midX, y: currentFrame.midY)
@@ -1510,7 +1579,7 @@ final class FloatingIndicatorController: NSObject {
                 isHovered ? "Hold \(config.dictationHotkey.label) to dictate" : "",
                 .colorWith(hex: 0xFFFFFF, alpha: 0.75),
                 .colorWith(hex: 0xFFFFFF, alpha: 0.75),
-                isHovered ? 1.0 : 0.85
+                isHovered ? 1.0 : 0.90
             )
         case .preparing:
             return (.clear, .colorWith(hex: 0xFFFFFF, alpha: 0.16), "", "", .white, .white, 1.0)
@@ -1611,6 +1680,15 @@ final class FloatingIndicatorController: NSObject {
 
     static func transcribingPillSizeForTesting(title: String, screenWidth: CGFloat) -> NSSize {
         transcribingPillSize(title: title, screenWidth: screenWidth)
+    }
+
+    static func idleHoverPillSize(hotkeyLabel: String, screenWidth: CGFloat) -> NSSize {
+        let title = "Hold \(hotkeyLabel) to dictate"
+        let font = NSFont.systemFont(ofSize: 11, weight: .regular)
+        let textWidth = ceil((title as NSString).size(withAttributes: [.font: font]).width)
+        let preferredWidth = 42 + textWidth + 22
+        let maxWidth = max(CGFloat(180), screenWidth - 32)
+        return NSSize(width: min(max(220, preferredWidth), maxWidth), height: 36)
     }
 
     static func computerUseTranscriptPillSizeForTesting(

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -117,6 +117,7 @@ final class FloatingIndicatorController: NSObject {
     private var textLabel: NSTextField?
     private var state: DictationState = .idle
     private var isHovered = false
+    private var preservesCollapsedLeftEdge = false
     private var hoverExitWorkItem: DispatchWorkItem?
     private let configStore: ConfigStore
     private var isMeetingRecording = false
@@ -226,9 +227,10 @@ final class FloatingIndicatorController: NSObject {
 
     func savePosition() {
         guard let frame = indicatorScreenFrame else { return }
-        let center = state == .idle
-            ? Self.idlePositionCenter(for: frame)
-            : CGPoint(x: frame.midX, y: frame.midY)
+        let center = Self.positionCenter(
+            for: frame,
+            preservesCollapsedLeftEdge: preservesCollapsedLeftEdge
+        )
         onPositionSaved?(center)
     }
 
@@ -393,6 +395,7 @@ final class FloatingIndicatorController: NSObject {
     func setState(_ state: DictationState, config: AppConfig) {
         let previousState = self.state
         let previousHover = isHovered
+        let previouslyPreservedCollapsedLeftEdge = preservesCollapsedLeftEdge
         if isComputerUseCursorMode {
             exitComputerUseCursorMode(restoreFrame: false)
         }
@@ -407,6 +410,7 @@ final class FloatingIndicatorController: NSObject {
         if state != .idle {
             isHovered = false
         }
+        preservesCollapsedLeftEdge = state == .idle && isHovered
         if !config.showFloatingIndicator && state == .idle {
             close()
             return
@@ -438,7 +442,10 @@ final class FloatingIndicatorController: NSObject {
            state != .idle,
            config.indicatorAnchor == .custom,
            let currentFrame = indicatorScreenFrame {
-            customPositionCenter = Self.idlePositionCenter(for: currentFrame)
+            customPositionCenter = Self.positionCenter(
+                for: currentFrame,
+                preservesCollapsedLeftEdge: previouslyPreservedCollapsedLeftEdge
+            )
         } else {
             customPositionCenter = nil
         }
@@ -555,6 +562,7 @@ final class FloatingIndicatorController: NSObject {
         isComputerUseCursorMode = true
         hoverExitWorkItem?.cancel()
         isHovered = false
+        preservesCollapsedLeftEdge = false
         isShowingLoading = false
         loadingSpinner?.stopAnimation(nil)
         loadingSpinner?.isHidden = true
@@ -636,6 +644,7 @@ final class FloatingIndicatorController: NSObject {
         guard let panel, let contentView, let iconLabel, let textLabel else { return }
         guard let screen = NSScreen.main?.visibleFrame else { return }
 
+        preservesCollapsedLeftEdge = false
         let warningFont = NSFont.systemFont(ofSize: 11, weight: .medium)
         let warningSize = warningPillSize(
             message: message,
@@ -709,6 +718,7 @@ final class FloatingIndicatorController: NSObject {
         guard let screen = NSScreen.main?.visibleFrame else { return }
 
         isShowingLoading = true
+        preservesCollapsedLeftEdge = false
         let loadingSize = loadingPillSize(message: message, screen: screen)
         let center = CGPoint(x: panel.frame.midX, y: panel.frame.midY)
         let x = min(max(center.x - loadingSize.width / 2, screen.minX), screen.maxX - loadingSize.width)
@@ -851,6 +861,7 @@ final class FloatingIndicatorController: NSObject {
         stopWaveformAnimation()
         hoverExitWorkItem?.cancel()
         hoverExitWorkItem = nil
+        preservesCollapsedLeftEdge = false
         panel?.close()
         panel = nil
         containerView = nil
@@ -1445,6 +1456,17 @@ final class FloatingIndicatorController: NSObject {
         collapsedSize: NSSize = NSSize(width: 44, height: 28)
     ) -> CGPoint {
         CGPoint(x: frame.minX + collapsedSize.width / 2, y: frame.midY)
+    }
+
+    static func positionCenter(
+        for frame: NSRect,
+        preservesCollapsedLeftEdge: Bool,
+        collapsedSize: NSSize = NSSize(width: 44, height: 28)
+    ) -> CGPoint {
+        guard preservesCollapsedLeftEdge else {
+            return CGPoint(x: frame.midX, y: frame.midY)
+        }
+        return idlePositionCenter(for: frame, collapsedSize: collapsedSize)
     }
 
     static func customIdleFrame(

--- a/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MenuBarIconRenderer.swift
@@ -2,6 +2,14 @@ import AppKit
 
 enum MenuBarIconRenderer {
 
+    private static let displaySize = NSSize(width: 18, height: 18)
+    /// Pixel bounds of the blue waveform inside the canonical 1024px app icon.
+    /// The menu-bar mark is extracted from this source directly; it is never
+    /// reconstructed from approximate bars or inferred measurements.
+    static let canonicalMarkSourceRect = CGRect(x: 195, y: 256, width: 635, height: 513)
+    static let canonicalMarkOpacityBoost: CGFloat = 1.08
+    static let canonicalMarkMask: CGImage? = loadCanonicalMarkMask()
+
     static let options: [(id: String, label: String)] = [
         ("muesli", "Muesli Logo"),
         ("mic.fill", "Microphone"),
@@ -17,16 +25,12 @@ enum MenuBarIconRenderer {
         ("doc.text", "Document"),
     ]
 
-    /// Returns a menu bar icon for the given choice.
-    /// "muesli" loads the bundled M logo; anything else renders an SF Symbol.
+    /// Returns the configured menu bar/floating indicator icon. The Muesli mark
+    /// is drawn as a resolution-independent template so its narrow waveform
+    /// gaps stay crisp at menu-bar scale.
     static func make(choice: String = "muesli") -> NSImage? {
         if choice == "muesli" {
-            if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
-               let image = NSImage(contentsOf: url) {
-                image.isTemplate = true
-                image.size = NSSize(width: 18, height: 18)
-                return image
-            }
+            return makeMuesliMark()
         }
         let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
         let image = NSImage(systemSymbolName: choice, accessibilityDescription: "Muesli")?
@@ -34,4 +38,196 @@ enum MenuBarIconRenderer {
         image?.isTemplate = true
         return image
     }
+
+    static func hotkeyCueLabel(for hotkey: HotkeyConfig) -> String {
+        if hotkey.isCombination {
+            return hotkey.label
+        }
+        switch hotkey.keyCode {
+        case 55: return "L⌘"
+        case 54: return "R⌘"
+        case 63: return "fn"
+        case 59: return "L⌃"
+        case 62: return "R⌃"
+        case 58: return "L⌥"
+        case 61: return "R⌥"
+        case 56: return "L⇧"
+        case 60: return "R⇧"
+        default: return hotkey.displayLabel
+        }
+    }
+
+    static func statusTitle(
+        hotkey: HotkeyConfig,
+        showsHotkey: Bool = true,
+        detail: String? = nil
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        if showsHotkey {
+            result.append(NSAttributedString(
+                string: "\u{2009}\(hotkeyCueLabel(for: hotkey))",
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: 9, weight: .medium),
+                    .baselineOffset: 1,
+                ]
+            ))
+        }
+        if let detail, !detail.isEmpty {
+            if result.length > 0 {
+                result.append(NSAttributedString(string: "  "))
+            }
+            result.append(NSAttributedString(
+                string: detail,
+                attributes: [.font: NSFont.menuBarFont(ofSize: 0)]
+            ))
+        }
+        return result
+    }
+
+    private static func makeMuesliMark() -> NSImage {
+        guard let canonicalMarkMask else {
+            return makeBundledMarkFallback()
+        }
+
+        let sourceSize = NSSize(
+            width: canonicalMarkMask.width,
+            height: canonicalMarkMask.height
+        )
+        let sourceImage = NSImage(cgImage: canonicalMarkMask, size: sourceSize)
+        let image = NSImage(size: displaySize, flipped: false) { rect in
+            let markHeight: CGFloat = 14
+            let markWidth = markHeight * sourceSize.width / sourceSize.height
+            let markRect = NSRect(
+                x: rect.midX - markWidth / 2,
+                y: rect.midY - markHeight / 2,
+                width: markWidth,
+                height: markHeight
+            )
+            sourceImage.draw(
+                in: markRect,
+                from: NSRect(origin: .zero, size: sourceSize),
+                operation: .sourceOver,
+                fraction: 1,
+                respectFlipped: true,
+                hints: [.interpolation: NSImageInterpolation.high]
+            )
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    private static func loadCanonicalMarkMask() -> CGImage? {
+        guard let sourceURL = canonicalAppIconURL(),
+              let sourceImage = NSImage(contentsOf: sourceURL),
+              let sourceCGImage = sourceImage.cgImage(
+                forProposedRect: nil,
+                context: nil,
+                hints: nil
+              ),
+              let croppedImage = sourceCGImage.cropping(to: canonicalMarkSourceRect) else {
+            return nil
+        }
+
+        let width = croppedImage.width
+        let height = croppedImage.height
+        let bytesPerRow = width * 4
+        let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue |
+            CGImageAlphaInfo.premultipliedLast.rawValue
+
+        guard let inputContext = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo
+        ), let inputData = inputContext.data else {
+            return nil
+        }
+
+        inputContext.interpolationQuality = .none
+        inputContext.draw(croppedImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let inputPixels = inputData.assumingMemoryBound(to: UInt8.self)
+        let pixelCount = width * height
+        var backgroundBlue = 255
+        var foregroundBlue = 0
+        for pixel in 0..<pixelCount {
+            let blue = Int(inputPixels[pixel * 4 + 2])
+            backgroundBlue = min(backgroundBlue, blue)
+            foregroundBlue = max(foregroundBlue, blue)
+        }
+        guard foregroundBlue > backgroundBlue else { return nil }
+
+        guard let outputContext = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo
+        ), let outputData = outputContext.data else {
+            return nil
+        }
+
+        let outputPixels = outputData.assumingMemoryBound(to: UInt8.self)
+        let blueRange = foregroundBlue - backgroundBlue
+        for pixel in 0..<pixelCount {
+            let offset = pixel * 4
+            let sourceBlue = Int(inputPixels[offset + 2])
+            let sourceAlpha = max(0, min(255, (sourceBlue - backgroundBlue) * 255 / blueRange))
+            let alpha = min(255, Int((CGFloat(sourceAlpha) * canonicalMarkOpacityBoost).rounded()))
+            outputPixels[offset] = 0
+            outputPixels[offset + 1] = 0
+            outputPixels[offset + 2] = 0
+            outputPixels[offset + 3] = UInt8(alpha)
+        }
+
+        return outputContext.makeImage()
+    }
+
+    private static func canonicalAppIconURL() -> URL? {
+        if let bundled = Bundle.main.url(forResource: "muesli_app_icon", withExtension: "png") {
+            return bundled
+        }
+
+        let fileManager = FileManager.default
+        let startingPoints = [
+            URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true),
+            URL(fileURLWithPath: #filePath).deletingLastPathComponent(),
+        ]
+        for startingPoint in startingPoints {
+            var directory = startingPoint
+            for _ in 0..<8 {
+                let candidate = directory.appendingPathComponent("assets/muesli_app_icon.png")
+                if fileManager.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
+                directory.deleteLastPathComponent()
+            }
+        }
+        return nil
+    }
+
+    private static func makeBundledMarkFallback() -> NSImage {
+        if let url = Bundle.main.url(forResource: "menu_m_template", withExtension: "png"),
+           let image = NSImage(contentsOf: url) {
+            image.size = displaySize
+            image.isTemplate = true
+            return image
+        }
+
+        let image = NSImage(
+            systemSymbolName: "waveform",
+            accessibilityDescription: "Muesli"
+        ) ?? NSImage(size: displaySize)
+        image.size = displaySize
+        image.isTemplate = true
+        return image
+    }
+
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -1103,6 +1103,7 @@ struct AppConfig: Codable {
     var launchAtLogin: Bool = false
     var openDashboardOnLaunch: Bool = true
     var showFloatingIndicator: Bool = true
+    var showHotkeyOnFloatingIndicator: Bool = false
     var indicatorAnchor: IndicatorAnchor = .midTrailing
     var dashboardWindowFrame: WindowFrame? = nil
     var indicatorOrigin: CGPointCodable? = nil
@@ -1139,6 +1140,7 @@ struct AppConfig: Codable {
     var muteSystemAudioDuringDictation: Bool = false
     var recordingColorHex: String = "1e1e2e"   // Catppuccin Mocha base, without #
     var menuBarIcon: String = "muesli"
+    var showHotkeyInMenuBar: Bool = true
     var showNextMeetingInMenuBar: Bool = true
     var maraudersMapUnlocked: Bool = false
     var maraudersMapAudioClip: String = "bbc_world_news"
@@ -1224,6 +1226,7 @@ struct AppConfig: Codable {
         case launchAtLogin = "launch_at_login"
         case openDashboardOnLaunch = "open_dashboard_on_launch"
         case showFloatingIndicator = "show_floating_indicator"
+        case showHotkeyOnFloatingIndicator = "show_hotkey_on_floating_indicator"
         case indicatorAnchor = "indicator_anchor"
         case dashboardWindowFrame = "dashboard_window_frame"
         case indicatorOrigin = "indicator_origin"
@@ -1258,6 +1261,7 @@ struct AppConfig: Codable {
         case muteSystemAudioDuringDictation = "mute_system_audio_during_dictation"
         case recordingColorHex = "recording_color_hex"
         case menuBarIcon = "menu_bar_icon"
+        case showHotkeyInMenuBar = "show_hotkey_in_menu_bar"
         case showNextMeetingInMenuBar = "show_next_meeting_in_menu_bar"
         case maraudersMapUnlocked = "marauders_map_unlocked"
         case maraudersMapAudioClip = "marauders_map_audio_clip"
@@ -1377,6 +1381,9 @@ struct AppConfig: Codable {
         launchAtLogin = (try? c.decode(Bool.self, forKey: .launchAtLogin)) ?? defaults.launchAtLogin
         openDashboardOnLaunch = (try? c.decode(Bool.self, forKey: .openDashboardOnLaunch)) ?? defaults.openDashboardOnLaunch
         showFloatingIndicator = (try? c.decode(Bool.self, forKey: .showFloatingIndicator)) ?? defaults.showFloatingIndicator
+        showHotkeyOnFloatingIndicator =
+            (try? c.decode(Bool.self, forKey: .showHotkeyOnFloatingIndicator))
+            ?? defaults.showHotkeyOnFloatingIndicator
         indicatorAnchor = (try? c.decode(IndicatorAnchor.self, forKey: .indicatorAnchor))
             ?? ((try? c.decodeIfPresent(CGPointCodable.self, forKey: .indicatorOrigin)) != nil ? .custom : .midTrailing)
         dashboardWindowFrame = try? c.decode(WindowFrame.self, forKey: .dashboardWindowFrame)
@@ -1429,6 +1436,9 @@ struct AppConfig: Codable {
         muteSystemAudioDuringDictation = (try? c.decode(Bool.self, forKey: .muteSystemAudioDuringDictation)) ?? defaults.muteSystemAudioDuringDictation
         recordingColorHex = (try? c.decode(String.self, forKey: .recordingColorHex)) ?? defaults.recordingColorHex
         menuBarIcon = (try? c.decode(String.self, forKey: .menuBarIcon)) ?? defaults.menuBarIcon
+        showHotkeyInMenuBar =
+            (try? c.decode(Bool.self, forKey: .showHotkeyInMenuBar))
+            ?? defaults.showHotkeyInMenuBar
         showNextMeetingInMenuBar = (try? c.decode(Bool.self, forKey: .showNextMeetingInMenuBar)) ?? defaults.showNextMeetingInMenuBar
         maraudersMapUnlocked = (try? c.decode(Bool.self, forKey: .maraudersMapUnlocked)) ?? defaults.maraudersMapUnlocked
         maraudersMapAudioClip = (try? c.decode(String.self, forKey: .maraudersMapAudioClip)) ?? defaults.maraudersMapAudioClip

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1516,6 +1516,13 @@ struct SettingsView: View {
                     }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Show hotkey on floating indicator") {
+                    settingsSwitch(isOn: appState.config.showHotkeyOnFloatingIndicator) { newValue in
+                        controller.updateConfig { $0.showHotkeyOnFloatingIndicator = newValue }
+                    }
+                    .disabled(!appState.config.showFloatingIndicator)
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Indicator position") {
                     let isCustom = appState.config.indicatorAnchor == .custom
                     let selection = isCustom ? customIndicatorPositionLabel : appState.config.indicatorAnchor.label
@@ -1542,6 +1549,12 @@ struct SettingsView: View {
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Menu bar icon") {
                     menuBarIconPicker
+                }
+                Divider().background(MuesliTheme.surfaceBorder)
+                settingsRow("Show hotkey in menu bar") {
+                    settingsSwitch(isOn: appState.config.showHotkeyInMenuBar) { newValue in
+                        controller.updateConfig { $0.showHotkeyInMenuBar = newValue }
+                    }
                 }
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Accent color") {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatusBarController.swift
@@ -46,11 +46,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     func setCountdownOverride(_ text: String?) {
         countdownOverride = text
-        if let text {
-            statusItem.button?.title = text
-        } else {
-            updateMenuBarTitle()
-        }
+        updateMenuBarTitle()
     }
 
     func refreshIcon() {
@@ -59,36 +55,37 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func updateMenuBarTitle() {
+        let detail: String?
         if let countdownOverride {
-            statusItem.button?.title = countdownOverride
-            return
-        }
-        guard controller.config.showNextMeetingInMenuBar else {
-            statusItem.button?.title = ""
-            return
-        }
+            detail = countdownOverride
+        } else if controller.config.showNextMeetingInMenuBar {
+            let now = Date()
+            let hidden = controller.appState.hiddenCalendarEventIDs
+            let endOfToday = Calendar.current.date(byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: now)) ?? now
+            let nextEvent = controller.appState.upcomingCalendarEvents
+                .filter { !$0.isAllDay && $0.startDate > now && $0.startDate < endOfToday && !hidden.contains($0.id) }
+                .sorted { $0.startDate < $1.startDate }
+                .first
 
-        let now = Date()
-        let hidden = controller.appState.hiddenCalendarEventIDs
-        let endOfToday = Calendar.current.date(byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: now)) ?? now
-        let nextEvent = controller.appState.upcomingCalendarEvents
-            .filter { !$0.isAllDay && $0.startDate > now && $0.startDate < endOfToday && !hidden.contains($0.id) }
-            .sorted { $0.startDate < $1.startDate }
-            .first
-
-        if let event = nextEvent {
-            let minutesUntil = Int(ceil(event.startDate.timeIntervalSince(now) / 60))
-            let truncatedTitle = event.title.count > 20
-                ? String(event.title.prefix(18)) + "…"
-                : event.title
-            if minutesUntil <= 60 {
-                statusItem.button?.title = " \(truncatedTitle) · \(formatTimeUntil(minutesUntil))"
+            if let event = nextEvent {
+                let minutesUntil = Int(ceil(event.startDate.timeIntervalSince(now) / 60))
+                let truncatedTitle = event.title.count > 20
+                    ? String(event.title.prefix(18)) + "…"
+                    : event.title
+                detail = minutesUntil <= 60
+                    ? "\(truncatedTitle) · \(formatTimeUntil(minutesUntil))"
+                    : truncatedTitle
             } else {
-                statusItem.button?.title = " \(truncatedTitle)"
+                detail = nil
             }
         } else {
-            statusItem.button?.title = ""
+            detail = nil
         }
+        statusItem.button?.attributedTitle = MenuBarIconRenderer.statusTitle(
+            hotkey: controller.config.dictationHotkey,
+            showsHotkey: controller.config.showHotkeyInMenuBar,
+            detail: detail
+        )
     }
 
     private func build() {

--- a/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppearanceEffectsTests.swift
@@ -49,4 +49,57 @@ struct MenuBarIconRendererTests {
         #expect((image?.size.width ?? 0) > 0)
         #expect((image?.size.height ?? 0) > 0)
     }
+
+    @Test("official mark is a resolution-independent template")
+    func officialMarkIsResolutionIndependent() {
+        let image = MenuBarIconRenderer.make(choice: "muesli")
+        #expect(image?.isTemplate == true)
+        #expect(image?.size == NSSize(width: 18, height: 18))
+        #expect(image?.representations.contains { $0 is NSCustomImageRep } == true)
+    }
+
+    @Test("official mark uses the canonical app artwork at source resolution")
+    func officialMarkUsesCanonicalArtwork() {
+        let sourceRect = MenuBarIconRenderer.canonicalMarkSourceRect
+        let mask = MenuBarIconRenderer.canonicalMarkMask
+
+        #expect(sourceRect == CGRect(x: 195, y: 256, width: 635, height: 513))
+        #expect(MenuBarIconRenderer.canonicalMarkOpacityBoost == 1.08)
+        #expect(mask?.width == 635)
+        #expect(mask?.height == 513)
+    }
+
+    @Test("hotkey cues preserve modifier side and combinations")
+    func hotkeyCueLabels() {
+        #expect(MenuBarIconRenderer.hotkeyCueLabel(for: HotkeyConfig(keyCode: 61, label: "Right Option")) == "R⌥")
+        #expect(MenuBarIconRenderer.hotkeyCueLabel(for: HotkeyConfig(keyCode: 59, label: "Left Ctrl")) == "L⌃")
+        #expect(MenuBarIconRenderer.hotkeyCueLabel(for: .meetingRecordingDefault) == "⌘⇧R")
+    }
+
+    @Test("status shortcut cue is compact while detail keeps menu bar size")
+    func statusShortcutCueTypography() {
+        let title = MenuBarIconRenderer.statusTitle(hotkey: .default, detail: "Meeting in 5m")
+        let cueFont = title.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        let detailIndex = (title.string as NSString).range(of: "Meeting").location
+        let detailFont = title.attribute(.font, at: detailIndex, effectiveRange: nil) as? NSFont
+
+        #expect(cueFont?.pointSize == 9)
+        #expect((detailFont?.pointSize ?? 0) > (cueFont?.pointSize ?? 0))
+    }
+
+    @Test("status shortcut cue can be hidden independently of meeting detail")
+    func statusShortcutCueCanBeHidden() {
+        let withoutHotkey = MenuBarIconRenderer.statusTitle(
+            hotkey: .default,
+            showsHotkey: false,
+            detail: "Meeting in 5m"
+        )
+        let withoutEither = MenuBarIconRenderer.statusTitle(
+            hotkey: .default,
+            showsHotkey: false
+        )
+
+        #expect(withoutHotkey.string == "Meeting in 5m")
+        #expect(withoutEither.string.isEmpty)
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -292,8 +292,31 @@ struct IndicatorFrameSizeTests {
     func expandedIdleDragSavesCollapsedCenter() {
         let expanded = NSRect(x: 515, y: 240, width: 220, height: 36)
         #expect(
-            FloatingIndicatorController.idlePositionCenter(for: expanded) ==
+            FloatingIndicatorController.positionCenter(
+                for: expanded,
+                preservesCollapsedLeftEdge: true
+            ) ==
             CGPoint(x: 537, y: 258)
+        )
+    }
+
+    @Test("centered loading and warning drags save their true midpoint")
+    @MainActor
+    func centeredTransientIdleDragsSaveMidpoint() {
+        let loading = NSRect(x: 515, y: 240, width: 180, height: 36)
+        let warning = NSRect(x: 280, y: 180, width: 312, height: 36)
+
+        #expect(
+            FloatingIndicatorController.positionCenter(
+                for: loading,
+                preservesCollapsedLeftEdge: false
+            ) == CGPoint(x: 605, y: 258)
+        )
+        #expect(
+            FloatingIndicatorController.positionCenter(
+                for: warning,
+                preservesCollapsedLeftEdge: false
+            ) == CGPoint(x: 436, y: 198)
         )
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -80,6 +80,37 @@ struct FloatingIndicatorVisibilityTests {
         #expect(config.showFloatingIndicator == false)
     }
 
+    @Test("floating hotkey defaults off while menu bar hotkey defaults on")
+    func hotkeyVisibilityRoundTrip() throws {
+        var config = AppConfig()
+        #expect(!config.showHotkeyOnFloatingIndicator)
+        #expect(config.showHotkeyInMenuBar)
+
+        config.showHotkeyOnFloatingIndicator = true
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.showHotkeyOnFloatingIndicator)
+        #expect(decoded.showHotkeyInMenuBar)
+    }
+
+    @Test("missing hotkey visibility preferences use fresh-install defaults")
+    func hotkeyVisibilityMissingKeysUseDefaults() throws {
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data("{}".utf8))
+
+        #expect(!config.showHotkeyOnFloatingIndicator)
+        #expect(config.showHotkeyInMenuBar)
+    }
+
+    @Test("hotkey visibility controls decode from snake_case JSON")
+    func hotkeyVisibilitySnakeCaseDecode() throws {
+        let json = #"{"show_hotkey_on_floating_indicator": false, "show_hotkey_in_menu_bar": false}"#
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(!config.showHotkeyOnFloatingIndicator)
+        #expect(!config.showHotkeyInMenuBar)
+    }
+
     @Test("meeting transcript hover defaults on and persists")
     func meetingTranscriptHoverRoundTrip() throws {
         var config = AppConfig()
@@ -188,6 +219,55 @@ struct IndicatorFrameSizeTests {
         #expect(
             FloatingIndicatorController.anchorCenter(.bottomCenter, in: visibleFrame, size: size) ==
             CGPoint(x: 700, y: 72)
+        )
+    }
+
+    @Test("custom idle hover keeps the collapsed pill's left edge")
+    @MainActor
+    func customIdleHoverKeepsLeftEdge() {
+        let visibleFrame = NSRect(x: 100, y: 50, width: 1200, height: 800)
+        let positionCenter = CGPoint(x: 422, y: 450)
+        let collapsed = FloatingIndicatorController.customIdleFrame(
+            positionCenter: positionCenter,
+            size: NSSize(width: 44, height: 28),
+            in: visibleFrame
+        )
+        let expanded = FloatingIndicatorController.customIdleFrame(
+            positionCenter: positionCenter,
+            size: NSSize(width: 220, height: 36),
+            in: visibleFrame
+        )
+
+        #expect(collapsed.minX == 400)
+        #expect(expanded.minX == collapsed.minX)
+        #expect(expanded.midY == collapsed.midY)
+    }
+
+    @Test("idle hover width leaves room for the complete hotkey instruction")
+    @MainActor
+    func idleHoverWidthFitsInstruction() {
+        let standard = FloatingIndicatorController.idleHoverPillSize(
+            hotkeyLabel: "Left Option",
+            screenWidth: 1200
+        )
+        let combination = FloatingIndicatorController.idleHoverPillSize(
+            hotkeyLabel: "Control Option Shift R",
+            screenWidth: 1200
+        )
+
+        #expect(standard.width >= 220)
+        #expect(combination.width > standard.width)
+        #expect(combination.width <= 1168)
+        #expect(standard.height == 36)
+    }
+
+    @Test("expanded idle drag saves the equivalent collapsed center")
+    @MainActor
+    func expandedIdleDragSavesCollapsedCenter() {
+        let expanded = NSRect(x: 515, y: 240, width: 220, height: 36)
+        #expect(
+            FloatingIndicatorController.idlePositionCenter(for: expanded) ==
+            CGPoint(x: 537, y: 258)
         )
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/QoLTests.swift
@@ -87,11 +87,12 @@ struct FloatingIndicatorVisibilityTests {
         #expect(config.showHotkeyInMenuBar)
 
         config.showHotkeyOnFloatingIndicator = true
+        config.showHotkeyInMenuBar = false
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
 
         #expect(decoded.showHotkeyOnFloatingIndicator)
-        #expect(decoded.showHotkeyInMenuBar)
+        #expect(!decoded.showHotkeyInMenuBar)
     }
 
     @Test("missing hotkey visibility preferences use fresh-install defaults")
@@ -241,6 +242,31 @@ struct IndicatorFrameSizeTests {
         #expect(collapsed.minX == 400)
         #expect(expanded.minX == collapsed.minX)
         #expect(expanded.midY == collapsed.midY)
+    }
+
+    @Test("custom indicator uses the display containing its saved position")
+    @MainActor
+    func customIndicatorUsesSecondaryDisplay() {
+        let primary = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let secondary = NSRect(x: -1920, y: -180, width: 1920, height: 1080)
+        let savedPosition = CGPoint(x: -960, y: 360)
+
+        let selectedFrame = FloatingIndicatorController.visibleFrameForCustomIndicator(
+            customPositionCenter: nil,
+            indicatorFrame: nil,
+            savedPositionCenter: savedPosition,
+            availableVisibleFrames: [primary, secondary],
+            fallback: primary
+        )
+        let expanded = FloatingIndicatorController.customIdleFrame(
+            positionCenter: savedPosition,
+            size: NSSize(width: 220, height: 36),
+            in: selectedFrame
+        )
+
+        #expect(selectedFrame == secondary)
+        #expect(secondary.contains(expanded))
+        #expect(expanded.minX == savedPosition.x - 22)
     }
 
     @Test("idle hover width leaves room for the complete hotkey instruction")


### PR DESCRIPTION
## Summary

- Fix the floating indicator so it remains draggable while hover-expanded and collapses back to its original anchored position.
- Render the official Muesli waveform from the canonical app artwork at high resolution across the menu bar, floating indicator, sidebar, and Appearance picker.
- Add independent Appearance controls for showing the dictation shortcut in the menu bar and floating indicator.
- Size the expanded instruction from its actual text so prompts such as “Hold Left Option to dictate” do not truncate prematurely.

## Root cause

The idle indicator collapsed on mouse-down before AppKit could begin dragging it, while hover expansion and collapse resized the panel around its expanded midpoint. The menu and floating marks also depended on lower-resolution template artwork rather than the canonical app icon.

## User impact

The floating indicator can now be dragged directly in either compact or hover-expanded form and returns to the position the user chose. The official waveform stays sharp at menu-bar scale. Shortcut cues can be controlled independently; fresh installs show the menu-bar cue and keep the floating-indicator cue off, while existing saved preferences remain intact.

## Validation

- Full native suite: 1,592 tests in 152 suites passed.
- `./scripts/test_classify_changed_files.sh`
- `./scripts/test_ci_test_shards.sh`
- `./scripts/verify_update_flow.sh --skip-dmg`
- Rebuilt and visually verified in `/Applications/MuesliDevC.app`.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None.

### AI assistance

Codex assisted with implementation, review, and test execution. The resulting changes were reviewed and validated locally.

Closes #397

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789150448&installation_model_id=422865&pr_number=402&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F402&signature=d71412ed3a092f86fecb9dd36752631de8ed8851717b00443df026b18fe94905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls to show or hide hotkey cues on the floating indicator and menu bar.
  * Improved menu bar status text with clearer hotkey and meeting details.
  * Added compact-mode hotkey cues and refreshed idle indicator visuals.
  * Enhanced the Muesli waveform icon for menu bar display.

* **Bug Fixes**
  * Improved floating-indicator behavior while dragging and hovering.
  * Preserved custom indicator positions during expansion and collapse.
  * Improved sizing, alignment, opacity, screen selection, and position saving for idle indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->