### PR TITLE
Recover meeting mic on confirmed health degradation; episode-level telemetry

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -15,6 +15,10 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
 
     private let directoryName: String
     private let queueLock = NSRecursiveLock()
+    /// Published independently of queueLock: invalidateForTeardown() must land
+    /// even while a worker is blocked inside AudioQueueStart holding queueLock,
+    /// so the post-start self-check observes it before start() returns.
+    private let teardownInvalidation = OSAllocatedUnfairLock(initialState: false)
     private let stateLock = OSAllocatedUnfairLock(initialState: FileState())
     private let processingQueue = DispatchQueue(label: "com.muesli.audio-queue-input-recorder-processing")
     private let failureCallbackQueue = DispatchQueue(label: "com.muesli.audio-queue-input-recorder-failures")
@@ -46,6 +50,9 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     func prepare() throws {
         queueLock.lock()
         defer { queueLock.unlock() }
+        guard !isPermanentlyInvalidated else {
+            throw Self.runtimeError(code: 9, message: "Recorder was invalidated by teardown")
+        }
 
         try prepareLocked()
     }
@@ -53,6 +60,9 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     func start() throws {
         queueLock.lock()
         defer { queueLock.unlock() }
+        guard !isPermanentlyInvalidated else {
+            throw Self.runtimeError(code: 9, message: "Recorder was invalidated by teardown")
+        }
 
         guard !isRunning else { return }
         try prepareLocked()
@@ -79,6 +89,17 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         emitLatency("audio_queue_start_begin")
         let status = AudioQueueStart(audioQueue, nil)
         emitLatency("audio_queue_start_end")
+        // AudioQueueStart can block while the daemon negotiates the route, and
+        // teardown may land during that window. If this instance was invalidated
+        // while the call was in flight, synchronously stop what just started
+        // before returning — capture must not outlive teardown.
+        if isPermanentlyInvalidated {
+            AudioQueueStop(audioQueue, true)
+            isRunning = false
+            captureGeneration &+= 1
+            cleanupAfterStartFailure()
+            throw Self.runtimeError(code: 9, message: "Recorder was invalidated by teardown")
+        }
         guard status == noErr else {
             isRunning = false
             captureGeneration &+= 1
@@ -162,6 +183,17 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
 
     func currentPower() -> Float {
         stateLock.withLock { $0.latestPowerDB }
+    }
+
+    /// Terminal and synchronous: after meeting teardown, this instance must
+    /// never start capture again, regardless of which queue a stale worker is
+    /// on. Distinct from cancel(), which disposes but permits re-prepare.
+    func invalidateForTeardown() {
+        teardownInvalidation.withLock { $0 = true }
+    }
+
+    private var isPermanentlyInvalidated: Bool {
+        teardownInvalidation.withLock { $0 }
     }
 
     func pause() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
@@ -121,8 +121,9 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
     }
 
     func invalidateForTeardown() {
-        lock.lock()
-        defer { lock.unlock() }
+        // Deliberately not under `lock`: start() holds `lock` across a
+        // potentially blocking child start(), and teardown invalidation must
+        // land during that window. `primary` and `fallback` are immutable.
         primary.invalidateForTeardown()
         fallback.invalidateForTeardown()
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FallbackStreamingDictationRecorder.swift
@@ -120,6 +120,13 @@ final class FallbackStreamingDictationRecorder: StreamingDictationRecording, Str
         wireCallbacks()
     }
 
+    func invalidateForTeardown() {
+        lock.lock()
+        defer { lock.unlock() }
+        primary.invalidateForTeardown()
+        fallback.invalidateForTeardown()
+    }
+
     func pause() {
         lock.lock()
         let recorder = activeRecorderLocked()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecording.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecording.swift
@@ -26,10 +26,23 @@ struct MeetingMicRecorderDiagnosticsSnapshot: Codable, Equatable {
     let route: MeetingMicRouteDiagnosticsSnapshot?
 }
 
+/// Result of a same-route recovery request. The distinction matters to the
+/// coordinator's accounting: a busy recorder is back-pressure (in-flight
+/// handoff already covers the episode), while an unavailable recorder cannot
+/// recover at all and the request must count toward the episode's attempt cap.
+enum MeetingMicRecoveryRequestResult: Equatable {
+    case initiated
+    case busy
+    case unavailable
+}
+
 protocol MeetingMicRecording: AnyObject {
     var preferredInputDeviceID: AudioObjectID? { get set }
     var onRawPCMSamples: (([Int16]) -> Void)? { get set }
     var onRecordingFailed: ((Error) -> Void)? { get set }
+    /// Fired when a route handoff settles: a candidate promoted to active, or
+    /// failed/timed out. Recorders without a handoff primitive never fire it.
+    var onHandoffOutcome: ((MeetingMicHandoffOutcome) -> Void)? { get set }
 
     func prepare() throws
     func start() throws
@@ -39,6 +52,25 @@ protocol MeetingMicRecording: AnyObject {
     func cancel()
     func currentPower() -> Float
     func diagnosticsSnapshot() -> MeetingMicRecorderDiagnosticsSnapshot
+
+    /// Permanently disqualify this instance from starting capture again —
+    /// synchronous, so teardown always wins against a stale queued handoff
+    /// worker. Default no-op for recorders without retained worker state.
+    func invalidateForTeardown()
+
+    /// Request a serialized same-route recovery: prepare a replacement capture
+    /// graph for the current input while the active graph keeps running, and
+    /// promote it only after it produces a non-empty buffer. Used when the
+    /// health tracker confirms a semantically dead graph (missing/zero
+    /// callbacks) that never raises an explicit CoreAudio error. Recorders
+    /// without a recovery primitive keep the default no-op (.unavailable).
+    @discardableResult
+    func requestSameRouteRecovery(reason: String) -> MeetingMicRecoveryRequestResult
+}
+
+extension MeetingMicRecording {
+    func invalidateForTeardown() {}
+    func requestSameRouteRecovery(reason: String) -> MeetingMicRecoveryRequestResult { .unavailable }
 }
 
 final class StreamingMeetingMicRecorderAdapter: MeetingMicRecording {
@@ -51,6 +83,8 @@ final class StreamingMeetingMicRecorderAdapter: MeetingMicRecording {
         get { recorder.onRecordingFailed }
         set { recorder.onRecordingFailed = newValue }
     }
+    /// No-op sink: this adapter has no handoff primitive, so it never fires.
+    var onHandoffOutcome: ((MeetingMicHandoffOutcome) -> Void)?
 
     private let recorder: StreamingDictationRecording
     private let kind: MeetingMicRecorderKind
@@ -90,6 +124,10 @@ final class StreamingMeetingMicRecorderAdapter: MeetingMicRecording {
 
     func cancel() {
         recorder.cancel()
+    }
+
+    func invalidateForTeardown() {
+        recorder.invalidateForTeardown()
     }
 
     func currentPower() -> Float {
@@ -155,6 +193,10 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         get { lock.withLock { $0.onRecordingFailedStorage } }
         set { lock.withLock { $0.onRecordingFailedStorage = newValue } }
     }
+    var onHandoffOutcome: ((MeetingMicHandoffOutcome) -> Void)? {
+        get { lock.withLock { $0.onHandoffOutcomeStorage } }
+        set { lock.withLock { $0.onHandoffOutcomeStorage = newValue } }
+    }
 
     private let systemDefaultRecorderFactory: RecorderFactory
     private let appScopedRecorderFactory: RecorderFactory
@@ -177,6 +219,7 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         var shouldRecoverOnResume = false
         var onRawPCMSamplesStorage: (([Int16]) -> Void)?
         var onRecordingFailedStorage: ((Error) -> Void)?
+        var onHandoffOutcomeStorage: ((MeetingMicHandoffOutcome) -> Void)?
     }
 
     private var preferredInputDeviceIDStorage: AudioObjectID? {
@@ -289,8 +332,19 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
                 state.shouldRecoverOnResume = false
                 return result
             }
+            // Poison every child synchronously, before any async cancellation:
+            // a handoff worker that slipped past the pending-candidate guard
+            // must find start() permanently rejected, never merely delayed.
+            invalidateChildrenForTeardown(children)
             return (children.0, children.1, takeUnusedSeedRecorders())
         }
+        resources.unused.forEach { $0.invalidateForTeardown() }
+        // The pending candidate is invalidated synchronously above; a worker
+        // mid-start self-stops via the post-start invalidation check before
+        // start() returns. Do NOT call its stop() synchronously here: that
+        // contends on the recorder's graph lock, which a blocked startup may
+        // hold, and would stall meeting teardown behind it (#322 class).
+        // Disposal stays on the async cleanup queue.
         cancelAsync(resources.pending)
         cancelAsync(resources.unused)
         let url = resources.active?.recorder.stop()
@@ -303,19 +357,32 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         let resources = lifecycleQueue.sync { () -> (Child?, Child?, [MeetingMicRecording]) in
             let children = lock.withLock { state -> (Child?, Child?) in
                 state.lifecycleState = .stopping
-                state.generation &+= 1
+                state.generation = state.generation &+ 1
                 let result = (state.active, state.pending)
                 state.active = nil
                 state.pending = nil
                 state.shouldRecoverOnResume = false
                 return result
             }
+            invalidateChildrenForTeardown(children)
             lock.withLock { $0.lifecycleState = .idle }
             return (children.0, children.1, takeUnusedSeedRecorders())
         }
-        cancelAsync(resources.0)
+        resources.2.forEach { $0.invalidateForTeardown() }
+        // Same contract as stop(): the pending candidate is already poisoned
+        // (never starts, or self-stops after a blocked start); only disposal
+        // is deferred to the cleanup queue.
         cancelAsync(resources.1)
+        cancelAsync(resources.0)
         cancelAsync(resources.2)
+    }
+
+    /// Synchronously poison active/pending children so no stale worker can
+    /// ever start them; the recording child is stopped first by the caller so
+    /// its WAV finalizes before invalidation.
+    private func invalidateChildrenForTeardown(_ children: (Child?, Child?)) {
+        children.0?.recorder.invalidateForTeardown()
+        children.1?.recorder.invalidateForTeardown()
     }
 
     func currentPower() -> Float {
@@ -337,6 +404,28 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
             )
         }
         return snapshot
+    }
+
+    /// Health-driven recovery entry point: the current graph is confirmed
+    /// degraded (missing/zero mic callbacks while system audio is active) but
+    /// never threw, so force a same-route candidate through the existing
+    /// serialized handoff. Reports .busy when a handoff is already pending
+    /// (back-pressure: the in-flight handoff covers this episode), and
+    /// .unavailable when the lifecycle is not in a recoverable state.
+    @discardableResult
+    func requestSameRouteRecovery(reason: String) -> MeetingMicRecoveryRequestResult {
+        fputs("[meeting-mic] health-triggered same-route recovery requested: \(reason)\n", stderr)
+        return lifecycleQueue.sync { [weak self] in
+            guard let self else { return .unavailable }
+            if let availability = self.lock.withLock({ state -> MeetingMicRecoveryRequestResult? in
+                guard state.lifecycleState == .running || state.lifecycleState == .failed else { return .unavailable }
+                guard state.pending == nil else { return .busy }
+                return nil
+            }) {
+                return availability
+            }
+            return self.beginHandoffIfNeeded(force: true) ? .initiated : .unavailable
+        }
     }
 
     private func ensureCurrentChild() throws -> Child {
@@ -363,14 +452,16 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         beginHandoffIfNeeded(force: force)
     }
 
