### PR TITLE
Update the 0.8.2 feature walkthrough

### DIFF
--- a/docs/release-notes/0.8.2.md
+++ b/docs/release-notes/0.8.2.md
@@ -1,0 +1,52 @@
+## Muesli 0.8.2
+
+Muesli 0.8.2 brings dictations and meetings into one local timeline, adds Apple's newest on-device speech technology on supported Macs, and makes meeting context easier to keep with the conversation.
+
+## One timeline for dictations and meetings
+
+- Timeline combines recent dictations and meetings in chronological order, with filters for source, destination app, and date.
+- Dictations can show the app that ultimately received the text, making it easier to find work from Mail, Notes, browsers, and other apps.
+- Existing Dictations and Meetings views remain available when you want a focused history.
+
+## Apple Speech on macOS 26
+
+- Macs running macOS 26 can use Apple's system-managed SpeechAnalyzer for dictation, meeting transcription, and imported recordings.
+- Apple Speech runs on-device, requires no separate Muesli model download, and follows the existing cleanup, diarization, summary, and persistence pipelines.
+- Keep the current macOS language automatically or select another language supported by Apple Speech.
+- On unsupported systems, Muesli continues to use its existing local model defaults.
+
+## Keep people with the meeting
+
+- Calendar organizers and attendees can be captured from EventKit and shown with the meeting.
+- Add someone from Apple Contacts or create a minimal new contact directly from the meeting header.
+- Search meetings by participant name or email address.
+- Participant data remains local to this Mac. It is not included in CloudKit sync, exports, CLI output, or telemetry.
+
+## Faster, more resilient model setup
+
+- Model downloads now resume interrupted transfers, validate downloaded files, check disk space, and show clearer download and preparation stages.
+- WhisperKit and supported local backends expose explicit language choices where available.
+- Qwen ASR and LocalVQE packaging paths have been hardened so installed models and acoustic cleanup load more reliably.
+
+## A more capable local CLI
+
+- The bundled `muesli-cli` can transcribe supported audio and video files with multiple local backends and return agent-friendly output.
+- Portable dictionary import and export make custom vocabulary easier to move between installations and automation workflows.
+
+## Meeting and dictation reliability
+
+- Dictation becomes available after a stopped meeting finishes audio transcription and cleanup, while title generation or summarization continues in the background.
+- Meeting microphone capture can recover from degraded or changing input routes, and system-audio capture now detects stalled taps more reliably.
+- Dictation drains the final audio buffer before transcription to reduce missing last words.
+- The floating recording indicator has more predictable drag behavior across displays and appearance settings.
+
+## macOS polish
+
+- Added standard macOS window and navigation shortcuts, including direct access to Dictations and Meetings.
+- Meeting notes render inline Markdown more naturally while remaining editable.
+- Invalid recording durations no longer distort words-per-minute statistics.
+
+## Privacy and compatibility
+
+- Audio, transcripts, meeting titles, contacts, file paths, hardware identifiers, and raw errors are not added to telemetry.
+- Muesli 0.8.2 requires Apple silicon and macOS 14.2 or later. Apple Speech requires macOS 26 and a system-supported SpeechAnalyzer language.

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTour.swift
@@ -35,6 +35,12 @@ struct MarketingVersion: Comparable, Equatable {
 }
 
 enum FeatureTourTarget: String, Hashable {
+    case timelineSidebar
+    case timelineApplications
+    case appleSpeechCard
+    case meetingPeople
+    case timelineFilters
+    case modelLibrary
     case insightsEntry
     case dictionarySuggestions
     case meetingsSidebar
@@ -45,11 +51,13 @@ enum FeatureTourTarget: String, Hashable {
 
     var modelsCategory: ModelsCategory? {
         switch self {
+        case .modelLibrary, .appleSpeechCard:
+            return .dictation
         case .streamingModels:
             return .streaming
         case .experimentalModels:
             return .dictation
-        case .insightsEntry, .dictionarySuggestions, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
+        case .timelineSidebar, .timelineApplications, .meetingPeople, .timelineFilters, .insightsEntry, .dictionarySuggestions, .meetingsSidebar, .liveCaptionsSetting, .cloudCleanupSetting:
             return nil
         }
     }
@@ -70,7 +78,11 @@ struct FeatureTour: Equatable {
 
     var displayVersion: String {
         guard let marketingVersion = MarketingVersion(version) else { return version }
-        return marketingVersion.components.prefix(2).map(String.init).joined(separator: ".")
+        var components = marketingVersion.components
+        while components.count > 2, components.last == 0 {
+            components.removeLast()
+        }
+        return components.map(String.init).joined(separator: ".")
     }
 }
 
@@ -84,76 +96,63 @@ extension AppState {
 
 enum FeatureTourCatalog {
     static var latest: FeatureTour {
-        latest(includeCloudCleanup: false)
+        latest(
+            includeApplicationFilter: false,
+            includeAppleSpeech: false,
+            includeMeetingPeople: false
+        )
     }
 
-    static func latest(includeCloudCleanup: Bool) -> FeatureTour {
+    static func latest(
+        includeApplicationFilter: Bool,
+        includeAppleSpeech: Bool,
+        includeMeetingPeople: Bool
+    ) -> FeatureTour {
         var steps = [
             FeatureTourStep(
-                id: "insights",
-                eyebrow: "LOCAL INSIGHTS",
-                title: "Your stats now open Insights",
-                message: "Select any stat card to explore private word, meeting, pace, streak, and daily activity trends calculated from your local history.",
-                systemImage: "chart.bar.xaxis",
-                target: .insightsEntry
-            ),
-            FeatureTourStep(
-                id: "dictionary-suggestions",
-                eyebrow: "SMARTER DICTIONARY",
-                title: "Turn corrections into custom words",
-                message: "Dictionary suggestions stay off by default. Turn them on to let Muesli notice corrections after dictation and offer a one-click way to remember names, brands, and domain terms.",
-                systemImage: "text.book.closed.fill",
-                target: .dictionarySuggestions
-            ),
-            FeatureTourStep(
-                id: "meeting-workspace",
-                eyebrow: "MEETING WORKSPACE",
-                title: "Continue work after the call",
-                message: "Open Meetings to see what is coming up, resume a recording, follow detected links, organize folders, and export notes, transcripts, or compressed audio.",
-                systemImage: "person.2.fill",
-                target: .meetingsSidebar
-            ),
-            FeatureTourStep(
-                id: "live-captions",
-                eyebrow: "LIVE MEETING CAPTIONS",
-                title: "Choose how meetings appear live",
-                message: "Live captions remain off by default. Download a supported streaming model, then choose it here to preview speech while a meeting is running.",
-                systemImage: "captions.bubble.fill",
-                target: .liveCaptionsSetting
-            ),
+                id: "timeline",
+                eyebrow: "ONE TIMELINE",
+                title: "Dictations and meetings, together",
+                message: "Timeline puts your recent work in one chronological view. Open it from the sidebar whenever you want to retrace what you dictated or discussed.",
+                systemImage: "clock.arrow.circlepath",
+                target: .timelineSidebar
+            )
         ]
 
-        if includeCloudCleanup {
+        if includeApplicationFilter {
             steps.append(FeatureTourStep(
-                id: "cloud-cleanup",
-                eyebrow: "CLOUD DICTATION CLEANUP",
-                title: "Your ChatGPT connection can refine dictation",
-                message: "Choose ChatGPT as the cleanup backend to remove filler words, format spoken lists, and apply your cleanup preset after local transcription.",
-                systemImage: "wand.and.stars",
-                target: .cloudCleanupSetting
+                id: "timeline-apps",
+                eyebrow: "FILTER BY APP",
+                title: "Find dictations by destination app",
+                message: "Use Apps to narrow Timeline to dictations sent to a specific destination, such as Mail, Notes, or your browser.",
+                systemImage: "square.grid.2x2",
+                target: .timelineApplications
             ))
         }
 
-        steps.append(contentsOf: [
-            FeatureTourStep(
-                id: "streaming-models",
-                eyebrow: "LIVE MODEL OPTIONS",
-                title: "Choose your live transcription engine",
-                message: "The Live Meetings tab offers Nemotron 3.5 when you want one live and saved meeting transcript, or Parakeet Live Captions when a fast English preview matters most.",
-                systemImage: "waveform.badge.mic",
-                target: .streamingModels
-            ),
-            FeatureTourStep(
-                id: "experimental-models",
-                eyebrow: "EXPERIMENTAL MODELS",
-                title: "Try new local dictation backends",
-                message: "Expand Experimental to try SenseVoice, Indic ASR, and Gemma 4. These early models can help with specific languages or evaluation, but may be less consistent.",
-                systemImage: "cpu",
-                target: .experimentalModels
-            )
-        ])
+        if includeAppleSpeech {
+            steps.append(FeatureTourStep(
+                id: "apple-speech",
+                eyebrow: "ON-DEVICE SPEECH",
+                title: "Try Apple's native on-device speech model",
+                message: "On macOS 26, Apple Speech can transcribe without a separate model download. Use your system language or choose another supported language in Models.",
+                systemImage: "apple.logo",
+                target: .appleSpeechCard
+            ))
+        }
 
-        return FeatureTour(version: "0.8.0", steps: steps)
+        if includeMeetingPeople {
+            steps.append(FeatureTourStep(
+                id: "meeting-people",
+                eyebrow: "MEETING ATTENDEES",
+                title: "Meeting attendees are now available!",
+                message: "See organizers and attendees from calendar events, or add people from Apple Contacts directly to a meeting.",
+                systemImage: "person.2.fill",
+                target: .meetingPeople
+            ))
+        }
+
+        return FeatureTour(version: "0.8.2", steps: steps)
     }
 }
 
@@ -179,8 +178,8 @@ enum FeatureTourPresentationPolicy {
         }
 
         guard let previousVersion else {
-            // 0.8 is the first release with this marker. A completed onboarding
-            // identifies an existing pre-0.8 install rather than a fresh install.
+            // A completed onboarding with no version marker identifies an
+            // existing install rather than a fresh install.
             return true
         }
         guard let previous = MarketingVersion(previousVersion) else { return true }

--- a/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FeatureTourView.swift
@@ -82,9 +82,9 @@ struct FeatureTourCalloutLayout {
 
     private static func preferredEdges(for target: FeatureTourTarget) -> [FeatureTourCalloutEdge] {
         switch target {
-        case .meetingsSidebar:
+        case .timelineSidebar, .meetingsSidebar:
             return [.trailing, .leading, .below, .above]
-        case .insightsEntry, .liveCaptionsSetting:
+        case .timelineApplications, .appleSpeechCard, .meetingPeople, .timelineFilters, .modelLibrary, .insightsEntry, .liveCaptionsSetting:
             return [.below, .above, .trailing, .leading]
         case .dictionarySuggestions, .cloudCleanupSetting, .streamingModels, .experimentalModels:
             return [.above, .below, .trailing, .leading]
@@ -276,6 +276,10 @@ struct FeatureTourOverlay: View {
                     .font(MuesliTheme.caption())
                     .monospacedDigit()
                     .foregroundStyle(MuesliTheme.textTertiary)
+
+                Button("Skip", action: onDismiss)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(MuesliTheme.textSecondary)
 
                 Spacer()
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingParticipantsView.swift
@@ -63,6 +63,7 @@ struct MeetingParticipantsView: View {
         }
         .buttonStyle(.plain)
         .fixedSize(horizontal: false, vertical: true)
+        .featureTourTarget(.meetingPeople)
         .help(participants.isEmpty ? "Add people to this meeting" : "Show \(peopleDescription)")
         .accessibilityLabel(
             participants.isEmpty ? "Add people to this meeting" : "\(peopleDescription) in this meeting"

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -84,6 +84,8 @@ struct ModelsView: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(maxWidth: 520)
+                    .id(FeatureTourTarget.modelLibrary.rawValue)
+                    .featureTourTarget(.modelLibrary)
 
                     selectedCategoryContent
                 }
@@ -94,7 +96,10 @@ struct ModelsView: View {
                 revealFeatureTourTargetIfNeeded(using: proxy)
             }
             .onChange(of: activeFeatureTourTarget) { _, target in
-                guard target == .streamingModels || target == .experimentalModels else { return }
+                guard target == .modelLibrary
+                        || target == .appleSpeechCard
+                        || target == .streamingModels
+                        || target == .experimentalModels else { return }
                 revealFeatureTourTargetIfNeeded(using: proxy)
             }
         }
@@ -171,11 +176,16 @@ struct ModelsView: View {
         switch appState.selectedModelsCategory {
         case .dictation:
             ForEach(BackendOption.systemManaged, id: \.model) { option in
+                let featureTourTarget: FeatureTourTarget? = option.backend == BackendOption.appleSpeechAnalyzer.backend
+                    ? .appleSpeechCard
+                    : nil
                 modelCard(
                     option: option,
                     logo: logoForBackend(option),
                     downloadedLabel: "Available"
                 )
+                .id(featureTourTarget?.rawValue ?? option.model)
+                .featureTourTarget(featureTourTarget)
             }
 
             familyCard(
@@ -235,6 +245,12 @@ struct ModelsView: View {
     private func revealFeatureTourTargetIfNeeded(using proxy: ScrollViewProxy) {
         let target: FeatureTourTarget
         switch activeFeatureTourTarget {
+        case .modelLibrary:
+            target = .modelLibrary
+            appState.selectedModelsCategory = .dictation
+        case .appleSpeechCard:
+            target = .appleSpeechCard
+            appState.selectedModelsCategory = .dictation
         case .streamingModels:
             target = .streamingModels
             appState.selectedModelsCategory = .streaming

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1014,7 +1014,7 @@ final class MuesliController: NSObject {
             TelemetryDeck.signal("feature_walkthrough.invitation_shown", parameters: [
                 "version": tour.version,
                 "step_count": "\(tour.steps.count)",
-                "includes_apple_speech": "\(tour.steps.contains { $0.id == "apple-speech" })",
+                "includes_apple_speech": "\(tour.steps.contains { $0.target == .appleSpeechCard })",
             ])
         })
         // The normal startup preload task continues while this invitation and
@@ -1132,9 +1132,11 @@ final class MuesliController: NSObject {
             appState.selectedMeetingID = nil
             appState.selectedMeetingRecord = nil
         case .meetingPeople:
-            if let meetingID = (try? dictationStore.recentMeetings(limit: 1))?.first?.id {
-                showMeetingDocument(id: meetingID)
+            guard let meetingID = (try? dictationStore.recentMeetings(limit: 1))?.first?.id else {
+                completeFeatureTour()
+                return
             }
+            showMeetingDocument(id: meetingID)
         case .liveCaptionsSetting:
             appState.selectedSettingsPane = .meetings
             appState.selectedTab = .settings

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1118,7 +1118,13 @@ final class MuesliController: NSObject {
             clearSearch()
         }
         switch step.target {
-        case .timelineSidebar, .timelineApplications, .timelineFilters:
+        case .timelineSidebar, .timelineFilters:
+            appState.selectedTab = .timeline
+        case .timelineApplications:
+            guard (try? dictationStore.dictationTargetApplications().isEmpty) == false else {
+                completeFeatureTour()
+                return
+            }
             appState.selectedTab = .timeline
         case .appleSpeechCard, .modelLibrary:
             showModels(category: .dictation)

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -714,9 +714,7 @@ final class MuesliController: NSObject {
         statusBarController = StatusBarController(controller: self, runtime: runtime)
         preferencesWindowController = PreferencesWindowController(controller: self)
         historyWindowController = RecentHistoryWindowController(store: dictationStore, controller: self)
-        let latestFeatureTour = FeatureTourCatalog.latest(
-            includeCloudCleanup: chatGPTAuth.isAuthenticated
-        )
+        let latestFeatureTour = latestFeatureTour()
         let automaticFeatureTour = featureTourStore.automaticTour(
             currentVersion: AppIdentity.marketingVersion,
             hasCompletedOnboarding: config.hasCompletedOnboarding,
@@ -975,9 +973,26 @@ final class MuesliController: NSObject {
     }
 
     @objc func showWhatsNew() {
-        let tour = FeatureTourCatalog.latest(includeCloudCleanup: chatGPTAuth.isAuthenticated)
+        let tour = latestFeatureTour()
         guard beginFeatureTour(tour, source: "manual") else { return }
         featureTourStore.markOffered(tour)
+    }
+
+    private func latestFeatureTour() -> FeatureTour {
+        let targetApplications = (try? dictationStore.dictationTargetApplications()) ?? []
+        let latestMeetingID = (try? dictationStore.recentMeetings(limit: 1))?.first?.id
+        return FeatureTourCatalog.latest(
+            includeApplicationFilter: !targetApplications.isEmpty,
+            includeAppleSpeech: Self.includesAppleSpeechInFeatureTour,
+            includeMeetingPeople: latestMeetingID != nil
+        )
+    }
+
+    private static var includesAppleSpeechInFeatureTour: Bool {
+        if #available(macOS 26.0, *) {
+            return AppleSpeechAnalyzerTranscriber.isSupportedOnCurrentSystem
+        }
+        return false
     }
 
     @discardableResult
@@ -999,7 +1014,7 @@ final class MuesliController: NSObject {
             TelemetryDeck.signal("feature_walkthrough.invitation_shown", parameters: [
                 "version": tour.version,
                 "step_count": "\(tour.steps.count)",
-                "includes_cloud_cleanup": "\(tour.steps.contains { $0.target == .cloudCleanupSetting })",
+                "includes_apple_speech": "\(tour.steps.contains { $0.id == "apple-speech" })",
             ])
         })
         // The normal startup preload task continues while this invitation and
@@ -1103,6 +1118,10 @@ final class MuesliController: NSObject {
             clearSearch()
         }
         switch step.target {
+        case .timelineSidebar, .timelineApplications, .timelineFilters:
+            appState.selectedTab = .timeline
+        case .appleSpeechCard, .modelLibrary:
+            showModels(category: .dictation)
         case .insightsEntry:
             appState.selectedTab = .timeline
         case .dictionarySuggestions:
@@ -1112,6 +1131,10 @@ final class MuesliController: NSObject {
             appState.meetingsNavigationState = .browser
             appState.selectedMeetingID = nil
             appState.selectedMeetingRecord = nil
+        case .meetingPeople:
+            if let meetingID = (try? dictationStore.recentMeetings(limit: 1))?.first?.id {
+                showMeetingDocument(id: meetingID)
+            }
         case .liveCaptionsSetting:
             appState.selectedSettingsPane = .meetings
             appState.selectedTab = .settings

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -535,6 +535,7 @@ struct SidebarView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, sidebarRowOuterPadding)
+        .featureTourTarget(tab == .timeline ? .timelineSidebar : nil)
     }
 
     @ViewBuilder

--- a/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
@@ -75,6 +75,7 @@ struct TimelineView: View {
                     selection: appState.timelineApplicationFilter,
                     onSelect: { controller.filterTimeline(application: $0) }
                 )
+                .featureTourTarget(.timelineApplications)
             }
             Spacer(minLength: 0)
             dateFilterMenu

--- a/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/FeatureTourTests.swift
@@ -8,12 +8,13 @@ struct FeatureTourTests {
 
     @Test("marketing versions compare numeric components and ignore prerelease suffixes")
     func versionComparison() throws {
-        #expect(try #require(MarketingVersion("0.7.1")) < #require(MarketingVersion("0.8.0")))
-        #expect(try #require(MarketingVersion("0.8")) == #require(MarketingVersion("0.8.0")))
-        #expect(try #require(MarketingVersion("0.8.0-preprod.1")) == #require(MarketingVersion("0.8.0")))
+        #expect(try #require(MarketingVersion("0.8.1")) < #require(MarketingVersion("0.8.2")))
+        #expect(try #require(MarketingVersion("0.8.2")) == #require(MarketingVersion("0.8.2.0")))
+        #expect(try #require(MarketingVersion("0.8.2-preprod.2")) == #require(MarketingVersion("0.8.2")))
         #expect(MarketingVersion("not-a-version") == nil)
         #expect(MarketingVersion("999999999999999999999999.0") == nil)
-        #expect(tour.displayVersion == "0.8")
+        #expect(tour.displayVersion == "0.8.2")
+        #expect(FeatureTour(version: "0.8.0", steps: []).displayVersion == "0.8")
     }
 
     @Test("target frame tracking ignores subpixel layout churn")
@@ -98,7 +99,7 @@ struct FeatureTourTests {
     @Test("existing users without legacy version markers see the first feature tour")
     func legacyUpgrade() {
         #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             previousVersion: nil,
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: true,
@@ -109,15 +110,15 @@ struct FeatureTourTests {
     @Test("fresh installs and pre-target versions do not see the tour")
     func ineligibleLaunches() {
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             previousVersion: nil,
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: false,
             tour: tour
         ))
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.7.1",
-            previousVersion: "0.7.0",
+            currentVersion: "0.8.1",
+            previousVersion: "0.8.0",
             lastPresentedTourVersion: nil,
             hasCompletedOnboarding: true,
             tour: tour
@@ -127,16 +128,16 @@ struct FeatureTourTests {
     @Test("upgrade crossing the target version presents once")
     func crossingTarget() {
         #expect(FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.0-preprod.1",
-            previousVersion: "0.7.1",
-            lastPresentedTourVersion: nil,
+            currentVersion: "0.8.2-preprod.2",
+            previousVersion: "0.8.1",
+            lastPresentedTourVersion: "0.8.0",
             hasCompletedOnboarding: true,
             tour: tour
         ))
         #expect(!FeatureTourPresentationPolicy.shouldPresentAutomatically(
-            currentVersion: "0.8.0",
-            previousVersion: "0.7.1",
-            lastPresentedTourVersion: "0.8.0",
+            currentVersion: "0.8.2",
+            previousVersion: "0.8.1",
+            lastPresentedTourVersion: "0.8.2",
             hasCompletedOnboarding: true,
             tour: tour
         ))
@@ -149,31 +150,56 @@ struct FeatureTourTests {
         ))
     }
 
-    @Test("0.8 catalog points each walkthrough step at a unique product location")
+    @Test("0.8.2 catalog highlights a small set of unique product locations")
     func catalogShape() {
-        #expect(tour.version == "0.8.0")
-        #expect(tour.steps.count == 6)
-        #expect(Set(tour.steps.map(\.id)).count == tour.steps.count)
-        #expect(Set(tour.steps.map(\.target)).count == tour.steps.count)
+        #expect(tour.version == "0.8.2")
+        #expect(tour.steps.map(\.target) == [.timelineSidebar])
 
-        let authenticatedTour = FeatureTourCatalog.latest(includeCloudCleanup: true)
-        #expect(authenticatedTour.steps.count == 7)
-        #expect(authenticatedTour.steps.contains { $0.target == .cloudCleanupSetting })
+        let fullTour = FeatureTourCatalog.latest(
+            includeApplicationFilter: true,
+            includeAppleSpeech: true,
+            includeMeetingPeople: true
+        )
+        #expect(fullTour.steps.count == 4)
+        #expect(Set(fullTour.steps.map(\.id)).count == fullTour.steps.count)
+        #expect(Set(fullTour.steps.map(\.target)).count == fullTour.steps.count)
+        #expect(fullTour.steps.map(\.target) == [
+            .timelineSidebar,
+            .timelineApplications,
+            .appleSpeechCard,
+            .meetingPeople,
+        ])
 
-        let dictionaryStep = tour.steps.first { $0.target == .dictionarySuggestions }
-        #expect(dictionaryStep?.message.contains("off by default") == true)
+        let timelineStep = fullTour.steps.first
+        #expect(timelineStep?.message.contains("sidebar") == true)
 
-        let streamingStep = tour.steps.first { $0.target == .streamingModels }
-        #expect(streamingStep?.message.contains("Nemotron 3.5") == true)
-        #expect(streamingStep?.message.contains("Parakeet Live Captions") == true)
-        #expect(streamingStep?.target.modelsCategory == .streaming)
+        let applicationStep = fullTour.steps.first { $0.target == .timelineApplications }
+        #expect(applicationStep?.id == "timeline-apps")
+        #expect(applicationStep?.message.contains("Mail") == true)
 
-        let experimentalStep = tour.steps.last
-        #expect(experimentalStep?.id == "experimental-models")
-        #expect(experimentalStep?.target == .experimentalModels)
-        #expect(experimentalStep?.message.contains("Indic ASR") == true)
-        #expect(experimentalStep?.message.contains("Gemma 4") == true)
-        #expect(experimentalStep?.target.modelsCategory == .dictation)
+        let appleSpeechStep = fullTour.steps.first { $0.target == .appleSpeechCard }
+        #expect(appleSpeechStep?.id == "apple-speech")
+        #expect(appleSpeechStep?.title == "Try Apple's native on-device speech model")
+        #expect(appleSpeechStep?.message.contains("macOS 26") == true)
+        #expect(appleSpeechStep?.target.modelsCategory == .dictation)
+
+        let peopleStep = fullTour.steps.last
+        #expect(peopleStep?.id == "meeting-people")
+        #expect(peopleStep?.title == "Meeting attendees are now available!")
+        #expect(peopleStep?.message.contains("Apple Contacts") == true)
+    }
+
+    @Test("catalog omits targets that cannot be rendered")
+    func unavailableTargetsAreOmitted() {
+        let tour = FeatureTourCatalog.latest(
+            includeApplicationFilter: false,
+            includeAppleSpeech: false,
+            includeMeetingPeople: false
+        )
+        #expect(tour.steps.map(\.target) == [.timelineSidebar])
+        #expect(!tour.steps.contains { $0.id == "timeline-apps" })
+        #expect(!tour.steps.contains { $0.id == "apple-speech" })
+        #expect(!tour.steps.contains { $0.id == "meeting-people" })
     }
 
     @Test("store suppresses fresh installs and presents a legacy upgrade only once")
@@ -184,15 +210,15 @@ struct FeatureTourTests {
         let store = FeatureTourStore(defaults: defaults)
 
         #expect(store.automaticTour(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             hasCompletedOnboarding: false,
             canPresent: false
         ) == nil)
 
         // A fresh install that later completes onboarding is already recorded at
-        // 0.8 and does not receive a second onboarding-like flow.
+        // 0.8.2 and does not receive a second onboarding-like flow.
         #expect(store.automaticTour(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             hasCompletedOnboarding: true,
             canPresent: true
         ) == nil)
@@ -200,14 +226,14 @@ struct FeatureTourTests {
         defaults.removePersistentDomain(forName: suiteName)
         let legacyStore = FeatureTourStore(defaults: defaults)
         let presented = try #require(legacyStore.automaticTour(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             hasCompletedOnboarding: true,
             canPresent: true
         ))
         legacyStore.markOffered(presented)
 
         #expect(legacyStore.automaticTour(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             hasCompletedOnboarding: true,
             canPresent: true
         ) == nil)
@@ -221,12 +247,12 @@ struct FeatureTourTests {
         let store = FeatureTourStore(defaults: defaults)
 
         #expect(store.automaticTour(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             hasCompletedOnboarding: true,
             canPresent: false
         ) == nil)
         #expect(store.automaticTour(
-            currentVersion: "0.8.0",
+            currentVersion: "0.8.2",
             hasCompletedOnboarding: true,
             canPresent: true
         ) != nil)


### PR DESCRIPTION
## Summary

- replace the previous walkthrough with a focused 0.8.2 tour for Timeline, destination-app filtering, Apple Speech, and meeting attendees
- anchor each step to the exact control it describes and open the most recent meeting for the attendee step
- add an explicit Skip action during the walkthrough
- include steps only when their UI is available: app filtering requires destination history, Apple Speech requires macOS 26 plus SpeechAnalyzer support, and attendees require an existing meeting
- add public-facing 0.8.2 release notes

## User impact

The walkthrough now demonstrates the features in context instead of spotlighting broad or unrelated sections. Macs below macOS 26 never receive the Apple Speech step, and users cannot become stuck on controls their configuration cannot render.

## Validation

- `swift test --package-path native/MuesliNative --scratch-path /Users/pranavhari/Library/Caches/muesli-spm/worktrees/muesli-1167756909/dev --filter FeatureTourTests` (11 passed)
- `MUESLI_SWIFTPM_SCRATCH_PATH=/Users/pranavhari/Library/Caches/muesli-spm/worktrees/muesli-1167756909/dev ./scripts/run_ci_test_shard.sh core` (342 passed)
- rebuilt, signed, installed, and launched `/Applications/MuesliDevA.app` using the existing shared cache

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789585777&installation_model_id=422865&pr_number=423&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F423&signature=20ab86bba2cd6285055b9401a4c0a19f93e9d7e1c4d02091385b9278765310d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an updated 0.8.2 feature tour covering Timeline, application filtering, Apple Speech, meeting participants, and model management.
  * Feature-tour guidance now adapts to available platform capabilities and app data.
  * Added contextual navigation to relevant settings and views for each tour step.
  * Added a visible **Skip** option for dismissing tour callouts.
* **Documentation**
  * Added release notes for version 0.8.2, including capabilities, reliability improvements, privacy details, and platform requirements.
* **Tests**
  * Expanded coverage for tour eligibility, version upgrades, optional steps, and presentation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->