### PR TITLE
Restore clipboard behavior and safely publish 0.8.3

### DIFF
--- a/docs/release-notes/0.8.3.md
+++ b/docs/release-notes/0.8.3.md
@@ -39,6 +39,7 @@ Muesli 0.8.3 brings dictations and meetings into one local timeline, adds Apple'
 - Dictation becomes available after a stopped meeting finishes audio transcription and cleanup, while title generation or summarization continues in the background.
 - Meeting microphone capture can recover from degraded or changing input routes, and system-audio capture now detects stalled taps more reliably.
 - Dictation drains the final audio buffer before transcription to reduce missing last words.
+- Dictation once again restores your previous clipboard shortly after pasting, while preserving anything newer you copy and keeping app attribution outside the paste-critical path.
 - iCloud text sync now uses Apple's durable sync engine while preserving Muesli's local outbox, improving recovery from interrupted syncs, account changes, and large pending histories.
 - The floating recording indicator has more predictable drag behavior across displays and appearance settings.
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -22,6 +22,11 @@ private enum DictationOutputMode {
     }
 }
 
+private struct DictationLatencyTraceToken: Sendable {
+    let id: UUID
+    let startedAt: Date
+}
+
 enum DictationBackendReadiness: Equatable {
     case preparing
     case ready
@@ -8268,13 +8273,29 @@ final class MuesliController: NSObject {
     }
 
     private func markDictationLatency(_ event: String, at date: Date) {
-        guard let traceID = dictationLatencyTraceID,
-              let startedAt = dictationLatencyTraceStartedAt else { return }
-        let elapsedMS = Int(date.timeIntervalSince(startedAt) * 1000)
+        guard let trace = currentDictationLatencyTrace else { return }
+        markDictationLatency(event, at: date, trace: trace)
+    }
+
+    private var currentDictationLatencyTrace: DictationLatencyTraceToken? {
+        guard let id = dictationLatencyTraceID,
+              let startedAt = dictationLatencyTraceStartedAt else { return nil }
+        return DictationLatencyTraceToken(id: id, startedAt: startedAt)
+    }
+
+    private func markDictationLatency(
+        _ event: String,
+        at date: Date = Date(),
+        trace: DictationLatencyTraceToken?
+    ) {
+        guard let trace else { return }
+        let elapsedMS = max(Int(date.timeIntervalSince(trace.startedAt) * 1000), 0)
         let timestamp = dictationLatencyTimestampFormatter.string(from: date)
         let routeKind = dictationAudioRoutingController.currentOutputRouteKindForDebug()
-        let routeDescription = dictationAudioRoutingController.currentRouteDebugDescription()
-        let line = "[dictation-latency] ts=\(timestamp) id=\(traceID.uuidString) event=\(event) elapsed_ms=\(elapsedMS) profile=\(dictationLatencyProfile(routeKind: routeKind)) \(routeDescription)"
+        // Keep the timing suffix content-free: never persist transcript, clipboard,
+        // application, account, or route-device identity. New completion events are
+        // represented by fixed PasteController.LifecycleEvent categories.
+        let line = "[dictation-latency] ts=\(timestamp) id=\(trace.id.uuidString) event=\(event) elapsed_ms=\(elapsedMS) profile=\(dictationLatencyProfile(routeKind: routeKind))"
         fputs("\(line)\n", stderr)
         appendDictationLatencyLog(line)
     }
@@ -8295,7 +8316,15 @@ final class MuesliController: NSObject {
     }
 
     private func finishDictationLatencyTrace(_ event: String) {
-        markDictationLatency(event)
+        finishDictationLatencyTrace(event, trace: currentDictationLatencyTrace)
+    }
+
+    private func finishDictationLatencyTrace(
+        _ event: String,
+        trace: DictationLatencyTraceToken?
+    ) {
+        markDictationLatency(event, trace: trace)
+        guard dictationLatencyTraceID == trace?.id else { return }
         dictationLatencyTraceID = nil
         dictationLatencyTraceStartedAt = nil
     }
@@ -8946,7 +8975,9 @@ final class MuesliController: NSObject {
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
 
-    private func completeStandardDictation(
+    /// Commits the transcript and releases the user-visible dictation state. Keep this path
+    /// bounded: it runs immediately after Cmd+V and must return before clipboard restoration.
+    private func commitStandardDictation(
         text: String,
         duration: TimeInterval,
         appContext: String,
@@ -8965,9 +8996,29 @@ final class MuesliController: NSObject {
         )
         scheduleICloudSyncAfterLocalChange()
         clearCapturedDictationSessionContext()
+        resetDictationOutputMode()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
+    }
+
+    /// Runs only once the pasteboard has either been restored or superseded by a newer copy.
+    /// The dashboard queries and optional Accessibility monitor cannot lengthen transcript
+    /// ownership of the clipboard or the visible Transcribing state.
+    private func finishStandardDictationBookkeeping(
+        text: String,
+        appContext: String,
+        outputMode: DictationOutputMode,
+        targetApp: DictationCorrectionTargetApp?,
+        backend: String
+    ) {
         statusBarController?.refresh()
-        historyWindowController?.reload()
-        syncAppState()
+        if let historyWindowController {
+            // reload() already calls syncAppState(); do not repeat the full query set.
+            historyWindowController.reload()
+        } else {
+            syncAppState()
+        }
         if outputMode == .paste, config.enableDictionaryCorrectionPrompts {
             // Dictionary correction prompts are an explicit opt-in
             // screen-context feature: they briefly read focused app
@@ -8981,12 +9032,8 @@ final class MuesliController: NSObject {
                 self?.addDictionarySuggestion(suggestion)
             }
         }
-        resetDictationOutputMode()
-        setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
-        syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
         TelemetryDeck.signal("dictation.completed", parameters: [
-            "backend": selectedBackend.backend,
+            "backend": backend,
             "paste_method": outputMode.pasteMethod,
         ])
     }
@@ -9020,7 +9067,8 @@ final class MuesliController: NSObject {
         }
 
         setState(.transcribing)
-        finishDictationLatencyTrace("ready_for_transcription")
+        markDictationLatency("ready_for_transcription")
+        let completionLatencyTrace = currentDictationLatencyTrace
         syncDictationRecorderWarmup(intent: .postDictation(.dictationStop))
         let isTestMode = isDictationTestMode
         let outputMode = currentDictationOutputMode
@@ -9058,6 +9106,9 @@ final class MuesliController: NSObject {
                 // Drop result if test was cancelled (user navigated away)
                 try Task.checkCancellation()
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                await MainActor.run {
+                    self.markDictationLatency("transcription_completed", trace: completionLatencyTrace)
+                }
 
                 // Test mode: route result to callback, skip history/paste
                 if isTestMode {
@@ -9068,6 +9119,7 @@ final class MuesliController: NSObject {
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
                         self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
+                        self.finishDictationLatencyTrace("test_completed", trace: completionLatencyTrace)
                     }
                     return
                 }
@@ -9082,18 +9134,21 @@ final class MuesliController: NSObject {
                         self.setState(.idle)
                         self.meetingMonitor.resumeAfterCooldown()
                         self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
+                        self.finishDictationLatencyTrace("empty_transcription", trace: completionLatencyTrace)
                     }
                     return
                 }
                 await MainActor.run {
                     if outputMode == .paste {
+                        var completionTargetApp: DictationCorrectionTargetApp?
                         PasteController.paste(
                             text: text,
                             requireStagedClipboardOwnership: true,
                             onPasteFinished: { [weak self] targetApplication in
                                 guard let self else { return }
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)
-                                self.completeStandardDictation(
+                                completionTargetApp = targetApp
+                                self.commitStandardDictation(
                                     text: text,
                                     duration: duration,
                                     appContext: storageContext,
@@ -9101,16 +9156,52 @@ final class MuesliController: NSObject {
                                     outputMode: outputMode,
                                     targetApp: targetApp
                                 )
+                                self.markDictationLatency(
+                                    "user_visible_completion",
+                                    trace: completionLatencyTrace
+                                )
+                            },
+                            onClipboardSettled: { [weak self] in
+                                guard let self else { return }
+                                self.finishStandardDictationBookkeeping(
+                                    text: text,
+                                    appContext: storageContext,
+                                    outputMode: outputMode,
+                                    targetApp: completionTargetApp,
+                                    backend: transcriptionBackend.backend
+                                )
+                                self.finishDictationLatencyTrace(
+                                    "bookkeeping_completed",
+                                    trace: completionLatencyTrace
+                                )
+                            },
+                            onLifecycleEvent: { [weak self] event in
+                                self?.markDictationLatency(
+                                    "paste_\(event.rawValue)",
+                                    trace: completionLatencyTrace
+                                )
                             }
                         )
                     } else {
-                        self.completeStandardDictation(
+                        self.commitStandardDictation(
                             text: text,
                             duration: duration,
                             appContext: storageContext,
                             startedAt: startedAt,
                             outputMode: outputMode,
                             targetApp: nil
+                        )
+                        self.markDictationLatency("user_visible_completion", trace: completionLatencyTrace)
+                        self.finishStandardDictationBookkeeping(
+                            text: text,
+                            appContext: storageContext,
+                            outputMode: outputMode,
+                            targetApp: nil,
+                            backend: transcriptionBackend.backend
+                        )
+                        self.finishDictationLatencyTrace(
+                            "bookkeeping_completed",
+                            trace: completionLatencyTrace
                         )
                     }
                 }
@@ -9122,6 +9213,7 @@ final class MuesliController: NSObject {
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionCancelled))
+                    self.finishDictationLatencyTrace("transcription_cancelled", trace: completionLatencyTrace)
                 }
             } catch {
                 fputs("[muesli-native] transcription failed: \(error)\n", stderr)
@@ -9141,6 +9233,7 @@ final class MuesliController: NSObject {
                     self.setState(.idle)
                     self.meetingMonitor.resumeAfterCooldown()
                     self.syncDictationRecorderWarmup(intent: .postDictation(.transcriptionFailed))
+                    self.finishDictationLatencyTrace("transcription_failed", trace: completionLatencyTrace)
                 }
             }
         }

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8986,8 +8986,8 @@ final class MuesliController: NSObject {
     }
 
     /// For paste output, runs only once the pasteboard has either been restored or superseded
-    /// by a newer copy. The dashboard queries and optional Accessibility monitor cannot lengthen
-    /// transcript ownership of the clipboard or the visible Transcribing state.
+    /// by a newer copy. Persistence and dashboard queries therefore cannot lengthen transcript
+    /// ownership of the clipboard or the visible Transcribing state.
     private func finishStandardDictationBookkeeping(
         text: String,
         duration: TimeInterval,
@@ -9013,19 +9013,6 @@ final class MuesliController: NSObject {
             historyWindowController.reload()
         } else {
             syncAppState()
-        }
-        if outputMode == .paste, config.enableDictionaryCorrectionPrompts {
-            // Dictionary correction prompts are an explicit opt-in
-            // screen-context feature: they briefly read focused app
-            // text via Accessibility after dictation, then stop when
-            // the bounded edit monitor session ends.
-            dictationCorrectionMonitor.start(
-                originalText: text,
-                appContext: appContext,
-                targetApp: targetApp
-            ) { [weak self] suggestion in
-                self?.addDictionarySuggestion(suggestion)
-            }
         }
         TelemetryDeck.signal("dictation.completed", parameters: [
             "backend": backend,
@@ -9144,6 +9131,18 @@ final class MuesliController: NSObject {
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)
                                 completionTargetApp = targetApp
                                 self.releaseStandardDictationState()
+                                if self.config.enableDictionaryCorrectionPrompts {
+                                    // This opt-in monitor only schedules its first Accessibility
+                                    // poll after 100 ms, so starting it here captures immediate
+                                    // edits without blocking the clipboard restoration timer.
+                                    self.dictationCorrectionMonitor.start(
+                                        originalText: text,
+                                        appContext: storageContext,
+                                        targetApp: targetApp
+                                    ) { [weak self] suggestion in
+                                        self?.addDictionarySuggestion(suggestion)
+                                    }
+                                }
                                 self.markDictationLatency(
                                     "user_visible_completion",
                                     trace: completionLatencyTrace

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -8975,15 +8975,27 @@ final class MuesliController: NSObject {
         syncDictationRecorderWarmup(intent: .idlePrewarm(.backendRecovery))
     }
 
-    /// Commits the transcript and releases the user-visible dictation state. Keep this path
-    /// bounded: it runs immediately after Cmd+V and must return before clipboard restoration.
-    private func commitStandardDictation(
+    /// Releases the user-visible dictation state immediately after Cmd+V. Keep this path
+    /// bounded so the main actor remains available for clipboard restoration.
+    private func releaseStandardDictationState() {
+        clearCapturedDictationSessionContext()
+        resetDictationOutputMode()
+        setState(.idle)
+        meetingMonitor.resumeAfterCooldown()
+        syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
+    }
+
+    /// For paste output, runs only once the pasteboard has either been restored or superseded
+    /// by a newer copy. The dashboard queries and optional Accessibility monitor cannot lengthen
+    /// transcript ownership of the clipboard or the visible Transcribing state.
+    private func finishStandardDictationBookkeeping(
         text: String,
         duration: TimeInterval,
         appContext: String,
         startedAt: Date,
         outputMode: DictationOutputMode,
-        targetApp: DictationCorrectionTargetApp?
+        targetApp: DictationCorrectionTargetApp?,
+        backend: String
     ) {
         _ = try? dictationStore.insertDictation(
             text: text,
@@ -8995,23 +9007,6 @@ final class MuesliController: NSObject {
             endedAt: Date()
         )
         scheduleICloudSyncAfterLocalChange()
-        clearCapturedDictationSessionContext()
-        resetDictationOutputMode()
-        setState(.idle)
-        meetingMonitor.resumeAfterCooldown()
-        syncDictationRecorderWarmup(intent: .postDictation(.transcriptionComplete))
-    }
-
-    /// Runs only once the pasteboard has either been restored or superseded by a newer copy.
-    /// The dashboard queries and optional Accessibility monitor cannot lengthen transcript
-    /// ownership of the clipboard or the visible Transcribing state.
-    private func finishStandardDictationBookkeeping(
-        text: String,
-        appContext: String,
-        outputMode: DictationOutputMode,
-        targetApp: DictationCorrectionTargetApp?,
-        backend: String
-    ) {
         statusBarController?.refresh()
         if let historyWindowController {
             // reload() already calls syncAppState(); do not repeat the full query set.
@@ -9148,14 +9143,7 @@ final class MuesliController: NSObject {
                                 guard let self else { return }
                                 let targetApp = self.externalDictationTargetApp(from: targetApplication)
                                 completionTargetApp = targetApp
-                                self.commitStandardDictation(
-                                    text: text,
-                                    duration: duration,
-                                    appContext: storageContext,
-                                    startedAt: startedAt,
-                                    outputMode: outputMode,
-                                    targetApp: targetApp
-                                )
+                                self.releaseStandardDictationState()
                                 self.markDictationLatency(
                                     "user_visible_completion",
                                     trace: completionLatencyTrace
@@ -9165,7 +9153,9 @@ final class MuesliController: NSObject {
                                 guard let self else { return }
                                 self.finishStandardDictationBookkeeping(
                                     text: text,
+                                    duration: duration,
                                     appContext: storageContext,
+                                    startedAt: startedAt,
                                     outputMode: outputMode,
                                     targetApp: completionTargetApp,
                                     backend: transcriptionBackend.backend
@@ -9183,18 +9173,13 @@ final class MuesliController: NSObject {
                             }
                         )
                     } else {
-                        self.commitStandardDictation(
+                        self.releaseStandardDictationState()
+                        self.markDictationLatency("user_visible_completion", trace: completionLatencyTrace)
+                        self.finishStandardDictationBookkeeping(
                             text: text,
                             duration: duration,
                             appContext: storageContext,
                             startedAt: startedAt,
-                            outputMode: outputMode,
-                            targetApp: nil
-                        )
-                        self.markDictationLatency("user_visible_completion", trace: completionLatencyTrace)
-                        self.finishStandardDictationBookkeeping(
-                            text: text,
-                            appContext: storageContext,
                             outputMode: outputMode,
                             targetApp: nil,
                             backend: transcriptionBackend.backend

--- a/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/PasteController.swift
@@ -4,6 +4,18 @@ import Foundation
 import MuesliCore
 
 enum PasteController {
+    enum LifecycleEvent: String, CaseIterable, Sendable {
+        case clipboardStaged = "clipboard_staged"
+        case clipboardStageFailed = "clipboard_stage_failed"
+        case targetSnapshotted = "target_snapshotted"
+        case pasteDispatched = "paste_dispatched"
+        case pasteDispatchFailed = "paste_dispatch_failed"
+        case clipboardOwnershipLost = "clipboard_ownership_lost"
+        case clipboardRestoreScheduled = "clipboard_restore_scheduled"
+        case clipboardRestored = "clipboard_restored"
+        case clipboardRestoreSkipped = "clipboard_restore_skipped"
+    }
+
     /// How long to wait after simulating Cmd+V before restoring the clipboard.
     /// The receiving app must have consumed the paste data within this window.
     private static let clipboardRestoreDelay: TimeInterval = 0.5
@@ -41,6 +53,7 @@ enum PasteController {
     /// For nonempty text, completion receives the target app only when the keyboard events
     /// were posted. When staged-clipboard ownership is required, a failed write or intervening
     /// clipboard change also completes with `nil` attribution and skips Cmd+V.
+    @MainActor
     static func paste(
         text: String,
         pasteboard: NSPasteboard = .general,
@@ -49,7 +62,9 @@ enum PasteController {
             NSWorkspace.shared.frontmostApplication
         },
         simulatePasteAction: @escaping @MainActor () -> Bool = PasteController.simulatePaste,
-        onPasteFinished: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in }
+        onPasteFinished: @escaping @MainActor (NSRunningApplication?) -> Void = { _ in },
+        onClipboardSettled: @escaping @MainActor () -> Void = {},
+        onLifecycleEvent: @escaping @MainActor (LifecycleEvent) -> Void = { _ in }
     ) {
         guard !text.isEmpty else { return }
 
@@ -59,34 +74,52 @@ enum PasteController {
         let clearedChangeCount = pasteboard.clearContents()
         let didStageText = pasteboard.setString(text, forType: .string)
         let pasteChangeCount = pasteboard.changeCount
+        onLifecycleEvent(didStageText ? .clipboardStaged : .clipboardStageFailed)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             // Snapshot immediately before Cmd+V so attribution and the paste event
             // refer to the same frontmost application.
             let targetApplication = targetApplicationProvider()
+            onLifecycleEvent(.targetSnapshotted)
             if requireStagedClipboardOwnership {
                 guard didStageText else {
                     // Restore only when Muesli still owns the cleared pasteboard. If another
                     // app wrote to it, preserving that newer content takes precedence.
                     if pasteboard.changeCount == clearedChangeCount {
                         restoreClipboard(pasteboard, from: savedItems)
+                        onLifecycleEvent(.clipboardRestored)
+                    } else {
+                        onLifecycleEvent(.clipboardRestoreSkipped)
                     }
                     onPasteFinished(nil)
+                    onClipboardSettled()
                     return
                 }
                 guard pasteboard.changeCount == pasteChangeCount else {
+                    onLifecycleEvent(.clipboardOwnershipLost)
                     onPasteFinished(nil)
+                    onClipboardSettled()
                     return
                 }
             }
             let didDispatchPaste = simulatePasteAction()
-            onPasteFinished(didDispatchPaste ? targetApplication : nil)
+            onLifecycleEvent(didDispatchPaste ? .pasteDispatched : .pasteDispatchFailed)
 
-            // Restore the original clipboard contents after the receiving app has consumed the paste.
+            // Arm restoration before completion bookkeeping. The dictation completion callback
+            // persists attribution and refreshes UI; neither is allowed to extend how long the
+            // transcript owns the user's clipboard.
+            onLifecycleEvent(.clipboardRestoreScheduled)
             DispatchQueue.main.asyncAfter(deadline: .now() + clipboardRestoreDelay) {
-                guard pasteboard.changeCount == pasteChangeCount else { return }
-                restoreClipboard(pasteboard, from: savedItems)
+                if pasteboard.changeCount == pasteChangeCount {
+                    restoreClipboard(pasteboard, from: savedItems)
+                    onLifecycleEvent(.clipboardRestored)
+                } else {
+                    onLifecycleEvent(.clipboardRestoreSkipped)
+                }
+                onClipboardSettled()
             }
+
+            onPasteFinished(didDispatchPaste ? targetApplication : nil)
         }
     }
 

--- a/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/PasteControllerTests.swift
@@ -4,6 +4,7 @@ import AppKit
 
 // .serialized: some tests still post keyboard events into the active session.
 @Suite("PasteController — clipboard-preserving paste and keystroke simulation", .serialized)
+@MainActor
 struct PasteControllerTests {
 
     private let clipboardPollInterval: TimeInterval = 0.05
@@ -118,6 +119,59 @@ struct PasteControllerTests {
         #expect(result.0 == ["snapshot", "command", "callback"])
         #expect(result.1 == expectedApplication.processIdentifier)
         _ = await waitForClipboardString(in: pasteboard, expected: nil)
+    }
+
+    @Test("paste arms restoration before completion bookkeeping and settles afterward")
+    func pasteRestorationOwnsCriticalPath() async {
+        let pasteboard = makePasteboard()
+        pasteboard.clearContents()
+        pasteboard.setString("original", forType: .string)
+
+        let events = await withCheckedContinuation { continuation in
+            var events: [String] = []
+            PasteController.paste(
+                text: "dictated text",
+                pasteboard: pasteboard,
+                targetApplicationProvider: { nil },
+                simulatePasteAction: { true },
+                onPasteFinished: { _ in
+                    events.append("completion_bookkeeping")
+                },
+                onClipboardSettled: {
+                    events.append("clipboard_settled")
+                    continuation.resume(returning: events)
+                },
+                onLifecycleEvent: { event in
+                    events.append(event.rawValue)
+                }
+            )
+        }
+
+        #expect(events == [
+            "clipboard_staged",
+            "target_snapshotted",
+            "paste_dispatched",
+            "clipboard_restore_scheduled",
+            "completion_bookkeeping",
+            "clipboard_restored",
+            "clipboard_settled",
+        ])
+        #expect(pasteboard.string(forType: .string) == "original")
+    }
+
+    @Test("paste lifecycle diagnostics expose only fixed content-free categories")
+    func lifecycleDiagnosticsAreContentFree() {
+        #expect(PasteController.LifecycleEvent.allCases.map(\.rawValue) == [
+            "clipboard_staged",
+            "clipboard_stage_failed",
+            "target_snapshotted",
+            "paste_dispatched",
+            "paste_dispatch_failed",
+            "clipboard_ownership_lost",
+            "clipboard_restore_scheduled",
+            "clipboard_restored",
+            "clipboard_restore_skipped",
+        ])
     }
 
     @Test("dictation paste skips Cmd+V and attribution after clipboard ownership changes")

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -192,6 +192,12 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   ```
 
 - [ ] **Open the release-metadata PR while the GitHub Release remains a draft.**
+
+  If the final GitHub publication call fails after this point, rerun the same
+  `release.sh X.Y.Z` command from exact `origin/main`. The pipeline recognizes
+  the existing versioned metadata branch and open PR, revalidates the hosted
+  notarized artifact, Production CloudKit entitlements, and appcast, then safely
+  resumes publication without recreating release metadata.
   - If appcast generation, release-note injection, validation, commit, push, or PR creation fails, stop and leave the GitHub Release as a draft.
 
 - [ ] **Publish the verified draft release only after the metadata PR exists.**

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -151,8 +151,6 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   - The local and hosted SHA256 hashes must match exactly
   - Must show `accepted` and `The validate action worked!`
 
-- [ ] **Publish the verified draft release**
-
 ## Appcast & Docs
 
 - [ ] **Generate the new release item without replacing appcast history:**
@@ -184,12 +182,17 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
   scripts/verify_update_flow.sh --version X.Y.Z --dmg dist-release/Muesli-X.Y.Z.dmg --require-notarized
   ```
 
-- [ ] **Push appcast + download link:**
+- [ ] **Push the appcast + download-link metadata branch:**
   ```bash
   git add docs/appcast.xml docs/index.html
   git commit -m "Update appcast for vX.Y.Z"
   git push
   ```
+
+- [ ] **Open the release-metadata PR while the GitHub Release remains a draft.**
+  - If appcast generation, release-note injection, validation, commit, push, or PR creation fails, stop and leave the GitHub Release as a draft.
+
+- [ ] **Publish the verified draft release only after the metadata PR exists.**
 
 ## Homebrew Cask
 

--- a/scripts/RELEASE_CHECKLIST.md
+++ b/scripts/RELEASE_CHECKLIST.md
@@ -184,9 +184,11 @@ If launch fails with `No matching profile found`, the embedded profile, bundle I
 
 - [ ] **Push the appcast + download-link metadata branch:**
   ```bash
+  git switch -c codex/release-X.Y.Z-appcast
   git add docs/appcast.xml docs/index.html
+  git add docs/llms.txt
   git commit -m "Update appcast for vX.Y.Z"
-  git push
+  git push -u origin codex/release-X.Y.Z-appcast
   ```
 
 - [ ] **Open the release-metadata PR while the GitHub Release remains a draft.**

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -220,14 +220,6 @@ verify_homebrew_autobump() {
 }
 
 resume_existing_release_publication() {
-  if ! git ls-remote --exit-code --heads origin "$RELEASE_METADATA_BRANCH" >/dev/null 2>&1; then
-    if git show-ref --verify --quiet "refs/heads/${RELEASE_METADATA_BRANCH}"; then
-      echo "ERROR: Local release metadata branch exists without its remote counterpart: $RELEASE_METADATA_BRANCH" >&2
-      exit 1
-    fi
-    return 1
-  fi
-
   echo "Existing release metadata branch found; validating the hosted release before resuming publication."
   git fetch origin \
     "refs/heads/${RELEASE_METADATA_BRANCH}:refs/remotes/origin/${RELEASE_METADATA_BRANCH}" \
@@ -241,17 +233,19 @@ resume_existing_release_publication() {
     --state open \
     --json url \
     --jq 'length')
-  if [[ "$metadata_pr_count" != "1" ]]; then
-    echo "ERROR: Expected exactly one open metadata PR for $RELEASE_METADATA_BRANCH; found $metadata_pr_count." >&2
+  if [[ "$metadata_pr_count" != "0" && "$metadata_pr_count" != "1" ]]; then
+    echo "ERROR: Expected zero or one open metadata PR for $RELEASE_METADATA_BRANCH; found $metadata_pr_count." >&2
     exit 1
   fi
-  RELEASE_METADATA_PR_URL=$(gh pr list \
-    --repo Muesli-HQ/muesli \
-    --base main \
-    --head "$RELEASE_METADATA_BRANCH" \
-    --state open \
-    --json url \
-    --jq '.[0].url')
+  if [[ "$metadata_pr_count" == "1" ]]; then
+    RELEASE_METADATA_PR_URL=$(gh pr list \
+      --repo Muesli-HQ/muesli \
+      --base main \
+      --head "$RELEASE_METADATA_BRANCH" \
+      --state open \
+      --json url \
+      --jq '.[0].url')
+  fi
 
   local release_is_draft
   release_is_draft=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null || true)
@@ -279,26 +273,42 @@ resume_existing_release_publication() {
     fi
   done
 
-  "$ROOT/scripts/verify_update_flow.sh" \
-    --version "$VERSION" \
-    --appcast "$metadata_appcast" \
-    --dmg "$hosted_dmg" \
-    --require-release-notes \
-    --require-notarized
+  if ! "$ROOT/scripts/verify_update_flow.sh" \
+      --version "$VERSION" \
+      --appcast "$metadata_appcast" \
+      --dmg "$hosted_dmg" \
+      --require-release-notes \
+      --require-notarized; then
+    echo "ERROR: Existing release metadata or hosted artifact failed update-flow validation." >&2
+    exit 1
+  fi
 
   HOSTED_MOUNT_POINT=$(hdiutil attach "$hosted_dmg" -nobrowse -readonly 2>&1 | awk -F'\t' '/\/Volumes\// {print $NF; exit}')
   if [[ -z "$HOSTED_MOUNT_POINT" ]]; then
     echo "ERROR: Could not mount hosted DMG while resuming $TAG." >&2
     exit 1
   fi
-  "$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
-    "$HOSTED_MOUNT_POINT/Muesli.app" \
-    Production \
-    com.muesli.app \
-    iCloud.com.mueslihq.muesli \
-    production
+  if ! "$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+      "$HOSTED_MOUNT_POINT/Muesli.app" \
+      Production \
+      com.muesli.app \
+      iCloud.com.mueslihq.muesli \
+      production; then
+    echo "ERROR: Existing hosted app failed Production CloudKit entitlement validation." >&2
+    exit 1
+  fi
   hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
   HOSTED_MOUNT_POINT=""
+
+  if [[ "$metadata_pr_count" == "0" ]]; then
+    RELEASE_METADATA_PR_URL=$(gh pr create \
+      --repo Muesli-HQ/muesli \
+      --base main \
+      --head "$RELEASE_METADATA_BRANCH" \
+      --title "Update release metadata for v${VERSION}" \
+      --body "Publishes the verified v${VERSION} Sparkle appcast entry and aligns the landing-page download metadata with the verified GitHub DMG. The GitHub release was kept as a draft through validation and creation of this PR; the public appcast remains unchanged until this PR is reviewed and merged.")
+    echo "  Recreated missing release metadata PR: $RELEASE_METADATA_PR_URL"
+  fi
 
   RELEASE_METADATA_VALIDATED=1
   muesli_require_release_publication_ready \
@@ -321,8 +331,17 @@ resume_existing_release_publication() {
   return 0
 }
 
-if resume_existing_release_publication; then
+if ! REMOTE_RELEASE_METADATA_REF=$(git ls-remote --heads origin "$RELEASE_METADATA_BRANCH"); then
+  echo "ERROR: Could not query remote release metadata branch $RELEASE_METADATA_BRANCH." >&2
+  exit 1
+fi
+if [[ -n "$REMOTE_RELEASE_METADATA_REF" ]]; then
+  resume_existing_release_publication
   exit 0
+fi
+if git show-ref --verify --quiet "refs/heads/${RELEASE_METADATA_BRANCH}"; then
+  echo "ERROR: Local release metadata branch exists without its remote counterpart: $RELEASE_METADATA_BRANCH" >&2
+  exit 1
 fi
 
 echo "=== Muesli Release v${VERSION} ==="

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,6 +36,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 source "$ROOT/scripts/muesli_spm_cache.sh"
 source "$ROOT/scripts/muesli_telemetry_channels.sh"
+source "$ROOT/scripts/release_publication_gate.sh"
 PACKAGE_DIR="$ROOT/native/MuesliNative"
 SWIFTPM_SCRATCH_PATH=""
 SWIFT_TEST_ARGS=(--package-path "$PACKAGE_DIR")
@@ -164,6 +165,7 @@ RELEASE_NOTES_FILE="${MUESLI_RELEASE_NOTES_FILE:-$DEFAULT_RELEASE_NOTES_FILE}"
 RELEASE_NOTES=""
 RELEASE_NOTES_FROM_FILE=0
 RELEASE_NOTES_ARGS=()
+RELEASE_METADATA_VALIDATED=0
 
 if [[ -n "${MUESLI_RELEASE_NOTES_FILE:-}" && ! -f "$RELEASE_NOTES_FILE" ]]; then
   echo "ERROR: release notes file not found: $RELEASE_NOTES_FILE" >&2
@@ -491,18 +493,8 @@ if ! echo "$HOSTED_APP_STAPLE_RESULT" | grep -q "worked"; then
   exit 1
 fi
 
-# --- Step 11: Publish the verified draft release ---
-echo "[11/13] Publishing verified GitHub release..."
-gh release edit "$TAG" \
-  --draft=false \
-  --title "$RELEASE_TITLE" \
-  "${RELEASE_NOTES_ARGS[@]}"
-
-RELEASE_URL=$(gh release view "$TAG" --json url -q .url)
-echo "  Release published: $RELEASE_URL"
-
-# --- Step 12: Open an appcast/landing metadata PR after release publication ---
-echo "[12/13] Preparing appcast and release metadata PR..."
+# --- Step 11: Validate appcast metadata and open its PR while release stays draft ---
+echo "[11/13] Preparing appcast and release metadata PR..."
 GENERATED_APPCAST="$VERIFY_DIR/generated-appcast.xml"
 "$GENERATE_APPCAST" "$OUTPUT_DIR" -o "$GENERATED_APPCAST"
 if [[ "$RELEASE_NOTES_FROM_FILE" == "1" ]]; then
@@ -534,6 +526,7 @@ echo "  Verifying Sparkle update flow metadata..."
   --dmg "$DMG_PATH" \
   --require-release-notes \
   --require-notarized
+RELEASE_METADATA_VALIDATED=1
 
 git add docs/appcast.xml docs/index.html docs/llms.txt
 if git diff --cached --quiet; then
@@ -547,9 +540,22 @@ else
     --base main \
     --head "$RELEASE_METADATA_BRANCH" \
     --title "Update release metadata for v${VERSION}" \
-    --body "Publishes the verified v${VERSION} Sparkle appcast entry and aligns the landing-page download metadata with the released GitHub DMG. The public appcast remains unchanged until this PR is reviewed and merged.")
+    --body "Publishes the verified v${VERSION} Sparkle appcast entry and aligns the landing-page download metadata with the verified GitHub DMG. The GitHub release was kept as a draft through validation and creation of this PR; the public appcast remains unchanged until this PR is reviewed and merged.")
   echo "  Release metadata PR: $RELEASE_METADATA_PR_URL"
 fi
+
+# --- Step 12: Publish only after appcast validation and metadata PR creation ---
+echo "[12/13] Publishing verified GitHub release..."
+muesli_require_release_publication_ready \
+  "$RELEASE_METADATA_VALIDATED" \
+  "${RELEASE_METADATA_PR_URL:-}"
+gh release edit "$TAG" \
+  --draft=false \
+  --title "$RELEASE_TITLE" \
+  "${RELEASE_NOTES_ARGS[@]}"
+
+RELEASE_URL=$(gh release view "$TAG" --json url -q .url)
+echo "  Release published: $RELEASE_URL"
 
 # --- Step 13: Verify the official Homebrew cask can see the new release ---
 echo "[13/13] Verifying official Homebrew cask livecheck..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -166,6 +166,7 @@ RELEASE_NOTES=""
 RELEASE_NOTES_FROM_FILE=0
 RELEASE_NOTES_ARGS=()
 RELEASE_METADATA_VALIDATED=0
+RELEASE_METADATA_PR_URL=""
 
 if [[ -n "${MUESLI_RELEASE_NOTES_FILE:-}" && ! -f "$RELEASE_NOTES_FILE" ]]; then
   echo "ERROR: release notes file not found: $RELEASE_NOTES_FILE" >&2
@@ -197,14 +198,6 @@ if ! git check-ref-format --branch "$RELEASE_METADATA_BRANCH" >/dev/null 2>&1; t
   echo "ERROR: Invalid release metadata branch: $RELEASE_METADATA_BRANCH" >&2
   exit 1
 fi
-if git show-ref --verify --quiet "refs/heads/${RELEASE_METADATA_BRANCH}"; then
-  echo "ERROR: Local release metadata branch already exists: $RELEASE_METADATA_BRANCH" >&2
-  exit 1
-fi
-if git ls-remote --exit-code --heads origin "$RELEASE_METADATA_BRANCH" >/dev/null 2>&1; then
-  echo "ERROR: Remote release metadata branch already exists: $RELEASE_METADATA_BRANCH" >&2
-  exit 1
-fi
 
 verify_homebrew_autobump() {
   if [[ "$SKIP_HOMEBREW_CHECK" == "1" ]]; then
@@ -225,6 +218,112 @@ verify_homebrew_autobump() {
   fi
   echo "  BrewTestBot should open ${HOMEBREW_CASK} version bump PRs automatically."
 }
+
+resume_existing_release_publication() {
+  if ! git ls-remote --exit-code --heads origin "$RELEASE_METADATA_BRANCH" >/dev/null 2>&1; then
+    if git show-ref --verify --quiet "refs/heads/${RELEASE_METADATA_BRANCH}"; then
+      echo "ERROR: Local release metadata branch exists without its remote counterpart: $RELEASE_METADATA_BRANCH" >&2
+      exit 1
+    fi
+    return 1
+  fi
+
+  echo "Existing release metadata branch found; validating the hosted release before resuming publication."
+  git fetch origin \
+    "refs/heads/${RELEASE_METADATA_BRANCH}:refs/remotes/origin/${RELEASE_METADATA_BRANCH}" \
+    --quiet
+
+  local metadata_pr_count
+  metadata_pr_count=$(gh pr list \
+    --repo Muesli-HQ/muesli \
+    --base main \
+    --head "$RELEASE_METADATA_BRANCH" \
+    --state open \
+    --json url \
+    --jq 'length')
+  if [[ "$metadata_pr_count" != "1" ]]; then
+    echo "ERROR: Expected exactly one open metadata PR for $RELEASE_METADATA_BRANCH; found $metadata_pr_count." >&2
+    exit 1
+  fi
+  RELEASE_METADATA_PR_URL=$(gh pr list \
+    --repo Muesli-HQ/muesli \
+    --base main \
+    --head "$RELEASE_METADATA_BRANCH" \
+    --state open \
+    --json url \
+    --jq '.[0].url')
+
+  local release_is_draft
+  release_is_draft=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null || true)
+  if [[ "$release_is_draft" != "true" && "$release_is_draft" != "false" ]]; then
+    echo "ERROR: Metadata exists, but GitHub release $TAG could not be found." >&2
+    exit 1
+  fi
+
+  VERIFY_DIR=$(mktemp -d)
+  local hosted_dmg="$VERIFY_DIR/Muesli-${VERSION}.dmg"
+  local metadata_appcast="$VERIFY_DIR/appcast.xml"
+  gh release download "$TAG" \
+    -p "Muesli-${VERSION}.dmg" \
+    -D "$VERIFY_DIR" \
+    --clobber >/dev/null
+  git show "origin/${RELEASE_METADATA_BRANCH}:docs/appcast.xml" > "$metadata_appcast"
+
+  local metadata_file
+  for metadata_file in docs/index.html docs/llms.txt; do
+    local metadata_surface="$VERIFY_DIR/$(basename "$metadata_file")"
+    git show "origin/${RELEASE_METADATA_BRANCH}:${metadata_file}" > "$metadata_surface"
+    if ! grep -Fq "$DOWNLOAD_URL" "$metadata_surface"; then
+      echo "ERROR: $metadata_file on $RELEASE_METADATA_BRANCH does not reference $DOWNLOAD_URL." >&2
+      exit 1
+    fi
+  done
+
+  "$ROOT/scripts/verify_update_flow.sh" \
+    --version "$VERSION" \
+    --appcast "$metadata_appcast" \
+    --dmg "$hosted_dmg" \
+    --require-release-notes \
+    --require-notarized
+
+  HOSTED_MOUNT_POINT=$(hdiutil attach "$hosted_dmg" -nobrowse -readonly 2>&1 | awk -F'\t' '/\/Volumes\// {print $NF; exit}')
+  if [[ -z "$HOSTED_MOUNT_POINT" ]]; then
+    echo "ERROR: Could not mount hosted DMG while resuming $TAG." >&2
+    exit 1
+  fi
+  "$ROOT/scripts/verify_signed_cloud_entitlements.sh" \
+    "$HOSTED_MOUNT_POINT/Muesli.app" \
+    Production \
+    com.muesli.app \
+    iCloud.com.mueslihq.muesli \
+    production
+  hdiutil detach "$HOSTED_MOUNT_POINT" -quiet 2>/dev/null
+  HOSTED_MOUNT_POINT=""
+
+  RELEASE_METADATA_VALIDATED=1
+  muesli_require_release_publication_ready \
+    "$RELEASE_METADATA_VALIDATED" \
+    "$RELEASE_METADATA_PR_URL"
+  if [[ "$release_is_draft" == "true" ]]; then
+    gh release edit "$TAG" \
+      --draft=false \
+      --title "$RELEASE_TITLE" \
+      "${RELEASE_NOTES_ARGS[@]}"
+    echo "  Resumed and published verified GitHub release $TAG."
+  else
+    echo "  GitHub release $TAG is already public; hosted artifact and metadata were revalidated."
+  fi
+
+  RELEASE_URL=$(gh release view "$TAG" --json url -q .url)
+  verify_homebrew_autobump
+  echo "  Release: $RELEASE_URL"
+  echo "  Production appcast publication is pending merge of $RELEASE_METADATA_PR_URL."
+  return 0
+}
+
+if resume_existing_release_publication; then
+  exit 0
+fi
 
 echo "=== Muesli Release v${VERSION} ==="
 echo ""

--- a/scripts/release_publication_gate.sh
+++ b/scripts/release_publication_gate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Keep the public GitHub transition behind both release-metadata gates. This is
+# deliberately a small sourceable function so CI can prove a failed appcast
+# validation never reaches publication without exercising signing/notarization.
+muesli_require_release_publication_ready() {
+  local metadata_validated="${1:-0}"
+  local metadata_pr_url="${2:-}"
+
+  if [[ "$metadata_validated" != "1" ]]; then
+    echo "ERROR: Release metadata validation did not complete; keeping the GitHub Release as a draft." >&2
+    return 1
+  fi
+  if [[ -z "$metadata_pr_url" ]]; then
+    echo "ERROR: Release metadata PR was not created; keeping the GitHub Release as a draft." >&2
+    return 1
+  fi
+}

--- a/scripts/test_verify_cloud_entitlements.py
+++ b/scripts/test_verify_cloud_entitlements.py
@@ -133,6 +133,16 @@ assert "gh release edit" not in metadata_section
 assert "gh release edit" in publication_section
 assert "muesli_require_release_publication_ready" in publication_section
 assert "RELEASE_METADATA_PR_URL" in publication_section
+assert "resume_existing_release_publication()" in stable_release
+assert "Existing release metadata branch found" in stable_release
+assert "Expected exactly one open metadata PR" in stable_release
+assert '--appcast "$metadata_appcast"' in stable_release
+assert '"$ROOT/scripts/verify_signed_cloud_entitlements.sh"' in stable_release
+assert "resume_existing_release_publication" in stable_release.split(
+    '# --- Step 0: Update version in build script ---',
+    maxsplit=1,
+)[0]
+assert "Remote release metadata branch already exists" not in stable_release
 
 ordered_release_gates = (
     '"$GENERATE_APPCAST"',

--- a/scripts/test_verify_cloud_entitlements.py
+++ b/scripts/test_verify_cloud_entitlements.py
@@ -110,13 +110,83 @@ assert stable_release.count("verify_signed_cloud_entitlements.sh") >= 2
 assert preprod_release.count("verify_signed_cloud_entitlements.sh") >= 2
 assert "CloudKit provisioning profiles require an explicit" in build_script
 
-metadata_section = stable_release.split(
-    "# --- Step 12: Open an appcast/landing metadata PR after release publication ---",
+metadata_marker = (
+    "# --- Step 11: Validate appcast metadata and open its PR while release stays draft ---"
+)
+publication_marker = (
+    "# --- Step 12: Publish only after appcast validation and metadata PR creation ---"
+)
+metadata_section = stable_release.split(metadata_marker, maxsplit=1)[1].split(
+    publication_marker,
     maxsplit=1,
-)[1].split("# --- Step 13:", maxsplit=1)[0]
+)[0]
+publication_section = stable_release.split(publication_marker, maxsplit=1)[1].split(
+    "# --- Step 13:",
+    maxsplit=1,
+)[0]
 assert 'RELEASE_METADATA_BRANCH="${MUESLI_RELEASE_METADATA_BRANCH:-codex/release-${VERSION}-appcast}"' in stable_release
 assert "gh pr create" in metadata_section
 assert "--base main" in metadata_section
 assert "git push origin main" not in metadata_section
+assert "verify_update_flow.sh" in metadata_section
+assert "gh release edit" not in metadata_section
+assert "gh release edit" in publication_section
+assert "muesli_require_release_publication_ready" in publication_section
+assert "RELEASE_METADATA_PR_URL" in publication_section
+
+ordered_release_gates = (
+    '"$GENERATE_APPCAST"',
+    'python3 "$UPDATE_APPCAST_RELEASE_NOTES"',
+    'python3 "$MERGE_APPCAST_ITEM"',
+    '"$ROOT/scripts/verify_update_flow.sh"',
+    "git commit --signoff",
+    "git push -u origin",
+    "gh pr create",
+    "gh release edit",
+)
+release_finalization = metadata_section + publication_section
+gate_offsets = [release_finalization.index(gate) for gate in ordered_release_gates]
+assert gate_offsets == sorted(gate_offsets), gate_offsets
+
+publication_gate = ROOT / "scripts" / "release_publication_gate.sh"
+failed_validation_probe = subprocess.run(
+    [
+        "bash",
+        "-c",
+        f'''set -euo pipefail
+source "{publication_gate}"
+published=0
+publish() {{ published=1; }}
+if muesli_require_release_publication_ready 0 "https://example.invalid/pr/1"; then
+  publish
+fi
+[[ "$published" == "0" ]]
+''',
+    ],
+    text=True,
+    capture_output=True,
+    check=False,
+)
+assert failed_validation_probe.returncode == 0, failed_validation_probe.stderr
+
+missing_pr_probe = subprocess.run(
+    ["bash", "-c", f'source "{publication_gate}"; muesli_require_release_publication_ready 1 ""'],
+    text=True,
+    capture_output=True,
+    check=False,
+)
+assert missing_pr_probe.returncode != 0
+
+ready_probe = subprocess.run(
+    [
+        "bash",
+        "-c",
+        f'source "{publication_gate}"; muesli_require_release_publication_ready 1 "https://example.invalid/pr/1"',
+    ],
+    text=True,
+    capture_output=True,
+    check=False,
+)
+assert ready_probe.returncode == 0, ready_probe.stderr
 
 print("CloudKit entitlement validator tests passed.")

--- a/scripts/test_verify_cloud_entitlements.py
+++ b/scripts/test_verify_cloud_entitlements.py
@@ -135,9 +135,12 @@ assert "muesli_require_release_publication_ready" in publication_section
 assert "RELEASE_METADATA_PR_URL" in publication_section
 assert "resume_existing_release_publication()" in stable_release
 assert "Existing release metadata branch found" in stable_release
-assert "Expected exactly one open metadata PR" in stable_release
+assert "Expected zero or one open metadata PR" in stable_release
 assert '--appcast "$metadata_appcast"' in stable_release
 assert '"$ROOT/scripts/verify_signed_cloud_entitlements.sh"' in stable_release
+assert "Existing release metadata or hosted artifact failed update-flow validation" in stable_release
+assert "Existing hosted app failed Production CloudKit entitlement validation" in stable_release
+assert "Recreated missing release metadata PR" in stable_release
 assert "resume_existing_release_publication" in stable_release.split(
     '# --- Step 0: Update version in build script ---',
     maxsplit=1,


### PR DESCRIPTION
## Summary
- restore the user's previous clipboard shortly after dictation paste while preserving newer copies
- release visible dictation state immediately, defer persistence/sync until clipboard settlement, and start opt-in correction monitoring early enough to capture immediate edits
- keep attribution/dashboard bookkeeping outside the paste-critical window and keep latency diagnostics content-free
- attribute completion telemetry to the backend actually used for the transcription
- preserve the merged 0.8.3 Production CloudKit entitlement contract
- keep the GitHub release draft until appcast generation, release-note injection, update-flow validation, metadata push, and metadata PR creation all succeed
- make a failed final publication safely resumable from the existing validated metadata branch and PR
- add the clipboard repair to the existing 0.8.3 release notes

## Validation
- 1,751 Swift tests across 161 suites passed
- PasteController + dictionary correction focused suites: 21/21 passed
- publication guard failure/missing-PR/success probes passed
- CloudKit entitlement validator and appcast merge tests passed
- shell syntax and `git diff --check` passed
- isolated 0.8.3 Developer ID candidate deep signature passed
- signed candidate verified as `com.muesli.app`, Production CloudKit, `iCloud.com.mueslihq.muesli`, production APNs
- manual MuesliDevA dictation test confirmed Cmd+V 480 ms after key release with post-processing disabled and clipboard restoration about 527 ms after dispatch

## Release sequencing
This PR must merge before `scripts/release.sh 0.8.3` is run. The stable pipeline then publishes only from exact `origin/main`; it creates a separate appcast metadata PR and the public Sparkle feed remains unchanged until that follow-up PR is reviewed and merged. If the final GitHub publication call fails, rerunning the command revalidates the hosted artifact, Production entitlements, appcast, and existing metadata PR before resuming.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dictation now restores the clipboard after pasting without overwriting newer clipboard content.
  - Clipboard history and follow-up actions wait until paste operations fully settle.
  - Dictation completion is more reliable across successful, cancelled, empty, and failed transcriptions.

- **Diagnostics**
  - Improved dictation and paste lifecycle reporting helps identify timing and reliability issues without exposing clipboard content.

- **Release Improvements**
  - Releases remain in draft until metadata validation succeeds and required release updates are submitted.
  - Release checks can resume safely and verify required update information before publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->