### PR TITLE
Publish MuesliPreprod 0.8.2-preprod.1

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,6 +6,32 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
+            <title>0.8.2-preprod.1</title>
+            <pubDate>Sat, 15 Aug 2026 23:15:37 +0530</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.8.2-preprod.1</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.8.2-preprod.1.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>8002001</sparkle:version>
+            <sparkle:shortVersionString>0.8.2-preprod.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.1/MuesliPreprod-0.8.2-preprod.1.dmg" length="98286984" type="application/octet-stream" sparkle:edSignature="4ztiG5qcNscEGfVyg3HUUfHXyx6ZM7GS5z3gHbxxy126C+hRVwEer9pNHkXGoOhQg0NXoMgNSuw1qgvPk5L7Cw=="/>
+        </item>
+        <item>
             <title>0.8.1-preprod.1</title>
             <pubDate>Sat, 01 Aug 2026 12:06:08 +0530</pubDate>
             <description><![CDATA[
@@ -34,37 +60,11 @@
         <item>
             <title>0.8.0-preprod.2</title>
             <pubDate>Tue, 14 Jul 2026 13:36:16 -0700</pubDate>
-            <description><![CDATA[
-<h2>MuesliPreprod 0.8.0-preprod.2</h2>
-<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
-<h3>Install</h3>
-<ul>
-<li>Download <code>MuesliPreprod-0.8.0-preprod.2.dmg</code></li>
-<li>Open the DMG and drag MuesliPreprod to Applications</li>
-<li>Launch MuesliPreprod from Applications</li>
-</ul>
-<h3>Notes</h3>
-<ul>
-<li>Installs alongside production Muesli.</li>
-<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
-<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
-<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
-</ul>
-]]></description>
             <sparkle:version>8000002</sparkle:version>
             <sparkle:shortVersionString>0.8.0-preprod.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.0-preprod.2/MuesliPreprod-0.8.0-preprod.2.dmg" length="94561043" type="application/octet-stream" sparkle:edSignature="PEQFKQNfLcKGRnRDIl4mNSltifJVAH1BLOnpeP3vS9WkA71PbqWYpy6777FW49rH1GprVWMFpJedlQP7hyiICA=="/>
-        </item>
-        <item>
-            <title>0.8.0-preprod.1</title>
-            <pubDate>Tue, 14 Jul 2026 11:09:19 -0700</pubDate>
-            <sparkle:version>8000001</sparkle:version>
-            <sparkle:shortVersionString>0.8.0-preprod.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.0-preprod.1/MuesliPreprod-0.8.0-preprod.1.dmg" length="94557093" type="application/octet-stream" sparkle:edSignature="qiixTLEWcRXDNTLNaCeMsPf+z3YIWilnCltXhcf63jHsxj23Vej3BmKivO4lSwQSDo/T8X7gPgFvGGXxMBFSCw=="/>
         </item>
         <item>
             <title>0.7.0-preprod.1</title>

--- a/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/StreamingVadControllerTests.swift
@@ -132,6 +132,9 @@ struct StreamingVadControllerTests {
 
         let deadline = ContinuousClock.now + .seconds(3)
         while boundaryProbe.count < 1, ContinuousClock.now < deadline {
+            // The controller deliberately delivers boundaries on the main queue.
+            // Yield there so this non-main-actor test exercises that delivery.
+            await MainActor.run {}
             try? await Task.sleep(for: .milliseconds(20))
         }
         controller.stop()


### PR DESCRIPTION
## Preprod release
Publishes the signed Sparkle appcast entry for MuesliPreprod 0.8.2-preprod.1.
- GitHub prerelease: https://github.com/Muesli-HQ/muesli/releases/tag/v0.8.2-preprod.1
- App and DMG notarized and stapled by Apple
- Sparkle update-flow verification passed for build 8002001
- Full native suite passed: 1,674 tests across 155 suites

Also includes a test-only MainActor yield that removes a full-suite scheduling flake in the streaming VAD boundary test.

Stable appcast, production release, and Homebrew remain unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789408224&installation_model_id=422865&pr_number=418&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F418&signature=9df1d071afdbdd75967443594a1395f58b76f16ab8c1a8e467c7f33c4b34efdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Added the `0.8.2-preprod.1` update to the pre-production release feed with refreshed download and signature details.
  * Removed the obsolete `0.8.0-preprod.1` entry while retaining the previous pre-production release.

* **Tests**
  * Improved speech boundary test timing to reliably account for callbacks delivered on the main thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->