### PR TITLE
fix: Preserve word boundaries in diarized imports

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptFormatter.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptFormatter.swift
@@ -32,7 +32,8 @@ enum TranscriptFormatter {
                 }
             }
 
-            taggedSystem = systemSegments.map { segment in
+            let lexicalUnits = normalizeLexicalUnits(systemSegments)
+            taggedSystem = lexicalUnits.map { segment in
                 let speaker = findSpeaker(for: segment, in: diarizationSegments, labelMap: speakerLabelMap)
                 return TaggedSegment(segment: segment, speaker: speaker)
             }
@@ -63,6 +64,7 @@ enum TranscriptFormatter {
     /// segments from the same speaker that are far apart in time stay separate
     /// so they interleave correctly with other speakers.
     private static let consolidationGapThreshold: TimeInterval = 2.0
+    private static let lexicalFragmentGapThreshold: TimeInterval = 0.35
 
     private static func consolidate(_ segments: [TaggedSegment]) -> [TaggedSegment] {
         guard !segments.isEmpty else { return [] }
@@ -172,6 +174,61 @@ enum TranscriptFormatter {
         return 0
     }
 
+    /// Reassembles token-timed ASR fragments before speaker attribution so a
+    /// diarization boundary cannot split one lexical word across speaker turns.
+    private static func normalizeLexicalUnits(_ segments: [SpeechSegment]) -> [SpeechSegment] {
+        let chronologicalSegments = segments.sorted { $0.start < $1.start }
+        guard let first = chronologicalSegments.first else { return [] }
+
+        var result: [SpeechSegment] = []
+        var current = first
+
+        for segment in chronologicalSegments.dropFirst() {
+            let gap = max(0, segment.start - current.end)
+            if shouldCombineIntoLexicalUnit(current.text, segment.text, gap: gap) {
+                current = SpeechSegment(
+                    start: current.start,
+                    end: max(current.end, segment.end),
+                    text: current.text + segment.text
+                )
+            } else {
+                result.append(current)
+                current = segment
+            }
+        }
+
+        result.append(current)
+        return result
+    }
+
+    private static func shouldCombineIntoLexicalUnit(
+        _ lhs: String,
+        _ rhs: String,
+        gap: TimeInterval
+    ) -> Bool {
+        let trimmedLHS = lhs.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedRHS = rhs.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLHS.isEmpty, !trimmedRHS.isEmpty else { return false }
+
+        if isPunctuationOnly(trimmedLHS) || isPunctuationOnly(trimmedRHS) {
+            return true
+        }
+
+        guard gap <= lexicalFragmentGapThreshold else { return false }
+
+        guard let lhsLast = lhs.last, let rhsFirst = rhs.first else { return false }
+        guard !lhsLast.isWhitespace, !rhsFirst.isWhitespace, !lhsLast.isPunctuation else {
+            return false
+        }
+
+        return !trimmedLHS.contains(where: \.isWhitespace)
+            && !trimmedRHS.contains(where: \.isWhitespace)
+    }
+
+    private static func isPunctuationOnly(_ text: String) -> Bool {
+        text.allSatisfy { $0.isPunctuation || $0.isSymbol }
+    }
+
     private static func appendText(_ lhs: String, _ rhs: String, gap: TimeInterval) -> String {
         if shouldConcatenateDirectly(lhs, rhs, gap: gap) {
             return lhs + rhs
@@ -180,7 +237,7 @@ enum TranscriptFormatter {
     }
 
     private static func shouldConcatenateDirectly(_ lhs: String, _ rhs: String, gap: TimeInterval) -> Bool {
-        guard gap <= 0.35 else { return false }
+        guard gap <= lexicalFragmentGapThreshold else { return false }
         guard !lhs.isEmpty, !rhs.isEmpty else { return false }
         guard !rhs.contains(where: \.isWhitespace) else { return false }
         guard let lhsLast = lhs.last, let rhsFirst = rhs.first else { return false }

--- a/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/AudioFileImportControllerTests.swift
@@ -145,6 +145,35 @@ struct AudioFileImportControllerTests {
         #expect(!result.contains("## Speaker Segments"))
     }
 
+    @Test("formatTranscriptWithSpeakers keeps imported token fragments intact")
+    func formatTranscriptWithSpeakersKeepsImportedWordsIntact() {
+        let segments = [
+            makeDiarSeg(speakerId: "SPEAKER_0", start: 0.0, end: 1.0),
+            makeDiarSeg(speakerId: "SPEAKER_1", start: 1.0, end: 2.0),
+        ]
+        let transcription = SpeechTranscriptionResult(
+            text: "How are you?",
+            segments: [
+                SpeechSegment(start: 0.7, end: 1.0, text: "H"),
+                SpeechSegment(start: 1.0, end: 1.2, text: "ow"),
+                SpeechSegment(start: 1.2, end: 1.4, text: " are"),
+                SpeechSegment(start: 1.4, end: 1.6, text: " you"),
+                SpeechSegment(start: 1.6, end: 1.7, text: "?"),
+            ]
+        )
+
+        let result = AudioFileImportController.formatTranscriptWithSpeakers(
+            transcription: transcription,
+            diarizationSegments: segments,
+            meetingStart: localMidnight()
+        )
+
+        #expect(result.contains("Speaker 1: How"))
+        #expect(result.contains("Speaker 2: are you?"))
+        #expect(!result.contains("Speaker 1: H\n"))
+        #expect(!result.contains("Speaker 2: ow"))
+    }
+
     @Test("formatTranscriptWithSpeakers falls back to raw text without ASR segments")
     func formatTranscriptWithSpeakersFallsBackWithoutASRSegments() {
         let segments = [

--- a/native/MuesliNative/Tests/MuesliTests/TranscriptFormatterTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/TranscriptFormatterTests.swift
@@ -382,6 +382,101 @@ struct TranscriptFormatterTests {
         #expect(lines[0].contains("Speaker 1: Hello world"))
     }
 
+    @Test("diarization assigns a fragmented word to one speaker")
+    func diarizationKeepsFragmentedWordIntact() {
+        let system = [
+            SpeechSegment(start: 0.7, end: 1.0, text: "H"),
+            SpeechSegment(start: 1.0, end: 1.2, text: "ow"),
+            SpeechSegment(start: 1.2, end: 1.5, text: " are"),
+        ]
+        let diarization = [
+            makeDiarSeg(speakerId: "spk_0", start: 0.0, end: 1.0),
+            makeDiarSeg(speakerId: "spk_1", start: 1.0, end: 2.0),
+        ]
+
+        let result = TranscriptFormatter.merge(
+            micSegments: [],
+            systemSegments: system,
+            diarizationSegments: diarization,
+            meetingStart: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(result.contains("Speaker 1: How"))
+        #expect(!result.contains("Speaker 1: H\n"))
+        #expect(!result.contains("Speaker 2: ow"))
+    }
+
+    @Test("diarization concatenates long subword fragments")
+    func diarizationConcatenatesLongSubwords() {
+        let system = [
+            SpeechSegment(start: 0.0, end: 0.2, text: "account"),
+            SpeechSegment(start: 0.2, end: 0.4, text: "ing"),
+            SpeechSegment(start: 0.4, end: 0.6, text: " complete"),
+            SpeechSegment(start: 0.6, end: 0.8, text: "ly"),
+            SpeechSegment(start: 0.8, end: 1.0, text: " healthi"),
+            SpeechSegment(start: 1.0, end: 1.2, text: "est"),
+        ]
+        let diarization = [
+            makeDiarSeg(speakerId: "spk_0", start: 0.0, end: 2.0),
+        ]
+
+        let result = TranscriptFormatter.merge(
+            micSegments: [],
+            systemSegments: system,
+            diarizationSegments: diarization,
+            meetingStart: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(result.contains("Speaker 1: accounting completely healthiest"))
+    }
+
+    @Test("diarization keeps punctuation with the preceding word")
+    func diarizationAttachesPunctuationBeforeSpeakerAttribution() {
+        let system = [
+            SpeechSegment(start: 0.7, end: 0.9, text: "Hello"),
+            SpeechSegment(start: 0.95, end: 1.15, text: "."),
+            SpeechSegment(start: 1.15, end: 1.4, text: " Next"),
+        ]
+        let diarization = [
+            makeDiarSeg(speakerId: "spk_0", start: 0.0, end: 1.0),
+            makeDiarSeg(speakerId: "spk_1", start: 1.0, end: 2.0),
+        ]
+
+        let result = TranscriptFormatter.merge(
+            micSegments: [],
+            systemSegments: system,
+            diarizationSegments: diarization,
+            meetingStart: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(result.contains("Speaker 1: Hello."))
+        #expect(result.contains("Speaker 2: Next"))
+        #expect(!result.contains("Speaker 2: ."))
+    }
+
+    @Test("diarization preserves explicit whitespace word boundaries")
+    func diarizationPreservesExplicitWhitespaceBoundaries() {
+        let system = [
+            SpeechSegment(start: 0.7, end: 0.9, text: "Hello"),
+            SpeechSegment(start: 0.99, end: 1.2, text: " world"),
+        ]
+        let diarization = [
+            makeDiarSeg(speakerId: "spk_0", start: 0.0, end: 1.0),
+            makeDiarSeg(speakerId: "spk_1", start: 1.0, end: 2.0),
+        ]
+
+        let result = TranscriptFormatter.merge(
+            micSegments: [],
+            systemSegments: system,
+            diarizationSegments: diarization,
+            meetingStart: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(result.contains("Speaker 1: Hello"))
+        #expect(result.contains("Speaker 2: world"))
+        #expect(!result.contains("Helloworld"))
+    }
+
     @Test("three speakers identified correctly")
     func threeSpeakers() {
         let meetingStart = Date(timeIntervalSince1970: 0)


### PR DESCRIPTION
## Summary

Normalize adjacent ASR token segments into lexical units before `TranscriptFormatter` performs speaker-overlap attribution, using the token text's real whitespace and punctuation boundaries rather than word length as the deciding signal and carrying the unit's full timestamp range. Attach punctuation to its neighboring lexical unit so punctuation cannot become a standalone speaker turn, then assign each completed word-sized unit to exactly one diarized speaker and run the existing chronological consolidation over those tagged units. Preserve explicit whitespace between distinct words, existing mic/system ordering, nearest-speaker fallback, and the non-diarized formatting path.

Imported multi-speaker recordings transcribed with Parakeet expose token-timing fragments to `TranscriptFormatter`, which currently assigns every fragment to a diarized speaker independently. A diarization boundary can therefore put fragments of one lexical word on different speaker turns, as in `H` / `ow`, and can leave punctuation at the start of the following turn. The formatter also guesses whether adjacent fragments form one word using a combined-length ceiling of eight characters, causing longer words such as `account` + `ing` to acquire a false space and inflate downstream word counts. This plan covers the imported-audio diarization defect; the follow-up's live, local-microphone-only splitting remains out of scope because it does not pass through imported system-audio diarization.

Fixes #413

## Validation

A token sequence `H` + `ow` whose timing straddles two diarization speakers produces one intact `How` on a single speaker line, never two partial turns.
Long subword fragments such as `account` + `ing`, `complete` + `ly`, and `healthi` + `est` concatenate without an inserted space regardless of their combined length.
Sentence punctuation at a diarization boundary remains attached to the adjacent lexical word and does not begin a new speaker line as an orphan token.
Tokens with an explicit whitespace boundary remain separate words, so nearby complete words are not accidentally concatenated by the new grouping behavior.
The imported-audio formatting entry point receives token-timed `SpeechTranscriptionResult` input and returns intact words with stable speaker labels, while empty segments, single-speaker input, and already timestamped transcripts retain their existing fallbacks.

## Contribution certification

- [ ] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [ ] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [ ] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

Not applicable to this change.

### AI assistance

Not applicable to this change.

AI was used for assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789803593&installation_model_id=422865&pr_number=446&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F446&signature=db0d9c3914ae4ec478d2f58d19fec96eb45a543ed67f2ab495d4306214cff60b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript formatting so words split across speaker diarization boundaries are combined correctly.
  * Preserved punctuation and explicit whitespace while assigning transcript text to speakers.
  * Prevented fragmented words from appearing as separate or incorrectly attributed speaker lines.

* **Tests**
  * Added coverage for fragmented words, long subwords, punctuation attachment, and whitespace boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->