### PR TITLE
Add EventKit meeting people and Contacts integration

### DIFF
--- a/native/MuesliNative/Package.swift
+++ b/native/MuesliNative/Package.swift
@@ -54,6 +54,8 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedLibrary("sqlite3"),
+                .linkedFramework("Contacts"),
+                .linkedFramework("ContactsUI"),
             ]
         ),
         .executableTarget(

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -4,6 +4,7 @@ import SQLite3
 public enum DictationStoreError: Error, LocalizedError {
     case dictationNotFound(id: Int64)
     case meetingNotFound(id: Int64)
+    case invalidParticipantIdentifier
 
     public var errorDescription: String? {
         switch self {
@@ -11,6 +12,8 @@ public enum DictationStoreError: Error, LocalizedError {
             return "Dictation \(id) no longer exists."
         case .meetingNotFound(let id):
             return "Meeting \(id) no longer exists."
+        case .invalidParticipantIdentifier:
+            return "That meeting participant could not be identified."
         }
     }
 }
@@ -132,6 +135,21 @@ public final class DictationStore {
         CREATE INDEX IF NOT EXISTS idx_meetings_start_time ON meetings(start_time DESC);
         CREATE INDEX IF NOT EXISTS idx_meetings_calendar_event_lookup ON meetings(calendar_event_id) WHERE calendar_event_id IS NOT NULL;
 
+        -- Calendar attendee snapshots and manually selected people are device-local.
+        -- Contacts identifiers are never sent through Muesli's sync layer.
+        CREATE TABLE IF NOT EXISTS meeting_participants (
+            meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+            participant_identifier TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            email_address TEXT,
+            insertion_order INTEGER NOT NULL,
+            source TEXT NOT NULL DEFAULT 'manual',
+            is_suppressed INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (meeting_id, participant_identifier)
+        );
+        CREATE INDEX IF NOT EXISTS idx_meeting_participants_order
+            ON meeting_participants(meeting_id, insertion_order);
+
         CREATE TABLE IF NOT EXISTS meeting_transcript_checkpoints (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
@@ -233,10 +251,36 @@ public final class DictationStore {
             "ALTER TABLE meetings ADD COLUMN calendar_source TEXT",
             "ALTER TABLE meetings ADD COLUMN calendar_id TEXT",
             "ALTER TABLE meetings ADD COLUMN calendar_series_id TEXT",
-            "ALTER TABLE meetings ADD COLUMN calendar_occurrence_start REAL"
+            "ALTER TABLE meetings ADD COLUMN calendar_occurrence_start REAL",
+            "ALTER TABLE meeting_participants ADD COLUMN source TEXT NOT NULL DEFAULT 'manual'",
+            "ALTER TABLE meeting_participants ADD COLUMN is_suppressed INTEGER NOT NULL DEFAULT 0"
         ] {
             _ = sqlite3_exec(db, sql, nil, nil, nil)
         }
+        // Migrate local development databases created by the superseded PR.
+        _ = sqlite3_exec(
+            db,
+            "UPDATE meeting_participants SET source = 'calendar' WHERE participant_identifier LIKE 'calendar:%'",
+            nil,
+            nil,
+            nil
+        )
+        _ = sqlite3_exec(
+            db,
+            """
+            UPDATE meeting_participants
+            SET is_suppressed = 1
+            WHERE EXISTS (
+                SELECT 1 FROM meeting_participant_suppressions
+                WHERE meeting_participant_suppressions.meeting_id = meeting_participants.meeting_id
+                  AND meeting_participant_suppressions.participant_identifier = meeting_participants.participant_identifier
+            )
+            """,
+            nil,
+            nil,
+            nil
+        )
+        _ = sqlite3_exec(db, "DROP TABLE IF EXISTS meeting_participant_suppressions", nil, nil, nil)
         try backfillLegacyTargetApplicationsIfNeeded(db: db)
         // Calendar metadata is not a meeting identity: one occurrence may be
         // recorded more than once, and recurring providers may reuse ids.
@@ -825,7 +869,22 @@ public final class DictationStore {
         let sql = """
         SELECT \(Self.meetingColumns)
         FROM meetings
-        WHERE deleted_at IS NULL AND (title LIKE ? ESCAPE '\\' OR raw_transcript LIKE ? ESCAPE '\\' OR formatted_notes LIKE ? ESCAPE '\\' OR manual_notes LIKE ? ESCAPE '\\')
+        WHERE deleted_at IS NULL AND (
+            title LIKE ? ESCAPE '\\'
+            OR raw_transcript LIKE ? ESCAPE '\\'
+            OR formatted_notes LIKE ? ESCAPE '\\'
+            OR manual_notes LIKE ? ESCAPE '\\'
+            OR EXISTS (
+                SELECT 1
+                FROM meeting_participants
+                WHERE meeting_participants.meeting_id = meetings.id
+                    AND meeting_participants.is_suppressed = 0
+                    AND (
+                        meeting_participants.display_name LIKE ? ESCAPE '\\'
+                        OR meeting_participants.email_address LIKE ? ESCAPE '\\'
+                    )
+            )
+        )
         ORDER BY id DESC
         LIMIT ?
         """
@@ -839,7 +898,9 @@ public final class DictationStore {
         sqlite3_bind_text(statement, 2, pattern.utf8String, -1, nil)
         sqlite3_bind_text(statement, 3, pattern.utf8String, -1, nil)
         sqlite3_bind_text(statement, 4, pattern.utf8String, -1, nil)
-        sqlite3_bind_int(statement, 5, Int32(limit))
+        sqlite3_bind_text(statement, 5, pattern.utf8String, -1, nil)
+        sqlite3_bind_text(statement, 6, pattern.utf8String, -1, nil)
+        sqlite3_bind_int(statement, 7, Int32(limit))
 
         var rows: [MeetingRecord] = []
         while sqlite3_step(statement) == SQLITE_ROW {
@@ -978,6 +1039,371 @@ public final class DictationStore {
             throw lastError(db)
         }
         return sqlite3_last_insert_rowid(db)
+    }
+
+    public func listMeetingParticipants(meetingID: Int64) throws -> [MeetingParticipant] {
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        SELECT meeting_id, participant_identifier, display_name, email_address, insertion_order
+        FROM meeting_participants
+        WHERE meeting_id = ? AND is_suppressed = 0
+        ORDER BY insertion_order, participant_identifier
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+
+        var participants: [MeetingParticipant] = []
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                participants.append(MeetingParticipant(
+                    meetingID: sqlite3_column_int64(statement, 0),
+                    participantIdentifier: stringColumn(statement, index: 1),
+                    displayName: stringColumn(statement, index: 2),
+                    emailAddress: sqlite3_column_type(statement, 3) == SQLITE_NULL
+                        ? nil
+                        : stringColumn(statement, index: 3),
+                    insertionOrder: Int(sqlite3_column_int64(statement, 4))
+                ))
+            case SQLITE_DONE:
+                return participants
+            default:
+                throw lastError(db)
+            }
+        }
+    }
+
+    public func attachMeetingParticipant(
+        meetingID: Int64,
+        participant: MeetingParticipantDraft
+    ) throws {
+        try attachMeetingParticipants(
+            meetingID: meetingID,
+            participants: [participant],
+            source: .manual
+        )
+    }
+
+    /// Upserts an EventKit attendee snapshot batch through one connection and transaction.
+    public func attachCalendarMeetingParticipants(
+        meetingID: Int64,
+        participants: [MeetingParticipantDraft]
+    ) throws {
+        try attachMeetingParticipants(
+            meetingID: meetingID,
+            participants: participants,
+            source: .calendar
+        )
+    }
+
+    private enum MeetingParticipantSource: String {
+        case calendar
+        case manual
+    }
+
+    private func attachMeetingParticipants(
+        meetingID: Int64,
+        participants: [MeetingParticipantDraft],
+        source: MeetingParticipantSource
+    ) throws {
+        guard !participants.isEmpty else { return }
+        let normalizedParticipants = try Self.normalizedMeetingParticipants(participants)
+
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        try exec("BEGIN IMMEDIATE TRANSACTION", db: db)
+        do {
+            try upsertMeetingParticipants(
+                meetingID: meetingID,
+                participants: normalizedParticipants,
+                source: source,
+                db: db
+            )
+            try exec("COMMIT", db: db)
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    /// Replaces only the calendar-owned portion of a meeting's local People
+    /// snapshot. Manual Contacts remain untouched, and calendar identities the
+    /// user explicitly removed remain suppressed.
+    public func reconcileCalendarMeetingParticipants(
+        meetingID: Int64,
+        participants: [MeetingParticipantDraft]
+    ) throws {
+        let normalizedParticipants = try Self.normalizedMeetingParticipants(participants)
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        try exec("BEGIN IMMEDIATE TRANSACTION", db: db)
+        do {
+            let incomingIdentifiers = Set(normalizedParticipants.map(\.participantIdentifier))
+            let storedIdentifiers = try calendarMeetingParticipantIdentifiers(
+                meetingID: meetingID,
+                db: db
+            )
+            for identifier in storedIdentifiers.subtracting(incomingIdentifiers) {
+                try deleteMeetingParticipant(
+                    meetingID: meetingID,
+                    participantIdentifier: identifier,
+                    db: db
+                )
+            }
+            try upsertMeetingParticipants(
+                meetingID: meetingID,
+                participants: normalizedParticipants,
+                source: .calendar,
+                db: db
+            )
+            try exec("COMMIT", db: db)
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    public func removeMeetingParticipant(
+        meetingID: Int64,
+        participantIdentifier: String
+    ) throws {
+        let normalizedIdentifier = participantIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedIdentifier.isEmpty else {
+            throw DictationStoreError.invalidParticipantIdentifier
+        }
+
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+
+        try exec("BEGIN IMMEDIATE TRANSACTION", db: db)
+        do {
+            if try meetingParticipantSource(
+                meetingID: meetingID,
+                participantIdentifier: normalizedIdentifier,
+                db: db
+            ) == .calendar {
+                try suppressMeetingParticipant(
+                    meetingID: meetingID,
+                    participantIdentifier: normalizedIdentifier,
+                    db: db
+                )
+            } else {
+                try deleteMeetingParticipant(
+                    meetingID: meetingID,
+                    participantIdentifier: normalizedIdentifier,
+                    db: db
+                )
+            }
+            try exec("COMMIT", db: db)
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
+    private static func normalizedMeetingParticipants(
+        _ participants: [MeetingParticipantDraft]
+    ) throws -> [MeetingParticipantDraft] {
+        try participants.map { participant in
+            let participantIdentifier = participant.participantIdentifier
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayName = participant.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !participantIdentifier.isEmpty, !displayName.isEmpty else {
+                throw DictationStoreError.invalidParticipantIdentifier
+            }
+            return MeetingParticipantDraft(
+                participantIdentifier: participantIdentifier,
+                displayName: displayName,
+                emailAddress: participant.emailAddress
+            )
+        }
+    }
+
+    private func upsertMeetingParticipants(
+        meetingID: Int64,
+        participants: [MeetingParticipantDraft],
+        source: MeetingParticipantSource,
+        db: OpaquePointer?
+    ) throws {
+        guard !participants.isEmpty else { return }
+
+        let sql = """
+        INSERT INTO meeting_participants
+            (meeting_id, participant_identifier, display_name, email_address, insertion_order, source)
+        VALUES (
+            ?,
+            ?,
+            ?,
+            ?,
+            COALESCE(
+                (SELECT MAX(insertion_order) + 1
+                 FROM meeting_participants
+                 WHERE meeting_id = ?),
+                0
+            ),
+            ?
+        )
+        ON CONFLICT(meeting_id, participant_identifier)
+        DO UPDATE SET
+            display_name = CASE
+                WHEN meeting_participants.source = 'manual' AND excluded.source = 'calendar'
+                    THEN meeting_participants.display_name
+                ELSE excluded.display_name
+            END,
+            email_address = CASE
+                WHEN meeting_participants.source = 'manual' AND excluded.source = 'calendar'
+                    THEN meeting_participants.email_address
+                ELSE COALESCE(excluded.email_address, meeting_participants.email_address)
+            END,
+            source = CASE
+                WHEN excluded.source = 'manual' THEN 'manual'
+                ELSE meeting_participants.source
+            END,
+            is_suppressed = CASE
+                WHEN excluded.source = 'manual' THEN 0
+                ELSE meeting_participants.is_suppressed
+            END
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        for participant in participants {
+            sqlite3_reset(statement)
+            sqlite3_clear_bindings(statement)
+            sqlite3_bind_int64(statement, 1, meetingID)
+            sqlite3_bind_text(
+                statement,
+                2,
+                (participant.participantIdentifier as NSString).utf8String,
+                -1,
+                nil
+            )
+            sqlite3_bind_text(
+                statement,
+                3,
+                (participant.displayName as NSString).utf8String,
+                -1,
+                nil
+            )
+            bindOptionalText(participant.emailAddress, at: 4, statement: statement)
+            sqlite3_bind_int64(statement, 5, meetingID)
+            sqlite3_bind_text(statement, 6, (source.rawValue as NSString).utf8String, -1, nil)
+            guard sqlite3_step(statement) == SQLITE_DONE else {
+                throw lastError(db)
+            }
+        }
+    }
+
+    private func calendarMeetingParticipantIdentifiers(
+        meetingID: Int64,
+        db: OpaquePointer?
+    ) throws -> Set<String> {
+        let sql = """
+        SELECT participant_identifier
+        FROM meeting_participants
+        WHERE meeting_id = ?
+            AND source = 'calendar'
+            AND is_suppressed = 0
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+
+        var identifiers = Set<String>()
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                identifiers.insert(stringColumn(statement, index: 0))
+            case SQLITE_DONE:
+                return identifiers
+            default:
+                throw lastError(db)
+            }
+        }
+    }
+
+    private func meetingParticipantSource(
+        meetingID: Int64,
+        participantIdentifier: String,
+        db: OpaquePointer?
+    ) throws -> MeetingParticipantSource? {
+        let sql = """
+        SELECT source
+        FROM meeting_participants
+        WHERE meeting_id = ? AND participant_identifier = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        sqlite3_bind_text(statement, 2, (participantIdentifier as NSString).utf8String, -1, nil)
+        switch sqlite3_step(statement) {
+        case SQLITE_ROW:
+            return MeetingParticipantSource(rawValue: stringColumn(statement, index: 0))
+        case SQLITE_DONE:
+            return nil
+        default:
+            throw lastError(db)
+        }
+    }
+
+    private func suppressMeetingParticipant(
+        meetingID: Int64,
+        participantIdentifier: String,
+        db: OpaquePointer?
+    ) throws {
+        let sql = """
+        UPDATE meeting_participants
+        SET is_suppressed = 1
+        WHERE meeting_id = ? AND participant_identifier = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        sqlite3_bind_text(statement, 2, (participantIdentifier as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    private func deleteMeetingParticipant(
+        meetingID: Int64,
+        participantIdentifier: String,
+        db: OpaquePointer?
+    ) throws {
+        let sql = """
+        DELETE FROM meeting_participants
+        WHERE meeting_id = ? AND participant_identifier = ?
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        sqlite3_bind_text(statement, 2, (participantIdentifier as NSString).utf8String, -1, nil)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
     }
 
     @discardableResult
@@ -1801,6 +2227,7 @@ public final class DictationStore {
         do {
             try deleteResumeSnapshot(meetingID: id, db: db)
             try deleteLiveTranscriptCheckpoints(meetingID: id, db: db)
+            try deleteMeetingParticipants(meetingID: id, db: db)
             let sql = """
             UPDATE meetings
             SET title = 'Deleted Meeting',
@@ -1916,6 +2343,7 @@ public final class DictationStore {
         defer { sqlite3_close(db) }
         try exec("DELETE FROM meeting_resume_snapshots", db: db)
         try exec("DELETE FROM meeting_transcript_checkpoints", db: db)
+        try exec("DELETE FROM meeting_participants", db: db)
         try exec(
             """
             UPDATE meetings
@@ -2605,6 +3033,19 @@ public final class DictationStore {
 
     private func deleteLiveTranscriptCheckpoints(meetingID: Int64, db: OpaquePointer?) throws {
         let sql = "DELETE FROM meeting_transcript_checkpoints WHERE meeting_id = ?"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw lastError(db)
+        }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_int64(statement, 1, meetingID)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw lastError(db)
+        }
+    }
+
+    private func deleteMeetingParticipants(meetingID: Int64, db: OpaquePointer?) throws {
+        let sql = "DELETE FROM meeting_participants WHERE meeting_id = ?"
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
             throw lastError(db)

--- a/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/StorageModels.swift
@@ -466,6 +466,48 @@ public struct MeetingRecord: Identifiable, Codable, Sendable {
     }
 }
 
+public struct MeetingParticipant: Identifiable, Equatable, Sendable {
+    public let meetingID: Int64
+    public let participantIdentifier: String
+    public let displayName: String
+    public let emailAddress: String?
+    public let insertionOrder: Int
+
+    public var id: String {
+        "\(meetingID):\(participantIdentifier)"
+    }
+
+    public init(
+        meetingID: Int64,
+        participantIdentifier: String,
+        displayName: String,
+        emailAddress: String? = nil,
+        insertionOrder: Int
+    ) {
+        self.meetingID = meetingID
+        self.participantIdentifier = participantIdentifier
+        self.displayName = displayName
+        self.emailAddress = emailAddress
+        self.insertionOrder = insertionOrder
+    }
+}
+
+public struct MeetingParticipantDraft: Equatable, Sendable {
+    public let participantIdentifier: String
+    public let displayName: String
+    public let emailAddress: String?
+
+    public init(
+        participantIdentifier: String,
+        displayName: String,
+        emailAddress: String? = nil
+    ) {
+        self.participantIdentifier = participantIdentifier
+        self.displayName = displayName
+        self.emailAddress = emailAddress
+    }
+}
+
 public struct MeetingFolder: Identifiable, Codable, Sendable {
     public let id: Int64
     public var name: String

--- a/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/CalendarMonitor.swift
@@ -3,6 +3,51 @@ import EventKit
 import Foundation
 import MuesliCore
 
+/// A local attendee snapshot sourced exclusively from EventKit. Direct Google
+/// API events retain the default empty attendee list.
+struct CalendarAttendee: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let emailAddress: String?
+
+    init?(identifier: String?, displayName: String?, emailAddress: String?) {
+        let normalizedEmail = Self.normalizedEmail(emailAddress ?? identifier)
+        let normalizedName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let fallbackIdentifier = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let resolvedName = normalizedName.isEmpty ? (normalizedEmail ?? "") : normalizedName
+        guard !resolvedName.isEmpty else { return nil }
+
+        let identity = normalizedEmail.map { "email:\($0)" }
+            ?? (fallbackIdentifier.isEmpty ? nil : "calendar:\(fallbackIdentifier.lowercased())")
+        guard let identity else { return nil }
+        self.id = identity
+        self.displayName = resolvedName
+        self.emailAddress = normalizedEmail
+    }
+
+    var participantDraft: MeetingParticipantDraft {
+        MeetingParticipantDraft(
+            participantIdentifier: id,
+            displayName: displayName,
+            emailAddress: emailAddress
+        )
+    }
+
+    static func deduplicated(_ attendees: [CalendarAttendee]) -> [CalendarAttendee] {
+        var seen = Set<String>()
+        return attendees.filter { seen.insert($0.id).inserted }
+    }
+
+    private static func normalizedEmail(_ candidate: String?) -> String? {
+        var value = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if value.lowercased().hasPrefix("mailto:") {
+            value.removeFirst("mailto:".count)
+        }
+        guard value.contains("@") else { return nil }
+        return value.lowercased()
+    }
+}
+
 struct UpcomingMeetingEvent {
     let id: String
     let title: String
@@ -144,7 +189,12 @@ final class CalendarMonitor {
             guard let startDate = event.startDate, let endDate = event.endDate else { continue }
             let ctx = CalendarEventContext(
                 id: event.eventIdentifier ?? UUID().uuidString,
-                title: event.title ?? "Meeting"
+                title: event.title ?? "Meeting",
+                calendarOccurrence: Self.occurrenceReference(
+                    for: event,
+                    eventID: event.eventIdentifier ?? "",
+                    startDate: startDate
+                )
             )
             // Currently active — return immediately
             if startDate <= now && endDate > now {
@@ -191,7 +241,8 @@ final class CalendarMonitor {
                     eventID: eventID,
                     startDate: startDate
                 ),
-                meetingURL: Self.extractMeetingURL(from: event)
+                meetingURL: Self.extractMeetingURL(from: event),
+                attendees: Self.attendees(from: event)
             )
         }
         return UnifiedCalendarEvent
@@ -217,6 +268,45 @@ final class CalendarMonitor {
                 ? (event.occurrenceDate ?? startDate)
                 : startDate
         )
+    }
+
+    private static func attendees(from event: EKEvent) -> [CalendarAttendee] {
+        let participants = [event.organizer].compactMap { $0 } + (event.attendees ?? [])
+        let attendees = participants.compactMap { participant -> CalendarAttendee? in
+            guard participant.participantType != .resource,
+                  participant.participantType != .room else { return nil }
+            return CalendarAttendee(
+                identifier: participant.url.absoluteString,
+                displayName: participant.name,
+                emailAddress: participant.url.absoluteString
+            )
+        }
+        return CalendarAttendee.deduplicated(attendees)
+    }
+
+    /// Resolves participants at the persistence boundary so recording entry
+    /// points only need to carry the existing occurrence identity.
+    static func attendees(for occurrence: CalendarOccurrenceReference) -> [CalendarAttendee] {
+        guard occurrence.provider == .eventKit else { return [] }
+
+        let freshStore = EKEventStore()
+        if let event = freshStore.event(withIdentifier: occurrence.eventID) {
+            return Self.attendees(from: event)
+        }
+
+        let start = occurrence.originalStartTime.addingTimeInterval(-60)
+        let end = occurrence.originalStartTime.addingTimeInterval(60)
+        let predicate = freshStore.predicateForEvents(withStart: start, end: end, calendars: nil)
+        guard let event = freshStore.events(matching: predicate).first(where: {
+            Self.occurrenceReference(
+                for: $0,
+                eventID: $0.eventIdentifier ?? "",
+                startDate: $0.startDate
+            ).identityKey == occurrence.identityKey
+        }) else {
+            return []
+        }
+        return Self.attendees(from: event)
     }
 
     /// Enumerate every event calendar EventKit exposes — iCloud, On-My-Mac,

--- a/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/GoogleCalendarClient.swift
@@ -16,6 +16,7 @@ struct UnifiedCalendarEvent: Identifiable, Equatable {
     var calendarID: String? = nil
     var calendarOccurrence: CalendarOccurrenceReference? = nil
     var meetingURL: URL? = nil
+    var attendees: [CalendarAttendee] = []
 
     enum CalendarSource: String {
         case eventKit

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactCreator.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactCreator.swift
@@ -1,0 +1,92 @@
+import Contacts
+import Foundation
+import MuesliCore
+
+struct NewMeetingContactDraft: Equatable, Sendable {
+    var givenName = ""
+    var familyName = ""
+    var emailAddress = ""
+
+    var canSave: Bool {
+        !normalizedGivenName.isEmpty || !normalizedFamilyName.isEmpty
+    }
+
+    var normalizedGivenName: String {
+        givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedFamilyName: String {
+        familyName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedEmailAddress: String {
+        emailAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum MeetingContactCreatorError: LocalizedError, Equatable {
+    case nameRequired
+    case accessDenied
+    case missingIdentifier
+
+    var errorDescription: String? {
+        switch self {
+        case .nameRequired:
+            return "Add a first or last name before saving this contact."
+        case .accessDenied:
+            return "Muesli does not have permission to add contacts. Enable Contacts access in System Settings."
+        case .missingIdentifier:
+            return "Apple Contacts saved the person without returning an identifier. Try choosing them from Contacts instead."
+        }
+    }
+}
+
+enum MeetingContactCreator {
+    static func create(_ draft: NewMeetingContactDraft) async throws -> MeetingParticipantDraft {
+        guard draft.canSave else {
+            throw MeetingContactCreatorError.nameRequired
+        }
+
+        let store = CNContactStore()
+        switch CNContactStore.authorizationStatus(for: .contacts) {
+        case .denied, .restricted:
+            throw MeetingContactCreatorError.accessDenied
+        default:
+            guard try await requestAccess(using: store) else {
+                throw MeetingContactCreatorError.accessDenied
+            }
+        }
+
+        return try await Task.detached(priority: .userInitiated) {
+            let contact = CNMutableContact()
+            contact.givenName = draft.normalizedGivenName
+            contact.familyName = draft.normalizedFamilyName
+            if !draft.normalizedEmailAddress.isEmpty {
+                contact.emailAddresses = [
+                    CNLabeledValue(label: CNLabelWork, value: draft.normalizedEmailAddress as NSString),
+                ]
+            }
+
+            let request = CNSaveRequest()
+            request.add(contact, toContainerWithIdentifier: nil)
+            try CNContactStore().execute(request)
+
+            guard !contact.identifier.isEmpty else {
+                throw MeetingContactCreatorError.missingIdentifier
+            }
+            return MeetingContactIdentity.participant(for: contact)
+        }.value
+    }
+
+    private static func requestAccess(using store: CNContactStore) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            store.requestAccess(for: .contacts) { granted, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactIdentity.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactIdentity.swift
@@ -1,0 +1,58 @@
+import Contacts
+import Foundation
+import MuesliCore
+
+enum MeetingContactIdentity {
+    static let unnamedFallback = "Unnamed contact"
+
+    static func displayName(for contact: CNContact) -> String {
+        let nameDescriptor = CNContactFormatter.descriptorForRequiredKeys(for: .fullName)
+        let fullName = contact.areKeysAvailable([nameDescriptor])
+            ? CNContactFormatter.string(from: contact, style: .fullName)
+            : nil
+        let nickname = contact.isKeyAvailable(CNContactNicknameKey) ? contact.nickname : nil
+        let organization = contact.isKeyAvailable(CNContactOrganizationNameKey) ? contact.organizationName : nil
+        let email = contact.isKeyAvailable(CNContactEmailAddressesKey)
+            ? contact.emailAddresses.first?.value as String?
+            : nil
+        let phone = contact.isKeyAvailable(CNContactPhoneNumbersKey)
+            ? contact.phoneNumbers.first?.value.stringValue
+            : nil
+        let candidates = [fullName, nickname, organization, email, phone]
+        for candidate in candidates {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return unnamedFallback
+    }
+
+    static func participant(for contact: CNContact) -> MeetingParticipantDraft {
+        let emailAddress = contact.isKeyAvailable(CNContactEmailAddressesKey)
+            ? contact.emailAddresses.first?.value as String?
+            : nil
+        let normalizedEmail = emailAddress?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return MeetingParticipantDraft(
+            participantIdentifier: normalizedEmail.flatMap { $0.isEmpty ? nil : "email:\($0)" }
+                ?? "contact:\(contact.identifier)",
+            displayName: displayName(for: contact),
+            emailAddress: normalizedEmail
+        )
+    }
+
+    static func isEmailFallback(_ displayName: String) -> Bool {
+        let normalizedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalizedName.contains("@")
+    }
+
+    static func compactDisplayName(_ displayName: String, emailAddress: String?) -> String {
+        guard isEmailFallback(displayName) else {
+            return displayName
+        }
+        let email = emailAddress ?? displayName
+        return email.split(separator: "@", maxSplits: 1).first.map(String.init) ?? displayName
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactPicker.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingContactPicker.swift
@@ -1,0 +1,89 @@
+import AppKit
+import Contacts
+import ContactsUI
+import SwiftUI
+
+struct MeetingContactPicker: NSViewRepresentable {
+    @Binding var isPresented: Bool
+    let onSelect: (CNContact) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.parent = self
+        guard isPresented else { return }
+        context.coordinator.presentIfNeeded(relativeTo: nsView)
+    }
+
+    final class Coordinator: NSObject, CNContactPickerDelegate {
+        var parent: MeetingContactPicker
+        private var picker: CNContactPicker?
+
+        init(parent: MeetingContactPicker) {
+            self.parent = parent
+        }
+
+        func presentIfNeeded(relativeTo view: NSView) {
+            // A live picker owns the presentation state. `updateNSView` re-runs on any
+            // SwiftUI re-render, so clearing the binding here would dismiss the popover
+            // the user is still using.
+            guard picker == nil else { return }
+
+            // No window means no anchor, so bail out without leaving `isPresented` stuck
+            // true. It is already true here, so a stale flag would make every later click
+            // a no-op change — no updateNSView, no presentation, and a dead button.
+            guard view.window != nil else {
+                resetPresentation()
+                return
+            }
+
+            // Deliberately no `displayedKeys`: per CNContactPicker.h, providing keys
+            // switches the picker to selecting values rather than whole contacts.
+            let picker = CNContactPicker()
+            picker.delegate = self
+            self.picker = picker
+
+            // Present after the current SwiftUI update pass. Showing the popover
+            // inline reads uncommitted layout for the anchor rect, and a synchronous
+            // delegate callback would mutate state during view update.
+            DispatchQueue.main.async { [weak self, weak view] in
+                guard let self, let view, view.window != nil else {
+                    self?.picker = nil
+                    self?.resetPresentation()
+                    return
+                }
+                guard self.picker === picker else { return }
+                picker.showRelative(to: view.bounds, of: view, preferredEdge: .maxY)
+            }
+        }
+
+        func contactPicker(_ picker: CNContactPicker, didSelect contact: CNContact) {
+            parent.onSelect(contact)
+            finish()
+        }
+
+        func contactPickerDidClose(_ picker: CNContactPicker) {
+            finish()
+        }
+
+        private func finish() {
+            picker = nil
+            resetPresentation()
+        }
+
+        /// Always deferred: `presentIfNeeded` runs inside `updateNSView`, and clearing
+        /// the binding synchronously there mutates state during a view update.
+        private func resetPresentation() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.parent.isPresented else { return }
+                self.parent.isPresented = false
+            }
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetailView.swift
@@ -23,6 +23,10 @@ private enum ManualNotesSaveStatus {
     }
 }
 
+enum MeetingHeaderLayout {
+    static let contextControlHeight: CGFloat = 28
+}
+
 // Wrapper views that isolate observation of liveMeetingTranscript.
 // Without these, MeetingDetailView.body would observe the property and
 // re-evaluate on every chunk (every ~5s), re-rendering the entire detail view.
@@ -210,18 +214,15 @@ struct MeetingDetailView: View {
                     )
 
                     HStack(spacing: MuesliTheme.spacing8) {
-                        Text(formatMeta(meeting))
-                            .font(MuesliTheme.callout())
-                            .foregroundStyle(MuesliTheme.textSecondary)
+                        metadataItem(systemImage: "calendar", text: MeetingBrowserLogic.formatStartTime(meeting.startTime))
+                        metadataDivider
+                        metadataItem(systemImage: "clock", text: formatDuration(meeting.durationSeconds))
+                        metadataDivider
+                        metadataItem(systemImage: "doc.text", text: "\(meeting.wordCount) words")
                         if let label = SyncOriginDisplay.badgeLabel(forMeetingSource: meeting.source) {
                             SyncOriginBadge(label: label)
                         }
-                        templateChip(for: appliedTemplate)
                     }
-
-                    folderPill(for: meeting)
-
-                    threadBreadcrumb
                 }
 
                 Spacer(minLength: MuesliTheme.spacing16)
@@ -229,16 +230,28 @@ struct MeetingDetailView: View {
                 VStack(alignment: .trailing, spacing: 10) {
                     if showsManualNotesEditor(for: meeting) {
                         recordingControlGroup(for: meeting)
-                        if meeting.status == .recording {
-                            recordingModePicker
-                        }
                     } else {
-                        documentModePicker
-
-                        headerActions(for: meeting, appliedTemplate: appliedTemplate)
+                        compactHeaderActions(for: meeting, appliedTemplate: appliedTemplate)
                     }
                 }
             }
+
+            HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                meetingContextStrip(for: meeting)
+                    .layoutPriority(1)
+                Spacer(minLength: MuesliTheme.spacing12)
+                detailModePicker(for: meeting)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(MuesliTheme.spacing8)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+            .overlay {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            }
+
+            threadBreadcrumb
 
             if let savedRecordingPath = meeting.savedRecordingPath,
                FileManager.default.fileExists(atPath: savedRecordingPath) {
@@ -255,6 +268,43 @@ struct MeetingDetailView: View {
         .padding(.horizontal, 40)
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func meetingContextStrip(for meeting: MeetingRecord) -> some View {
+        HStack(alignment: .center, spacing: MuesliTheme.spacing16) {
+            folderPill(for: meeting)
+            Divider()
+                .frame(height: 20)
+            MeetingParticipantsView(
+                meetingID: meeting.id,
+                controller: controller
+            )
+        }
+    }
+
+    private func metadataItem(systemImage: String, text: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: systemImage)
+                .font(.system(size: 10, weight: .medium))
+            Text(text)
+                .font(MuesliTheme.callout())
+        }
+        .foregroundStyle(MuesliTheme.textSecondary)
+    }
+
+    private var metadataDivider: some View {
+        Text("·")
+            .font(MuesliTheme.callout())
+            .foregroundStyle(MuesliTheme.textTertiary)
+    }
+
+    @ViewBuilder
+    private func detailModePicker(for meeting: MeetingRecord) -> some View {
+        if meeting.status == .recording, showsManualNotesEditor(for: meeting) {
+            recordingModePicker
+        } else if !showsManualNotesEditor(for: meeting) {
+            documentModePicker
+        }
     }
 
     @ViewBuilder
@@ -449,66 +499,46 @@ struct MeetingDetailView: View {
     }
 
     @ViewBuilder
-    private func headerActions(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: MuesliTheme.spacing8) {
-                resumeChooserIfAvailable(for: meeting)
-                templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                exportMenu(for: meeting)
-                summaryAction(for: meeting)
-                editButton(for: meeting)
-                moreActionsMenu(for: meeting)
+    private func compactHeaderActions(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            resumeChooserIfAvailable(for: meeting)
+            exportMenu(for: meeting)
+
+            if isSummarizing {
+                ProgressView()
+                    .controlSize(.small)
+                    .help("Summarizing meeting")
             }
 
-            VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
-                HStack(spacing: MuesliTheme.spacing8) {
-                    resumeChooserIfAvailable(for: meeting)
-                    templateMenu(for: meeting, appliedTemplate: appliedTemplate)
-                    exportMenu(for: meeting)
-                    summaryAction(for: meeting)
-                }
-                HStack(spacing: MuesliTheme.spacing8) {
-                    editButton(for: meeting)
-                    moreActionsMenu(for: meeting)
-                }
+            if isEditingNotes || isEditingTranscript {
+                editButton(for: meeting)
+            } else {
+                compactMoreActionsMenu(for: meeting, appliedTemplate: appliedTemplate)
             }
         }
     }
 
-    @ViewBuilder
-    private func summaryAction(for meeting: MeetingRecord) -> some View {
-        if isSummarizing {
-            HStack(spacing: 6) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Summarizing...")
-                    .font(.system(size: 11))
-                    .foregroundStyle(MuesliTheme.textTertiary)
+    private func beginSummary(for meeting: MeetingRecord) {
+        guard !isSummarizing else { return }
+        isSummarizing = true
+        let completion: (Result<Void, Error>) -> Void = { [meeting] result in
+            isSummarizing = false
+            switch result {
+            case .success:
+                if let updated = controller.meeting(id: meeting.id) {
+                    syncLocalState(with: updated)
+                }
+            case .failure(let error):
+                syncPendingTemplateSelectionIfNeeded(
+                    for: controller.meeting(id: meeting.id) ?? meeting
+                )
+                summaryErrorMessage = error.localizedDescription
             }
-            .padding(.horizontal, MuesliTheme.spacing8)
+        }
+        if hasPendingTemplateChange(for: meeting) {
+            controller.applyMeetingTemplate(id: pendingTemplateID, to: meeting, completion: completion)
         } else {
-            iconButton("sparkles", label: primarySummaryActionLabel(for: meeting)) {
-                isSummarizing = true
-                let completion: (Result<Void, Error>) -> Void = { [meeting] result in
-                    isSummarizing = false
-                    switch result {
-                    case .success:
-                        if let updated = controller.meeting(id: meeting.id) {
-                            syncLocalState(with: updated)
-                        }
-                    case .failure(let error):
-                        syncPendingTemplateSelectionIfNeeded(
-                            for: controller.meeting(id: meeting.id) ?? meeting
-                        )
-                        summaryErrorMessage = error.localizedDescription
-                    }
-                }
-                if hasPendingTemplateChange(for: meeting) {
-                    controller.applyMeetingTemplate(id: pendingTemplateID, to: meeting, completion: completion)
-                } else {
-                    controller.resummarize(meeting: meeting, completion: completion)
-                }
-            }
+            controller.resummarize(meeting: meeting, completion: completion)
         }
     }
 
@@ -518,39 +548,43 @@ struct MeetingDetailView: View {
             isEditingNotes || isEditingTranscript ? "checkmark.circle" : "pencil",
             label: editButtonLabel
         ) {
-            if isEditingNotes {
-                notesSaveTask?.cancel()
-                notesSaveTask = nil
-                controller.updateMeetingNotes(id: meeting.id, notes: editableNotes)
-                isEditingNotes = false
-            } else if isEditingTranscript {
-                guard !isRetranscribing else { return }
-                transcriptSaveTask?.cancel()
-                transcriptSaveTask = nil
-                let shouldPromptForResummary = Self.shouldPromptForTranscriptResummary(
-                    hadStructuredNotes: transcriptEditHadStructuredNotes,
-                    originalTranscript: transcriptEditOriginalTranscript,
-                    editedTranscript: editableTranscript
-                )
-                controller.updateMeetingTranscript(id: meeting.id, transcript: editableTranscript)
-                isEditingTranscript = false
-                transcriptEditOriginalTranscript = nil
-                transcriptEditHadStructuredNotes = false
-                if shouldPromptForResummary {
-                    transcriptResummaryPromptMeetingID = meeting.id
-                }
-            } else if documentMode == .transcript {
-                editableTranscript = meeting.rawTranscript
-                transcriptEditOriginalTranscript = meeting.rawTranscript
-                transcriptEditHadStructuredNotes = meeting.notesState == .structuredNotes
-                isEditingTranscript = true
-            } else {
-                documentMode = .notes
-                editableNotes = Self.notesContent(for: meeting)
-                isEditingNotes = true
-            }
+            toggleEditing(for: meeting)
         }
         .disabled(isRetranscribing && !isEditingNotes && !isEditingTranscript)
+    }
+
+    private func toggleEditing(for meeting: MeetingRecord) {
+        if isEditingNotes {
+            notesSaveTask?.cancel()
+            notesSaveTask = nil
+            controller.updateMeetingNotes(id: meeting.id, notes: editableNotes)
+            isEditingNotes = false
+        } else if isEditingTranscript {
+            guard !isRetranscribing else { return }
+            transcriptSaveTask?.cancel()
+            transcriptSaveTask = nil
+            let shouldPromptForResummary = Self.shouldPromptForTranscriptResummary(
+                hadStructuredNotes: transcriptEditHadStructuredNotes,
+                originalTranscript: transcriptEditOriginalTranscript,
+                editedTranscript: editableTranscript
+            )
+            controller.updateMeetingTranscript(id: meeting.id, transcript: editableTranscript)
+            isEditingTranscript = false
+            transcriptEditOriginalTranscript = nil
+            transcriptEditHadStructuredNotes = false
+            if shouldPromptForResummary {
+                transcriptResummaryPromptMeetingID = meeting.id
+            }
+        } else if documentMode == .transcript {
+            editableTranscript = meeting.rawTranscript
+            transcriptEditOriginalTranscript = meeting.rawTranscript
+            transcriptEditHadStructuredNotes = meeting.notesState == .structuredNotes
+            isEditingTranscript = true
+        } else {
+            documentMode = .notes
+            editableNotes = Self.notesContent(for: meeting)
+            isEditingNotes = true
+        }
     }
 
     @ViewBuilder
@@ -590,8 +624,7 @@ struct MeetingDetailView: View {
     }
 
     @ViewBuilder
-    private func templateMenu(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
-        Menu {
+    private func templateMenuItems(for meeting: MeetingRecord, appliedTemplate: MeetingTemplateSnapshot) -> some View {
             Button {
                 pendingTemplateID = MeetingTemplates.autoID
             } label: {
@@ -638,27 +671,6 @@ struct MeetingDetailView: View {
             Button("Manage Templates…") {
                 controller.showMeetingTemplatesManager()
             }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: iconName(forSelectionOn: meeting, appliedTemplate: appliedTemplate))
-                    .font(.system(size: 10))
-                Text(labelForSelection(on: meeting, appliedTemplate: appliedTemplate))
-                    .font(.system(size: 11, weight: .medium))
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 9))
-            }
-            .foregroundStyle(MuesliTheme.textSecondary)
-            .padding(.horizontal, MuesliTheme.spacing8)
-            .padding(.vertical, 5)
-            .background(MuesliTheme.surfacePrimary)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-            )
-        }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
     }
 
     @ViewBuilder
@@ -874,10 +886,37 @@ struct MeetingDetailView: View {
         .disabled(isEditingNotes || isEditingTranscript)
     }
 
-    @ViewBuilder
-    private func moreActionsMenu(for meeting: MeetingRecord) -> some View {
-        if meeting.savedRecordingPath != nil || controller.canDeleteMeeting(meeting) {
+    private func compactMoreActionsMenu(
+        for meeting: MeetingRecord,
+        appliedTemplate: MeetingTemplateSnapshot
+    ) -> some View {
+        Menu {
             Menu {
+                templateMenuItems(for: meeting, appliedTemplate: appliedTemplate)
+            } label: {
+                Label(
+                    "Template: \(labelForSelection(on: meeting, appliedTemplate: appliedTemplate))",
+                    systemImage: iconName(forSelectionOn: meeting, appliedTemplate: appliedTemplate)
+                )
+            }
+
+            Button {
+                beginSummary(for: meeting)
+            } label: {
+                Label(primarySummaryActionLabel(for: meeting), systemImage: "sparkles")
+            }
+            .disabled(isSummarizing || isRetranscribing)
+
+            Button {
+                toggleEditing(for: meeting)
+            } label: {
+                Label(editButtonLabel, systemImage: "pencil")
+            }
+            .disabled(isRetranscribing)
+
+            if meeting.savedRecordingPath != nil || controller.canDeleteMeeting(meeting) {
+                Divider()
+
                 if let savedRecordingPath = meeting.savedRecordingPath {
                     Button {
                         controller.revealMeetingRecordingInFinder(path: savedRecordingPath)
@@ -887,20 +926,16 @@ struct MeetingDetailView: View {
                 }
 
                 if controller.canDeleteMeeting(meeting) {
-                    if meeting.savedRecordingPath != nil {
-                        Divider()
-                    }
                     Button(role: .destructive) {
                         showDeleteConfirmation = true
                     } label: {
                         Label("Delete Meeting", systemImage: "trash")
                     }
                 }
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 12, weight: .semibold))
-                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(MuesliTheme.textSecondary)
                 .frame(width: 30, height: 28)
                 .background(MuesliTheme.surfacePrimary)
@@ -909,11 +944,10 @@ struct MeetingDetailView: View {
                     RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                         .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
                 )
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            .help("More actions")
         }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("More actions")
     }
 
     private func templateMenuItem(title: String, systemImage: String, isSelected: Bool) -> some View {
@@ -994,7 +1028,7 @@ struct MeetingDetailView: View {
                 Text(isPaused ? "Resume" : "Pause")
                     .font(.system(size: 12, weight: .semibold))
             }
-            .foregroundStyle(isPaused ? MuesliTheme.backgroundBase : MuesliTheme.textPrimary)
+            .foregroundStyle(isPaused ? Color.white : MuesliTheme.textPrimary)
             .padding(.horizontal, MuesliTheme.spacing12)
             .padding(.vertical, 7)
             .background(isPaused ? MuesliTheme.accent : MuesliTheme.surfacePrimary)
@@ -1026,7 +1060,7 @@ struct MeetingDetailView: View {
                     Text("Resume")
                         .font(.system(size: 12, weight: .semibold))
                 }
-                .foregroundStyle(MuesliTheme.backgroundBase)
+                .foregroundStyle(Color.white)
                 .padding(.horizontal, MuesliTheme.spacing12)
                 .padding(.vertical, 7)
                 .background(MuesliTheme.accent)
@@ -1048,7 +1082,7 @@ struct MeetingDetailView: View {
             } label: {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(MuesliTheme.backgroundBase)
+                    .foregroundStyle(Color.white)
                     .padding(.horizontal, 8)
                     .frame(maxHeight: .infinity)
                     .background(MuesliTheme.accent)
@@ -1094,21 +1128,6 @@ struct MeetingDetailView: View {
         iconButton("xmark", label: "Discard") {
             controller.discardMeetingWithConfirmation()
         }
-    }
-
-    @ViewBuilder
-    private func templateChip(for snapshot: MeetingTemplateSnapshot) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: iconName(for: snapshot))
-                .font(.system(size: 10))
-            Text(snapshot.name)
-                .font(.system(size: 11, weight: .medium))
-        }
-        .foregroundStyle(MuesliTheme.accent)
-        .padding(.horizontal, MuesliTheme.spacing8)
-        .padding(.vertical, 4)
-        .background(MuesliTheme.accentSubtle)
-        .clipShape(Capsule())
     }
 
     /// Breadcrumb strip shown when this meeting is part of a follow-up thread:
@@ -1195,11 +1214,11 @@ struct MeetingDetailView: View {
             }
             .foregroundStyle(hasFolder ? MuesliTheme.accent : MuesliTheme.textSecondary)
             .padding(.horizontal, MuesliTheme.spacing8)
-            .padding(.vertical, 4)
+            .frame(height: MeetingHeaderLayout.contextControlHeight)
             .background(hasFolder ? MuesliTheme.accentSubtle : MuesliTheme.backgroundRaised)
-            .clipShape(Capsule())
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             .overlay(
-                Capsule()
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
                     .strokeBorder(hasFolder ? Color.clear : MuesliTheme.surfaceBorder, lineWidth: 1)
             )
         }
@@ -1589,12 +1608,6 @@ struct MeetingDetailView: View {
         }
         editableManualNotes = persistedManualNotes
         manualNotesSaveStatus = .saved
-    }
-
-    private func formatMeta(_ meeting: MeetingRecord) -> String {
-        let time = MeetingBrowserLogic.formatStartTime(meeting.startTime)
-        let duration = formatDuration(meeting.durationSeconds)
-        return "\(time)  \u{2022}  \(duration)  \u{2022}  \(meeting.wordCount) words"
     }
 
     private func formatDuration(_ seconds: Double) -> String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingDetector.swift
@@ -28,6 +28,7 @@ struct MeetingSignals {
 struct CalendarEventContext {
     let id: String
     let title: String
+    var calendarOccurrence: CalendarOccurrenceReference? = nil
 }
 
 /// A running application on the system.

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
@@ -1,0 +1,273 @@
+import Contacts
+import MuesliCore
+import SwiftUI
+
+extension Notification.Name {
+    static let meetingParticipantsDidChange = Notification.Name("MuesliMeetingParticipantsDidChange")
+}
+
+struct MeetingParticipantsView: View {
+    let meetingID: Int64
+    let controller: MuesliController
+
+    @State private var participants: [MeetingParticipant] = []
+    @State private var isContactPickerPresented = false
+    @State private var isNewContactPresented = false
+    @State private var isPeoplePopoverPresented = false
+    @State private var errorMessage: String?
+
+    private var peopleDescription: String {
+        participants.count == 1 ? "1 person" : "\(participants.count) people"
+    }
+
+    private var firstParticipantName: String? {
+        participants.first.map {
+            MeetingContactIdentity.compactDisplayName(
+                $0.displayName,
+                emailAddress: $0.emailAddress
+            )
+        }
+    }
+
+    var body: some View {
+        Button {
+            isPeoplePopoverPresented.toggle()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: participants.isEmpty ? "person.2" : "person.2.fill")
+
+                if let firstParticipantName {
+                    Text(firstParticipantName)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    if participants.count > 1 {
+                        Text("+\(participants.count - 1)")
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+                } else {
+                    Text("Add people")
+                }
+            }
+            .font(MuesliTheme.caption())
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.horizontal, 10)
+            .frame(height: MeetingHeaderLayout.contextControlHeight)
+            .frame(maxWidth: 220)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: false, vertical: true)
+        .help(participants.isEmpty ? "Add people to this meeting" : "Show \(peopleDescription)")
+        .accessibilityLabel(
+            participants.isEmpty ? "Add people to this meeting" : "\(peopleDescription) in this meeting"
+        )
+        .popover(isPresented: $isPeoplePopoverPresented, arrowEdge: .bottom) {
+            peoplePopover
+        }
+        .background {
+            MeetingContactPicker(isPresented: $isContactPickerPresented) { contact in
+                Task { await attach(contact) }
+            }
+        }
+        .task(id: meetingID) {
+            await reload()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .meetingParticipantsDidChange)) { notification in
+            guard notification.object as? Int64 == meetingID else { return }
+            Task { await reload() }
+        }
+        .sheet(isPresented: $isNewContactPresented) {
+            NewMeetingContactView { participant in
+                Task { await attach(participant) }
+            }
+        }
+        .alert("Couldn't Update People", isPresented: errorBinding) {
+            Button("OK", role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "The meeting's people could not be updated.")
+        }
+    }
+
+    private var peoplePopover: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                Text("People")
+                    .font(MuesliTheme.title3())
+
+                if !participants.isEmpty {
+                    Text(peopleDescription)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+
+                Spacer()
+
+                addPersonMenu
+            }
+
+            Divider()
+
+            if participants.isEmpty {
+                Text("No one has been added yet.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, MuesliTheme.spacing8)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                        ForEach(participants) { participant in
+                            participantListRow(participant)
+                        }
+                    }
+                }
+                .frame(maxHeight: 320)
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+        .frame(width: 340)
+    }
+
+    private var addPersonMenu: some View {
+        Menu {
+            Button {
+                chooseExistingContact()
+            } label: {
+                Label("Choose from Contacts…", systemImage: "person.crop.circle.badge.plus")
+            }
+
+            Button {
+                createNewContact()
+            } label: {
+                Label("Create New Contact…", systemImage: "person.badge.plus")
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "person.badge.plus")
+                Text("Add person")
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+            }
+            .font(MuesliTheme.caption())
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.horizontal, 9)
+            .frame(height: MeetingHeaderLayout.contextControlHeight)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .overlay {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Choose or create an Apple contact")
+    }
+
+    private func participantListRow(_ participant: MeetingParticipant) -> some View {
+        let displayName = MeetingContactIdentity.compactDisplayName(
+            participant.displayName,
+            emailAddress: participant.emailAddress
+        )
+        return HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: "person.crop.circle.fill")
+                .font(.system(size: 18))
+                .foregroundStyle(MuesliTheme.textTertiary)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(displayName)
+                    .font(MuesliTheme.callout())
+                if let email = participant.emailAddress, email != displayName {
+                    Text(email)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                }
+            }
+
+            Spacer()
+
+            Button {
+                remove(participant)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .help("Remove \(displayName)")
+        }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { presented in
+                if !presented {
+                    errorMessage = nil
+                }
+            }
+        )
+    }
+
+    private func chooseExistingContact() {
+        isPeoplePopoverPresented = false
+        Task { @MainActor in
+            await Task.yield()
+            isContactPickerPresented = true
+        }
+    }
+
+    private func createNewContact() {
+        isPeoplePopoverPresented = false
+        Task { @MainActor in
+            await Task.yield()
+            isNewContactPresented = true
+        }
+    }
+
+    private func reload() async {
+        do {
+            participants = try await controller.meetingParticipants(meetingID: meetingID)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func attach(_ contact: CNContact) async {
+        await attach(MeetingContactIdentity.participant(for: contact))
+    }
+
+    private func attach(_ participant: MeetingParticipantDraft) async {
+        do {
+            try await controller.attachMeetingParticipant(
+                meetingID: meetingID,
+                participant: participant
+            )
+            await reload()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func remove(_ participant: MeetingParticipant) {
+        Task {
+            do {
+                try await controller.removeMeetingParticipant(
+                    meetingID: meetingID,
+                    participantIdentifier: participant.participantIdentifier
+                )
+                await reload()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -232,7 +232,8 @@ struct MeetingsView: View {
                     meeting: meeting,
                     controller: controller,
                     appState: appState,
-                    onBack: { controller.showMeetingsHome(folderID: appState.selectedFolderID) }
+                    onBack: { controller.showMeetingsHome(folderID: appState.selectedFolderID) },
+                    backLabel: "Back to Meetings"
                 )
                 .id(meeting.id)
             } else {
@@ -461,7 +462,12 @@ struct MeetingsView: View {
                                    !appState.isMeetingRecording,
                                    !appState.isMeetingStarting {
                                     Button {
-                                        controller.joinAndRecord(title: event.title, meetingURL: meetingURL, endDate: event.endDate)
+                                        controller.joinAndRecord(
+                                            title: event.title,
+                                            meetingURL: meetingURL,
+                                            endDate: event.endDate,
+                                            calendarOccurrence: event.resolvedCalendarOccurrence
+                                        )
                                     } label: {
                                         HStack(spacing: 4) {
                                             Image(systemName: "video.fill")

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -182,6 +182,17 @@ struct PendingMeetingCompletionNotification {
     let title: String
 }
 
+private struct CalendarParticipantReconciliationSnapshot: Sendable {
+    let occurrence: CalendarOccurrenceReference
+    let startDate: Date
+    let participants: [MeetingParticipantDraft]
+}
+
+private enum CalendarAttendeePersistenceMode: Sendable, Equatable {
+    case attach
+    case reconcile
+}
+
 enum MeetingRetranscriptionError: Error, LocalizedError {
     case controllerUnavailable
     case recordingUnavailable
@@ -402,6 +413,9 @@ final class MuesliController: NSObject {
     private var liveManualNotesLastPersistedAt: [Int64: Date] = [:]
     private var liveManualNotesLastPersistedValue: [Int64: String] = [:]
     private var liveManualNotesPersistWorkItems: [Int64: DispatchWorkItem] = [:]
+    private var calendarAttendeePersistenceTasks: [
+        Int64: (generation: UUID, task: Task<Bool, Never>)
+    ] = [:]
     private let liveManualNotesPersistInterval: TimeInterval = 0.75
     private var staleLiveMeetingRecoveryFailures = Set<Int64>()
     private var dictationState: DictationState = .idle
@@ -862,6 +876,11 @@ final class MuesliController: NSObject {
         activeComputerUseAudioSessionID = nil
         pendingComputerUseStopSessionID = nil
         pendingComputerUseStopStartedAt = nil
+        let attendeePersistenceTasks = calendarAttendeePersistenceTasks.values.map(\.task)
+        calendarAttendeePersistenceTasks.removeAll()
+        for task in attendeePersistenceTasks {
+            _ = await task.value
+        }
         calendarMonitor.stop()
         calendarCheckTimer?.invalidate()
         calendarCheckTimer = nil
@@ -2870,6 +2889,43 @@ final class MuesliController: NSObject {
         return true
     }
 
+    /// Reconciles only EventKit-backed meetings that have not started. This is
+    /// called from EKEventStoreChangedNotification, never from the Google
+    /// Calendar fallback timer, so participant freshness remains event-driven.
+    func reconcilePendingEventKitCalendarAttendees(
+        events: [UnifiedCalendarEvent],
+        now: Date = Date()
+    ) async {
+        let snapshots = events.compactMap { event -> CalendarParticipantReconciliationSnapshot? in
+            guard event.source == .eventKit, event.startDate > now else { return nil }
+            return CalendarParticipantReconciliationSnapshot(
+                occurrence: event.resolvedCalendarOccurrence,
+                startDate: event.startDate,
+                participants: event.attendees.map(\.participantDraft)
+            )
+        }
+        guard !snapshots.isEmpty else { return }
+
+        let databaseURL = dictationStore.resolvedDatabaseURL
+        let matches = await Task.detached(priority: .utility) {
+            let store = DictationStore(databaseURL: databaseURL)
+            return snapshots.compactMap { snapshot -> (Int64, [MeetingParticipantDraft])? in
+                guard snapshot.startDate > now,
+                      let meeting = try? store.meetingByCalendarOccurrence(snapshot.occurrence),
+                      meeting.status != .recording,
+                      meeting.status != .processing else {
+                    return nil
+                }
+                return (meeting.id, snapshot.participants)
+            }
+        }.value
+
+        let activeMeetingIDs = Set([activeMeetingID, meetingStartMeetingID].compactMap { $0 })
+        for (meetingID, participants) in matches where !activeMeetingIDs.contains(meetingID) {
+            persistCalendarParticipants(participants, meetingID: meetingID, mode: .reconcile)
+        }
+    }
+
     func startCalendarMonitoring() {
         // Event-driven: refresh when macOS reports calendar changes.
         // EKEventStoreChangedNotification is delivered via NotificationCenter,
@@ -2880,6 +2936,9 @@ final class MuesliController: NSObject {
                 self.refreshAvailableEventKitCalendars()
                 let refreshed = await self.refreshUpcomingCalendarEvents()
                 guard refreshed else { return }
+                await self.reconcilePendingEventKitCalendarAttendees(
+                    events: self.appState.upcomingCalendarEvents
+                )
                 self.checkUpcomingCalendarNotifications()
                 self.meetingMonitor.refreshState(trigger: .calendarChanged)
             }
@@ -2904,11 +2963,15 @@ final class MuesliController: NSObject {
             }
         }
 
-        // Run first cycle immediately
+        // Run one initial reconciliation so changes made while Muesli was not
+        // running are reflected without waiting for another EventKit change.
         Task { @MainActor in
             self.refreshAvailableEventKitCalendars()
             let refreshed = await self.refreshUpcomingCalendarEvents()
             guard refreshed else { return }
+            await self.reconcilePendingEventKitCalendarAttendees(
+                events: self.appState.upcomingCalendarEvents
+            )
             self.checkUpcomingCalendarNotifications()
             self.meetingMonitor.refreshState(trigger: .calendarChanged)
         }
@@ -4366,6 +4429,136 @@ final class MuesliController: NSObject {
 
     // MARK: - Meeting Editing
 
+    func meetingParticipants(meetingID: Int64) async throws -> [MeetingParticipant] {
+        await waitForCalendarAttendeePersistence(meetingID: meetingID)
+        let databaseURL = dictationStore.resolvedDatabaseURL
+        return try await Task.detached(priority: .userInitiated) {
+            try DictationStore(databaseURL: databaseURL).listMeetingParticipants(meetingID: meetingID)
+        }.value
+    }
+
+    func attachMeetingParticipant(
+        meetingID: Int64,
+        participant: MeetingParticipantDraft
+    ) async throws {
+        let databaseURL = dictationStore.resolvedDatabaseURL
+        try await Task.detached(priority: .userInitiated) {
+            try DictationStore(databaseURL: databaseURL).attachMeetingParticipant(
+                meetingID: meetingID,
+                participant: participant
+            )
+        }.value
+    }
+
+    func removeMeetingParticipant(
+        meetingID: Int64,
+        participantIdentifier: String
+    ) async throws {
+        let databaseURL = dictationStore.resolvedDatabaseURL
+        try await Task.detached(priority: .userInitiated) {
+            try DictationStore(databaseURL: databaseURL).removeMeetingParticipant(
+                meetingID: meetingID,
+                participantIdentifier: participantIdentifier
+            )
+        }.value
+    }
+
+    private func persistCalendarAttendees(
+        _ attendees: [CalendarAttendee],
+        meetingID: Int64,
+        mode: CalendarAttendeePersistenceMode = .attach
+    ) {
+        persistCalendarParticipants(
+            attendees.map(\.participantDraft),
+            meetingID: meetingID,
+            mode: mode
+        )
+    }
+
+    private func persistCalendarAttendees(
+        for occurrence: CalendarOccurrenceReference?,
+        meetingID: Int64
+    ) {
+        guard let occurrence, occurrence.provider == .eventKit else { return }
+
+        if let cached = appState.upcomingCalendarEvents.first(where: {
+            $0.source == .eventKit && $0.resolvedCalendarOccurrence.identityKey == occurrence.identityKey
+        }) {
+            persistCalendarAttendees(cached.attendees, meetingID: meetingID)
+            return
+        }
+
+        Task { [weak self] in
+            let attendees = await Task.detached(priority: .utility) {
+                CalendarMonitor.attendees(for: occurrence)
+            }.value
+            self?.persistCalendarAttendees(attendees, meetingID: meetingID)
+        }
+    }
+
+    private func persistCalendarParticipants(
+        _ participants: [MeetingParticipantDraft],
+        meetingID: Int64,
+        mode: CalendarAttendeePersistenceMode
+    ) {
+        guard mode == .reconcile || !participants.isEmpty else { return }
+
+        let databaseURL = dictationStore.resolvedDatabaseURL
+        let previousTask = calendarAttendeePersistenceTasks[meetingID]?.task
+        let generation = UUID()
+        let task = Task.detached(priority: .utility) {
+            _ = await previousTask?.value
+            do {
+                let store = DictationStore(databaseURL: databaseURL)
+                switch mode {
+                case .attach:
+                    try store.attachCalendarMeetingParticipants(
+                        meetingID: meetingID,
+                        participants: participants
+                    )
+                case .reconcile:
+                    try store.reconcileCalendarMeetingParticipants(
+                        meetingID: meetingID,
+                        participants: participants
+                    )
+                }
+                return true
+            } catch {
+                fputs(
+                    "[calendar] failed to save attendees for meeting \(meetingID): \(error)\n",
+                    stderr
+                )
+                return false
+            }
+        }
+        calendarAttendeePersistenceTasks[meetingID] = (generation, task)
+
+        Task { [weak self] in
+            let didPersist = await task.value
+            guard let self,
+                  self.calendarAttendeePersistenceTasks[meetingID]?.generation == generation else {
+                return
+            }
+            self.calendarAttendeePersistenceTasks.removeValue(forKey: meetingID)
+            if didPersist {
+                NotificationCenter.default.post(
+                    name: .meetingParticipantsDidChange,
+                    object: meetingID
+                )
+            }
+        }
+    }
+
+    private func waitForCalendarAttendeePersistence(meetingID: Int64) async {
+        while let pending = calendarAttendeePersistenceTasks[meetingID] {
+            _ = await pending.task.value
+            guard let current = calendarAttendeePersistenceTasks[meetingID],
+                  current.generation != pending.generation else {
+                return
+            }
+        }
+    }
+
     private func notesContextForResummary(_ meeting: MeetingRecord) -> String? {
         Self.notesContextForResummary(meeting)
     }
@@ -4667,6 +4860,7 @@ final class MuesliController: NSObject {
                 systemAudioPath: nil,
                 calendarOccurrence: occurrence
             )
+            persistCalendarAttendees(event.attendees, meetingID: meetingID)
             if let folderID {
                 try? dictationStore.moveMeeting(id: meetingID, toFolder: folderID)
             }
@@ -5099,6 +5293,7 @@ final class MuesliController: NSObject {
                 followUpToID: followUpToID,
                 calendarOccurrence: calendarOccurrence
             )
+            persistCalendarAttendees(for: calendarOccurrence, meetingID: meetingID)
             activeMeetingID = meetingID
             activeMeetingAudioWarning = nil
             syncAppState()
@@ -7342,8 +7537,12 @@ final class MuesliController: NSObject {
             platform: MeetingPlatform(candidate.platform),
             onStartRecording: { [weak self] in
                 guard let self else { return }
+                let calendarEvent = candidate.evidence.contains(.calendarEvent)
+                    ? self.currentOrNearbyCachedCalendarEvent()
+                    : nil
                 if self.startMeetingRecordingFromEntryPoint(
                     title: title,
+                    calendarOccurrence: calendarEvent?.calendarOccurrence,
                     autoStopSource: MeetingAutoStopSource(candidate: candidate),
                     presentation: .backgroundPill,
                     startOrigin: .detectedPrompt
@@ -9159,9 +9358,19 @@ func selectCurrentOrNearbyCachedCalendarEvent(
         .sorted { $0.startDate < $1.startDate }
 
     if let active = candidates.first(where: { $0.startDate <= now && $0.endDate > now }) {
-        return CalendarEventContext(id: active.id, title: active.title)
+        return CalendarEventContext(
+            id: active.id,
+            title: active.title,
+            calendarOccurrence: active.resolvedCalendarOccurrence
+        )
     }
 
     return candidates.first(where: { $0.startDate > now })
-        .map { CalendarEventContext(id: $0.id, title: $0.title) }
+        .map {
+            CalendarEventContext(
+                id: $0.id,
+                title: $0.title,
+                calendarOccurrence: $0.resolvedCalendarOccurrence
+            )
+        }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/NewMeetingContactView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/NewMeetingContactView.swift
@@ -1,0 +1,128 @@
+import AppKit
+import MuesliCore
+import SwiftUI
+
+struct NewMeetingContactView: View {
+    let onCreated: (MeetingParticipantDraft) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft = NewMeetingContactDraft()
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var isAccessDenied = false
+    @FocusState private var focusedField: Field?
+
+    private enum Field {
+        case firstName
+        case lastName
+        case email
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Create New Contact")
+                    .font(MuesliTheme.title2())
+                Text("Save this person to Apple Contacts and add them to the meeting.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+
+            Grid(alignment: .leading, horizontalSpacing: MuesliTheme.spacing12, verticalSpacing: MuesliTheme.spacing12) {
+                contactField("First name", text: $draft.givenName, field: .firstName)
+                contactField("Last name", text: $draft.familyName, field: .lastName)
+                contactField("Email", text: $draft.emailAddress, field: .email)
+            }
+
+            HStack(spacing: MuesliTheme.spacing12) {
+                if isSaving {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Saving to Contacts…")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+
+                Spacer()
+
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Save Contact") {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(!draft.canSave || isSaving)
+            }
+        }
+        .padding(MuesliTheme.spacing24)
+        .frame(width: 430)
+        .interactiveDismissDisabled(isSaving)
+        .onAppear {
+            focusedField = .firstName
+        }
+        .alert("Couldn't Save Contact", isPresented: errorBinding) {
+            if isAccessDenied {
+                Button("Open System Settings") {
+                    openContactsPrivacyPane()
+                    errorMessage = nil
+                }
+            }
+            Button("OK", role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "The contact could not be saved.")
+        }
+    }
+
+    private func contactField(_ label: String, text: Binding<String>, field: Field) -> some View {
+        GridRow {
+            Text(label)
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 78, alignment: .trailing)
+            TextField(label, text: text)
+                .textFieldStyle(.roundedBorder)
+                .focused($focusedField, equals: field)
+                .frame(minWidth: 270)
+        }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { presented in
+                if !presented {
+                    errorMessage = nil
+                }
+            }
+        )
+    }
+
+    private func save() {
+        guard draft.canSave, !isSaving else { return }
+        isSaving = true
+        Task { @MainActor in
+            defer { isSaving = false }
+            do {
+                let participant = try await MeetingContactCreator.create(draft)
+                dismiss()
+                onCreated(participant)
+            } catch {
+                isAccessDenied = (error as? MeetingContactCreatorError) == .accessDenied
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func openContactsPrivacyPane() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/DictationStoreTests.swift
@@ -3301,6 +3301,27 @@ struct DictationStoreTests {
         #expect(results.map(\.id).contains(id))
     }
 
+    @Test("searchMeetings matches participant names and emails")
+    func searchMeetingsParticipants() throws {
+        let store = try makeStore()
+        let id = try store.createLiveMeeting(
+            title: "Weekly Sync",
+            calendarEventID: nil,
+            startTime: Date()
+        )
+        try store.attachMeetingParticipant(
+            meetingID: id,
+            participant: MeetingParticipantDraft(
+                participantIdentifier: "calendar:pranav@muesli.works",
+                displayName: "Pranav Hari",
+                emailAddress: "pranav@muesli.works"
+            )
+        )
+
+        #expect(try store.searchMeetings(query: "Pranav Hari").map(\.id) == [id])
+        #expect(try store.searchMeetings(query: "pranav@muesli.works").map(\.id) == [id])
+    }
+
     @Test("search is case-insensitive for ASCII")
     func searchCaseInsensitive() throws {
         let store = try makeStore()

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -67,6 +67,29 @@ struct GoogleCalendarTests {
         #expect(event?.source == .googleCalendar)
     }
 
+    @Test("does not import people from the unreleased direct Google integration")
+    func directGoogleEventsDoNotCarryPeople() throws {
+        let item: [String: Any] = [
+            "id": "event-with-people",
+            "summary": "Sprint Planning",
+            "start": ["dateTime": "2026-04-10T14:00:00Z"],
+            "end": ["dateTime": "2026-04-10T15:00:00Z"],
+            "organizer": [
+                "email": "alice@example.test",
+                "displayName": "Alice Example",
+            ],
+            "attendees": [
+                ["email": "alice@example.test", "displayName": "Alice Example"],
+                ["email": "bob@example.test", "displayName": "Bob Example"],
+                ["email": "room@example.test", "displayName": "Conference Room", "resource": true],
+            ],
+        ]
+
+        let event = try #require(GoogleCalendarClient().parseEvent(item, calendarID: "primary"))
+
+        #expect(event.attendees.isEmpty)
+    }
+
     @Test("parses all-day event from Google Calendar API response")
     func parsesAllDayEvent() {
         let item: [String: Any] = [
@@ -390,8 +413,8 @@ struct GoogleCalendarTests {
         #expect(event.startDate == date("2026-04-10T15:30:00Z"))
     }
 
-    @Test("calendar placeholders deduplicate one occurrence but allow the next recurrence")
-    func calendarPlaceholderOccurrenceDeduplication() throws {
+    @Test("calendar placeholders reconcile before start, preserve removals, and allow the next recurrence")
+    func calendarPlaceholderOccurrenceDeduplication() async throws {
         let databaseURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-calendar-occurrence-\(UUID().uuidString).db")
         let store = DictationStore(databaseURL: databaseURL)
@@ -413,6 +436,11 @@ struct GoogleCalendarTests {
             seriesID: "shared-series-id",
             originalStartTime: firstStart
         )
+        let attendee = try #require(CalendarAttendee(
+            identifier: "alice@example.test",
+            displayName: "Alice Example",
+            emailAddress: "alice@example.test"
+        ))
         let firstEvent = UnifiedCalendarEvent(
             id: "shared-series-id",
             title: "Daily sync",
@@ -421,7 +449,8 @@ struct GoogleCalendarTests {
             isAllDay: false,
             source: .eventKit,
             calendarID: "work",
-            calendarOccurrence: firstOccurrence
+            calendarOccurrence: firstOccurrence,
+            attendees: [attendee]
         )
         controller.createMeetingFromCalendarEvent(firstEvent, folderID: nil)
         controller.createMeetingFromCalendarEvent(firstEvent, folderID: nil)
@@ -452,6 +481,63 @@ struct GoogleCalendarTests {
             firstOccurrence.identityKey,
             nextOccurrence.identityKey,
         ]))
+        let firstMeeting = try #require(meetings.first(where: {
+            $0.calendarOccurrence?.identityKey == firstOccurrence.identityKey
+        }))
+        let firstMeetingParticipants = try await controller.meetingParticipants(meetingID: firstMeeting.id)
+        #expect(firstMeetingParticipants.map(\.displayName) == [
+            "Alice Example",
+        ])
+
+        let participant = try #require(firstMeetingParticipants.first)
+        try await controller.removeMeetingParticipant(
+            meetingID: firstMeeting.id,
+            participantIdentifier: participant.participantIdentifier
+        )
+        let folderID = try store.createFolder(name: "Filed calendar meetings")
+        controller.createMeetingFromCalendarEvent(firstEvent, folderID: folderID)
+
+        #expect(try await controller.meetingParticipants(meetingID: firstMeeting.id).isEmpty)
+        #expect(try store.meeting(id: firstMeeting.id)?.folderID == folderID)
+
+        let bob = try #require(CalendarAttendee(
+            identifier: "bob@example.test",
+            displayName: "Bob Example",
+            emailAddress: "bob@example.test"
+        ))
+        let refreshedEvent = UnifiedCalendarEvent(
+            id: firstEvent.id,
+            title: firstEvent.title,
+            startDate: firstEvent.startDate,
+            endDate: firstEvent.endDate,
+            isAllDay: false,
+            source: .eventKit,
+            calendarID: firstEvent.calendarID,
+            calendarOccurrence: firstOccurrence,
+            attendees: [attendee, bob]
+        )
+        await controller.reconcilePendingEventKitCalendarAttendees(
+            events: [refreshedEvent],
+            now: firstStart.addingTimeInterval(-60)
+        )
+        #expect(try await controller.meetingParticipants(meetingID: firstMeeting.id).map(\.displayName) == [
+            "Bob Example",
+        ])
+
+        let carol = try #require(CalendarAttendee(
+            identifier: "carol@example.test",
+            displayName: "Carol Example",
+            emailAddress: "carol@example.test"
+        ))
+        var afterStartEvent = refreshedEvent
+        afterStartEvent.attendees = [carol]
+        await controller.reconcilePendingEventKitCalendarAttendees(
+            events: [afterStartEvent],
+            now: firstStart
+        )
+        #expect(try await controller.meetingParticipants(meetingID: firstMeeting.id).map(\.displayName) == [
+            "Bob Example",
+        ])
     }
 
     @Test("event sync cache resets when upcoming window changes")

--- a/native/MuesliNative/Tests/MuesliTests/MeetingContactIdentityTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingContactIdentityTests.swift
@@ -1,0 +1,152 @@
+import Contacts
+import Testing
+@testable import MuesliNativeApp
+
+@Suite("Meeting contact identity")
+struct MeetingContactIdentityTests {
+    @Test("uses a conventional full name")
+    func fullName() {
+        let contact = CNMutableContact()
+        contact.givenName = "Alice"
+        contact.familyName = "Example"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Alice Example")
+    }
+
+    @Test("falls back to nickname")
+    func nickname() {
+        let contact = CNMutableContact()
+        contact.nickname = "Ace"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Ace")
+    }
+
+    @Test("falls back to organization")
+    func organization() {
+        let contact = CNMutableContact()
+        contact.organizationName = "Example Industries Ltd."
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Example Industries Ltd.")
+    }
+
+    @Test("falls back to email")
+    func email() {
+        let contact = CNMutableContact()
+        contact.emailAddresses = [
+            CNLabeledValue(label: CNLabelWork, value: "alice@example.test" as NSString),
+        ]
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "alice@example.test")
+    }
+
+    @Test("falls back to phone")
+    func phone() {
+        let contact = CNMutableContact()
+        contact.phoneNumbers = [
+            CNLabeledValue(label: CNLabelPhoneNumberMobile, value: CNPhoneNumber(stringValue: "+1 555 0100")),
+        ]
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "+1 555 0100")
+    }
+
+    @Test("falls back to an unnamed label")
+    func unnamed() {
+        #expect(MeetingContactIdentity.displayName(for: CNMutableContact()) == MeetingContactIdentity.unnamedFallback)
+    }
+
+    @Test("prefers the strongest available identity")
+    func precedenceChain() {
+        let contact = CNMutableContact()
+        contact.givenName = "Alice"
+        contact.familyName = "Example"
+        contact.nickname = "Ace"
+        contact.organizationName = "Example Industries Ltd."
+        contact.emailAddresses = [
+            CNLabeledValue(label: CNLabelWork, value: "alice@example.test" as NSString),
+        ]
+        contact.phoneNumbers = [
+            CNLabeledValue(label: CNLabelPhoneNumberMobile, value: CNPhoneNumber(stringValue: "+1 555 0100")),
+        ]
+
+        // Peel the candidates off one at a time; each step pins the next rung down.
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Alice Example")
+        contact.givenName = ""
+        contact.familyName = ""
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Ace")
+        contact.nickname = ""
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Example Industries Ltd.")
+        contact.organizationName = ""
+        #expect(MeetingContactIdentity.displayName(for: contact) == "alice@example.test")
+        contact.emailAddresses = []
+        #expect(MeetingContactIdentity.displayName(for: contact) == "+1 555 0100")
+    }
+
+    @Test("treats whitespace-only values as absent")
+    func whitespaceOnlyNameFallsThrough() {
+        let contact = CNMutableContact()
+        contact.givenName = "   "
+        contact.familyName = "\n"
+        contact.nickname = "Fallback"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Fallback")
+    }
+
+    @Test("handles a single-name contact")
+    func singleName() {
+        let contact = CNMutableContact()
+        contact.givenName = "Nova"
+
+        #expect(MeetingContactIdentity.displayName(for: contact) == "Nova")
+    }
+
+    @Test("manual participant uses normalized email identity when available")
+    func participantSnapshot() {
+        let contact = CNMutableContact()
+        contact.givenName = "Dana"
+        contact.familyName = "Sample"
+        contact.emailAddresses = [
+            CNLabeledValue(label: CNLabelWork, value: "dana@example.test" as NSString),
+        ]
+
+        let participant = MeetingContactIdentity.participant(for: contact)
+
+        #expect(participant.participantIdentifier == "email:dana@example.test")
+        #expect(participant.displayName == "Dana Sample")
+        #expect(participant.emailAddress == "dana@example.test")
+    }
+
+    @Test("new contact input requires a name and trims saved fields")
+    func newContactDraftValidation() {
+        var draft = NewMeetingContactDraft()
+        #expect(!draft.canSave)
+
+        draft.givenName = "  Dana "
+        draft.familyName = " Sample\n"
+        draft.emailAddress = " dana@example.test "
+
+        #expect(draft.canSave)
+        #expect(draft.normalizedGivenName == "Dana")
+        #expect(draft.normalizedFamilyName == "Sample")
+        #expect(draft.normalizedEmailAddress == "dana@example.test")
+    }
+
+    @Test("email-only attendees use a compact local-part fallback")
+    func compactEmailFallback() {
+        #expect(
+            MeetingContactIdentity.compactDisplayName(
+                "dana@example.test",
+                emailAddress: "dana@example.test"
+            ) == "dana"
+        )
+        #expect(
+            MeetingContactIdentity.compactDisplayName(
+                "Dana Sample",
+                emailAddress: "dana@example.test"
+            ) == "Dana Sample"
+        )
+        #expect(
+            MeetingContactIdentity.isEmailFallback("personal@example.test")
+        )
+    }
+
+}

--- a/native/MuesliNative/Tests/MuesliTests/MeetingParticipantStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingParticipantStoreTests.swift
@@ -1,0 +1,293 @@
+import Foundation
+import MuesliCore
+import SQLite3
+import Testing
+
+@Suite("Meeting participants", .serialized)
+struct MeetingParticipantStoreTests {
+    private func makeStore() throws -> DictationStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-participants-\(UUID().uuidString).db")
+        let store = DictationStore(databaseURL: url)
+        try store.migrateIfNeeded()
+        return store
+    }
+
+    private func makeMeeting(in store: DictationStore, title: String = "Participants") throws -> Int64 {
+        let start = Date(timeIntervalSince1970: 1_775_000_000)
+        return try store.insertMeeting(
+            title: title,
+            calendarEventID: nil,
+            startTime: start,
+            endTime: start.addingTimeInterval(60),
+            rawTranscript: "",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+    }
+
+    private func participant(
+        _ identifier: String,
+        name: String,
+        email: String? = nil
+    ) -> MeetingParticipantDraft {
+        MeetingParticipantDraft(
+            participantIdentifier: identifier,
+            displayName: name,
+            emailAddress: email
+        )
+    }
+
+    @Test("participant migration is idempotent and creates the expected columns")
+    func migrationIsIdempotent() throws {
+        let store = try makeStore()
+
+        try store.migrateIfNeeded()
+
+        var database: OpaquePointer?
+        #expect(sqlite3_open(store.databasePath().path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        #expect(sqlite3_prepare_v2(
+            database,
+            "PRAGMA table_info(meeting_participants)",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK)
+        defer { sqlite3_finalize(statement) }
+
+        var columns: [String] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let name = sqlite3_column_text(statement, 1) {
+                columns.append(String(cString: name))
+            }
+        }
+        #expect(columns == [
+            "meeting_id",
+            "participant_identifier",
+            "display_name",
+            "email_address",
+            "insertion_order",
+            "source",
+            "is_suppressed",
+        ])
+    }
+
+    @Test("calendar attendee snapshots retain their names and emails")
+    func calendarAttendeeReadback() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [participant(
+                "email:alice@example.test",
+                name: "Alice Example",
+                email: "alice@example.test"
+            )]
+        )
+
+        let saved = try #require(store.listMeetingParticipants(meetingID: meetingID).first)
+        #expect(saved.participantIdentifier == "email:alice@example.test")
+        #expect(saved.displayName == "Alice Example")
+        #expect(saved.emailAddress == "alice@example.test")
+    }
+
+    @Test("manual contacts do not require an email address")
+    func manualContactWithoutEmail() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant("contact:local-id", name: "Local Person")
+        )
+
+        let saved = try #require(store.listMeetingParticipants(meetingID: meetingID).first)
+        #expect(saved.displayName == "Local Person")
+        #expect(saved.emailAddress == nil)
+    }
+
+    @Test("re-adding a participant refreshes its snapshot without changing order")
+    func duplicateRefreshesSnapshot() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant("contact:alice", name: "Alice")
+        )
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant(
+                "contact:alice",
+                name: "Alice Example",
+                email: "alice@example.test"
+            )
+        )
+
+        let saved = try #require(store.listMeetingParticipants(meetingID: meetingID).first)
+        #expect(saved.displayName == "Alice Example")
+        #expect(saved.emailAddress == "alice@example.test")
+        #expect(saved.insertionOrder == 0)
+    }
+
+    @Test("participants preserve insertion order and can be removed")
+    func insertionOrderAndRemoval() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant("contact:b", name: "B")
+        )
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant("contact:a", name: "A")
+        )
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.displayName) == ["B", "A"])
+
+        try store.removeMeetingParticipant(
+            meetingID: meetingID,
+            participantIdentifier: "contact:b"
+        )
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.displayName) == ["A"])
+    }
+
+    @Test("participant batches preserve order and refresh existing snapshots")
+    func batchInsertAndRefresh() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [
+                participant("calendar:alice", name: "Alice"),
+                participant("calendar:bob", name: "Bob", email: "bob@example.test"),
+                participant("calendar:carol", name: "Carol"),
+            ]
+        )
+        try store.attachCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [
+                participant("calendar:bob", name: "Bob Example"),
+                participant("calendar:dana", name: "Dana"),
+            ]
+        )
+
+        let saved = try store.listMeetingParticipants(meetingID: meetingID)
+        #expect(saved.map(\.displayName) == ["Alice", "Bob Example", "Carol", "Dana"])
+        #expect(saved.map(\.insertionOrder) == [0, 1, 2, 3])
+        #expect(saved[1].emailAddress == "bob@example.test")
+    }
+
+    @Test("calendar reconciliation preserves local curation while refreshing the event snapshot")
+    func calendarReconciliationPreservesLocalCuration() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [
+                participant("email:alice@example.test", name: "Alice"),
+                participant("email:carol@example.test", name: "Carol"),
+            ]
+        )
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant("contact:local-id", name: "Local Person")
+        )
+        try store.removeMeetingParticipant(
+            meetingID: meetingID,
+            participantIdentifier: "email:alice@example.test"
+        )
+
+        try store.reconcileCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [
+                participant("email:alice@example.test", name: "Alice Renamed"),
+                participant("email:carol@example.test", name: "Carol Renamed"),
+                participant("email:bob@example.test", name: "Bob"),
+            ]
+        )
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.displayName) == [
+            "Carol Renamed",
+            "Local Person",
+            "Bob",
+        ])
+
+        try store.reconcileCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [
+                participant("email:alice@example.test", name: "Alice Renamed Again"),
+            ]
+        )
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).map(\.displayName) == [
+            "Local Person",
+        ])
+    }
+
+    @Test("manual contact replaces the matching calendar attendee and survives later event changes")
+    func manualContactWinsEmailDeduplication() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+
+        try store.attachCalendarMeetingParticipants(
+            meetingID: meetingID,
+            participants: [participant(
+                "email:alice@example.test",
+                name: "Alice from Calendar",
+                email: "alice@example.test"
+            )]
+        )
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant(
+                "email:alice@example.test",
+                name: "Alice from Contacts",
+                email: "alice@example.test"
+            )
+        )
+
+        try store.reconcileCalendarMeetingParticipants(meetingID: meetingID, participants: [])
+
+        let saved = try store.listMeetingParticipants(meetingID: meetingID)
+        #expect(saved.count == 1)
+        #expect(saved.first?.displayName == "Alice from Contacts")
+    }
+
+    @Test("participants cannot be attached to a missing meeting")
+    func missingMeetingIsRejected() throws {
+        let store = try makeStore()
+
+        #expect(throws: Error.self) {
+            try store.attachMeetingParticipant(
+                meetingID: 999,
+                participant: participant("calendar:missing", name: "Missing")
+            )
+        }
+    }
+
+    @Test("deleting a meeting removes its local participant snapshots")
+    func meetingDeletionRemovesParticipants() throws {
+        let store = try makeStore()
+        let meetingID = try makeMeeting(in: store)
+        try store.attachMeetingParticipant(
+            meetingID: meetingID,
+            participant: participant("contact:alice", name: "Alice")
+        )
+        try store.removeMeetingParticipant(
+            meetingID: meetingID,
+            participantIdentifier: "contact:alice"
+        )
+
+        try store.deleteMeeting(id: meetingID)
+
+        #expect(try store.listMeetingParticipants(meetingID: meetingID).isEmpty)
+    }
+}

--- a/scripts/Muesli.entitlements
+++ b/scripts/Muesli.entitlements
@@ -8,6 +8,8 @@
     <false/>
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
     <key>com.apple.developer.icloud-container-identifiers</key>

--- a/scripts/MuesliLocalOnly.entitlements
+++ b/scripts/MuesliLocalOnly.entitlements
@@ -8,6 +8,8 @@
     <false/>
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
 </dict>

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -285,6 +285,8 @@ cat > "$STAGED_APP_DIR/Contents/Info.plist" <<PLIST
   <string>$APP_DISPLAY_NAME captures screen content for meeting context.</string>
   <key>NSCalendarsFullAccessUsageDescription</key>
   <string>$APP_DISPLAY_NAME reads calendar events to help with meeting recordings.</string>
+  <key>NSContactsUsageDescription</key>
+  <string>$APP_DISPLAY_NAME lets you add people from Contacts to meeting notes.</string>
   <key>SUFeedURL</key>
   <string>$SPARKLE_FEED_URL</string>
   <key>SUPublicEDKey</key>

--- a/scripts/run_ci_test_shard.sh
+++ b/scripts/run_ci_test_shard.sh
@@ -79,7 +79,9 @@ case "${shard}" in
       AudioGraphExceptionBridgeTests
       DiagnosticIncidentTests
       DictationAudioRouteControllerTests
+      MeetingContactIdentityTests
       MeetingDetectorTests
+      MeetingParticipantStoreTests
       MeetingProcessingStageTests
       MeetingRecordingWriterTests
       MeetingResumePolicyTests


### PR DESCRIPTION
## Summary

- snapshot meeting organizers and attendees from macOS EventKit into local-only SQLite storage
- keep future EventKit meetings current through `EKEventStoreChanged` plus one initial refresh, without attendee polling
- add a native Apple Contacts picker and a minimal create-contact flow
- render a compact first-person `+N` chip with a full people popover
- include participant names and emails in meeting search
- streamline the meeting detail header while preserving Search, Timeline, and Meetings return destinations

## Scope boundaries

- EventKit is the only attendee source. Direct Google OAuth calendar events intentionally carry no people; Google accounts linked through macOS are covered through EventKit.
- Participant data stays device-local and is excluded from CloudKit sync, CLI JSON, exports, and telemetry.
- Calendar reconciliation stops when the occurrence starts and never overwrites a manual contact choice with the same normalized email.

## Attribution

This is a fresh signed successor to #346 and #416. It is based in part on the original MIT-licensed meeting participant work by @salmonumbrella in #346, credited in the commit trailer.

Related: #347

## Validation

- focused participant, Contacts, search, and calendar suites: 54 tests passed
- meetings CI shard: 401 tests passed across 26 suites
- full Swift package suite: 1,743 tests passed across 161 suites
- `./scripts/test_classify_changed_files.sh`
- `./scripts/test_ci_test_shards.sh`
- `./scripts/verify_update_flow.sh --skip-dmg`
- `./scripts/dev-test.sh --lane A --local-only`
- in-app verification of compact header, people popover, native Contacts search, new-contact sheet, participant search, and origin-aware back labels
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789566309&installation_model_id=422865&pr_number=422&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F422&signature=ee3f93ba8e7330d372147d1b97f225000a859997db3db93104500ef5bce0160c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->