### PR TITLE
Give every dashboard page a heading and align the layout to the window chrome

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/AboutView.swift
@@ -146,7 +146,9 @@ struct AboutView: View {
 
                 Spacer(minLength: MuesliTheme.spacing32)
             }
-            .padding(MuesliTheme.spacing32)
+            .padding(.horizontal, MuesliTheme.spacing32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, MuesliTheme.spacing32)
         }
         .background(MuesliTheme.backgroundBase)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictationsView.swift
@@ -54,6 +54,10 @@ struct DictationsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            PageTitle("Dictations")
+                .padding(.horizontal, MuesliTheme.spacing24)
+                .padding(.top, MuesliTheme.pageTop)
+
             StatsHeaderView(
                 dictationStats: appState.filteredDictationStats,
                 meetingStats: appState.meetingStats,

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -32,7 +32,9 @@ struct DictionaryView: View {
                 }
                 wordList
             }
-            .padding(MuesliTheme.spacing32)
+            .padding(.horizontal, MuesliTheme.spacing32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, MuesliTheme.spacing32)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(MuesliTheme.backgroundBase)
@@ -354,7 +356,9 @@ struct DictionaryView: View {
                 .foregroundStyle(MuesliTheme.textTertiary)
         }
         .frame(maxWidth: .infinity)
-        .padding(MuesliTheme.spacing32)
+        .padding(.horizontal, MuesliTheme.spacing32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, MuesliTheme.spacing32)
     }
 
     private var columnHeader: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DictionaryView.swift
@@ -356,9 +356,7 @@ struct DictionaryView: View {
                 .foregroundStyle(MuesliTheme.textTertiary)
         }
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, MuesliTheme.spacing32)
-            .padding(.top, MuesliTheme.pageTop)
-            .padding(.bottom, MuesliTheme.spacing32)
+        .padding(MuesliTheme.spacing32)
     }
 
     private var columnHeader: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MeetingsView.swift
