### PR TITLE
Isolate the config store in tests so the suite stops rewriting the real config

### DIFF
--- a/native/MuesliNative/Tests/MuesliTests/ConfigStoreTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ConfigStoreTests.swift
@@ -6,18 +6,28 @@ import MuesliCore
 @Suite("ConfigStore", .serialized)
 struct ConfigStoreTests {
 
+    /// A throwaway support directory. Tests must never read or write the real
+    /// config.json: `swift test` runs on machines where Muesli is installed, and
+    /// a test that saves into the live support directory rewrites the settings of
+    /// whoever is running the suite.
+    private func makeStore() -> ConfigStore {
+        ConfigStore(
+            supportDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("muesli-config-store-\(UUID().uuidString)", isDirectory: true)
+        )
+    }
+
     @Test("load returns a valid config")
     func loadReturnsConfig() {
-        let store = ConfigStore()
+        let store = makeStore()
         let config = store.load()
-        // Hotkey may have been customized by user — just verify it loaded
         #expect(HotkeyConfig.label(for: config.dictationHotkey.keyCode) != nil)
         #expect(!config.sttBackend.isEmpty)
     }
 
     @Test("save and load round-trip")
     func saveLoadRoundTrip() {
-        let store = ConfigStore()
+        let store = makeStore()
         let original = store.load()
 
         var config = original
@@ -40,9 +50,6 @@ struct ConfigStoreTests {
         #expect(loaded.whisperLanguage == WhisperKitLanguage.german.rawValue)
         #expect(loaded.appleSpeechLanguage == "en-US")
         #expect(loaded.meetingSummaryBackend == "openrouter")
-
-        // Restore original
-        store.save(original)
     }
 
     @Test("config path is in Application Support")
@@ -55,7 +62,7 @@ struct ConfigStoreTests {
 
     @Test("saved config uses owner-only file permissions")
     func configPermissions() throws {
-        let store = ConfigStore()
+        let store = makeStore()
         let original = store.load()
 
         store.save(original)

--- a/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/GoogleCalendarTests.swift
@@ -495,7 +495,11 @@ struct GoogleCalendarTests {
                 appIcon: nil,
                 bundlePath: nil
             ),
-            dictationStore: store
+            dictationStore: store,
+            configStore: ConfigStore(
+                supportDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("muesli-calendar-support-\(UUID().uuidString)", isDirectory: true)
+            )
         )
         let firstStart = date("2026-04-10T14:00:00Z")
         let firstOccurrence = CalendarOccurrenceReference(

--- a/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingHookIntegrationTests.swift
@@ -152,8 +152,14 @@ struct MeetingHookIntegrationTests {
                 bundlePath: nil
             ),
             dictationStore: store,
+            configStore: ConfigStore(supportDirectory: makeSupportDirectory()),
             meetingHookDispatcher: dispatcher
         )
+    }
+
+    private func makeSupportDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-hook-support-\(UUID().uuidString)", isDirectory: true)
     }
 
     private func makeStore() throws -> DictationStore {

--- a/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/MeetingsNavigationTests.swift
@@ -562,7 +562,8 @@ struct MeetingsNavigationTests {
                 appIcon: nil,
                 bundlePath: nil
             ),
-            dictationStore: store
+            dictationStore: store,
+            configStore: ConfigStore(supportDirectory: makeSupportDirectory())
         )
 
         let liveMeeting = try #require(try store.meeting(id: meetingID))

--- a/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/NemotronStreamingTests.swift
@@ -764,7 +764,10 @@ struct NemotronDictationModePolicyTests {
     @MainActor
     @Test("showWarning is callable without crash in idle state")
     func showWarningIdleNoCrash() {
-        let configStore = ConfigStore()
+        let configStore = ConfigStore(
+            supportDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("muesli-indicator-support-\(UUID().uuidString)", isDirectory: true)
+        )
         let config = configStore.load()
         let indicator = FloatingIndicatorController(configStore: configStore)
         // First setState creates the panel so subsequent calls are correctly sequenced
@@ -776,7 +779,10 @@ struct NemotronDictationModePolicyTests {
     @MainActor
     @Test("showWarning is a no-op when indicator is in recording state")
     func showWarningIgnoredDuringRecording() {
-        let configStore = ConfigStore()
+        let configStore = ConfigStore(
+            supportDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("muesli-indicator-support-\(UUID().uuidString)", isDirectory: true)
+        )
         let config = configStore.load()
         let indicator = FloatingIndicatorController(configStore: configStore)
         // Create panel first so setState(.recording) sets state correctly


### PR DESCRIPTION
## Summary

Running `swift test` on a machine where Muesli is installed rewrites the user's own settings.

`MuesliController.init` already takes a `configStore:` and `ConfigStore.init` already takes a
`supportDirectory:`, so the seams exist. Several tests just construct them with the defaults,
which resolve to the live support directory.

The clearest case is `MeetingHookIntegrationTests`:

```swift
controller.updateConfig {
    $0.meetingHookEnabled = true
    $0.meetingHookPath = "/definitely/missing/hook.sh"
    $0.meetingHookTimeoutSeconds = 1
}
```

`updateConfig` calls `configStore.save(config)`, and that store points at
`~/Library/Application Support/Muesli/config.json`. The suite passes, and afterwards the
installed app is configured with a hook path that does not exist and a 1 second hook timeout,
with no record of what was there before.

This is not hypothetical. On my machine it silently replaced a working post-meeting hook and
flipped `meeting_recording_save_policy` from `always` to `prompt`. The next real meeting ran
with those settings: the hook never fired, and the recording was not kept, so the audio is gone.
The only trace was one line in `meeting-hook.log` saying the executable does not exist.

It also cannot be worked around from the outside. macOS resolves Application Support from the
user record rather than `$HOME`, so running the suite with `HOME` pointed at a scratch directory
still writes the real file. I verified that directly before writing this.

## Changes

`MeetingsNavigationTests` already has the right shape, injecting
`ConfigStore(supportDirectory: makeSupportDirectory())`. This applies the same idiom to the
remaining places rather than introducing a new convention.

- `MeetingHookIntegrationTests`, `GoogleCalendarTests` and one direct controller construction in
  `MeetingsNavigationTests` now inject a throwaway support directory.
- `ConfigStoreTests` uses a throwaway store for the load, round-trip and permission tests. The
  round-trip no longer has to save the user's config back afterwards, because it never touches
  it. `config path is in Application Support` deliberately keeps the default store: it asserts
  the real location and only reads it.
- The two `FloatingIndicatorController` tests in `NemotronStreamingTests` no longer load the live
  config, so they stop depending on how the machine happens to be set up.

No production code changes.

## Validation

- `swift test --filter "ConfigStoreTests|MeetingHookIntegrationTests|GoogleCalendarTests|MeetingsNavigationTests"`,
  101 tests in 5 suites, all passing.
- Diffed `config.json` before and after a full run of those suites: identical, no keys changed.
- Reverted the patch and re-ran `MeetingHookIntegrationTests`: `meeting_hook_path` became
  `/definitely/missing/hook.sh` and `meeting_hook_timeout_seconds` became `1` again, which is how
  the original breakage was reproduced.
- `scripts/test_ci_test_shards.sh` passes.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None.

### AI assistance

Written with Claude Code. I reviewed the diff, ran the suites, and reproduced both the failure
and the fix on a dev build before opening this.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789809669&installation_model_id=422865&pr_number=448&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F448&signature=be720fb337d84c88501a78c506c8e6b82d31740f4ed8bd4a4da37efea2ff7fde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by using temporary configuration directories.
  - Reduced interference between tests involving configuration, calendar placeholders, meetings, and warning displays.
  - Updated persistence and permission checks to avoid affecting default application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->