-    private func beginHandoffIfNeeded(force: Bool = false) {
+    /// Returns true when a candidate handoff was actually started.
+    @discardableResult
+    private func beginHandoffIfNeeded(force: Bool = false) -> Bool {
         let request = lock.withLock { state -> (AudioObjectID, UInt64)? in
             guard state.lifecycleState == .running || state.lifecycleState == .failed,
                   state.pending == nil,
                   force || state.active?.deviceID != state.preferredInputDeviceIDStorage else { return nil }
             return (state.preferredInputDeviceIDStorage ?? kAudioObjectUnknown, state.generation)
         }
-        guard let (encodedDeviceID, generation) = request else { return }
+        guard let (encodedDeviceID, generation) = request else { return false }
         let deviceID = encodedDeviceID == kAudioObjectUnknown ? nil : encodedDeviceID
         let candidate = makeChild(deviceID: deviceID, generation: generation)
         lock.withLock { $0.pending = candidate }
@@ -392,7 +483,16 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         )
         handoffWorkerQueue.async { [weak self] in
             do {
+                // Revalidate immediately before each stage: stop()/cancel()
+                // clear the pending candidate and bump the generation, but this
+                // queued worker can execute afterward — without the guard a
+                // stale candidate would start capture after the meeting ended.
+                guard self?.isPendingCandidateCurrent(candidate.id, generation: generation) == true else { return }
                 try candidate.recorder.prepare()
+                guard self?.isPendingCandidateCurrent(candidate.id, generation: generation) == true else {
+                    candidate.recorder.cancel()
+                    return
+                }
                 try candidate.recorder.start()
             } catch {
                 self?.lifecycleQueue.async { [weak self] in
@@ -403,6 +503,15 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
                     )
                 }
             }
+        }
+        return true
+    }
+
+    private func isPendingCandidateCurrent(_ candidateID: UUID, generation: UInt64) -> Bool {
+        lock.withLock { state in
+            state.pending?.id == candidateID
+                && state.generation == generation
+                && (state.lifecycleState == .running || state.lifecycleState == .failed)
         }
     }
 
@@ -495,6 +604,7 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         }
         guard transition.completed else { return }
         onRawPCMSamplesStorage?(firstSamples)
+        onHandoffOutcome?(.promoted)
         retireAfterHandoffAsync(transition.old)
     }
 
@@ -508,6 +618,8 @@ final class RouteAwareMeetingMicRecorder: MeetingMicRecording {
         }
         guard let result else { return }
         cancelAsync(result.candidate)
