### PR TITLE
Drain the buffer ring on stop; 512-frame dictation buffers

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -134,8 +134,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
             AudioQueueStop(queueToStop, false)
             // Bounded wait for the drain (3-buffer ring of 32ms buffers drains
             // in well under 100ms); bail out immediately if a successor
-            // start() took over the queue (generation bumped), and force-stop
-            // only while this capture still owns the queue.
+            // start() took over the queue (generation bumped).
             var waitedMs = 0
             while isQueueRunning(queueToStop), waitedMs < 500 {
                 let superseded = queueLock.withLock { captureGeneration != generationToFinish }
@@ -143,43 +142,55 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
                 usleep(10_000)
                 waitedMs += 10
             }
-            let ownsQueue = queueLock.withLock {
-                captureGeneration == generationToFinish && isDraining
-            }
+            // Force-stop a wedged drain only while this capture still owns
+            // the queue. start() holds queueLock across its entire setup
+            // (including AudioQueueStart), so checking + stopping under
+            // queueLock cannot interleave with a successor capture.
+            queueLock.lock()
+            let ownsQueue = captureGeneration == generationToFinish && isDraining
             if ownsQueue, isQueueRunning(queueToStop) {
                 AudioQueueStop(queueToStop, true)
+            }
+            if ownsQueue {
+                isDraining = false
+            }
+            queueLock.unlock()
+            guard ownsQueue else {
+                emitLatency("audio_queue_stop_end")
+                return nil
             }
             emitLatency("audio_queue_stop_end")
         }
 
-        queueLock.lock()
-        let stillOwner = captureGeneration == generationToFinish
-        if stillOwner {
-            isDraining = false
-        }
-        queueLock.unlock()
-        // A successor start() superseded this capture mid-drain: it owns the
-        // queue and has already replaced the file state, so there is nothing
-        // left to finalize for the abandoned capture.
-        guard stillOwner else { return nil }
-
+        // Drain the processing closures for this generation BEFORE the
+        // generation bump below — otherwise the drained tail buffers (the
+        // final word) would be dropped by the generation check.
         emitLatency("audio_queue_processing_drain_begin")
         processingQueue.sync {}
         emitLatency("audio_queue_processing_drain_end")
 
+        // Ownership re-check, generation bump, and file-state transfer are a
+        // single atomic section under queueLock: start() performs its own
+        // state install + generation bump under the same lock, so a successor
+        // either runs entirely before this section (check fails, we return
+        // nil and never touch its file) or entirely after (it sees the bumped
+        // generation and a fresh state).
         queueLock.lock()
