### PR TITLE
Update preprod appcast for v0.8.2-preprod.2

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,6 +6,32 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
+            <title>0.8.2-preprod.2</title>
+            <pubDate>Tue, 18 Aug 2026 02:06:49 +0530</pubDate>
+            <description><![CDATA[
+<h2>MuesliPreprod 0.8.2-preprod.2</h2>
+<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
+<h3>Install</h3>
+<ul>
+<li>Download <code>MuesliPreprod-0.8.2-preprod.2.dmg</code></li>
+<li>Open the DMG and drag MuesliPreprod to Applications</li>
+<li>Launch MuesliPreprod from Applications</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+<li>Installs alongside production Muesli.</li>
+<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
+<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
+<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
+</ul>
+]]></description>
+            <sparkle:version>8002002</sparkle:version>
+            <sparkle:shortVersionString>0.8.2-preprod.2</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.2/MuesliPreprod-0.8.2-preprod.2.dmg" length="98655352" type="application/octet-stream" sparkle:edSignature="DGy7uLrYvep5w3wsg5w3Z5Al/nAH2DE4TWiEFrXe/9s/PR2HQrgTesLOcupgDzdF3AXZm64E9tThd1IoMLxxBw=="/>
+        </item>
+        <item>
             <title>0.8.2-preprod.1</title>
             <pubDate>Sat, 15 Aug 2026 23:15:37 +0530</pubDate>
             <description><![CDATA[
@@ -56,15 +82,6 @@
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.1-preprod.1/MuesliPreprod-0.8.1-preprod.1.dmg" length="94740278" type="application/octet-stream" sparkle:edSignature="rrmXPXvwS9ZiYp36FXOLCHmZgAKU4qgnxCIZBSAKBUt+dwNX7e/x8b9ZuPRxpG5eWmff+LpvnJwSPjG0xqhICQ=="/>
-        </item>
-        <item>
-            <title>0.8.0-preprod.2</title>
-            <pubDate>Tue, 14 Jul 2026 13:36:16 -0700</pubDate>
-            <sparkle:version>8000002</sparkle:version>
-            <sparkle:shortVersionString>0.8.0-preprod.2</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.0-preprod.2/MuesliPreprod-0.8.0-preprod.2.dmg" length="94561043" type="application/octet-stream" sparkle:edSignature="PEQFKQNfLcKGRnRDIl4mNSltifJVAH1BLOnpeP3vS9WkA71PbqWYpy6777FW49rH1GprVWMFpJedlQP7hyiICA=="/>
         </item>
         <item>
             <title>0.7.0-preprod.1</title>


### PR DESCRIPTION
## Summary

- publish the Sparkle appcast entry for `MuesliPreprod 0.8.2-preprod.2`
- point the feed at the signed and notarized GitHub prerelease DMG
- retain the existing rolling appcast history

## Verification

- rebuilt current `origin/main` as `/Applications/MuesliDev.app`
- 1,744 native tests across 161 suites passed
- app and DMG notarization accepted by Apple and stapled successfully
- hosted DMG SHA-256 matches the local artifact
- Sparkle EdDSA signature, enclosure length, bundle metadata, installer helper, hardened runtime, Gatekeeper, and staple validation passed
- `./scripts/verify_update_flow.sh` passed for Sparkle version `8002002`

Release: https://github.com/Muesli-HQ/muesli/releases/tag/v0.8.2-preprod.2

The production appcast, public download page, and Homebrew configuration are unchanged. Manual Sparkle upgrade testing can begin after this appcast PR is merged and GitHub Pages serves the updated feed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789591212&installation_model_id=422865&pr_number=424&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F424&signature=44ee19814c7f64ffe8282e6b74ee735c841bef2ff2211521e3ba9565faa86c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `0.8.2-preprod.2` pre-release update to the Sparkle update feed.
  * Included installation notes, compatibility requirements, and signed download information.

* **Chores**
  * Removed the outdated `0.8.0-preprod.2` update entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->