### PR TITLE
Update preprod appcast for v0.8.2-preprod.3

### DIFF
--- a/docs/appcast-preprod.xml
+++ b/docs/appcast-preprod.xml
@@ -6,14 +6,14 @@
         <language>en</language>
         <!-- Items are added by scripts/release-preprod.sh -->
         <item>
-            <title>0.8.2-preprod.2</title>
-            <pubDate>Tue, 18 Aug 2026 02:06:49 +0530</pubDate>
+            <title>0.8.2-preprod.3</title>
+            <pubDate>Tue, 18 Aug 2026 09:23:48 +0530</pubDate>
             <description><![CDATA[
-<h2>MuesliPreprod 0.8.2-preprod.2</h2>
+<h2>MuesliPreprod 0.8.2-preprod.3</h2>
 <p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
 <h3>Install</h3>
 <ul>
-<li>Download <code>MuesliPreprod-0.8.2-preprod.2.dmg</code></li>
+<li>Download <code>MuesliPreprod-0.8.2-preprod.3.dmg</code></li>
 <li>Open the DMG and drag MuesliPreprod to Applications</li>
 <li>Launch MuesliPreprod from Applications</li>
 </ul>
@@ -25,6 +25,15 @@
 <li>Does not update the production appcast, public download page, or Homebrew tap.</li>
 </ul>
 ]]></description>
+            <sparkle:version>8002003</sparkle:version>
+            <sparkle:shortVersionString>0.8.2-preprod.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.3/MuesliPreprod-0.8.2-preprod.3.dmg" length="98654711" type="application/octet-stream" sparkle:edSignature="W5y1XskmeHkOWoLhayR3hq8s8Qqa+maa3QGIoocZAtzopynG3Jsdi3zn22RjARWh+Gi5p3569YMS+uuJy5LECA=="/>
+        </item>
+        <item>
+            <title>0.8.2-preprod.2</title>
+            <pubDate>Tue, 18 Aug 2026 02:06:49 +0530</pubDate>
             <sparkle:version>8002002</sparkle:version>
             <sparkle:shortVersionString>0.8.2-preprod.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
@@ -56,32 +65,6 @@
             <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.2-preprod.1/MuesliPreprod-0.8.2-preprod.1.dmg" length="98286984" type="application/octet-stream" sparkle:edSignature="4ztiG5qcNscEGfVyg3HUUfHXyx6ZM7GS5z3gHbxxy126C+hRVwEer9pNHkXGoOhQg0NXoMgNSuw1qgvPk5L7Cw=="/>
-        </item>
-        <item>
-            <title>0.8.1-preprod.1</title>
-            <pubDate>Sat, 01 Aug 2026 12:06:08 +0530</pubDate>
-            <description><![CDATA[
-<h2>MuesliPreprod 0.8.1-preprod.1</h2>
-<p>Pre-production build for validating the Sparkle update flow before a stable release.</p>
-<h3>Install</h3>
-<ul>
-<li>Download <code>MuesliPreprod-0.8.1-preprod.1.dmg</code></li>
-<li>Open the DMG and drag MuesliPreprod to Applications</li>
-<li>Launch MuesliPreprod from Applications</li>
-</ul>
-<h3>Notes</h3>
-<ul>
-<li>Installs alongside production Muesli.</li>
-<li>Stores data separately in <code>~/Library/Application Support/MuesliPreprod/</code>.</li>
-<li>Uses the pre-production Sparkle feed: <code>https://muesli-hq.github.io/muesli/appcast-preprod.xml</code>.</li>
-<li>Does not update the production appcast, public download page, or Homebrew tap.</li>
-</ul>
-]]></description>
-            <sparkle:version>8001001</sparkle:version>
-            <sparkle:shortVersionString>0.8.1-preprod.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.2</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/Muesli-HQ/muesli/releases/download/v0.8.1-preprod.1/MuesliPreprod-0.8.1-preprod.1.dmg" length="94740278" type="application/octet-stream" sparkle:edSignature="rrmXPXvwS9ZiYp36FXOLCHmZgAKU4qgnxCIZBSAKBUt+dwNX7e/x8b9ZuPRxpG5eWmff+LpvnJwSPjG0xqhICQ=="/>
         </item>
         <item>
             <title>0.7.0-preprod.1</title>


### PR DESCRIPTION
## Summary

- publish the signed and notarized MuesliPreprod 0.8.2-preprod.3 release
- update the preprod Sparkle feed to build 8002003
- retain preprod.2 and preprod.1 entries for update compatibility

## Verification

- full native suite passed: 1,745 tests across 161 suites
- app bundle notarization accepted and stapled
- DMG notarization accepted and stapled
- hosted DMG SHA-256 matches the local artifact: `03b311708b7c0770479c326a3993117ab198e81a2f364589b3c8abc74cd6ac0d`
- Sparkle EdDSA signature, enclosure length, bundle metadata, code signatures, hardened runtime, and update flow verified
- stable production appcast, website, and Homebrew distribution are unchanged

## Preprod validation

After this PR merges, update MuesliPreprod from 0.8.2-preprod.2 to 0.8.2-preprod.3 through Sparkle and confirm the updated 0.8.2 What's New tour is offered automatically on first launch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789617431&installation_model_id=422865&pr_number=427&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F427&signature=a29e9309a705e565ceab13c9753d8cf799063a28294ea83e23621aeb17c5ea34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Added the Sparkle pre-release version 0.8.2-preprod.3 to the update feed.
  * Updated release details, including version information, download package, file size, and signature.
  * Retained the previous 0.8.2-preprod.2 entry for availability.
  * Removed the outdated 0.8.1-preprod.1 entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->