-        if captureGeneration == generationToFinish {
-            captureGeneration &+= 1
+        guard captureGeneration == generationToFinish else {
+            queueLock.unlock()
+            return nil
         }
+        isDraining = false
         isPaused = false
-        queueLock.unlock()
-
-        emitLatency("audio_queue_finalize_begin")
+        captureGeneration &+= 1
         let finalState = stateLock.withLock { state -> FileState in
             let old = state
             state = FileState()
             return old
         }
+        queueLock.unlock()
+
+        emitLatency("audio_queue_finalize_begin")
         let url = finalizeFile(finalState)
         emitLatency("audio_queue_finalize_end")
         return url

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -133,21 +133,35 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
             emitLatency("audio_queue_stop_begin")
             AudioQueueStop(queueToStop, false)
             // Bounded wait for the drain (3-buffer ring of 32ms buffers drains
-            // in well under 100ms); force-stop if the queue ever wedges.
+            // in well under 100ms); bail out immediately if a successor
+            // start() took over the queue (generation bumped), and force-stop
+            // only while this capture still owns the queue.
             var waitedMs = 0
             while isQueueRunning(queueToStop), waitedMs < 500 {
+                let superseded = queueLock.withLock { captureGeneration != generationToFinish }
+                if superseded { break }
                 usleep(10_000)
                 waitedMs += 10
             }
-            if isQueueRunning(queueToStop) {
+            let ownsQueue = queueLock.withLock {
+                captureGeneration == generationToFinish && isDraining
+            }
+            if ownsQueue, isQueueRunning(queueToStop) {
                 AudioQueueStop(queueToStop, true)
             }
             emitLatency("audio_queue_stop_end")
         }
 
         queueLock.lock()
-        isDraining = false
+        let stillOwner = captureGeneration == generationToFinish
+        if stillOwner {
+            isDraining = false
+        }
         queueLock.unlock()
+        // A successor start() superseded this capture mid-drain: it owns the
+        // queue and has already replaced the file state, so there is nothing
+        // left to finalize for the abandoned capture.
+        guard stillOwner else { return nil }
 
         emitLatency("audio_queue_processing_drain_begin")
         processingQueue.sync {}
@@ -175,7 +189,10 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         var running: UInt32 = 0
         var size = UInt32(MemoryLayout<UInt32>.size)
         let status = AudioQueueGetProperty(queue, kAudioQueueProperty_IsRunning, &running, &size)
-        return status == noErr && running != 0
+        // Treat a query failure as "still running": the wait loop is bounded
+        // (500ms), and assuming stopped on failure would silently skip the
+        // drain that preserves the final word's tail.
+        return status != noErr || running != 0
     }
 
     func cancel() {

--- a/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AudioQueueInputRecorder.swift
@@ -10,7 +10,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     var preferredInputDeviceID: AudioObjectID?
 
     private static let sampleRate: Double = 16_000
-    private static let framesPerBuffer: UInt32 = 4096
+    private static let framesPerBuffer: UInt32 = 512
     private static let bufferCount = 3
 
     private let directoryName: String
@@ -29,6 +29,9 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
     private var preparedInputDeviceID: AudioObjectID?
     private var isPrepared = false
     private var isRunning = false
+    /// True while stop() drains the buffer ring: callbacks keep delivering the
+    /// final buffers (the tail word) but are not re-enqueued.
+    private var isDraining = false
     private var isPaused = false
     private var captureGeneration: UInt64 = 0
 
@@ -75,6 +78,7 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         let fileState = try createNewFile()
         stateLock.withLock { $0 = fileState }
         isPaused = false
+        isDraining = false
 
         for buffer in buffers {
             let status = AudioQueueEnqueueBuffer(audioQueue, buffer, 0, nil)
@@ -115,15 +119,35 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
             return nil
         }
         isRunning = false
+        // Graceful stop: AudioQueueStop(_, false) delivers the in-flight
+        // buffers (including the partially filled one holding the final word's
+        // tail) before the queue halts, instead of discarding them. The
+        // callback keeps accepting buffers while draining but does not
+        // re-enqueue, so the ring empties and the queue stops itself.
+        isDraining = true
         let generationToFinish = captureGeneration
         let queueToStop = audioQueue
         queueLock.unlock()
 
         if let queueToStop {
             emitLatency("audio_queue_stop_begin")
-            AudioQueueStop(queueToStop, true)
+            AudioQueueStop(queueToStop, false)
+            // Bounded wait for the drain (3-buffer ring of 32ms buffers drains
+            // in well under 100ms); force-stop if the queue ever wedges.
+            var waitedMs = 0
+            while isQueueRunning(queueToStop), waitedMs < 500 {
+                usleep(10_000)
+                waitedMs += 10
+            }
+            if isQueueRunning(queueToStop) {
+                AudioQueueStop(queueToStop, true)
+            }
             emitLatency("audio_queue_stop_end")
         }
+
+        queueLock.lock()
+        isDraining = false
+        queueLock.unlock()
 
         emitLatency("audio_queue_processing_drain_begin")
         processingQueue.sync {}
@@ -147,10 +171,18 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
         return url
     }
 
