### PR TITLE
Add unified timeline and dictation app attribution

### DIFF
--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -22,6 +22,7 @@ public struct MeetingThreadNavigation: Equatable, Sendable {
 }
 
 public final class DictationStore {
+    private static let targetApplicationBackfillMigration = "dictation_target_application_from_app_context_v1"
     public static let defaultTombstoneRetentionInterval: TimeInterval = 30 * 24 * 60 * 60
 
     private static let iso8601Formatter = ISO8601DateFormatter()
@@ -30,6 +31,7 @@ public final class DictationStore {
     private let databaseURL: URL
     private static let dictationColumns = """
     d.id, d.timestamp, d.duration_seconds, d.raw_text, d.app_context, d.word_count, d.source,
+    d.target_app_name, d.target_app_bundle_id,
     t.id, t.final_status, t.final_message, t.trace_json, t.created_at
     """
     private static let meetingColumns = """
@@ -65,6 +67,8 @@ public final class DictationStore {
             app_context TEXT,
             word_count INTEGER NOT NULL DEFAULT 0,
             source TEXT NOT NULL DEFAULT 'dictation',
+            target_app_name TEXT,
+            target_app_bundle_id TEXT,
             started_at TEXT,
             ended_at TEXT,
             updated_at REAL NOT NULL DEFAULT 0,
@@ -147,6 +151,11 @@ public final class DictationStore {
             updated_at REAL NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS local_migrations (
+            identifier TEXT PRIMARY KEY,
+            completed_at REAL NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS meeting_resume_snapshots (
             meeting_id INTEGER PRIMARY KEY REFERENCES meetings(id) ON DELETE CASCADE,
             raw_transcript TEXT NOT NULL DEFAULT '',
@@ -210,6 +219,8 @@ public final class DictationStore {
             "ALTER TABLE dictations ADD COLUMN cloud_system_fields BLOB",
             "ALTER TABLE dictations ADD COLUMN last_synced_at REAL",
             "ALTER TABLE dictations ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE dictations ADD COLUMN target_app_name TEXT",
+            "ALTER TABLE dictations ADD COLUMN target_app_bundle_id TEXT",
             "ALTER TABLE meetings ADD COLUMN updated_at REAL NOT NULL DEFAULT 0",
             "ALTER TABLE meetings ADD COLUMN deleted_at REAL",
             "ALTER TABLE meetings ADD COLUMN cloud_record_name TEXT",
@@ -226,6 +237,7 @@ public final class DictationStore {
         ] {
             _ = sqlite3_exec(db, sql, nil, nil, nil)
         }
+        try backfillLegacyTargetApplicationsIfNeeded(db: db)
         // Calendar metadata is not a meeting identity: one occurrence may be
         // recorded more than once, and recurring providers may reuse ids.
         // Replace the legacy uniqueness constraint with lookup-only indexes.
@@ -331,6 +343,8 @@ public final class DictationStore {
         durationSeconds: Double,
         appContext: String = "",
         source: String = "dictation",
+        targetAppName: String? = nil,
+        targetAppBundleID: String? = nil,
         startedAt: Date,
         endedAt: Date
     ) throws -> Int64 {
@@ -339,8 +353,9 @@ public final class DictationStore {
 
         let sql = """
         INSERT INTO dictations
-        (timestamp, duration_seconds, raw_text, app_context, word_count, source, started_at, ended_at, updated_at, sync_dirty)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+        (timestamp, duration_seconds, raw_text, app_context, word_count, source,
+         target_app_name, target_app_bundle_id, started_at, ended_at, updated_at, sync_dirty)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
@@ -357,9 +372,11 @@ public final class DictationStore {
         sqlite3_bind_text(statement, 4, (appContext as NSString).utf8String, -1, nil)
         sqlite3_bind_int(statement, 5, Int32(Self.countWords(in: text)))
         sqlite3_bind_text(statement, 6, (source as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(statement, 7, (started as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(statement, 8, (ended as NSString).utf8String, -1, nil)
-        sqlite3_bind_double(statement, 9, Date().timeIntervalSince1970)
+        bindOptionalText(targetAppName, at: 7, statement: statement)
+        bindOptionalText(targetAppBundleID, at: 8, statement: statement)
+        sqlite3_bind_text(statement, 9, (started as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(statement, 10, (ended as NSString).utf8String, -1, nil)
+        sqlite3_bind_double(statement, 11, Date().timeIntervalSince1970)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw lastError(db)
@@ -372,31 +389,21 @@ public final class DictationStore {
         offset: Int = 0,
         fromDate: String? = nil,
         toDate: String? = nil,
-        origin: RecordOriginFilter = .all
+        origin: RecordOriginFilter = .all,
+        targetApplication: DictationTargetApplication? = nil
     ) throws -> [DictationRecord] {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
-        var conditions: [String] = []
-        var boundValues: [String] = []
-        if let fromDate {
-            conditions.append("d.timestamp >= ?")
-            boundValues.append(fromDate)
-        }
-        if let toDate {
-            conditions.append("d.timestamp <= ?")
-            boundValues.append(toDate)
-        }
-        switch origin {
-        case .all:
-            break
-        case .thisMac:
-            conditions.append("LOWER(TRIM(COALESCE(d.source, ''))) <> 'ios'")
-        case .fromIPhone:
-            conditions.append("LOWER(TRIM(COALESCE(d.source, ''))) = 'ios'")
-        }
-        conditions.insert("d.deleted_at IS NULL", at: 0)
-        let whereClause = "WHERE " + conditions.joined(separator: " AND ")
+        let filter = historyFilterConditions(
+            alias: "d",
+            dateColumn: "timestamp",
+            fromDate: fromDate,
+            toDate: toDate,
+            origin: origin,
+            targetApplication: targetApplication
+        )
+        let whereClause = "WHERE " + filter.conditions.joined(separator: " AND ")
 
         let sql = """
         SELECT \(Self.dictationColumns)
@@ -411,11 +418,11 @@ public final class DictationStore {
             throw lastError(db)
         }
         defer { sqlite3_finalize(statement) }
-        for (index, value) in boundValues.enumerated() {
+        for (index, value) in filter.boundValues.enumerated() {
             sqlite3_bind_text(statement, Int32(index + 1), (value as NSString).utf8String, -1, nil)
         }
-        let limitIndex = Int32(boundValues.count + 1)
-        let offsetIndex = Int32(boundValues.count + 2)
+        let limitIndex = Int32(filter.boundValues.count + 1)
+        let offsetIndex = Int32(filter.boundValues.count + 2)
         sqlite3_bind_int(statement, limitIndex, Int32(limit))
         sqlite3_bind_int(statement, offsetIndex, Int32(offset))
 
@@ -426,9 +433,51 @@ public final class DictationStore {
         return rows
     }
 
+    public func dictationTargetApplications() throws -> [DictationTargetApplication] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT target_app_name, NULLIF(TRIM(target_app_bundle_id), '')
+        FROM dictations
+        WHERE deleted_at IS NULL
+          AND TRIM(COALESCE(target_app_name, '')) <> ''
+          AND id IN (
+              SELECT MAX(id)
+              FROM dictations
+              WHERE deleted_at IS NULL
+                AND TRIM(COALESCE(target_app_name, '')) <> ''
+              GROUP BY COALESCE(
+                  NULLIF(TRIM(target_app_bundle_id), ''),
+                  'name:' || LOWER(TRIM(target_app_name))
+              )
+          )
+        ORDER BY target_app_name COLLATE NOCASE ASC
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var applications: [DictationTargetApplication] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            applications.append(DictationTargetApplication(
+                name: stringColumn(statement, index: 0),
+                bundleID: optionalStringColumn(statement, index: 1)
+            ))
+        }
+        return applications
+    }
+
     public func dictation(id: Int64) throws -> DictationRecord? {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
+
+        return try dictation(id: id, db: db)
+    }
+
+    private func dictation(id: Int64, db: OpaquePointer?) throws -> DictationRecord? {
 
         let sql = """
         SELECT \(Self.dictationColumns)
@@ -448,6 +497,81 @@ public final class DictationStore {
             return nil
         }
         return makeDictationRecord(statement)
+    }
+
+    public func timelineEntries(
+        limit: Int = 50,
+        offset: Int = 0,
+        fromDate: String? = nil,
+        toDate: String? = nil,
+        origin: RecordOriginFilter = .all,
+        targetApplication: DictationTargetApplication? = nil
+    ) throws -> [TimelineEntry] {
+        guard limit > 0 else { return [] }
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let dictationFilter = historyFilterConditions(
+            alias: "d",
+            dateColumn: "timestamp",
+            fromDate: fromDate,
+            toDate: toDate,
+            origin: origin,
+            targetApplication: targetApplication
+        )
+        var meetingFilter = historyFilterConditions(
+            alias: "m",
+            dateColumn: "start_time",
+            fromDate: fromDate,
+            toDate: toDate,
+            origin: origin
+        )
+        if targetApplication != nil {
+            meetingFilter.conditions.append("0 = 1")
+        }
+        let sql = """
+        WITH timeline(kind, record_id, sort_time) AS (
+            SELECT 0, d.id, d.timestamp
+            FROM dictations d
+            WHERE \(dictationFilter.conditions.joined(separator: " AND "))
+            UNION ALL
+            SELECT 1, m.id, m.start_time
+            FROM meetings m
+            WHERE \(meetingFilter.conditions.joined(separator: " AND "))
+        )
+        SELECT kind, record_id
+        FROM timeline
+        ORDER BY julianday(sort_time) DESC, sort_time DESC, kind ASC, record_id DESC
+        LIMIT ? OFFSET ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        let boundValues = dictationFilter.boundValues + meetingFilter.boundValues
+        for (index, value) in boundValues.enumerated() {
+            sqlite3_bind_text(statement, Int32(index + 1), (value as NSString).utf8String, -1, nil)
+        }
+        sqlite3_bind_int(statement, Int32(boundValues.count + 1), Int32(limit))
+        sqlite3_bind_int(statement, Int32(boundValues.count + 2), Int32(max(0, offset)))
+
+        var keys: [(kind: Int32, id: Int64)] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            keys.append((sqlite3_column_int(statement, 0), sqlite3_column_int64(statement, 1)))
+        }
+
+        var entries: [TimelineEntry] = []
+        entries.reserveCapacity(keys.count)
+        for key in keys {
+            if key.kind == 0, let record = try dictation(id: key.id, db: db) {
+                entries.append(.dictation(record))
+            } else if key.kind == 1, let record = try meeting(id: key.id, db: db) {
+                entries.append(.meeting(record))
+            }
+        }
+        return entries
     }
 
     public func meetingCounts(
@@ -630,6 +754,11 @@ public final class DictationStore {
     public func meeting(id: Int64) throws -> MeetingRecord? {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
+
+        return try meeting(id: id, db: db)
+    }
+
+    private func meeting(id: Int64, db: OpaquePointer?) throws -> MeetingRecord? {
 
         let sql = """
         SELECT \(Self.meetingColumns)
@@ -1062,10 +1191,23 @@ public final class DictationStore {
         return optionalStringColumn(statement, index: 0)
     }
 
-    public func dictationStats() throws -> DictationStats {
+    public func dictationStats(
+        fromDate: String? = nil,
+        toDate: String? = nil,
+        origin: RecordOriginFilter = .all,
+        targetApplication: DictationTargetApplication? = nil
+    ) throws -> DictationStats {
         let db = try openDatabase()
         defer { sqlite3_close(db) }
 
+        let filter = historyFilterConditions(
+            alias: nil,
+            dateColumn: "timestamp",
+            fromDate: fromDate,
+            toDate: toDate,
+            origin: origin,
+            targetApplication: targetApplication
+        )
         let sql = """
         SELECT
             COUNT(*) AS total_sessions,
@@ -1075,13 +1217,16 @@ public final class DictationStore {
             COALESCE(SUM(CASE WHEN duration_seconds > 0 THEN duration_seconds ELSE 0 END), 0)
                 AS timed_duration_seconds
         FROM dictations
-        WHERE deleted_at IS NULL
+        WHERE \(filter.conditions.joined(separator: " AND "))
         """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
             throw lastError(db)
         }
         defer { sqlite3_finalize(statement) }
+        for (index, value) in filter.boundValues.enumerated() {
+            sqlite3_bind_text(statement, Int32(index + 1), (value as NSString).utf8String, -1, nil)
+        }
         guard sqlite3_step(statement) == SQLITE_ROW else {
             return DictationStats(totalWords: 0, totalSessions: 0, averageWordsPerSession: 0, averageWPM: 0, currentStreakDays: 0, longestStreakDays: 0)
         }
@@ -1090,7 +1235,13 @@ public final class DictationStore {
         let totalWords = Int(sqlite3_column_int(statement, 1))
         let timedWords = Int(sqlite3_column_int(statement, 2))
         let timedDuration = sqlite3_column_double(statement, 3)
-        let streaks = try dictationStreaks(db: db)
+        let streaks = try dictationStreaks(
+            fromDate: fromDate,
+            toDate: toDate,
+            origin: origin,
+            targetApplication: targetApplication,
+            db: db
+        )
         return DictationStats(
             totalWords: totalWords,
             totalSessions: totalSessions,
@@ -1182,7 +1333,13 @@ public final class DictationStore {
                 cursor = next
             }
 
-            let streaks = try dictationStreaks(db: db)
+            let streaks = try dictationStreaks(
+                fromDate: nil,
+                toDate: nil,
+                origin: .all,
+                targetApplication: nil,
+                db: db
+            )
             let snapshot = InsightsSnapshot(
                 range: range,
                 generatedAt: now,
@@ -3985,21 +4142,21 @@ public final class DictationStore {
 
     private func makeDictationRecord(_ statement: OpaquePointer?) -> DictationRecord {
         let trace: ComputerUseTraceRecord?
-        if sqlite3_column_type(statement, 7) == SQLITE_NULL {
+        if sqlite3_column_type(statement, 9) == SQLITE_NULL {
             trace = nil
         } else {
-            let traceJSON = stringColumn(statement, index: 10)
+            let traceJSON = stringColumn(statement, index: 12)
             let events = (try? JSONDecoder().decode(
                 [ComputerUseTraceEvent].self,
                 from: Data(traceJSON.utf8)
             )) ?? []
             trace = ComputerUseTraceRecord(
-                id: sqlite3_column_int64(statement, 7),
+                id: sqlite3_column_int64(statement, 9),
                 dictationID: sqlite3_column_int64(statement, 0),
-                finalStatus: stringColumn(statement, index: 8),
-                finalMessage: stringColumn(statement, index: 9),
+                finalStatus: stringColumn(statement, index: 10),
+                finalMessage: stringColumn(statement, index: 11),
                 events: events,
-                createdAt: stringColumn(statement, index: 11)
+                createdAt: stringColumn(statement, index: 13)
             )
         }
 
@@ -4011,6 +4168,8 @@ public final class DictationStore {
             appContext: stringColumn(statement, index: 4),
             wordCount: Int(sqlite3_column_int(statement, 5)),
             source: stringColumn(statement, index: 6),
+            targetAppName: optionalStringColumn(statement, index: 7),
+            targetAppBundleID: optionalStringColumn(statement, index: 8),
             computerUseTrace: trace
         )
     }
@@ -4181,11 +4340,25 @@ public final class DictationStore {
         return Date(timeIntervalSince1970: value)
     }
 
-    private func dictationStreaks(db: OpaquePointer?) throws -> (current: Int, longest: Int) {
+    private func dictationStreaks(
+        fromDate: String?,
+        toDate: String?,
+        origin: RecordOriginFilter,
+        targetApplication: DictationTargetApplication?,
+        db: OpaquePointer?
+    ) throws -> (current: Int, longest: Int) {
+        let filter = historyFilterConditions(
+            alias: nil,
+            dateColumn: "timestamp",
+            fromDate: fromDate,
+            toDate: toDate,
+            origin: origin,
+            targetApplication: targetApplication
+        )
         let sql = """
         SELECT DISTINCT date(timestamp) AS used_day
         FROM dictations
-        WHERE deleted_at IS NULL
+        WHERE \(filter.conditions.joined(separator: " AND "))
         ORDER BY used_day ASC
         """
         var statement: OpaquePointer?
@@ -4193,6 +4366,9 @@ public final class DictationStore {
             throw lastError(db)
         }
         defer { sqlite3_finalize(statement) }
+        for (index, value) in filter.boundValues.enumerated() {
+            sqlite3_bind_text(statement, Int32(index + 1), (value as NSString).utf8String, -1, nil)
+        }
 
         var days: [Date] = []
         let formatter = ISO8601DateFormatter()
@@ -4203,6 +4379,107 @@ public final class DictationStore {
             }
         }
         return Self.computeStreak(days: days)
+    }
+
+    private func historyFilterConditions(
+        alias: String?,
+        dateColumn: String,
+        fromDate: String?,
+        toDate: String?,
+        origin: RecordOriginFilter,
+        targetApplication: DictationTargetApplication? = nil
+    ) -> (conditions: [String], boundValues: [String]) {
+        let prefix = alias.map { "\($0)." } ?? ""
+        var conditions = ["\(prefix)deleted_at IS NULL"]
+        var boundValues: [String] = []
+        if let fromDate {
+            conditions.append("\(prefix)\(dateColumn) >= ?")
+            boundValues.append(fromDate)
+        }
+        if let toDate {
+            conditions.append("\(prefix)\(dateColumn) <= ?")
+            boundValues.append(toDate)
+        }
+        switch origin {
+        case .all:
+            break
+        case .thisMac:
+            conditions.append("LOWER(TRIM(COALESCE(\(prefix)source, ''))) <> 'ios'")
+        case .fromIPhone:
+            conditions.append("LOWER(TRIM(COALESCE(\(prefix)source, ''))) = 'ios'")
+        }
+        if let targetApplication {
+            if let bundleID = targetApplication.bundleID, !bundleID.isEmpty {
+                conditions.append("TRIM(COALESCE(\(prefix)target_app_bundle_id, '')) = ?")
+                boundValues.append(bundleID)
+            } else {
+                conditions.append("TRIM(COALESCE(\(prefix)target_app_bundle_id, '')) = ''")
+                conditions.append("LOWER(TRIM(COALESCE(\(prefix)target_app_name, ''))) = LOWER(?)")
+                boundValues.append(targetApplication.name)
+            }
+        }
+        return (conditions, boundValues)
+    }
+
+    private func backfillLegacyTargetApplicationsIfNeeded(db: OpaquePointer?) throws {
+        guard !(try targetApplicationBackfillCompleted(db: db)) else { return }
+
+        try exec("BEGIN IMMEDIATE TRANSACTION", db: db)
+        do {
+            if !(try targetApplicationBackfillCompleted(db: db)) {
+                try exec(
+                    """
+                    WITH contexts AS (
+                        SELECT id,
+                               TRIM(SUBSTR(app_context, 1, INSTR(app_context, '|') - 1)) AS app_name,
+                               SUBSTR(app_context, INSTR(app_context, '|') + 1) AS remainder
+                        FROM dictations
+                        WHERE target_app_name IS NULL
+                          AND target_app_bundle_id IS NULL
+                          AND INSTR(app_context, '|') > 0
+                          AND LOWER(TRIM(COALESCE(source, ''))) NOT IN ('ios', 'cua')
+                    ), parsed AS (
+                        SELECT id, app_name,
+                               TRIM(CASE WHEN INSTR(remainder, '|') > 0
+                                   THEN SUBSTR(remainder, 1, INSTR(remainder, '|') - 1)
+                                   ELSE remainder
+                               END) AS bundle_id
+                        FROM contexts
+                    )
+                    UPDATE dictations
+                    SET target_app_name = parsed.app_name,
+                        target_app_bundle_id = parsed.bundle_id
+                    FROM parsed
+                    WHERE dictations.id = parsed.id
+                      AND parsed.app_name <> ''
+                      AND parsed.bundle_id <> '';
+                    INSERT INTO local_migrations (identifier, completed_at)
+                    VALUES ('\(Self.targetApplicationBackfillMigration)', CAST(strftime('%s', 'now') AS REAL));
+                    """,
+                    db: db
+                )
+            }
+            try exec("COMMIT", db: db)
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    private func targetApplicationBackfillCompleted(db: OpaquePointer?) throws -> Bool {
+        let sql = """
+        SELECT EXISTS(
+            SELECT 1 FROM local_migrations
+            WHERE identifier = '\(Self.targetApplicationBackfillMigration)'
+        )
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW else { throw lastError(db) }
+        return sqlite3_column_int(statement, 0) != 0
     }
 
     private static func computeStreak(days: [Date]) -> (current: Int, longest: Int) {

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -139,6 +139,23 @@ public struct LiveTranscriptCheckpointEntry: Sendable, Equatable {
     }
 }
 
+public struct DictationTargetApplication: Identifiable, Hashable, Sendable {
+    public let name: String
+    public let bundleID: String?
+
+    public init(name: String, bundleID: String?) {
+        self.name = name
+        self.bundleID = bundleID
+    }
+
+    public var id: String {
+        if let bundleID, !bundleID.isEmpty {
+            return "bundle:\(bundleID)"
+        }
+        return "name:\(name.lowercased())"
+    }
+}
+
 public struct DictationRecord: Identifiable, Codable, Sendable {
     public let id: Int64
     public let timestamp: String
@@ -147,6 +164,8 @@ public struct DictationRecord: Identifiable, Codable, Sendable {
     public let appContext: String
     public let wordCount: Int
     public let source: String
+    public let targetAppName: String?
+    public let targetAppBundleID: String?
     public let computerUseTrace: ComputerUseTraceRecord?
 
     public init(
@@ -157,6 +176,8 @@ public struct DictationRecord: Identifiable, Codable, Sendable {
         appContext: String,
         wordCount: Int,
         source: String = "dictation",
+        targetAppName: String? = nil,
+        targetAppBundleID: String? = nil,
         computerUseTrace: ComputerUseTraceRecord? = nil
     ) {
         self.id = id
@@ -166,7 +187,32 @@ public struct DictationRecord: Identifiable, Codable, Sendable {
         self.appContext = appContext
         self.wordCount = wordCount
         self.source = source
+        self.targetAppName = targetAppName
+        self.targetAppBundleID = targetAppBundleID
         self.computerUseTrace = computerUseTrace
+    }
+}
+
+public enum TimelineEntry: Identifiable, Sendable {
+    case dictation(DictationRecord)
+    case meeting(MeetingRecord)
+
+    public var id: String {
+        switch self {
+        case .dictation(let record):
+            return "dictation:\(record.id)"
+        case .meeting(let record):
+            return "meeting:\(record.id)"
+        }
+    }
+
+    public var timestamp: String {
+        switch self {
+        case .dictation(let record):
+            return record.timestamp
+        case .meeting(let record):
+            return record.startTime
+        }
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AppState.swift
@@ -3,6 +3,7 @@ import Observation
 import MuesliCore
 
 enum DashboardTab: String, CaseIterable {
+    case timeline
     case dictations
     case insights
     case meetings
@@ -63,6 +64,48 @@ enum MeetingsNavigationState: Equatable {
     case document(Int64)
 }
 
+enum MeetingDetailReturnDestination: Equatable {
+    case meetings
+    case timeline
+}
+
+enum HistoryDateFilter: String, CaseIterable, Hashable {
+    case all
+    case last2Days
+    case lastWeek
+    case last2Weeks
+    case lastMonth
+    case last3Months
+
+    var label: String {
+        switch self {
+        case .all: return "All time"
+        case .last2Days: return "Last 2 days"
+        case .lastWeek: return "Last week"
+        case .last2Weeks: return "Last 2 weeks"
+        case .lastMonth: return "Last month"
+        case .last3Months: return "Last 3 months"
+        }
+    }
+
+    func fromDate(relativeTo now: Date = Date(), calendar: Calendar = .current) -> Date? {
+        switch self {
+        case .all:
+            return nil
+        case .last2Days:
+            return calendar.date(byAdding: .day, value: -2, to: now)
+        case .lastWeek:
+            return calendar.date(byAdding: .day, value: -7, to: now)
+        case .last2Weeks:
+            return calendar.date(byAdding: .day, value: -14, to: now)
+        case .lastMonth:
+            return calendar.date(byAdding: .month, value: -1, to: now)
+        case .last3Months:
+            return calendar.date(byAdding: .month, value: -3, to: now)
+        }
+    }
+}
+
 enum SparkleUpdateStatus: Equatable {
     case idle
     case checking
@@ -100,6 +143,7 @@ struct ActiveMeetingAudioWarning: Equatable {
 @Observable
 final class AppState {
     // Dashboard data
+    var timelineRows: [TimelineEntry] = []
     var dictationRows: [DictationRecord] = []
     var meetingRows: [MeetingRecord] = []
     var totalMeetingCount: Int = 0
@@ -110,9 +154,14 @@ final class AppState {
     var folders: [MeetingFolder] = []
     var selectedFolderID: Int64?  // nil = "All Meetings"
     var meetingsNavigationState: MeetingsNavigationState = .browser
+    var meetingDetailReturnDestination: MeetingDetailReturnDestination = .meetings
     var meetingNotesFocusRequest = 0
     var isMeetingTemplatesManagerPresented: Bool = false
     var dictationStats: DictationStats = DictationStats(
+        totalWords: 0, totalSessions: 0, averageWordsPerSession: 0,
+        averageWPM: 0, currentStreakDays: 0, longestStreakDays: 0
+    )
+    var filteredDictationStats: DictationStats = DictationStats(
         totalWords: 0, totalSessions: 0, averageWordsPerSession: 0,
         averageWPM: 0, currentStreakDays: 0, longestStreakDays: 0
     )
@@ -187,8 +236,20 @@ final class AppState {
     var dictationFromDate: String? = nil
     var dictationToDate: String? = nil
     var dictationOriginFilter: RecordOriginFilter = .all
+    var dictationApplicationFilter: DictationTargetApplication?
+    var dictationTargetApplications: [DictationTargetApplication] = []
     var hasMoreDictations: Bool = true
     var meetingOriginFilter: RecordOriginFilter = .all
+
+    // Timeline pagination, filtering, and session navigation state
+    var timelinePageSize: Int = 50
+    var timelineFromDate: String? = nil
+    var timelineToDate: String? = nil
+    var timelineOriginFilter: RecordOriginFilter = .all
+    var timelineApplicationFilter: DictationTargetApplication?
+    var timelineDateFilter: HistoryDateFilter = .all
+    var hasMoreTimelineEntries: Bool = true
+    var timelineScrollAnchor: String?
 
     // Search
     var searchQuery: String = ""
@@ -198,7 +259,11 @@ final class AppState {
     var isSearchActive: Bool { !searchQuery.isEmpty }
 
     // Navigation
-    var selectedTab: DashboardTab = .dictations
+    var selectedTab: DashboardTab = .timeline
+    var insightsReturnTab: DashboardTab = .timeline
+    var insightsBackLabel: String {
+        insightsReturnTab == .dictations ? "Back to Dictations" : "Back to Timeline"
+    }
     var insightsInitialSection: InsightsSection = .words
     var selectedSettingsPane: SettingsPane = .general
     var selectedModelsCategory: ModelsCategory = .dictation

--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -125,17 +125,31 @@ struct DashboardRootView: View {
                 backLabel: "Back to Search"
             )
             .id(id)
+        } else if appState.selectedTab == .timeline,
+                  appState.meetingDetailReturnDestination == .timeline,
+                  case .document(let id) = appState.meetingsNavigationState {
+            MeetingDetailView(
+                meeting: appState.selectedMeeting,
+                controller: controller,
+                appState: appState,
+                onBack: { controller.showTimelineHome() },
+                backLabel: "Back to Timeline"
+            )
+            .id(id)
         } else if appState.isSearchActive {
             SearchResultsView(appState: appState, controller: controller)
         } else {
             switch appState.selectedTab {
+            case .timeline:
+                TimelineView(appState: appState, controller: controller)
             case .dictations:
                 DictationsView(appState: appState, controller: controller)
             case .insights:
                 InsightsView(
                     initialSection: appState.insightsInitialSection,
                     loadSnapshot: { range in try await controller.insightsSnapshot(range: range) },
-                    onBack: { controller.closeInsights() }
+                    onBack: { controller.closeInsights() },
+                    backLabel: appState.insightsBackLabel
                 )
             case .meetings:
                 MeetingsView(appState: appState, controller: controller)

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationAttributionPolicy.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationAttributionPolicy.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum DictationAttributionPolicy {
+    static func shouldPersist(
+        isPasteOutput: Bool,
+        source: String,
+        text: String
+    ) -> Bool {
+        guard isPasteOutput,
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+        switch source.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "cua", "ios":
+            return false
+        default:
+            return true
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationRowView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationRowView.swift
@@ -65,6 +65,13 @@ struct DictationRowView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
+                if let targetAppName = record.targetAppName {
+                    TargetApplicationIconView(
+                        appName: targetAppName,
+                        bundleIdentifier: record.targetAppBundleID
+                    )
+                }
+
                 HStack(spacing: 8) {
                     if record.computerUseTrace != nil {
                         Button {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -1,50 +1,10 @@
-import AppKit
-import CoreImage.CIFilterBuiltins
 import SwiftUI
-import TelemetryDeck
 import MuesliCore
-
-enum DictationFilter: Hashable {
-    case all, last2Days, lastWeek, last2Weeks, lastMonth, last3Months
-
-    var label: String {
-        switch self {
-        case .all: return "All time"
-        case .last2Days: return "Last 2 days"
-        case .lastWeek: return "Last week"
-        case .last2Weeks: return "Last 2 weeks"
-        case .lastMonth: return "Last month"
-        case .last3Months: return "Last 3 months"
-        }
-    }
-}
-
-enum ICloudBridgeWorkingCopy {
-    static func title(isActivationPending: Bool) -> String {
-        isActivationPending
-            ? "Setting up private iCloud sync"
-            : "Syncing with private iCloud"
-    }
-
-    static func subtitle(isActivationPending: Bool) -> String {
-        isActivationPending
-            ? "Creating the sync channel and pulling your latest text records."
-            : "Checking for new text and uploading local changes."
-    }
-
-    static func buttonHelp(isActivationPending: Bool) -> String {
-        isActivationPending
-            ? "Sync setup is in progress"
-            : "Text sync is in progress"
-    }
-}
 
 struct DictationsView: View {
     let appState: AppState
     let controller: MuesliController
-    @State private var selectedFilter: DictationFilter = .all
-    @State private var bridgePromptSeen = false
-    @State private var isBridgeQRCodePresented = false
+    @State private var selectedFilter: HistoryDateFilter = .all
 
     private var groupedDictations: [(id: Date, header: String, records: [DictationRecord])] {
         let calendar = Calendar.current
@@ -95,13 +55,14 @@ struct DictationsView: View {
     var body: some View {
         VStack(spacing: 0) {
             StatsHeaderView(
-                dictationStats: appState.dictationStats,
+                dictationStats: appState.filteredDictationStats,
                 meetingStats: appState.meetingStats,
+                showsMeetingStat: false,
                 onSelect: { controller.openInsights(section: $0) }
             )
 
             if appState.config.showIOSCompanionPrompt {
-                iPhoneBridgeCard
+                IPhoneBridgeCard(appState: appState, controller: controller)
                     .padding(.horizontal, MuesliTheme.spacing24)
                     .padding(.bottom, MuesliTheme.spacing12)
             }
@@ -198,262 +159,13 @@ struct DictationsView: View {
                 }
             }
         }
-        .sheet(isPresented: $isBridgeQRCodePresented) {
-            IPhoneBridgeQRCodeSheet(
-                deepLinkURL: IPhoneBridgeLinks.iOSSyncDeepLinkURL,
-                installURL: IPhoneBridgeLinks.installURL
-            )
-        }
-    }
-
-    private var bridgeState: ICloudBridgeState {
-        appState.iCloudBridgeState
-    }
-
-    private var iPhoneBridgeCard: some View {
-        HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-            BridgeSyncIcon(
-                systemName: bridgeIcon,
-                isAnimating: bridgeSyncIconIsAnimating,
-                font: .system(size: 18, weight: .semibold)
-            )
-                .foregroundStyle(bridgeIconColor)
-                .frame(width: 28)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(bridgeTitle)
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                Text(bridgeSubtitle)
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                    .lineLimit(2)
-            }
-
-            Spacer(minLength: MuesliTheme.spacing12)
-
-            if shouldShowBridgeHandoffButton {
-                Button {
-                    isBridgeQRCodePresented = true
-                    TelemetryDeck.signal("bridge_qr_shown", parameters: ["platform": "macos"])
-                } label: {
-                    Image(systemName: "qrcode")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                        .frame(width: 28, height: 28)
-                        .background(MuesliTheme.surfacePrimary)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-                .buttonStyle(.plain)
-                .help("Show iPhone setup QR")
-            }
-
-            Button {
-                bridgePrimaryAction()
-            } label: {
-                HStack(spacing: 6) {
-                    Text(bridgeButtonTitle)
-                    BridgeSyncIcon(
-                        systemName: bridgeButtonIcon,
-                        isAnimating: bridgeButtonIconIsAnimating,
-                        font: .system(size: 12, weight: .semibold)
-                    )
-                }
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 12)
-                    .frame(height: 28)
-                    .background(MuesliTheme.accent)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            }
-            .buttonStyle(.plain)
-            .disabled(bridgeActionDisabled)
-            .help(bridgeButtonHelp)
-
-            Button {
-                controller.updateConfig { $0.showIOSCompanionPrompt = false }
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                    .frame(width: 28, height: 28)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            }
-            .buttonStyle(.plain)
-            .help("Hide iOS companion prompt")
-        }
-        .padding(MuesliTheme.spacing12)
-        .background(MuesliTheme.backgroundRaised)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
-        .onAppear {
-            guard !bridgePromptSeen else { return }
-            bridgePromptSeen = true
-            TelemetryDeck.signal("bridge_prompt_seen", parameters: ["platform": "macos"])
-        }
-    }
-
-    private var shouldShowBridgeHandoffButton: Bool {
-        guard appState.config.iCloudSyncEnabled else { return false }
-        switch bridgeState {
-        case .needsICloud, .error:
-            return false
-        case .active:
-            return appState.iCloudBridgeCompanionDeviceName == nil
-        case .notConfigured, .checkingICloud, .syncing:
-            return false
-        }
-    }
-
-    private var bridgeSyncIconIsAnimating: Bool {
-        isBridgeSyncWorking && bridgeIcon == "arrow.triangle.2.circlepath"
-    }
-
-    private var bridgeButtonIconIsAnimating: Bool {
-        isBridgeSyncWorking && bridgeButtonIcon == "arrow.triangle.2.circlepath"
-    }
-
-    private var isBridgeSyncWorking: Bool {
-        bridgeState == .checkingICloud || bridgeState == .syncing
-    }
-
-    private var bridgeIcon: String {
-        switch bridgeState {
-        case .active:
-            return "checkmark.icloud"
-        case .checkingICloud, .syncing:
-            return "arrow.triangle.2.circlepath"
-        case .needsICloud, .error:
-            return "exclamationmark.icloud"
-        case .notConfigured:
-            return "iphone.gen3"
-        }
-    }
-
-    private var bridgeIconColor: Color {
-        switch bridgeState {
-        case .active:
-            return MuesliTheme.success
-        case .needsICloud, .error:
-            return MuesliTheme.transcribing
-        default:
-            return MuesliTheme.accent
-        }
-    }
-
-    private var bridgeTitle: String {
-        switch bridgeState {
-        case .active:
-            guard let deviceName = appState.iCloudBridgeCompanionDeviceName else {
-                if let lastSyncedAt = appState.iCloudLastSyncedAt {
-                    return "iCloud sync active · \(relativeSyncTime(lastSyncedAt))"
-                }
-                return "iCloud sync active"
-            }
-            if let lastSyncedAt = appState.iCloudLastSyncedAt {
-                return "Synced with \(deviceName) · \(relativeSyncTime(lastSyncedAt))"
-            }
-            return "Synced with \(deviceName)"
-        case .checkingICloud:
-            return "Setting up private iCloud sync"
-        case .syncing:
-            return ICloudBridgeWorkingCopy.title(
-                isActivationPending: appState.isICloudBridgeActivationPending
-            )
-        case .needsICloud:
-            return "Sign in to iCloud to sync"
-        case .error:
-            return "iPhone sync needs attention"
-        case .notConfigured:
-            return "Use Muesli on iPhone"
-        }
-    }
-
-    private var bridgeSubtitle: String {
-        switch bridgeState {
-        case .active:
-            if let deviceName = appState.iCloudBridgeCompanionDeviceName {
-                return "Private iCloud text sync is on with \(deviceName). Audio stays local."
-            }
-            return "Scan the QR code to connect your iPhone. Audio stays local."
-        case .checkingICloud:
-            return "Checking this Mac's iCloud account..."
-        case .syncing:
-            return ICloudBridgeWorkingCopy.subtitle(
-                isActivationPending: appState.isICloudBridgeActivationPending
-            )
-        case .needsICloud, .error:
-            return appState.iCloudBridgeMessage ?? "Open iCloud settings, then try again."
-        case .notConfigured:
-            return "Your Muesli history follows you through private iCloud. Audio stays local."
-        }
-    }
-
-    private var bridgeButtonTitle: String {
-        switch bridgeState {
-        case .active:
-            return "Sync"
-        case .checkingICloud, .syncing:
-            return "Syncing"
-        case .needsICloud, .error:
-            return "Try again"
-        case .notConfigured:
-            return "Set up private iCloud sync"
-        }
-    }
-
-    private var bridgeButtonIcon: String {
-        switch bridgeState {
-        case .notConfigured:
-            return "icloud"
-        default:
-            return "arrow.triangle.2.circlepath"
-        }
-    }
-
-    private var bridgeActionDisabled: Bool {
-        bridgeState == .checkingICloud || bridgeState == .syncing
-    }
-
-    private var bridgeButtonHelp: String {
-        switch bridgeState {
-        case .active:
-            return "Sync text with iCloud"
-        case .checkingICloud:
-            return "Sync setup is in progress"
-        case .syncing:
-            return ICloudBridgeWorkingCopy.buttonHelp(
-                isActivationPending: appState.isICloudBridgeActivationPending
-            )
-        default:
-            return "Set up private iCloud text sync"
-        }
-    }
-
-    private func bridgePrimaryAction() {
-        switch bridgeState {
-        case .active:
-            controller.performICloudSync()
-        case .checkingICloud, .syncing:
-            break
-        default:
-            controller.enableIPhoneBridgeSync()
-        }
-    }
-
-    private func relativeSyncTime(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .short
-        return formatter.localizedString(for: date, relativeTo: Date())
     }
 
     private var emptyStateInstruction: String {
-        if appState.dictationOriginFilter != .all || selectedFilter != .all {
-            return "Try another source or time range"
+        if appState.dictationOriginFilter != .all
+            || selectedFilter != .all
+            || appState.dictationApplicationFilter != nil {
+            return "Try another source, app, or time range"
         }
         return appState.config.resolvedOnboardingUseCase.includesVoiceNotes
             ? "Click Record Voice Note to capture your first note"
@@ -461,6 +173,9 @@ struct DictationsView: View {
     }
 
     private var emptyStateTitle: String {
+        if let application = appState.dictationApplicationFilter {
+            return "No dictations for \(application.name)"
+        }
         switch appState.dictationOriginFilter {
         case .all: return "No dictations yet"
         case .thisMac: return "No dictations from this Mac"
@@ -474,6 +189,13 @@ struct DictationsView: View {
                 get: { appState.dictationOriginFilter },
                 set: { controller.filterDictations(origin: $0) }
             ))
+            if !appState.dictationTargetApplications.isEmpty || appState.dictationApplicationFilter != nil {
+                TargetApplicationFilterMenu(
+                    applications: appState.dictationTargetApplications,
+                    selection: appState.dictationApplicationFilter,
+                    onSelect: { controller.filterDictations(application: $0) }
+                )
+            }
             Spacer(minLength: 0)
             dateFilterButton
         }
@@ -537,8 +259,8 @@ struct DictationsView: View {
     }
 
     /// Build filter options dynamically based on the date range of actual data.
-    private var availableFilters: [DictationFilter] {
-        var filters: [DictationFilter] = [.all]
+    private var availableFilters: [HistoryDateFilter] {
+        var filters: [HistoryDateFilter] = [.all]
         let calendar = Calendar.current
         let now = Date()
 
@@ -559,23 +281,11 @@ struct DictationsView: View {
         return filters
     }
 
-    private func applyFilter(_ filter: DictationFilter) {
-        let calendar = Calendar.current
-        let now = Date()
-
-        switch filter {
-        case .all:
+    private func applyFilter(_ filter: HistoryDateFilter) {
+        if filter == .all {
             controller.clearDictationFilter()
-        case .last2Days:
-            controller.filterDictations(from: calendar.date(byAdding: .day, value: -2, to: now), to: nil)
-        case .lastWeek:
-            controller.filterDictations(from: calendar.date(byAdding: .day, value: -7, to: now), to: nil)
-        case .last2Weeks:
-            controller.filterDictations(from: calendar.date(byAdding: .day, value: -14, to: now), to: nil)
-        case .lastMonth:
-            controller.filterDictations(from: calendar.date(byAdding: .month, value: -1, to: now), to: nil)
-        case .last3Months:
-            controller.filterDictations(from: calendar.date(byAdding: .month, value: -3, to: now), to: nil)
+        } else {
+            controller.filterDictations(from: filter.fromDate(), to: nil)
         }
     }
 
@@ -625,159 +335,6 @@ struct DictationsView: View {
             return clean.count > 5 ? String(clean.suffix(8).prefix(5)) : clean
         }
         return Self.timeFormatter.string(from: date)
-    }
-}
-
-private struct BridgeSyncIcon: View {
-    let systemName: String
-    let isAnimating: Bool
-    let font: Font
-    @State private var rotationDegrees = 0.0
-
-    var body: some View {
-        Image(systemName: systemName)
-            .font(font)
-            .symbolRenderingMode(.hierarchical)
-            .rotationEffect(.degrees(rotationDegrees))
-            .onAppear {
-                updateRotation(animated: false)
-            }
-            .onChange(of: isAnimating) { _, _ in
-                updateRotation(animated: true)
-            }
-    }
-
-    private func updateRotation(animated: Bool) {
-        guard isAnimating else {
-            if animated {
-                withAnimation(.easeOut(duration: 0.15)) {
-                    rotationDegrees = 0
-                }
-            } else {
-                rotationDegrees = 0
-            }
-            return
-        }
-
-        rotationDegrees = 0
-        withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
-            rotationDegrees = 360
-        }
-    }
-}
-
-private struct IPhoneBridgeQRCodeSheet: View {
-    let deepLinkURL: URL
-    let installURL: URL
-    @Environment(\.dismiss) private var dismiss
-    @State private var didCopySetupLink = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                    Text("Open Muesli on iPhone")
-                        .font(MuesliTheme.title3())
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("Scan this after installing the iPhone app. The QR only opens setup; private iCloud does the actual sync.")
-                        .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer()
-
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                        .frame(width: 28, height: 28)
-                        .background(MuesliTheme.surfacePrimary)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-                .buttonStyle(.plain)
-            }
-
-            HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
-                QRCodeImage(payload: deepLinkURL.absoluteString)
-                    .frame(width: 148, height: 148)
-                    .padding(MuesliTheme.spacing8)
-                    .background(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                    Label("Same iCloud account", systemImage: "icloud")
-                    Label("Text sync only", systemImage: "text.badge.checkmark")
-                    Label("Audio stays local", systemImage: "lock")
-                }
-                .font(MuesliTheme.caption())
-                .foregroundStyle(MuesliTheme.textSecondary)
-            }
-
-            HStack(spacing: MuesliTheme.spacing8) {
-                Button("Open iPhone app page") {
-                    NSWorkspace.shared.open(installURL)
-                }
-                .buttonStyle(.bordered)
-
-                Button(didCopySetupLink ? "Copied!" : "Copy setup link") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(deepLinkURL.absoluteString, forType: .string)
-                    didCopySetupLink = true
-                    Task { @MainActor in
-                        try? await Task.sleep(for: .milliseconds(1500))
-                        didCopySetupLink = false
-                    }
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-        .padding(MuesliTheme.spacing20)
-        .frame(width: 430)
-        .background(MuesliTheme.backgroundBase)
-    }
-}
-
-private struct QRCodeImage: View {
-    let payload: String
-    @State private var cachedImage: NSImage?
-
-    var body: some View {
-        Group {
-            if let image = cachedImage {
-                Image(nsImage: image)
-                    .interpolation(.none)
-                    .resizable()
-                    .scaledToFit()
-            } else {
-                Image(systemName: "qrcode")
-                    .font(.system(size: 96, weight: .regular))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-            }
-        }
-        .accessibilityLabel("iPhone sync setup QR code")
-        .onAppear {
-            if cachedImage == nil {
-                cachedImage = makeQRCodeImage(payload: payload)
-            }
-        }
-    }
-
-    private func makeQRCodeImage(payload: String) -> NSImage? {
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(payload.utf8)
-        filter.correctionLevel = "M"
-
-        guard let outputImage = filter.outputImage?.transformed(by: CGAffineTransform(scaleX: 8, y: 8)) else {
-            return nil
-        }
-
-        let representation = NSCIImageRep(ciImage: outputImage)
-        let image = NSImage(size: representation.size)
-        image.addRepresentation(representation)
-        return image
     }
 }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/IPhoneBridgeCard.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/IPhoneBridgeCard.swift
@@ -1,0 +1,407 @@
+import AppKit
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+import TelemetryDeck
+
+enum ICloudBridgeWorkingCopy {
+    static func title(isActivationPending: Bool) -> String {
+        isActivationPending
+            ? "Setting up private iCloud sync"
+            : "Syncing with private iCloud"
+    }
+
+    static func subtitle(isActivationPending: Bool) -> String {
+        isActivationPending
+            ? "Creating the sync channel and pulling your latest text records."
+            : "Checking for new text and uploading local changes."
+    }
+
+    static func buttonHelp(isActivationPending: Bool) -> String {
+        isActivationPending
+            ? "Sync setup is in progress"
+            : "Text sync is in progress"
+    }
+}
+struct IPhoneBridgeCard: View {
+    let appState: AppState
+    let controller: MuesliController
+
+    @State private var promptSeen = false
+    @State private var isQRCodePresented = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+            BridgeSyncIcon(
+                systemName: bridgeIcon,
+                isAnimating: bridgeSyncIconIsAnimating,
+                font: .system(size: 18, weight: .semibold)
+            )
+            .foregroundStyle(bridgeIconColor)
+            .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(bridgeTitle)
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(bridgeSubtitle)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: MuesliTheme.spacing12)
+
+            if shouldShowHandoffButton {
+                Button {
+                    isQRCodePresented = true
+                    TelemetryDeck.signal("bridge_qr_shown", parameters: ["platform": "macos"])
+                } label: {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+                .help("Show iPhone setup QR")
+            }
+
+            Button(action: primaryAction) {
+                HStack(spacing: 6) {
+                    Text(buttonTitle)
+                    BridgeSyncIcon(
+                        systemName: buttonIcon,
+                        isAnimating: buttonIconIsAnimating,
+                        font: .system(size: 12, weight: .semibold)
+                    )
+                }
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 12)
+                .frame(height: 28)
+                .background(MuesliTheme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+            .disabled(actionDisabled)
+            .help(buttonHelp)
+
+            Button {
+                controller.updateConfig { $0.showIOSCompanionPrompt = false }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .frame(width: 28, height: 28)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
+            .help("Hide iOS companion prompt")
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.backgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+        .onAppear {
+            guard !promptSeen else { return }
+            promptSeen = true
+            TelemetryDeck.signal("bridge_prompt_seen", parameters: ["platform": "macos"])
+        }
+        .sheet(isPresented: $isQRCodePresented) {
+            IPhoneBridgeQRCodeSheet(
+                deepLinkURL: IPhoneBridgeLinks.iOSSyncDeepLinkURL,
+                installURL: IPhoneBridgeLinks.installURL
+            )
+        }
+    }
+
+    private var bridgeState: ICloudBridgeState {
+        appState.iCloudBridgeState
+    }
+
+    private var shouldShowHandoffButton: Bool {
+        guard appState.config.iCloudSyncEnabled else { return false }
+        switch bridgeState {
+        case .needsICloud, .error:
+            return false
+        case .active:
+            return appState.iCloudBridgeCompanionDeviceName == nil
+        case .notConfigured, .checkingICloud, .syncing:
+            return false
+        }
+    }
+
+    private var bridgeSyncIconIsAnimating: Bool {
+        isSyncWorking && bridgeIcon == "arrow.triangle.2.circlepath"
+    }
+
+    private var buttonIconIsAnimating: Bool {
+        isSyncWorking && buttonIcon == "arrow.triangle.2.circlepath"
+    }
+
+    private var isSyncWorking: Bool {
+        bridgeState == .checkingICloud || bridgeState == .syncing
+    }
+
+    private var bridgeIcon: String {
+        switch bridgeState {
+        case .active: return "checkmark.icloud"
+        case .checkingICloud, .syncing: return "arrow.triangle.2.circlepath"
+        case .needsICloud, .error: return "exclamationmark.icloud"
+        case .notConfigured: return "iphone.gen3"
+        }
+    }
+
+    private var bridgeIconColor: Color {
+        switch bridgeState {
+        case .active: return MuesliTheme.success
+        case .needsICloud, .error: return MuesliTheme.transcribing
+        default: return MuesliTheme.accent
+        }
+    }
+
+    private var bridgeTitle: String {
+        switch bridgeState {
+        case .active:
+            guard let deviceName = appState.iCloudBridgeCompanionDeviceName else {
+                if let lastSyncedAt = appState.iCloudLastSyncedAt {
+                    return "iCloud sync active · \(relativeSyncTime(lastSyncedAt))"
+                }
+                return "iCloud sync active"
+            }
+            if let lastSyncedAt = appState.iCloudLastSyncedAt {
+                return "Synced with \(deviceName) · \(relativeSyncTime(lastSyncedAt))"
+            }
+            return "Synced with \(deviceName)"
+        case .checkingICloud:
+            return "Setting up private iCloud sync"
+        case .syncing:
+            return ICloudBridgeWorkingCopy.title(
+                isActivationPending: appState.isICloudBridgeActivationPending
+            )
+        case .needsICloud:
+            return "Sign in to iCloud to sync"
+        case .error:
+            return "iPhone sync needs attention"
+        case .notConfigured:
+            return "Use Muesli on iPhone"
+        }
+    }
+
+    private var bridgeSubtitle: String {
+        switch bridgeState {
+        case .active:
+            if let deviceName = appState.iCloudBridgeCompanionDeviceName {
+                return "Private iCloud text sync is on with \(deviceName). Audio stays local."
+            }
+            return "Scan the QR code to connect your iPhone. Audio stays local."
+        case .checkingICloud:
+            return "Checking this Mac's iCloud account..."
+        case .syncing:
+            return ICloudBridgeWorkingCopy.subtitle(
+                isActivationPending: appState.isICloudBridgeActivationPending
+            )
+        case .needsICloud, .error:
+            return appState.iCloudBridgeMessage ?? "Open iCloud settings, then try again."
+        case .notConfigured:
+            return "Your Muesli history follows you through private iCloud. Audio stays local."
+        }
+    }
+
+    private var buttonTitle: String {
+        switch bridgeState {
+        case .active: return "Sync"
+        case .checkingICloud, .syncing: return "Syncing"
+        case .needsICloud, .error: return "Try again"
+        case .notConfigured: return "Set up private iCloud sync"
+        }
+    }
+
+    private var buttonIcon: String {
+        bridgeState == .notConfigured ? "icloud" : "arrow.triangle.2.circlepath"
+    }
+
+    private var actionDisabled: Bool {
+        bridgeState == .checkingICloud || bridgeState == .syncing
+    }
+
+    private var buttonHelp: String {
+        switch bridgeState {
+        case .active:
+            return "Sync text with iCloud"
+        case .checkingICloud:
+            return "Sync setup is in progress"
+        case .syncing:
+            return ICloudBridgeWorkingCopy.buttonHelp(
+                isActivationPending: appState.isICloudBridgeActivationPending
+            )
+        default:
+            return "Set up private iCloud text sync"
+        }
+    }
+
+    private func primaryAction() {
+        switch bridgeState {
+        case .active:
+            controller.performICloudSync()
+        case .checkingICloud, .syncing:
+            break
+        default:
+            controller.enableIPhoneBridgeSync()
+        }
+    }
+
+    private func relativeSyncTime(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+private struct BridgeSyncIcon: View {
+    let systemName: String
+    let isAnimating: Bool
+    let font: Font
+    @State private var rotationDegrees = 0.0
+
+    var body: some View {
+        Image(systemName: systemName)
+            .font(font)
+            .symbolRenderingMode(.hierarchical)
+            .rotationEffect(.degrees(rotationDegrees))
+            .onAppear { updateRotation(animated: false) }
+            .onChange(of: isAnimating) { _, _ in updateRotation(animated: true) }
+    }
+
+    private func updateRotation(animated: Bool) {
+        guard isAnimating else {
+            if animated {
+                withAnimation(.easeOut(duration: 0.15)) { rotationDegrees = 0 }
+            } else {
+                rotationDegrees = 0
+            }
+            return
+        }
+
+        rotationDegrees = 0
+        withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
+            rotationDegrees = 360
+        }
+    }
+}
+
+private struct IPhoneBridgeQRCodeSheet: View {
+    let deepLinkURL: URL
+    let installURL: URL
+    @Environment(\.dismiss) private var dismiss
+    @State private var didCopySetupLink = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text("Open Muesli on iPhone")
+                        .font(MuesliTheme.title3())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Scan this after installing the iPhone app. The QR only opens setup; private iCloud does the actual sync.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
+                QRCodeImage(payload: deepLinkURL.absoluteString)
+                    .frame(width: 148, height: 148)
+                    .padding(MuesliTheme.spacing8)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                    Label("Same iCloud account", systemImage: "icloud")
+                    Label("Text sync only", systemImage: "text.badge.checkmark")
+                    Label("Audio stays local", systemImage: "lock")
+                }
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            }
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                Button("Open iPhone app page") { NSWorkspace.shared.open(installURL) }
+                    .buttonStyle(.bordered)
+
+                Button(didCopySetupLink ? "Copied!" : "Copy setup link") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(deepLinkURL.absoluteString, forType: .string)
+                    didCopySetupLink = true
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(1500))
+                        didCopySetupLink = false
+                    }
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(MuesliTheme.spacing20)
+        .frame(width: 430)
+        .background(MuesliTheme.backgroundBase)
+    }
+}
+
+private struct QRCodeImage: View {
+    let payload: String
+    @State private var cachedImage: NSImage?
+
+    var body: some View {
+        Group {
+            if let cachedImage {
+                Image(nsImage: cachedImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(systemName: "qrcode")
+                    .font(.system(size: 96, weight: .regular))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+        }
+        .accessibilityLabel("iPhone sync setup QR code")
+        .onAppear {
+            if cachedImage == nil {
+                cachedImage = makeQRCodeImage(payload: payload)
+            }
+        }
+    }
+
+    private func makeQRCodeImage(payload: String) -> NSImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(payload.utf8)
+        filter.correctionLevel = "M"
+        guard let outputImage = filter.outputImage?
+            .transformed(by: CGAffineTransform(scaleX: 8, y: 8)) else {
+            return nil
+        }
+
+        let representation = NSCIImageRep(ciImage: outputImage)
+        let image = NSImage(size: representation.size)
+        image.addRepresentation(representation)
+        return image
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/InsightsView.swift
@@ -5,6 +5,7 @@ struct InsightsView: View {
     let initialSection: InsightsSection
     let loadSnapshot: (InsightsRange) async throws -> InsightsSnapshot
     let onBack: () -> Void
+    let backLabel: String
 
     @State private var range: InsightsRange = .twelveMonths
     @State private var metric: InsightsMetric
@@ -18,11 +19,13 @@ struct InsightsView: View {
     init(
         initialSection: InsightsSection,
         loadSnapshot: @escaping (InsightsRange) async throws -> InsightsSnapshot,
-        onBack: @escaping () -> Void
+        onBack: @escaping () -> Void,
+        backLabel: String
     ) {
         self.initialSection = initialSection
         self.loadSnapshot = loadSnapshot
         self.onBack = onBack
+        self.backLabel = backLabel
         _metric = State(initialValue: initialSection == .meetings ? .meetings : .words)
     }
 
@@ -86,7 +89,7 @@ struct InsightsView: View {
     private var headerIdentity: some View {
         HStack(spacing: 16) {
             Button(action: onBack) {
-                Label("Back to Dictations", systemImage: "chevron.left")
+                Label(backLabel, systemImage: "chevron.left")
             }
             .buttonStyle(.plain)
             .font(.system(size: 13, weight: .semibold))

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -1159,7 +1159,11 @@ struct MeetingDetailView: View {
 
     private func threadLink(icon: String, text: String, targetID: Int64) -> some View {
         Button {
-            controller.showMeetingDocument(id: targetID)
+            if appState.meetingDetailReturnDestination == .timeline {
+                controller.showTimelineMeetingDocument(id: targetID)
+            } else {
+                controller.showMeetingDocument(id: targetID)
+            }
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: icon)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8859,10 +8859,9 @@ final class MuesliController: NSObject {
                     if outputMode == .paste {
                         PasteController.paste(
                             text: text,
-                            onPasteDispatched: { [weak self] targetApplication in
+                            onPasteFinished: { [weak self] targetApplication in
                                 guard let self else { return }
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)
-                                    ?? startingTargetApp
                                 self.completeStandardDictation(
                                     text: text,
                                     duration: duration,

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8859,6 +8859,7 @@ final class MuesliController: NSObject {
                     if outputMode == .paste {
                         PasteController.paste(
                             text: text,
+                            requireStagedClipboardOwnership: true,
                             onPasteFinished: { [weak self] targetApplication in
                                 guard let self else { return }
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8309,12 +8309,17 @@ final class MuesliController: NSObject {
         capturedDictationCorrectionTargetApp = nil
     }
 
-    private func captureDictationCorrectionTargetApp() {
-        capturedDictationCorrectionTargetApp = DictationCorrectionTargetApp(
-            app: NSWorkspace.shared.frontmostApplication == NSRunningApplication.current
+    private func currentExternalDictationTargetApp() -> DictationCorrectionTargetApp? {
+        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+        return DictationCorrectionTargetApp(
+            app: frontmostApplication == NSRunningApplication.current
                 ? lastExternalApp
-                : NSWorkspace.shared.frontmostApplication
+                : frontmostApplication
         )
+    }
+
+    private func captureDictationCorrectionTargetApp() {
+        capturedDictationCorrectionTargetApp = currentExternalDictationTargetApp()
     }
 
     private func handleStart() {
@@ -8675,7 +8680,10 @@ final class MuesliController: NSObject {
             source: "dictation",
             text: cleaned
         )
-        let targetApp = shouldPersistTargetApp ? capturedDictationCorrectionTargetApp : nil
+        // If focus moved during streaming, attribute the completed session to the app active at stop.
+        let targetApp = shouldPersistTargetApp
+            ? currentExternalDictationTargetApp() ?? capturedDictationCorrectionTargetApp
+            : nil
 
         if !config.maraudersMapUnlocked { checkMaraudersMapActivation(cleaned) }
 
@@ -8742,9 +8750,9 @@ final class MuesliController: NSObject {
         let whisperTranscriptionLanguage = config.resolvedWhisperLanguage
         let capturedContext = capturedDictationContext
         let promptContext = capturedContext.map { DictationContextCapture.formatForPrompt($0) }
-        let correctionTargetApp = capturedDictationCorrectionTargetApp
+        let startingTargetApp = capturedDictationCorrectionTargetApp
         let storageContext = capturedContext.map { DictationContextCapture.formatForStorage($0) }
-            ?? correctionTargetApp?.appContext
+            ?? startingTargetApp?.appContext
             ?? ""
         let task = Task { [weak self] in
             guard let self else { return }
@@ -8802,12 +8810,16 @@ final class MuesliController: NSObject {
                     source: "dictation",
                     text: text
                 )
+                // Resolve at finalization so the app receiving the completed paste is authoritative.
+                let targetApp = shouldPersistTargetApp
+                    ? self.currentExternalDictationTargetApp() ?? startingTargetApp
+                    : nil
                 _ = try? self.dictationStore.insertDictation(
                     text: text,
                     durationSeconds: duration,
                     appContext: storageContext,
-                    targetAppName: shouldPersistTargetApp ? correctionTargetApp?.appName : nil,
-                    targetAppBundleID: shouldPersistTargetApp ? correctionTargetApp?.bundleID : nil,
+                    targetAppName: targetApp?.appName,
+                    targetAppBundleID: targetApp?.bundleID,
                     startedAt: startedAt,
                     endedAt: Date()
                 )
@@ -8827,7 +8839,7 @@ final class MuesliController: NSObject {
                             self.dictationCorrectionMonitor.start(
                                 originalText: text,
                                 appContext: storageContext,
-                                targetApp: correctionTargetApp
+                                targetApp: targetApp
                             ) { [weak self] suggestion in
                                 self?.addDictionarySuggestion(suggestion)
                             }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8309,13 +8309,18 @@ final class MuesliController: NSObject {
         capturedDictationCorrectionTargetApp = nil
     }
 
-    private func currentExternalDictationTargetApp() -> DictationCorrectionTargetApp? {
-        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+    private func externalDictationTargetApp(
+        from frontmostApplication: NSRunningApplication?
+    ) -> DictationCorrectionTargetApp? {
         return DictationCorrectionTargetApp(
             app: frontmostApplication == NSRunningApplication.current
                 ? lastExternalApp
                 : frontmostApplication
         )
+    }
+
+    private func currentExternalDictationTargetApp() -> DictationCorrectionTargetApp? {
+        externalDictationTargetApp(from: NSWorkspace.shared.frontmostApplication)
     }
 
     private func captureDictationCorrectionTargetApp() {
@@ -8711,6 +8716,51 @@ final class MuesliController: NSObject {
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
 
+    private func completeStandardDictation(
+        text: String,
+        duration: TimeInterval,
+        appContext: String,
+        startedAt: Date,
+        outputMode: DictationOutputMode,
+        targetApp: DictationCorrectionTargetApp?
+    ) {
+        _ = try? dictationStore.insertDictation(
+            text: text,
+            durationSeconds: duration,
+            appContext: appContext,
+            targetAppName: targetApp?.appName,
+            targetAppBundleID: targetApp?.bundleID,
+            startedAt: startedAt,
+            endedAt: Date()
+        )
+        scheduleICloudSyncAfterLocalChange()
+        clearCapturedDictationSessionContext()
+        statusBarController?.refresh()
+        historyWindowController?.reload()
+        syncAppState()
+        if outputMode == .paste, config.enableDictionaryCorrectionPrompts {
+            // Dictionary correction prompts are an explicit opt-in
+            // screen-context feature: they briefly read focused app
+            // text via Accessibility after dictation, then stop when
+            // the bounded edit monitor session ends.
+            dictationCorrectionMonitor.start(
+                originalText: text,
+                appContext: appContext,
+                targetApp: targetApp
+            ) { [weak self] suggestion in
+                self?.addDictionarySuggestion(suggestion)
+            }
+        }
+        resetDictationOutputMode()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
+        TelemetryDeck.signal("dictation.completed", parameters: [
+            "backend": selectedBackend.backend,
+            "paste_method": outputMode.pasteMethod,
+        ])
+    }
+
     private func finishStandardDictationStop(wavURL stoppedWavURL: URL?, startedAt: Date) {
         markDictationLatency("stop_finished")
         guard let wavURL = stoppedWavURL else {
@@ -8805,54 +8855,34 @@ final class MuesliController: NSObject {
                     }
                     return
                 }
-                let shouldPersistTargetApp = DictationAttributionPolicy.shouldPersist(
-                    isPasteOutput: outputMode == .paste,
-                    source: "dictation",
-                    text: text
-                )
-                // Resolve at finalization so the app receiving the completed paste is authoritative.
-                let targetApp = shouldPersistTargetApp
-                    ? self.currentExternalDictationTargetApp() ?? startingTargetApp
-                    : nil
-                _ = try? self.dictationStore.insertDictation(
-                    text: text,
-                    durationSeconds: duration,
-                    appContext: storageContext,
-                    targetAppName: targetApp?.appName,
-                    targetAppBundleID: targetApp?.bundleID,
-                    startedAt: startedAt,
-                    endedAt: Date()
-                )
                 await MainActor.run {
-                    self.scheduleICloudSyncAfterLocalChange()
-                    self.clearCapturedDictationSessionContext()
-                    self.statusBarController?.refresh()
-                    self.historyWindowController?.reload()
-                    self.syncAppState()
-                    if outputMode != .voiceNote {
-                        PasteController.paste(text: text)
-                        if self.config.enableDictionaryCorrectionPrompts {
-                            // Dictionary correction prompts are an explicit opt-in
-                            // screen-context feature: they briefly read focused app
-                            // text via Accessibility after dictation, then stop when
-                            // the bounded edit monitor session ends.
-                            self.dictationCorrectionMonitor.start(
-                                originalText: text,
-                                appContext: storageContext,
-                                targetApp: targetApp
-                            ) { [weak self] suggestion in
-                                self?.addDictionarySuggestion(suggestion)
+                    if outputMode == .paste {
+                        PasteController.paste(
+                            text: text,
+                            onPasteDispatched: { [weak self] targetApplication in
+                                guard let self else { return }
+                                let targetApp = self.externalDictationTargetApp(from: targetApplication)
+                                    ?? startingTargetApp
+                                self.completeStandardDictation(
+                                    text: text,
+                                    duration: duration,
+                                    appContext: storageContext,
+                                    startedAt: startedAt,
+                                    outputMode: outputMode,
+                                    targetApp: targetApp
+                                )
                             }
-                        }
+                        )
+                    } else {
+                        self.completeStandardDictation(
+                            text: text,
+                            duration: duration,
+                            appContext: storageContext,
+                            startedAt: startedAt,
+                            outputMode: outputMode,
+                            targetApp: nil
+                        )
                     }
-                    self.resetDictationOutputMode()
-                    self.setState(.idle)
-                    self.meetingMonitor.resumeAfterCooldown()
-                    self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
-                    TelemetryDeck.signal("dictation.completed", parameters: [
-                        "backend": self.selectedBackend.backend,
-                        "paste_method": outputMode.pasteMethod,
-                    ])
                 }
             } catch is CancellationError {
                 fputs("[muesli-native] test dictation cancelled\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -919,11 +919,30 @@ final class MuesliController: NSObject {
         )
     }
 
+    private func filteredDictationStats() -> DictationStats {
+        (try? dictationStore.dictationStats(
+            fromDate: appState.dictationFromDate,
+            toDate: appState.dictationToDate,
+            origin: appState.dictationOriginFilter,
+            targetApplication: appState.dictationApplicationFilter
+        )) ?? DictationStats(
+            totalWords: 0,
+            totalSessions: 0,
+            averageWordsPerSession: 0,
+            averageWPM: 0,
+            currentStreakDays: 0,
+            longestStreakDays: 0
+        )
+    }
+
     func meetingStats() -> MeetingStats {
         (try? dictationStore.meetingStats()) ?? MeetingStats(totalWords: 0, totalMeetings: 0, averageWPM: 0)
     }
 
     func openInsights(section: InsightsSection) {
+        if appState.selectedTab == .timeline || appState.selectedTab == .dictations {
+            appState.insightsReturnTab = appState.selectedTab
+        }
         appState.insightsInitialSection = section
         appState.selectedTab = .insights
     }
@@ -1051,7 +1070,7 @@ final class MuesliController: NSObject {
         }
         appState.activeFeatureTour = nil
         appState.featureTourStepIndex = 0
-        appState.selectedTab = .dictations
+        appState.selectedTab = .timeline
     }
 
     private func showFeatureTourStep(_ index: Int, in tour: FeatureTour) {
@@ -1066,7 +1085,7 @@ final class MuesliController: NSObject {
         }
         switch step.target {
         case .insightsEntry:
-            appState.selectedTab = .dictations
+            appState.selectedTab = .timeline
         case .dictionarySuggestions:
             appState.selectedTab = .dictionary
         case .meetingsSidebar:
@@ -1088,7 +1107,7 @@ final class MuesliController: NSObject {
     }
 
     func closeInsights() {
-        appState.selectedTab = .dictations
+        appState.selectedTab = appState.insightsReturnTab
     }
 
     func insightsSnapshot(range: InsightsRange) async throws -> InsightsSnapshot {
@@ -1130,15 +1149,27 @@ final class MuesliController: NSObject {
     }
 
     func syncAppState() {
+        let timelineRows = (try? dictationStore.timelineEntries(
+            limit: appState.timelinePageSize,
+            offset: 0,
+            fromDate: appState.timelineFromDate,
+            toDate: appState.timelineToDate,
+            origin: appState.timelineOriginFilter,
+            targetApplication: appState.timelineApplicationFilter
+        )) ?? []
+        appState.timelineRows = timelineRows
+        appState.hasMoreTimelineEntries = timelineRows.count >= appState.timelinePageSize
         let rows = (try? dictationStore.recentDictations(
             limit: appState.dictationPageSize,
             offset: 0,
             fromDate: appState.dictationFromDate,
             toDate: appState.dictationToDate,
-            origin: appState.dictationOriginFilter
+            origin: appState.dictationOriginFilter,
+            targetApplication: appState.dictationApplicationFilter
         )) ?? []
         appState.dictationRows = rows
         appState.hasMoreDictations = rows.count >= appState.dictationPageSize
+        appState.dictationTargetApplications = (try? dictationStore.dictationTargetApplications()) ?? []
         appState.meetingRows = (try? dictationStore.recentMeetings(
             limit: 200,
             folderID: appState.selectedFolderID,
@@ -1163,6 +1194,7 @@ final class MuesliController: NSObject {
         // Sort folders into a depth-first tree order so children appear beneath parents.
         appState.folders = Self.treeOrderedFolders(allFolders, order: order)
         appState.dictationStats = dictationStats()
+        appState.filteredDictationStats = filteredDictationStats()
         appState.meetingStats = meetingStats()
         refreshContributionMilestonePrompt(
             totalWords: appState.dictationStats.totalWords,
@@ -3970,8 +4002,24 @@ final class MuesliController: NSObject {
         syncAppState()
     }
 
+    func showTimelineHome() {
+        appState.selectedTab = .timeline
+        appState.meetingsNavigationState = .browser
+        appState.selectedMeetingID = nil
+        appState.selectedMeetingRecord = nil
+    }
+
     func showMeetingDocument(id: Int64) {
         appState.selectedTab = .meetings
+        appState.meetingDetailReturnDestination = .meetings
+        appState.selectedMeetingID = id
+        appState.selectedMeetingRecord = meeting(id: id)
+        appState.meetingsNavigationState = .document(id)
+    }
+
+    func showTimelineMeetingDocument(id: Int64) {
+        appState.selectedTab = .timeline
+        appState.meetingDetailReturnDestination = .timeline
         appState.selectedMeetingID = id
         appState.selectedMeetingRecord = meeting(id: id)
         appState.meetingsNavigationState = .document(id)
@@ -4643,10 +4691,51 @@ final class MuesliController: NSObject {
             offset: offset,
             fromDate: appState.dictationFromDate,
             toDate: appState.dictationToDate,
-            origin: appState.dictationOriginFilter
+            origin: appState.dictationOriginFilter,
+            targetApplication: appState.dictationApplicationFilter
         )) ?? []
         appState.dictationRows.append(contentsOf: more)
         appState.hasMoreDictations = more.count >= appState.dictationPageSize
+    }
+
+    func loadMoreTimelineEntries() {
+        guard appState.hasMoreTimelineEntries else { return }
+        let offset = appState.timelineRows.count
+        let more = (try? dictationStore.timelineEntries(
+            limit: appState.timelinePageSize,
+            offset: offset,
+            fromDate: appState.timelineFromDate,
+            toDate: appState.timelineToDate,
+            origin: appState.timelineOriginFilter,
+            targetApplication: appState.timelineApplicationFilter
+        )) ?? []
+        appState.timelineRows.append(contentsOf: more)
+        appState.hasMoreTimelineEntries = more.count >= appState.timelinePageSize
+    }
+
+    func filterTimeline(dateFilter: HistoryDateFilter) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        appState.timelineDateFilter = dateFilter
+        appState.timelineFromDate = dateFilter.fromDate().map { formatter.string(from: $0) }
+        appState.timelineToDate = nil
+        appState.timelineScrollAnchor = nil
+        syncAppState()
+        appState.timelineScrollAnchor = appState.timelineRows.first?.id
+    }
+
+    func filterTimeline(origin: RecordOriginFilter) {
+        appState.timelineOriginFilter = origin
+        appState.timelineScrollAnchor = nil
+        syncAppState()
+        appState.timelineScrollAnchor = appState.timelineRows.first?.id
+    }
+
+    func filterTimeline(application: DictationTargetApplication?) {
+        appState.timelineApplicationFilter = application
+        appState.timelineScrollAnchor = nil
+        syncAppState()
+        appState.timelineScrollAnchor = appState.timelineRows.first?.id
     }
 
     func filterDictations(from: Date?, to: Date?) {
@@ -4665,6 +4754,11 @@ final class MuesliController: NSObject {
 
     func filterDictations(origin: RecordOriginFilter) {
         appState.dictationOriginFilter = origin
+        syncAppState()
+    }
+
+    func filterDictations(application: DictationTargetApplication?) {
+        appState.dictationApplicationFilter = application
         syncAppState()
     }
 
@@ -8572,9 +8666,16 @@ final class MuesliController: NSObject {
         nemotron35StreamingSessionID = nil
         previousStreamText = ""
         let duration = max(Date().timeIntervalSince(startedAt), 0)
+        let outputMode = currentDictationOutputMode
         fputs("[muesli-native] Nemotron streaming stop, got \(finalText.count) chars\n", stderr)
         let cleaned = FillerWordFilter.apply(finalText)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let shouldPersistTargetApp = DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: outputMode == .paste,
+            source: "dictation",
+            text: cleaned
+        )
+        let targetApp = shouldPersistTargetApp ? capturedDictationCorrectionTargetApp : nil
 
         if !config.maraudersMapUnlocked { checkMaraudersMapActivation(cleaned) }
 
@@ -8582,6 +8683,8 @@ final class MuesliController: NSObject {
             _ = try? dictationStore.insertDictation(
                 text: cleaned,
                 durationSeconds: duration,
+                targetAppName: targetApp?.appName,
+                targetAppBundleID: targetApp?.bundleID,
                 startedAt: startedAt,
                 endedAt: Date()
             )
@@ -8694,10 +8797,17 @@ final class MuesliController: NSObject {
                     }
                     return
                 }
+                let shouldPersistTargetApp = DictationAttributionPolicy.shouldPersist(
+                    isPasteOutput: outputMode == .paste,
+                    source: "dictation",
+                    text: text
+                )
                 _ = try? self.dictationStore.insertDictation(
                     text: text,
                     durationSeconds: duration,
                     appContext: storageContext,
+                    targetAppName: shouldPersistTargetApp ? correctionTargetApp?.appName : nil,
+                    targetAppBundleID: shouldPersistTargetApp ? correctionTargetApp?.bundleID : nil,
                     startedAt: startedAt,
                     endedAt: Date()
                 )

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -39,10 +39,12 @@ enum PasteController {
     /// If the clipboard cannot be saved (e.g. lazy-provided data), falls back to a simple
     /// paste without restoration.
     /// For nonempty text, completion receives the target app only when the keyboard events
-    /// were posted; event-setup failure completes with `nil` attribution.
+    /// were posted. When staged-clipboard ownership is required, a failed write or intervening
+    /// clipboard change also completes with `nil` attribution and skips Cmd+V.
     static func paste(
         text: String,
         pasteboard: NSPasteboard = .general,
+        requireStagedClipboardOwnership: Bool = false,
         targetApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
             NSWorkspace.shared.frontmostApplication
         },
@@ -54,14 +56,29 @@ enum PasteController {
         // Save current clipboard contents (all types) so we can restore after paste.
         let savedItems = saveClipboard(pasteboard)
 
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        let clearedChangeCount = pasteboard.clearContents()
+        let didStageText = pasteboard.setString(text, forType: .string)
         let pasteChangeCount = pasteboard.changeCount
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             // Snapshot immediately before Cmd+V so attribution and the paste event
             // refer to the same frontmost application.
             let targetApplication = targetApplicationProvider()
+            if requireStagedClipboardOwnership {
+                guard didStageText else {
+                    // Restore only when Muesli still owns the cleared pasteboard. If another
+                    // app wrote to it, preserving that newer content takes precedence.
+                    if pasteboard.changeCount == clearedChangeCount {
+                        restoreClipboard(pasteboard, from: savedItems)
+                    }
+                    onPasteFinished(nil)
+                    return
+                }
+                guard pasteboard.changeCount == pasteChangeCount else {
+                    onPasteFinished(nil)
+                    return
+                }
+            }
             let didDispatchPaste = simulatePasteAction()
             onPasteFinished(didDispatchPaste ? targetApplication : nil)
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -41,7 +41,11 @@ enum PasteController {
     static func paste(
         text: String,
         pasteboard: NSPasteboard = .general,
-        simulatePasteAction: @escaping () -> Void = PasteController.simulatePaste
+        targetApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
+            NSWorkspace.shared.frontmostApplication
+        },
+        simulatePasteAction: @escaping @MainActor () -> Void = PasteController.simulatePaste,
+        onPasteDispatched: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in }
     ) {
         guard !text.isEmpty else { return }
 
@@ -53,7 +57,11 @@ enum PasteController {
         let pasteChangeCount = pasteboard.changeCount
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            // Snapshot immediately before Cmd+V so attribution and the paste event
+            // refer to the same frontmost application.
+            let targetApplication = targetApplicationProvider()
             simulatePasteAction()
+            onPasteDispatched(targetApplication)
 
             // Restore the original clipboard contents after the receiving app has consumed the paste.
             DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -38,14 +38,16 @@ enum PasteController {
     /// Flow: save clipboard → write text → Cmd+V → restore clipboard after delay.
     /// If the clipboard cannot be saved (e.g. lazy-provided data), falls back to a simple
     /// paste without restoration.
+    /// For nonempty text, completion receives the target app only when the keyboard events
+    /// were posted; event-setup failure completes with `nil` attribution.
     static func paste(
         text: String,
         pasteboard: NSPasteboard = .general,
         targetApplicationProvider: @escaping @MainActor () -> NSRunningApplication? = {
             NSWorkspace.shared.frontmostApplication
         },
-        simulatePasteAction: @escaping @MainActor () -> Void = PasteController.simulatePaste,
-        onPasteDispatched: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in }
+        simulatePasteAction: @escaping @MainActor () -> Bool = PasteController.simulatePaste,
+        onPasteFinished: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in }
     ) {
         guard !text.isEmpty else { return }
 
@@ -60,8 +62,8 @@ enum PasteController {
             // Snapshot immediately before Cmd+V so attribution and the paste event
             // refer to the same frontmost application.
             let targetApplication = targetApplicationProvider()
-            simulatePasteAction()
-            onPasteDispatched(targetApplication)
+            let didDispatchPaste = simulatePasteAction()
+            onPasteFinished(didDispatchPaste ? targetApplication : nil)
 
             // Restore the original clipboard contents after the receiving app has consumed the paste.
             DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
@@ -95,18 +97,23 @@ enum PasteController {
 
     // MARK: - Private
 
-    private static func simulatePaste() {
+    private static func simulatePaste() -> Bool {
         guard let source = CGEventSource(stateID: .combinedSessionState) else {
             fputs("[muesli-native] failed to create event source for paste\n", stderr)
-            return
+            return false
         }
         let keyCode: CGKeyCode = 9 // V
-        let commandDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
-        commandDown?.flags = .maskCommand
-        let commandUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
-        commandUp?.flags = .maskCommand
-        commandDown?.post(tap: .cghidEventTap)
-        commandUp?.post(tap: .cghidEventTap)
+        guard let commandDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+              let commandUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        else {
+            fputs("[muesli-native] failed to create keyboard events for paste\n", stderr)
+            return false
+        }
+        commandDown.flags = .maskCommand
+        commandUp.flags = .maskCommand
+        commandDown.post(tap: .cghidEventTap)
+        commandUp.post(tap: .cghidEventTap)
+        return true
     }
 
     private static func postPhysicalKey(source: CGEventSource, keyCode: CGKeyCode, flags: CGEventFlags) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SearchResultsView.swift
@@ -175,6 +175,14 @@ private struct SearchDictationRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
+            if let targetAppName = record.targetAppName {
+                TargetApplicationIconView(
+                    appName: targetAppName,
+                    bundleIdentifier: record.targetAppBundleID,
+                    size: 18
+                )
+            }
+
             HStack(spacing: 8) {
                 if record.computerUseTrace != nil, let onCopyTrace {
                     Button(action: onCopyTrace) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -102,6 +102,7 @@ struct SidebarView: View {
             sidebarHeader
             searchBar
 
+            sidebarItem(tab: .timeline, icon: "clock.fill", label: "Timeline")
             sidebarItem(tab: .dictations, icon: "mic.fill", label: "Dictations")
             meetingsSection
             sidebarItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
@@ -487,7 +488,11 @@ struct SidebarView: View {
         let isSelected = appState.selectedTab == tab
         Button {
             withAnimation(.easeInOut(duration: 0.15)) {
-                appState.selectedTab = tab
+                if tab == .timeline {
+                    controller.showTimelineHome()
+                } else {
+                    appState.selectedTab = tab
+                }
             }
         } label: {
             HStack(spacing: MuesliTheme.spacing12) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/StatsHeaderView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/StatsHeaderView.swift
@@ -4,9 +4,21 @@ import MuesliCore
 struct StatsHeaderView: View {
     let dictationStats: DictationStats
     let meetingStats: MeetingStats
+    var showsMeetingStat = true
+    var tracksInsightsFeatureTour = false
     let onSelect: (InsightsSection) -> Void
 
+    @ViewBuilder
     var body: some View {
+        if tracksInsightsFeatureTour {
+            cards
+                .featureTourTarget(.insightsEntry)
+        } else {
+            cards
+        }
+    }
+
+    private var cards: some View {
         HStack(spacing: MuesliTheme.spacing16) {
             StatCard(
                 icon: "flame.fill",
@@ -32,16 +44,17 @@ struct StatsHeaderView: View {
                 accessibilityHint: "Open speaking pace insights",
                 action: { onSelect(.pace) }
             )
-            StatCard(
-                icon: "person.2.fill",
-                iconColor: MuesliTheme.accent,
-                value: "\(meetingStats.totalMeetings)",
-                label: "meetings",
-                accessibilityHint: "Open meeting insights",
-                action: { onSelect(.meetings) }
-            )
+            if showsMeetingStat {
+                StatCard(
+                    icon: "person.2.fill",
+                    iconColor: MuesliTheme.accent,
+                    value: "\(meetingStats.totalMeetings)",
+                    label: "meetings",
+                    accessibilityHint: "Open meeting insights",
+                    action: { onSelect(.meetings) }
+                )
+            }
         }
-        .featureTourTarget(.insightsEntry)
         .padding(.horizontal, MuesliTheme.spacing24)
         .padding(.vertical, MuesliTheme.spacing20)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TargetApplicationIconView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TargetApplicationIconView.swift
@@ -1,0 +1,131 @@
+import AppKit
+import SwiftUI
+import MuesliCore
+
+@MainActor
+private enum TargetApplicationIconResolver {
+    private static let cache = NSCache<NSString, NSImage>()
+
+    static func icon(bundleIdentifier: String?) -> NSImage? {
+        guard let bundleIdentifier = bundleIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !bundleIdentifier.isEmpty else {
+            return nil
+        }
+
+        let key = bundleIdentifier as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let runningURL = NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleIdentifier)
+            .first?
+            .bundleURL
+        guard let applicationURL = runningURL
+                ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
+            return nil
+        }
+
+        let icon = NSWorkspace.shared.icon(forFile: applicationURL.path)
+        cache.setObject(icon, forKey: key)
+        return icon
+    }
+}
+
+struct TargetApplicationIconView: View {
+    let appName: String
+    let bundleIdentifier: String?
+    var size: CGFloat = 20
+
+    private var accessibilityText: String {
+        "Dictated into \(appName)"
+    }
+
+    var body: some View {
+        Group {
+            if let icon = TargetApplicationIconResolver.icon(bundleIdentifier: bundleIdentifier) {
+                Image(nsImage: icon)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(systemName: "app.dashed")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(size * 0.13)
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: size * 0.22))
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .help(accessibilityText)
+    }
+}
+
+struct TargetApplicationFilterMenu: View {
+    let applications: [DictationTargetApplication]
+    let selection: DictationTargetApplication?
+    let onSelect: (DictationTargetApplication?) -> Void
+
+    var body: some View {
+        Menu {
+            Button {
+                onSelect(nil)
+            } label: {
+                HStack {
+                    Text("All apps")
+                    if selection == nil {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            if !applications.isEmpty {
+                Divider()
+                ForEach(applications) { application in
+                    Button {
+                        onSelect(application)
+                    } label: {
+                        HStack {
+                            Text(application.name)
+                            if selection?.id == application.id {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                if let selection {
+                    TargetApplicationIconView(
+                        appName: selection.name,
+                        bundleIdentifier: selection.bundleID,
+                        size: 16
+                    )
+                    Text(selection.name)
+                        .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                } else {
+                    Image(systemName: "square.grid.2x2")
+                        .font(.system(size: 11))
+                    Text("Apps")
+                        .font(.system(size: 11, weight: .medium))
+                }
+            }
+            .foregroundStyle(selection == nil ? MuesliTheme.textTertiary : MuesliTheme.accent)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(selection == nil ? Color.clear : MuesliTheme.accent.opacity(0.12))
+            .clipShape(Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(selection.map { "Showing dictations for \($0.name)" } ?? "Filter by destination app")
+        .accessibilityLabel("Destination application filter")
+        .accessibilityValue(selection?.name ?? "All apps")
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
@@ -1,0 +1,321 @@
+import SwiftUI
+import MuesliCore
+
+struct TimelineView: View {
+    let appState: AppState
+    let controller: MuesliController
+
+    private struct DayGroup: Identifiable {
+        let id: Date
+        let header: String
+        let entries: [TimelineEntry]
+    }
+
+    private var groupedEntries: [DayGroup] {
+        let calendar = Calendar.current
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
+        var entriesByDay: [Date: [TimelineEntry]] = [:]
+        for entry in appState.timelineRows {
+            let date = MeetingBrowserLogic.parseDate(entry.timestamp) ?? now
+            let day = calendar.startOfDay(for: date)
+            entriesByDay[day, default: []].append(entry)
+        }
+        return entriesByDay.keys.sorted(by: >).map { day in
+            let header: String
+            if day == today {
+                header = "TODAY"
+            } else if day == yesterday {
+                header = "YESTERDAY"
+            } else {
+                header = day.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated)).uppercased()
+            }
+            return DayGroup(id: day, header: header, entries: entriesByDay[day] ?? [])
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            StatsHeaderView(
+                dictationStats: appState.dictationStats,
+                meetingStats: appState.meetingStats,
+                showsMeetingStat: true,
+                tracksInsightsFeatureTour: true,
+                onSelect: { controller.openInsights(section: $0) }
+            )
+
+            if appState.config.showIOSCompanionPrompt {
+                IPhoneBridgeCard(appState: appState, controller: controller)
+                    .padding(.horizontal, MuesliTheme.spacing24)
+                    .padding(.bottom, MuesliTheme.spacing12)
+            }
+
+            filterBar
+                .padding(.horizontal, MuesliTheme.spacing24)
+                .padding(.bottom, MuesliTheme.spacing12)
+
+            if appState.timelineRows.isEmpty {
+                emptyState
+            } else {
+                timelineScrollView
+            }
+        }
+    }
+
+    private var filterBar: some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            RecordOriginPicker(selection: Binding(
+                get: { appState.timelineOriginFilter },
+                set: { controller.filterTimeline(origin: $0) }
+            ))
+            if !appState.dictationTargetApplications.isEmpty || appState.timelineApplicationFilter != nil {
+                TargetApplicationFilterMenu(
+                    applications: appState.dictationTargetApplications,
+                    selection: appState.timelineApplicationFilter,
+                    onSelect: { controller.filterTimeline(application: $0) }
+                )
+            }
+            Spacer(minLength: 0)
+            dateFilterMenu
+        }
+    }
+
+    private var dateFilterMenu: some View {
+        Menu {
+            ForEach(HistoryDateFilter.allCases, id: \.self) { filter in
+                Button {
+                    controller.filterTimeline(dateFilter: filter)
+                } label: {
+                    HStack {
+                        Text(filter.label)
+                        if appState.timelineDateFilter == filter {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(.system(size: 11))
+                if appState.timelineDateFilter != .all {
+                    Text(appState.timelineDateFilter.label)
+                        .font(.system(size: 11))
+                }
+            }
+            .foregroundStyle(
+                appState.timelineDateFilter == .all
+                    ? MuesliTheme.textTertiary
+                    : MuesliTheme.accent
+            )
+            .padding(.horizontal, appState.timelineDateFilter == .all ? 0 : 8)
+            .padding(.vertical, 3)
+            .background(
+                appState.timelineDateFilter == .all
+                    ? Color.clear
+                    : MuesliTheme.accent.opacity(0.12)
+            )
+            .clipShape(Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: MuesliTheme.spacing12) {
+            Spacer()
+            Image(systemName: "clock.badge.questionmark")
+                .font(.system(size: 40, weight: .thin))
+                .foregroundStyle(MuesliTheme.textTertiary)
+            Text(emptyStateTitle)
+                .font(MuesliTheme.title3())
+                .foregroundStyle(MuesliTheme.textSecondary)
+            Text("Try another source, app, or time range")
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textTertiary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyStateTitle: String {
+        if let application = appState.timelineApplicationFilter {
+            return "No dictations for \(application.name)"
+        }
+        switch appState.timelineOriginFilter {
+        case .all: return "No activity yet"
+        case .thisMac: return "No activity from this Mac"
+        case .fromIPhone: return "No activity from iPhone"
+        }
+    }
+
+    private var timelineScrollView: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+                ForEach(groupedEntries) { group in
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                        Text(group.header)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .padding(.leading, MuesliTheme.spacing4)
+
+                        VStack(spacing: 1) {
+                            ForEach(group.entries) { entry in
+                                timelineRow(entry)
+                                    .id(entry.id)
+                            }
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                        )
+                    }
+                }
+
+                if appState.hasMoreTimelineEntries {
+                    Color.clear
+                        .frame(height: 1)
+                        .onAppear { controller.loadMoreTimelineEntries() }
+                }
+            }
+            .scrollTargetLayout()
+            .padding(.horizontal, MuesliTheme.spacing24)
+            .padding(.bottom, MuesliTheme.spacing24)
+        }
+        .scrollPosition(id: Binding(
+            get: { appState.timelineScrollAnchor },
+            set: { appState.timelineScrollAnchor = $0 }
+        ), anchor: .top)
+    }
+
+    @ViewBuilder
+    private func timelineRow(_ entry: TimelineEntry) -> some View {
+        switch entry {
+        case .dictation(let record):
+            DictationRowView(
+                record: record,
+                timeOnly: Self.formatTime(record.timestamp),
+                onCopy: { controller.copyToClipboard(record.rawText) },
+                onCopyTrace: record.computerUseTrace == nil ? nil : {
+                    controller.copyToClipboard(ComputerUseTraceFormatter.debugText(for: record))
+                },
+                onDelete: { controller.deleteDictation(id: record.id) }
+            )
+        case .meeting(let record):
+            TimelineMeetingRow(record: record) {
+                controller.showTimelineMeetingDocument(id: record.id)
+            }
+        }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.dateFormat = "hh:mm a"
+        return formatter
+    }()
+
+    fileprivate static func formatTime(_ raw: String) -> String {
+        guard let date = MeetingBrowserLogic.parseDate(raw) else {
+            return MeetingBrowserLogic.formatStartTime(raw)
+        }
+        return timeFormatter.string(from: date)
+    }
+}
+
+private struct TimelineMeetingRow: View {
+    let record: MeetingRecord
+    let onSelect: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: MuesliTheme.spacing20) {
+            Text(TimelineView.formatTime(record.startTime))
+                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .frame(width: 80, alignment: .leading)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    Image(systemName: "person.2.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .accessibilityLabel("Meeting")
+
+                    Text(record.title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+
+                    Text(record.status.displayLabel)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(record.status.displayColor)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(record.status.displayColor.opacity(0.12))
+                        .clipShape(Capsule())
+
+                    if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: record.source) {
+                        SyncOriginBadge(label: label)
+                    } else {
+                        SyncOriginBadge(label: "Mac", help: "Recorded on this Mac")
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Text(Self.formatDuration(record.durationSeconds))
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+
+                Text(previewText)
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(.horizontal, MuesliTheme.spacing20)
+        .padding(.vertical, MuesliTheme.spacing16)
+        .background(isHovered ? MuesliTheme.backgroundHover : MuesliTheme.backgroundRaised)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) { isHovered = hovering }
+        }
+        .onTapGesture(perform: onSelect)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Open meeting")
+    }
+
+    private var previewText: String {
+        let content: String
+        if !record.manualNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           record.status != .completed {
+            content = record.manualNotes
+        } else if !record.formattedNotes.isEmpty {
+            content = record.formattedNotes
+        } else {
+            content = record.rawTranscript
+        }
+        let preview = MeetingPreviewText.snippet(from: content)
+        return preview.isEmpty ? "No transcript or notes yet" : preview
+    }
+
+    private static func formatDuration(_ seconds: Double) -> String {
+        let rounded = max(0, Int(seconds.rounded()))
+        if rounded >= 3600 {
+            return "\(rounded / 3600)h \((rounded % 3600) / 60)m"
+        }
+        if rounded >= 60 {
+            let minutes = rounded / 60
+            let remainingSeconds = rounded % 60
+            return remainingSeconds == 0 ? "\(minutes)m" : "\(minutes)m \(remainingSeconds)s"
+        }
+        return "\(rounded)s"
+    }
+
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
@@ -166,6 +166,7 @@ struct TimelineView: View {
                                     .id(entry.id)
                             }
                         }
+                        .scrollTargetLayout()
                         .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
                         .overlay(
                             RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
@@ -180,7 +181,6 @@ struct TimelineView: View {
                         .onAppear { controller.loadMoreTimelineEntries() }
                 }
             }
-            .scrollTargetLayout()
             .padding(.horizontal, MuesliTheme.spacing24)
             .padding(.bottom, MuesliTheme.spacing24)
         }

--- a/native/MuesliNative/Tests/MuesliTests/DictationAttributionPolicyTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationAttributionPolicyTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Dictation attribution policy")
+struct DictationAttributionPolicyTests {
+    @Test("standard and streaming pasted dictations retain attribution")
+    func pastedDictationsAreAttributed() {
+        #expect(DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: true,
+            source: "dictation",
+            text: "Standard result"
+        ))
+        #expect(DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: true,
+            source: "dictation",
+            text: "Streaming result"
+        ))
+    }
+
+    @Test("voice notes CUA iPhone and empty results remain unattributed")
+    func excludedCaptureKindsAreNotAttributed() {
+        #expect(!DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: false,
+            source: "dictation",
+            text: "Voice note"
+        ))
+        #expect(!DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: true,
+            source: "cua",
+            text: "Open Notes"
+        ))
+        #expect(!DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: true,
+            source: "ios",
+            text: "Remote dictation"
+        ))
+        #expect(!DictationAttributionPolicy.shouldPersist(
+            isPasteOutput: true,
+            source: "dictation",
+            text: "   "
+        ))
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -3315,4 +3315,338 @@ struct DictationStoreTests {
         #expect(lower.count == 1)
         #expect(mixed.count == 1)
     }
+
+    @Test("dictation target app migration backfills legacy context exactly once")
+    func targetAppLegacyMigration() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-target-app-legacy-\(UUID().uuidString).db")
+        var db: OpaquePointer?
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        let legacySQL = """
+        CREATE TABLE dictations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            duration_seconds REAL,
+            raw_text TEXT NOT NULL,
+            app_context TEXT,
+            word_count INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'dictation'
+        );
+        INSERT INTO dictations (
+            timestamp, duration_seconds, raw_text, app_context, word_count, source
+        ) VALUES (
+            '2026-08-01T10:00:00Z', 2, 'Historical dictation', 'Notes|com.apple.Notes', 2, 'dictation'
+        );
+        INSERT INTO dictations (
+            timestamp, duration_seconds, raw_text, app_context, word_count, source
+        ) VALUES
+            ('2026-08-01T09:00:00Z', 2, 'Malformed context', 'Not structured', 2, 'dictation'),
+            ('2026-08-01T08:00:00Z', 2, 'iPhone context', 'Mail|com.apple.mobilemail', 2, 'ios'),
+            ('2026-08-01T07:00:00Z', 2, 'CUA context', 'Safari|com.apple.Safari', 2, 'cua');
+        """
+        #expect(sqlite3_exec(db, legacySQL, nil, nil, nil) == SQLITE_OK)
+        sqlite3_close(db)
+
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+
+        #expect(sqlite3_open(url.path, &db) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            db,
+            """
+            INSERT INTO dictations (
+                timestamp, duration_seconds, raw_text, app_context, word_count, source
+            ) VALUES (
+                '2026-08-02T10:00:00Z', 2, 'Added after migration', 'TextEdit|com.apple.TextEdit', 3, 'dictation'
+            );
+            """,
+            nil,
+            nil,
+            nil
+        ) == SQLITE_OK)
+        sqlite3_close(db)
+
+        try store.migrateIfNeeded()
+
+        let rows = try store.recentDictations(limit: 10)
+        let historical = try #require(rows.first { $0.rawText == "Historical dictation" })
+        #expect(historical.appContext == "Notes|com.apple.Notes")
+        #expect(historical.targetAppName == "Notes")
+        #expect(historical.targetAppBundleID == "com.apple.Notes")
+
+        let addedAfterMigration = try #require(rows.first { $0.rawText == "Added after migration" })
+        #expect(addedAfterMigration.targetAppName == nil)
+        #expect(addedAfterMigration.targetAppBundleID == nil)
+
+        for excludedText in ["Malformed context", "iPhone context", "CUA context"] {
+            let excluded = try #require(rows.first { $0.rawText == excludedText })
+            #expect(excluded.targetAppName == nil)
+            #expect(excluded.targetAppBundleID == nil)
+        }
+    }
+
+    @Test("dictation target app metadata inserts and reads back")
+    func targetAppInsertReadback() throws {
+        let store = try makeStore()
+        let endedAt = Date(timeIntervalSince1970: 1_776_000_000)
+        let id = try store.insertDictation(
+            text: "Attributed text",
+            durationSeconds: 2,
+            appContext: "cleanup context",
+            targetAppName: "Notes",
+            targetAppBundleID: "com.apple.Notes",
+            startedAt: endedAt.addingTimeInterval(-2),
+            endedAt: endedAt
+        )
+
+        let row = try #require(try store.dictation(id: id))
+        #expect(row.appContext == "cleanup context")
+        #expect(row.targetAppName == "Notes")
+        #expect(row.targetAppBundleID == "com.apple.Notes")
+    }
+
+    @Test("destination app filters rows stats and timeline before pagination")
+    func targetApplicationFiltering() throws {
+        let store = try makeStore()
+        let now = Date(timeIntervalSince1970: 1_776_000_000)
+        let notes = DictationTargetApplication(name: "Notes", bundleID: "com.apple.Notes")
+        let textEdit = DictationTargetApplication(name: "TextEdit", bundleID: "com.apple.TextEdit")
+
+        _ = try store.insertDictation(
+            text: "Notes has three words",
+            durationSeconds: 2,
+            targetAppName: notes.name,
+            targetAppBundleID: notes.bundleID,
+            startedAt: now.addingTimeInterval(-2),
+            endedAt: now
+        )
+        _ = try store.insertDictation(
+            text: "TextEdit row",
+            durationSeconds: 4,
+            targetAppName: textEdit.name,
+            targetAppBundleID: textEdit.bundleID,
+            startedAt: now.addingTimeInterval(8),
+            endedAt: now.addingTimeInterval(12)
+        )
+        _ = try store.insertMeeting(
+            title: "Newer meeting",
+            calendarEventID: nil,
+            startTime: now.addingTimeInterval(20),
+            endTime: now.addingTimeInterval(30),
+            rawTranscript: "Meeting transcript",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+
+        let applications = try store.dictationTargetApplications()
+        #expect(applications.map(\.id) == [notes.id, textEdit.id])
+
+        let rows = try store.recentDictations(limit: 1, targetApplication: notes)
+        #expect(rows.map(\.rawText) == ["Notes has three words"])
+
+        let stats = try store.dictationStats(targetApplication: notes)
+        #expect(stats.totalSessions == 1)
+        #expect(stats.totalWords == 4)
+        #expect(stats.averageWPM == 120)
+
+        let timeline = try store.timelineEntries(limit: 1, targetApplication: notes)
+        #expect(timeline.count == 1)
+        guard case .dictation(let record) = timeline[0] else {
+            Issue.record("Expected app-filtered timeline to contain only dictations")
+            return
+        }
+        #expect(record.rawText == "Notes has three words")
+    }
+
+    @Test("timeline combines record kinds with deterministic chronology and offsets")
+    func timelineChronologyAndOffsets() throws {
+        let store = try makeStore()
+        let tiedAt = Date(timeIntervalSince1970: 1_776_000_000)
+        let olderAt = tiedAt.addingTimeInterval(-60)
+        let olderDictationID = try store.insertDictation(
+            text: "Older",
+            durationSeconds: 1,
+            startedAt: olderAt.addingTimeInterval(-1),
+            endedAt: olderAt
+        )
+        let meetingID = try store.insertMeeting(
+            title: "Tied meeting",
+            calendarEventID: nil,
+            startTime: tiedAt,
+            endTime: tiedAt.addingTimeInterval(60),
+            rawTranscript: "Meeting transcript",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        let dictationID = try store.insertDictation(
+            text: "Tied dictation",
+            durationSeconds: 1,
+            startedAt: tiedAt.addingTimeInterval(-1),
+            endedAt: tiedAt
+        )
+
+        #expect(try store.timelineEntries(limit: 10).map(\.id) == [
+            "dictation:\(dictationID)",
+            "meeting:\(meetingID)",
+            "dictation:\(olderDictationID)",
+        ])
+        #expect(try store.timelineEntries(limit: 1, offset: 1).map(\.id) == ["meeting:\(meetingID)"])
+    }
+
+    @Test("timeline applies origin and date filters before pagination and excludes tombstones")
+    func timelineFiltersBeforePagination() throws {
+        let store = try makeStore()
+        let base = Date(timeIntervalSince1970: 1_776_000_000)
+        let macMeetingID = try store.insertMeeting(
+            title: "Mac meeting",
+            calendarEventID: nil,
+            startTime: base,
+            endTime: base.addingTimeInterval(30),
+            rawTranscript: "Mac",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        _ = try store.insertDictation(
+            text: "Newer iPhone text",
+            durationSeconds: 1,
+            source: "ios",
+            startedAt: base.addingTimeInterval(59),
+            endedAt: base.addingTimeInterval(60)
+        )
+        let deletedID = try store.insertDictation(
+            text: "Deleted Mac text",
+            durationSeconds: 1,
+            startedAt: base.addingTimeInterval(119),
+            endedAt: base.addingTimeInterval(120)
+        )
+        try store.deleteDictation(id: deletedID)
+
+        let formatter = ISO8601DateFormatter()
+        let macOnly = try store.timelineEntries(
+            limit: 1,
+            fromDate: formatter.string(from: base.addingTimeInterval(-1)),
+            toDate: formatter.string(from: base.addingTimeInterval(90)),
+            origin: .thisMac
+        )
+        #expect(macOnly.map(\.id) == ["meeting:\(macMeetingID)"])
+        #expect(!(try store.timelineEntries(limit: 10).map(\.id).contains("dictation:\(deletedID)")))
+    }
+
+    @Test("timeline includes every visible meeting status")
+    func timelineIncludesEveryMeetingStatus() throws {
+        let store = try makeStore()
+        let base = Date(timeIntervalSince1970: 1_776_000_000)
+        var expectedStatuses = Set<String>()
+        for (index, status) in [
+            MeetingStatus.recording,
+            .processing,
+            .completed,
+            .noteOnly,
+            .failed,
+        ].enumerated() {
+            let start = base.addingTimeInterval(Double(index * 60))
+            let id = try store.insertMeeting(
+                title: status.rawValue,
+                calendarEventID: nil,
+                startTime: start,
+                endTime: start.addingTimeInterval(30),
+                rawTranscript: "Transcript",
+                formattedNotes: "",
+                micAudioPath: nil,
+                systemAudioPath: nil
+            )
+            try store.updateMeetingStatus(id: id, status: status)
+            expectedStatuses.insert(status.rawValue)
+        }
+
+        let actualStatuses: Set<String> = Set(try store.timelineEntries(limit: 20).compactMap { entry -> String? in
+            guard case .meeting(let meeting) = entry else { return nil }
+            return meeting.status.rawValue
+        })
+        #expect(actualStatuses == expectedStatuses)
+    }
+
+    @Test("dictation stats consistently apply origin and date filters")
+    func filteredDictationStats() throws {
+        let store = try makeStore()
+        let now = Date()
+        _ = try store.insertDictation(
+            text: "two words",
+            durationSeconds: 60,
+            startedAt: now.addingTimeInterval(-60),
+            endedAt: now
+        )
+        _ = try store.insertDictation(
+            text: "three phone words",
+            durationSeconds: 60,
+            source: "ios",
+            startedAt: now.addingTimeInterval(-60),
+            endedAt: now
+        )
+        _ = try store.insertDictation(
+            text: "old words are excluded",
+            durationSeconds: 60,
+            startedAt: now.addingTimeInterval(-86_460),
+            endedAt: now.addingTimeInterval(-86_400)
+        )
+
+        let formatter = ISO8601DateFormatter()
+        let macRecent = try store.dictationStats(
+            fromDate: formatter.string(from: now.addingTimeInterval(-3_600)),
+            origin: .thisMac
+        )
+        #expect(macRecent.totalSessions == 1)
+        #expect(macRecent.totalWords == 2)
+        #expect(macRecent.averageWPM == 2)
+
+        let iPhone = try store.dictationStats(origin: .fromIPhone)
+        #expect(iPhone.totalSessions == 1)
+        #expect(iPhone.totalWords == 3)
+        #expect(iPhone.averageWPM == 3)
+    }
+
+    @Test("target app metadata stays local across sync export import and remote updates")
+    func targetAppMetadataIsLocalOnly() throws {
+        let sourceStore = try makeStore()
+        let importedStore = try makeStore()
+        let endedAt = Date(timeIntervalSince1970: 1_776_000_000)
+        let localID = try sourceStore.insertDictation(
+            text: "Local attributed text",
+            durationSeconds: 2,
+            targetAppName: "Notes",
+            targetAppBundleID: "com.apple.Notes",
+            startedAt: endedAt.addingTimeInterval(-2),
+            endedAt: endedAt
+        )
+        let outbound = try #require(try sourceStore.textRecordsNeedingSync().first { $0.kind == .dictation })
+        let encoded = String(decoding: try JSONEncoder().encode(outbound), as: UTF8.self)
+        #expect(!encoded.contains("targetApp"))
+        #expect(try importedStore.upsertSyncedTextRecord(outbound))
+        let imported = try #require(try importedStore.recentDictations(limit: 1).first)
+        #expect(imported.targetAppName == nil)
+        #expect(imported.targetAppBundleID == nil)
+
+        let remoteUpdate = SyncTextRecord(
+            id: outbound.id,
+            kind: .dictation,
+            text: "Remote text update",
+            source: outbound.source,
+            localSource: outbound.localSource,
+            createdAt: outbound.createdAt,
+            updatedAt: outbound.updatedAt.addingTimeInterval(60),
+            startedAt: outbound.startedAt,
+            endedAt: outbound.endedAt,
+            durationSeconds: outbound.durationSeconds,
+            wordCount: 3,
+            cloudChangeTag: "new-tag"
+        )
+        #expect(try sourceStore.upsertSyncedTextRecord(remoteUpdate))
+        let updatedLocal = try #require(try sourceStore.dictation(id: localID))
+        #expect(updatedLocal.rawText == "Remote text update")
+        #expect(updatedLocal.targetAppName == "Notes")
+        #expect(updatedLocal.targetAppBundleID == "com.apple.Notes")
+    }
 }

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -61,6 +61,7 @@ struct MeetingsNavigationTests {
     func meetingsDefaultToBrowser() {
         let appState = AppState()
 
+        #expect(appState.selectedTab == .timeline)
         #expect(appState.meetingsNavigationState == .browser)
         #expect(appState.selectedMeeting == nil)
     }
@@ -92,15 +93,22 @@ struct MeetingsNavigationTests {
         }
     }
 
-    @Test("closing insights returns to dictations")
-    func closingInsightsReturnsToDictations() {
+    @Test("closing insights returns to the originating history view")
+    func closingInsightsReturnsToOrigin() {
         let controller = makeController()
         controller.openInsights(section: .meetings)
+        #expect(controller.appState.insightsBackLabel == "Back to Timeline")
 
         controller.closeInsights()
 
-        #expect(controller.appState.selectedTab == .dictations)
+        #expect(controller.appState.selectedTab == .timeline)
         #expect(controller.appState.insightsInitialSection == .meetings)
+
+        controller.appState.selectedTab = .dictations
+        controller.openInsights(section: .words)
+        #expect(controller.appState.insightsBackLabel == "Back to Dictations")
+        controller.closeInsights()
+        #expect(controller.appState.selectedTab == .dictations)
     }
 
     @Test("discard confirmation maps checkbox selections to meeting discard resolutions")
@@ -171,6 +179,85 @@ struct MeetingsNavigationTests {
         #expect(controller.appState.selectedMeetingID == 202)
         #expect(controller.appState.meetingsNavigationState == .document(202))
         #expect(controller.appState.selectedFolderID == 55)
+    }
+
+    @Test("timeline meeting route preserves timeline filters and scroll anchor")
+    func timelineMeetingRoutePreservesTimelineState() throws {
+        let store = try makeStore()
+        let meetingID = try insertMeeting(in: store, title: "Timeline meeting", savedRecordingPath: nil)
+        let controller = makeController(dictationStore: store)
+        controller.appState.timelineOriginFilter = .fromIPhone
+        controller.appState.timelineDateFilter = .lastWeek
+        controller.appState.timelineFromDate = "2026-08-09T00:00:00Z"
+        let notes = DictationTargetApplication(name: "Notes", bundleID: "com.apple.Notes")
+        controller.appState.timelineApplicationFilter = notes
+        controller.appState.timelineScrollAnchor = "dictation:77"
+
+        controller.showTimelineMeetingDocument(id: meetingID)
+
+        #expect(controller.appState.selectedTab == .timeline)
+        #expect(controller.appState.meetingDetailReturnDestination == .timeline)
+        #expect(controller.appState.meetingsNavigationState == .document(meetingID))
+        #expect(controller.appState.timelineOriginFilter == .fromIPhone)
+        #expect(controller.appState.timelineDateFilter == .lastWeek)
+        #expect(controller.appState.timelineFromDate == "2026-08-09T00:00:00Z")
+        #expect(controller.appState.timelineApplicationFilter == notes)
+        #expect(controller.appState.timelineScrollAnchor == "dictation:77")
+
+        controller.showTimelineHome()
+        #expect(controller.appState.meetingsNavigationState == .browser)
+        #expect(controller.appState.selectedMeetingID == nil)
+        #expect(controller.appState.timelineOriginFilter == .fromIPhone)
+        #expect(controller.appState.timelineDateFilter == .lastWeek)
+        #expect(controller.appState.timelineApplicationFilter == notes)
+        #expect(controller.appState.timelineScrollAnchor == "dictation:77")
+    }
+
+    @Test("timeline pagination and filter changes reset to the newest composite anchor")
+    func timelinePaginationAndFilterReset() throws {
+        let store = try makeStore()
+        let base = Date(timeIntervalSince1970: 1_776_000_000)
+        let notes = DictationTargetApplication(name: "Notes", bundleID: "com.apple.Notes")
+        for index in 0..<3 {
+            let endedAt = base.addingTimeInterval(Double(index))
+            _ = try store.insertDictation(
+                text: "Row \(index)",
+                durationSeconds: 1,
+                targetAppName: index == 0 ? notes.name : "TextEdit",
+                targetAppBundleID: index == 0 ? notes.bundleID : "com.apple.TextEdit",
+                startedAt: endedAt.addingTimeInterval(-1),
+                endedAt: endedAt
+            )
+        }
+        let controller = makeController(dictationStore: store)
+        controller.appState.timelinePageSize = 2
+        controller.syncAppState()
+
+        #expect(controller.appState.timelineRows.count == 2)
+        #expect(controller.appState.hasMoreTimelineEntries)
+        controller.loadMoreTimelineEntries()
+        #expect(controller.appState.timelineRows.count == 3)
+        #expect(!controller.appState.hasMoreTimelineEntries)
+
+        controller.appState.timelineScrollAnchor = controller.appState.timelineRows.last?.id
+        controller.filterTimeline(origin: .thisMac)
+        #expect(controller.appState.timelineRows.count == 2)
+        #expect(controller.appState.timelineScrollAnchor == controller.appState.timelineRows.first?.id)
+
+        controller.filterTimeline(dateFilter: .last2Days)
+        #expect(controller.appState.timelineDateFilter == .last2Days)
+        #expect(controller.appState.timelineScrollAnchor == controller.appState.timelineRows.first?.id)
+
+        controller.filterTimeline(dateFilter: .all)
+        controller.filterTimeline(application: notes)
+        #expect(controller.appState.timelineApplicationFilter == notes)
+        #expect(controller.appState.timelineRows.count == 1)
+        #expect(controller.appState.timelineScrollAnchor == controller.appState.timelineRows.first?.id)
+
+        controller.filterDictations(application: notes)
+        #expect(controller.appState.dictationApplicationFilter == notes)
+        #expect(controller.appState.dictationRows.count == 1)
+        #expect(controller.appState.filteredDictationStats.totalSessions == 1)
     }
 
     @Test("showMeetingsHome returns to browser and preserves prior meeting selection")

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCLITests.swift
@@ -78,6 +78,31 @@ struct MuesliCLITests {
         #expect(detailPayload.selectedTemplatePrompt == "## Weekly Overview")
     }
 
+    @Test("dictation CLI payloads do not expose local target app metadata")
+    func dictationPayloadExcludesTargetAppMetadata() throws {
+        let record = DictationRecord(
+            id: 7,
+            timestamp: "2026-08-16T10:00:00Z",
+            durationSeconds: 2,
+            rawText: "Hello Notes",
+            appContext: "cleanup context",
+            wordCount: 2,
+            targetAppName: "Notes",
+            targetAppBundleID: "com.apple.Notes"
+        )
+
+        for payload in [
+            try JSONEncoder().encode(DictationListRow(record)),
+            try JSONEncoder().encode(DictationDetailPayload(record)),
+        ] {
+            let object = try #require(JSONSerialization.jsonObject(with: payload) as? [String: Any])
+            #expect(object["targetAppName"] == nil)
+            #expect(object["targetAppBundleID"] == nil)
+            #expect(object["target_app_name"] == nil)
+            #expect(object["target_app_bundle_id"] == nil)
+        }
+    }
+
     @Test("transcribe validation rejects unsupported file extensions")
     func transcribeRejectsUnsupportedExtension() {
         #expect(throws: Error.self) {

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -90,6 +90,35 @@ struct PasteControllerTests {
         _ = await waitForClipboardString(in: pasteboard, expected: "original")
     }
 
+    @Test("paste reports the application snapshotted at Cmd+V dispatch")
+    func pasteReportsApplicationAtCommandDispatch() async {
+        let pasteboard = makePasteboard()
+        let expectedApplication = NSRunningApplication.current
+
+        let result = await withCheckedContinuation { continuation in
+            var events: [String] = []
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                targetApplicationProvider: {
+                    events.append("snapshot")
+                    return expectedApplication
+                },
+                simulatePasteAction: {
+                    events.append("command")
+                },
+                onPasteDispatched: { application in
+                    events.append("callback")
+                    continuation.resume(returning: (events, application?.processIdentifier))
+                }
+            )
+        }
+
+        #expect(result.0 == ["snapshot", "command", "callback"])
+        #expect(result.1 == expectedApplication.processIdentifier)
+        _ = await waitForClipboardString(in: pasteboard, expected: nil)
+    }
+
     @Test("paste restores clipboard after delay")
     func pasteRestoresClipboard() async throws {
         let pasteboard = makePasteboard()

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -120,6 +120,72 @@ struct PasteControllerTests {
         _ = await waitForClipboardString(in: pasteboard, expected: nil)
     }
 
+    @Test("dictation paste skips Cmd+V and attribution after clipboard ownership changes")
+    func dictationPasteSkipsDispatchAfterClipboardOwnershipChanges() async throws {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let events = await withCheckedContinuation { continuation in
+            var events: [String] = []
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                requireStagedClipboardOwnership: true,
+                targetApplicationProvider: {
+                    events.append("snapshot")
+                    pasteboard.clearContents()
+                    pasteboard.setString("user-copied-during-delay", forType: .string)
+                    return NSRunningApplication.current
+                },
+                simulatePasteAction: {
+                    events.append("command")
+                    return true
+                },
+                onPasteFinished: { application in
+                    events.append(application == nil ? "unattributed" : "attributed")
+                    continuation.resume(returning: events)
+                }
+            )
+        }
+
+        #expect(events == ["snapshot", "unattributed"])
+        try await Task.sleep(nanoseconds: 700_000_000)
+        #expect(pasteboard.string(forType: .string) == "user-copied-during-delay")
+    }
+
+    @Test("shared paste remains ungated unless clipboard ownership is required")
+    func sharedPasteRemainsUngatedByDefault() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let events = await withCheckedContinuation { continuation in
+            var events: [String] = []
+            PasteController.paste(
+                text: "pasted text",
+                pasteboard: pasteboard,
+                targetApplicationProvider: {
+                    events.append("snapshot")
+                    pasteboard.clearContents()
+                    pasteboard.setString("newer-clipboard-content", forType: .string)
+                    return NSRunningApplication.current
+                },
+                simulatePasteAction: {
+                    events.append("command")
+                    return true
+                },
+                onPasteFinished: { _ in
+                    events.append("callback")
+                    continuation.resume(returning: events)
+                }
+            )
+        }
+
+        #expect(events == ["snapshot", "command", "callback"])
+        #expect(pasteboard.string(forType: .string) == "newer-clipboard-content")
+    }
+
     @Test("paste completes without attribution when Cmd+V setup fails")
     func pasteFailureRemainsUnattributed() async {
         let pasteboard = makePasteboard()

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -70,7 +70,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("original", forType: .string)
 
-        PasteController.paste(text: "", pasteboard: pasteboard, simulatePasteAction: {})
+        PasteController.paste(text: "", pasteboard: pasteboard, simulatePasteAction: { true })
 
         #expect(pasteboard.string(forType: .string) == "original")
     }
@@ -81,7 +81,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("original", forType: .string)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: {})
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
 
         // Immediately after paste(), the clipboard holds the dictation text
         // (restoration happens asynchronously after ~500ms)
@@ -106,8 +106,9 @@ struct PasteControllerTests {
                 },
                 simulatePasteAction: {
                     events.append("command")
+                    return true
                 },
-                onPasteDispatched: { application in
+                onPasteFinished: { application in
                     events.append("callback")
                     continuation.resume(returning: (events, application?.processIdentifier))
                 }
@@ -119,13 +120,34 @@ struct PasteControllerTests {
         _ = await waitForClipboardString(in: pasteboard, expected: nil)
     }
 
+    @Test("paste completes without attribution when Cmd+V setup fails")
+    func pasteFailureRemainsUnattributed() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let application = await withCheckedContinuation { continuation in
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                targetApplicationProvider: { NSRunningApplication.current },
+                simulatePasteAction: { false },
+                onPasteFinished: { continuation.resume(returning: $0) }
+            )
+        }
+
+        #expect(application == nil)
+        let restored = await waitForClipboardString(in: pasteboard, expected: "original")
+        #expect(restored == "original")
+    }
+
     @Test("paste restores clipboard after delay")
     func pasteRestoresClipboard() async throws {
         let pasteboard = makePasteboard()
         pasteboard.clearContents()
         pasteboard.setString("user-copied-text", forType: .string)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: {})
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
 
         let restored = await waitForClipboardString(in: pasteboard, expected: "user-copied-text")
 
@@ -137,7 +159,7 @@ struct PasteControllerTests {
         let pasteboard = makePasteboard()
         pasteboard.clearContents()
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: {})
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
 
         let restored = await waitForClipboardString(in: pasteboard, expected: nil)
 
@@ -159,7 +181,7 @@ struct PasteControllerTests {
         let countBefore = pasteboard.pasteboardItems?.count ?? 0
         #expect(countBefore == 2)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: {})
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
 
         let (countAfter, texts) = await waitForClipboardItems(
             in: pasteboard,
@@ -177,7 +199,7 @@ struct PasteControllerTests {
         pasteboard.clearContents()
         pasteboard.setString("original", forType: .string)
 
-        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: {})
+        PasteController.paste(text: "dictated text", pasteboard: pasteboard, simulatePasteAction: { true })
         try await Task.sleep(nanoseconds: 100_000_000)
 
         pasteboard.clearContents()

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -49,6 +49,7 @@ case "${shard}" in
       DeltaPasteTests
       TranscriptAccumulationTests
       StreamingDictationControllerLifecycleTests
+      DictationAttributionPolicyTests
       NemotronDictationModePolicyTests
       Nemotron35StreamStateTests
       Nemotron35BackendMetadataTests


### PR DESCRIPTION
## Summary

- Add **Timeline** as the first sidebar item and default dashboard view, combining dictations and meetings in one newest-first, day-grouped feed with origin, date, and destination-app filters.
- Add local SQLite destination-app attribution for pasted Mac dictations, including standard and Nemotron streaming capture, cached AppKit icon resolution, app icons in Timeline/Dictations/Search, and filtered Dictations stats.
- Add a durable one-time backfill from existing screen-context `app_context` rows and application filtering for the historical records that can be inferred.
- Preserve Timeline filters, pagination, and composite scroll anchors across meeting navigation; make Insights and meeting detail return to the originating view.
- Reuse the extracted iPhone bridge card across Timeline and Dictations.

## Data and privacy

Destination app name and bundle ID remain local-only SQLite metadata. They are intentionally excluded from CloudKit sync records, telemetry, and CLI JSON. Remote imports remain unattributed, and remote updates preserve existing local attribution.

The legacy backfill runs once per database using the existing local migration marker pattern. It only considers historical rows that already contain usable screen-context metadata and does not run as a recurring process.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /private/tmp/muesli-spm-unified-timeline-pr`: **1,715 tests in 159 suites passed**
- `./scripts/test_classify_changed_files.sh`: passed
- `./scripts/test_ci_test_shards.sh`: passed
- `./scripts/verify_update_flow.sh --skip-dmg`: passed
- `git diff --check`: passed
- MuesliDevB build/install/launch and manual visual inspection completed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789484787&installation_model_id=422865&pr_number=421&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F421&signature=31e2372a6a47bc07dc88347682a991cf1d9cd753b05b89ecd02800aae4fde30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Timeline view combining dictations and meetings, grouped by day.
  * Added date, source, and target-application filters with pagination and preserved navigation state.
  * Added target-application icons and filtering across dictation history and search results.
  * Added filtered dictation statistics and improved Insights navigation.
  * Added an iPhone bridge card with sync status, QR setup, retry, and dismissal actions.
* **Privacy**
  * Target-application details remain local and are excluded from exported dictation data.
  * Dictation history is saved only for eligible pasted text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->