### PR TITLE
Add Apple SpeechAnalyzer transcription backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
     if: needs.changes.outputs.full_ci == 'true'
     runs-on: macos-15
     timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -100,6 +102,8 @@ jobs:
     if: needs.changes.outputs.full_ci == 'true'
     runs-on: macos-15
     timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +124,8 @@ jobs:
     if: needs.changes.outputs.full_ci == 'true'
     runs-on: macos-15
     timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,9 @@ jobs:
       - name: Run test shard
         run: bash ./scripts/run_ci_test_shard.sh "${{ matrix.shard }}"
 
-  # Exercise the runtime-supported Apple Speech catalogue path while the
-  # macOS 15 shards continue to verify the older-system fallback behavior.
+  # Compile and exercise Apple Speech on macOS 26. Hosted runners do not
+  # guarantee that SpeechTranscriber language assets are provisioned, so the
+  # catalogue's available/unavailable policy is covered deterministically.
   apple_speech_macos26:
     needs: changes
     if: needs.changes.outputs.full_ci == 'true'
@@ -127,15 +128,18 @@ jobs:
     timeout-minutes: 30
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
-      MUESLI_REQUIRE_APPLE_SPEECH_AVAILABLE: "1"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Test Apple Speech supported-system path
-        run: swift test --package-path native/MuesliNative --filter AppleSpeechAnalyzerBackendTests
+      - name: Test Apple Speech on macOS 26
+        run: |
+          swift test \
+            --package-path native/MuesliNative \
+            --scratch-path "${RUNNER_TEMP}/muesli-apple-speech-macos26" \
+            --filter AppleSpeechAnalyzerBackendTests
 
   # Packaged CLI smoke test — verify the app bundle contains muesli-cli
   cli-smoke:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,25 @@ jobs:
       - name: Run test shard
         run: bash ./scripts/run_ci_test_shard.sh "${{ matrix.shard }}"
 
+  # Exercise the runtime-supported Apple Speech catalogue path while the
+  # macOS 15 shards continue to verify the older-system fallback behavior.
+  apple_speech_macos26:
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      MUESLI_REQUIRE_APPLE_SPEECH_AVAILABLE: "1"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Test Apple Speech supported-system path
+        run: swift test --package-path native/MuesliNative --filter AppleSpeechAnalyzerBackendTests
+
   # Packaged CLI smoke test — verify the app bundle contains muesli-cli
   cli-smoke:
     needs: changes
@@ -165,7 +184,7 @@ jobs:
   # This is the only required check in branch protection
   ci-gate:
     if: always()
-    needs: [changes, classifier-tests, build_release, test_shards, cli-smoke, update-flow]
+    needs: [changes, classifier-tests, build_release, test_shards, apple_speech_macos26, cli-smoke, update-flow]
     runs-on: ubuntu-latest
     steps:
       - name: Check result
@@ -174,10 +193,11 @@ jobs:
              [[ "${{ needs.classifier-tests.result }}" == "success" ]] && \
              [[ "${{ needs.build_release.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.test_shards.result }}" =~ ^(success|skipped)$ ]] && \
+             [[ "${{ needs.apple_speech_macos26.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.cli-smoke.result }}" =~ ^(success|skipped)$ ]] && \
              [[ "${{ needs.update-flow.result }}" =~ ^(success|skipped)$ ]]; then
-            echo "CI passed (changes: ${{ needs.changes.result }}, classifier-tests: ${{ needs.classifier-tests.result }}, build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
+            echo "CI passed (changes: ${{ needs.changes.result }}, classifier-tests: ${{ needs.classifier-tests.result }}, build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, apple_speech_macos26: ${{ needs.apple_speech_macos26.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
           else