+        let isTimeout = (error as NSError).domain == "MeetingMicrophoneRoute" && (error as NSError).code == 1
+        onHandoffOutcome?(isTimeout ? .timedOut : .failed)
         let outcome = result.isTerminalRecovery
             ? "microphone recovery failed"
             : "microphone handoff failed; continuing current route"

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
@@ -1,0 +1,394 @@
+import Foundation
+
+enum MeetingMicHealthEpisodeKind: String, Equatable {
+    case degraded = "meeting.microphone.degraded"
+    case recovered = "meeting.microphone.recovered"
+    case unrecovered = "meeting.microphone.unrecovered"
+    /// The capture device is muted/zero-gain at the source (user intent), which
+    /// presents the same all-zero signature as a broken route. Classified
+    /// separately so user intent never triggers recovery work or failure
+    /// telemetry, and so production can measure how common it is.
+    case userMuted = "meeting.microphone.user_muted"
+}
+
+enum MeetingMicHandoffOutcome: String, Equatable {
+    case promoted
+    case timedOut = "timed_out"
+    case failed = "failed"
+}
+
+/// Privacy-safe coarse context attached to episode telemetry: no audio, device
+/// names, or user content — only enum/classification-level fields.
+struct MeetingMicEpisodeContext: Equatable {
+    var recorderKind: String?
+    var routeCategory: String?
+    var selectedInputResolved: Bool?
+}
+
+struct MeetingMicHealthEpisodeEvent: Equatable {
+    let kind: MeetingMicHealthEpisodeKind
+    let episodeID: UUID
+    let reason: String
+    let state: String
+    let durationSeconds: TimeInterval
+    let flapCount: Int
+    let recoveryAttempts: Int
+    let handoffPromotions: Int
+    let lastHandoffOutcome: MeetingMicHandoffOutcome?
+    /// True when at least one recovery handoff promoted a replacement graph
+    /// during this episode before the healthy transition.
+    let recoveryCredited: Bool
+    let context: MeetingMicEpisodeContext
+}
+
+/// Bounded authorization set for episode telemetry callbacks. Sessions emit
+/// their terminal event while stopping/discarding — after the controller's
+/// active-meeting identity has moved on — and more than one recently stopped
+/// meeting can have callbacks queued on the main actor at once, so a single
+/// "last stopped" slot is not safe authorization. Membership is by meeting ID,
+/// authorized at session creation, with simple FIFO eviction.
+struct RecentMeetingIdentityGate {
+    private var order: [Int64] = []
+    private var members = Set<Int64>()
+    private let capacity: Int
+
+    init(capacity: Int = 8) {
+        self.capacity = capacity
+    }
+
+    mutating func authorize(_ id: Int64) {
+        guard !members.contains(id) else { return }
+        members.insert(id)
+        order.append(id)
+        while order.count > capacity {
+            members.remove(order.removeFirst())
+        }
+    }
+
+    func allows(_ id: Int64) -> Bool {
+        members.contains(id)
+    }
+}
+
+/// Turns the raw mic-health state stream into one episode per degradation and
+/// drives bounded same-route recovery attempts while a meeting is degraded.
+///
+/// Design notes:
+/// - Flapping is collapsed into a single episode: a *sustained* healthy period
+///   (not one healthy buffer) is required to close an episode as recovered, so
+///   a degraded→healthy-blip→degraded route cannot reset the retry budget.
+/// - All state commits under a non-recursive lock; injected callbacks run after
+///   unlock. Recovery reservations carry a unique token, stored on the episode,
+///   revalidated immediately before dispatch and settled on rollback — a
+///   callback that closes or replaces the episode invalidates the token.
+/// - After finishMeeting(), late snapshots are ignored so a callback enqueued
+///   before teardown cannot open a dangling episode.
+final class MeetingMicRecoveryCoordinator {
+    struct Policy: Equatable {
+        /// Minimum wall-clock gap between recovery attempts within an episode.
+        var attemptCooldown: TimeInterval = 15
+        /// Maximum recovery attempts per episode.
+        var maxAttemptsPerEpisode: Int = 3
+        /// Continuous healthy delivery required before an episode may close as
+        /// recovered. Prevents a single healthy buffer from resetting the
+        /// retry budget on a flapping route.
+        var sustainedHealthySeconds: TimeInterval = 10
+
+        static let `default` = Policy()
+    }
+
+    private struct Episode {
+        let id: UUID
+        let startedAt: Date
+        let initialReason: String
+        let initialState: MeetingMicHealthState
+        var flapCount: Int
+        var recoveryAttempts: Int
+        var lastAttemptAt: Date?
+        var pendingRecoveryToken: UUID?
+        var handoffPromotions: Int
+        var lastHandoffOutcome: MeetingMicHandoffOutcome?
+        /// First timestamp of the current continuous healthy run, if any.
+        var healthySince: Date?
+    }
+
+    /// Called after the coordinator's lock is released when a recovery attempt
+    /// should start. `.busy` (a handoff is already pending) is back-pressure:
+    /// the attempt is refunded but the cooldown timestamp is retained so
+    /// refusal cannot churn per-snapshot. `.unavailable` keeps the attempt
+    /// counted so the episode cap bounds total requests.
+    var recoveryRequest: (String) -> MeetingMicRecoveryRequestResult = { _ in .unavailable }
+    /// Called after the coordinator's lock is released.
+    var onEpisodeEvent: ((MeetingMicHealthEpisodeEvent) -> Void)?
+    /// Coarse, privacy-safe context for telemetry; evaluated at event time.
+    var contextProvider: () -> MeetingMicEpisodeContext = { MeetingMicEpisodeContext() }
+    /// Evaluated once at episode confirmation (never per sample). When the
+    /// capture device is muted/zero-gain at the source, no recovery episode
+    /// opens: the all-zero signature is user intent, not a broken route.
+    /// Called outside the coordinator lock (may read device state via HAL).
+    var isInputMuted: () -> Bool = { false }
+    /// Fired at most once per meeting when confirmed degradation is classified
+    /// as user-muted input. Runs after the coordinator lock is released.
+    var onUserMuted: (() -> Void)?
+
+    private let policy: Policy
+    private let now: () -> Date
+    private let lock = NSLock()
+    private var episode: Episode?
+    private var previousState: MeetingMicHealthState?
+    private var finished = false
+    /// True while degradation snapshots are suppressed because the input was
+    /// muted at confirmation. Cleared when the input un-mutes or the state
+    /// leaves degraded, so a genuinely broken route still opens an episode.
+    private var mutedSuppressed = false
+    private var mutedSignalEmitted = false
+
+    init(policy: Policy = .default, now: @escaping () -> Date = Date.init) {
+        self.policy = policy
+        self.now = now
+    }
+
+    func process(_ snapshot: MeetingMicHealthSnapshot) {
+        // State transitions commit under the lock; event construction (which
+        // evaluates the injected contextProvider) and all callbacks run after
+        // the lock is released.
+        struct PendingEvent {
+            let kind: MeetingMicHealthEpisodeKind
+            let episode: Episode
+            let duration: TimeInterval
+        }
+        var pendingEvent: PendingEvent?
+        var recoveryToDispatch: (token: UUID, reason: String)?
+        // The mute read (HAL, can block) happens before the lock; the snapshot
+        // state itself needs no lock.
+        let degradedNow = Self.isDegraded(snapshot.state)
+        let inputMuted = degradedNow ? isInputMuted() : false
+        var emitUserMuted = false
+
+        lock.lock()
+        if !finished {
+            let currentState = snapshot.state
+            let previous = previousState
+            previousState = currentState
+            let timestamp = now()
+            if !degradedNow {
+                mutedSuppressed = false
+            }
+
+            switch (degradedNow, episode != nil) {
+            case (true, true):
+                var active = episode!
+                // A flap is any state change while the episode is open: a
+                // return to degradation after a neutral/healthy blip, or a
+                // change in degradation mode.
+                if let previous, previous != currentState {
+                    active.flapCount += 1
+                }
+                active.healthySince = nil
+                if let reservation = reserveRecoveryIfDueLocked(&active, at: timestamp) {
+                    recoveryToDispatch = reservation
+                }
+                episode = active
+            case (true, false):
+                // Degradation confirmed with no episode open. If the capture
+                // device is muted/zero-gain at the source, this is user
+                // intent, not a broken route: signal it once and suppress
+                // recovery work. If the input un-mutes while still degraded,
+                // the route may be genuinely broken — open the episode then.
+                if inputMuted {
+                    mutedSuppressed = true
+                    if !mutedSignalEmitted {
+                        mutedSignalEmitted = true
+                        emitUserMuted = true
+                    }
+                } else if mutedSuppressed {
+                    // Un-muted while still degraded: now the route may be
+                    // genuinely broken — fall through to opening the episode.
+                    mutedSuppressed = false
+                }
+                if !mutedSuppressed {
+                    let reason = snapshot.transitions.last?.reason ?? "unknown"
+                    var newEpisode = Episode(
+                        id: UUID(),
+                        startedAt: timestamp,
+                        initialReason: reason,
+                        initialState: currentState,
+                        flapCount: 0,
+                        recoveryAttempts: 0,
+                        lastAttemptAt: nil,
+                        pendingRecoveryToken: nil,
+                        handoffPromotions: 0,
+                        lastHandoffOutcome: nil,
+                        healthySince: nil
+                    )
+                    // The degraded event reports attempts as of episode start
+                    // (0); the immediate first attempt is reserved below and
+                    // reflected in the episode's closing event.
+                    pendingEvent = PendingEvent(kind: .degraded, episode: newEpisode, duration: 0)
+                    // The tracker already confirmed degradation for ~3s;
+                    // attempt recovery immediately at episode start.
+                    recoveryToDispatch = reserveRecoveryLocked(&newEpisode, at: timestamp)
+                    episode = newEpisode
+                }
+            case (false, true):
+                var active = episode!
+                if currentState == .healthy {
+                    if active.healthySince == nil {
+                        active.healthySince = timestamp
+                    }
+                    if timestamp.timeIntervalSince(active.healthySince!) >= policy.sustainedHealthySeconds {
+                        // Sustained healthy delivery: close as recovered. The
+                        // retry budget is only released here, never on a blip.
+                        episode = nil
+                        pendingEvent = PendingEvent(
+                            kind: .recovered,
+                            episode: active,
+                            duration: timestamp.timeIntervalSince(active.startedAt)
+                        )
+                    } else {
+                        episode = active
+                    }
+                } else {
+                    // Neutral state (e.g. waitingForAudio): keep the episode
+                    // open without counting anything.
+                    episode = active
+                }
+            case (false, false):
+                break
+            }
+        }
+        let dispatch = recoveryToDispatch
+        lock.unlock()
+
+        if emitUserMuted {
+            onUserMuted?()
+        }
+        if let pendingEvent {
+            onEpisodeEvent?(makeEvent(pendingEvent.kind, episode: pendingEvent.episode, duration: pendingEvent.duration))
+        }
+        if let dispatch {
+            dispatchRecovery(dispatch)
+        }
+    }
+
+    /// Record the outcome of a recovery handoff (called by the recorder layer).
+    /// A promotion during an open episode marks the recovery as creditable if
+    /// healthy delivery follows.
+    func noteHandoffOutcome(_ outcome: MeetingMicHandoffOutcome) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var active = episode else { return }
+        active.lastHandoffOutcome = outcome
+        if outcome == .promoted {
+            active.handoffPromotions += 1
+        }
+        episode = active
+    }
+
+    /// Call when the meeting stops. An episode still degraded at meeting end is
+    /// the terminal condition that warrants an error-level signal; an episode
+    /// with healthy-but-not-yet-sustained delivery closes as recovered. After
+    /// this, further snapshots are ignored.
+    func finishMeeting() {
+        var pendingEvent: (kind: MeetingMicHealthEpisodeKind, episode: Episode, duration: TimeInterval)?
+        lock.lock()
+        finished = true
+        if let active = episode {
+            episode = nil
+            let timestamp = now()
+            let kind: MeetingMicHealthEpisodeKind = active.healthySince != nil ? .recovered : .unrecovered
+            pendingEvent = (kind, active, timestamp.timeIntervalSince(active.startedAt))
+        }
+        lock.unlock()
+
+        if let pendingEvent {
+            onEpisodeEvent?(makeEvent(pendingEvent.kind, episode: pendingEvent.episode, duration: pendingEvent.duration))
+        }
+    }
+
+    var hasActiveEpisode: Bool {
+        lock.withLock { episode != nil }
+    }
+
+    private static func isDegraded(_ state: MeetingMicHealthState) -> Bool {
+        state == .micCallbacksMissing || state == .micAllZeroWhileSystemActive
+    }
+
+    /// Builds the event outside the lock: evaluates the injected context
+    /// provider without holding coordinator state.
+    private func makeEvent(
+        _ kind: MeetingMicHealthEpisodeKind,
+        episode: Episode,
+        duration: TimeInterval
+    ) -> MeetingMicHealthEpisodeEvent {
+        MeetingMicHealthEpisodeEvent(
+            kind: kind,
+            episodeID: episode.id,
+            reason: episode.initialReason,
+            state: episode.initialState.rawValue,
+            durationSeconds: duration,
+            flapCount: episode.flapCount,
+            recoveryAttempts: episode.recoveryAttempts,
+            handoffPromotions: episode.handoffPromotions,
+            lastHandoffOutcome: episode.lastHandoffOutcome,
+            recoveryCredited: episode.handoffPromotions > 0,
+            context: contextProvider()
+        )
+    }
+
+    /// Must be called with `lock` held. Reserves an attempt and issues a unique
+    /// token stored on the episode; the token is revalidated at dispatch.
+    private func reserveRecoveryIfDueLocked(
+        _ active: inout Episode,
+        at timestamp: Date
+    ) -> (token: UUID, reason: String)? {
+        if let lastAttemptAt = active.lastAttemptAt,
+           timestamp.timeIntervalSince(lastAttemptAt) < policy.attemptCooldown {
+            return nil
+        }
+        return reserveRecoveryLocked(&active, at: timestamp)
+    }
+
+    private func reserveRecoveryLocked(
+        _ active: inout Episode,
+        at timestamp: Date
+    ) -> (token: UUID, reason: String)? {
+        guard active.recoveryAttempts < policy.maxAttemptsPerEpisode,
+              active.pendingRecoveryToken == nil else { return nil }
+        let token = UUID()
+        active.recoveryAttempts += 1
+        active.lastAttemptAt = timestamp
+        active.pendingRecoveryToken = token
+        return (token, active.initialReason)
+    }
+
+    /// Runs outside the lock. Revalidates the reservation token immediately
+    /// before dispatch: an episode that closed or moved on invalidates it.
+    private func dispatchRecovery(_ reservation: (token: UUID, reason: String)) {
+        lock.lock()
+        guard !finished,
+              let active = episode,
+              active.pendingRecoveryToken == reservation.token else {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+
+        let result = recoveryRequest(reservation.reason)
+
+        lock.lock()
+        if var active = episode, active.pendingRecoveryToken == reservation.token {
+            active.pendingRecoveryToken = nil
+            if result == .busy {
+                // Back-pressure from an in-flight handoff: refund the attempt
+                // so it does not burn the episode budget, but KEEP
+                // lastAttemptAt so the cooldown still throttles re-dispatch.
+                active.recoveryAttempts -= 1
+            }
+            // .unavailable keeps the attempt counted: the per-episode cap must
+            // bound total recovery requests, not only accepted ones.
+            episode = active
+        }
+        lock.unlock()
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingMicRecoveryCoordinator.swift
@@ -122,10 +122,11 @@ final class MeetingMicRecoveryCoordinator {
     var onEpisodeEvent: ((MeetingMicHealthEpisodeEvent) -> Void)?
     /// Coarse, privacy-safe context for telemetry; evaluated at event time.
     var contextProvider: () -> MeetingMicEpisodeContext = { MeetingMicEpisodeContext() }
-    /// Evaluated once at episode confirmation (never per sample). When the
-    /// capture device is muted/zero-gain at the source, no recovery episode
-    /// opens: the all-zero signature is user intent, not a broken route.
-    /// Called outside the coordinator lock (may read device state via HAL).
+    /// Evaluated at episode confirmation and at most once per second while
+    /// suppressed — never per sample batch. When the capture device is
+    /// muted/zero-gain at the source, no recovery episode opens: the all-zero
+    /// signature is user intent, not a broken route. Called outside the
+    /// coordinator lock (may read device state via HAL).
     var isInputMuted: () -> Bool = { false }
     /// Fired at most once per meeting when confirmed degradation is classified
     /// as user-muted input. Runs after the coordinator lock is released.
@@ -142,6 +143,9 @@ final class MeetingMicRecoveryCoordinator {
     /// leaves degraded, so a genuinely broken route still opens an episode.
     private var mutedSuppressed = false
     private var mutedSignalEmitted = false
+    /// Throttles HAL mute reads to 1Hz while degradation is open but
+    /// suppressed; nil while an episode is open (no reads at all then).
+    private var lastMuteCheckAt: Date?
 
     init(policy: Policy = .default, now: @escaping () -> Date = Date.init) {
         self.policy = policy
@@ -159,10 +163,27 @@ final class MeetingMicRecoveryCoordinator {
         }
         var pendingEvent: PendingEvent?
         var recoveryToDispatch: (token: UUID, reason: String)?
-        // The mute read (HAL, can block) happens before the lock; the snapshot
-        // state itself needs no lock.
+
+        // The mute read (HAL, can block) runs outside the lock, and only when
+        // it can change behavior: an open episode never consults it, and
+        // suppressed degradation re-reads at most once per second to notice
+        // un-muting without polling the HAL per sample batch.
         let degradedNow = Self.isDegraded(snapshot.state)
-        let inputMuted = degradedNow ? isInputMuted() : false
+        var inputMuted = false
+        if degradedNow {
+            let shouldCheck: Bool = lock.withLock {
+                guard episode == nil else { return false }
+                if let lastMuteCheckAt,
+                   now().timeIntervalSince(lastMuteCheckAt) < 1 { return false }
+                lastMuteCheckAt = now()
+                return true
+            }
+            if shouldCheck {
+                inputMuted = isInputMuted()
+            } else {
+                inputMuted = lock.withLock { mutedSuppressed }
+            }
+        }
         var emitUserMuted = false
 
         lock.lock()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -289,7 +289,8 @@ final class MeetingSession {
 
     /// True when the capture device is muted or zero-gain at the source (user
     /// intent), which presents the same all-zero signature as a broken route.
-    /// Read once per degradation confirmation, never per sample.
+    /// Called by the coordinator at episode confirmation and at most 1Hz while
+    /// a suppressed degradation continues — never per sample batch.
     private func isCaptureInputMuted() -> Bool {
         var deviceID = meetingMicRecorder.preferredInputDeviceID ?? kAudioObjectUnknown
         if deviceID == kAudioObjectUnknown {
@@ -310,9 +311,12 @@ final class MeetingSession {
         )
         var volume: Float32 = 1
         var volumeSize = UInt32(MemoryLayout<Float32>.size)
-        if AudioObjectGetPropertyData(deviceID, &volumeAddress, 0, nil, &volumeSize, &volume) == noErr {
-            return volume <= 0.0001
+        if AudioObjectGetPropertyData(deviceID, &volumeAddress, 0, nil, &volumeSize, &volume) == noErr,
+           volume <= 0.0001 {
+            return true
         }
+        // A device can hold nonzero gain while its separate mute control is
+        // engaged — a successful nonzero volume read is not proof of unmuted.
         var muteAddress = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyMute,
             mScope: kAudioObjectPropertyScopeInput,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -304,28 +304,33 @@ final class MeetingSession {
                 AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
             ) == noErr, deviceID != kAudioObjectUnknown else { return false }
         }
-        var volumeAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyVolumeScalar,
-            mScope: kAudioObjectPropertyScopeInput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var volume: Float32 = 1
-        var volumeSize = UInt32(MemoryLayout<Float32>.size)
-        if AudioObjectGetPropertyData(deviceID, &volumeAddress, 0, nil, &volumeSize, &volume) == noErr,
-           volume <= 0.0001 {
-            return true
-        }
-        // A device can hold nonzero gain while its separate mute control is
-        // engaged — a successful nonzero volume read is not proof of unmuted.
-        var muteAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyMute,
-            mScope: kAudioObjectPropertyScopeInput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var muted: UInt32 = 0
-        var muteSize = UInt32(MemoryLayout<UInt32>.size)
-        if AudioObjectGetPropertyData(deviceID, &muteAddress, 0, nil, &muteSize, &muted) == noErr {
-            return muted != 0
+        // Volume and mute controls may live on the main element (0) or on
+        // individual input channels (1...). Check main plus the first two
+        // channel elements; a read failure just means "no control there".
+        let elements: [AudioObjectPropertyElement] = [kAudioObjectPropertyElementMain, 1, 2]
+        for element in elements {
+            var volumeAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyVolumeScalar,
+                mScope: kAudioObjectPropertyScopeInput,
+                mElement: element
+            )
+            var volume: Float32 = 1
+            var volumeSize = UInt32(MemoryLayout<Float32>.size)
+            if AudioObjectGetPropertyData(deviceID, &volumeAddress, 0, nil, &volumeSize, &volume) == noErr,
+               volume <= 0.0001 {
+                return true
+            }
+            var muteAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyMute,
+                mScope: kAudioObjectPropertyScopeInput,
+                mElement: element
+            )
+            var muted: UInt32 = 0
+            var muteSize = UInt32(MemoryLayout<UInt32>.size)
+            if AudioObjectGetPropertyData(deviceID, &muteAddress, 0, nil, &muteSize, &muted) == noErr,
+               muted != 0 {
+                return true
+            }
         }
         return false
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -306,8 +306,8 @@ final class MeetingSession {
         }
         // Volume and mute controls may live on the main element (0) or on any
         // input channel. Enumerate the device's actual input channel count via
-        // the stream configuration and probe every channel (capped at 8 for
-        // interface sanity); a read failure just means "no control there".
+        // the stream configuration and probe every channel; a read failure
+        // just means "no control there".
         var elements: [AudioObjectPropertyElement] = [kAudioObjectPropertyElementMain]
         var configAddress = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyStreamConfiguration,
@@ -326,7 +326,7 @@ final class MeetingSession {
                 let buffers = UnsafeMutableAudioBufferListPointer(bufferList)
                 let channelCount = buffers.reduce(0) { $0 + Int($1.mNumberChannels) }
                 if channelCount > 0 {
-                    elements.append(contentsOf: (1...min(channelCount, 8)).map { AudioObjectPropertyElement($0) })
+                    elements.append(contentsOf: (1...channelCount).map { AudioObjectPropertyElement($0) })
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -304,10 +304,32 @@ final class MeetingSession {
                 AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
             ) == noErr, deviceID != kAudioObjectUnknown else { return false }
         }
-        // Volume and mute controls may live on the main element (0) or on
-        // individual input channels (1...). Check main plus the first two
-        // channel elements; a read failure just means "no control there".
-        let elements: [AudioObjectPropertyElement] = [kAudioObjectPropertyElementMain, 1, 2]
+        // Volume and mute controls may live on the main element (0) or on any
+        // input channel. Enumerate the device's actual input channel count via
+        // the stream configuration and probe every channel (capped at 8 for
+        // interface sanity); a read failure just means "no control there".
+        var elements: [AudioObjectPropertyElement] = [kAudioObjectPropertyElementMain]
+        var configAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var configSize: UInt32 = 0
+        if AudioObjectGetPropertyDataSize(deviceID, &configAddress, 0, nil, &configSize) == noErr, configSize > 0 {
+            let raw = UnsafeMutableRawPointer.allocate(
+                byteCount: Int(configSize),
+                alignment: MemoryLayout<AudioBufferList>.alignment
+            )
+            defer { raw.deallocate() }
+            if AudioObjectGetPropertyData(deviceID, &configAddress, 0, nil, &configSize, raw) == noErr {
+                let bufferList = raw.assumingMemoryBound(to: AudioBufferList.self)
+                let buffers = UnsafeMutableAudioBufferListPointer(bufferList)
+                let channelCount = buffers.reduce(0) { $0 + Int($1.mNumberChannels) }
+                if channelCount > 0 {
+                    elements.append(contentsOf: (1...min(channelCount, 8)).map { AudioObjectPropertyElement($0) })
+                }
+            }
+        }
         for element in elements {
             var volumeAddress = AudioObjectPropertyAddress(
                 mSelector: kAudioDevicePropertyVolumeScalar,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingSession.swift
@@ -174,6 +174,7 @@ final class MeetingSession {
     private let micChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let systemChunkHealthTracker = MeetingTranscriptChunkHealthTracker()
     private let micHealthTracker = MeetingMicHealthTracker()
+    private let micRecoveryCoordinator = MeetingMicRecoveryCoordinator()
     private let chunkRotationQueue = DispatchQueue(label: "MuesliNative.MeetingSession.chunkRotation")
     private let pausedDisplayLock = OSAllocatedUnfairLock(initialState: false)
     private var chunkTimingTracker = MeetingChunkTimingTracker()
@@ -181,6 +182,14 @@ final class MeetingSession {
     private var systemChunkRecorder: PCMChunkRecorder?
     var onProgress: ((MeetingProcessingStage) -> Void)?
     var onMicHealthChanged: ((MeetingMicHealthSnapshot) -> Void)?
+    /// Episode-level mic-health events: one degraded/recovered pair per actual
+    /// degradation episode, or a single unrecovered event if the meeting ends
+    /// while degraded. Feed telemetry here; keep per-snapshot UI updates on
+    /// onMicHealthChanged.
+    var onMicHealthEpisode: ((MeetingMicHealthEpisodeEvent) -> Void)?
+    /// Fired at most once per meeting when confirmed degradation is classified
+    /// as user-muted input (no recovery episode is opened in that case).
+    var onMicHealthUserMuted: (() -> Void)?
     var manualNotesProvider: (() async -> String?)?
     var liveTitleProvider: (() async -> String?)?
     /// Formatted notes of the predecessor meeting when this session records a
@@ -242,6 +251,32 @@ final class MeetingSession {
         } else {
             self.systemAudioRecorder = SystemAudioRecorder()
         }
+        micRecoveryCoordinator.recoveryRequest = { [weak meetingMicRecorder] reason in
+            guard let meetingMicRecorder else { return .unavailable }
+            return meetingMicRecorder.requestSameRouteRecovery(reason: reason)
+        }
+        micRecoveryCoordinator.onEpisodeEvent = { [weak self] event in
+            self?.onMicHealthEpisode?(event)
+        }
+        micRecoveryCoordinator.isInputMuted = { [weak self] in
+            self?.isCaptureInputMuted() ?? false
+        }
+        micRecoveryCoordinator.onUserMuted = { [weak self] in
+            self?.onMicHealthUserMuted?()
+        }
+        micRecoveryCoordinator.contextProvider = { [weak meetingMicRecorder] in
+            guard let snapshot = meetingMicRecorder?.diagnosticsSnapshot() else {
+                return MeetingMicEpisodeContext()
+            }
+            return MeetingMicEpisodeContext(
+                recorderKind: snapshot.recorderKind.rawValue,
+                routeCategory: snapshot.route?.outputRouteKind,
+                selectedInputResolved: snapshot.route?.selectedInputDeviceResolved
+            )
+        }
+        meetingMicRecorder.onHandoffOutcome = { [weak micRecoveryCoordinator] outcome in
+            micRecoveryCoordinator?.noteHandoffOutcome(outcome)
+        }
     }
 
     func updateBackend(_ backend: BackendOption) {
@@ -250,6 +285,45 @@ final class MeetingSession {
 
     func setPreferredMicrophoneInputDeviceID(_ deviceID: AudioObjectID?) {
         meetingMicRecorder.preferredInputDeviceID = deviceID
+    }
+
+    /// True when the capture device is muted or zero-gain at the source (user
+    /// intent), which presents the same all-zero signature as a broken route.
+    /// Read once per degradation confirmation, never per sample.
+    private func isCaptureInputMuted() -> Bool {
+        var deviceID = meetingMicRecorder.preferredInputDeviceID ?? kAudioObjectUnknown
+        if deviceID == kAudioObjectUnknown {
+            var address = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var size = UInt32(MemoryLayout<AudioObjectID>.size)
+            guard AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+            ) == noErr, deviceID != kAudioObjectUnknown else { return false }
+        }
+        var volumeAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var volume: Float32 = 1
+        var volumeSize = UInt32(MemoryLayout<Float32>.size)
+        if AudioObjectGetPropertyData(deviceID, &volumeAddress, 0, nil, &volumeSize, &volume) == noErr {
+            return volume <= 0.0001
+        }
+        var muteAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var muted: UInt32 = 0
+        var muteSize = UInt32(MemoryLayout<UInt32>.size)
+        if AudioObjectGetPropertyData(deviceID, &muteAddress, 0, nil, &muteSize, &muted) == noErr {
+            return muted != 0
+        }
+        return false
     }
 
     private func currentBackend() -> BackendOption {
@@ -493,6 +567,9 @@ final class MeetingSession {
             systemChunkRecorder = nil
             return (rawRecorder, systemRecorder)
         }
+        // Same contract as stop(): the queue barrier above drains pending
+        // sample callbacks; only then is episode state final.
+        micRecoveryCoordinator.finishMeeting()
         stopPartialSessions()
         vadController?.stop()
         vadController = nil
@@ -548,6 +625,11 @@ final class MeetingSession {
             let lastSystemChunkTiming = systemChunkTimingTracker.finish()
             return (meetingStart, lastChunkTiming, lastRawMicURL, lastSystemChunkTiming, lastSystemChunkURL)
         }
+        // The chunkRotationQueue barrier above guarantees every sample callback
+        // enqueued before teardown has been processed and that later callbacks
+        // bail on isRecording == false. Only now is the coordinator's episode
+        // state final; close any open degradation episode as unrecovered.
+        micRecoveryCoordinator.finishMeeting()
         let rawStreamingMicURL = meetingMicRecorder.stop()
         let retainedRecordingURL = retainedRecordingWriter?.stop()
         retainedRecordingWriter = nil
@@ -1013,6 +1095,7 @@ final class MeetingSession {
 
             let healthSnapshot = self.micHealthTracker.noteRawMicSamples(rawSamples)
             self.onMicHealthChanged?(healthSnapshot)
+            self.micRecoveryCoordinator.process(healthSnapshot)
             self.retainedRecordingWriter?.appendMic(rawSamples)
 
             let floatSamples = rawSamples.map { Float($0) / 32767.0 }
@@ -1038,6 +1121,7 @@ final class MeetingSession {
 
             let healthSnapshot = self.micHealthTracker.noteSystemSamples(samples)
             self.onMicHealthChanged?(healthSnapshot)
+            self.micRecoveryCoordinator.process(healthSnapshot)
             self.retainedRecordingWriter?.appendSystem(samples)
             self.systemChunkRecorder?.append(samples)
             self.systemChunkTimingTracker.append(sampleCount: samples.count)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -361,6 +361,10 @@ final class MuesliController: NSObject {
     private var activeMeetingSession: MeetingSession?
     private weak var preparingMeetingSession: MeetingSession?
     private var activeMeetingID: Int64?
+    /// Set when a meeting stops, so telemetry events legitimately emitted by
+    /// the stopping session (after activeMeetingID is cleared) still pass the
+    /// session-identity gate. Replaced on the next meeting start.
+    private var micEpisodeTelemetryGate = RecentMeetingIdentityGate()
     private var liveMeetingTranscriptGeneration: UUID?
     private var activeMeetingAudioWarning: ActiveMeetingAudioWarning?
     private var liveMeetingTitleCache: [Int64: String] = [:]
@@ -5473,6 +5477,10 @@ final class MuesliController: NSObject {
                 )
                 let micHealthWarningLock = NSLock()
                 var lastForwardedMicHealthWarning: String?
+                // Authorize this session's episode telemetry for its whole
+                // lifetime, including the terminal event emitted after the
+                // active-meeting identity has moved on during stop/discard.
+                micEpisodeTelemetryGate.authorize(meetingID)
                 meetingSession.onMicHealthChanged = { [weak self] snapshot in
                     let warningMessage = snapshot.warningMessage
                     micHealthWarningLock.lock()
@@ -5484,13 +5492,64 @@ final class MuesliController: NSObject {
                         guard let self,
                               self.activeMeetingID == meetingID || self.meetingStartMeetingID == meetingID else { return }
                         self.updateActiveMeetingAudioWarning(meetingID: meetingID, health: snapshot)
-                        if warningMessage != nil {
+                    }
+                }
+                // Episode-level telemetry replaces per-flap error events:
+                // exactly one degraded/recovered signal pair per degradation
+                // episode, and an error only when the meeting ends unrecovered.
+                meetingSession.onMicHealthUserMuted = { [weak self] in
+                    Task { @MainActor in
+                        guard let self, self.micEpisodeTelemetryGate.allows(meetingID) else { return }
+                        TelemetryDeck.signal(MeetingMicHealthEpisodeKind.userMuted.rawValue, parameters: [:])
+                    }
+                }
+                meetingSession.onMicHealthEpisode = { [weak self] event in
+                    Task { @MainActor in
+                        guard let self else { return }
+                        // Terminal events legitimately arrive while the meeting
+                        // is stopping: stopMeetingRecording clears
+                        // activeMeetingID before MeetingSession.stop() runs, so
+                        // also accept the most recently stopped meeting.
+                        guard self.micEpisodeTelemetryGate.allows(meetingID) else { return }
+                        var parameters: [String: String] = [
+                            "episode_id": event.episodeID.uuidString,
+                            "reason": event.reason,
+                            "state": event.state,
+                            "duration_ms": String(Int(event.durationSeconds * 1000)),
+                            "flap_count": String(event.flapCount),
+                            "recovery_attempts": String(event.recoveryAttempts),
+                            "handoff_promotions": String(event.handoffPromotions),
+                            "recovery_credited": String(event.recoveryCredited),
+                        ]
+                        if let outcome = event.lastHandoffOutcome {
+                            parameters["last_handoff_outcome"] = outcome.rawValue
+                        }
+                        if let recorderKind = event.context.recorderKind {
+                            parameters["recorder_kind"] = recorderKind
+                        }
+                        if let routeCategory = event.context.routeCategory {
+                            parameters["route_category"] = routeCategory
+                        }
+                        if let resolved = event.context.selectedInputResolved {
+                            parameters["selected_input_resolved"] = String(resolved)
+                        }
+                        switch event.kind {
+                        case .degraded, .recovered:
+                            TelemetryDeck.signal(event.kind.rawValue, parameters: parameters)
+                        case .unrecovered:
+                            // Rich episode signal with full classification, plus
+                            // the legacy error incident for dashboard continuity.
+                            TelemetryDeck.signal(event.kind.rawValue, parameters: parameters)
                             self.recordDiagnosticIncident(
                                 kind: .meetingMicrophoneCaptureFailed,
                                 severity: .warning,
                                 stage: .meetingMicrophoneCapture,
                                 promptUser: false
                             )
+                        case .userMuted:
+                            // Emitted via onMicHealthUserMuted, not the episode
+                            // stream; nothing to do here.
+                            break
                         }
                     }
                 }
@@ -5724,6 +5783,7 @@ final class MuesliController: NSObject {
             disarmMeetingAutoStop()
             indicator.setMeetingRecording(false, config: config)
             if let meetingID = activeMeetingID {
+                micEpisodeTelemetryGate.authorize(meetingID)
                 activeMeetingID = nil
                 if activeMeetingAudioWarning?.meetingID == meetingID {
                     activeMeetingAudioWarning = nil
@@ -5739,6 +5799,9 @@ final class MuesliController: NSObject {
         self.activeMeetingSession = nil
         indicator.setMeetingRecording(false, config: config)
         if let meetingID = activeMeetingID {
+            // Preserve identity for episode terminal telemetry emitted by the
+            // discarding session (it hops to the main actor asynchronously).
+            micEpisodeTelemetryGate.authorize(meetingID)
             activeMeetingID = nil
             if activeMeetingAudioWarning?.meetingID == meetingID {
                 activeMeetingAudioWarning = nil
@@ -6022,6 +6085,9 @@ final class MuesliController: NSObject {
 
         // Unblock new recordings immediately — transcription runs in the background
         activeMeetingSession = nil
+        if let activeMeetingID {
+            micEpisodeTelemetryGate.authorize(activeMeetingID)
+        }
         activeMeetingID = nil
         if let liveMeetingID, activeMeetingAudioWarning?.meetingID == liveMeetingID {
             activeMeetingAudioWarning = nil

--- a/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StreamingMicRecorder.swift
@@ -16,6 +16,17 @@ protocol StreamingDictationRecording: AnyObject {
     func stop() -> URL?
     func cancel()
     func currentPower() -> Float
+
+    /// Permanently disqualify this recorder instance from ever starting
+    /// capture again. Unlike cancel() (which disposes but allows re-prepare),
+    /// this is terminal and synchronous, so a stale handoff worker that calls
+    /// start() after meeting teardown loses the race no matter the
+    /// interleaving. Default no-op for recorders that don't need it.
+    func invalidateForTeardown()
+}
+
+extension StreamingDictationRecording {
+    func invalidateForTeardown() {}
 }
 
 protocol StreamingDictationLatencyReporting: AnyObject {
@@ -56,6 +67,10 @@ final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictatio
     private let directoryName: String
     private let recoversFromInputConfigurationChanges: Bool
     private let graphLock = NSRecursiveLock()
+    /// Published independently of graphLock: invalidateForTeardown() must land
+    /// even while a worker is blocked in engine startup holding graphLock, so
+    /// the post-start self-check observes it before start() returns.
+    private let teardownInvalidation = OSAllocatedUnfairLock(initialState: false)
     private let lock = OSAllocatedUnfairLock(initialState: FileState())
     private let failureLock = OSAllocatedUnfairLock(initialState: FailureState())
     private let failureCallbackQueue = DispatchQueue(label: "com.muesli.streaming-mic-recorder-failures")
@@ -100,6 +115,11 @@ final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictatio
     func prepare() throws {
         graphLock.lock()
         defer { graphLock.unlock() }
+        guard !isPermanentlyInvalidated else {
+            throw NSError(domain: "StreamingMicRecorder", code: 9, userInfo: [
+                NSLocalizedDescriptionKey: "Recorder was invalidated by teardown",
+            ])
+        }
 
         try prepareLocked()
     }
@@ -148,6 +168,11 @@ final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictatio
         graphLock.lock()
         defer { graphLock.unlock() }
 
+        guard !isPermanentlyInvalidated else {
+            throw NSError(domain: "StreamingMicRecorder", code: 9, userInfo: [
+                NSLocalizedDescriptionKey: "Recorder was invalidated by teardown",
+            ])
+        }
         guard !runState.isRunning else { return }
         try prepareLocked()
         let recordingID = UUID()
@@ -162,6 +187,26 @@ final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictatio
         installConfigurationChangeObserverIfNeeded(recordingID: recordingID)
         do {
             try startEngineWithTapLocked(recordingID: recordingID)
+            // Engine start can block while the daemon negotiates the route;
+            // teardown may have landed during that window. Synchronously stop
+            // what just started rather than letting capture outlive teardown.
+            if isPermanentlyInvalidated {
+                removeTapIfNeeded()
+                stopEngineSafely()
+                removeConfigurationChangeObserverIfNeeded()
+                clearFailureState()
+                let state = lock.withLock { state -> FileState in
+                    let old = state
+                    state = FileState()
+                    return old
+                }
+                if let url = state.fileURL {
+                    try? FileManager.default.removeItem(at: url)
+                }
+                throw NSError(domain: "StreamingMicRecorder", code: 9, userInfo: [
+                    NSLocalizedDescriptionKey: "Recorder was invalidated by teardown",
+                ])
+            }
             runState.markStarted()
         } catch {
             removeTapIfNeeded()
@@ -439,6 +484,16 @@ final class StreamingMicRecorder: StreamingDictationRecording, StreamingDictatio
         lock.withLock { state in
             state.isPaused = false
         }
+    }
+
+    /// Terminal and synchronous: this instance must never start capture again
+    /// after meeting teardown. Distinct from cancel(), which permits reuse.
+    func invalidateForTeardown() {
+        teardownInvalidation.withLock { $0 = true }
+    }
+
+    private var isPermanentlyInvalidated: Bool {
+        teardownInvalidation.withLock { $0 }
     }
 
     func cancel() {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
@@ -242,10 +242,25 @@ struct MeetingMicRecoveryCoordinatorTests {
         #expect(harness.events.isEmpty)
 
         muted = false
-        harness.systemActive(seconds: 1) // still degraded, no longer muted
+        harness.advance(seconds: 1.5)      // past the 1Hz mute-read throttle
+        harness.systemActive(seconds: 1)   // still degraded, no longer muted
 
         #expect(harness.events.map(\.kind) == [.degraded])
         #expect(harness.recoveryRequests.count == 1)
+    }
+
+    @Test("no mute reads happen while an episode is open")
+    func noMuteReadsWhileEpisodeOpen() {
+        let harness = Harness()
+        var reads = 0
+        harness.coordinator.isInputMuted = { reads += 1; return false }
+
+        harness.systemActive(seconds: 3)   // episode opens at t=3
+        let readsAtOpen = reads
+        harness.systemActive(seconds: 10)  // episode open: zero further reads
+
+        #expect(readsAtOpen == 1)
+        #expect(reads == 1)
     }
 
     @Test("muted classification does not latch past a healthy stretch")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingMicRecoveryCoordinatorTests.swift
@@ -1,0 +1,367 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+struct MeetingMicRecoveryCoordinatorTests {
+    private final class Harness {
+        let tracker = MeetingMicHealthTracker()
+        var coordinator: MeetingMicRecoveryCoordinator!
+        var events: [MeetingMicHealthEpisodeEvent] = []
+        var recoveryRequests: [String] = []
+        var now = Date(timeIntervalSince1970: 1_000_000)
+
+        init(cooldown: TimeInterval = 15, maxAttempts: Int = 3) {
+            coordinator = MeetingMicRecoveryCoordinator(
+                policy: .init(attemptCooldown: cooldown, maxAttemptsPerEpisode: maxAttempts),
+                now: { [weak self] in self?.now ?? Date() }
+            )
+            coordinator.recoveryRequest = { [weak self] reason in
+                self?.recoveryRequests.append(reason)
+                return .initiated
+            }
+            coordinator.onEpisodeEvent = { [weak self] event in
+                self?.events.append(event)
+            }
+        }
+
+        /// 0.1s of active system audio per call; the tracker declares
+        /// degradation after 3s (48000 samples) of active system audio with no
+        /// mic signal.
+        func systemActive(seconds: Int) {
+            let chunks = seconds * 10
+            for _ in 0..<chunks {
+                let snapshot = tracker.noteSystemSamples(Array(repeating: 2000, count: 1600), now: now)
+                coordinator.process(snapshot)
+                now = now.addingTimeInterval(0.1)
+            }
+        }
+
+        func micSignal() {
+            let snapshot = tracker.noteRawMicSamples(Array(repeating: 1000, count: 1600), now: now)
+            coordinator.process(snapshot)
+        }
+
+        func advance(seconds: TimeInterval) {
+            now = now.addingTimeInterval(seconds)
+        }
+
+        func micSilence() {
+            let snapshot = tracker.noteRawMicSamples(Array(repeating: 0, count: 1600), now: now)
+            coordinator.process(snapshot)
+        }
+    }
+
+    @Test("confirmed missing callbacks start one episode and one recovery attempt")
+    func episodeStartsOnConfirmedDegradation() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+
+        #expect(harness.events.count == 1)
+        #expect(harness.events.first?.kind == .degraded)
+        #expect(harness.events.first?.reason == "system_audio_active_without_mic_callbacks")
+        #expect(harness.events.first?.state == MeetingMicHealthState.micCallbacksMissing.rawValue)
+        #expect(harness.recoveryRequests == ["system_audio_active_without_mic_callbacks"])
+    }
+
+    @Test("continued degradation does not emit duplicate events or premature retries")
+    func continuedDegradationIsSilent() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.systemActive(seconds: 5)
+
+        #expect(harness.events.count == 1)
+        #expect(harness.recoveryRequests.count == 1)
+    }
+
+    @Test("degradation mode change within an episode counts a flap without a new episode")
+    func modeChangeCountsFlap() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.micSilence()
+        harness.systemActive(seconds: 4)
+
+        #expect(harness.events.count == 1)
+        #expect(harness.recoveryRequests.count == 1)
+        // micAllZeroWhileSystemActive follows micCallbacksMissing: same episode.
+        #expect(harness.coordinator.hasActiveEpisode)
+    }
+
+    @Test("recovery retries after cooldown and stops at the attempt cap")
+    func recoveryCooldownAndCap() {
+        let harness = Harness(cooldown: 0.5, maxAttempts: 2)
+        harness.systemActive(seconds: 3) // exactly reaches the 3s confirmation threshold
+        #expect(harness.recoveryRequests.count == 1)
+
+        harness.systemActive(seconds: 1) // 1s > 0.5s cooldown
+        #expect(harness.recoveryRequests.count == 2)
+
+        harness.systemActive(seconds: 1)
+        #expect(harness.recoveryRequests.count == 2) // cap reached
+    }
+
+    @Test("signal recovery closes the episode with exactly one recovered event after sustained health")
+    func recoveryClosesEpisode() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.micSignal()
+        harness.advance(seconds: 10)
+        harness.micSignal()
+
+        #expect(harness.events.map(\.kind) == [.degraded, .recovered])
+        #expect(harness.events.last?.recoveryAttempts == 1)
+        #expect(!harness.coordinator.hasActiveEpisode)
+    }
+
+    @Test("a healthy blip does not close the episode or reset the retry budget")
+    func healthyBlipKeepsEpisodeOpen() {
+        let harness = Harness(cooldown: 0.5, maxAttempts: 2)
+        harness.systemActive(seconds: 3)           // episode starts at t=3, attempt 1
+        harness.micSignal()                        // healthy blip (not sustained)
+        harness.micSilence()                       // mic goes all-zero again
+        harness.systemActive(seconds: 4)           // re-degrades (zero-mic) at ~t=6: flap, attempt 2
+
+        #expect(harness.events.map(\.kind) == [.degraded])
+        #expect(harness.recoveryRequests.count == 2)
+        #expect(harness.coordinator.hasActiveEpisode)
+
+        harness.systemActive(seconds: 2)           // still degraded; budget exhausted
+        #expect(harness.recoveryRequests.count == 2)
+    }
+
+    @Test("a second episode after sustained recovery is a new episode")
+    func secondEpisodeIsDistinct() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.micSignal()
+        harness.advance(seconds: 10)
+        harness.micSignal()
+        harness.systemActive(seconds: 4)
+
+        #expect(harness.events.map(\.kind) == [.degraded, .recovered, .degraded])
+        #expect(harness.events[0].episodeID != harness.events[2].episodeID)
+    }
+
+    @Test("meeting ending after a healthy blip closes as recovered, not unrecovered")
+    func meetingEndAfterHealthyBlipIsRecovered() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.micSignal()                        // healthy but not sustained
+        harness.coordinator.finishMeeting()
+
+        #expect(harness.events.map(\.kind) == [.degraded, .recovered])
+    }
+
+    @Test("a recovery reserved before the episode closed is never dispatched")
+    func closedEpisodeInvalidatesPendingRecovery() {
+        let harness = Harness()
+        harness.coordinator.onEpisodeEvent = { [weak harness] event in
+            harness?.events.append(event)
+            guard let harness, event.kind == .degraded else { return }
+            // Recover synchronously inside the event callback, before the
+            // coordinator dispatches the reserved recovery.
+            harness.micSignal()
+            harness.advance(seconds: 10)
+            harness.micSignal()
+        }
+        harness.systemActive(seconds: 4)
+
+        #expect(harness.events.map(\.kind) == [.degraded, .recovered])
+        #expect(harness.recoveryRequests.isEmpty)
+    }
+
+    @Test("meeting ending while degraded emits one unrecovered event")
+    func meetingEndWhileDegradedIsTerminal() {
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.coordinator.finishMeeting()
+
+        #expect(harness.events.map(\.kind) == [.degraded, .unrecovered])
+        #expect(!harness.coordinator.hasActiveEpisode)
+    }
+
+    @Test("finishMeeting without an episode is silent")
+    func finishMeetingWithoutEpisode() {
+        let harness = Harness()
+        harness.micSignal()
+        harness.coordinator.finishMeeting()
+        #expect(harness.events.isEmpty)
+    }
+
+    @Test("snapshots processed after finishMeeting cannot open a dangling episode")
+    func lateSnapshotsAfterFinishMeetingAreIgnored() {
+        // Regression test for the stop()-ordering race: a sample callback
+        // enqueued before teardown can run after finishMeeting(); it must not
+        // open an episode that never sees a terminal event.
+        let harness = Harness()
+        harness.systemActive(seconds: 4)
+        harness.coordinator.finishMeeting()
+        #expect(harness.events.map(\.kind) == [.degraded, .unrecovered])
+
+        harness.systemActive(seconds: 4)
+        #expect(harness.events.map(\.kind) == [.degraded, .unrecovered])
+        #expect(harness.recoveryRequests.count == 1)
+        #expect(!harness.coordinator.hasActiveEpisode)
+    }
+
+    @Test("ordinary mic silence without system audio never starts an episode, even past the confirmation window")
+    func quietRoomIsNotDegraded() {
+        let harness = Harness()
+        // Feed zero mic samples for longer than the detector's 3s confirmation
+        // threshold, with no system audio present.
+        for _ in 0..<40 {
+            harness.micSilence()
+            harness.advance(seconds: 0.1)
+        }
+        #expect(harness.events.isEmpty)
+        #expect(harness.recoveryRequests.isEmpty)
+    }
+
+    @Test("muted input at confirmation suppresses the episode and signals once")
+    func mutedInputSuppressesEpisode() {
+        let harness = Harness()
+        var mutedSignals = 0
+        harness.coordinator.isInputMuted = { true }
+        harness.coordinator.onUserMuted = { mutedSignals += 1 }
+
+        harness.systemActive(seconds: 4)
+        harness.systemActive(seconds: 4)
+
+        #expect(harness.events.isEmpty)
+        #expect(harness.recoveryRequests.isEmpty)
+        #expect(mutedSignals == 1)
+        #expect(!harness.coordinator.hasActiveEpisode)
+    }
+
+    @Test("un-muting while still degraded opens the episode then")
+    func unmuteWhileDegradedOpensEpisode() {
+        let harness = Harness()
+        var muted = true
+        harness.coordinator.isInputMuted = { muted }
+
+        harness.systemActive(seconds: 4) // muted: suppressed
+        #expect(harness.events.isEmpty)
+
+        muted = false
+        harness.systemActive(seconds: 1) // still degraded, no longer muted
+
+        #expect(harness.events.map(\.kind) == [.degraded])
+        #expect(harness.recoveryRequests.count == 1)
+    }
+
+    @Test("muted classification does not latch past a healthy stretch")
+    func mutedClassificationDoesNotLatch() {
+        let harness = Harness()
+        var muted = true
+        harness.coordinator.isInputMuted = { muted }
+
+        harness.systemActive(seconds: 4)   // muted episode suppressed
+        muted = false
+        harness.micSignal()                // healthy
+        harness.systemActive(seconds: 4)   // new degradation, unmuted
+
+        #expect(harness.events.map(\.kind) == [.degraded])
+        #expect(harness.recoveryRequests.count == 1)
+    }
+
+    @Test("unavailable recovery counts toward the cap so refusals cannot churn forever")
+    func unavailableRecoveryCountsTowardCap() {
+        let harness = Harness(cooldown: 0.5, maxAttempts: 2)
+        var requestCount = 0
+        harness.coordinator.recoveryRequest = { _ in
+            requestCount += 1
+            return .unavailable
+        }
+        harness.systemActive(seconds: 3)   // dispatch #1
+        harness.systemActive(seconds: 1)   // past cooldown: dispatch #2
+        harness.systemActive(seconds: 2)   // cap reached: no more
+
+        #expect(requestCount == 2)
+        #expect(harness.events.first?.recoveryAttempts == 0) // measured at episode start
+    }
+
+    @Test("transient recovery refusals are throttled by the cooldown, not per-snapshot")
+    func transientRefusalsRespectCooldown() {
+        // Simulates a handoff already pending: the recorder declines (false)
+        // while degradation continues. The coordinator must not re-dispatch
+        // per snapshot — the refusal keeps its back-pressure timestamp.
+        let harness = Harness() // default 15s cooldown
+        var requestCount = 0
+        harness.coordinator.recoveryRequest = { _ in
+            requestCount += 1
+            return .busy
+        }
+        harness.systemActive(seconds: 3)   // episode start: dispatch #1 at t=3
+        harness.systemActive(seconds: 10)  // t=3→13, all within cooldown
+        #expect(requestCount == 1)
+
+        harness.systemActive(seconds: 6)   // t=13→19: cooldown elapsed at t=18
+        #expect(requestCount == 2)
+    }
+
+    @Test("episode event callbacks may re-enter process without deadlock")
+    func episodeCallbackReentryDoesNotDeadlock() {
+        let harness = Harness()
+        var reentered = false
+        harness.coordinator.onEpisodeEvent = { [weak harness] event in
+            harness?.events.append(event)
+            guard let harness, !reentered else { return }
+            reentered = true
+            // Re-enter synchronously, as if a consumer fed a health snapshot back.
+            harness.micSignal()
+        }
+        harness.systemActive(seconds: 4) // must complete without deadlock
+        #expect(harness.events.contains { $0.kind == .degraded })
+    }
+
+    @Test("recovery request callback may re-enter process without deadlock")
+    func recoveryCallbackReentryDoesNotDeadlock() {
+        let harness = Harness()
+        harness.coordinator.recoveryRequest = { [weak harness] reason in
+            harness?.recoveryRequests.append(reason)
+            // Synchronous re-entry, as if a recovery drove an audio callback
+            // straight back into the coordinator.
+            harness?.micSignal()
+            return .initiated
+        }
+        harness.systemActive(seconds: 4)
+        #expect(!harness.recoveryRequests.isEmpty)
+    }
+}
+
+struct RecentMeetingIdentityGateTests {
+    @Test("authorized meetings pass until evicted past capacity")
+    func capacityEviction() {
+        var gate = RecentMeetingIdentityGate(capacity: 2)
+        gate.authorize(1)
+        gate.authorize(2)
+        #expect(gate.allows(1))
+        gate.authorize(3)
+        #expect(!gate.allows(1))
+        #expect(gate.allows(3))
+    }
+
+    @Test("a stopped meeting remains authorized alongside a newer stopped meeting")
+    func twoStoppedMeetingsStayAuthorized() {
+        var gate = RecentMeetingIdentityGate()
+        gate.authorize(10)
+        gate.authorize(11)
+        gate.authorize(12)
+        #expect(gate.allows(10))
+        #expect(gate.allows(11))
+        #expect(gate.allows(12))
+        #expect(!gate.allows(99))
+    }
+
+    @Test("re-authorizing an existing member does not evict")
+    func reauthorizationIsIdempotent() {
+        var gate = RecentMeetingIdentityGate(capacity: 2)
+        gate.authorize(1)
+        gate.authorize(2)
+        gate.authorize(1)
+        gate.authorize(3)
+        // Order is 1,2,3? No: re-authorize(1) is a no-op, so 1 is oldest and evicted.
+        #expect(!gate.allows(1))
+        #expect(gate.allows(2))
+        #expect(gate.allows(3))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/RouteAwareMeetingMicRecorderTests.swift
@@ -561,6 +561,145 @@ struct RouteAwareMeetingMicRecorderTests {
         #expect(!state.isRunning)
     }
 
+    @Test("health-triggered recovery hands off the same route and promotes on first buffer")
+    func healthTriggeredRecoveryPromotesOnFirstBuffer() async throws {
+        let degraded = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let replacement = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        var factoryCalls = 0
+        let recorder = RouteAwareMeetingMicRecorder(
+            systemDefaultRecorder: degraded,
+            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
+            systemDefaultRecorderFactory: {
+                factoryCalls += 1
+                return replacement
+            },
+            handoffTimeout: 1,
+            handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
+        )
+        var samples: [[Int16]] = []
+        recorder.onRawPCMSamples = { samples.append($0) }
+
+        try recorder.start()
+        #expect(recorder.requestSameRouteRecovery(reason: "system_audio_active_with_zero_mic") == .initiated)
+        try await waitUntil { replacement.startCalls == 1 }
+        #expect(factoryCalls == 1)
+
+        // No samples yet: the degraded graph remains active and un-retired.
+        #expect(degraded.stopCalls == 0)
+
+        replacement.onRawPCMSamples?([4, 5, 6])
+        try await waitUntil { samples == [[4, 5, 6]] }
+        #expect(degraded.stopCalls == 1)
+    }
+
+    @Test("health-triggered recovery is a no-op when not recording")
+    func healthRecoveryIgnoredWhenNotRunning() {
+        var factoryCalls = 0
+        let recorder = RouteAwareMeetingMicRecorder(
+            systemDefaultRecorder: FakeMeetingMicRecorder(kind: .systemDefaultStreaming),
+            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
+            systemDefaultRecorderFactory: {
+                factoryCalls += 1
+                return FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+            },
+            handoffTimeout: 1,
+            handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
+        )
+
+        #expect(recorder.requestSameRouteRecovery(reason: "system_audio_active_without_mic_callbacks") == .unavailable)
+        #expect(factoryCalls == 0)
+    }
+
+    @Test("a second health recovery request does not stack behind a pending handoff")
+    func healthRecoveryDoesNotStackPendingHandoffs() async throws {
+        let degraded = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        var factoryCalls = 0
+        let recorder = RouteAwareMeetingMicRecorder(
+            systemDefaultRecorder: degraded,
+            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
+            systemDefaultRecorderFactory: {
+                factoryCalls += 1
+                return FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+            },
+            handoffTimeout: 1,
+            handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
+        )
+
+        try recorder.start()
+        #expect(recorder.requestSameRouteRecovery(reason: "first") == .initiated)
+        #expect(recorder.requestSameRouteRecovery(reason: "second") == .busy)
+        try await waitUntil { factoryCalls == 1 }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(factoryCalls == 1)
+    }
+
+    @Test("handoff outcome reports promotion and candidate failure")
+    func handoffOutcomeReportsPromotionAndFailure() async throws {
+        let failingReplacement = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        failingReplacement.startError = NSError(domain: "test", code: 7)
+        let goodReplacement = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        var replacements = [failingReplacement, goodReplacement]
+        let initial = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let recorder = RouteAwareMeetingMicRecorder(
+            systemDefaultRecorder: initial,
+            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
+            systemDefaultRecorderFactory: { replacements.removeFirst() },
+            handoffTimeout: 1,
+            handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
+        )
+        var outcomes: [MeetingMicHandoffOutcome] = []
+        recorder.onHandoffOutcome = { outcomes.append($0) }
+
+        try recorder.start()
+        #expect(recorder.requestSameRouteRecovery(reason: "first attempt") == .initiated)
+        try await waitUntil { failingReplacement.cancelCalls == 1 }
+        try await waitUntil { outcomes == [.failed] }
+
+        #expect(recorder.requestSameRouteRecovery(reason: "second attempt") == .initiated)
+        try await waitUntil { goodReplacement.startCalls == 1 }
+        goodReplacement.onRawPCMSamples?([1, 2])
+        try await waitUntil { outcomes == [.failed, .promoted] }
+        try await waitUntil { initial.stopCalls == 1 }
+    }
+
+    @Test("stop while a recovery candidate is queued never starts the candidate")
+    func stopWithQueuedRecoveryNeverStartsCandidate() throws {
+        let prepareStarted = DispatchSemaphore(value: 0)
+        let allowPrepare = DispatchSemaphore(value: 0)
+        let initial = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        let candidate = FakeMeetingMicRecorder(kind: .systemDefaultStreaming)
+        candidate.onPrepareStarted = { prepareStarted.signal() }
+        candidate.prepareGate = allowPrepare
+        let recorder = RouteAwareMeetingMicRecorder(
+            systemDefaultRecorder: initial,
+            appScopedRecorder: FakeMeetingMicRecorder(kind: .appScopedAudioQueue),
+            systemDefaultRecorderFactory: { candidate },
+            handoffTimeout: 1,
+            handoffTimeoutScheduler: disabledMeetingMicHandoffTimeoutScheduler
+        )
+
+        try recorder.start()
+        #expect(recorder.requestSameRouteRecovery(reason: "queued then stopped") == .initiated)
+        #expect(prepareStarted.wait(timeout: .now() + 2) == .success)
+
+        // Tear down while the worker is blocked inside candidate.prepare().
+        _ = recorder.stop()
+
+        // Teardown must poison the candidate synchronously — before the worker
+        // is even released — so no interleaving can start capture afterwards.
+        #expect(candidate.invalidatedForTeardown)
+        allowPrepare.signal()
+
+        // The worker must not proceed to start() after teardown cleared the
+        // pending candidate — capture must never begin after meeting end.
+        let quiesced = DispatchSemaphore(value: 0)
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { quiesced.signal() }
+        #expect(quiesced.wait(timeout: .now() + 2) == .success)
+        #expect(candidate.startCalls == 0)
+        #expect(candidate.cancelCalls >= 1)
+    }
+
+
     private func waitUntil(
         timeout: Duration = .seconds(5),
         condition: @escaping () -> Bool
@@ -606,6 +745,7 @@ private final class FakeMeetingMicRecorder: MeetingMicRecording {
     var preferredInputDeviceID: AudioObjectID?
     var onRawPCMSamples: (([Int16]) -> Void)?
     var onRecordingFailed: ((Error) -> Void)?
+    var onHandoffOutcome: ((MeetingMicHandoffOutcome) -> Void)?
 
     let kind: MeetingMicRecorderKind
     var prepareCalls = 0
@@ -617,6 +757,9 @@ private final class FakeMeetingMicRecorder: MeetingMicRecording {
     var startError: Error?
     var onStart: (() -> Void)?
     var onCancel: (() -> Void)?
+    var onPrepareStarted: (() -> Void)?
+    var prepareGate: DispatchSemaphore?
+    var invalidatedForTeardown = false
 
     init(kind: MeetingMicRecorderKind) {
         self.kind = kind
@@ -624,9 +767,16 @@ private final class FakeMeetingMicRecorder: MeetingMicRecording {
 
     func prepare() throws {
         prepareCalls += 1
+        onPrepareStarted?()
+        prepareGate?.wait()
     }
 
     func start() throws {
+        if invalidatedForTeardown {
+            throw NSError(domain: "test", code: 9, userInfo: [
+                NSLocalizedDescriptionKey: "invalidated",
+            ])
+        }
         startCalls += 1
         onStart?()
         if let startError { throw startError }
@@ -648,6 +798,10 @@ private final class FakeMeetingMicRecorder: MeetingMicRecording {
     func cancel() {
         cancelCalls += 1
         onCancel?()
+    }
+
+    func invalidateForTeardown() {
+        invalidatedForTeardown = true
     }
 
     func currentPower() -> Float {


### PR DESCRIPTION
## Why

Production telemetry on 0.8.1 (analysis: `Context/handoff-2026-08-11-repeated-mic-failure-errors.md`): `meeting_microphone_capture_failed` is the dominant diagnostic error — 1,568 events / 92 users in 10 days, ~17.6% affected-user prevalence in the latest 24h window, power-law concentrated (top 5 users = 68%), macOS 26-skewed. Issue #381 is the canonical report: a Phone/WhatsApp call starts, the mic graph keeps "running" but delivers silence, and the user loses their side of the transcript.

Two compounding defects:
1. **Detection never connected to recovery.** `MeetingMicHealthTracker` confirms a dead mic graph, but `RouteAwareMeetingMicRecorder` only recovered on explicit recorder errors — and a semantically-dead graph never throws.
2. **Telemetry inflated and anonymized it.** Every warning flap emitted an error; three distinct internal reasons collapsed into one generic event.

## What changes

- **`MeetingMicRecoveryCoordinator`** (new): collapses health-state flapping into one episode per degradation. Recovery: immediate first attempt after the tracker's ~3s confirmation, 15s cooldown, max 3 attempts per episode. Episodes close as *recovered* only after **10s of sustained healthy delivery** — a healthy blip on a flapping route never resets the retry budget. Meeting end while degraded = `unrecovered` (terminal); healthy-but-unsustained at end = `recovered`.
- **`requestSameRouteRecovery(reason:)`** on `RouteAwareMeetingMicRecorder`: reuses the existing serialized handoff — the active recorder keeps capturing while a candidate prepares, and the candidate promotes only after producing a non-empty buffer. Returns `.initiated / .busy / .unavailable` so coordinator accounting separates back-pressure (refunded attempt, cooldown retained) from genuine unavailability (counts toward the cap).
- **Teardown safety** (recovery handoffs can be queued near meeting end — a new exposure): children are poisoned synchronously via `invalidateForTeardown()`, published on a dedicated lock independent of the startup critical section; a start blocked through teardown self-stops and discards before returning; handoff workers revalidate candidate identity + generation + lifecycle before prepare and before start. Capture can never begin or outlive meeting teardown.
- **User-mute classification**: at episode confirmation (once — never per sample), the capture device's input gain/mute state is read via HAL. Muted input (user intent — same all-zero signature as a broken route) suppresses the episode, spends zero recovery work, and emits `meeting.microphone.user_muted` once per meeting. Un-muting while still degraded opens the episode normally.
- **Telemetry**: `meeting.microphone.degraded / .recovered / .unrecovered` signals once per episode with episode id, reason, state, duration, flap count, attempts, handoff outcome (promoted/failed/timed_out), recovery attribution, recorder kind, coarse route category, device-resolution flag. The legacy `meeting_microphone_capture_failed` error now fires only for meetings that end unrecovered. A bounded `RecentMeetingIdentityGate` (8 IDs, FIFO) authorizes terminal callbacks for sessions whose identity moved on during stop/discard.

Privacy: episode fields are enums/counts/coarse categories only — no audio, device names, titles, or content. User-facing warning UI unchanged.

## Validation

- 25+ new tests: coordinator episode lifecycle (flaps, cooldown/cap, sustained-close, terminal-on-stop, quiet-room negative, mute classification, callback re-entry), recorder handoff outcomes, teardown-during-queued-recovery (candidate poisoned synchronously, never starts), identity-gate eviction.
- **Full suite: 1623/1623 green** on macOS 26.5.2. (Two unrelated timing flakes observed across runs — Diarizer preload coordination, PasteController clipboard simulation; both pass standalone and are untouched by this diff.)
- **Live validation on a dev lane (macOS 26.5.2)**: real meeting + muted input produced the expected sequence — degradation confirmed in ~3s, exactly 3 bounded recovery attempts at 15s intervals (no storm), healthy on unmute, episode closed recovered, no error emitted, transcript intact end-to-end.

## Design history note

This supersedes #396 (closed): same final code, squashed, with the hardening rationale above folded into the description. The review rounds there (Greptile 5/5 on the final iteration, plus Codex/CodeRabbit/Devin threads) hardened the teardown and accounting semantics documented above.

## Contribution Certification

- [x] I certify that this contribution is my original work and I have the right to submit it under the project's license.

## Third-Party Materials

None.

## AI Assistance

Developed with AI assistance (OpenAI Codex): design, implementation, tests, and review iteration. All CoreAudio lifecycle behavior was validated by direct local experiment on macOS 26.5.2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229728&installation_model_id=422865&pr_number=406&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F406&signature=7e43e92db8290724e7b4a00d95cafce1e3d106972d335ea274c412b7157e25bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic microphone health monitoring and recovery for degraded or interrupted meeting audio.
  * Added same-route recovery attempts with reporting for successful, failed, or timed-out microphone handoffs.
  * Added clearer handling and telemetry for muted or zero-gain microphone input.
  * Improved protection against recording activity restarting during meeting teardown.
  * Improved microphone diagnostics by grouping related issues into health episodes and reporting only unrecovered incidents.

* **Tests**
  * Added comprehensive coverage for recovery episodes, retries, handoffs, muting, teardown races, and meeting lifecycle events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->