### PR TITLE
Rebase #134: allow dictation while meeting transcription finishes

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4644,6 +4644,10 @@ final class MuesliController: NSObject {
         activeMeetingSession?.isRecording == true || isStoppingMeetingRecording
     }
 
+    private var isMeetingCapturingAudio: Bool {
+        activeMeetingSession?.isRecording == true || isStartingMeetingRecording
+    }
+
     func isMeetingRecordingPaused() -> Bool {
         activeMeetingSession?.isPaused == true
     }
@@ -6007,8 +6011,7 @@ final class MuesliController: NSObject {
             syncAppState()
         }
         indicator.setMeetingRecording(false, config: config)
-        indicator.setTranscribingTitle("Transcribing", config: config)
-        setState(.transcribing)
+        setMeetingProcessingStatus("Transcribing")
         let processingGeneration = backgroundMeetingProcessingCount + 1
         sessionToStop.onProgress = { [weak self] stage in
             Task { @MainActor [weak self] in
@@ -6100,7 +6103,9 @@ final class MuesliController: NSObject {
                     self.pendingResumePriorTranscript[liveMeetingID] = nil
                 }
                 if !self.isMeetingRecording() && !self.isStartingMeetingRecording && self.backgroundMeetingProcessingCount == 0 {
-                    self.setState(.idle)
+                    if !self.isDictationActivityInProgress {
+                        self.setState(.idle)
+                    }
                     self.statusBarController?.refresh()
                 }
                 self.endMeetingActivity()
@@ -7254,7 +7259,7 @@ final class MuesliController: NSObject {
     }
 
     private var canPrepareComputerUseCommand: Bool {
-        !isMeetingRecording()
+        !isMeetingCapturingAudio
             && !isDictationTestMode
             && dictationStartedAt == nil
             && computerUseCommandStartedAt == nil
@@ -7266,7 +7271,7 @@ final class MuesliController: NSObject {
     }
 
     private var canStartComputerUseCommand: Bool {
-        !isMeetingRecording()
+        !isMeetingCapturingAudio
             && !isDictationTestMode
             && dictationStartedAt == nil
             && computerUseCommandStartedAt == nil
@@ -7566,7 +7571,7 @@ final class MuesliController: NSObject {
     private func handlePrepare() {
         if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
         fputs("[muesli-native] prepare\n", stderr)
         if dictationLatencyTraceID == nil {
@@ -7587,7 +7592,7 @@ final class MuesliController: NSObject {
     private func handleArm() {
         if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
         if dictationLatencyTraceID == nil {
             beginDictationLatencyTrace(reason: "hotkey")
@@ -7623,7 +7628,7 @@ final class MuesliController: NSObject {
             && AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
             && dictationState == .idle
             && computerUseCommandStartedAt == nil
-            && !isMeetingRecording()
+            && !isMeetingCapturingAudio
             && !isStartingMeetingRecording
             && !isStoppingMeetingRecording
     }
@@ -7933,7 +7938,7 @@ final class MuesliController: NSObject {
     private func handleStart() {
         if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
 
         // Nemotron backends support hold-to-talk (record → transcribe on release) in
@@ -8078,7 +8083,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleCancel() {
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         if shouldIgnoreDictationCleanupForComputerUseActivity() { return }
         fputs("[muesli-native] cancel\n", stderr)
         resetDictationOutputMode()
@@ -8109,7 +8114,7 @@ final class MuesliController: NSObject {
     private func handleToggleStart(outputMode: DictationOutputMode? = nil) {
         if shouldRejectDictationForComputerUseActivity() { return }
         guard ensureDictationBackendReady() else { return }
-        if isMeetingRecording() { return }
+        if isMeetingCapturingAudio { return }
         if blockDictationForMeetingActivityIfNeeded() { return }
         fputs("[muesli-native] toggle dictation start\n", stderr)
         if dictationLatencyTraceID == nil {
@@ -8169,7 +8174,7 @@ final class MuesliController: NSObject {
     }
 
     private func handleStop() {
-        if isMeetingRecording() {
+        if isMeetingCapturingAudio {
             cancelDictationAudioSessionForMeetingRecordingIfNeeded()
             return
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -4645,7 +4645,7 @@ final class MuesliController: NSObject {
     }
 
     private var isMeetingCapturingAudio: Bool {
-        activeMeetingSession?.isRecording == true || isStartingMeetingRecording
+        activeMeetingSession?.isRecording == true
     }
 
     func isMeetingRecordingPaused() -> Bool {
@@ -6109,10 +6109,7 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                 }
                 self.endMeetingActivity()
-                if self.isDictationActivityInProgress {
-                    self.meetingMonitor.suppressWhileActive()
-                    self.meetingMonitor.refreshState()
-                }
+                self.resumeMeetingMonitorAfterForegroundCapture()
                 self.historyWindowController?.reload()
                 self.syncAppState()
                 self.clearLiveMeetingTranscript(ownerID: liveMeetingID)
@@ -7068,6 +7065,18 @@ final class MuesliController: NSObject {
         indicator.setState(.transcribing, config: config)
     }
 
+    private func resumeMeetingMonitorAfterForegroundCapture() {
+        if isMeetingRecording()
+            || isStartingMeetingRecording
+            || isDictationActivityInProgress
+            || backgroundMeetingProcessingCount > 0 {
+            meetingMonitor.suppressWhileActive()
+        } else {
+            meetingMonitor.resumeAfterCooldown()
+        }
+        meetingMonitor.refreshState()
+    }
+
     private func handleComputerUsePrepare() {
         guard canPrepareComputerUseCommand else { return }
         fputs("[cua] prepare\n", stderr)
@@ -7821,8 +7830,7 @@ final class MuesliController: NSObject {
             pendingReleaseSoundSessionID = nil
             clearCapturedDictationSessionContext()
             setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
-            meetingMonitor.refreshState()
+            resumeMeetingMonitorAfterForegroundCapture()
             finishDictationLatencyTrace("audio_session_failed")
         case .latency(let event, let date):
             markDictationLatency(event, at: date)
@@ -8054,8 +8062,7 @@ final class MuesliController: NSObject {
         indicator.setToggleDictation(false, config: config)
         resetDictationOutputMode()
         setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
-        meetingMonitor.refreshState()
+        resumeMeetingMonitorAfterForegroundCapture()
         finishDictationLatencyTrace("nemotron_start_failed")
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
@@ -8082,8 +8089,7 @@ final class MuesliController: NSObject {
         indicator.setToggleDictation(false, config: config)
         resetDictationOutputMode()
         setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
-        meetingMonitor.refreshState()
+        resumeMeetingMonitorAfterForegroundCapture()
         finishDictationLatencyTrace("nemotron_runtime_failed")
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
@@ -8111,8 +8117,7 @@ final class MuesliController: NSObject {
         pendingDictationStopStartedAt = nil
         pendingReleaseSoundSessionID = nil
         setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
-        meetingMonitor.refreshState()
+        resumeMeetingMonitorAfterForegroundCapture()
         finishDictationLatencyTrace("cancelled")
         syncDictationRecorderWarmup(intent: .postDictation(.cancel))
     }
@@ -8302,7 +8307,7 @@ final class MuesliController: NSObject {
         clearCapturedDictationSessionContext()
         resetDictationOutputMode()
         setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
+        resumeMeetingMonitorAfterForegroundCapture()
         fputs("[muesli-native] Nemotron streaming done (\(String(format: "%.1f", duration))s)\n", stderr)
         finishDictationLatencyTrace("nemotron_stop")
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
@@ -8315,7 +8320,7 @@ final class MuesliController: NSObject {
             clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
+            resumeMeetingMonitorAfterForegroundCapture()
             finishDictationLatencyTrace("stop_without_wav")
             syncDictationRecorderWarmup(intent: .postDictation(.stopWithoutWav))
             return
@@ -8330,7 +8335,7 @@ final class MuesliController: NSObject {
             clearCapturedDictationSessionContext()
             resetDictationOutputMode()
             setState(.idle)
-            meetingMonitor.resumeAfterCooldown()
+            resumeMeetingMonitorAfterForegroundCapture()
             finishDictationLatencyTrace("short_recording")
             syncDictationRecorderWarmup(intent: .postDictation(.shortRecording))
             return
@@ -8382,7 +8387,7 @@ final class MuesliController: NSObject {
                         self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
-                        self.meetingMonitor.resumeAfterCooldown()
+                        self.resumeMeetingMonitorAfterForegroundCapture()
                         self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
                     }
                     return
@@ -8396,7 +8401,7 @@ final class MuesliController: NSObject {
                         self.clearCapturedDictationSessionContext()
                         self.resetDictationOutputMode()
                         self.setState(.idle)
-                        self.meetingMonitor.resumeAfterCooldown()
+                        self.resumeMeetingMonitorAfterForegroundCapture()
                         self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
                     }
                     return
@@ -8432,7 +8437,7 @@ final class MuesliController: NSObject {
                     }
                     self.resetDictationOutputMode()
                     self.setState(.idle)
-                    self.meetingMonitor.resumeAfterCooldown()
+                    self.resumeMeetingMonitorAfterForegroundCapture()
                     self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
                     TelemetryDeck.signal("dictation.completed", parameters: [
                         "backend": self.selectedBackend.backend,
@@ -8445,7 +8450,7 @@ final class MuesliController: NSObject {
                     self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
                     self.setState(.idle)
-                    self.meetingMonitor.resumeAfterCooldown()
+                    self.resumeMeetingMonitorAfterForegroundCapture()
                     self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionCancelled))
                 }
             } catch {
@@ -8464,7 +8469,7 @@ final class MuesliController: NSObject {
                     self.clearCapturedDictationSessionContext()
                     self.resetDictationOutputMode()
                     self.setState(.idle)
-                    self.meetingMonitor.resumeAfterCooldown()
+                    self.resumeMeetingMonitorAfterForegroundCapture()
                     self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionFailed))
                 }
             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -6109,6 +6109,10 @@ final class MuesliController: NSObject {
                     self.statusBarController?.refresh()
                 }
                 self.endMeetingActivity()
+                if self.isDictationActivityInProgress {
+                    self.meetingMonitor.suppressWhileActive()
+                    self.meetingMonitor.refreshState()
+                }
                 self.historyWindowController?.reload()
                 self.syncAppState()
                 self.clearLiveMeetingTranscript(ownerID: liveMeetingID)
@@ -7059,7 +7063,9 @@ final class MuesliController: NSObject {
     private func setMeetingProcessingStatus(_ status: String) {
         statusBarController?.setStatus(status)
         statusBarController?.refresh()
+        guard !isDictationActivityInProgress else { return }
         indicator.setTranscribingTitle(status, config: config)
+        indicator.setState(.transcribing, config: config)
     }
 
     private func handleComputerUsePrepare() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebase of https://github.com/Muesli-HQ/muesli/pull/134 onto current `main`, with conflicts resolved. This does **not** merge #134; it only keeps the change up to date for review.

Original #134 is a fork PR (`rogersterling/muesli`), so its branch could not be force-pushed from this repo. Use this branch for merge-worthiness review instead of merging the conflicted fork PR.

The original intent is preserved on top of today's meeting lifecycle:

- Treat **live meeting audio capture** separately from **background transcription / post-processing** after stop.
- Keep blocking dictation and computer-use while a meeting is actually capturing audio.
- Do **not** put the shared dictation state into `.transcribing` when a stopped meeting is processing in the background, so dictation can run during that window.
- Isolate the meeting processing indicator so it does not steal the floating indicator during dictation.
- When dictation/computer-use ends, resume meeting detection only if no meeting start, live recording, dictation activity, or background meeting processing is still in progress.

Conflict resolution notes:

- Kept main's `DictationAudioSessionManager` paths; the original PR still targeted the old `recorder.prepare()` / `recorder.start()` API.
- Kept main's `blockDictationForMeetingActivityIfNeeded()`, backend-readiness, and computer-use rejection checks.
- Kept main's `cancelDictationAudioSessionForMeetingRecordingIfNeeded()` on stop, gated with `isMeetingCapturingAudio` instead of `isMeetingRecording()`.
- Mapped "meeting finalization" onto `backgroundMeetingProcessingCount`, since main now clears `isStoppingMeetingRecording` immediately when processing moves to the background.

## Validation

- Rebased the three #134 commits onto `origin/main` and resolved conflicts in `MuesliController.swift`.
- Linux CI scripts passed: `./scripts/test_classify_changed_files.sh`, `./scripts/test_ci_test_shards.sh`, `./scripts/verify_update_flow.sh --skip-dmg`.
- Native `swift test` / `MuesliDev` were **not** run (Linux cloud agent).

## Contribution certification

- [ ] Every non-merge commit in this pull request has a valid `Signed-off-by` trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under Muesli's [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

The three rebased commits keep the original authorship from #134 (`Roger Sterling`). They do not add new `Signed-off-by` trailers.

### Third-party materials

None.

### AI assistance

Cursor cloud agent rebased #134 onto current `main` and resolved merge conflicts in `MuesliController.swift`. No new feature design beyond adapting the original PR to main's current meeting/dictation APIs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68b010ea-3cf2-4538-98e2-279c1b28d382?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68b010ea-3cf2-4538-98e2-279c1b28d382&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789223258&installation_model_id=422865&pr_number=405&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F405&signature=be971cc8c25f09356e1c5c233920b3f9cc1b65e1658976c422f178a9afa33ca6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->