-            echo "CI failed (changes: ${{ needs.changes.result }}, classifier-tests: ${{ needs.classifier-tests.result }}, build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
+            echo "CI failed (changes: ${{ needs.changes.result }}, classifier-tests: ${{ needs.classifier-tests.result }}, build_release: ${{ needs.build_release.result }}, test_shards: ${{ needs.test_shards.result }}, apple_speech_macos26: ${{ needs.apple_speech_macos26.result }}, cli-smoke: ${{ needs.cli-smoke.result }}, update-flow: ${{ needs.update-flow.result }})"
             exit 1
           fi

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
@@ -1,0 +1,248 @@
+import AVFoundation
+import CoreMedia
+import Foundation
+import MuesliCore
+import Speech
+
+struct AppleSpeechTranscriptAccumulator: Sendable {
+    private(set) var text = ""
+    private(set) var segments: [SpeechSegment] = []
+
+    mutating func receive(text rawText: String, isFinal: Bool, start: Double, end: Double) {
+        guard isFinal else { return }
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        if !text.isEmpty {
+            text.append(" ")
+        }
+        text.append(trimmed)
+
+        let safeStart = start.isFinite ? max(0, start) : 0
+        let safeEnd = end.isFinite ? max(safeStart, end) : safeStart
+        segments.append(SpeechSegment(start: safeStart, end: safeEnd, text: trimmed))
+    }
+}
+
+enum AppleSpeechAnalyzerError: LocalizedError, Sendable {
+    case unavailable
+    case unsupportedLocale(String)
+    case assetUnavailable(String)
+    case reservationUnavailable(Int)
+    case emptyTranscript
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Apple Speech requires macOS 26 and compatible Apple hardware."
+        case .unsupportedLocale(let identifier):
+            return "Apple Speech does not support the \(identifier) locale on this Mac."
+        case .assetUnavailable(let identifier):
+            return "The Apple Speech model for \(identifier) is unavailable."
+        case .reservationUnavailable(let maximum):
+            return "Apple Speech cannot reserve another language on this Mac (limit: \(maximum))."
+        case .emptyTranscript:
+            return "Apple Speech completed without producing a transcript."
+        }
+    }
+}
+
+@available(macOS 26.0, *)
+actor AppleSpeechAnalyzerTranscriber {
+    static let modelID = "apple-speech-transcriber"
+
+    static var isSupportedOnCurrentSystem: Bool {
+        SpeechTranscriber.isAvailable
+    }
+
+    private var preparedLocale: Locale?
+
+    func prepare(
+        requestedLocale: Locale = .current,
+        progress: ((Double, String?) -> Void)? = nil,
+        progressSnapshot: ModelDownloadProgressHandler? = nil
+    ) async throws -> Locale {
+        guard SpeechTranscriber.isAvailable else {
+            throw AppleSpeechAnalyzerError.unavailable
+        }
+
+        let locale = try await resolveLocale(requestedLocale)
+        let transcriber = makeTranscriber(locale: locale)
+        let status = await AssetInventory.status(forModules: [transcriber])
+
+        if preparedLocale == locale, status == .installed {
+            progress?(1, "Apple Speech ready")
+            progressSnapshot?(readySnapshot())
+            return locale
+        }
+
+        progress?(0.05, "Preparing Apple Speech for \(locale.localizedString(forIdentifier: locale.identifier) ?? locale.identifier)...")
+        progressSnapshot?(ModelDownloadProgress.preparing(
+            modelID: Self.modelID,
+            message: "Preparing Apple Speech..."
+        ))
+
+        try await reserve(locale: locale)
+        try Task.checkCancellation()
+
+        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+            let progressBox = AppleSpeechProgressBox(request.progress)
+            let progressTask = Task { [progress, progressSnapshot] in
+                while !Task.isCancelled && !progressBox.progress.isFinished {
+                    let fraction = min(max(progressBox.progress.fractionCompleted, 0), 1)
+                    let mappedFraction = 0.1 + (fraction * 0.8)
+                    progress?(mappedFraction, "Downloading Apple Speech...")
+                    progressSnapshot?(downloadSnapshot(fraction: fraction))
+                    try? await Task.sleep(for: .milliseconds(200))
+                }
+            }
+            defer { progressTask.cancel() }
+
+            try await withTaskCancellationHandler {
+                try await request.downloadAndInstall()
+            } onCancel: {
+                progressBox.progress.cancel()
+            }
+        }
+
+        try Task.checkCancellation()
+        guard await AssetInventory.status(forModules: [transcriber]) == .installed else {
+            throw AppleSpeechAnalyzerError.assetUnavailable(locale.identifier(.bcp47))
+        }
+
+        preparedLocale = locale
+        progress?(1, "Apple Speech ready")
+        progressSnapshot?(readySnapshot())
+        fputs("[muesli-native] Apple Speech ready for \(locale.identifier(.bcp47))\n", stderr)
+        return locale
+    }
+
+    func transcribe(wavURL: URL, requestedLocale: Locale = .current) async throws -> SpeechTranscriptionResult {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        let locale = try await prepare(requestedLocale: requestedLocale)
+        let transcriber = makeTranscriber(locale: locale)
+        let analyzer = SpeechAnalyzer(
+            modules: [transcriber],
+            options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering)
+        )
+        let audioFile = try AVAudioFile(forReading: wavURL)
+
+        async let collected = collectResults(from: transcriber)
+        if let lastSample = try await analyzer.analyzeSequence(from: audioFile) {
+            try await analyzer.finalizeAndFinish(through: lastSample)
+        } else {
+            await analyzer.cancelAndFinishNow()
+        }
+
+        let result = try await collected
+        guard !result.text.isEmpty else {
+            throw AppleSpeechAnalyzerError.emptyTranscript
+        }
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - startedAt
+        let elapsedText = String(format: "%.3f", elapsed)
+        fputs(
+            "[muesli-native] Apple Speech result: \(result.text.prefix(80)) (locale \(locale.identifier(.bcp47)), took \(elapsedText)s)\n",
+            stderr
+        )
+        return result
+    }
+
+    private func resolveLocale(_ requestedLocale: Locale) async throws -> Locale {
+        if let locale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) {
+            return locale
+        }
+
+        let languageCode = requestedLocale.language.languageCode?.identifier
+        if let languageCode,
+           let languageLocale = await SpeechTranscriber.supportedLocale(
+               equivalentTo: Locale(identifier: languageCode)
+           ) {
+            return languageLocale
+        }
+
+        if let english = await SpeechTranscriber.supportedLocale(
+            equivalentTo: Locale(identifier: "en-US")
+        ) {
+            fputs(
+                "[muesli-native] Apple Speech locale \(requestedLocale.identifier(.bcp47)) unavailable; using \(english.identifier(.bcp47))\n",
+                stderr
+            )
+            return english
+        }
+
+        guard let firstSupported = await SpeechTranscriber.supportedLocales.first else {
+            throw AppleSpeechAnalyzerError.unsupportedLocale(requestedLocale.identifier(.bcp47))
+        }
+        return firstSupported
+    }
+
+    private func reserve(locale: Locale) async throws {
+        let reserved = await AssetInventory.reservedLocales
+        if reserved.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+            return
+        }
+
+        guard reserved.count < max(1, AssetInventory.maximumReservedLocales),
+              try await AssetInventory.reserve(locale: locale) else {
+            throw AppleSpeechAnalyzerError.reservationUnavailable(AssetInventory.maximumReservedLocales)
+        }
+    }
+
+    private func makeTranscriber(locale: Locale) -> SpeechTranscriber {
+        SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [],
+            attributeOptions: [.audioTimeRange]
+        )
+    }
+
+    private func collectResults(from transcriber: SpeechTranscriber) async throws -> SpeechTranscriptionResult {
+        var accumulator = AppleSpeechTranscriptAccumulator()
+        for try await result in transcriber.results {
+            let start = CMTimeGetSeconds(result.range.start)
+            let end = CMTimeGetSeconds(CMTimeRangeGetEnd(result.range))
+            accumulator.receive(
+                text: String(result.text.characters),
+                isFinal: result.isFinal,
+                start: start,
+                end: end
+            )
+        }
+        return SpeechTranscriptionResult(text: accumulator.text, segments: accumulator.segments)
+    }
+
+    private func downloadSnapshot(fraction: Double) -> ModelDownloadProgress {
+        let total: Int64 = 10_000
+        return ModelDownloadProgress(
+            modelID: Self.modelID,
+            phase: .downloading,
+            currentFile: nil,
+            completedBytes: Int64(Double(total) * fraction),
+            totalBytes: total,
+            currentFileCompletedBytes: 0,
+            currentFileTotalBytes: nil,
+            bytesPerSecond: 0,
+            estimatedSecondsRemaining: nil,
+            retryCount: 0,
+            message: "Downloading Apple Speech..."
+        )
+    }
+
+    private func readySnapshot() -> ModelDownloadProgress {
+        ModelDownloadProgress.preparing(
+            modelID: Self.modelID,
+            message: "Apple Speech ready"
+        ).replacing(phase: .ready, message: "Apple Speech ready")
+    }
+}
+
+@available(macOS 26.0, *)
+private final class AppleSpeechProgressBox: @unchecked Sendable {
+    let progress: Progress
+
+    init(_ progress: Progress) {
+        self.progress = progress
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppleSpeechAnalyzerBackend.swift
@@ -5,22 +5,82 @@ import MuesliCore
 import Speech
 
 struct AppleSpeechTranscriptAccumulator: Sendable {
-    private(set) var text = ""
+    private var accumulatedText = ""
     private(set) var segments: [SpeechSegment] = []
+
+    var text: String {
+        accumulatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     mutating func receive(text rawText: String, isFinal: Bool, start: Double, end: Double) {
         guard isFinal else { return }
         let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        if !text.isEmpty {
-            text.append(" ")
-        }
-        text.append(trimmed)
+        accumulatedText.append(rawText)
 
         let safeStart = start.isFinite ? max(0, start) : 0
         let safeEnd = end.isFinite ? max(safeStart, end) : safeStart
         segments.append(SpeechSegment(start: safeStart, end: safeEnd, text: trimmed))
+    }
+}
+
+struct AppleSpeechLocaleResolver: Sendable {
+    let supportedLocale: @Sendable (Locale) async -> Locale?
+
+    func resolve(_ requestedLocale: Locale) async throws -> Locale {
+        if let locale = await supportedLocale(requestedLocale) {
+            return locale
+        }
+
+        if let languageCode = requestedLocale.language.languageCode?.identifier,
+           let languageLocale = await supportedLocale(Locale(identifier: languageCode)) {
+            return languageLocale
+        }
+
+        throw AppleSpeechAnalyzerError.unsupportedLocale(requestedLocale.identifier(.bcp47))
+    }
+}
+
+actor AppleSpeechPreparationTaskCache {
+    private var tasks: [String: Task<Locale, Error>] = [:]
+
+    func value(
+        for localeIdentifier: String,
+        operation: @escaping @Sendable () async throws -> Locale
+    ) async throws -> Locale {
+        if let task = tasks[localeIdentifier] {
+            return try await task.value
+        }
+
+        let task = Task { try await operation() }
+        tasks[localeIdentifier] = task
+        do {
+            let locale = try await task.value
+            tasks.removeValue(forKey: localeIdentifier)
+            return locale
+        } catch {
+            tasks.removeValue(forKey: localeIdentifier)
+            throw error
+        }
+    }
+}
+
+struct AppleSpeechReservationOwnership: Sendable {
+    private var localesByIdentifier: [String: Locale] = [:]
+
+    mutating func record(_ locale: Locale) {
+        localesByIdentifier[locale.identifier(.bcp47)] = locale
+    }
+
+    mutating func remove(_ locale: Locale) {
+        localesByIdentifier.removeValue(forKey: locale.identifier(.bcp47))
+    }
+
+    func locales(excluding identifier: String? = nil) -> [Locale] {
+        localesByIdentifier.compactMap { key, locale in
+            key == identifier ? nil : locale
+        }
     }
 }
 
@@ -48,6 +108,13 @@ enum AppleSpeechAnalyzerError: LocalizedError, Sendable {
 }
 
 @available(macOS 26.0, *)
+extension AppleSpeechLocaleResolver {
+    static let live = AppleSpeechLocaleResolver { locale in
+        await SpeechTranscriber.supportedLocale(equivalentTo: locale)
+    }
+}
+
+@available(macOS 26.0, *)
 actor AppleSpeechAnalyzerTranscriber {
     static let modelID = "apple-speech-transcriber"
 
@@ -55,7 +122,14 @@ actor AppleSpeechAnalyzerTranscriber {
         SpeechTranscriber.isAvailable
     }
 
+    private let localeResolver: AppleSpeechLocaleResolver
+    private let preparationTasks = AppleSpeechPreparationTaskCache()
+    private var reservationOwnership = AppleSpeechReservationOwnership()
     private var preparedLocale: Locale?
+
+    init(localeResolver: AppleSpeechLocaleResolver = .live) {
+        self.localeResolver = localeResolver
+    }
 
     func prepare(
         requestedLocale: Locale = .current,
@@ -66,18 +140,34 @@ actor AppleSpeechAnalyzerTranscriber {
             throw AppleSpeechAnalyzerError.unavailable
         }
 
-        let locale = try await resolveLocale(requestedLocale)
+        let locale = try await localeResolver.resolve(requestedLocale)
+        let callbacks = AppleSpeechPreparationCallbacks(
+            progress: progress,
+            progressSnapshot: progressSnapshot
+        )
+        let prepared = try await preparationTasks.value(
+            for: locale.identifier(.bcp47)
+        ) { [self, callbacks] in
+            try await performPrepare(locale: locale, callbacks: callbacks)
+        }
+        callbacks.progress?(1, "Apple Speech ready")
+        callbacks.progressSnapshot?(readySnapshot())
+        return prepared
+    }
+
+    private func performPrepare(
+        locale: Locale,
+        callbacks: AppleSpeechPreparationCallbacks
+    ) async throws -> Locale {
         let transcriber = makeTranscriber(locale: locale)
         let status = await AssetInventory.status(forModules: [transcriber])
 
         if preparedLocale == locale, status == .installed {
-            progress?(1, "Apple Speech ready")
-            progressSnapshot?(readySnapshot())
             return locale
         }
 
-        progress?(0.05, "Preparing Apple Speech for \(locale.localizedString(forIdentifier: locale.identifier) ?? locale.identifier)...")
-        progressSnapshot?(ModelDownloadProgress.preparing(
+        callbacks.progress?(0.05, "Preparing Apple Speech for \(locale.localizedString(forIdentifier: locale.identifier) ?? locale.identifier)...")
+        callbacks.progressSnapshot?(ModelDownloadProgress.preparing(
             modelID: Self.modelID,
             message: "Preparing Apple Speech..."
         ))
@@ -87,12 +177,12 @@ actor AppleSpeechAnalyzerTranscriber {
 
         if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
             let progressBox = AppleSpeechProgressBox(request.progress)
-            let progressTask = Task { [progress, progressSnapshot] in
+            let progressTask = Task { [callbacks] in
                 while !Task.isCancelled && !progressBox.progress.isFinished {
                     let fraction = min(max(progressBox.progress.fractionCompleted, 0), 1)
                     let mappedFraction = 0.1 + (fraction * 0.8)
-                    progress?(mappedFraction, "Downloading Apple Speech...")
-                    progressSnapshot?(downloadSnapshot(fraction: fraction))
+                    callbacks.progress?(mappedFraction, "Downloading Apple Speech...")
+                    callbacks.progressSnapshot?(downloadSnapshot(fraction: fraction))
                     try? await Task.sleep(for: .milliseconds(200))
                 }
             }
@@ -111,10 +201,13 @@ actor AppleSpeechAnalyzerTranscriber {
         }
 
         preparedLocale = locale
-        progress?(1, "Apple Speech ready")
-        progressSnapshot?(readySnapshot())
         fputs("[muesli-native] Apple Speech ready for \(locale.identifier(.bcp47))\n", stderr)
         return locale
+    }
+
+    func releaseReservations() async {
+        await releaseOwnedReservations()
+        preparedLocale = nil
     }
 
     func transcribe(wavURL: URL, requestedLocale: Locale = .current) async throws -> SpeechTranscriptionResult {
@@ -142,50 +235,33 @@ actor AppleSpeechAnalyzerTranscriber {
         let elapsed = CFAbsoluteTimeGetCurrent() - startedAt
         let elapsedText = String(format: "%.3f", elapsed)
         fputs(
-            "[muesli-native] Apple Speech result: \(result.text.prefix(80)) (locale \(locale.identifier(.bcp47)), took \(elapsedText)s)\n",
+            "[muesli-native] Apple Speech completed \(result.text.count) characters in \(elapsedText)s (locale \(locale.identifier(.bcp47)))\n",
             stderr
         )
         return result
     }
 
-    private func resolveLocale(_ requestedLocale: Locale) async throws -> Locale {
-        if let locale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) {
-            return locale
-        }
-
-        let languageCode = requestedLocale.language.languageCode?.identifier
-        if let languageCode,
-           let languageLocale = await SpeechTranscriber.supportedLocale(
-               equivalentTo: Locale(identifier: languageCode)
-           ) {
-            return languageLocale
-        }
-
-        if let english = await SpeechTranscriber.supportedLocale(
-            equivalentTo: Locale(identifier: "en-US")
-        ) {
-            fputs(
-                "[muesli-native] Apple Speech locale \(requestedLocale.identifier(.bcp47)) unavailable; using \(english.identifier(.bcp47))\n",
-                stderr
-            )
-            return english
-        }
-
-        guard let firstSupported = await SpeechTranscriber.supportedLocales.first else {
-            throw AppleSpeechAnalyzerError.unsupportedLocale(requestedLocale.identifier(.bcp47))
-        }
-        return firstSupported
-    }
-
     private func reserve(locale: Locale) async throws {
+        let localeIdentifier = locale.identifier(.bcp47)
+        await releaseOwnedReservations(except: localeIdentifier)
+
         let reserved = await AssetInventory.reservedLocales
-        if reserved.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+        if reserved.contains(where: { $0.identifier(.bcp47) == localeIdentifier }) {
             return
         }
 
-        guard reserved.count < max(1, AssetInventory.maximumReservedLocales),
+        guard reserved.count < AssetInventory.maximumReservedLocales,
               try await AssetInventory.reserve(locale: locale) else {
             throw AppleSpeechAnalyzerError.reservationUnavailable(AssetInventory.maximumReservedLocales)
+        }
+        reservationOwnership.record(locale)
+    }
+
+    private func releaseOwnedReservations(except localeIdentifier: String? = nil) async {
+        for locale in reservationOwnership.locales(excluding: localeIdentifier) {
+            if await AssetInventory.release(reservedLocale: locale) {
+                reservationOwnership.remove(locale)
+            }
         }
     }
 
@@ -194,7 +270,7 @@ actor AppleSpeechAnalyzerTranscriber {
             locale: locale,
             transcriptionOptions: [],
             reportingOptions: [],
-            attributeOptions: [.audioTimeRange]
+            attributeOptions: []
         )
     }
 
@@ -244,5 +320,18 @@ private final class AppleSpeechProgressBox: @unchecked Sendable {
 
     init(_ progress: Progress) {
         self.progress = progress
+    }
+}
+
+private final class AppleSpeechPreparationCallbacks: @unchecked Sendable {
+    let progress: ((Double, String?) -> Void)?
+    let progressSnapshot: ModelDownloadProgressHandler?
+
+    init(
+        progress: ((Double, String?) -> Void)?,
+        progressSnapshot: ModelDownloadProgressHandler?
+    ) {
+        self.progress = progress
+        self.progressSnapshot = progressSnapshot
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -3,6 +3,13 @@ import Foundation
 import MuesliCore
 
 struct BackendOption: Equatable {
+    struct Catalog {
+        let systemManaged: [BackendOption]
+        let all: [BackendOption]
+        let onboardingDefault: BackendOption
+        let onboarding: [BackendOption]
+    }
+
     let backend: String
     let model: String
     let label: String
@@ -158,13 +165,6 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
-    static let systemManaged: [BackendOption] = {
-        if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
-            return [.appleSpeechAnalyzer]
-        }
-        return []
-    }()
-
     static let experimental: [BackendOption] = [
         .senseVoiceSmall, .indicASR, .gemma4E2BLiteRT,
     ]
@@ -176,34 +176,56 @@ struct BackendOption: Equatable {
         .nemotron35Multilingual,
     ]
 
-    /// Models available for download and use.
-    static let all: [BackendOption] = {
-        systemManaged
+    static func catalog(appleSpeechAvailable: Bool) -> Catalog {
+        let systemManaged: [BackendOption] = appleSpeechAvailable ? [.appleSpeechAnalyzer] : []
+        let all = systemManaged
             + parakeetFamily
             + [.qwen3Asr]
             + whisperFamily
             + [.cohereTranscribe]
             + streaming
             + experimental
+        let onboardingDefault = systemManaged.first ?? .parakeetMultilingual
+        let onboardingCandidates: [BackendOption] = [
+            onboardingDefault,
+            .parakeetMultilingual,
+            .whisperTiny,
+            .whisperSmall,
+            .cohereTranscribe,
+            .nemotron35Multilingual,
+        ]
+        let onboarding = onboardingCandidates.reduce(into: [BackendOption]()) { options, option in
+            if !options.contains(option) {
+                options.append(option)
+            }
+        }
+
+        return Catalog(
+            systemManaged: systemManaged,
+            all: all,
+            onboardingDefault: onboardingDefault,
+            onboarding: onboarding
+        )
+    }
+
+    private static let currentCatalog: Catalog = {
+        if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
+            return catalog(appleSpeechAvailable: true)
+        }
+        return catalog(appleSpeechAvailable: false)
     }()
+
+    static let systemManaged = currentCatalog.systemManaged
+
+    /// Models available for download and use.
+    static let all = currentCatalog.all
 
     /// The first-run default uses the system-managed backend when the OS exposes it.
     /// Parakeet remains the deterministic fallback for older or unsupported Macs.
-    static let onboardingDefault: BackendOption = systemManaged.first ?? .parakeetMultilingual
+    static let onboardingDefault = currentCatalog.onboardingDefault
 
     /// Curated first-run choices. Experimental models are excluded by default.
-    static let onboarding: [BackendOption] = [
-        onboardingDefault,
-        .parakeetMultilingual,
-        .whisperTiny,
-        .whisperSmall,
-        .cohereTranscribe,
-        .nemotron35Multilingual,
-    ].reduce(into: []) { options, option in
-        if !options.contains(option) {
-            options.append(option)
-        }
-    }
+    static let onboarding = currentCatalog.onboarding
 
     /// Models coming soon — shown greyed out in the Models tab.
     static let comingSoon: [BackendOption] = []

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -127,6 +127,15 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
+    static let appleSpeechAnalyzer = BackendOption(
+        backend: "apple-speech",
+        model: "apple-speech-transcriber",
+        label: "Apple Speech",
+        sizeLabel: "System managed",
+        description: "Apple's private, on-device speech model for macOS 26. It is designed for dictation, meetings, distant speakers, and long recordings, while macOS manages the language assets and updates.",
+        recommended: false
+    )
+
     // Default alias
     static let whisper = parakeetMultilingual
 
@@ -149,6 +158,13 @@ struct BackendOption: Equatable {
         recommended: false
     )
 
+    static let systemManaged: [BackendOption] = {
+        if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
+            return [.appleSpeechAnalyzer]
+        }
+        return []
+    }()
+
     static let experimental: [BackendOption] = [
         .senseVoiceSmall, .indicASR, .gemma4E2BLiteRT,
     ]
@@ -162,7 +178,8 @@ struct BackendOption: Equatable {
 
     /// Models available for download and use.
     static let all: [BackendOption] = {
-        parakeetFamily
+        systemManaged
+            + parakeetFamily
             + [.qwen3Asr]
             + whisperFamily
             + [.cohereTranscribe]
@@ -170,10 +187,23 @@ struct BackendOption: Equatable {
             + experimental
     }()
 
-    /// Curated first-run choices shown in onboarding's "Other models" section.
-    /// This is a deliberate hand-picked list, not a derived rule. Experimental models
-    /// are excluded by default.
-    static let onboarding: [BackendOption] = [.parakeetMultilingual, .whisperTiny, .whisperSmall, .cohereTranscribe, .nemotron35Multilingual]
+    /// The first-run default uses the system-managed backend when the OS exposes it.
+    /// Parakeet remains the deterministic fallback for older or unsupported Macs.
+    static let onboardingDefault: BackendOption = systemManaged.first ?? .parakeetMultilingual
+
+    /// Curated first-run choices. Experimental models are excluded by default.
+    static let onboarding: [BackendOption] = [
+        onboardingDefault,
+        .parakeetMultilingual,
+        .whisperTiny,
+        .whisperSmall,
+        .cohereTranscribe,
+        .nemotron35Multilingual,
+    ].reduce(into: []) { options, option in
+        if !options.contains(option) {
+            options.append(option)
+        }
+    }
 
     /// Models coming soon — shown greyed out in the Models tab.
     static let comingSoon: [BackendOption] = []
@@ -200,6 +230,10 @@ struct BackendOption: Equatable {
 
     var supportsMeetingTranscription: Bool {
         !isStreamingDictationBackend
+    }
+
+    var isSystemManaged: Bool {
+        backend == "apple-speech"
     }
 
     /// Multilingual WhisperKit models expose language selection (auto-detect or pinned code).
@@ -247,6 +281,11 @@ struct BackendOption: Equatable {
             return SenseVoiceTranscriber.isModelDownloaded(fileManager: fm)
         case "gemma4-litert":
             return Gemma4LiteRTModelStore.isAvailableLocally()
+        case "apple-speech":
+            if #available(macOS 26.0, *) {
+                return AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem
+            }
+            return false
         default:
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -168,6 +168,14 @@ struct ModelsView: View {
     private var selectedCategoryContent: some View {
         switch appState.selectedModelsCategory {
         case .dictation:
+            ForEach(BackendOption.systemManaged, id: \.model) { option in
+                modelCard(
+                    option: option,
+                    logo: logoForBackend(option),
+                    downloadedLabel: "Available"
+                )
+            }
+
             familyCard(
                 title: "Parakeet Family",
                 subtitle: "The most responsive choices for everyday dictation, with multilingual and English-only options.",
@@ -951,7 +959,13 @@ struct ModelsView: View {
 
     @ViewBuilder
     private func brandLogo(_ name: String?) -> some View {
-        if let name,
+        if name == "apple-system-logo" {
+            Image(systemName: "apple.logo")
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .frame(width: 24, height: 24)
+                .padding(.top, 2)
+        } else if let name,
            let url = Bundle.main.url(forResource: name, withExtension: "png")
                 ?? Bundle.main.url(forResource: name, withExtension: "svg"),
            let nsImage = NSImage(contentsOf: url) {
@@ -974,6 +988,7 @@ struct ModelsView: View {
         case "indicasr": return "ai4bharat-logo"
         case "sensevoice": return "qwen-logo"
         case "gemma4-litert": return "google-logo"
+        case "apple-speech": return "apple-system-logo"
         default: return nil
         }
     }
@@ -1020,15 +1035,17 @@ struct ModelsView: View {
                     .help(activationDisabledReason ?? actionTitle)
                 }
 
-                Button {
-                    modelToDelete = option
-                } label: {
-                    Image(systemName: "trash")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.red.opacity(0.6))
-                        .frame(width: 20, height: 20)
+                if !option.isSystemManaged {
+                    Button {
+                        modelToDelete = option
+                    } label: {
+                        Image(systemName: "trash")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.red.opacity(0.6))
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             } else {
                 Button("Download") {
                     startDownload(option)
@@ -1761,6 +1778,11 @@ struct ModelsView: View {
             return SenseVoiceTranscriber.isModelDownloaded(fileManager: fm)
         case "gemma4-litert":
             return Gemma4LiteRTModelStore.isAvailableLocally(fileManager: fm)
+        case "apple-speech":
+            if #available(macOS 26.0, *) {
+                return AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem
+            }
+            return false
         default:
             return false
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1297,6 +1297,8 @@ final class MuesliController: NSObject {
 
     func updateConfig(_ mutate: (inout AppConfig) -> Void) {
         let wasICloudSyncEnabled = config.iCloudSyncEnabled
+        let wasUsingAppleSpeech = selectedBackend.backend == "apple-speech"
+            || selectedMeetingTranscriptionBackend.backend == "apple-speech"
         let previousMeetingInputDeviceUID = config.meetingInputDeviceUID
         let previousHotkeyTriggerThresholdMS = config.hotkeyTriggerThresholdMS
         let previousComputerUseHotkeyTriggerThresholdMS = config.computerUseHotkeyTriggerThresholdMS
@@ -1346,6 +1348,13 @@ final class MuesliController: NSObject {
             config.meetingTranscriptionModel != selectedMeetingTranscriptionBackend.model {
             config.meetingTranscriptionBackend = selectedMeetingTranscriptionBackend.backend
             config.meetingTranscriptionModel = selectedMeetingTranscriptionBackend.model
+        }
+        let isUsingAppleSpeech = selectedBackend.backend == "apple-speech"
+            || selectedMeetingTranscriptionBackend.backend == "apple-speech"
+        if wasUsingAppleSpeech && !isUsingAppleSpeech {
+            Task { [weak self] in
+                await self?.transcriptionCoordinator.unloadAppleSpeechTranscriber()
+            }
         }
         configStore.save(config)
         selectedMeetingSummaryBackend = MeetingSummaryBackendOption.all.first(where: {

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingView.swift
@@ -77,13 +77,20 @@ struct OnboardingView: View {
     }
 
     private var onboardingAlternativeModels: [BackendOption] {
-        var options = BackendOption.onboarding.filter { $0 != .parakeetMultilingual }
+        var options = BackendOption.onboarding.filter { $0 != BackendOption.onboardingDefault }
         if BackendOption.onboarding.contains(selectedBackend),
-           selectedBackend != .parakeetMultilingual,
+           selectedBackend != BackendOption.onboardingDefault,
            !options.contains(selectedBackend) {
             options.insert(selectedBackend, at: 0)
         }
         return options
+    }
+
+    private var onboardingModelDescription: String {
+        if BackendOption.onboardingDefault == .appleSpeechAnalyzer {
+            return "Use Apple Speech, or choose another local model to download while you continue setup."
+        }
+        return "Start with a fast local model. Larger models can download while you continue setup."
     }
 
     init(
@@ -91,7 +98,7 @@ struct OnboardingView: View {
         appState: AppState,
         initialStep: Int = 0,
         initialUserName: String = "",
-        initialBackend: BackendOption = .parakeetMultilingual,
+        initialBackend: BackendOption = BackendOption.onboardingDefault,
         initialCohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
         initialHotkey: HotkeyConfig = .default,
         initialSystemAudioRequested: Bool = false,
@@ -128,7 +135,9 @@ struct OnboardingView: View {
         _currentStep = State(initialValue: effectiveInitialStep)
         _userName = State(initialValue: initialUserName)
         _selectedUseCase = State(initialValue: initialUseCase)
-        let sanitizedInitialBackend = BackendOption.onboarding.contains(initialBackend) ? initialBackend : .parakeetMultilingual
+        let sanitizedInitialBackend = BackendOption.onboarding.contains(initialBackend)
+            ? initialBackend
+            : BackendOption.onboardingDefault
         _selectedBackend = State(initialValue: sanitizedInitialBackend)
         _selectedCohereLanguage = State(initialValue: initialCohereLanguage)
         _selectedHotkey = State(initialValue: initialHotkey)
@@ -669,7 +678,7 @@ struct OnboardingView: View {
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
-                Text("Start with a fast local model.\nLarger models are available after setup.")
+                Text(onboardingModelDescription)
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .multilineTextAlignment(.center)
@@ -678,7 +687,7 @@ struct OnboardingView: View {
 
             ScrollView {
                 VStack(spacing: MuesliTheme.spacing8) {
-                    modelCard(option: .parakeetMultilingual)
+                    modelCard(option: BackendOption.onboardingDefault)
 
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) {
@@ -769,7 +778,7 @@ struct OnboardingView: View {
                         Text(option.label)
                             .font(MuesliTheme.headline())
                             .foregroundStyle(MuesliTheme.textPrimary)
-                        if option.recommended {
+                        if option == BackendOption.onboardingDefault {
                             Text("Recommended")
                                 .font(.system(size: 9, weight: .semibold))
                                 .foregroundStyle(.white)

--- a/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/OnboardingWindowController.swift
@@ -65,7 +65,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         if let progress = resumeProgress {
             let backend = BackendOption.all.first(where: {
                 $0.backend == progress.selectedBackendKey && $0.model == progress.selectedModelKey
-            }) ?? .parakeetMultilingual
+            }) ?? BackendOption.onboardingDefault
             let cohereLanguage = CohereTranscribeLanguage.resolved(progress.selectedCohereLanguageCode)
             let hotkey = HotkeyConfig(keyCode: progress.hotkeyKeyCode, label: progress.hotkeyLabel)
             rootView = OnboardingView(

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -732,12 +732,15 @@ struct SettingsView: View {
                 .frame(height: 24)
             }
             Divider().background(MuesliTheme.surfaceBorder)
-            settingsRow("Show transcript on hover") {
+            settingsRow(
+                "Show transcript on hover",
+                description: "Show recent transcript beside the waveform.",
+                controlWidth: meetingControlWidth
+            ) {
                 settingsSwitch(isOn: appState.config.showMeetingTranscriptOnIndicatorHover) { newValue in
                     controller.updateConfig { $0.showMeetingTranscriptOnIndicatorHover = newValue }
                 }
             }
-            settingsDescription("Show recent transcript beside the waveform.")
             Divider().background(MuesliTheme.surfaceBorder)
             settingsRow(
                 "Live preview model",

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -13,6 +13,85 @@ struct SpeechTranscriptionResult: Sendable {
     let segments: [SpeechSegment]
 }
 
+actor AppleSpeechUseLifecycle {
+    typealias Cleanup = @Sendable () async -> Void
+
+    struct Snapshot: Equatable, Sendable {
+        let activeUseCount: Int
+        let hasDeferredCleanup: Bool
+        let isCleaningUp: Bool
+    }
+
+    private struct CleanupOperation {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private var activeUseCount = 0
+    private var deferredCleanup: Cleanup?
+    private var cleanupOperation: CleanupOperation?
+
+    func beginUse() async {
+        deferredCleanup = nil
+        activeUseCount += 1
+
+        if let operation = cleanupOperation {
+            await operation.task.value
+            finishCleanupIfCurrent(operation.id)
+        }
+    }
+
+    func endUse() async {
+        precondition(activeUseCount > 0, "Apple Speech use ended without a matching begin")
+        activeUseCount -= 1
+        if activeUseCount == 0 {
+            await runDeferredCleanupIfNeeded()
+        }
+    }
+
+    func requestCleanup(_ cleanup: @escaping Cleanup) async {
+        deferredCleanup = cleanup
+
+        if let operation = cleanupOperation {
+            await operation.task.value
+            finishCleanupIfCurrent(operation.id)
+            if activeUseCount == 0 {
+                await runDeferredCleanupIfNeeded()
+            }
+            return
+        }
+
+        if activeUseCount == 0 {
+            await runDeferredCleanupIfNeeded()
+        }
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            activeUseCount: activeUseCount,
+            hasDeferredCleanup: deferredCleanup != nil,
+            isCleaningUp: cleanupOperation != nil
+        )
+    }
+
+    private func runDeferredCleanupIfNeeded() async {
+        guard cleanupOperation == nil, let cleanup = deferredCleanup else { return }
+        deferredCleanup = nil
+
+        let id = UUID()
+        let task = Task { await cleanup() }
+        cleanupOperation = CleanupOperation(id: id, task: task)
+        await task.value
+        finishCleanupIfCurrent(id)
+    }
+
+    private func finishCleanupIfCurrent(_ id: UUID) {
+        if cleanupOperation?.id == id {
+            cleanupOperation = nil
+        }
+    }
+}
+
 actor TranscriptionCoordinator {
     typealias DiarizerModelLoader = @Sendable (DiarizerRuntimePolicy) async throws -> DiarizerModels
     typealias VADLoader = @Sendable () async throws -> VadManager
@@ -46,6 +125,7 @@ actor TranscriptionCoordinator {
     private var _indicASRTranscriber: Any?
     private var _gemma4LiteRTTranscriber: Any?
     private var _appleSpeechTranscriber: Any?
+    private let appleSpeechLifecycle = AppleSpeechUseLifecycle()
     private let senseVoiceTranscriber = SenseVoiceTranscriber()
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
@@ -136,11 +216,20 @@ actor TranscriptionCoordinator {
     }
 
     func unloadAppleSpeechTranscriber() async {
-        if #available(macOS 26.0, *),
-           let transcriber = _appleSpeechTranscriber as? AppleSpeechAnalyzerTranscriber {
-            await transcriber.releaseReservations()
-            _appleSpeechTranscriber = nil
+        if #available(macOS 26.0, *) {
+            await appleSpeechLifecycle.requestCleanup { [weak self] in
+                await self?.releaseAppleSpeechTranscriber()
+            }
         }
+    }
+
+    @available(macOS 26.0, *)
+    private func releaseAppleSpeechTranscriber() async {
+        guard let transcriber = _appleSpeechTranscriber as? AppleSpeechAnalyzerTranscriber else { return }
+        await transcriber.releaseReservations()
+        guard let current = _appleSpeechTranscriber as? AppleSpeechAnalyzerTranscriber,
+              current === transcriber else { return }
+        _appleSpeechTranscriber = nil
     }
 
     @available(macOS 15, *)
@@ -278,6 +367,41 @@ actor TranscriptionCoordinator {
         return _appleSpeechTranscriber as! AppleSpeechAnalyzerTranscriber
     }
 
+    @available(macOS 26.0, *)
+    private func prepareAppleSpeech(
+        progress: ((Double, String?) -> Void)?,
+        progressSnapshot: ModelDownloadProgressHandler?
+    ) async throws {
+        await appleSpeechLifecycle.beginUse()
+        let transcriber = appleSpeechTranscriber
+        do {
+            try Task.checkCancellation()
+            _ = try await transcriber.prepare(
+                progress: progress,
+                progressSnapshot: progressSnapshot
+            )
+            await appleSpeechLifecycle.endUse()
+        } catch {
+            await appleSpeechLifecycle.endUse()
+            throw error
+        }
+    }
+
+    @available(macOS 26.0, *)
+    private func transcribeWithAppleSpeech(url: URL) async throws -> SpeechTranscriptionResult {
+        await appleSpeechLifecycle.beginUse()
+        let transcriber = appleSpeechTranscriber
+        do {
+            try Task.checkCancellation()
+            let result = try await transcriber.transcribe(wavURL: url)
+            await appleSpeechLifecycle.endUse()
+            return result
+        } catch {
+            await appleSpeechLifecycle.endUse()
+            throw error
+        }
+    }
+
     func preload(
         backend: BackendOption,
         enablePostProcessor: Bool = false,
@@ -397,7 +521,7 @@ actor TranscriptionCoordinator {
             }
         case "apple-speech":
             if #available(macOS 26.0, *) {
-                _ = try await appleSpeechTranscriber.prepare(
+                try await prepareAppleSpeech(
                     progress: progress,
                     progressSnapshot: progressSnapshot
                 )
@@ -1088,7 +1212,7 @@ actor TranscriptionCoordinator {
             return try await transcribeWithGemma4LiteRT(url: url)
         case "apple-speech":
             if #available(macOS 26.0, *) {
-                return try await appleSpeechTranscriber.transcribe(wavURL: url)
+                return try await transcribeWithAppleSpeech(url: url)
             }
             throw AppleSpeechAnalyzerError.unavailable
         default:

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -35,7 +35,7 @@ actor TranscriptionCoordinator {
     private static let defaultDiarizerLoadOperationTimeout: Duration = .seconds(300)
 
     static let explicitlyRoutedBackendIdentifiers: Set<String> = [
-        "whisper", "nemotron35", "qwen", "cohere", "indicasr", "sensevoice", "gemma4-litert",
+        "whisper", "nemotron35", "qwen", "cohere", "indicasr", "sensevoice", "gemma4-litert", "apple-speech",
     ]
 
     private let fluidTranscriber = FluidAudioTranscriber()
@@ -45,6 +45,7 @@ actor TranscriptionCoordinator {
     private var _cohereTranscriber: Any?
     private var _indicASRTranscriber: Any?
     private var _gemma4LiteRTTranscriber: Any?
+    private var _appleSpeechTranscriber: Any?
     private let senseVoiceTranscriber = SenseVoiceTranscriber()
     private var vadManager: VadManager?
     private var diarizerManager: DiarizerManager?
@@ -261,6 +262,14 @@ actor TranscriptionCoordinator {
         return _gemma4LiteRTTranscriber as! Gemma4LiteRTTranscriber
     }
 
+    @available(macOS 26.0, *)
+    private var appleSpeechTranscriber: AppleSpeechAnalyzerTranscriber {
+        if _appleSpeechTranscriber == nil {
+            _appleSpeechTranscriber = AppleSpeechAnalyzerTranscriber()
+        }
+        return _appleSpeechTranscriber as! AppleSpeechAnalyzerTranscriber
+    }
+
     func preload(
         backend: BackendOption,
         enablePostProcessor: Bool = false,
@@ -377,6 +386,15 @@ actor TranscriptionCoordinator {
                 throw NSError(domain: "MuesliTranscriptionRuntime", code: 7, userInfo: [
                     NSLocalizedDescriptionKey: "Gemma 4 E2B requires macOS 15 or later.",
                 ])
+            }
+        case "apple-speech":
+            if #available(macOS 26.0, *) {
+                _ = try await appleSpeechTranscriber.prepare(
+                    progress: progress,
+                    progressSnapshot: progressSnapshot
+                )
+            } else {
+                throw AppleSpeechAnalyzerError.unavailable
             }
         default:
             throw NSError(domain: "MuesliTranscriptionRuntime", code: 5, userInfo: [
@@ -1060,6 +1078,11 @@ actor TranscriptionCoordinator {
             return try await transcribeWithSenseVoice(url: url)
         case "gemma4-litert":
             return try await transcribeWithGemma4LiteRT(url: url)
+        case "apple-speech":
+            if #available(macOS 26.0, *) {
+                return try await appleSpeechTranscriber.transcribe(wavURL: url)
+            }
+            throw AppleSpeechAnalyzerError.unavailable
         default:
             return try await transcribeWithFluidAudio(url: url)
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -135,6 +135,14 @@ actor TranscriptionCoordinator {
         }
     }
 
+    func unloadAppleSpeechTranscriber() async {
+        if #available(macOS 26.0, *),
+           let transcriber = _appleSpeechTranscriber as? AppleSpeechAnalyzerTranscriber {
+            await transcriber.releaseReservations()
+            _appleSpeechTranscriber = nil
+        }
+    }
+
     @available(macOS 15, *)
     private var qwen3Transcriber: Qwen3AsrTranscriber {
         if _qwen3Transcriber == nil {

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -91,8 +91,34 @@ struct AppleSpeechAnalyzerBackendTests {
         #expect(await counter.value == 1)
     }
 
-    @Test("reservation ownership only returns stale owned locales")
-    func reservationOwnershipTracksCleanupCandidates() {
+    @Test("failed preparation is removed so a later attempt can retry")
+    func failedPreparationCanRetry() async throws {
+        let cache = AppleSpeechPreparationTaskCache()
+        let counter = AppleSpeechTestCounter()
+
+        do {
+            _ = try await cache.value(for: "en-US") {
+                await counter.increment()
+                throw AppleSpeechTestError.preparationFailed
+            }
+            Issue.record("Expected the first preparation to fail")
+        } catch AppleSpeechTestError.preparationFailed {
+            // Expected path.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let locale = try await cache.value(for: "en-US") {
+            await counter.increment()
+            return Locale(identifier: "en-US")
+        }
+
+        #expect(locale.identifier(.bcp47) == "en-US")
+        #expect(await counter.value == 2)
+    }
+
+    @Test("stale reservation cleanup preserves the newer owned locale")
+    func staleReservationCleanupPreservesNewerLocale() {
         var ownership = AppleSpeechReservationOwnership()
         ownership.record(Locale(identifier: "en-US"))
         ownership.record(Locale(identifier: "fr-FR"))
@@ -123,6 +149,23 @@ struct AppleSpeechAnalyzerBackendTests {
             #expect(!BackendOption.onboarding.contains(option))
         }
     }
+
+    @Test("macOS 26 CI exercises the supported Apple Speech catalogue path")
+    func requiredSupportedSystemCoverage() {
+        guard ProcessInfo.processInfo.environment["MUESLI_REQUIRE_APPLE_SPEECH_AVAILABLE"] == "1" else {
+            return
+        }
+
+        guard #available(macOS 26.0, *) else {
+            Issue.record("The supported-system Apple Speech test requires macOS 26")
+            return
+        }
+
+        #expect(AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem)
+        #expect(BackendOption.systemManaged.contains(.appleSpeechAnalyzer))
+        #expect(BackendOption.all.contains(.appleSpeechAnalyzer))
+        #expect(BackendOption.onboardingDefault == .appleSpeechAnalyzer)
+    }
 }
 
 private actor AppleSpeechTestCounter {
@@ -131,4 +174,8 @@ private actor AppleSpeechTestCounter {
     func increment() {
         value += 1
     }
+}
+
+private enum AppleSpeechTestError: Error {
+    case preparationFailed
 }

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -19,13 +19,88 @@ struct AppleSpeechAnalyzerBackendTests {
     @Test("final segments are normalized and joined")
     func accumulatorBuildsTimestampedTranscript() {
         var accumulator = AppleSpeechTranscriptAccumulator()
-        accumulator.receive(text: "  First segment  ", isFinal: true, start: -1, end: 1)
-        accumulator.receive(text: "Second segment", isFinal: true, start: 1, end: .infinity)
+        accumulator.receive(text: "  First segment ", isFinal: true, start: -1, end: 1)
+        accumulator.receive(text: "Second segment  ", isFinal: true, start: 1, end: .infinity)
 
         #expect(accumulator.text == "First segment Second segment")
         #expect(accumulator.segments.map(\.text) == ["First segment", "Second segment"])
         #expect(accumulator.segments[0].start == 0)
         #expect(accumulator.segments[1].end == 1)
+    }
+
+    @Test("final results preserve Apple punctuation and line breaks")
+    func accumulatorPreservesResultFormatting() {
+        var accumulator = AppleSpeechTranscriptAccumulator()
+        accumulator.receive(text: "Hello", isFinal: true, start: 0, end: 0.5)
+        accumulator.receive(text: ",", isFinal: true, start: 0.5, end: 0.6)
+        accumulator.receive(text: "\nNext line", isFinal: true, start: 0.6, end: 1.5)
+
+        #expect(accumulator.text == "Hello,\nNext line")
+        #expect(accumulator.segments.map(\.text) == ["Hello", ",", "Next line"])
+    }
+
+    @Test("locale resolver uses exact or language-equivalent supported locale")
+    func localeResolverUsesSupportedEquivalent() async throws {
+        let exactResolver = AppleSpeechLocaleResolver { locale in
+            locale.identifier(.bcp47) == "en-IN" ? locale : nil
+        }
+        let exact = try await exactResolver.resolve(Locale(identifier: "en-IN"))
+        #expect(exact.identifier(.bcp47) == "en-IN")
+
+        let languageResolver = AppleSpeechLocaleResolver { locale in
+            locale.language.languageCode?.identifier == "en" && locale.region == nil
+                ? Locale(identifier: "en-US")
+                : nil
+        }
+        let languageEquivalent = try await languageResolver.resolve(Locale(identifier: "en-IN"))
+        #expect(languageEquivalent.identifier(.bcp47) == "en-US")
+    }
+
+    @Test("locale resolver rejects unsupported languages")
+    func localeResolverRejectsUnsupportedLanguage() async {
+        let resolver = AppleSpeechLocaleResolver { _ in nil }
+
+        do {
+            _ = try await resolver.resolve(Locale(identifier: "zz-ZZ"))
+            Issue.record("Expected an unsupported-locale error")
+        } catch AppleSpeechAnalyzerError.unsupportedLocale(let identifier) {
+            #expect(identifier == "zz-ZZ")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("concurrent preparation requests share one operation")
+    func preparationRequestsAreCoalesced() async throws {
+        let cache = AppleSpeechPreparationTaskCache()
+        let counter = AppleSpeechTestCounter()
+
+        async let first = cache.value(for: "en-US") {
+            await counter.increment()
+            try await Task.sleep(for: .milliseconds(100))
+            return Locale(identifier: "en-US")
+        }
+        async let second = cache.value(for: "en-US") {
+            await counter.increment()
+            try await Task.sleep(for: .milliseconds(100))
+            return Locale(identifier: "en-US")
+        }
+
+        let locales = try await [first, second]
+        #expect(locales.allSatisfy { $0.identifier(.bcp47) == "en-US" })
+        #expect(await counter.value == 1)
+    }
+
+    @Test("reservation ownership only returns stale owned locales")
+    func reservationOwnershipTracksCleanupCandidates() {
+        var ownership = AppleSpeechReservationOwnership()
+        ownership.record(Locale(identifier: "en-US"))
+        ownership.record(Locale(identifier: "fr-FR"))
+
+        #expect(ownership.locales(excluding: "fr-FR").map { $0.identifier(.bcp47) } == ["en-US"])
+
+        ownership.remove(Locale(identifier: "en-US"))
+        #expect(ownership.locales(excluding: "fr-FR").isEmpty)
     }
 
     @Test("backend is system managed and only catalogued when supported")
@@ -47,5 +122,13 @@ struct AppleSpeechAnalyzerBackendTests {
             #expect(BackendOption.onboardingDefault == .parakeetMultilingual)
             #expect(!BackendOption.onboarding.contains(option))
         }
+    }
+}
+
+private actor AppleSpeechTestCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -150,21 +150,24 @@ struct AppleSpeechAnalyzerBackendTests {
         }
     }
 
-    @Test("macOS 26 CI exercises the supported Apple Speech catalogue path")
-    func requiredSupportedSystemCoverage() {
-        guard ProcessInfo.processInfo.environment["MUESLI_REQUIRE_APPLE_SPEECH_AVAILABLE"] == "1" else {
-            return
-        }
+    @Test("supported catalogue makes Apple Speech the onboarding default")
+    func supportedCatalogue() {
+        let catalog = BackendOption.catalog(appleSpeechAvailable: true)
 
-        guard #available(macOS 26.0, *) else {
-            Issue.record("The supported-system Apple Speech test requires macOS 26")
-            return
-        }
+        #expect(catalog.systemManaged == [.appleSpeechAnalyzer])
+        #expect(catalog.all.contains(.appleSpeechAnalyzer))
+        #expect(catalog.onboardingDefault == .appleSpeechAnalyzer)
+        #expect(catalog.onboarding.first == .appleSpeechAnalyzer)
+    }
 
-        #expect(AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem)
-        #expect(BackendOption.systemManaged.contains(.appleSpeechAnalyzer))
-        #expect(BackendOption.all.contains(.appleSpeechAnalyzer))
-        #expect(BackendOption.onboardingDefault == .appleSpeechAnalyzer)
+    @Test("unsupported catalogue falls back to Parakeet")
+    func unsupportedCatalogue() {
+        let catalog = BackendOption.catalog(appleSpeechAvailable: false)
+
+        #expect(catalog.systemManaged.isEmpty)
+        #expect(!catalog.all.contains(.appleSpeechAnalyzer))
+        #expect(catalog.onboardingDefault == .parakeetMultilingual)
+        #expect(!catalog.onboarding.contains(.appleSpeechAnalyzer))
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AppleSpeechAnalyzerBackendTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Apple SpeechAnalyzer backend")
+struct AppleSpeechAnalyzerBackendTests {
+    @Test("volatile results do not duplicate finalized text")
+    func accumulatorIgnoresVolatileResults() {
+        var accumulator = AppleSpeechTranscriptAccumulator()
+        accumulator.receive(text: "draft", isFinal: false, start: 0, end: 0.5)
+        accumulator.receive(text: "Final words", isFinal: true, start: 0, end: 1.25)
+
+        #expect(accumulator.text == "Final words")
+        #expect(accumulator.segments.count == 1)
+        #expect(accumulator.segments[0].start == 0)
+        #expect(accumulator.segments[0].end == 1.25)
+    }
+
+    @Test("final segments are normalized and joined")
+    func accumulatorBuildsTimestampedTranscript() {
+        var accumulator = AppleSpeechTranscriptAccumulator()
+        accumulator.receive(text: "  First segment  ", isFinal: true, start: -1, end: 1)
+        accumulator.receive(text: "Second segment", isFinal: true, start: 1, end: .infinity)
+
+        #expect(accumulator.text == "First segment Second segment")
+        #expect(accumulator.segments.map(\.text) == ["First segment", "Second segment"])
+        #expect(accumulator.segments[0].start == 0)
+        #expect(accumulator.segments[1].end == 1)
+    }
+
+    @Test("backend is system managed and only catalogued when supported")
+    func backendMetadata() {
+        let option = BackendOption.appleSpeechAnalyzer
+
+        #expect(option.backend == "apple-speech")
+        #expect(option.isSystemManaged)
+        #expect(option.supportsMeetingTranscription)
+        #expect(!BackendOption.experimental.contains(option))
+        if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
+            #expect(BackendOption.systemManaged.contains(option))
+            #expect(BackendOption.all.contains(option))
+            #expect(BackendOption.onboardingDefault == option)
+            #expect(BackendOption.onboarding.contains(option))
+        } else {
+            #expect(!BackendOption.systemManaged.contains(option))
+            #expect(!BackendOption.all.contains(option))
+            #expect(BackendOption.onboardingDefault == .parakeetMultilingual)
+            #expect(!BackendOption.onboarding.contains(option))
+        }
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/BackendTests.swift
@@ -456,7 +456,7 @@ struct BackendCoverageTests {
     @Test("size labels are human-readable")
     func sizeLabelsReadable() {
         for option in BackendOption.all {
-            #expect(option.sizeLabel.contains("MB") || option.sizeLabel.contains("GB"),
+            #expect(option.isSystemManaged || option.sizeLabel.contains("MB") || option.sizeLabel.contains("GB"),
                     "\(option.label) sizeLabel should contain MB or GB: \(option.sizeLabel)")
         }
     }

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -26,7 +26,7 @@ struct BackendOptionTests {
 
     @Test("backend field is one of the known backends")
     func knownBackends() {
-        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron35", "cohere", "indicasr", "sensevoice", "gemma4-litert"]
+        let known: Set<String> = ["fluidaudio", "whisper", "qwen", "nemotron35", "cohere", "indicasr", "sensevoice", "gemma4-litert", "apple-speech"]
         for option in BackendOption.all {
             #expect(known.contains(option.backend), "Unknown backend: \(option.backend)")
         }
@@ -299,13 +299,24 @@ struct BackendOptionTests {
         #expect(!BackendOption.experimental.contains(.cohereTranscribe))
     }
 
-    @Test("onboarding offers the conservative models plus Nemotron 3.5")
+    @Test("onboarding defaults to Apple Speech when available and keeps conservative alternatives")
     func onboardingModelChoices() {
-        #expect(BackendOption.onboarding == [.parakeetMultilingual, .whisperTiny, .whisperSmall, .cohereTranscribe, .nemotron35Multilingual])
+        #expect(BackendOption.onboarding.first == BackendOption.onboardingDefault)
+        #expect(BackendOption.onboarding.contains(.parakeetMultilingual))
+        #expect(BackendOption.onboarding.contains(.whisperTiny))
+        #expect(BackendOption.onboarding.contains(.whisperSmall))
+        #expect(BackendOption.onboarding.contains(.cohereTranscribe))
         for option in BackendOption.experimental {
             #expect(!BackendOption.onboarding.contains(option))
         }
         #expect(BackendOption.onboarding.contains(.nemotron35Multilingual))
+        if #available(macOS 26.0, *), AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem {
+            #expect(BackendOption.onboardingDefault == .appleSpeechAnalyzer)
+            #expect(BackendOption.onboarding.contains(.appleSpeechAnalyzer))
+        } else {
+            #expect(BackendOption.onboardingDefault == .parakeetMultilingual)
+            #expect(!BackendOption.onboarding.contains(.appleSpeechAnalyzer))
+        }
     }
 
     @Test("only Nemotron backends use streaming dictation")

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -175,8 +175,12 @@ struct TranscriptionCoordinatorTests {
             await lifecycle.beginUse()
             await useStarted.increment()
         }
-        await Task.yield()
+        for _ in 0..<100 {
+            if (await lifecycle.snapshot()).activeUseCount > 0 { break }
+            await Task.yield()
+        }
 
+        #expect((await lifecycle.snapshot()).activeUseCount == 1)
         #expect(await useStarted.value == 0)
         #expect((await lifecycle.snapshot()).isCleaningUp)
 

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptionRuntimeTests.swift
@@ -91,8 +91,177 @@ struct TranscriptionCoordinatorTests {
 
     @Test("backend routing covers all known backends")
     func allBackendsCovered() {
-        let backends = Set(BackendOption.all.map(\.backend))
+        var backends = Set(BackendOption.all.map(\.backend))
+        backends.insert(BackendOption.appleSpeechAnalyzer.backend)
         #expect(backends == TranscriptionCoordinator.explicitlyRoutedBackendIdentifiers.union(["fluidaudio"]))
+    }
+
+    @Test("Apple Speech cleanup waits for an active use")
+    func appleSpeechCleanupWaitsForActiveUse() async {
+        let lifecycle = AppleSpeechUseLifecycle()
+        let cleanupCount = TranscriptionLifecycleTestCounter()
+
+        await lifecycle.beginUse()
+        await lifecycle.requestCleanup {
+            await cleanupCount.increment()
+        }
+
+        #expect(await lifecycle.snapshot() == .init(
+            activeUseCount: 1,
+            hasDeferredCleanup: true,
+            isCleaningUp: false
+        ))
+        #expect(await cleanupCount.value == 0)
+
+        await lifecycle.endUse()
+        #expect(await cleanupCount.value == 1)
+    }
+
+    @Test("Apple Speech cleanup waits for dictation and meeting uses")
+    func appleSpeechCleanupWaitsForCombinedUses() async {
+        let lifecycle = AppleSpeechUseLifecycle()
+        let cleanupCount = TranscriptionLifecycleTestCounter()
+
+        await lifecycle.beginUse()
+        await lifecycle.beginUse()
+        await lifecycle.requestCleanup {
+            await cleanupCount.increment()
+        }
+
+        await lifecycle.endUse()
+        #expect(await cleanupCount.value == 0)
+        await lifecycle.endUse()
+        #expect(await cleanupCount.value == 1)
+    }
+
+    @Test("a newer Apple Speech use cancels a deferred stale cleanup")
+    func newerAppleSpeechUseCancelsDeferredCleanup() async {
+        let lifecycle = AppleSpeechUseLifecycle()
+        let cleanupCount = TranscriptionLifecycleTestCounter()
+
+        await lifecycle.beginUse()
+        await lifecycle.requestCleanup {
+            await cleanupCount.increment()
+        }
+        await lifecycle.beginUse()
+
+        await lifecycle.endUse()
+        await lifecycle.endUse()
+
+        #expect(await cleanupCount.value == 0)
+        #expect(await lifecycle.snapshot() == .init(
+            activeUseCount: 0,
+            hasDeferredCleanup: false,
+            isCleaningUp: false
+        ))
+    }
+
+    @Test("a new Apple Speech use waits for in-flight cleanup")
+    func appleSpeechUseWaitsForCleanup() async {
+        let lifecycle = AppleSpeechUseLifecycle()
+        let cleanupStarted = TranscriptionLifecycleTestLatch()
+        let allowCleanup = TranscriptionLifecycleTestLatch()
+        let useStarted = TranscriptionLifecycleTestCounter()
+
+        let cleanupTask = Task {
+            await lifecycle.requestCleanup {
+                await cleanupStarted.signal()
+                await allowCleanup.wait()
+            }
+        }
+        await cleanupStarted.wait()
+
+        let useTask = Task {
+            await lifecycle.beginUse()
+            await useStarted.increment()
+        }
+        await Task.yield()
+
+        #expect(await useStarted.value == 0)
+        #expect((await lifecycle.snapshot()).isCleaningUp)
+
+        await allowCleanup.signal()
+        await cleanupTask.value
+        await useTask.value
+
+        #expect(await useStarted.value == 1)
+        await lifecycle.endUse()
+    }
+
+    @Test("a newer cleanup request survives an older in-flight cleanup")
+    func newerAppleSpeechCleanupIsNotDropped() async {
+        let lifecycle = AppleSpeechUseLifecycle()
+        let firstCleanupStarted = TranscriptionLifecycleTestLatch()
+        let allowFirstCleanup = TranscriptionLifecycleTestLatch()
+        let secondCleanupCount = TranscriptionLifecycleTestCounter()
+
+        let firstCleanupTask = Task {
+            await lifecycle.requestCleanup {
+                await firstCleanupStarted.signal()
+                await allowFirstCleanup.wait()
+            }
+        }
+        await firstCleanupStarted.wait()
+
+        let useTask = Task {
+            await lifecycle.beginUse()
+        }
+        for _ in 0..<100 {
+            if (await lifecycle.snapshot()).activeUseCount > 0 { break }
+            await Task.yield()
+        }
+        #expect((await lifecycle.snapshot()).activeUseCount == 1)
+
+        let secondCleanupTask = Task {
+            await lifecycle.requestCleanup {
+                await secondCleanupCount.increment()
+            }
+        }
+        for _ in 0..<100 {
+            if (await lifecycle.snapshot()).hasDeferredCleanup { break }
+            await Task.yield()
+        }
+        #expect((await lifecycle.snapshot()).hasDeferredCleanup)
+
+        await allowFirstCleanup.signal()
+        await firstCleanupTask.value
+        await useTask.value
+        await secondCleanupTask.value
+
+        #expect(await secondCleanupCount.value == 0)
+        #expect((await lifecycle.snapshot()).hasDeferredCleanup)
+
+        await lifecycle.endUse()
+        #expect(await secondCleanupCount.value == 1)
+    }
+}
+
+private actor TranscriptionLifecycleTestCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}
+
+private actor TranscriptionLifecycleTestLatch {
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isSignaled { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func signal() {
+        isSignaled = true
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
     }
 }
 

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -40,6 +40,7 @@ case "${shard}" in
   dictation-transcription)
     filters=(
       FluidAudioTranscriberTests
+      AppleSpeechAnalyzerBackendTests
       BackendCoverageTests
       FillerWordFilterTests
       JaroWinklerTests


### PR DESCRIPTION
## Summary

- add a macOS 26+ Apple SpeechAnalyzer backend for dictation, live meeting chunks, and imported recordings
- expose Apple Speech as a system-managed regular model and make it the conditional onboarding default
- preserve existing dictation cleanup and meeting diarization, reconciliation, summary, and persistence pipelines
- align the Meetings transcript-hover setting and add backend and catalogue coverage
- reject unsupported languages instead of silently falling back, coalesce concurrent model preparation, and release only Muesli-owned locale reservations
- preserve Apple-provided transcript formatting and keep diagnostics free of transcript content
- serialize Apple Speech use and cleanup so stale unloads cannot clear a newer preparation or active transcription

## Availability

- only catalogued on macOS 26+ when `SpeechTranscriber.isAvailable`
- runtime preload and transcription paths are separately availability-gated
- Parakeet v3 remains the onboarding fallback on older or unsupported Macs
- CI retains macOS 15 fallback coverage and adds a focused macOS 26/Xcode 26.3 job without changing the app's macOS 14.2 deployment target

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/preprod` (1,693 tests, 157 suites)
- `MUESLI_REQUIRE_APPLE_SPEECH_AVAILABLE=1 swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/preprod --filter AppleSpeechAnalyzerBackendTests`
- `swift build --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/preprod -c release --product MuesliNativeApp`
- `./scripts/test_classify_changed_files.sh`
- `./scripts/test_ci_test_shards.sh`
- `./scripts/verify_update_flow.sh --skip-dmg`
- rebuilt and manually tested `/Applications/MuesliDevA.app` for Apple Speech dictation, meeting transcription, model catalogue, onboarding selection, and settings alignment

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

Apple's Speech framework APIs and the system-provided `apple.logo` SF Symbol are used under Apple's platform terms. No third-party code, models, datasets, media, or bundled assets are introduced.

### AI assistance

OpenAI Codex was used for codebase analysis, implementation, test authoring, and review-feedback iteration. The maintainer reviewed the changes and ran the automated and manual validation listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple Speech transcription support on macOS 26 and later.
  - Apple Speech is automatically preferred during onboarding when available, with Parakeet retained as a fallback.
  - System-managed speech options now appear in model selection and cannot be deleted.
  - Added progress and status updates while preparing speech assets and transcribing recordings.

- **Improvements**
  - Improved onboarding recommendations and model descriptions.
  - Updated meeting transcription settings layout for clearer inline guidance.
  - Added clearer handling for unsupported languages, unavailable speech services, and missing speech assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->