### PR TITLE
Restore production iCloud sync in Muesli 0.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Verify Sparkle update metadata
         run: ./scripts/verify_update_flow.sh --skip-dmg
 
+      - name: Test CloudKit release entitlement contract
+        run: python3 ./scripts/test_verify_cloud_entitlements.py
+
   # Gate job — always runs, always reports a status
   # This is the only required check in branch protection
   ci-gate:

--- a/docs/release-notes/0.8.3.md
+++ b/docs/release-notes/0.8.3.md
@@ -1,11 +1,54 @@
 ## Muesli 0.8.3
 
-This hotfix restores private iCloud text sync for production macOS builds.
+Muesli 0.8.3 brings dictations and meetings into one local timeline, adds Apple's newest on-device speech technology on supported Macs, and makes meeting context easier to keep with the conversation.
 
-### Fixed
+## One timeline for dictations and meetings
 
-- Restores the Production CloudKit environment entitlement in the signed macOS app.
-- Safely reconciles text records created under the affected 0.8.2 sync namespace when the private iCloud account matches.
-- Adds release gates that reject missing, malformed, or mismatched CloudKit and push-notification entitlements before publication.
+- Timeline combines recent dictations and meetings in chronological order, with filters for source, destination app, and date.
+- Dictations can show the app that ultimately received the text, making it easier to find work from Mail, Notes, browsers, and other apps.
+- Existing Dictations and Meetings views remain available when you want a focused history.
 
-Audio remains local to each device; only text records and their sync metadata use private iCloud.
+## Apple Speech on macOS 26
+
+- Macs running macOS 26 can use Apple's system-managed SpeechAnalyzer for dictation, meeting transcription, and imported recordings.
+- Apple Speech runs on-device, requires no separate Muesli model download, and follows the existing cleanup, diarization, summary, and persistence pipelines.
+- Keep the current macOS language automatically or select another language supported by Apple Speech.
+- On unsupported systems, Muesli continues to use its existing local model defaults.
+
+## Keep people with the meeting
+
+- Calendar organizers and attendees can be captured from EventKit and shown with the meeting.
+- Add someone from Apple Contacts or create a minimal new contact directly from the meeting header.
+- Search meetings by participant name or email address.
+- Participant data remains local to this Mac. It is not included in CloudKit sync, exports, CLI output, or telemetry.
+
+## Faster, more resilient model setup
+
+- Model downloads now resume interrupted transfers, validate downloaded files, check disk space, and show clearer download and preparation stages.
+- WhisperKit and supported local backends expose explicit language choices where available.
+- Qwen ASR and LocalVQE packaging paths have been hardened so installed models and acoustic cleanup load more reliably.
+
+## A more capable local CLI
+
+- The bundled `muesli-cli` can transcribe supported audio and video files with multiple local backends and return agent-friendly output.
+- Portable dictionary import and export make custom vocabulary easier to move between installations and automation workflows.
+
+## Meeting and dictation reliability
+
+- Production iCloud text sync is restored for signed macOS builds, with safe reconciliation for affected 0.8.2 installations when the private iCloud account matches.
+- Dictation becomes available after a stopped meeting finishes audio transcription and cleanup, while title generation or summarization continues in the background.
+- Meeting microphone capture can recover from degraded or changing input routes, and system-audio capture now detects stalled taps more reliably.
+- Dictation drains the final audio buffer before transcription to reduce missing last words.
+- iCloud text sync now uses Apple's durable sync engine while preserving Muesli's local outbox, improving recovery from interrupted syncs, account changes, and large pending histories.
+- The floating recording indicator has more predictable drag behavior across displays and appearance settings.
+
+## macOS polish
+
+- Added standard macOS window and navigation shortcuts, including direct access to Dictations and Meetings.
+- Meeting notes render inline Markdown more naturally while remaining editable.
+- Invalid recording durations no longer distort words-per-minute statistics.
+
+## Privacy and compatibility
+
+- Audio, transcripts, meeting titles, contacts, file paths, hardware identifiers, and raw errors are not added to telemetry.
+- Muesli 0.8.3 requires Apple silicon and macOS 14.2 or later. Apple Speech requires macOS 26 and a system-supported SpeechAnalyzer language.

--- a/docs/release-notes/0.8.3.md
+++ b/docs/release-notes/0.8.3.md
@@ -1,0 +1,11 @@
+## Muesli 0.8.3
+
+This hotfix restores private iCloud text sync for production macOS builds.
+
+### Fixed
+
+- Restores the Production CloudKit environment entitlement in the signed macOS app.
+- Safely reconciles text records created under the affected 0.8.2 sync namespace when the private iCloud account matches.
+- Adds release gates that reject missing, malformed, or mismatched CloudKit and push-notification entitlements before publication.
+
+Audio remains local to each device; only text records and their sync metadata use private iCloud.

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -3558,6 +3558,105 @@ public final class DictationStore {
         guard sqlite3_step(statement) == SQLITE_DONE else { throw lastError(db) }
     }
 
