### PR TITLE
Cherry-pick sidebar layout and shortcut-pill hover from #329

### DIFF
--- a/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/DashboardRootView.swift
@@ -5,11 +5,25 @@ struct DashboardRootView: View {
     let appState: AppState
     let controller: MuesliController
     @State private var featureTourTargetFrames: [FeatureTourTarget: CGRect] = [:]
+    @State private var isSidebarCollapsed = false
 
     var body: some View {
         NavigationSplitView {
-            SidebarView(appState: appState, controller: controller)
-                .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 300)
+            SidebarView(
+                appState: appState,
+                controller: controller,
+                isCollapsed: isSidebarCollapsed,
+                onToggleCollapsed: {
+                    withAnimation(.easeInOut(duration: 0.22)) {
+                        isSidebarCollapsed.toggle()
+                    }
+                }
+            )
+            .navigationSplitViewColumnWidth(
+                min: isSidebarCollapsed ? 68 : 240,
+                ideal: isSidebarCollapsed ? 68 : 260,
+                max: isSidebarCollapsed ? 68 : 300
+            )
         } detail: {
             detailContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -108,6 +108,42 @@ private final class HoverIndicatorView: NSView {
     }
 }
 
+// A self-contained rounded "shortcut pill" shown beside the idle indicator on
+// hover when `IndicatorHoverStyle.shortcutPill` is configured. Drawn as one
+// rounded rectangle so the label never inherits the mic surface's shape.
+private final class IdleShortcutPillView: NSView {
+    var title = "" {
+        didSet { needsDisplay = true }
+    }
+
+    override var isOpaque: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let pillRect = bounds.insetBy(dx: 0.5, dy: 0.5)
+        let pillPath = NSBezierPath(roundedRect: pillRect, xRadius: 14, yRadius: 14)
+        NSColor.black.withAlphaComponent(0.97).setFill()
+        pillPath.fill()
+        NSColor.white.withAlphaComponent(0.16).setStroke()
+        pillPath.lineWidth = 1
+        pillPath.stroke()
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 15, weight: .regular),
+            .foregroundColor: NSColor.white.withAlphaComponent(0.88),
+            .paragraphStyle: paragraph
+        ]
+        let attributedTitle = NSAttributedString(string: title, attributes: attributes)
+        let textSize = attributedTitle.size()
+        attributedTitle.draw(at: NSPoint(
+            x: floor((bounds.width - textSize.width) / 2),
+            y: floor((bounds.height - textSize.height) / 2)
+        ))
+    }
+}
+
 @MainActor
 final class FloatingIndicatorController: NSObject {
     private var panel: NSPanel?
@@ -136,6 +172,8 @@ final class FloatingIndicatorController: NSObject {
     )
     private var glassView: NSVisualEffectView?
     private var tintLayer: CALayer?
+    private var idleShortcutPillView: IdleShortcutPillView?
+    private var idleIconBackgroundLayer: CALayer?
     private var micIconView: NSImageView?
     private var wandIconView: NSImageView?
     private var barLayers: [CALayer] = []
@@ -537,6 +575,8 @@ final class FloatingIndicatorController: NSObject {
                 )
             }
         case .preparing:
+            idleShortcutPillView?.isHidden = true
+            idleIconBackgroundLayer?.isHidden = true
             ensureWaveformAnimation(in: targetFrame.size, mode: .waiting)
         default:
             break
