### PR TITLE
Add standard macOS window shortcuts

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppDelegate.swift
@@ -110,7 +110,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         controller?.showWhatsNew()
     }
 
+    @objc func showDictations(_ sender: Any?) {
+        controller?.openHistoryWindow(tab: .dictations)
+    }
+
+    @objc func showMeetings(_ sender: Any?) {
+        controller?.openHistoryWindow(tab: .meetings)
+    }
+
     private func installStandardEditMenu() {
+        let menus = standardMenus()
+        NSApp.windowsMenu = menus.windowMenu
+        NSApp.mainMenu = menus.mainMenu
+    }
+
+    func standardMenus() -> (mainMenu: NSMenu, windowMenu: NSMenu) {
         let mainMenu = NSMenu()
 
         let appMenuItem = NSMenuItem()
@@ -129,6 +143,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         whatsNewItem.target = self
         appMenu.addItem(whatsNewItem)
+        appMenu.addItem(.separator())
+        appMenu.addItem(
+            withTitle: "Hide \(AppIdentity.displayName)",
+            action: #selector(NSApplication.hide(_:)),
+            keyEquivalent: "h"
+        )
+        let hideOthersItem = NSMenuItem(
+            title: "Hide Others",
+            action: #selector(NSApplication.hideOtherApplications(_:)),
+            keyEquivalent: "h"
+        )
+        hideOthersItem.keyEquivalentModifierMask = [.command, .option]
+        appMenu.addItem(hideOthersItem)
+        appMenu.addItem(
+            withTitle: "Show All",
+            action: #selector(NSApplication.unhideAllApplications(_:)),
+            keyEquivalent: ""
+        )
         appMenu.addItem(.separator())
         appMenu.addItem(
             withTitle: "Quit \(AppIdentity.displayName)",
@@ -165,18 +197,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
 
-        let windowMenuItem = NSMenuItem()
+        let viewMenuItem = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
+        let viewMenu = NSMenu(title: "View")
+        let dictationsItem = NSMenuItem(
+            title: "Dictations",
+            action: #selector(AppDelegate.showDictations(_:)),
+            keyEquivalent: "1"
+        )
+        dictationsItem.target = self
+        viewMenu.addItem(dictationsItem)
+        let meetingsItem = NSMenuItem(
+            title: "Meetings",
+            action: #selector(AppDelegate.showMeetings(_:)),
+            keyEquivalent: "2"
+        )
+        meetingsItem.target = self
+        viewMenu.addItem(meetingsItem)
+        viewMenuItem.submenu = viewMenu
+        mainMenu.addItem(viewMenuItem)
+
+        let windowMenuItem = NSMenuItem(title: "Window", action: nil, keyEquivalent: "")
         let windowMenu = NSMenu(title: "Window")
+        windowMenu.addItem(
+            withTitle: "Minimize",
+            action: #selector(NSWindow.performMiniaturize(_:)),
+            keyEquivalent: "m"
+        )
+        windowMenu.addItem(
+            withTitle: "Zoom",
+            action: #selector(NSWindow.performZoom(_:)),
+            keyEquivalent: ""
+        )
+        windowMenu.addItem(.separator())
         windowMenu.addItem(
             withTitle: "Close Window",
             action: #selector(NSWindow.performClose(_:)),
             keyEquivalent: "w"
         )
+        windowMenu.addItem(.separator())
+        windowMenu.addItem(
+            withTitle: "Bring All to Front",
+            action: #selector(NSApplication.arrangeInFront(_:)),
+            keyEquivalent: ""
+        )
         windowMenuItem.submenu = windowMenu
         mainMenu.addItem(windowMenuItem)
-        NSApp.windowsMenu = windowMenu
-
-        NSApp.mainMenu = mainMenu
+        return (mainMenu, windowMenu)
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/StandardMenuShortcutTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/StandardMenuShortcutTests.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Standard app menu shortcuts")
+@MainActor
+struct StandardMenuShortcutTests {
+    @Test("Window menu configuration retains its direct submenu reference")
+    func windowMenuConfigurationRetainsDirectSubmenuReference() {
+        let menus = AppDelegate().standardMenus()
+        #expect(menus.mainMenu.items.contains { $0.submenu === menus.windowMenu })
+    }
+
+    @Test("app menu exposes standard hide commands")
+    func appMenuExposesStandardHideCommands() throws {
+        let appMenu = try requiredMenu(standardMainMenu().items.first?.submenu, message: "Missing app menu")
+
+        let hide = try requiredItem(appMenu.item(withTitle: "Hide \(AppIdentity.displayName)"), message: "Missing Hide command")
+        #expect(hide.action == #selector(NSApplication.hide(_:)))
+        #expect(hide.keyEquivalent == "h")
+        #expect(hide.keyEquivalentModifierMask == NSEvent.ModifierFlags.command)
+
+        let hideOthers = try requiredItem(appMenu.item(withTitle: "Hide Others"), message: "Missing Hide Others command")
+        #expect(hideOthers.action == #selector(NSApplication.hideOtherApplications(_:)))
+        #expect(hideOthers.keyEquivalent == "h")
+        #expect(hideOthers.keyEquivalentModifierMask == [.command, .option])
+
+        let showAll = try requiredItem(appMenu.item(withTitle: "Show All"), message: "Missing Show All command")
+        #expect(showAll.action == #selector(NSApplication.unhideAllApplications(_:)))
+    }
+
+    @Test("Window menu exposes standard window management commands")
+    func windowMenuExposesStandardWindowManagementCommands() throws {
+        let windowMenu = try requiredMenu(standardMainMenu().item(withTitle: "Window")?.submenu, message: "Missing Window menu")
+
+        let minimize = try requiredItem(windowMenu.item(withTitle: "Minimize"), message: "Missing Minimize command")
+        #expect(minimize.action == #selector(NSWindow.performMiniaturize(_:)))
+        #expect(minimize.keyEquivalent == "m")
+        #expect(minimize.keyEquivalentModifierMask == NSEvent.ModifierFlags.command)
+
+        let zoom = try requiredItem(windowMenu.item(withTitle: "Zoom"), message: "Missing Zoom command")
+        #expect(zoom.action == #selector(NSWindow.performZoom(_:)))
+
+        let close = try requiredItem(windowMenu.item(withTitle: "Close Window"), message: "Missing Close Window command")
+        #expect(close.action == #selector(NSWindow.performClose(_:)))
+        #expect(close.keyEquivalent == "w")
+        #expect(close.keyEquivalentModifierMask == NSEvent.ModifierFlags.command)
+
+        let bringAllToFront = try requiredItem(windowMenu.item(withTitle: "Bring All to Front"), message: "Missing Bring All to Front command")
+        #expect(bringAllToFront.action == #selector(NSApplication.arrangeInFront(_:)))
+    }
+
+    @Test("View menu exposes dashboard navigation shortcuts")
+    func viewMenuExposesDashboardNavigationShortcuts() throws {
+        let viewMenu = try requiredMenu(standardMainMenu().item(withTitle: "View")?.submenu, message: "Missing View menu")
+
+        let dictations = try requiredItem(viewMenu.item(withTitle: "Dictations"), message: "Missing Dictations command")
+        #expect(dictations.action == #selector(AppDelegate.showDictations(_:)))
+        #expect(dictations.keyEquivalent == "1")
+        #expect(dictations.keyEquivalentModifierMask == NSEvent.ModifierFlags.command)
+
+        let meetings = try requiredItem(viewMenu.item(withTitle: "Meetings"), message: "Missing Meetings command")
+        #expect(meetings.action == #selector(AppDelegate.showMeetings(_:)))
+        #expect(meetings.keyEquivalent == "2")
+        #expect(meetings.keyEquivalentModifierMask == NSEvent.ModifierFlags.command)
+    }
+
+    private func standardMainMenu() -> NSMenu {
+        AppDelegate().standardMenus().mainMenu
+    }
+
+    private func requiredMenu(_ menu: NSMenu?, message: String) throws -> NSMenu {
+        guard let menu else {
+            throw MenuTestError(message: message)
+        }
+        return menu
+    }
+
+    private func requiredItem(_ item: NSMenuItem?, message: String) throws -> NSMenuItem {
+        guard let item else {
+            throw MenuTestError(message: message)
+        }
+        return item
+    }
+}
+
+private struct MenuTestError: Error, CustomStringConvertible {
+    let message: String
+
+    var description: String { message }
+}

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -26,6 +26,7 @@ case "${shard}" in
       FloatingIndicatorVisibilityTests
       IndicatorFrameSizeTests
       OpenAILogoShapeTests
+      StandardMenuShortcutTests
       MeetingChunkCollectorTests
       AppConfigTests
       CGPointCodableTests


### PR DESCRIPTION
## Summary

- Add the standard macOS App menu hide commands: Hide, Hide Others, and Show All.
- Add Window menu actions for Minimize (Cmd-M), Zoom, and Bring All to Front, registering the Window submenu directly with AppKit.
- Add app-local View shortcuts: Cmd-1 opens Dictations and Cmd-2 opens Meetings. macOS users can override these menu commands through App Shortcuts without Muesli globally capturing them.
- Cover the menu contract and direct Window submenu wiring with focused tests.

## Validation

- swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/preprod (1,678 tests in 156 suites)
- ./scripts/run_ci_test_shard.sh core (330 tests in 20 suites)
- ./scripts/test_ci_test_shards.sh
- ./scripts/dev-test.sh --lane A (built, signed, installed, and launched /Applications/MuesliDevA.app before the final wiring-only change)

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid Signed-off-by trailer from its author under the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it under the [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client, institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and other assets introduced by this pull request, including their sources and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the resulting changes.

### Third-party materials

None.

### AI assistance

OpenAI Codex was used to implement and test the change; the maintainer reviewed the resulting patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the standard application menu with commands for hiding, showing, and managing windows.
  * Added clearer window actions, including minimize, zoom, close, and bring all windows to front.
  * Added View menu commands for accessing Dictations and Meetings.
  * Updated menu shortcuts and labels for a more consistent desktop experience.

* **Tests**
  * Added coverage to verify standard menu commands, titles, actions, and keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->