+    private func isQueueRunning(_ queue: AudioQueueRef) -> Bool {
+        var running: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioQueueGetProperty(queue, kAudioQueueProperty_IsRunning, &running, &size)
+        return status == noErr && running != 0
+    }
+
     func cancel() {
         queueLock.lock()
         isRunning = false
         isPaused = false
+        isDraining = false
         captureGeneration &+= 1
         let queueToDispose = audioQueue
         let callbackUserDataToRelease = queueCallbackUserData
@@ -322,22 +354,30 @@ final class AudioQueueInputRecorder: StreamingDictationRecording, StreamingDicta
 
     private func handleInputBuffer(queue: AudioQueueRef, buffer: AudioQueueBufferRef) {
         queueLock.lock()
-        let shouldProcess = isRunning
+        let shouldProcess = isRunning || isDraining
+        let draining = isDraining
         let generation = captureGeneration
         queueLock.unlock()
         guard shouldProcess else { return }
 
         let byteCount = Int(buffer.pointee.mAudioDataByteSize)
         guard byteCount > 0 else {
-            AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+            if !draining {
+                AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+            }
             return
         }
 
         let audioData = Data(bytes: buffer.pointee.mAudioData, count: byteCount)
-        let enqueueStatus = AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
-        if enqueueStatus != noErr {
-            reportFailure(Self.runtimeError(code: 8, message: "AudioQueueEnqueueBuffer failed: \(enqueueStatus)"))
-            return
+        // While draining, deliver but do not re-enqueue: the ring empties and
+        // the queue stops itself, carrying the final partial buffer (the tail
+        // of the user's last word) into the file first.
+        if !draining {
+            let enqueueStatus = AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+            if enqueueStatus != noErr {
+                reportFailure(Self.runtimeError(code: 8, message: "AudioQueueEnqueueBuffer failed: \(enqueueStatus)"))
+                return
+            }
         }
 
         processingQueue.async { [weak self] in


### PR DESCRIPTION
## Why

Two user-visible capture bugs, one mechanism — the 4096-frame (256ms) AudioQueue buffer plus an immediate stop:

1. **Tail-word truncation.** `stop()` called `AudioQueueStop(queue, true)`, which discards the in-flight partial buffer. Releasing the hotkey as the last word ended dropped up to 256ms of tail audio — observed in real transcripts (e.g. "jumps over the lazy." missing its final word) and reproduced live on dev lanes.
2. **First-buffer latency.** First audio surfaced ~247ms after `AudioQueueStart` — one full 256ms buffer period — on top of the ~73ms start, making the dictation UI feel a beat behind.

## What changes

- **Graceful stop with drain**: `stop()` now uses `AudioQueueStop(queue, false)`; the callback keeps accepting buffers while draining (without re-enqueueing), so the ring empties and the final partial buffer lands in the WAV. A bounded 500ms wait + force-stop guards a wedged drain. Measured cost: ~100ms added to an already-async stop. `cancel()` (failure paths) is unchanged — still immediate disposal.
- **512-frame buffers** (32ms cadence): first audio surfaces ~31ms after start (measured live on a headphone route), power metering and first-speech detection react proportionally sooner, and worst-case tail loss shrinks to ~32ms even if a drain ever misbehaves. Transcription accuracy is unaffected — the WAV content is identical; only delivery cadence changes.

## Validation

- Live on a dev lane (macOS 26.5.2, headphone route): hotkey-release-on-final-word dictations keep the last word; `first_buffer` at 31ms after `AudioQueueStart` (was ~247ms); stop drain ~104ms bounded.
- Full SwiftPM suite green locally; the only full-suite failures this week were the known timing flakes (PasteController, StreamingVadController, Diarizer preload), all passing standalone and untouched by this diff.

Note: buffer-level behavior isn't unit-testable without a live input device (TCC); validation was the lane run above. Happy to add a seam if reviewers want one.

## Contribution Certification

- [x] I certify that this contribution is my original work and I have the right to submit it under the project's license.

## Third-Party Materials

None.

## AI Assistance

Developed with AI assistance (OpenAI Codex). All latency/truncation claims were measured live on macOS 26.5.2 via the dictation latency telemetry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789326175&installation_model_id=422865&pr_number=417&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F417&signature=623570cc7b557f8a824222e4f7f52972c6d1a5e09078af183558cd6abfc0c34f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording shutdown to preserve trailing audio.
  * Added graceful draining of queued audio before stopping.
  * Reduced audio buffering to improve recording responsiveness.
  * Improved handling of empty buffers and recording state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->