@@ -835,6 +875,10 @@ final class FloatingIndicatorController: NSObject {
         isHovered = hovered
         let config = configStore.load()
         setState(.idle, config: config)
+        if hovered, config.indicatorHoverStyle == .shortcutPill {
+            animateIdleHoverPop()
+        }
+
     }
 
     func scheduleHoverExit() {
@@ -1066,6 +1110,64 @@ final class FloatingIndicatorController: NSObject {
         CATransaction.commit()
     }
 
+    /// Idle layout for `IndicatorHoverStyle.shortcutPill`: the resting state is a
+    /// thin grip handle; on hover the mic capsule and an adjacent rounded label
+    /// pill appear without resizing the window.
+    private func layoutShortcutPillIdle(frameSize: NSSize, config: AppConfig) {
+        // Transparent host: only the mic capsule and the label pill draw. The
+        // classic pill's tint/glass/border would paint the whole canvas as one blob.
+        tintLayer?.isHidden = true
+        glassView?.isHidden = true
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        contentView?.layer?.borderWidth = 0
+        contentView?.layer?.backgroundColor = NSColor.clear.cgColor
+        CATransaction.commit()
+        wandIconView?.isHidden = true
+        iconLabel?.isHidden = true
+        textLabel?.isHidden = true
+        textLabel?.alphaValue = 0
+
+        let title = "Dictate \(config.dictationHotkey.displayLabel)"
+        let labelWidth = idleLabelWidth(title: title)
+        let placement = idleHoverPlacement(for: config.indicatorAnchor)
+        let idleFrames = idleHoverFrames(
+            placement: placement,
+            frameSize: frameSize,
+            labelWidth: labelWidth
+        )
+        idleShortcutPillView?.isHidden = !isHovered
+        idleShortcutPillView?.frame = idleFrames.label
+        idleShortcutPillView?.title = title
+
+        let restingHandle = idleRestingHandleFrame(
+            placement: placement,
+            frameSize: frameSize
+        )
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        idleIconBackgroundLayer?.isHidden = false
+        idleIconBackgroundLayer?.backgroundColor = isHovered
+            ? NSColor.colorWith(hex: 0x111111, alpha: 1).cgColor
+            : NSColor.colorWith(hex: 0x696969, alpha: 0.82).cgColor
+        idleIconBackgroundLayer?.borderWidth = isHovered ? 1 : 0
+        idleIconBackgroundLayer?.frame = isHovered ? idleFrames.icon : restingHandle
+        idleIconBackgroundLayer?.cornerRadius = isHovered ? 18 : 5
+        CATransaction.commit()
+
+        let iconSize = NSSize(width: 15, height: 15)
+        micIconView?.isHidden = !isHovered
+        if let mic = micIconView {
+            mic.alphaValue = 1
+            mic.frame = NSRect(
+                x: idleFrames.icon.midX - iconSize.width / 2,
+                y: idleFrames.icon.midY - iconSize.height / 2,
+                width: iconSize.width,
+                height: iconSize.height
+            )
+        }
+    }
+
     private func applyGlassState(_ state: DictationState, frameSize: NSSize) {
         let config = configStore.load()
         let radius = frameSize.height / 2
@@ -1102,6 +1204,12 @@ final class FloatingIndicatorController: NSObject {
 
         switch state {
         case .idle:
+            if config.indicatorHoverStyle == .shortcutPill {
+                layoutShortcutPillIdle(frameSize: frameSize, config: config)
+                return
+            }
+            idleShortcutPillView?.isHidden = true
+            idleIconBackgroundLayer?.isHidden = true
             // Mic symbol centred (or left-aligned when hovered beside text).
             wandIconView?.isHidden = true
             iconLabel?.isHidden = true
@@ -1155,6 +1263,8 @@ final class FloatingIndicatorController: NSObject {
             }
 
         case .recording:
+            idleShortcutPillView?.isHidden = true
+            idleIconBackgroundLayer?.isHidden = true
             // Waveform bars replace mic icon during recording.
             wandIconView?.isHidden = true
             iconLabel?.isHidden = false   // keeps the ✕ cancel label
@@ -1411,6 +1521,22 @@ final class FloatingIndicatorController: NSObject {
         contentView.layer?.insertSublayer(tint, at: 0)
         tintLayer = tint
 
+        // Shortcut-pill hover style: adjacent label pill + mic capsule/handle.
+        let shortcutPill = IdleShortcutPillView(frame: .zero)
+        shortcutPill.wantsLayer = true
+        shortcutPill.isHidden = true
+        contentView.addSubview(shortcutPill)
+        idleShortcutPillView = shortcutPill
+
+        let iconBackground = CALayer()
+        iconBackground.backgroundColor = NSColor.colorWith(hex: 0x111111, alpha: 1).cgColor
+        iconBackground.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        iconBackground.borderWidth = 1
+        iconBackground.cornerCurve = .circular
+        iconBackground.isHidden = true
+        contentView.layer?.insertSublayer(iconBackground, above: tint)
+        idleIconBackgroundLayer = iconBackground
+
         // Idle icon — uses the user's selected menu bar icon from config.
         // Falls back to waveform.badge.microphone if the configured icon can't be loaded.
         let config = configStore.load()
@@ -1578,9 +1704,22 @@ final class FloatingIndicatorController: NSObject {
         let size: NSSize
         switch state {
         case .idle:
-            size = isHovered
-                ? Self.idleHoverPillSize(hotkeyLabel: config.dictationHotkey.label, screenWidth: screen.width)
-                : NSSize(width: 44, height: 28)
+            if config.indicatorHoverStyle == .shortcutPill {
+                // Fixed canvas: the window never resizes on hover. Only child
+                // visibility changes, so the pill cannot reveal or crossfade.
+                let title = "Dictate \(config.dictationHotkey.displayLabel)"
+                let labelWidth = idleLabelWidth(title: title)
+                switch idleHoverPlacement(for: config.indicatorAnchor) {
+                case .above, .below:
+                    size = NSSize(width: max(labelWidth, 36) + 4, height: 82)
+                case .leading, .trailing:
+                    size = NSSize(width: labelWidth + 46, height: 40)
+                }
+            } else {
+                size = isHovered
+                    ? Self.idleHoverPillSize(hotkeyLabel: config.dictationHotkey.label, screenWidth: screen.width)
+                    : NSSize(width: 44, height: 28)
+            }
         case .preparing: size = NSSize(width: 76, height: 22)
         case .recording: size = NSSize(width: 76, height: 22)
         case .transcribing:
@@ -1635,6 +1774,88 @@ final class FloatingIndicatorController: NSObject {
         let x = min(max(center.x - size.width / 2, screen.minX), screen.maxX - size.width)
         let y = min(max(center.y - size.height / 2, screen.minY), screen.maxY - size.height)
         return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+
+    // MARK: - Shortcut-pill hover (IndicatorHoverStyle.shortcutPill)
+
+    private enum IdleHoverPlacement {
+        case above, below, leading, trailing
+    }
+
+    private func idleHoverPlacement(for anchor: IndicatorAnchor) -> IdleHoverPlacement {
+        switch anchor {
+        case .topLeading, .topCenter, .topTrailing: return .below
+        case .midLeading: return .trailing
+        case .midTrailing: return .leading
+        case .bottomLeading, .bottomCenter, .bottomTrailing, .custom: return .above
+        }
+    }
+
+    private func idleLabelWidth(title: String) -> CGFloat {
+        let font = NSFont.systemFont(ofSize: 15, weight: .regular)
+        let measured = ceil((title as NSString).size(withAttributes: [.font: font]).width)
+        return max(108, measured + 28)
+    }
+
+    private func idleHoverFrames(
+        placement: IdleHoverPlacement,
+        frameSize: NSSize,
+        labelWidth: CGFloat
+    ) -> (label: CGRect, icon: CGRect) {
+        let iconSize: CGFloat = 36
+        let labelHeight: CGFloat = 36
+        let gap: CGFloat = 6
+        let inset: CGFloat = 2
+        switch placement {
+        case .above:
+            return (
+                CGRect(x: (frameSize.width - labelWidth) / 2, y: inset + iconSize + gap, width: labelWidth, height: labelHeight),
+                CGRect(x: (frameSize.width - iconSize) / 2, y: inset, width: iconSize, height: iconSize)
+            )
+        case .below:
+            return (
+                CGRect(x: (frameSize.width - labelWidth) / 2, y: inset, width: labelWidth, height: labelHeight),
+                CGRect(x: (frameSize.width - iconSize) / 2, y: inset + labelHeight + gap, width: iconSize, height: iconSize)
+            )
+        case .leading:
+            return (
+                CGRect(x: inset, y: (frameSize.height - labelHeight) / 2, width: labelWidth, height: labelHeight),
+                CGRect(x: inset + labelWidth + gap, y: inset, width: iconSize, height: iconSize)
+            )
+        case .trailing:
+            return (
+                CGRect(x: inset + iconSize + gap, y: (frameSize.height - labelHeight) / 2, width: labelWidth, height: labelHeight),
+                CGRect(x: inset, y: inset, width: iconSize, height: iconSize)
+            )
+        }
+    }
+
+    private func idleRestingHandleFrame(
+        placement: IdleHoverPlacement,
+        frameSize: NSSize
+    ) -> CGRect {
+        let inset: CGFloat = 2
+        switch placement {
+        case .above: return CGRect(x: (frameSize.width - 30) / 2, y: inset, width: 30, height: 8)
+        case .below: return CGRect(x: (frameSize.width - 30) / 2, y: frameSize.height - inset - 8, width: 30, height: 8)
+        case .leading: return CGRect(x: frameSize.width - inset - 8, y: (frameSize.height - 30) / 2, width: 8, height: 30)
+        case .trailing: return CGRect(x: inset, y: (frameSize.height - 30) / 2, width: 8, height: 30)
+        }
+    }
+
+    private func animateIdleHoverPop() {
+        let bounce = CAKeyframeAnimation(keyPath: "transform.translation.y")
+        bounce.values = [0, 2, -0.5, 0]
+        bounce.keyTimes = [0, 0.45, 0.75, 1]
+        bounce.duration = 0.16
+        bounce.timingFunctions = [
+            CAMediaTimingFunction(name: .easeOut),
+            CAMediaTimingFunction(name: .easeInEaseOut),
+            CAMediaTimingFunction(name: .easeInEaseOut)
+        ]
+        idleIconBackgroundLayer?.add(bounce, forKey: "idle-hover-bounce")
+        micIconView?.layer?.add(bounce, forKey: "idle-hover-bounce")
     }
 
     private func styleForState(_ state: DictationState, config: AppConfig) -> (background: NSColor, border: NSColor, icon: String, title: String, iconColor: NSColor, textColor: NSColor, alpha: CGFloat) {

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -171,6 +171,7 @@ final class FloatingIndicatorController: NSObject {
     private var textLabel: NSTextField?
     private var state: DictationState = .idle
     private var isHovered = false
+    private var lastLoadedConfig: AppConfig?
     private var preservesCollapsedLeftEdge = false
     private var hoverExitWorkItem: DispatchWorkItem?
     private let configStore: ConfigStore
@@ -449,6 +450,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func setState(_ state: DictationState, config: AppConfig) {
+        lastLoadedConfig = config
         let previousState = self.state
         let previousHover = isHovered
         let previouslyPreservedCollapsedLeftEdge = preservesCollapsedLeftEdge
@@ -456,6 +458,9 @@ final class FloatingIndicatorController: NSObject {
             exitComputerUseCursorMode(restoreFrame: false)
         }
         self.state = state
+        if state != .idle {
+            hideShortcutPillChrome()
+        }
         if state != .transcribing {
             transcribingTitle = "Transcribing"
             computerUseTranscriptText = nil
@@ -1136,7 +1141,9 @@ final class FloatingIndicatorController: NSObject {
     /// uses the full panel; shortcut-pill limits interaction to the visible
     /// resting grip, expanding to the label pill + mic capsule only while hovered.
     func pointerInteractiveRect(in bounds: NSRect) -> NSRect {
-        let config = configStore.load()
+        // Cache: hit-testing runs on the pointer hot path; reading + decoding
+        // config from disk per event would add avoidable main-thread latency.
+        let config = lastLoadedConfig ?? configStore.load()
         guard state == .idle, config.indicatorHoverStyle == .shortcutPill else { return bounds }
         let placement = idleHoverPlacement(for: config.indicatorAnchor)
         if isHovered {
@@ -1177,9 +1184,11 @@ final class FloatingIndicatorController: NSObject {
         case .below:
             pill = CGRect(x: handle.midX - pillW / 2, y: handle.maxY - pillH, width: pillW, height: pillH)
         case .leading:
-            pill = CGRect(x: handle.minX, y: handle.midY - pillH / 2, width: pillW, height: pillH)
-        case .trailing:
+            // Grip sits at the canvas's trailing edge; pop leftward from it.
             pill = CGRect(x: handle.maxX - pillW, y: handle.midY - pillH / 2, width: pillW, height: pillH)
+        case .trailing:
+            // Grip sits at the leading edge; pop rightward from it.
+            pill = CGRect(x: handle.minX, y: handle.midY - pillH / 2, width: pillW, height: pillH)
         }
         return (pill, title, font, textWidth)
     }
@@ -1878,45 +1887,6 @@ final class FloatingIndicatorController: NSObject {
         case .midLeading: return .trailing
         case .midTrailing: return .leading
         case .bottomLeading, .bottomCenter, .bottomTrailing, .custom: return .above
-        }
-    }
-
-    private func idleLabelWidth(title: String) -> CGFloat {
-        let font = NSFont.systemFont(ofSize: 15, weight: .regular)
-        let measured = ceil((title as NSString).size(withAttributes: [.font: font]).width)
-        return max(108, measured + 28)
-    }
-
-    private func idleHoverFrames(
-        placement: IdleHoverPlacement,
-        frameSize: NSSize,
-        labelWidth: CGFloat
-    ) -> (label: CGRect, icon: CGRect) {
-        let iconSize: CGFloat = 36  // vertical footprint only; the capsule is a 44x28 stadium pill
-        let labelHeight: CGFloat = 36
-        let gap: CGFloat = 6
-        let inset: CGFloat = 2
-        switch placement {
-        case .above:
-            return (
-                CGRect(x: (frameSize.width - labelWidth) / 2, y: inset + iconSize + gap, width: labelWidth, height: labelHeight),
-                CGRect(x: (frameSize.width - iconSize) / 2, y: inset, width: iconSize, height: iconSize)
-            )
-        case .below:
-            return (
-                CGRect(x: (frameSize.width - labelWidth) / 2, y: inset, width: labelWidth, height: labelHeight),
-                CGRect(x: (frameSize.width - iconSize) / 2, y: inset + labelHeight + gap, width: iconSize, height: iconSize)
-            )
-        case .leading:
-            return (
-                CGRect(x: inset, y: (frameSize.height - labelHeight) / 2, width: labelWidth, height: labelHeight),
-                CGRect(x: inset + labelWidth + gap, y: inset, width: iconSize, height: iconSize)
-            )
-        case .trailing:
-            return (
-                CGRect(x: inset + iconSize + gap, y: (frameSize.height - labelHeight) / 2, width: labelWidth, height: labelHeight),
-                CGRect(x: inset, y: inset, width: iconSize, height: iconSize)
-            )
         }
     }
 

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -1133,17 +1133,48 @@ final class FloatingIndicatorController: NSObject {
         guard state == .idle, config.indicatorHoverStyle == .shortcutPill else { return bounds }
         let placement = idleHoverPlacement(for: config.indicatorAnchor)
         if isHovered {
-            let title = "Dictate \(config.dictationHotkey.displayLabel)"
-            let frames = idleHoverFrames(
+            let (pill, _, _, _) = shortcutPillHoverFrame(
                 placement: placement,
                 frameSize: bounds.size,
-                labelWidth: idleLabelWidth(title: title)
+                config: config
             )
-            return frames.label.union(frames.icon).insetBy(dx: -6, dy: -6).intersection(bounds)
+            return pill.insetBy(dx: -6, dy: -6).intersection(bounds)
         }
         return idleRestingHandleFrame(placement: placement, frameSize: bounds.size)
             .insetBy(dx: -6, dy: -6)
             .intersection(bounds)
+    }
+
+    /// Unified hover pill for `IndicatorHoverStyle.shortcutPill`: the classic
+    /// stadium shape (icon + text in one rounded rectangle), popping
+    /// bottom-to-top from the resting grip instead of left-to-right.
+    private func shortcutPillHoverFrame(
+        placement: IdleHoverPlacement,
+        frameSize: NSSize,
+        config: AppConfig
+    ) -> (pill: CGRect, title: String, font: NSFont, textWidth: CGFloat) {
+        let title = "Hold \(config.dictationHotkey.label) to dictate"
+        let font = NSFont.systemFont(ofSize: 13, weight: .regular)
+        let textWidth = ceil((title as NSString).size(withAttributes: [.font: font]).width) + 4
+        let pad: CGFloat = 14
+        let gap: CGFloat = 6
+        let iconW: CGFloat = 15
+        let pillW = pad + iconW + gap + textWidth + pad
+        let pillH: CGFloat = 30
+        let handle = idleRestingHandleFrame(placement: placement, frameSize: frameSize)
+        let pill: CGRect
+        switch placement {
+        case .above:
+            // Grip at the canvas bottom; the pill grows upward from its baseline.
+            pill = CGRect(x: handle.midX - pillW / 2, y: handle.minY, width: pillW, height: pillH)
+        case .below:
+            pill = CGRect(x: handle.midX - pillW / 2, y: handle.maxY - pillH, width: pillW, height: pillH)
+        case .leading:
+            pill = CGRect(x: handle.minX, y: handle.midY - pillH / 2, width: pillW, height: pillH)
+        case .trailing:
+            pill = CGRect(x: handle.maxX - pillW, y: handle.midY - pillH / 2, width: pillW, height: pillH)
+        }
+        return (pill, title, font, textWidth)
     }
 
     /// Shortcut-pill chrome belongs to the idle presentation only. Every
@@ -1158,8 +1189,8 @@ final class FloatingIndicatorController: NSObject {
     /// thin grip handle; on hover the mic capsule and an adjacent rounded label
     /// pill appear without resizing the window.
     private func layoutShortcutPillIdle(frameSize: NSSize, config: AppConfig) {
-        // Transparent host: only the mic capsule and the label pill draw. The
-        // classic pill's tint/glass/border would paint the whole canvas as one blob.
+        // Transparent host: only the resting grip or the unified hover pill
+        // draws. The classic canvas chrome would paint the whole area as a blob.
         tintLayer?.isHidden = true
         glassView?.isHidden = true
         CATransaction.begin()
@@ -1169,25 +1200,19 @@ final class FloatingIndicatorController: NSObject {
         CATransaction.commit()
         wandIconView?.isHidden = true
         iconLabel?.isHidden = true
-        textLabel?.isHidden = true
-        textLabel?.alphaValue = 0
+        idleShortcutPillView?.isHidden = true
 
-        let title = "Dictate \(config.dictationHotkey.displayLabel)"
-        let labelWidth = idleLabelWidth(title: title)
         let placement = idleHoverPlacement(for: config.indicatorAnchor)
-        let idleFrames = idleHoverFrames(
+        let (pillFrame, title, font, textWidth) = shortcutPillHoverFrame(
             placement: placement,
             frameSize: frameSize,
-            labelWidth: labelWidth
+            config: config
         )
-        idleShortcutPillView?.isHidden = !isHovered
-        idleShortcutPillView?.frame = idleFrames.label
-        idleShortcutPillView?.title = title
-
         let restingHandle = idleRestingHandleFrame(
             placement: placement,
             frameSize: frameSize
         )
+
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         idleIconBackgroundLayer?.isHidden = false
@@ -1195,14 +1220,8 @@ final class FloatingIndicatorController: NSObject {
             ? NSColor.colorWith(hex: 0x111111, alpha: 1).cgColor
             : NSColor.colorWith(hex: 0x696969, alpha: 0.82).cgColor
         idleIconBackgroundLayer?.borderWidth = isHovered ? 1 : 0
-        let hoveredCapsule = CGRect(
-            x: idleFrames.icon.midX - 22,
-            y: idleFrames.icon.midY - 14,
-            width: 44,
-            height: 28
-        )
-        idleIconBackgroundLayer?.frame = isHovered ? hoveredCapsule : restingHandle
-        idleIconBackgroundLayer?.cornerRadius = isHovered ? 14 : 5
+        idleIconBackgroundLayer?.frame = isHovered ? pillFrame : restingHandle
+        idleIconBackgroundLayer?.cornerRadius = isHovered ? pillFrame.height / 2 : 5
         CATransaction.commit()
 
         let iconSize = NSSize(width: 15, height: 15)
@@ -1210,10 +1229,25 @@ final class FloatingIndicatorController: NSObject {
         if let mic = micIconView {
             mic.alphaValue = 1
             mic.frame = NSRect(
-                x: idleFrames.icon.midX - iconSize.width / 2,
-                y: idleFrames.icon.midY - iconSize.height / 2,
+                x: pillFrame.minX + 14,
+                y: pillFrame.midY - iconSize.height / 2,
                 width: iconSize.width,
                 height: iconSize.height
+            )
+        }
+
+        if let textLabel {
+            textLabel.stringValue = title
+            textLabel.font = font
+            textLabel.textColor = .white.withAlphaComponent(0.88)
+            textLabel.alignment = .left
+            textLabel.isHidden = !isHovered
+            textLabel.alphaValue = isHovered ? 1 : 0
+            textLabel.frame = NSRect(
+                x: pillFrame.minX + 14 + 15 + 6,
+                y: pillFrame.midY - 8,
+                width: textWidth,
+                height: 16
             )
         }
     }
@@ -1754,16 +1788,14 @@ final class FloatingIndicatorController: NSObject {
         switch state {
         case .idle:
             if config.indicatorHoverStyle == .shortcutPill {
-                // Fixed canvas: the window never resizes on hover. Only child
-                // visibility changes, so the pill cannot reveal or crossfade.
-                let title = "Dictate \(config.dictationHotkey.displayLabel)"
-                let labelWidth = idleLabelWidth(title: title)
-                switch idleHoverPlacement(for: config.indicatorAnchor) {
-                case .above, .below:
-                    size = NSSize(width: max(labelWidth, 36) + 4, height: 82)
-                case .leading, .trailing:
-                    size = NSSize(width: labelWidth + 46, height: 40)
-                }
+                // Fixed canvas sized to the unified hover pill: the window never
+                // resizes on hover, only child visibility changes.
+                let (pill, _, _, _) = shortcutPillHoverFrame(
+                    placement: idleHoverPlacement(for: config.indicatorAnchor),
+                    frameSize: .zero,
+                    config: config
+                )
+                size = NSSize(width: pill.width + 4, height: 40)
             } else {
                 size = isHovered
                     ? Self.idleHoverPillSize(hotkeyLabel: config.dictationHotkey.label, screenWidth: screen.width)

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -50,10 +50,17 @@ private final class HoverIndicatorView: NSView {
         if let trackingAreaRef {
             removeTrackingArea(trackingAreaRef)
         }
+        // .inVisibleRect would discard a narrowed rect and track the full
+        // bounds, so only include it when the interactive rect is the full
+        // bounds (classic style); shortcut-pill tracks its explicit rect.
         let interactiveRect = owner?.pointerInteractiveRect(in: bounds) ?? bounds
+        var options: NSTrackingArea.Options = [.mouseEnteredAndExited, .activeAlways]
+        if interactiveRect.equalTo(bounds) {
+            options.insert(.inVisibleRect)
+        }
         let tracking = NSTrackingArea(
             rect: interactiveRect,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            options: options,
             owner: self,
             userInfo: nil
         )

--- a/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/FloatingIndicatorController.swift
@@ -35,13 +35,24 @@ private final class HoverIndicatorView: NSView {
     private var windowOriginAtMouseDown: NSPoint?
     private var didDrag = false
 
+    /// In shortcut-pill mode the panel is a large fixed canvas, but only the
+    /// visible grip (resting) or pill + capsule (hovered) should intercept
+    /// input. Outside those rects clicks fall through to apps underneath.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if let owner, !owner.pointerInteractiveRect(in: bounds).contains(point) {
+            return nil
+        }
+        return super.hitTest(point)
+    }
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         if let trackingAreaRef {
             removeTrackingArea(trackingAreaRef)
         }
+        let interactiveRect = owner?.pointerInteractiveRect(in: bounds) ?? bounds
         let tracking = NSTrackingArea(
-            rect: bounds,
+            rect: interactiveRect,
             options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
@@ -575,8 +586,7 @@ final class FloatingIndicatorController: NSObject {
                 )
             }
         case .preparing:
-            idleShortcutPillView?.isHidden = true
-            idleIconBackgroundLayer?.isHidden = true
+            hideShortcutPillChrome()
             ensureWaveformAnimation(in: targetFrame.size, mode: .waiting)
         default:
             break
@@ -590,6 +600,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func showComputerUseCursor(at quartzPoint: CGPoint, label rawLabel: String?) {
+        hideShortcutPillChrome()
         let config = configStore.load()
         if panel == nil {
             createPanel(config: config)
@@ -678,6 +689,7 @@ final class FloatingIndicatorController: NSObject {
 
     /// Flash a brief warning message on the indicator pill, then snap back to idle.
     func showWarning(_ message: String, icon: String = "⚡", duration: TimeInterval = 2.5) {
+        hideShortcutPillChrome()
         guard state == .idle else { return }
         let config = configStore.load()
         if panel == nil { createPanel(config: config) }
@@ -752,6 +764,7 @@ final class FloatingIndicatorController: NSObject {
     }
 
     func showLoading(_ message: String) {
+        hideShortcutPillChrome()
         let config = configStore.load()
         if panel == nil { createPanel(config: config) }
         guard let panel, let contentView, let textLabel else { return }
@@ -875,6 +888,7 @@ final class FloatingIndicatorController: NSObject {
         isHovered = hovered
         let config = configStore.load()
         setState(.idle, config: config)
+        contentView?.updateTrackingAreas()
         if hovered, config.indicatorHoverStyle == .shortcutPill {
             animateIdleHoverPop()
         }
@@ -1110,6 +1124,36 @@ final class FloatingIndicatorController: NSObject {
         CATransaction.commit()
     }
 
+
+    /// The rect that should respond to pointer input right now. Classic style
+    /// uses the full panel; shortcut-pill limits interaction to the visible
+    /// resting grip, expanding to the label pill + mic capsule only while hovered.
+    func pointerInteractiveRect(in bounds: NSRect) -> NSRect {
+        let config = configStore.load()
+        guard state == .idle, config.indicatorHoverStyle == .shortcutPill else { return bounds }
+        let placement = idleHoverPlacement(for: config.indicatorAnchor)
+        if isHovered {
+            let title = "Dictate \(config.dictationHotkey.displayLabel)"
+            let frames = idleHoverFrames(
+                placement: placement,
+                frameSize: bounds.size,
+                labelWidth: idleLabelWidth(title: title)
+            )
+            return frames.label.union(frames.icon).insetBy(dx: -6, dy: -6).intersection(bounds)
+        }
+        return idleRestingHandleFrame(placement: placement, frameSize: bounds.size)
+            .insetBy(dx: -6, dy: -6)
+            .intersection(bounds)
+    }
+
+    /// Shortcut-pill chrome belongs to the idle presentation only. Every
+    /// non-idle path (transcribing, loading, warning, automation cursor) must
+    /// clear it or the grip/label lingers on top of those overlays.
+    private func hideShortcutPillChrome() {
+        idleShortcutPillView?.isHidden = true
+        idleIconBackgroundLayer?.isHidden = true
+    }
+
     /// Idle layout for `IndicatorHoverStyle.shortcutPill`: the resting state is a
     /// thin grip handle; on hover the mic capsule and an adjacent rounded label
     /// pill appear without resizing the window.
@@ -1151,8 +1195,14 @@ final class FloatingIndicatorController: NSObject {
             ? NSColor.colorWith(hex: 0x111111, alpha: 1).cgColor
             : NSColor.colorWith(hex: 0x696969, alpha: 0.82).cgColor
         idleIconBackgroundLayer?.borderWidth = isHovered ? 1 : 0
-        idleIconBackgroundLayer?.frame = isHovered ? idleFrames.icon : restingHandle
-        idleIconBackgroundLayer?.cornerRadius = isHovered ? 18 : 5
+        let hoveredCapsule = CGRect(
+            x: idleFrames.icon.midX - 22,
+            y: idleFrames.icon.midY - 14,
+            width: 44,
+            height: 28
+        )
+        idleIconBackgroundLayer?.frame = isHovered ? hoveredCapsule : restingHandle
+        idleIconBackgroundLayer?.cornerRadius = isHovered ? 14 : 5
         CATransaction.commit()
 
         let iconSize = NSSize(width: 15, height: 15)
@@ -1263,8 +1313,7 @@ final class FloatingIndicatorController: NSObject {
             }
 
         case .recording:
-            idleShortcutPillView?.isHidden = true
-            idleIconBackgroundLayer?.isHidden = true
+            hideShortcutPillChrome()
             // Waveform bars replace mic icon during recording.
             wandIconView?.isHidden = true
             iconLabel?.isHidden = false   // keeps the ✕ cancel label
@@ -1723,6 +1772,7 @@ final class FloatingIndicatorController: NSObject {
         case .preparing: size = NSSize(width: 76, height: 22)
         case .recording: size = NSSize(width: 76, height: 22)
         case .transcribing:
+            hideShortcutPillChrome()
             if let transcript = computerUseTranscriptText {
                 size = Self.computerUseTranscriptPillSize(transcript: transcript, screen: screen)
             } else {
@@ -1803,7 +1853,7 @@ final class FloatingIndicatorController: NSObject {
         frameSize: NSSize,
         labelWidth: CGFloat
     ) -> (label: CGRect, icon: CGRect) {
-        let iconSize: CGFloat = 36
+        let iconSize: CGFloat = 36  // vertical footprint only; the capsule is a 44x28 stadium pill
         let labelHeight: CGFloat = 36
         let gap: CGFloat = 6
         let inset: CGFloat = 2

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -959,6 +959,18 @@ struct DictionarySuggestion: Codable, Equatable, Identifiable, Sendable {
     }
 }
 
+enum IndicatorHoverStyle: String, Codable, CaseIterable {
+    case classic = "classic"
+    case shortcutPill = "shortcut_pill"
+
+    var label: String {
+        switch self {
+        case .classic: return "Classic"
+        case .shortcutPill: return "Shortcut pill"
+        }
+    }
+}
+
 enum IndicatorAnchor: String, Codable, CaseIterable {
     case topLeading = "top_leading"
     case topCenter = "top_center"
@@ -1167,6 +1179,7 @@ struct AppConfig: Codable {
     var openDashboardOnLaunch: Bool = true
     var showFloatingIndicator: Bool = true
     var showHotkeyOnFloatingIndicator: Bool = false
+    var indicatorHoverStyle: IndicatorHoverStyle = .classic
     var indicatorAnchor: IndicatorAnchor = .midTrailing
     var dashboardWindowFrame: WindowFrame? = nil
     var indicatorOrigin: CGPointCodable? = nil
@@ -1292,6 +1305,7 @@ struct AppConfig: Codable {
         case openDashboardOnLaunch = "open_dashboard_on_launch"
         case showFloatingIndicator = "show_floating_indicator"
         case showHotkeyOnFloatingIndicator = "show_hotkey_on_floating_indicator"
+        case indicatorHoverStyle = "indicator_hover_style"
         case indicatorAnchor = "indicator_anchor"
         case dashboardWindowFrame = "dashboard_window_frame"
         case indicatorOrigin = "indicator_origin"
@@ -1453,6 +1467,9 @@ struct AppConfig: Codable {
         showHotkeyOnFloatingIndicator =
             (try? c.decode(Bool.self, forKey: .showHotkeyOnFloatingIndicator))
             ?? defaults.showHotkeyOnFloatingIndicator
+        indicatorHoverStyle =
+            (try? c.decode(IndicatorHoverStyle.self, forKey: .indicatorHoverStyle))
+            ?? defaults.indicatorHoverStyle
         indicatorAnchor = (try? c.decode(IndicatorAnchor.self, forKey: .indicatorAnchor))
             ?? ((try? c.decodeIfPresent(CGPointCodable.self, forKey: .indicatorOrigin)) != nil ? .custom : .midTrailing)
         dashboardWindowFrame = try? c.decode(WindowFrame.self, forKey: .dashboardWindowFrame)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SettingsView.swift
@@ -1540,6 +1540,17 @@ struct SettingsView: View {
                     }
                     .disabled(!appState.config.showFloatingIndicator)
                 }
+                settingsRow("Hover style") {
+                    settingsMenu(
+                        selection: appState.config.indicatorHoverStyle.label,
+                        options: IndicatorHoverStyle.allCases.map(\.label)
+                    ) { label in
+                        guard let style = IndicatorHoverStyle.allCases.first(where: { $0.label == label }) else { return }
+                        controller.updateConfig { $0.indicatorHoverStyle = style }
+                    }
+                    .disabled(!appState.config.showFloatingIndicator)
+                }
+                settingsDescription("Classic grows the pill to show the hotkey. Shortcut pill keeps a thin grip and pops a separate label on hover.")
                 Divider().background(MuesliTheme.surfaceBorder)
                 settingsRow("Indicator position") {
                     let isCustom = appState.config.indicatorAnchor == .custom

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -171,6 +171,13 @@ struct SidebarView: View {
         .buttonStyle(.plain)
         .help(label)
         .accessibilityLabel(label)
+        // Match the expanded rows so a tour targeting the sidebar keeps its
+        // spotlight when the rail is collapsed mid-tour.
+        .featureTourTarget(
+            tab == .timeline ? .timelineSidebar
+            : tab == .meetings ? .meetingsSidebar
+            : nil
+        )
     }
 
     private var expandedSidebar: some View {

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -151,6 +151,11 @@ struct SidebarView: View {
             withAnimation(.easeInOut(duration: 0.15)) {
                 if tab == .timeline {
                     controller.showTimelineHome()
+                } else if tab == .meetings {
+                    // Mirror the expanded Meetings action: returning to the
+                    // rail must restore the browser, not leave a document open.
+                    meetingsExpanded = true
+                    controller.showMeetingsHome()
                 } else {
                     appState.selectedTab = tab
                 }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -10,6 +10,8 @@ struct SidebarView: View {
 
     let appState: AppState
     let controller: MuesliController
+    var isCollapsed: Bool = false
+    var onToggleCollapsed: () -> Void = {}
     @Environment(\.colorScheme) private var colorScheme
     @State private var meetingsExpanded = true
     @State private var renamingFolderID: Int64?
@@ -98,24 +100,95 @@ struct SidebarView: View {
     }
 
     var body: some View {
+        if isCollapsed {
+            collapsedSidebar
+        } else {
+            expandedSidebar
+        }
+    }
+
+    private var collapsedSidebar: some View {
+        VStack(spacing: MuesliTheme.spacing8) {
+            sidebarToggleButton
+                .padding(.top, MuesliTheme.spacing16)
+                .padding(.bottom, MuesliTheme.spacing12)
+
+            collapsedItem(tab: .timeline, icon: "clock.fill", label: "Timeline")
+            collapsedItem(tab: .dictations, icon: "waveform", label: "Dictations")
+            collapsedItem(tab: .meetings, icon: "person.2.fill", label: "Meetings")
+            collapsedItem(tab: .insights, icon: "chart.bar.xaxis", label: "Insights")
+            collapsedItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
+
+            Spacer()
+
+            collapsedItem(tab: .models, icon: "cpu", label: "Models")
+            collapsedItem(tab: .shortcuts, icon: "command", label: "Shortcuts")
+            collapsedItem(tab: .settings, icon: "gearshape", label: "Settings")
+            collapsedItem(tab: .about, icon: "info.circle", label: "About")
+                .padding(.bottom, MuesliTheme.spacing16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuesliTheme.backgroundDeep)
+    }
+
+    private var sidebarToggleButton: some View {
+        Button(action: onToggleCollapsed) {
+            Image(systemName: "sidebar.left")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .frame(width: 36, height: 36)
+                .background(MuesliTheme.backgroundRaised.opacity(0.72))
+                .clipShape(Circle())
+                .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help(isCollapsed ? "Expand sidebar" : "Collapse sidebar")
+        .accessibilityLabel(isCollapsed ? "Expand sidebar" : "Collapse sidebar")
+    }
+
+    private func collapsedItem(tab: DashboardTab, icon: String, label: String) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                if tab == .timeline {
+                    controller.showTimelineHome()
+                } else {
+                    appState.selectedTab = tab
+                }
+            }
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(appState.selectedTab == tab ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                .frame(width: 40, height: 36)
+                .background(appState.selectedTab == tab ? MuesliTheme.surfacePrimary : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        }
+        .buttonStyle(.plain)
+        .help(label)
+        .accessibilityLabel(label)
+    }
+
+    private var expandedSidebar: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             sidebarHeader
             searchBar
 
             sidebarItem(tab: .timeline, icon: "clock.fill", label: "Timeline")
-            sidebarItem(tab: .dictations, icon: "mic.fill", label: "Dictations")
+            sidebarItem(tab: .dictations, icon: "waveform", label: "Dictations")
             meetingsSection
+            sidebarItem(tab: .insights, icon: "chart.bar.xaxis", label: "Insights")
             sidebarItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
-            sidebarItem(tab: .models, icon: "square.and.arrow.down", label: "Models")
-            sidebarItem(tab: .shortcuts, icon: "keyboard", label: "Shortcuts")
 
             Spacer()
 
             modelPreparationStatus
             spreadTheWordSection
+            sidebarItem(tab: .models, icon: "cpu", label: "Models")
+            sidebarItem(tab: .shortcuts, icon: "command", label: "Shortcuts")
             sidebarItem(tab: .settings, icon: "gearshape", label: "Settings")
             sidebarItem(tab: .about, icon: "info.circle", label: "About", updateCTA: pendingUpdateCTA)
             darkModeToggle
+                .padding(.top, MuesliTheme.spacing12)
                 .padding(.bottom, MuesliTheme.spacing16)
         }
         .frame(maxHeight: .infinity)
@@ -158,30 +231,34 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var sidebarHeader: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-            HStack(spacing: MuesliTheme.spacing12) {
-                Group {
-                    if appState.config.menuBarIcon == "muesli",
-                       let img = MenuBarIconRenderer.make(choice: "muesli") {
-                        Image(nsImage: img)
-                            .resizable()
-                            .scaledToFit()
-                    } else {
-                        Image(systemName: appState.config.menuBarIcon)
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                HStack(spacing: MuesliTheme.spacing12) {
+                    Group {
+                        if appState.config.menuBarIcon == "muesli",
+                           let img = MenuBarIconRenderer.make(choice: "muesli") {
+                            Image(nsImage: img)
+                                .resizable()
+                                .scaledToFit()
+                        } else {
+                            Image(systemName: appState.config.menuBarIcon)
+                        }
                     }
+                    .frame(width: 22, height: 22)
+                    .foregroundStyle(MuesliTheme.accent)
+                    Text("muesli")
+                        .font(MuesliTheme.title2())
+                        .foregroundStyle(MuesliTheme.textPrimary)
                 }
-                .frame(width: 22, height: 22)
-                .foregroundStyle(MuesliTheme.accent)
-                Text("muesli")
-                    .font(MuesliTheme.title2())
-                    .foregroundStyle(MuesliTheme.textPrimary)
+                if !userName.isEmpty {
+                    Text("Hi, \(userName)")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .padding(.leading, 34)
+                }
             }
-            if !userName.isEmpty {
-                Text("Hi, \(userName)")
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                    .padding(.leading, 34)
-            }
+            Spacer(minLength: MuesliTheme.spacing8)
+            sidebarToggleButton
         }
         .padding(.horizontal, MuesliTheme.spacing16)
         .padding(.top, MuesliTheme.pageTop)


### PR DESCRIPTION
## Summary

Surgical extraction of the two liked elements from #329 (which is otherwise too broad to merge). Nothing else from that PR is included — no copy changes, no dashboard redesign, no settings/dictionary redesign.

**Sidebar layout + icons** (adapted for main's NavigationSplitView):
- Insights as a first-class sidebar item (`chart.bar.xaxis`)
- Models, Shortcuts, Settings, About move to the bottom section with refreshed icons (`cpu`, `command`); Dictations uses `waveform`
- Collapsible navigation rail: a header toggle collapses the sidebar to a 68pt icon rail and back. Implemented inside NavigationSplitView (column width swap), so main's window behavior, resizing, and fullscreen are unchanged. Timeline, greeting, All Meetings row, feature-tour targets, and the theme-toggle hit area all preserved.

**Shortcut-pill hover** (opt-in):
- New `IndicatorHoverStyle` config: `classic` (default, current behavior) | `shortcut_pill`, exposed in Settings → Appearance → **Hover style**
- `shortcut_pill`: fixed-size **transparent** canvas — a thin grip handle at rest; on hover the mic capsule and a separate rounded "Dictate \<hotkey\>" pill appear (placement-aware: above/below/leading/trailing), with a pop animation on entry. No window resize, no canvas-level tint/border (the two are visually distinct elements, verified by pixel capture).

## Validation

- Full suite: 1,784/1,784
- Visual verification on dev lane C: sidebar layout + collapsed rail + resting grip + hover pill all pixel-captured and reviewed; the hover picker row verified in Settings → Appearance

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid Signed-off-by trailer under the DCO.
- [x] I created this contribution or otherwise have the right to submit it under Muesli's MIT License.

### AI assistance

OpenCode: extracted and adapted the two features from #329, built the opt-in setting, validated locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789804027&installation_model_id=422865&pr_number=447&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F447&signature=a4f9e7dce45c718b890c2541c224725771a295802daa5976e3b3fc50de861925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible sidebar with compact icon-only navigation, tooltips, accessibility labels, and an Insights section.
  * Added an Appearance setting to choose the floating indicator’s hover style.
  * Introduced a shortcut-pill hover style with a “Dictate” label, microphone control, directional placement, and animated feedback.

* **Improvements**
  * Hover style preferences now default to the classic appearance when unavailable.
  * Improved floating indicator interaction, hover tracking, visibility, and transitions.
  * Updated compact navigation to preserve expected Meetings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->