@@ -261,6 +261,8 @@ struct MeetingsView: View {
         ScrollView {
             let presentation = browserPresentation
             VStack(alignment: .leading, spacing: MuesliTheme.spacing24) {
+                PageTitle("Meetings")
+
                 if !appState.upcomingCalendarEvents.isEmpty {
                     comingUpSection
                 }
@@ -305,7 +307,8 @@ struct MeetingsView: View {
             }
             .frame(maxWidth: 960, alignment: .leading)
             .padding(.horizontal, 40)
-            .padding(.vertical, 32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, 32)
             .frame(maxWidth: .infinity, alignment: .center)
         }
         .onDrop(of: ["public.file-url"], isTargeted: nil) { providers in
@@ -586,7 +589,7 @@ struct MeetingsView: View {
     @ViewBuilder
     private var browserHeaderTitle: some View {
         Text(currentFolderName)
-            .font(.system(size: 30, weight: .bold))
+            .font(MuesliTheme.title2())
             .foregroundStyle(MuesliTheme.textPrimary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -89,7 +89,9 @@ struct ModelsView: View {
 
                     selectedCategoryContent
                 }
-                .padding(MuesliTheme.spacing32)
+                .padding(.horizontal, MuesliTheme.spacing32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, MuesliTheme.spacing32)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .onAppear {

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -1200,6 +1200,7 @@ public final class MuesliController: NSObject {
         statusBarController?.setStatus("Idle")
         statusBarController?.refresh()
         historyWindowController?.updateBackendLabel()
+        historyWindowController?.applyThemeAppearance()
         historyWindowController?.reload()
         preferencesWindowController?.refresh()
         refreshIndicatorVisibility()

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliTheme.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliTheme.swift
@@ -4,7 +4,7 @@ import MuesliCore
 enum MuesliTheme {
     // MARK: - Colors — Backgrounds (layered)
 
-    static let backgroundDeepDarkHex = 0x111214
+    static let backgroundDeepDarkHex = 0x0B0C0E
     static let backgroundDeepLightHex = 0xF5F5F7
     static let backgroundDeep   = Color.adaptive(dark: backgroundDeepDarkHex, light: backgroundDeepLightHex)
 
@@ -64,8 +64,8 @@ enum MuesliTheme {
 
     // MARK: - Typography (SF Pro via .system())
 
-    static func title1() -> Font { .system(size: 28, weight: .bold) }
-    static func title2() -> Font { .system(size: 22, weight: .semibold) }
+    static func title1() -> Font { .system(size: 26, weight: .bold) }
+    static func title2() -> Font { .system(size: 20, weight: .semibold) }
     static func title3() -> Font { .system(size: 18, weight: .semibold) }
     static func headline() -> Font { .system(size: 15, weight: .semibold) }
     static func body() -> Font { .system(size: 14, weight: .regular) }
@@ -74,6 +74,10 @@ enum MuesliTheme {
     static func captionMedium() -> Font { .system(size: 12, weight: .medium) }
 
     // MARK: - Spacing (4pt grid)
+
+    /// Top padding for page content and for the sidebar header, so a page's heading lines up
+    /// with the app name in the sidebar.
+    static let pageTop: CGFloat = 8
 
     static let spacing4: CGFloat = 4
     static let spacing8: CGFloat = 8
@@ -126,5 +130,21 @@ extension NSColor {
                 alpha: 1.0
             )
         }
+    }
+}
+
+/// Page heading used by every dashboard page, so titles stay identical across tabs.
+struct PageTitle: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text)
+            .font(MuesliTheme.title1())
+            .foregroundStyle(MuesliTheme.textPrimary)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -129,7 +129,12 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
         window.title = AppIdentity.displayName
         window.isReleasedWhenClosed = false
         window.delegate = self
-        window.titlebarAppearsTransparent = true
+        // Opaque titlebar: with .fullSizeContentView a transparent titlebar
+        // renders the system chrome material over the detail column, and that
+        // material follows the OS theme rather than the app's (dark strip with
+        // OS dark + app light). An opaque titlebar resolves against the
+        // window's own appearance and background color, which we control.
+        window.titlebarAppearsTransparent = false
         window.titleVisibility = .hidden
         window.backgroundColor = MuesliTheme.backgroundDeepNSColor
         applyAppearance(to: window)

--- a/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/RecentHistoryWindowController.swift
@@ -122,7 +122,7 @@ final class RecentHistoryWindowController: NSObject, NSWindowDelegate {
     private func buildWindow() {
         let window = NSWindow(
             contentRect: NSRect(x: 180, y: 140, width: 1120, height: 790),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -248,7 +248,9 @@ struct SettingsView: View {
                     settingsPanePicker
                     paneContent
                 }
-                .padding(MuesliTheme.spacing32)
+                .padding(.horizontal, MuesliTheme.spacing32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, MuesliTheme.spacing32)
             }
             .background(MuesliTheme.backgroundBase)
             .onAppear {

--- a/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ShortcutsView.swift
@@ -33,7 +33,9 @@ struct ShortcutsView: View {
 
                 resetButton
             }
-            .padding(MuesliTheme.spacing32)
+            .padding(.horizontal, MuesliTheme.spacing32)
+            .padding(.top, MuesliTheme.pageTop)
+            .padding(.bottom, MuesliTheme.spacing32)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onDisappear {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -184,7 +184,7 @@ struct SidebarView: View {
             }
         }
         .padding(.horizontal, MuesliTheme.spacing16)
-        .padding(.top, MuesliTheme.spacing24)
+        .padding(.top, MuesliTheme.pageTop)
         .padding(.bottom, MuesliTheme.spacing20)
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/SyncOriginDisplay.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SyncOriginDisplay.swift
@@ -38,7 +38,9 @@ struct RecordOriginPicker: View {
         }
         .pickerStyle(.segmented)
         .labelsHidden()
-        .frame(width: 240)
+        // The segmented control's intrinsic width is wider than a hardcoded frame, and the extra
+        // width bleeds out of it — which pushed the filter row past the page's leading padding.
+        .fixedSize()
         .help("Filter by the device where the recording was created")
         .accessibilityLabel("Record source")
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TimelineView.swift
@@ -37,6 +37,10 @@ struct TimelineView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            PageTitle("Timeline")
+                .padding(.horizontal, MuesliTheme.spacing24)
+                .padding(.top, MuesliTheme.pageTop)
+
             StatsHeaderView(
                 dictationStats: appState.dictationStats,
                 meetingStats: appState.meetingStats,


### PR DESCRIPTION
## Summary

#433 has landed, so this branch is now rebased on top of it and contains only the layout and
typography work.

Timeline, Dictations and Meetings had no heading, so the window opened with no indication of where
you were, while Dictionary, Models, Shortcuts, Settings and About each rendered their own. Rather
than add three more one-off titles, this adds a shared `PageTitle` and uses it everywhere a heading
was missing, then lines the layout up with the window chrome.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/esteugene/muesli/pr-assets/assets/light-theme-before.png) | ![after](https://raw.githubusercontent.com/esteugene/muesli/pr-assets/assets/layout-after-light.png) |

Dark theme: ![dark](https://raw.githubusercontent.com/esteugene/muesli/pr-assets/assets/layout-after-dark.png)

Changes:

- Run the split view under the titlebar (`.fullSizeContentView`) so the sidebar and the detail
  column reach the top of the window instead of leaving a flat strip above them.
- Add `MuesliTheme.pageTop` and use it for the sidebar header and for every page, so a page heading
  lines up with the app name in the sidebar. Because the columns now run to the top, this also keeps
  headings clear of the traffic lights when the sidebar is collapsed.
- Scale headings down to 26/20, and replace the hardcoded 30pt folder title in `MeetingsView` with
  `title2()`: a page now reads H1 then H2 instead of two titles of the same size, and the folder
  title follows the theme scale.
- Drop the fixed 240pt width on the segmented record-origin picker. The control is intrinsically
  wider than that, and the overflow rendered past the page's leading padding, so the filter row sat
  ~24pt left of everything else on Timeline, Dictations and Meetings.
- Darken the dark-theme sidebar to `#0B0C0E`. Sidebar-to-content contrast was 1.045:1, which read as
  a single surface; it is now 1.089:1, matching what the light theme already had. Cards stay
  distinguishable from the content background (1.064:1).

Insights is left alone: it has its own header with a back button rather than a page title.

## Validation

- `scripts/run_ci_test_shard.sh core` — 348 tests in 21 suites, and the shard-assignment check
  passes. The one local failure elsewhere, `ContributionMilestoneTests` "share message and URLs
  include encoded milestone content", asserts a US-grouped `31,000` while this machine's locale
  formats the same number as `31.000`; it fails the same way on unmodified `main` (#435).
- `MUESLI_SKIP_SIGN=1 ./scripts/dev-test.sh`, then in MuesliDev: launched each tab in the light and
  the dark theme, and checked the filter row against the page padding on Timeline, Dictations and
  Meetings, and switched themes with the sidebar control while the window stayed open. Screenshots
  are that dev build on an empty database.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

Implementation drafted with Claude Code across several rounds of visual review; I directed the
design decisions, reviewed the diff and checked every page in both themes in a local build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent page titles to Dictations, Meetings, and Timeline views.
  * Improved light and dark theme handling across dashboard windows.
  * Added adaptive background colors and shared heading styles.
  * Improved segmented control sizing for sync origin selection.

* **Improvements**
  * Refined spacing and padding across dashboard pages for a more consistent layout.
  * Updated typography, folder headers, and theme toggle controls.

* **Tests**
  * Added coverage for light and dark window appearance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