+    /// Promotes a legacy environment namespace only when its hashed account owner
+    /// exactly matches the current account. The obsolete CKSyncEngine cursor is
+    /// discarded and eligible text rows are requeued without reading or changing
+    /// authored content, timestamps, or record names. Environment-ambiguous
+    /// CloudKit version metadata is cleared so it cannot be reused in Production.
+    public func migrateCloudSyncAccountScope(
+        expectedScope: String,
+        fromKey legacyAccountScopeKey: String,
+        legacyStateKey: String,
+        toKey accountScopeKey: String
+    ) throws -> Bool {
+        guard legacyAccountScopeKey != accountScopeKey else { return false }
+        let db = try openDatabase()
+        defer { sqlite3_close(db) }
+        try exec("BEGIN IMMEDIATE TRANSACTION", db: db)
+        do {
+            func stateValue(for key: String) throws -> Data? {
+                let sql = "SELECT value FROM cloud_sync_state WHERE key = ? LIMIT 1"
+                var statement: OpaquePointer?
+                guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+                    throw lastError(db)
+                }
+                defer { sqlite3_finalize(statement) }
+                sqlite3_bind_text(statement, 1, (key as NSString).utf8String, -1, nil)
+                switch sqlite3_step(statement) {
+                case SQLITE_ROW:
+                    guard let bytes = sqlite3_column_blob(statement, 0) else { return Data() }
+                    return Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, 0)))
+                case SQLITE_DONE:
+                    return nil
+                default:
+                    throw lastError(db)
+                }
+            }
+
+            guard try stateValue(for: accountScopeKey) == nil,
+                  try stateValue(for: legacyAccountScopeKey) == Data(expectedScope.utf8) else {
+                try exec("COMMIT", db: db)
+                return false
+            }
+
+            let insertSQL = "INSERT INTO cloud_sync_state (key, value, updated_at) VALUES (?, ?, ?)"
+            var insertStatement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, insertSQL, -1, &insertStatement, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_text(insertStatement, 1, (accountScopeKey as NSString).utf8String, -1, nil)
+            bindOptionalBlob(Data(expectedScope.utf8), at: 2, statement: insertStatement)
+            sqlite3_bind_double(insertStatement, 3, Date().timeIntervalSince1970)
+            guard sqlite3_step(insertStatement) == SQLITE_DONE else {
+                sqlite3_finalize(insertStatement)
+                throw lastError(db)
+            }
+            sqlite3_finalize(insertStatement)
+
+            let deleteSQL = "DELETE FROM cloud_sync_state WHERE key IN (?, ?)"
+            var deleteStatement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, deleteSQL, -1, &deleteStatement, nil) == SQLITE_OK else {
+                throw lastError(db)
+            }
+            sqlite3_bind_text(deleteStatement, 1, (legacyAccountScopeKey as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(deleteStatement, 2, (legacyStateKey as NSString).utf8String, -1, nil)
+            guard sqlite3_step(deleteStatement) == SQLITE_DONE else {
+                sqlite3_finalize(deleteStatement)
+                throw lastError(db)
+            }
+            sqlite3_finalize(deleteStatement)
+
+            try exec(
+                """
+                UPDATE dictations
+                SET cloud_change_tag = NULL,
+                    cloud_system_fields = NULL,
+                    last_synced_at = NULL,
+                    sync_dirty = 1
+                WHERE cloud_record_name IS NOT NULL
+                """,
+                db: db
+            )
+            try exec(
+                """
+                UPDATE meetings
+                SET cloud_change_tag = NULL,
+                    cloud_system_fields = NULL,
+                    last_synced_at = NULL,
+                    sync_dirty = 1
+                WHERE cloud_record_name IS NOT NULL
+                  AND meeting_status NOT IN ('recording', 'processing')
+                """,
+                db: db
+            )
+            try exec("COMMIT", db: db)
+            return true
+        } catch {
+            _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            throw error
+        }
+    }
+
     /// Atomically claims an environment-scoped CloudKit account boundary.
     /// The first claimant wins; subsequent callers may only confirm the same scope.
     public func claimCloudSyncAccountScope(_ scope: String, forKey key: String) throws -> Bool {

--- a/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
+++ b/native/MuesliNative/Sources/MuesliCore/DictationStore.swift
@@ -3643,9 +3643,11 @@ public final class DictationStore {
                 SET cloud_change_tag = NULL,
                     cloud_system_fields = NULL,
                     last_synced_at = NULL,
-                    sync_dirty = 1
+                    sync_dirty = CASE
+                        WHEN meeting_status NOT IN ('recording', 'processing') THEN 1
+                        ELSE sync_dirty
+                    END
                 WHERE cloud_record_name IS NOT NULL
-                  AND meeting_status NOT IN ('recording', 'processing')
                 """,
                 db: db
             )

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliCKSyncEngine.swift
@@ -108,6 +108,11 @@ enum MuesliCKSyncError: Error {
     case accountChanged
 }
 
+struct MuesliCKSyncLegacyScopeMigration: Sendable, Equatable {
+    let accountScopeKey: String
+    let stateKey: String
+}
+
 /// Owns the single CKSyncEngine instance for Muesli's private text-record zone.
 ///
 /// SQLite's `sync_dirty` flags remain the durable outbox. Before every send we
@@ -120,12 +125,22 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     static var accountScopeKey: String {
         "cksyncengine.private.MuesliSyncZone.\(MuesliICloudSyncEngine.cloudKitEnvironmentKeyComponent).account-owner.v1"
     }
+    static var productionLegacyScopeMigration: MuesliCKSyncLegacyScopeMigration? {
+        guard MuesliICloudSyncEngine.cloudKitEnvironmentKeyComponent == "production" else {
+            return nil
+        }
+        return MuesliCKSyncLegacyScopeMigration(
+            accountScopeKey: "cksyncengine.private.MuesliSyncZone.unspecified.account-owner.v1",
+            stateKey: "cksyncengine.private.MuesliSyncZone.unspecified.v1"
+        )
+    }
     private static let subscriptionID = "muesli-cksyncengine-private-v1"
     private static let uploadBatchSize = 200
     private static let maximumUploadBatchesPerSync = 50
 
     private let store: DictationStore
     private let legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Set<String>)?
+    private let legacyScopeMigration: MuesliCKSyncLegacyScopeMigration?
     private var container: CKContainer?
     private var preflight: MuesliICloudSyncEngine?
     private var engine: CKSyncEngine?
@@ -153,12 +168,14 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         store: DictationStore,
         container: CKContainer? = nil,
         legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Set<String>)? = nil,
+        legacyScopeMigration: MuesliCKSyncLegacyScopeMigration? = MuesliCKSyncEngine.productionLegacyScopeMigration,
         bridgeRefreshDidFinish: (@MainActor @Sendable () -> Void)? = nil,
         engineCancellationObserver: @escaping @Sendable () async -> Void = {}
     ) {
         self.store = store
         self.container = container
         self.legacyAccountRecordVerifier = legacyAccountRecordVerifier
+        self.legacyScopeMigration = legacyScopeMigration
         self.bridgeRefreshDidFinish = bridgeRefreshDidFinish
         self.engineCancellationObserver = engineCancellationObserver
     }
@@ -760,6 +777,18 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 fputs("[muesli-native] CKSyncEngine account boundary blocked\n", stderr)
             }
             return matches
+        }
+
+        if let legacyScopeMigration,
+           try store.migrateCloudSyncAccountScope(
+               expectedScope: requestedScope,
+               fromKey: legacyScopeMigration.accountScopeKey,
+               legacyStateKey: legacyScopeMigration.stateKey,
+               toKey: Self.accountScopeKey
+           ) {
+            accountBoundaryBlocked = false
+            fputs("[muesli-native] CKSyncEngine repaired legacy environment scope\n", stderr)
+            return true
         }
 
         let legacyRecordNames = try store.textRecordNamesRequiringAccountVerification()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliICloudSyncEngine.swift
@@ -430,22 +430,43 @@ final class MuesliICloudSyncEngine {
     static var hasRequiredEntitlement: Bool {
         guard
             let task = SecTaskCreateFromSelf(nil),
-            let value = SecTaskCopyValueForEntitlement(
+            let containerValue = SecTaskCopyValueForEntitlement(
                 task,
                 "com.apple.developer.icloud-container-identifiers" as CFString,
                 nil
-            )
+            ),
+            let environmentValue = SecTaskCopyValueForEntitlement(
+                task,
+                "com.apple.developer.icloud-container-environment" as CFString,
+                nil
+            ) as? String
         else {
             return false
         }
 
-        if let containers = value as? [String] {
-            return containers.contains(Schema.containerIdentifier)
+        return hasRequiredCloudEntitlements(
+            containers: containerValue,
+            environment: environmentValue
+        )
+    }
+
+    static func hasRequiredCloudEntitlements(containers: Any, environment: String) -> Bool {
+        let hasContainer: Bool
+        if let containers = containers as? [String] {
+            hasContainer = containers.contains(Schema.containerIdentifier)
+        } else if let container = containers as? String {
+            hasContainer = container == Schema.containerIdentifier
+        } else {
+            hasContainer = false
         }
-        if let container = value as? String {
-            return container == Schema.containerIdentifier
+
+        let normalizedEnvironment = environment
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalizedEnvironment == "development" || normalizedEnvironment == "production" else {
+            return false
         }
-        return false
+        return hasContainer
     }
 
     static var cloudKitEnvironmentKeyComponent: String {

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -613,6 +613,31 @@ struct MuesliCKSyncEngineTests {
         #expect(firstScope.hasPrefix("sha256:"))
     }
 
+    @Test("CloudKit runtime requires both the private container and an explicit environment")
+    func cloudEntitlementContractRejectsUnspecifiedEnvironment() {
+        let container = MuesliICloudSyncEngine.Schema.containerIdentifier
+        #expect(MuesliICloudSyncEngine.hasRequiredCloudEntitlements(
+            containers: [container],
+            environment: "Production"
+        ))
+        #expect(MuesliICloudSyncEngine.hasRequiredCloudEntitlements(
+            containers: container,
+            environment: "Development"
+        ))
+        #expect(!MuesliICloudSyncEngine.hasRequiredCloudEntitlements(
+            containers: [container],
+            environment: ""
+        ))
+        #expect(!MuesliICloudSyncEngine.hasRequiredCloudEntitlements(
+            containers: [container],
+            environment: "unspecified"
+        ))
+        #expect(!MuesliICloudSyncEngine.hasRequiredCloudEntitlements(
+            containers: ["iCloud.example.wrong"],
+            environment: "Production"
+        ))
+    }
+
     @Test("legacy provenance requires the exact complete stable-ID set")
     func accountProvenanceRequiresEveryRecord() {
         let required = Set(["stable-a", "stable-b"])
@@ -711,6 +736,113 @@ struct MuesliCKSyncEngineTests {
         #expect(try await coordinator.handleAccountChange(currentUser: owner, state: state))
         #expect(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey)
             == Data(MuesliCKSyncEngine.accountScope(for: owner).utf8))
+        #expect(state.pendingRecordZoneChanges.isEmpty)
+    }
+
+    @Test("matching unspecified owner safely migrates and requeues for Production")
+    func matchingUnspecifiedOwnerMigratesToProduction() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Keep authored text private during environment repair",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        #expect(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "existing-production-tag",
+            systemFields: Data([0x01, 0x02]),
+            recordUpdatedAt: local.updatedAt
+        ))
+
+        let owner = CKRecord.ID(recordName: "same-private-owner")
+        let scope = MuesliCKSyncEngine.accountScope(for: owner)
+        let migration = MuesliCKSyncLegacyScopeMigration(
+            accountScopeKey: "test.unspecified.owner",
+            stateKey: "test.unspecified.state"
+        )
+        try store.saveCloudSyncStateData(Data(scope.utf8), forKey: migration.accountScopeKey)
+        try store.saveCloudSyncStateData(Data("obsolete-cursor".utf8), forKey: migration.stateKey)
+
+        let state = TestCKSyncPendingState()
+        let coordinator = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { _ in
+                Issue.record("An exact legacy owner match must not query authored records")
+                return []
+            },
+            legacyScopeMigration: migration
+        )
+
+        #expect(try await coordinator.handleAccountChange(currentUser: owner, state: state))
+        #expect(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey)
+            == Data(scope.utf8))
+        #expect(try store.cloudSyncStateData(forKey: migration.accountScopeKey) == nil)
+        #expect(try store.cloudSyncStateData(forKey: migration.stateKey) == nil)
+        #expect(state.pendingRecordZoneChanges == [
+            .saveRecord(CKRecord.ID(
+                recordName: local.id,
+                zoneID: MuesliICloudSyncEngine.Schema.syncZoneID
+            )),
+        ])
+
+        let preserved = try #require(try store.textRecordForSync(recordName: local.id))
+        #expect(preserved.text == "Keep authored text private during environment repair")
+        #expect(preserved.cloudChangeTag == nil)
+        #expect(preserved.cloudSystemFields == nil)
+        #expect(try store.hasTextRecordsNeedingSync())
+    }
+
+    @Test("mismatched unspecified owner remains blocked and untouched")
+    func mismatchedUnspecifiedOwnerDoesNotMigrate() async throws {
+        let store = try makeStore()
+        _ = try store.insertDictation(
+            text: "Never cross an account boundary",
+            durationSeconds: 2,
+            startedAt: Date().addingTimeInterval(-2),
+            endedAt: Date()
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        #expect(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "other-account-tag",
+            systemFields: Data([0x03]),
+            recordUpdatedAt: local.updatedAt
+        ))
+
+        let migration = MuesliCKSyncLegacyScopeMigration(
+            accountScopeKey: "test.unspecified.owner.mismatch",
+            stateKey: "test.unspecified.state.mismatch"
+        )
+        let oldScope = MuesliCKSyncEngine.accountScope(
+            for: CKRecord.ID(recordName: "old-private-owner")
+        )
+        try store.saveCloudSyncStateData(Data(oldScope.utf8), forKey: migration.accountScopeKey)
+        try store.saveCloudSyncStateData(Data("keep-cursor".utf8), forKey: migration.stateKey)
+
+        let state = TestCKSyncPendingState()
+        let coordinator = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { names in
+                #expect(names == Set([local.id]))
+                return []
+            },
+            legacyScopeMigration: migration
+        )
+
+        #expect(try await coordinator.handleAccountChange(
+            currentUser: CKRecord.ID(recordName: "different-private-owner"),
+            state: state
+        ) == false)
+        #expect(try store.cloudSyncStateData(forKey: migration.accountScopeKey)
+            == Data(oldScope.utf8))
+        #expect(try store.cloudSyncStateData(forKey: migration.stateKey)
+            == Data("keep-cursor".utf8))
+        #expect(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey) == nil)
+        #expect(try !store.hasTextRecordsNeedingSync())
         #expect(state.pendingRecordZoneChanges.isEmpty)
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -795,6 +795,65 @@ struct MuesliCKSyncEngineTests {
         #expect(try store.hasTextRecordsNeedingSync())
     }
 
+    @Test("unspecified migration clears in-progress meeting metadata without uploading it")
+    func matchingUnspecifiedOwnerRepairsInProgressMeetingMetadata() async throws {
+        let store = try makeStore()
+        let meetingID = try store.insertMeeting(
+            title: "Private in-progress meeting",
+            calendarEventID: nil,
+            startTime: Date().addingTimeInterval(-60),
+            endTime: Date(),
+            rawTranscript: "Keep the local transcript untouched",
+            formattedNotes: "",
+            micAudioPath: nil,
+            systemAudioPath: nil
+        )
+        let local = try #require(try store.textRecordsNeedingSync().first)
+        #expect(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "obsolete-unspecified-tag",
+            systemFields: Data([0x04, 0x05]),
+            recordUpdatedAt: local.updatedAt
+        ))
+        try store.updateMeetingStatus(id: meetingID, status: .processing)
+
+        let owner = CKRecord.ID(recordName: "same-private-owner-in-progress")
+        let scope = MuesliCKSyncEngine.accountScope(for: owner)
+        let migration = MuesliCKSyncLegacyScopeMigration(
+            accountScopeKey: "test.unspecified.owner.in-progress",
+            stateKey: "test.unspecified.state.in-progress"
+        )
+        try store.saveCloudSyncStateData(Data(scope.utf8), forKey: migration.accountScopeKey)
+        try store.saveCloudSyncStateData(Data("obsolete-cursor".utf8), forKey: migration.stateKey)
+
+        let state = TestCKSyncPendingState()
+        let coordinator = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { _ in
+                Issue.record("An exact legacy owner match must not query authored records")
+                return []
+            },
+            legacyScopeMigration: migration
+        )
+
+        #expect(try await coordinator.handleAccountChange(currentUser: owner, state: state))
+        #expect(state.pendingRecordZoneChanges.isEmpty)
+        #expect(try store.textRecordsNeedingSync().isEmpty)
+
+        let repaired = try #require(try store.textRecordForSync(recordName: local.id))
+        #expect(repaired.text == "Keep the local transcript untouched")
+        #expect(repaired.meetingStatus == .processing)
+        #expect(repaired.cloudChangeTag == nil)
+        #expect(repaired.cloudSystemFields == nil)
+
+        try store.updateMeetingStatus(id: meetingID, status: .completed)
+        let eligible = try #require(try store.textRecordsNeedingSync().first)
+        #expect(eligible.id == local.id)
+        #expect(eligible.cloudChangeTag == nil)
+        #expect(eligible.cloudSystemFields == nil)
+    }
+
     @Test("mismatched unspecified owner remains blocked and untouched")
     func mismatchedUnspecifiedOwnerDoesNotMigrate() async throws {
         let store = try makeStore()

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -59,7 +59,18 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   - Must show CloudKit container `iCloud.com.mueslihq.muesli`
   - Must show CloudKit environment `Production`
   - Must show APNs environment `production` when using the production Developer ID CloudKit profile
-- [ ] Run `scripts/verify_signed_cloud_entitlements.sh` against the built app, the app inside the local DMG, and the app inside the re-downloaded GitHub asset.
+- [ ] Verify the built app:
+  ```bash
+  scripts/verify_signed_cloud_entitlements.sh /Applications/Muesli.app Production com.muesli.app iCloud.com.mueslihq.muesli production
+  ```
+- [ ] Mount the local DMG, then verify its app:
+  ```bash
+  scripts/verify_signed_cloud_entitlements.sh /Volumes/Muesli/Muesli.app Production com.muesli.app iCloud.com.mueslihq.muesli production
+  ```
+- [ ] Re-download and mount the GitHub release DMG, then verify its app with the same command:
+  ```bash
+  scripts/verify_signed_cloud_entitlements.sh /Volumes/Muesli/Muesli.app Production com.muesli.app iCloud.com.mueslihq.muesli production
+  ```
 - [ ] Stable and pre-production builds explicitly set `MUESLI_ICLOUD_CONTAINER_ENVIRONMENT=Production`; omission must fail closed.
 
 ## Notarize & Staple (CRITICAL ORDER)

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -72,6 +72,8 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   scripts/verify_signed_cloud_entitlements.sh /Volumes/Muesli/Muesli.app Production com.muesli.app iCloud.com.mueslihq.muesli production
   ```
 - [ ] Stable and pre-production builds explicitly set `MUESLI_ICLOUD_CONTAINER_ENVIRONMENT=Production`; omission must fail closed.
+- [ ] The stable release creates a dedicated `codex/release-<version>-appcast` PR for `docs/appcast.xml`, `docs/index.html`, and `docs/llms.txt`; it must not push those files directly to `main`.
+- [ ] Merge the release metadata PR only after confirming its Sparkle enclosure URL, length, EdDSA signature, version, and release notes match the verified GitHub Release asset.
 
 ## Notarize & Staple (CRITICAL ORDER)
 

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -59,6 +59,8 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   - Must show CloudKit container `iCloud.com.mueslihq.muesli`
   - Must show CloudKit environment `Production`
   - Must show APNs environment `production` when using the production Developer ID CloudKit profile
+- [ ] Run `scripts/verify_signed_cloud_entitlements.sh` against the built app, the app inside the local DMG, and the app inside the re-downloaded GitHub asset.
+- [ ] Stable and pre-production builds explicitly set `MUESLI_ICLOUD_CONTAINER_ENVIRONMENT=Production`; omission must fail closed.
 
 ## Notarize & Staple (CRITICAL ORDER)
 

--- a/scripts/build_native_app.sh
+++ b/scripts/build_native_app.sh
@@ -18,7 +18,7 @@ APP_SUPPORT_DIR_NAME="${MUESLI_SUPPORT_DIR_NAME:-$APP_DISPLAY_NAME}"
 BUNDLE_ID="${MUESLI_BUNDLE_ID:-com.muesli.app}"
 TELEMETRYDECK_APP_ID="${MUESLI_TELEMETRYDECK_APP_ID:-}"
 TELEMETRY_CHANNEL="${MUESLI_TELEMETRY_CHANNEL:-unconfigured}"
-DEFAULT_APP_VERSION="0.8.2"
+DEFAULT_APP_VERSION="0.8.3"
 APP_VERSION="${MUESLI_BUILD_VERSION:-$DEFAULT_APP_VERSION}"
 APP_BUNDLE_VERSION="${MUESLI_BUNDLE_VERSION:-$APP_VERSION}"
 APP_SHORT_VERSION="${MUESLI_SHORT_VERSION:-$APP_VERSION}"
@@ -369,6 +369,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
   TEMP_ENTITLEMENTS=""
   APS_ENVIRONMENT="${MUESLI_APS_ENVIRONMENT:-}"
   ICLOUD_CONTAINER_ENVIRONMENT="${MUESLI_ICLOUD_CONTAINER_ENVIRONMENT:-}"
+  ICLOUD_CONTAINER_ID="${MUESLI_ICLOUD_CONTAINER_ID:-iCloud.com.mueslihq.muesli}"
   PROFILE_PLIST=""
   SIGN_TEMP_FILES=()
   cleanup_sign_temp_files() {
@@ -406,6 +407,13 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
         APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:aps-environment' "$PROFILE_PLIST" 2>/dev/null || true)"
       fi
     fi
+
+    if /usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.icloud-container-environment' "$PROFILE_PLIST" >/dev/null 2>&1 \
+      && [[ -z "$ICLOUD_CONTAINER_ENVIRONMENT" ]]; then
+      echo "ERROR: CloudKit provisioning profiles require an explicit MUESLI_ICLOUD_CONTAINER_ENVIRONMENT." >&2
+      echo "Set it to Development or Production; signed builds may not silently use an unspecified environment." >&2
+      exit 1
+    fi
   fi
 
   if [[ -n "$APS_ENVIRONMENT" || -n "$PROFILE_PLIST" ]]; then
@@ -437,6 +445,7 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
           exit 1
           ;;
       esac
+      ICLOUD_CONTAINER_ENVIRONMENT="$value"
       /usr/libexec/PlistBuddy -c "Delete :$key" "$TEMP_ENTITLEMENTS" >/dev/null 2>&1 || true
       /usr/libexec/PlistBuddy -c "Add :$key string $value" "$TEMP_ENTITLEMENTS"
       echo "Using iCloud entitlement: $key=$value"
@@ -476,6 +485,18 @@ if [[ "$SKIP_SIGN" != "1" ]]; then
     exit 1
   fi
   echo "  Deep signature valid."
+  if [[ -n "$ICLOUD_CONTAINER_ENVIRONMENT" ]]; then
+    if [[ -z "$APS_ENVIRONMENT" ]]; then
+      echo "ERROR: CloudKit signed builds require an APNs environment from the profile or MUESLI_APS_ENVIRONMENT." >&2
+      exit 1
+    fi
+    "$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+      "$APP_DIR" \
+      "$ICLOUD_CONTAINER_ENVIRONMENT" \
+      "$BUNDLE_ID" \
+      "$ICLOUD_CONTAINER_ID" \
+      "$APS_ENVIRONMENT"
+  fi
 else
   # No Developer ID certificate: ad-hoc sign for local dev instead of leaving the
   # bundle with SwiftPM's incoherent per-binary signature. An ad-hoc *bundle* signature

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -54,9 +54,13 @@ APPCAST_PATH="$ROOT/docs/appcast-preprod.xml"
 GENERATE_APPCAST="$(muesli_spm_artifacts_dir "$PACKAGE_DIR" "$SWIFTPM_SCRATCH_PATH")/sparkle/Sparkle/bin/generate_appcast"
 UPDATE_APPCAST_RELEASE_NOTES="$ROOT/scripts/update_appcast_release_notes.py"
 VERIFY_DIR=""
+MOUNT_POINT=""
 HOSTED_MOUNT_POINT=""
 
 cleanup() {
+  if [[ -n "$MOUNT_POINT" ]]; then
+    hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+  fi
   if [[ -n "$HOSTED_MOUNT_POINT" ]]; then
     hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null || true
   fi
@@ -267,6 +271,7 @@ STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/${APP_NAME}.app" 2>&1)
   iCloud.com.mueslihq.muesli \
   production
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
+MOUNT_POINT=""
 
 if ! echo "$SPCTL_RESULT" | grep -q "accepted"; then
   echo "  RELEASE ABORTED: App inside DMG rejected by Gatekeeper."

--- a/scripts/release-preprod.sh
+++ b/scripts/release-preprod.sh
@@ -186,6 +186,7 @@ PREPROD_BUILD_ENV=(
   MUESLI_TELEMETRY_CHANNEL="preprod"
   MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY"
   MUESLI_PROVISIONING_PROFILE="$PROVISIONING_PROFILE"
+  MUESLI_ICLOUD_CONTAINER_ENVIRONMENT="Production"
 )
 echo "  Bundle ID: $BUNDLE_ID"
 echo "  Profile:   $PROVISIONING_PROFILE"
@@ -259,6 +260,12 @@ fi
 
 SPCTL_RESULT=$(spctl -a -vv "$MOUNT_POINT/${APP_NAME}.app" 2>&1)
 STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/${APP_NAME}.app" 2>&1)
+"$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+  "$MOUNT_POINT/${APP_NAME}.app" \
+  Production \
+  "$BUNDLE_ID" \
+  iCloud.com.mueslihq.muesli \
+  production
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
 
 if ! echo "$SPCTL_RESULT" | grep -q "accepted"; then
@@ -338,6 +345,12 @@ fi
 
 HOSTED_MOUNT_POINT=$(hdiutil attach "$HOSTED_DMG" -nobrowse 2>&1 | grep "/Volumes" | awk -F'\t' '{print $NF}')
 HOSTED_APP_SPCTL=$(spctl -a -vv "$HOSTED_MOUNT_POINT/${APP_NAME}.app" 2>&1)
+"$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+  "$HOSTED_MOUNT_POINT/${APP_NAME}.app" \
+  Production \
+  "$BUNDLE_ID" \
+  iCloud.com.mueslihq.muesli \
+  production
 hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
 HOSTED_MOUNT_POINT=""
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -63,10 +63,14 @@ HOMEBREW_CASK="${MUESLI_HOMEBREW_CASK:-muesli}"
 SKIP_HOMEBREW_CHECK="${MUESLI_SKIP_HOMEBREW_CHECK:-0}"
 RELEASE_PR_MODE="${MUESLI_RELEASE_PR_MODE:-0}"
 VERIFY_DIR=""
+MOUNT_POINT=""
 HOSTED_MOUNT_POINT=""
 HOMEBREW_CHECK_STATUS="skipped"
 
 cleanup() {
+  if [[ -n "$MOUNT_POINT" ]]; then
+    hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
+  fi
   if [[ -n "$HOSTED_MOUNT_POINT" ]]; then
     hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null || true
   fi
@@ -323,6 +327,7 @@ echo "  $STAPLE_RESULT"
   production
 
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
+MOUNT_POINT=""
 
 if ! echo "$SPCTL_RESULT" | grep -q "accepted"; then
   echo ""
@@ -458,6 +463,7 @@ echo "  $HOSTED_APP_STAPLE_RESULT"
   production
 
 hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
+HOSTED_MOUNT_POINT=""
 
 if ! echo "$HOSTED_APP_SPCTL_RESULT" | grep -q "accepted"; then
   echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 #   5. Verify the local DMG and the app inside it
 #   6. Create GitHub release and upload DMG
 #   7. Re-download the hosted DMG from GitHub Releases and verify that exact file
-#   8. Update downstream release surfaces from the verified hosted DMG:
+#   8. Open a PR for downstream release surfaces from the verified hosted DMG:
 #      - GitHub Pages appcast + landing-page metadata
 #      - Official Homebrew cask livecheck/autobump verification
 #
@@ -158,6 +158,7 @@ fi
 DOWNLOAD_URL="https://github.com/Muesli-HQ/muesli/releases/download/v${VERSION}/Muesli-${VERSION}.dmg"
 TAG="v${VERSION}"
 RELEASE_TITLE="Muesli ${VERSION}"
+RELEASE_METADATA_BRANCH="${MUESLI_RELEASE_METADATA_BRANCH:-codex/release-${VERSION}-appcast}"
 DEFAULT_RELEASE_NOTES_FILE="$ROOT/docs/release-notes/${VERSION}.md"
 RELEASE_NOTES_FILE="${MUESLI_RELEASE_NOTES_FILE:-$DEFAULT_RELEASE_NOTES_FILE}"
 RELEASE_NOTES=""
@@ -188,6 +189,19 @@ Signed, notarized, and stapled by Apple.
 EOF
 )"
   RELEASE_NOTES_ARGS=(--notes "$RELEASE_NOTES")
+fi
+
+if ! git check-ref-format --branch "$RELEASE_METADATA_BRANCH" >/dev/null 2>&1; then
+  echo "ERROR: Invalid release metadata branch: $RELEASE_METADATA_BRANCH" >&2
+  exit 1
+fi
+if git show-ref --verify --quiet "refs/heads/${RELEASE_METADATA_BRANCH}"; then
+  echo "ERROR: Local release metadata branch already exists: $RELEASE_METADATA_BRANCH" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --heads origin "$RELEASE_METADATA_BRANCH" >/dev/null 2>&1; then
+  echo "ERROR: Remote release metadata branch already exists: $RELEASE_METADATA_BRANCH" >&2
+  exit 1
 fi
 
 verify_homebrew_autobump() {
@@ -487,8 +501,8 @@ gh release edit "$TAG" \
 RELEASE_URL=$(gh release view "$TAG" --json url -q .url)
 echo "  Release published: $RELEASE_URL"
 
-# --- Step 12: Update appcast and landing-page links after release publication ---
-echo "[12/13] Updating appcast and release metadata..."
+# --- Step 12: Open an appcast/landing metadata PR after release publication ---
+echo "[12/13] Preparing appcast and release metadata PR..."
 GENERATED_APPCAST="$VERIFY_DIR/generated-appcast.xml"
 "$GENERATE_APPCAST" "$OUTPUT_DIR" -o "$GENERATED_APPCAST"
 if [[ "$RELEASE_NOTES_FROM_FILE" == "1" ]]; then
@@ -523,16 +537,18 @@ echo "  Verifying Sparkle update flow metadata..."
 
 git add docs/appcast.xml docs/index.html docs/llms.txt
 if git diff --cached --quiet; then
-  echo "  No docs changes to commit."
+  echo "ERROR: Release metadata did not change for v${VERSION}; refusing to publish an appcast-less release." >&2
+  exit 1
 else
-  git commit -m "Update release metadata for v${VERSION}"
-  if [[ "$RELEASE_PR_MODE" == "1" ]]; then
-    git push origin HEAD
-    echo "  Pushed appcast and landing-page updates to ${CURRENT_BRANCH} for review."
-  else
-    git push origin main
-    echo "  Pushed appcast and landing-page updates to main."
-  fi
+  git switch -c "$RELEASE_METADATA_BRANCH"
+  git commit --signoff -m "Update release metadata for v${VERSION}"
+  git push -u origin "$RELEASE_METADATA_BRANCH"
+  RELEASE_METADATA_PR_URL=$(gh pr create \
+    --base main \
+    --head "$RELEASE_METADATA_BRANCH" \
+    --title "Update release metadata for v${VERSION}" \
+    --body "Publishes the verified v${VERSION} Sparkle appcast entry and aligns the landing-page download metadata with the released GitHub DMG. The public appcast remains unchanged until this PR is reviewed and merged.")
+  echo "  Release metadata PR: $RELEASE_METADATA_PR_URL"
 fi
 
 # --- Step 13: Verify the official Homebrew cask can see the new release ---
@@ -545,9 +561,7 @@ echo "  Version: ${VERSION}"
 echo "  DMG: $DMG_PATH"
 echo "  Release: $RELEASE_URL"
 echo "  Hosted asset verified."
-if [[ "$RELEASE_PR_MODE" == "1" ]]; then
-  echo "  Production appcast publication is pending merge of ${CURRENT_BRANCH}."
-fi
+echo "  Production appcast publication is pending merge of $RELEASE_METADATA_PR_URL."
 if [[ "$HOMEBREW_CHECK_STATUS" == "verified" ]]; then
   echo "  Homebrew cask livecheck verified for ${HOMEBREW_CASK}."
   echo "  Watch Homebrew/homebrew-cask for the BrewTestBot autobump PR."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -116,12 +116,18 @@ assert_release_branch_contains_origin_main() {
 }
 
 if [[ "$RELEASE_PR_MODE" == "1" ]]; then
-  if [[ -z "$CURRENT_BRANCH" || "$CURRENT_BRANCH" == "main" ]]; then
-    echo "ERROR: MUESLI_RELEASE_PR_MODE=1 requires a dedicated release branch." >&2
-    exit 1
-  fi
-  assert_release_branch_contains_origin_main
-  echo "Release PR mode enabled: metadata will be pushed to ${CURRENT_BRANCH}, not main."
+  echo "ERROR: MUESLI_RELEASE_PR_MODE is no longer allowed to publish stable artifacts." >&2
+  echo "Merge the release code and version PR first, then publish from the current origin/main." >&2
+  exit 1
+fi
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "ERROR: Stable releases must be published from main after the release PR is merged." >&2
+  exit 1
+fi
+assert_release_branch_contains_origin_main
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+  echo "ERROR: main must exactly match origin/main before publishing a stable release." >&2
+  exit 1
 fi
 
 if [[ ! -f "$UPDATE_APPCAST_RELEASE_NOTES" ]]; then
@@ -226,6 +232,7 @@ RELEASE_BUILD_ENV=(
   MUESLI_INSTALL_DIR="$INSTALL_DIR"
   MUESLI_PROVISIONING_PROFILE="$PROVISIONING_PROFILE"
   MUESLI_SIGN_IDENTITY="$SIGN_IDENTITY"
+  MUESLI_ICLOUD_CONTAINER_ENVIRONMENT="Production"
   MUESLI_TELEMETRYDECK_APP_ID="$MUESLI_TELEMETRYDECK_PRODUCTION_APP_ID"
   MUESLI_TELEMETRY_CHANNEL="production"
   "${BUILD_ENV[@]}"
@@ -307,6 +314,13 @@ echo "  $SPCTL_RESULT"
 
 STAPLE_RESULT=$(xcrun stapler validate "$MOUNT_POINT/Muesli.app" 2>&1)
 echo "  $STAPLE_RESULT"
+
+"$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+  "$MOUNT_POINT/Muesli.app" \
+  Production \
+  com.muesli.app \
+  iCloud.com.mueslihq.muesli \
+  production
 
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null
 
@@ -435,6 +449,13 @@ echo "  $HOSTED_APP_SPCTL_RESULT"
 
 HOSTED_APP_STAPLE_RESULT=$(xcrun stapler validate "$HOSTED_MOUNT_POINT/Muesli.app" 2>&1)
 echo "  $HOSTED_APP_STAPLE_RESULT"
+
+"$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+  "$HOSTED_MOUNT_POINT/Muesli.app" \
+  Production \
+  com.muesli.app \
+  iCloud.com.mueslihq.muesli \
+  production
 
 hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
 

--- a/scripts/test_verify_cloud_entitlements.py
+++ b/scripts/test_verify_cloud_entitlements.py
@@ -110,4 +110,13 @@ assert stable_release.count("verify_signed_cloud_entitlements.sh") >= 2
 assert preprod_release.count("verify_signed_cloud_entitlements.sh") >= 2
 assert "CloudKit provisioning profiles require an explicit" in build_script
 
+metadata_section = stable_release.split(
+    "# --- Step 12: Open an appcast/landing metadata PR after release publication ---",
+    maxsplit=1,
+)[1].split("# --- Step 13:", maxsplit=1)[0]
+assert 'RELEASE_METADATA_BRANCH="${MUESLI_RELEASE_METADATA_BRANCH:-codex/release-${VERSION}-appcast}"' in stable_release
+assert "gh pr create" in metadata_section
+assert "--base main" in metadata_section
+assert "git push origin main" not in metadata_section
+
 print("CloudKit entitlement validator tests passed.")

--- a/scripts/test_verify_cloud_entitlements.py
+++ b/scripts/test_verify_cloud_entitlements.py
@@ -45,6 +45,9 @@ base_entitlements = {
 }
 base_profile = {
     "Entitlements": {
+        "com.apple.application-identifier": "58W55QJ567.com.muesli.app",
+        "com.apple.developer.team-identifier": "58W55QJ567",
+        "com.apple.developer.aps-environment": "production",
         "com.apple.developer.icloud-container-environment": ["Development", "Production"],
         "com.apple.developer.icloud-container-identifiers": ["iCloud.com.mueslihq.muesli"],
     }
@@ -69,11 +72,34 @@ assert run(missing_environment, base_profile).returncode != 0
 
 wrong_profile = {
     "Entitlements": {
+        "com.apple.application-identifier": "58W55QJ567.com.muesli.app",
+        "com.apple.developer.team-identifier": "58W55QJ567",
+        "com.apple.developer.aps-environment": "production",
         "com.apple.developer.icloud-container-environment": "Development",
         "com.apple.developer.icloud-container-identifiers": ["iCloud.com.mueslihq.muesli"],
     }
 }
 assert run(base_entitlements, wrong_profile).returncode != 0
+
+for key, bad_value in (
+    ("com.apple.application-identifier", "58W55QJ567.com.example.wrong"),
+    ("com.apple.developer.team-identifier", "DIFFERENT01"),
+    ("com.apple.developer.aps-environment", "development"),
+):
+    candidate_profile = {"Entitlements": dict(base_profile["Entitlements"])}
+    candidate_profile["Entitlements"][key] = bad_value
+    result = run(base_entitlements, candidate_profile)
+    assert result.returncode != 0, (key, result.stdout, result.stderr)
+
+for missing_key in (
+    "com.apple.application-identifier",
+    "com.apple.developer.team-identifier",
+    "com.apple.developer.aps-environment",
+):
+    candidate_profile = {"Entitlements": dict(base_profile["Entitlements"])}
+    candidate_profile["Entitlements"].pop(missing_key)
+    result = run(base_entitlements, candidate_profile)
+    assert result.returncode != 0, (missing_key, result.stdout, result.stderr)
 
 stable_release = (ROOT / "scripts" / "release.sh").read_text(encoding="utf-8")
 preprod_release = (ROOT / "scripts" / "release-preprod.sh").read_text(encoding="utf-8")

--- a/scripts/test_verify_cloud_entitlements.py
+++ b/scripts/test_verify_cloud_entitlements.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import plistlib
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = ROOT / "scripts" / "verify_cloud_entitlements.py"
+
+
+def write_plist(path: Path, value: dict) -> None:
+    with path.open("wb") as handle:
+        plistlib.dump(value, handle)
+
+
+def run(entitlements: dict, profile: dict | None = None) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        entitlements_path = root / "entitlements.plist"
+        write_plist(entitlements_path, entitlements)
+        command = [
+            "python3", str(VALIDATOR),
+            "--entitlements", str(entitlements_path),
+            "--environment", "Production",
+            "--bundle-id", "com.muesli.app",
+            "--container", "iCloud.com.mueslihq.muesli",
+            "--aps-environment", "production",
+        ]
+        if profile is not None:
+            profile_path = root / "profile.plist"
+            write_plist(profile_path, profile)
+            command.extend(["--profile", str(profile_path)])
+        return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+base_entitlements = {
+    "com.apple.application-identifier": "58W55QJ567.com.muesli.app",
+    "com.apple.developer.team-identifier": "58W55QJ567",
+    "com.apple.developer.icloud-container-environment": "Production",
+    "com.apple.developer.icloud-container-identifiers": ["iCloud.com.mueslihq.muesli"],
+    "com.apple.developer.icloud-services": ["CloudKit"],
+    "com.apple.developer.aps-environment": "production",
+}
+base_profile = {
+    "Entitlements": {
+        "com.apple.developer.icloud-container-environment": ["Development", "Production"],
+        "com.apple.developer.icloud-container-identifiers": ["iCloud.com.mueslihq.muesli"],
+    }
+}
+
+assert run(base_entitlements, base_profile).returncode == 0
+
+for key, bad_value in (
+    ("com.apple.developer.icloud-container-environment", "Development"),
+    ("com.apple.developer.aps-environment", "development"),
+    ("com.apple.developer.icloud-container-identifiers", ["iCloud.example.wrong"]),
+    ("com.apple.developer.icloud-services", ["Documents"]),
+):
+    candidate = dict(base_entitlements)
+    candidate[key] = bad_value
+    result = run(candidate, base_profile)
+    assert result.returncode != 0, (key, result.stdout, result.stderr)
+
+missing_environment = dict(base_entitlements)
+missing_environment.pop("com.apple.developer.icloud-container-environment")
+assert run(missing_environment, base_profile).returncode != 0
+
+wrong_profile = {
+    "Entitlements": {
+        "com.apple.developer.icloud-container-environment": "Development",
+        "com.apple.developer.icloud-container-identifiers": ["iCloud.com.mueslihq.muesli"],
+    }
+}
+assert run(base_entitlements, wrong_profile).returncode != 0
+
+stable_release = (ROOT / "scripts" / "release.sh").read_text(encoding="utf-8")
+preprod_release = (ROOT / "scripts" / "release-preprod.sh").read_text(encoding="utf-8")
+build_script = (ROOT / "scripts" / "build_native_app.sh").read_text(encoding="utf-8")
+assert 'MUESLI_ICLOUD_CONTAINER_ENVIRONMENT="Production"' in stable_release
+assert 'MUESLI_ICLOUD_CONTAINER_ENVIRONMENT="Production"' in preprod_release
+assert stable_release.count("verify_signed_cloud_entitlements.sh") >= 2
+assert preprod_release.count("verify_signed_cloud_entitlements.sh") >= 2
+assert "CloudKit provisioning profiles require an explicit" in build_script
+
+print("CloudKit entitlement validator tests passed.")

--- a/scripts/verify_cloud_entitlements.py
+++ b/scripts/verify_cloud_entitlements.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate the privacy-safe CloudKit contract of a signed Muesli app."""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def load_plist(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as handle:
+            value = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException) as exc:
+        fail(f"could not read plist {path}: {exc}")
+    if not isinstance(value, dict):
+        fail(f"plist root is not a dictionary: {path}")
+    return value
+
+
+def string_value(mapping: dict[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"missing string entitlement: {key}")
+    return value
+
+
+def string_list(mapping: dict[str, Any], key: str) -> list[str]:
+    value = mapping.get(key)
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    fail(f"missing string-list entitlement: {key}")
+
+
+def validate(
+    entitlements: dict[str, Any],
+    expected_environment: str,
+    expected_bundle_id: str,
+    expected_container: str,
+    expected_aps: str,
+    profile: dict[str, Any] | None,
+) -> None:
+    environment_key = "com.apple.developer.icloud-container-environment"
+    app_identifier_key = "com.apple.application-identifier"
+    if app_identifier_key not in entitlements:
+        app_identifier_key = "application-identifier"
+
+    environment = string_value(entitlements, environment_key)
+    if environment != expected_environment:
+        fail(
+            f"signed CloudKit environment is {environment!r}, "
+            f"expected {expected_environment!r}"
+        )
+
+    app_identifier = string_value(entitlements, app_identifier_key)
+    team_id = string_value(entitlements, "com.apple.developer.team-identifier")
+    if app_identifier != f"{team_id}.{expected_bundle_id}":
+        fail("signed application identifier does not match the team and bundle ID")
+
+    containers = string_list(
+        entitlements, "com.apple.developer.icloud-container-identifiers"
+    )
+    if expected_container not in containers:
+        fail("signed app is missing the required iCloud container")
+
+    services = string_list(entitlements, "com.apple.developer.icloud-services")
+    if "CloudKit" not in services:
+        fail("signed app is missing the CloudKit service entitlement")
+
+    aps = entitlements.get("com.apple.developer.aps-environment")
+    if aps is None:
+        aps = entitlements.get("aps-environment")
+    if aps != expected_aps:
+        fail(f"signed APNs environment is {aps!r}, expected {expected_aps!r}")
+
+    if profile is None:
+        return
+    profile_entitlements = profile.get("Entitlements")
+    if not isinstance(profile_entitlements, dict):
+        fail("embedded provisioning profile has no Entitlements dictionary")
+
+    profile_environments = string_list(profile_entitlements, environment_key)
+    if expected_environment not in profile_environments:
+        fail("provisioning profile does not permit the expected CloudKit environment")
+    profile_containers = string_list(
+        profile_entitlements, "com.apple.developer.icloud-container-identifiers"
+    )
+    if expected_container not in profile_containers:
+        fail("provisioning profile does not permit the required iCloud container")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--entitlements", type=Path, required=True)
+    parser.add_argument("--environment", choices=("Development", "Production"), required=True)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--container", required=True)
+    parser.add_argument("--aps-environment", choices=("development", "production"), required=True)
+    parser.add_argument("--profile", type=Path)
+    args = parser.parse_args()
+
+    try:
+        validate(
+            load_plist(args.entitlements),
+            args.environment,
+            args.bundle_id,
+            args.container,
+            args.aps_environment,
+            load_plist(args.profile) if args.profile else None,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"CloudKit entitlement contract OK: {args.bundle_id} / {args.environment}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_cloud_entitlements.py
+++ b/scripts/verify_cloud_entitlements.py
@@ -88,6 +88,30 @@ def validate(
     if not isinstance(profile_entitlements, dict):
         fail("embedded provisioning profile has no Entitlements dictionary")
 
+    profile_app_identifier_key = "com.apple.application-identifier"
+    if profile_app_identifier_key not in profile_entitlements:
+        profile_app_identifier_key = "application-identifier"
+    profile_app_identifier = string_value(
+        profile_entitlements, profile_app_identifier_key
+    )
+    if profile_app_identifier != app_identifier:
+        fail("provisioning profile application identifier does not match the signed app")
+
+    profile_team_id = string_value(
+        profile_entitlements, "com.apple.developer.team-identifier"
+    )
+    if profile_team_id != team_id:
+        fail("provisioning profile team identifier does not match the signed app")
+
+    profile_aps = profile_entitlements.get("com.apple.developer.aps-environment")
+    if profile_aps is None:
+        profile_aps = profile_entitlements.get("aps-environment")
+    if profile_aps != expected_aps:
+        fail(
+            f"provisioning profile APNs environment is {profile_aps!r}, "
+            f"expected {expected_aps!r}"
+        )
+
     profile_environments = string_list(profile_entitlements, environment_key)
     if expected_environment not in profile_environments:
         fail("provisioning profile does not permit the expected CloudKit environment")

--- a/scripts/verify_signed_cloud_entitlements.sh
+++ b/scripts/verify_signed_cloud_entitlements.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: $0 <app> <Development|Production> <bundle-id> <container-id> <development|production>" >&2
+  exit 2
+fi
+
+APP_PATH="$1"
+EXPECTED_ENVIRONMENT="$2"
+EXPECTED_BUNDLE_ID="$3"
+EXPECTED_CONTAINER="$4"
+EXPECTED_APS_ENVIRONMENT="$5"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "ERROR: app bundle not found: $APP_PATH" >&2
+  exit 1
+fi
+
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/muesli-cloud-entitlements.XXXXXX")"
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+ENTITLEMENTS_PLIST="$TEMP_DIR/entitlements.plist"
+if ! codesign -d --entitlements :- "$APP_PATH" > "$ENTITLEMENTS_PLIST" 2>/dev/null; then
+  echo "ERROR: unable to extract signed app entitlements" >&2
+  exit 1
+fi
+
+VALIDATOR_ARGS=(
+  --entitlements "$ENTITLEMENTS_PLIST"
+  --environment "$EXPECTED_ENVIRONMENT"
+  --bundle-id "$EXPECTED_BUNDLE_ID"
+  --container "$EXPECTED_CONTAINER"
+  --aps-environment "$EXPECTED_APS_ENVIRONMENT"
+)
+
+PROFILE="$APP_PATH/Contents/embedded.provisionprofile"
+if [[ -f "$PROFILE" ]]; then
+  PROFILE_PLIST="$TEMP_DIR/profile.plist"
+  if ! security cms -D -i "$PROFILE" > "$PROFILE_PLIST" 2>/dev/null; then
+    if ! openssl smime -inform der -verify -noverify -in "$PROFILE" -out "$PROFILE_PLIST" >/dev/null 2>&1; then
+      echo "ERROR: unable to decode embedded provisioning profile" >&2
+      exit 1
+    fi
+  fi
+  VALIDATOR_ARGS+=(--profile "$PROFILE_PLIST")
+fi
+
+python3 "$ROOT/scripts/verify_cloud_entitlements.py" "${VALIDATOR_ARGS[@]}"


### PR DESCRIPTION
## Summary
- explicitly sign stable and pre-production macOS builds for the Production CloudKit environment
- safely migrate the affected 0.8.2 unspecified CKSyncEngine namespace only when the hashed private-account scope exactly matches
- fail closed at runtime when a CloudKit environment entitlement is absent
- verify signature, CloudKit, container, APNs, bundle, team, and embedded-profile contracts before publication
- require stable publication from the merged origin/main and include 0.8.3 release notes

## Privacy and migration safety
- compares only SHA-256 account scopes; no raw CloudKit user identifiers or authored content are logged
- mismatched accounts remain blocked and local data is untouched
- matching records retain text, timestamps, and stable IDs while ambiguous CloudKit version metadata is cleared and the durable outbox is requeued
- audio remains local

## Verification
- full Swift suite: 1,748 tests across 161 suites passed
- focused MuesliCKSyncEngineTests: 34/34 passed
- entitlement validator fixtures and release-contract assertions passed
- signed isolated 0.8.3 candidate passed codesign --verify --deep --strict and exact Production CloudKit/profile validation
- current installed app, application data, and TCC permissions were not modified

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789632162&installation_model_id=422865&pr_number=430&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F430&signature=aab4e5e2b2a02d4768ad8fff27efc15b00290f4e332aeee081ba037717069272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified dictation and meeting timeline.
  * Apple Speech support on macOS 26.
  * Meeting participants from Calendar and Contacts.
  * Expanded command-line capabilities.
  * Restored and improved iCloud synchronization.
  * Added macOS shortcuts and presentation improvements.

* **Bug Fixes**
  * Improved recording and transcription reliability.
  * More resilient model setup.
  * Smoother migration for existing iCloud sync data.

* **Documentation**
  * Added Muesli 0.8.3 release notes.
  * Updated Apple silicon and macOS compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->