### PR TITLE
Vendor Qwen3 ASR from FluidAudio so the pin can advance

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+Muesli includes software vendored from FluidAudio
+(https://github.com/FluidInference/FluidAudio), licensed under the
+Apache License, Version 2.0.
+
+The vendored sources live in:
+  native/MuesliNative/Sources/MuesliCore/Qwen3ASR/
+
+A copy of the Apache License, Version 2.0 is included alongside those
+sources in LICENSE-Apache-2.0. The files were copied from FluidAudio
+v0.15.1 (ASR/Qwen3/) and renamed with a MuesliQwen3 prefix; this
+distribution preserves that origin and license.

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -755,7 +755,10 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
         }
         let start = CFAbsoluteTimeGetCurrent()
         let samples = try AudioConverter().resampleAudioFile(wavURL)
-        let text = try await (manager as! MuesliQwen3AsrManager).transcribe(audioSamples: samples)
+        guard let qwen3Manager = manager as? MuesliQwen3AsrManager else {
+            throw CLIError.invalidInput("Qwen3 ASR model was not loaded.", fix: "Run the command again after the model finishes downloading.")
+        }
+        let text = try await qwen3Manager.transcribe(audioSamples: samples)
         progress("transcription complete in \(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s")
         return HeadlessTranscription(text: text, durationSeconds: nil)
     }

--- a/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
+++ b/native/MuesliNative/Sources/MuesliCLI/TranscribeCommand.swift
@@ -720,10 +720,10 @@ actor SenseVoiceCLITranscriber: AudioTranscribing {
     }
 }
 
-/// Wraps FluidAudio's `Qwen3AsrManager` directly — a thin wrapper, same shape as
+/// Wraps the vendored `MuesliQwen3AsrManager` directly — a thin wrapper, same shape as
 /// the app's `Qwen3AsrTranscriber` (`Qwen3AsrBackend.swift`), reusing the app's
 /// default model cache. Requires macOS 15+ for CoreML stateful decoder support,
-/// same constraint FluidAudio's `Qwen3AsrManager` itself carries.
+/// same constraint the vendored manager itself carries.
 actor Qwen3AsrCLITranscriber: AudioTranscribing {
     func transcribe(wavURL: URL, model: TranscribeModel, progress: @escaping (String) -> Void) async throws -> HeadlessTranscription {
         guard #available(macOS 15, *) else {
@@ -744,7 +744,7 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
                 }
             ) { modelDir in
                 progress("preparing model")
-                let mgr = Qwen3AsrManager()
+                let mgr = MuesliQwen3AsrManager()
                 try await mgr.loadModels(from: modelDir)
                 return mgr
             }
@@ -755,12 +755,12 @@ actor Qwen3AsrCLITranscriber: AudioTranscribing {
         }
         let start = CFAbsoluteTimeGetCurrent()
         let samples = try AudioConverter().resampleAudioFile(wavURL)
-        let text = try await (manager as! Qwen3AsrManager).transcribe(audioSamples: samples)
+        let text = try await (manager as! MuesliQwen3AsrManager).transcribe(audioSamples: samples)
         progress("transcription complete in \(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s")
         return HeadlessTranscription(text: text, durationSeconds: nil)
     }
 
-    // Stored as Any: `Qwen3AsrManager` itself is `@available(macOS 15, *)` in FluidAudio,
+    // Stored as Any: the vendored manager is `@available(macOS 15, *)`,
     // and a stored property of that type would force this whole actor declaration behind
     // the same guard — but `RoutingAudioTranscriber` needs to construct this actor
     // unconditionally on any deployment target, and only fail at call time on older OSes.

--- a/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
+++ b/native/MuesliNative/Sources/MuesliCore/ManagedASRModelDownloads.swift
@@ -248,18 +248,24 @@ public enum ManagedASRModelPlans {
     }
 
     public static func qwen3ASRInt8(modelsRoot: URL? = nil) -> ManagedASRModelPlan {
+        let directory = (modelsRoot ?? fluidAudioModelsRoot())
+            .appendingPathComponent("qwen3-asr-0.6b/int8", isDirectory: true)
+        return qwen3ASRInt8(cacheDirectory: directory)
+    }
+
+    /// Qwen3 ASR int8 plan with an explicit install directory, so callers can
+    /// install into any location the managed downloader supports.
+    public static func qwen3ASRInt8(cacheDirectory: URL) -> ManagedASRModelPlan {
         let required = [
             "qwen3_asr_audio_encoder_v2.mlmodelc",
             "qwen3_asr_decoder_stateful.mlmodelc",
             "qwen3_asr_embeddings.bin",
             "vocab.json",
         ]
-        let directory = (modelsRoot ?? fluidAudioModelsRoot())
-            .appendingPathComponent("qwen3-asr-0.6b/int8", isDirectory: true)
         return ManagedASRModelPlan(
             modelID: "FluidInference/qwen3-asr-0.6b-coreml",
             repository: "FluidInference/qwen3-asr-0.6b-coreml",
-            cacheDirectory: directory,
+            cacheDirectory: cacheDirectory,
             selections: [
                 HuggingFaceModelSelection(
                     remoteDirectory: "int8",

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/LICENSE-Apache-2.0
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/LICENSE-Apache-2.0
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrConfig.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrConfig.swift
@@ -1,0 +1,162 @@
+// Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
+// Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
+// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+import Foundation
+
+// MARK: - Qwen3-ASR Model Configuration
+
+/// Configuration constants for the Qwen3-ASR-0.6B CoreML model.
+///
+/// Architecture: audio_encoder -> embedding + merge -> 28 decoder layers -> lm_head
+/// The audio encoder processes mel spectrograms in fixed-size windows.
+/// The LLM decoder generates text autoregressively with KV-cache.
+public enum MuesliQwen3AsrConfig {
+    // MARK: Audio
+
+    public static let sampleRate = 16000
+    public static let numMelBins = 128
+
+    /// Audio encoder window size in mel frames (n_window * 2).
+    /// The encoder processes chunks of this size.
+    public static let melWindowSize = 100
+
+    /// Conv2D downsampling factor: 3 layers of stride-2 -> 8x reduction.
+    public static let convDownsampleFactor = 8
+
+    /// Output frames per mel window: ceil(100/8) = 13.
+    public static let outputFramesPerWindow = (melWindowSize + convDownsampleFactor - 1) / convDownsampleFactor
+
+    // MARK: Encoder
+
+    public static let encoderDModel = 896
+    public static let encoderOutputDim = 1024
+    public static let encoderNumLayers = 18
+    public static let encoderNumHeads = 14
+
+    // MARK: Decoder (LLM)
+
+    public static let hiddenSize = 1024
+    public static let intermediateSize = 3072
+    public static let numDecoderLayers = 28
+    public static let numAttentionHeads = 16
+    public static let numKVHeads = 8
+    public static let headDim = 128
+    public static let vocabSize = 151_936
+    public static let ropeTheta: Double = 1_000_000
+    public static let mropeSection = [24, 20, 20]
+
+    // MARK: Special Tokens
+
+    public static let audioStartTokenId = 151_669
+    public static let audioEndTokenId = 151_670
+    public static let audioTokenId = 151_676
+    public static let asrTextTokenId = 151_704
+    public static let eosTokenIds: Set<Int> = [151_645, 151_643]
+
+    // MARK: Chat Template Tokens
+
+    public static let imStartTokenId = 151_644
+    public static let imEndTokenId = 151_645
+    public static let systemTokenId = 8948
+    public static let userTokenId = 872
+    public static let assistantTokenId = 77_091
+    public static let newlineTokenId = 198
+
+    // MARK: Generation
+
+    public static let maxSequenceLength = 4096
+    public static let maxAudioSeconds: Double = 30.0
+
+    /// Maximum KV cache sequence length for the stateful decoder model.
+    /// Must match the value used during CoreML conversion.
+    public static let maxCacheSeqLen = 512
+
+    // MARK: - Supported Languages
+
+    /// Supported languages for Qwen3-ASR (30 languages + 22 Chinese dialects).
+    /// Use ISO 639-1 codes or English names. Pass nil for automatic detection.
+    public enum Language: String, CaseIterable, Sendable {
+        case chinese = "zh"
+        case english = "en"
+        case cantonese = "yue"
+        case arabic = "ar"
+        case german = "de"
+        case french = "fr"
+        case spanish = "es"
+        case portuguese = "pt"
+        case indonesian = "id"
+        case italian = "it"
+        case korean = "ko"
+        case russian = "ru"
+        case thai = "th"
+        case vietnamese = "vi"
+        case japanese = "ja"
+        case turkish = "tr"
+        case hindi = "hi"
+        case malay = "ms"
+        case dutch = "nl"
+        case swedish = "sv"
+        case danish = "da"
+        case finnish = "fi"
+        case polish = "pl"
+        case czech = "cs"
+        case filipino = "fil"
+        case persian = "fa"
+        case greek = "el"
+        case hungarian = "hu"
+        case macedonian = "mk"
+        case romanian = "ro"
+
+        /// English name for the language (used in Qwen3-ASR prompts).
+        public var englishName: String {
+            switch self {
+            case .chinese: return "Chinese"
+            case .english: return "English"
+            case .cantonese: return "Cantonese"
+            case .arabic: return "Arabic"
+            case .german: return "German"
+            case .french: return "French"
+            case .spanish: return "Spanish"
+            case .portuguese: return "Portuguese"
+            case .indonesian: return "Indonesian"
+            case .italian: return "Italian"
+            case .korean: return "Korean"
+            case .russian: return "Russian"
+            case .thai: return "Thai"
+            case .vietnamese: return "Vietnamese"
+            case .japanese: return "Japanese"
+            case .turkish: return "Turkish"
+            case .hindi: return "Hindi"
+            case .malay: return "Malay"
+            case .dutch: return "Dutch"
+            case .swedish: return "Swedish"
+            case .danish: return "Danish"
+            case .finnish: return "Finnish"
+            case .polish: return "Polish"
+            case .czech: return "Czech"
+            case .filipino: return "Filipino"
+            case .persian: return "Persian"
+            case .greek: return "Greek"
+            case .hungarian: return "Hungarian"
+            case .macedonian: return "Macedonian"
+            case .romanian: return "Romanian"
+            }
+        }
+
+        /// Initialize from ISO code or English name.
+        public init?(from string: String) {
+            let lowercased = string.lowercased()
+            // Try ISO code first
+            if let lang = Language(rawValue: lowercased) {
+                self = lang
+                return
+            }
+            // Try English name
+            if let lang = Language.allCases.first(where: { $0.englishName.lowercased() == lowercased }) {
+                self = lang
+                return
+            }
+            return nil
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrConfig.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrConfig.swift
@@ -1,6 +1,6 @@
 // Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
 // Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
-// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+// Licensed under the Apache License, Version 2.0; see LICENSE-Apache-2.0 in this directory.
 import Foundation
 
 // MARK: - Qwen3-ASR Model Configuration

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrManager.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrManager.swift
@@ -53,7 +53,7 @@ public actor MuesliQwen3AsrManager {
         let maxSamples = Int(MuesliQwen3AsrConfig.maxAudioSeconds * 16_000)
         guard audioSamples.count <= maxSamples else {
             throw MuesliQwen3AsrError.audioTooLong(
-                "Audio is \(audioSamples.count / 16_000)s long; Qwen3-ASR supports up to \(Int(MuesliQwen3AsrConfig.maxAudioSeconds))s."
+                "Audio is \(String(format: "%.1f", Double(audioSamples.count) / 16_000.0))s long; Qwen3-ASR supports up to \(Int(MuesliQwen3AsrConfig.maxAudioSeconds))s."
             )
         }
         let mel = melExtractor.compute(audio: audioSamples)

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrManager.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrManager.swift
@@ -1,0 +1,562 @@
+// Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
+// Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
+// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+import Accelerate
+@preconcurrency import CoreML
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "FluidAudio", category: "MuesliQwen3AsrManager")
+
+// MARK: - Qwen3-ASR Manager (2-model pipeline)
+
+/// Manages Qwen3-ASR CoreML inference using the optimized 2-model pipeline.
+///
+/// This uses Swift-side embedding lookup from a preloaded weight matrix,
+/// eliminating the embedding CoreML model. Reduces CoreML calls from 3 to 2 per token.
+///
+/// Pipeline:
+/// 1. Audio -> mel spectrogram -> audio encoder -> audio features
+/// 2. Build prompt tokens -> Swift-side embedding lookup -> merge audio features
+/// 3. Prefill through decoder -> first token
+/// 4. Decode loop: Swift embedding -> decoder -> next token
+@available(macOS 15, iOS 18, *)
+public actor MuesliQwen3AsrManager {
+    private var models: MuesliQwen3AsrModels?
+    private let rope: MuesliQwen3RoPE
+    private let melExtractor: MuesliQwen3WhisperMelSpectrogram
+
+    public init() {
+        self.rope = MuesliQwen3RoPE()
+        self.melExtractor = MuesliQwen3WhisperMelSpectrogram()
+    }
+
+    /// Load all models from the specified directory.
+    public func loadModels(from directory: URL, computeUnits: MLComputeUnits = .all) async throws {
+        models = try await MuesliQwen3AsrModels.load(from: directory, computeUnits: computeUnits)
+        logger.info("Qwen3-ASR models (2-model pipeline) loaded successfully")
+    }
+
+    /// Transcribe raw audio samples.
+    ///
+    /// - Parameters:
+    ///   - audioSamples: 16kHz mono Float32 audio samples.
+    ///   - language: Optional language hint (ISO code like "en", "zh", or English name like "English").
+    ///               Pass nil for automatic language detection.
+    ///   - maxNewTokens: Maximum number of tokens to generate.
+    /// - Returns: Transcribed text.
+    public func transcribe(
+        audioSamples: [Float],
+        language: String? = nil,
+        maxNewTokens: Int = 512
+    ) async throws -> String {
+        let mel = melExtractor.compute(audio: audioSamples)
+        guard !mel.isEmpty else {
+            throw MuesliQwen3AsrError.generationFailed("Audio too short to extract mel spectrogram")
+        }
+        return try await transcribe(melSpectrogram: mel, language: language, maxNewTokens: maxNewTokens)
+    }
+
+    /// Transcribe raw audio samples with typed language.
+    public func transcribe(
+        audioSamples: [Float],
+        language: MuesliQwen3AsrConfig.Language?,
+        maxNewTokens: Int = 512
+    ) async throws -> String {
+        try await transcribe(
+            audioSamples: audioSamples,
+            language: language?.englishName,
+            maxNewTokens: maxNewTokens
+        )
+    }
+
+    /// Transcribe from a pre-computed mel spectrogram.
+    public func transcribe(
+        melSpectrogram: [[Float]],
+        language: String? = nil,
+        maxNewTokens: Int = 512
+    ) async throws -> String {
+        guard let models = models else {
+            throw MuesliQwen3AsrError.generationFailed("Models not loaded")
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+
+        // Resolve language
+        let resolvedLanguage: MuesliQwen3AsrConfig.Language?
+        if let lang = language {
+            resolvedLanguage = MuesliQwen3AsrConfig.Language(from: lang)
+            if resolvedLanguage == nil {
+                logger.warning("Unknown language '\(lang)', using automatic detection")
+            }
+        } else {
+            resolvedLanguage = nil
+        }
+
+        // Step 1: Encode audio
+        let t1 = CFAbsoluteTimeGetCurrent()
+        let audioFeatures = try encodeAudio(melSpectrogram: melSpectrogram, models: models)
+        let numAudioFrames = audioFeatures.count
+        let audioEncodeTime = CFAbsoluteTimeGetCurrent() - t1
+
+        // Step 2: Build chat template with audio tokens
+        let promptTokens = buildPromptTokens(numAudioFrames: numAudioFrames, language: resolvedLanguage)
+
+        // Step 3: Swift-side embedding + audio merge
+        let t3 = CFAbsoluteTimeGetCurrent()
+        let initialEmbeddings = embedAndMerge(
+            promptTokens: promptTokens,
+            audioFeatures: audioFeatures,
+            models: models
+        )
+        let embedTime = CFAbsoluteTimeGetCurrent() - t3
+
+        // Step 4: Autoregressive generation
+        let t4 = CFAbsoluteTimeGetCurrent()
+        let generatedTokenIds = try generate(
+            initialEmbeddings: initialEmbeddings,
+            promptLength: promptTokens.count,
+            maxNewTokens: maxNewTokens,
+            models: models
+        )
+        let generateTime = CFAbsoluteTimeGetCurrent() - t4
+
+        // Step 5: Decode tokens to text
+        let text = decodeTokens(generatedTokenIds, vocabulary: models.vocabulary)
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        logger.debug(
+            "Timing: audio=\(String(format: "%.2f", audioEncodeTime))s embed=\(String(format: "%.2f", embedTime))s gen=\(String(format: "%.2f", generateTime))s total=\(String(format: "%.2f", elapsed))s prompt=\(promptTokens.count) decoded=\(generatedTokenIds.count)"
+        )
+
+        return text
+    }
+
+    // MARK: - Audio Encoding
+
+    private func encodeAudio(
+        melSpectrogram: [[Float]],
+        models: MuesliQwen3AsrModels
+    ) throws -> [[Float]] {
+        let windowSize = MuesliQwen3AsrConfig.melWindowSize
+        let numFrames = melSpectrogram.first?.count ?? 0
+
+        var allFeatures: [[Float]] = []
+        var offset = 0
+
+        while offset < numFrames {
+            let end = min(offset + windowSize, numFrames)
+            let currentWindowSize = end - offset
+
+            let melInput = try createMelInput(
+                melSpectrogram: melSpectrogram,
+                offset: offset,
+                windowSize: currentWindowSize,
+                padTo: windowSize
+            )
+
+            let prediction = try models.audioEncoder.prediction(from: melInput)
+            guard let features = prediction.featureValue(for: "audio_features")?.multiArrayValue else {
+                throw MuesliQwen3AsrError.encoderFailed("No audio_features output")
+            }
+
+            let numOutputFrames: Int
+            if currentWindowSize == windowSize {
+                numOutputFrames = MuesliQwen3AsrConfig.outputFramesPerWindow
+            } else {
+                numOutputFrames =
+                    (currentWindowSize + MuesliQwen3AsrConfig.convDownsampleFactor - 1)
+                    / MuesliQwen3AsrConfig.convDownsampleFactor
+            }
+
+            for f in 0..<numOutputFrames {
+                var vec = [Float](repeating: 0.0, count: MuesliQwen3AsrConfig.encoderOutputDim)
+                for d in 0..<MuesliQwen3AsrConfig.encoderOutputDim {
+                    let idx = f * MuesliQwen3AsrConfig.encoderOutputDim + d
+                    vec[d] = features[idx].floatValue
+                }
+                allFeatures.append(vec)
+            }
+
+            offset += windowSize
+        }
+
+        return allFeatures
+    }
+
+    private func createMelInput(
+        melSpectrogram: [[Float]],
+        offset: Int,
+        windowSize: Int,
+        padTo: Int
+    ) throws -> MLDictionaryFeatureProvider {
+        let shape: [NSNumber] = [1, NSNumber(value: MuesliQwen3AsrConfig.numMelBins), NSNumber(value: padTo)]
+        let array = try MLMultiArray(shape: shape, dataType: .float32)
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: array.count)
+
+        ptr.initialize(repeating: 0.0, count: array.count)
+
+        for bin in 0..<MuesliQwen3AsrConfig.numMelBins {
+            for t in 0..<windowSize {
+                let srcIdx = offset + t
+                if srcIdx < (melSpectrogram[bin].count) {
+                    let dstIdx = bin * padTo + t
+                    ptr[dstIdx] = melSpectrogram[bin][srcIdx]
+                }
+            }
+        }
+
+        return try MLDictionaryFeatureProvider(dictionary: [
+            "mel_input": MLFeatureValue(multiArray: array)
+        ])
+    }
+
+    // MARK: - Token Building
+
+    /// Task description token IDs for language-specific transcription.
+    /// These are tokenized versions of "Transcribe the audio to {Language} text."
+    private static let taskTokens: [MuesliQwen3AsrConfig.Language: [Int32]] = [
+        .english: [3246, 56541, 279, 7461, 311, 6364, 1467, 13],
+        .chinese: [3246, 56541, 279, 7461, 311, 8449, 1467, 13],
+        .cantonese: [3246, 56541, 279, 7461, 311, 56782, 26730, 1467, 13],
+        .japanese: [3246, 56541, 279, 7461, 311, 11411, 1467, 13],
+        .korean: [3246, 56541, 279, 7461, 311, 15791, 1467, 13],
+        .french: [3246, 56541, 279, 7461, 311, 8620, 1467, 13],
+        .german: [3246, 56541, 279, 7461, 311, 6581, 1467, 13],
+        .spanish: [3246, 56541, 279, 7461, 311, 14610, 1467, 13],
+        .portuguese: [3246, 56541, 279, 7461, 311, 42322, 1467, 13],
+        .italian: [3246, 56541, 279, 7461, 311, 15333, 1467, 13],
+        .russian: [3246, 56541, 279, 7461, 311, 10479, 1467, 13],
+        .arabic: [3246, 56541, 279, 7461, 311, 17900, 1467, 13],
+        .hindi: [3246, 56541, 279, 7461, 311, 43083, 1467, 13],
+        .thai: [3246, 56541, 279, 7461, 311, 40764, 1467, 13],
+        .vietnamese: [3246, 56541, 279, 7461, 311, 48416, 1467, 13],
+        .indonesian: [3246, 56541, 279, 7461, 311, 66986, 1467, 13],
+        .malay: [3246, 56541, 279, 7461, 311, 80985, 1467, 13],
+        .turkish: [3246, 56541, 279, 7461, 311, 38703, 1467, 13],
+        .dutch: [3246, 56541, 279, 7461, 311, 19227, 1467, 13],
+        .swedish: [3246, 56541, 279, 7461, 311, 54259, 1467, 13],
+        .danish: [3246, 56541, 279, 7461, 311, 39093, 1467, 13],
+        .finnish: [3246, 56541, 279, 7461, 311, 56391, 1467, 13],
+        .polish: [3246, 56541, 279, 7461, 311, 34827, 1467, 13],
+        .czech: [3246, 56541, 279, 7461, 311, 51728, 1467, 13],
+        .greek: [3246, 56541, 279, 7461, 311, 18173, 1467, 13],
+        .hungarian: [3246, 56541, 279, 7461, 311, 57751, 1467, 13],
+        .romanian: [3246, 56541, 279, 7461, 311, 56949, 1467, 13],
+        .persian: [3246, 56541, 279, 7461, 311, 59181, 1467, 13],
+        .filipino: [3246, 56541, 279, 7461, 311, 66847, 1467, 13],
+        .macedonian: [3246, 56541, 279, 7461, 311, 17067, 103881, 1467, 13],
+    ]
+
+    private func buildPromptTokens(numAudioFrames: Int, language: MuesliQwen3AsrConfig.Language?) -> [Int32] {
+        var tokens: [Int32] = []
+
+        // System message with optional task description
+        tokens.append(Int32(MuesliQwen3AsrConfig.imStartTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.systemTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.newlineTokenId))
+        if let lang = language, let taskToks = Self.taskTokens[lang] {
+            tokens.append(contentsOf: taskToks)
+        }
+        tokens.append(Int32(MuesliQwen3AsrConfig.imEndTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.newlineTokenId))
+
+        // User message with audio
+        tokens.append(Int32(MuesliQwen3AsrConfig.imStartTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.userTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.newlineTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.audioStartTokenId))
+        for _ in 0..<numAudioFrames {
+            tokens.append(Int32(MuesliQwen3AsrConfig.audioTokenId))
+        }
+        tokens.append(Int32(MuesliQwen3AsrConfig.audioEndTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.imEndTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.newlineTokenId))
+
+        // Assistant start
+        tokens.append(Int32(MuesliQwen3AsrConfig.imStartTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.assistantTokenId))
+        tokens.append(Int32(MuesliQwen3AsrConfig.newlineTokenId))
+
+        return tokens
+    }
+
+    // MARK: - Swift-side Embedding & Audio Merge
+
+    private func embedAndMerge(
+        promptTokens: [Int32],
+        audioFeatures: [[Float]],
+        models: MuesliQwen3AsrModels
+    ) -> [[Float]] {
+        // Swift-side embedding lookup (no CoreML call!)
+        var embeddings = models.embeddingWeights.embeddings(for: promptTokens)
+
+        // Replace audio_token positions with audio features
+        var audioIdx = 0
+        for i in 0..<promptTokens.count {
+            if promptTokens[i] == Int32(MuesliQwen3AsrConfig.audioTokenId), audioIdx < audioFeatures.count {
+                embeddings[i] = audioFeatures[audioIdx]
+                audioIdx += 1
+            }
+        }
+
+        return embeddings
+    }
+
+    // MARK: - Autoregressive Generation
+
+    private func generate(
+        initialEmbeddings: [[Float]],
+        promptLength: Int,
+        maxNewTokens: Int,
+        models: MuesliQwen3AsrModels
+    ) throws -> [Int] {
+        let state = models.decoderStateful.makeState()
+        var generatedTokens: [Int] = []
+        var currentPosition = 0
+
+        guard promptLength > 0 else {
+            throw MuesliQwen3AsrError.generationFailed("Empty prompt")
+        }
+
+        let effectiveMaxNew = min(maxNewTokens, MuesliQwen3AsrConfig.maxCacheSeqLen - promptLength)
+        guard effectiveMaxNew > 0 else {
+            throw MuesliQwen3AsrError.generationFailed(
+                "Prompt length \(promptLength) exceeds cache capacity \(MuesliQwen3AsrConfig.maxCacheSeqLen)"
+            )
+        }
+
+        // ---- Prefill ----
+        let prefillStart = CFAbsoluteTimeGetCurrent()
+
+        let (prefillCos, prefillSin) = rope.computeRange(startPosition: 0, count: promptLength)
+        let hiddenArray = try createBatchedHiddenArray(
+            embeddings: Array(initialEmbeddings[0..<promptLength])
+        )
+        let cosArray = try createBatchedPositionArray(values: prefillCos, seqLen: promptLength)
+        let sinArray = try createBatchedPositionArray(values: prefillSin, seqLen: promptLength)
+        let prefillMask = try createPrefillMask(seqLen: promptLength)
+
+        let prefillLogits = try runStatefulDecoder(
+            hiddenStates: hiddenArray,
+            positionCos: cosArray,
+            positionSin: sinArray,
+            mask: prefillMask,
+            state: state,
+            models: models
+        )
+
+        currentPosition = promptLength
+
+        // Preallocate decode buffers
+        let decHiddenArray = try MLMultiArray(
+            shape: [1, 1, NSNumber(value: MuesliQwen3AsrConfig.hiddenSize)], dataType: .float32
+        )
+        let decHiddenPtr = decHiddenArray.dataPointer.bindMemory(
+            to: Float.self, capacity: MuesliQwen3AsrConfig.hiddenSize
+        )
+        let decodeCosArray = try MLMultiArray(
+            shape: [1, 1, NSNumber(value: MuesliQwen3AsrConfig.headDim)], dataType: .float32
+        )
+        let decodeCosPtr = decodeCosArray.dataPointer.bindMemory(
+            to: Float.self, capacity: MuesliQwen3AsrConfig.headDim
+        )
+        let decodeSinArray = try MLMultiArray(
+            shape: [1, 1, NSNumber(value: MuesliQwen3AsrConfig.headDim)], dataType: .float32
+        )
+        let decodeSinPtr = decodeSinArray.dataPointer.bindMemory(
+            to: Float.self, capacity: MuesliQwen3AsrConfig.headDim
+        )
+
+        // Get first token from prefill logits
+        let firstTokenId = argmaxFromLogits(prefillLogits)
+        if !MuesliQwen3AsrConfig.eosTokenIds.contains(firstTokenId) {
+            generatedTokens.append(firstTokenId)
+        }
+
+        let prefillTime = CFAbsoluteTimeGetCurrent() - prefillStart
+        logger.debug("Prefill: \(String(format: "%.3f", prefillTime))s for \(promptLength) tokens")
+
+        // ---- Decode ----
+        if MuesliQwen3AsrConfig.eosTokenIds.contains(firstTokenId) {
+            return generatedTokens
+        }
+
+        let decodeStart = CFAbsoluteTimeGetCurrent()
+
+        for _ in 1..<effectiveMaxNew {
+            guard let lastTokenId = generatedTokens.last else { break }
+
+            // Swift-side embedding lookup (no CoreML call!)
+            let nextEmbedding = models.embeddingWeights.embedding(for: lastTokenId)
+
+            nextEmbedding.withUnsafeBufferPointer { src in
+                _ = memcpy(decHiddenPtr, src.baseAddress!, MuesliQwen3AsrConfig.hiddenSize * MemoryLayout<Float>.size)
+            }
+            rope.fill(position: currentPosition, cosPtr: decodeCosPtr, sinPtr: decodeSinPtr)
+            let endStep = currentPosition + 1
+            let mask = try createDecodeMask(endStep: endStep)
+
+            let logits = try runStatefulDecoder(
+                hiddenStates: decHiddenArray,
+                positionCos: decodeCosArray,
+                positionSin: decodeSinArray,
+                mask: mask,
+                state: state,
+                models: models
+            )
+
+            currentPosition += 1
+
+            let tokenId = argmaxFromLogits(logits)
+
+            if MuesliQwen3AsrConfig.eosTokenIds.contains(tokenId) {
+                break
+            }
+
+            generatedTokens.append(tokenId)
+        }
+
+        let decodeTime = CFAbsoluteTimeGetCurrent() - decodeStart
+        let perToken = generatedTokens.isEmpty ? 0.0 : decodeTime / Double(generatedTokens.count)
+        logger.debug(
+            "Decode: \(String(format: "%.3f", decodeTime))s for \(generatedTokens.count) tokens (\(String(format: "%.1f", perToken * 1000))ms/tok)"
+        )
+        return generatedTokens
+    }
+
+    // MARK: - Stateful Decoder
+
+    private func runStatefulDecoder(
+        hiddenStates: MLMultiArray,
+        positionCos: MLMultiArray,
+        positionSin: MLMultiArray,
+        mask: MLMultiArray,
+        state: MLState,
+        models: MuesliQwen3AsrModels
+    ) throws -> MLMultiArray {
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "hidden_states": MLFeatureValue(multiArray: hiddenStates),
+            "position_cos": MLFeatureValue(multiArray: positionCos),
+            "position_sin": MLFeatureValue(multiArray: positionSin),
+            "attention_mask": MLFeatureValue(multiArray: mask),
+        ])
+
+        let output = try models.decoderStateful.prediction(from: input, using: state)
+
+        guard let logits = output.featureValue(for: "logits")?.multiArrayValue else {
+            throw MuesliQwen3AsrError.decoderFailed("Missing logits from stateful decoder")
+        }
+
+        return logits
+    }
+
+    // MARK: - Argmax
+
+    private func argmaxFromLogits(_ logits: MLMultiArray) -> Int {
+        let ptr = logits.dataPointer.bindMemory(to: Float.self, capacity: MuesliQwen3AsrConfig.vocabSize)
+        var maxVal: Float = 0
+        var maxIdx: vDSP_Length = 0
+        vDSP_maxvi(ptr, 1, &maxVal, &maxIdx, vDSP_Length(MuesliQwen3AsrConfig.vocabSize))
+        return Int(maxIdx)
+    }
+
+    // MARK: - Text Decoding
+
+    private static let bpeUnicodeToByte: [UInt32: UInt8] = {
+        var printable = [Int]()
+        printable.append(contentsOf: 33...126)
+        printable.append(contentsOf: 161...172)
+        printable.append(contentsOf: 174...255)
+        let printableSet = Set(printable)
+
+        var mapping = [UInt32: UInt8]()
+        for b in printable {
+            mapping[UInt32(b)] = UInt8(b)
+        }
+        var extra: UInt32 = 256
+        for b in 0...255 {
+            if !printableSet.contains(b) {
+                mapping[extra] = UInt8(b)
+                extra += 1
+            }
+        }
+        return mapping
+    }()
+
+    private func decodeTokens(_ tokenIds: [Int], vocabulary: [Int: String]) -> String {
+        var startIdx = 0
+        if let asrIdx = tokenIds.firstIndex(of: MuesliQwen3AsrConfig.asrTextTokenId) {
+            startIdx = asrIdx + 1
+        }
+        let transcriptionTokens = Array(tokenIds[startIdx...])
+
+        var pieces: [String] = []
+        for id in transcriptionTokens {
+            if let piece = vocabulary[id] {
+                pieces.append(piece)
+            }
+        }
+        let raw = pieces.joined()
+
+        var bytes = [UInt8]()
+        for scalar in raw.unicodeScalars {
+            if let byte = Self.bpeUnicodeToByte[scalar.value] {
+                bytes.append(byte)
+            }
+        }
+
+        let decoded = String(bytes: bytes, encoding: .utf8) ?? String(raw.filter { $0.isASCII })
+        return decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - MLMultiArray Helpers
+
+    private func createPrefillMask(seqLen: Int) throws -> MLMultiArray {
+        let shape: [NSNumber] = [1, 1, NSNumber(value: seqLen), NSNumber(value: seqLen)]
+        let array = try MLMultiArray(shape: shape, dataType: .float32)
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: seqLen * seqLen)
+        for i in 0..<seqLen {
+            for j in 0..<seqLen {
+                ptr[i * seqLen + j] = j > i ? Float(-1e9) : 0.0
+            }
+        }
+        return array
+    }
+
+    private func createDecodeMask(endStep: Int) throws -> MLMultiArray {
+        let shape: [NSNumber] = [1, 1, 1, NSNumber(value: endStep)]
+        let array = try MLMultiArray(shape: shape, dataType: .float32)
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: endStep)
+        for i in 0..<endStep {
+            ptr[i] = 0.0
+        }
+        return array
+    }
+
+    private func createBatchedHiddenArray(embeddings: [[Float]]) throws -> MLMultiArray {
+        let seqLen = embeddings.count
+        let shape: [NSNumber] = [1, NSNumber(value: seqLen), NSNumber(value: MuesliQwen3AsrConfig.hiddenSize)]
+        let array = try MLMultiArray(shape: shape, dataType: .float32)
+        let totalCount = seqLen * MuesliQwen3AsrConfig.hiddenSize
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: totalCount)
+        for i in 0..<seqLen {
+            let offset = i * MuesliQwen3AsrConfig.hiddenSize
+            let emb = embeddings[i]
+            for j in 0..<MuesliQwen3AsrConfig.hiddenSize {
+                ptr[offset + j] = emb[j]
+            }
+        }
+        return array
+    }
+
+    private func createBatchedPositionArray(values: [Float], seqLen: Int) throws -> MLMultiArray {
+        let shape: [NSNumber] = [1, NSNumber(value: seqLen), NSNumber(value: MuesliQwen3AsrConfig.headDim)]
+        let array = try MLMultiArray(shape: shape, dataType: .float32)
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: values.count)
+        for i in 0..<values.count {
+            ptr[i] = values[i]
+        }
+        return array
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrManager.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrManager.swift
@@ -1,6 +1,6 @@
 // Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
 // Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
-// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+// Licensed under the Apache License, Version 2.0; see LICENSE-Apache-2.0 in this directory.
 import Accelerate
 @preconcurrency import CoreML
 import Foundation
@@ -50,6 +50,12 @@ public actor MuesliQwen3AsrManager {
         language: String? = nil,
         maxNewTokens: Int = 512
     ) async throws -> String {
+        let maxSamples = Int(MuesliQwen3AsrConfig.maxAudioSeconds * 16_000)
+        guard audioSamples.count <= maxSamples else {
+            throw MuesliQwen3AsrError.audioTooLong(
+                "Audio is \(audioSamples.count / 16_000)s long; Qwen3-ASR supports up to \(Int(MuesliQwen3AsrConfig.maxAudioSeconds))s."
+            )
+        }
         let mel = melExtractor.compute(audio: audioSamples)
         guard !mel.isEmpty else {
             throw MuesliQwen3AsrError.generationFailed("Audio too short to extract mel spectrogram")

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -150,6 +150,13 @@ public struct MuesliQwen3AsrModels: Sendable {
 
         logger.info("Downloading Qwen3-ASR \(variant.rawValue) models via managed downloader...")
         let plan = ManagedASRModelPlans.qwen3ASRInt8()
+        if force {
+            // The managed downloader short-circuits on its canonical cache, so a
+            // forced re-download must purge that cache (and the requested
+            // destination) before starting, or stale artifacts survive.
+            try? plan.delete(fileManager: .default)
+            try? FileManager.default.removeItem(at: targetDir)
+        }
         _ = try await ManagedASRModelDownloader.downloadIfNeeded(
             plan,
             progress: { fraction, _ in progressHandler?(fraction) }
@@ -322,9 +329,10 @@ public final class MuesliQwen3EmbeddingWeights: Sendable {
             throw MuesliQwen3AsrError.invalidVocabulary
         }
 
-        // Read header
-        let vocab = fileData.withUnsafeBytes { $0.load(fromByteOffset: 0, as: UInt32.self) }
-        let hidden = fileData.withUnsafeBytes { $0.load(fromByteOffset: 4, as: UInt32.self) }
+        // Read header. Data's backing buffer is not guaranteed to be aligned, so
+        // use loadUnaligned to avoid trapping on unaligned addresses.
+        let vocab = fileData.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 0, as: UInt32.self) }
+        let hidden = fileData.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 4, as: UInt32.self) }
         self.vocabSize = Int(vocab)
         self.hiddenSize = Int(hidden)
 
@@ -363,11 +371,12 @@ public final class MuesliQwen3EmbeddingWeights: Sendable {
 
         #if arch(arm64)
         data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
-            let f16Ptr = ptr.baseAddress!.advanced(by: offset)
-                .assumingMemoryBound(to: Float16.self)
-
             for i in 0..<hiddenSize {
-                result[i] = Float(f16Ptr[i])
+                let value = ptr.loadUnaligned(
+                    fromByteOffset: offset + i * 2,
+                    as: Float16.self
+                )
+                result[i] = Float(value)
             }
         }
         #else

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -144,135 +144,21 @@ public struct MuesliQwen3AsrModels: Sendable {
             return targetDir
         }
 
+        // Delegate entirely to the managed downloader: the plan's cacheDirectory
+        // IS the requested destination, so the downloader's own resume/marker
+        // machinery owns the directory (same semantics as every other model in
+        // the app). `force` reuses the app-standard delete-then-download flow.
         logger.info("Downloading Qwen3-ASR \(variant.rawValue) models via managed downloader...")
-        let plan = ManagedASRModelPlans.qwen3ASRInt8()
-        let cacheBackup: URL?
-        let destinationBackup: URL?
+        let plan = ManagedASRModelPlans.qwen3ASRInt8(cacheDirectory: targetDir)
         if force {
-            // The managed downloader short-circuits on its canonical cache, so a
-            // forced re-download must move that cache (and the requested
-            // destination) aside before starting. Keep backups so a failed
-            // re-download restores the previous installation instead of leaving
-            // nothing usable. If moving the destination aside fails after the
-            // cache was already moved, put the cache back before rethrowing.
-            cacheBackup = try Self.stageAside(plan.cacheDirectory, fileManager: .default)
-            if targetDir.standardizedFileURL != plan.cacheDirectory.standardizedFileURL {
-                do {
-                    destinationBackup = try Self.stageAside(targetDir, fileManager: .default)
-                } catch {
-                    if let cacheBackup {
-                        try? Self.restore(staged: cacheBackup, to: plan.cacheDirectory, fileManager: .default)
-                    }
-                    throw error
-                }
-            } else {
-                destinationBackup = nil
-            }
-        } else {
-            cacheBackup = nil
-            destinationBackup = nil
+            try? plan.delete(fileManager: .default)
         }
-        // The managed plan installs into its canonical cache directory. Honor a
-        // caller-provided destination by copying the artifacts there, so
-        // `downloadAndLoad(to:)` always loads from a directory that has them.
-        do {
-            _ = try await ManagedASRModelDownloader.downloadIfNeeded(
-                plan,
-                progress: { fraction, _ in progressHandler?(fraction) }
-            )
-            if let directory,
-               directory.standardizedFileURL != plan.cacheDirectory.standardizedFileURL {
-                try installArtifacts(from: plan.cacheDirectory, to: directory)
-            }
-        } catch {
-            // Roll back every staged-aside directory on ANY failure (download or
-            // artifact install), so a forced refresh can never leave the custom
-            // destination or the canonical cache unusable.
-            if let cacheBackup {
-                try? Self.restore(staged: cacheBackup, to: plan.cacheDirectory, fileManager: .default)
-            }
-            if let destinationBackup {
-                try? Self.restore(staged: destinationBackup, to: targetDir, fileManager: .default)
-            }
-            throw error
-        }
-        if let cacheBackup {
-            try? FileManager.default.removeItem(at: cacheBackup)
-        }
-        if let destinationBackup {
-            try? FileManager.default.removeItem(at: destinationBackup)
-        }
-
+        _ = try await ManagedASRModelDownloader.downloadIfNeeded(
+            plan,
+            progress: { fraction, _ in progressHandler?(fraction) }
+        )
         logger.info("Successfully downloaded Qwen3-ASR \(variant.rawValue) models")
         return targetDir
-    }
-
-    /// Copy the artifacts in `source` into `destination`, replacing any existing
-    /// files with the same names. Creates `destination` if needed.
-    ///
-    /// Stage-then-swap with rollback: artifacts are fully copied into a
-    /// temporary sibling directory first, the existing destination is moved
-    /// aside, and the staged set is moved into place. A failure at any step
-    /// restores the previous installation, so a broken copy can never leave the
-    /// destination unusable.
-    static func installArtifacts(from source: URL, to destination: URL) throws {
-        let fileManager = FileManager.default
-        let parent = destination.deletingLastPathComponent()
-        let staging = parent.appendingPathComponent(".qwen3-install-\(UUID().uuidString)", isDirectory: true)
-        defer { try? fileManager.removeItem(at: staging) }
-
-        try fileManager.createDirectory(at: staging, withIntermediateDirectories: true)
-        let contents = try fileManager.contentsOfDirectory(
-            at: source,
-            includingPropertiesForKeys: nil
-        )
-        for item in contents {
-            try fileManager.copyItem(
-                at: item,
-                to: staging.appendingPathComponent(item.lastPathComponent)
-            )
-        }
-
-        // Move the existing installation aside, then swap the staged set in.
-        // Restore the previous installation if the swap fails.
-        let old = fileManager.fileExists(atPath: destination.path)
-            ? parent.appendingPathComponent(".qwen3-old-\(UUID().uuidString)", isDirectory: true)
-            : nil
-        if let old {
-            try fileManager.moveItem(at: destination, to: old)
-        }
-        do {
-            try fileManager.moveItem(at: staging, to: destination)
-        } catch {
-            if let old, fileManager.fileExists(atPath: old.path) {
-                try? fileManager.moveItem(at: old, to: destination)
-            }
-            throw error
-        }
-        if let old {
-            try? fileManager.removeItem(at: old)
-        }
-    }
-
-    /// Move a directory aside (rename) so its original location can be rebuilt.
-    /// Returns the backup URL, or nil if the directory does not exist.
-    static func stageAside(_ directory: URL, fileManager: FileManager = .default) throws -> URL? {
-        guard fileManager.fileExists(atPath: directory.path) else { return nil }
-        let backup = directory.deletingLastPathComponent()
-            .appendingPathComponent(".qwen3-backup-\(UUID().uuidString)", isDirectory: true)
-        try fileManager.moveItem(at: directory, to: backup)
-        return backup
-    }
-
-    /// Restore a staged-aside directory into its original location.
-    static func restore(
-        staged backup: URL,
-        to directory: URL,
-        fileManager: FileManager = .default
-    ) {
-        guard fileManager.fileExists(atPath: backup.path) else { return }
-        try? fileManager.removeItem(at: directory)
-        try? fileManager.moveItem(at: backup, to: directory)
     }
 
     /// Check if all required model files exist locally.

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -153,11 +153,21 @@ public struct MuesliQwen3AsrModels: Sendable {
             // forced re-download must move that cache (and the requested
             // destination) aside before starting. Keep backups so a failed
             // re-download restores the previous installation instead of leaving
-            // nothing usable.
+            // nothing usable. If moving the destination aside fails after the
+            // cache was already moved, put the cache back before rethrowing.
             cacheBackup = try Self.stageAside(plan.cacheDirectory, fileManager: .default)
-            destinationBackup = targetDir.standardizedFileURL != plan.cacheDirectory.standardizedFileURL
-                ? try Self.stageAside(targetDir, fileManager: .default)
-                : nil
+            if targetDir.standardizedFileURL != plan.cacheDirectory.standardizedFileURL {
+                do {
+                    destinationBackup = try Self.stageAside(targetDir, fileManager: .default)
+                } catch {
+                    if let cacheBackup {
+                        try? Self.restore(staged: cacheBackup, to: plan.cacheDirectory, fileManager: .default)
+                    }
+                    throw error
+                }
+            } else {
+                destinationBackup = nil
+            }
         } else {
             cacheBackup = nil
             destinationBackup = nil

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -1,0 +1,379 @@
+// Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
+// Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
+// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+@preconcurrency import CoreML
+import Foundation
+import OSLog
+
+/// Model artifact file names for the vendored Qwen3 ASR backend.
+private enum MuesliQwen3ModelFiles {
+    static let audioEncoder = "qwen3_asr_audio_encoder_v2.mlmodelc"
+    static let decoderStateful = "qwen3_asr_decoder_stateful.mlmodelc"
+    static let embeddings = "qwen3_asr_embeddings.bin"
+    static let vocab = "vocab.json"
+}
+
+private let logger = Logger(subsystem: "FluidAudio", category: "MuesliQwen3AsrModels")
+
+/// Qwen3-ASR model variant (precision).
+public enum MuesliQwen3AsrVariant: String, CaseIterable, Sendable {
+    /// Full precision (FP16 weights). Best speed, ~1.75 GB.
+    case f32
+    /// Int8 quantized weights. Half the RAM (~900 MB), same quality.
+    case int8
+
+    /// On-disk cache folder name (matches the layout Muesli's managed downloader uses).
+    public var folderName: String {
+        switch self {
+        case .f32: return "qwen3-asr-0.6b/f32"
+        case .int8: return "qwen3-asr-0.6b/int8"
+        }
+    }
+}
+
+// MARK: - Qwen3-ASR CoreML Model Container (2-model pipeline)
+
+/// Holds CoreML model components for the optimized 2-model Qwen3-ASR pipeline.
+///
+/// This uses Swift-side embedding lookup from a preloaded weight matrix,
+/// eliminating the embedding CoreML model. Reduces CoreML calls from 3 to 2 per token.
+///
+/// Components:
+/// - `audioEncoder`: mel spectrogram -> 1024-dim audio features (single window)
+/// - `decoderStateful`: stateful decoder with fused lmHead (outputs logits directly)
+/// - `embeddingWeights`: [151936, 1024] float16 matrix for Swift-side embedding lookup
+@available(macOS 15, iOS 18, *)
+public struct MuesliQwen3AsrModels: Sendable {
+    public let audioEncoder: MLModel
+    public let decoderStateful: MLModel
+    public let embeddingWeights: MuesliQwen3EmbeddingWeights
+    public let vocabulary: [Int: String]
+
+    /// Load Qwen3-ASR models (2-model pipeline with Swift-side embedding) from a directory.
+    ///
+    /// Expected directory structure:
+    /// ```
+    /// qwen3-asr/
+    ///   qwen3_asr_audio_encoder_v2.mlmodelc
+    ///   qwen3_asr_decoder_stateful.mlmodelc
+    ///   qwen3_asr_embeddings.bin  (float16 embedding weights)
+    ///   vocab.json
+    /// ```
+    public static func load(
+        from directory: URL,
+        computeUnits: MLComputeUnits = .all
+    ) async throws -> MuesliQwen3AsrModels {
+        let modelConfig = MLModelConfiguration()
+        modelConfig.computeUnits = computeUnits
+
+        logger.info("Loading Qwen3-ASR models (2-model pipeline) from \(directory.path)")
+        let start = CFAbsoluteTimeGetCurrent()
+
+        // Load audio encoder
+        let audioEncoder = try await loadModel(
+            named: "qwen3_asr_audio_encoder_v2",
+            from: directory,
+            configuration: modelConfig
+        )
+
+        // Load stateful decoder (with fused lmHead)
+        let decoderStateful = try await loadModel(
+            named: "qwen3_asr_decoder_stateful",
+            from: directory,
+            configuration: modelConfig
+        )
+
+        // Load embedding weights for Swift-side lookup
+        let embeddingWeights = try loadMuesliQwen3EmbeddingWeights(from: directory)
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        logger.info("Loaded Qwen3-ASR models (2-model) in \(String(format: "%.2f", elapsed))s")
+
+        // Load vocabulary from tokenizer
+        let vocabulary = try loadVocabulary(from: directory)
+
+        return MuesliQwen3AsrModels(
+            audioEncoder: audioEncoder,
+            decoderStateful: decoderStateful,
+            embeddingWeights: embeddingWeights,
+            vocabulary: vocabulary
+        )
+    }
+
+    /// Download models from HuggingFace and load them.
+    ///
+    /// Downloads to the default cache directory if not already present,
+    /// then loads all model components.
+    public static func downloadAndLoad(
+        variant: MuesliQwen3AsrVariant = .int8,
+        to directory: URL? = nil,
+        computeUnits: MLComputeUnits = .all,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> MuesliQwen3AsrModels {
+        let targetDir = try await download(variant: variant, to: directory, progressHandler: progressHandler)
+        return try await load(from: targetDir, computeUnits: computeUnits)
+    }
+
+    /// Download Qwen3-ASR models through Muesli's managed model downloader.
+    ///
+    /// - Parameters:
+    ///   - variant: Model variant to download (`.int8` managed; `.f32` unsupported).
+    ///   - directory: Target directory. Uses default cache directory if nil.
+    ///   - force: Force re-download even if models exist.
+    ///   - progressHandler: Optional callback for download progress updates.
+    /// - Returns: Path to the directory containing the downloaded models.
+    @discardableResult
+    public static func download(
+        variant: MuesliQwen3AsrVariant = .int8,
+        to directory: URL? = nil,
+        force: Bool = false,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> URL {
+        let targetDir = directory ?? defaultCacheDirectory(variant: variant)
+
+        guard variant == .int8 else {
+            throw MuesliQwen3AsrError.downloadUnavailable(
+                "The f32 variant is not managed; use the int8 managed plan."
+            )
+        }
+
+        if !force && modelsExist(at: targetDir) {
+            logger.info("Qwen3-ASR \(variant.rawValue) models already present at: \(targetDir.path)")
+            return targetDir
+        }
+
+        if force {
+            try? FileManager.default.removeItem(at: targetDir)
+        }
+
+        logger.info("Downloading Qwen3-ASR \(variant.rawValue) models via managed downloader...")
+        _ = try await ManagedASRModelDownloader.downloadIfNeeded(
+            ManagedASRModelPlans.qwen3ASRInt8(),
+            progress: { fraction, _ in progressHandler?(fraction) }
+        )
+        logger.info("Successfully downloaded Qwen3-ASR \(variant.rawValue) models")
+        return targetDir
+    }
+
+    /// Check if all required model files exist locally.
+    public static func modelsExist(at directory: URL) -> Bool {
+        let fm = FileManager.default
+        let requiredFiles = [
+            MuesliQwen3ModelFiles.audioEncoder,
+            MuesliQwen3ModelFiles.decoderStateful,
+            MuesliQwen3ModelFiles.embeddings,
+            MuesliQwen3ModelFiles.vocab,
+        ]
+        return requiredFiles.allSatisfy { file in
+            fm.fileExists(atPath: directory.appendingPathComponent(file).path)
+        }
+    }
+
+    /// Root directory for all FluidAudio model caches.
+    private static func modelsRootDirectory() -> URL {
+        guard
+            let appSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory, in: .userDomainMask
+            ).first
+        else {
+            // Fallback to temporary directory if application support unavailable
+            return FileManager.default.temporaryDirectory
+                .appendingPathComponent("FluidAudio", isDirectory: true)
+                .appendingPathComponent("Models", isDirectory: true)
+        }
+        return
+            appSupport
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    /// Default cache directory for Qwen3-ASR models.
+    public static func defaultCacheDirectory(variant: MuesliQwen3AsrVariant = .f32) -> URL {
+        modelsRootDirectory()
+            .appendingPathComponent(variant.folderName, isDirectory: true)
+    }
+
+    // MARK: Private
+
+    private static func loadModel(
+        named name: String,
+        from directory: URL,
+        configuration: MLModelConfiguration
+    ) async throws -> MLModel {
+        // Try .mlmodelc first (pre-compiled), then compile .mlpackage on the fly
+        let compiledPath = directory.appendingPathComponent("\(name).mlmodelc")
+        let packagePath = directory.appendingPathComponent("\(name).mlpackage")
+
+        let modelURL: URL
+        if FileManager.default.fileExists(atPath: compiledPath.path) {
+            modelURL = compiledPath
+        } else if FileManager.default.fileExists(atPath: packagePath.path) {
+            // .mlpackage must be compiled to .mlmodelc before loading
+            logger.info("Compiling \(name).mlpackage -> .mlmodelc ...")
+            let compileStart = CFAbsoluteTimeGetCurrent()
+            let compiledURL = try await MLModel.compileModel(at: packagePath)
+            let compileElapsed = CFAbsoluteTimeGetCurrent() - compileStart
+            logger.info("  \(name): compiled in \(String(format: "%.2f", compileElapsed))s")
+
+            // Move compiled model next to the package for caching
+            try? FileManager.default.removeItem(at: compiledPath)
+            try FileManager.default.copyItem(at: compiledURL, to: compiledPath)
+            // Clean up the temp compiled model
+            try? FileManager.default.removeItem(at: compiledURL)
+
+            modelURL = compiledPath
+        } else {
+            throw MuesliQwen3AsrError.modelNotFound(name)
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        let model = try await MLModel.load(contentsOf: modelURL, configuration: configuration)
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        logger.debug("  \(name): loaded in \(String(format: "%.2f", elapsed))s")
+        return model
+    }
+
+    private static func loadMuesliQwen3EmbeddingWeights(from directory: URL) throws -> MuesliQwen3EmbeddingWeights {
+        let path = directory.appendingPathComponent(MuesliQwen3ModelFiles.embeddings)
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            throw MuesliQwen3AsrError.modelNotFound("qwen3_asr_embeddings.bin")
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        let weights = try MuesliQwen3EmbeddingWeights(contentsOf: path)
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        logger.info(
+            "Loaded embedding weights in \(String(format: "%.2f", elapsed))s (\(weights.vocabSize) x \(weights.hiddenSize))"
+        )
+        return weights
+    }
+
+    private static func loadVocabulary(from directory: URL) throws -> [Int: String] {
+        let vocabPath = directory.appendingPathComponent("vocab.json")
+        guard FileManager.default.fileExists(atPath: vocabPath.path) else {
+            throw MuesliQwen3AsrError.modelNotFound("vocab.json")
+        }
+
+        let data = try Data(contentsOf: vocabPath)
+        guard let stringToId = try JSONSerialization.jsonObject(with: data) as? [String: Int] else {
+            throw MuesliQwen3AsrError.invalidVocabulary
+        }
+
+        // Invert: token string -> token ID becomes token ID -> token string
+        var idToString: [Int: String] = [:]
+        idToString.reserveCapacity(stringToId.count)
+        for (token, id) in stringToId {
+            idToString[id] = token
+        }
+        logger.info("Loaded vocabulary: \(idToString.count) tokens")
+        return idToString
+    }
+}
+
+// MARK: - Embedding Weights
+
+/// Preloaded embedding weights for Swift-side token embedding lookup.
+/// Eliminates the need for a separate embedding CoreML model.
+public final class MuesliQwen3EmbeddingWeights: Sendable {
+    public let vocabSize: Int
+    public let hiddenSize: Int
+    private let data: Data
+
+    /// Load embedding weights from a binary file.
+    /// Format: uint32 vocabSize, uint32 hiddenSize, then float16[vocabSize * hiddenSize]
+    public init(contentsOf url: URL) throws {
+        let fileData = try Data(contentsOf: url)
+        guard fileData.count >= 8 else {
+            throw MuesliQwen3AsrError.invalidVocabulary
+        }
+
+        // Read header
+        let vocab = fileData.withUnsafeBytes { $0.load(fromByteOffset: 0, as: UInt32.self) }
+        let hidden = fileData.withUnsafeBytes { $0.load(fromByteOffset: 4, as: UInt32.self) }
+        self.vocabSize = Int(vocab)
+        self.hiddenSize = Int(hidden)
+
+        // Validate against config
+        guard vocabSize == MuesliQwen3AsrConfig.vocabSize else {
+            throw MuesliQwen3AsrError.generationFailed(
+                "Embedding vocab size \(vocabSize) != config \(MuesliQwen3AsrConfig.vocabSize)"
+            )
+        }
+        guard hiddenSize == MuesliQwen3AsrConfig.hiddenSize else {
+            throw MuesliQwen3AsrError.generationFailed(
+                "Embedding hidden size \(hiddenSize) != config \(MuesliQwen3AsrConfig.hiddenSize)"
+            )
+        }
+
+        // Verify file size
+        let expectedSize = 8 + vocabSize * hiddenSize * 2  // header + float16 data
+        guard fileData.count == expectedSize else {
+            throw MuesliQwen3AsrError.generationFailed(
+                "Embedding file size mismatch: expected \(expectedSize), got \(fileData.count)"
+            )
+        }
+
+        self.data = fileData
+    }
+
+    /// Get embedding vector for a token ID.
+    /// Returns float32 array of length hiddenSize.
+    public func embedding(for tokenId: Int) -> [Float] {
+        guard tokenId >= 0, tokenId < vocabSize else {
+            return [Float](repeating: 0, count: hiddenSize)
+        }
+
+        let offset = 8 + tokenId * hiddenSize * 2  // header + token offset (float16)
+        var result = [Float](repeating: 0, count: hiddenSize)
+
+        #if arch(arm64)
+        data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+            let f16Ptr = ptr.baseAddress!.advanced(by: offset)
+                .assumingMemoryBound(to: Float16.self)
+
+            for i in 0..<hiddenSize {
+                result[i] = Float(f16Ptr[i])
+            }
+        }
+        #else
+        // Float16 is only available on Apple Silicon
+        fatalError("Qwen3-ASR requires Apple Silicon (arm64)")
+        #endif
+
+        return result
+    }
+
+    /// Get embeddings for multiple token IDs.
+    /// Returns [seqLen][hiddenSize] array.
+    public func embeddings(for tokenIds: [Int32]) -> [[Float]] {
+        tokenIds.map { embedding(for: Int($0)) }
+    }
+}
+
+// MARK: - Errors
+
+public enum MuesliQwen3AsrError: Error, LocalizedError {
+    case modelNotFound(String)
+    case invalidVocabulary
+    case encoderFailed(String)
+    case decoderFailed(String)
+    case generationFailed(String)
+    case downloadUnavailable(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotFound(let name):
+            return "Qwen3-ASR model not found: \(name)"
+        case .invalidVocabulary:
+            return "Invalid vocabulary file"
+        case .encoderFailed(let detail):
+            return "Audio encoder failed: \(detail)"
+        case .decoderFailed(let detail):
+            return "Decoder failed: \(detail)"
+        case .generationFailed(let detail):
+            return "Generation failed: \(detail)"
+        case .downloadUnavailable(let detail):
+            return detail
+        }
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -151,7 +151,9 @@ public struct MuesliQwen3AsrModels: Sendable {
         logger.info("Downloading Qwen3-ASR \(variant.rawValue) models via managed downloader...")
         let plan = ManagedASRModelPlans.qwen3ASRInt8(cacheDirectory: targetDir)
         if force {
-            try? plan.delete(fileManager: .default)
+            // A failed delete would let the downloader short-circuit on the stale
+            // cache, so surface the failure instead of silently keeping old files.
+            try plan.delete(fileManager: .default)
         }
         _ = try await ManagedASRModelDownloader.downloadIfNeeded(
             plan,

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -144,23 +144,44 @@ public struct MuesliQwen3AsrModels: Sendable {
             return targetDir
         }
 
-        if force {
-            try? FileManager.default.removeItem(at: targetDir)
-        }
-
         logger.info("Downloading Qwen3-ASR \(variant.rawValue) models via managed downloader...")
         let plan = ManagedASRModelPlans.qwen3ASRInt8()
+        let cacheBackup: URL?
+        let destinationBackup: URL?
         if force {
             // The managed downloader short-circuits on its canonical cache, so a
-            // forced re-download must purge that cache (and the requested
-            // destination) before starting, or stale artifacts survive.
-            try? plan.delete(fileManager: .default)
-            try? FileManager.default.removeItem(at: targetDir)
+            // forced re-download must move that cache (and the requested
+            // destination) aside before starting. Keep backups so a failed
+            // re-download restores the previous installation instead of leaving
+            // nothing usable.
+            cacheBackup = try Self.stageAside(plan.cacheDirectory, fileManager: .default)
+            destinationBackup = targetDir.standardizedFileURL != plan.cacheDirectory.standardizedFileURL
+                ? try Self.stageAside(targetDir, fileManager: .default)
+                : nil
+        } else {
+            cacheBackup = nil
+            destinationBackup = nil
         }
-        _ = try await ManagedASRModelDownloader.downloadIfNeeded(
-            plan,
-            progress: { fraction, _ in progressHandler?(fraction) }
-        )
+        do {
+            _ = try await ManagedASRModelDownloader.downloadIfNeeded(
+                plan,
+                progress: { fraction, _ in progressHandler?(fraction) }
+            )
+        } catch {
+            if let cacheBackup {
+                try? Self.restore(staged: cacheBackup, to: plan.cacheDirectory, fileManager: .default)
+            }
+            if let destinationBackup {
+                try? Self.restore(staged: destinationBackup, to: targetDir, fileManager: .default)
+            }
+            throw error
+        }
+        if let cacheBackup {
+            try? FileManager.default.removeItem(at: cacheBackup)
+        }
+        if let destinationBackup {
+            try? FileManager.default.removeItem(at: destinationBackup)
+        }
 
         // The managed plan installs into its canonical cache directory. Honor a
         // caller-provided destination by copying the artifacts there, so
@@ -176,20 +197,55 @@ public struct MuesliQwen3AsrModels: Sendable {
 
     /// Copy the artifacts in `source` into `destination`, replacing any existing
     /// files with the same names. Creates `destination` if needed.
+    ///
+    /// Stage-then-swap: artifacts are fully copied into a temporary sibling
+    /// directory first, then swapped into place. A failure mid-copy leaves the
+    /// existing installation untouched instead of deleting live artifacts before
+    /// their replacements are ready.
     static func installArtifacts(from source: URL, to destination: URL) throws {
         let fileManager = FileManager.default
+        let staging = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".qwen3-install-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: staging) }
+
+        try fileManager.createDirectory(at: staging, withIntermediateDirectories: true)
         let contents = try fileManager.contentsOfDirectory(
             at: source,
             includingPropertiesForKeys: nil
         )
-        try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
         for item in contents {
-            let target = destination.appendingPathComponent(item.lastPathComponent)
-            if fileManager.fileExists(atPath: target.path) {
-                try fileManager.removeItem(at: target)
-            }
-            try fileManager.copyItem(at: item, to: target)
+            try fileManager.copyItem(
+                at: item,
+                to: staging.appendingPathComponent(item.lastPathComponent)
+            )
         }
+
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.moveItem(at: staging, to: destination)
+    }
+
+    /// Move a directory aside (rename) so its original location can be rebuilt.
+    /// Returns the backup URL, or nil if the directory does not exist.
+    static func stageAside(_ directory: URL, fileManager: FileManager = .default) throws -> URL? {
+        guard fileManager.fileExists(atPath: directory.path) else { return nil }
+        let backup = directory.deletingLastPathComponent()
+            .appendingPathComponent(".qwen3-backup-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.moveItem(at: directory, to: backup)
+        return backup
+    }
+
+    /// Restore a staged-aside directory into its original location.
+    static func restore(
+        staged backup: URL,
+        to directory: URL,
+        fileManager: FileManager = .default
+    ) {
+        guard fileManager.fileExists(atPath: backup.path) else { return }
+        try? fileManager.removeItem(at: directory)
+        try? fileManager.moveItem(at: backup, to: directory)
     }
 
     /// Check if all required model files exist locally.

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -1,14 +1,16 @@
 // Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
 // Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
-// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+// Licensed under the Apache License, Version 2.0; see LICENSE-Apache-2.0 in this directory.
 @preconcurrency import CoreML
 import Foundation
 import OSLog
 
 /// Model artifact file names for the vendored Qwen3 ASR backend.
 private enum MuesliQwen3ModelFiles {
-    static let audioEncoder = "qwen3_asr_audio_encoder_v2.mlmodelc"
-    static let decoderStateful = "qwen3_asr_decoder_stateful.mlmodelc"
+    static let audioEncoderName = "qwen3_asr_audio_encoder_v2"
+    static let decoderStatefulName = "qwen3_asr_decoder_stateful"
+    static let audioEncoder = "\(audioEncoderName).mlmodelc"
+    static let decoderStateful = "\(decoderStatefulName).mlmodelc"
     static let embeddings = "qwen3_asr_embeddings.bin"
     static let vocab = "vocab.json"
 }
@@ -71,14 +73,14 @@ public struct MuesliQwen3AsrModels: Sendable {
 
         // Load audio encoder
         let audioEncoder = try await loadModel(
-            named: "qwen3_asr_audio_encoder_v2",
+            named: MuesliQwen3ModelFiles.audioEncoderName,
             from: directory,
             configuration: modelConfig
         )
 
         // Load stateful decoder (with fused lmHead)
         let decoderStateful = try await loadModel(
-            named: "qwen3_asr_decoder_stateful",
+            named: MuesliQwen3ModelFiles.decoderStatefulName,
             from: directory,
             configuration: modelConfig
         )
@@ -262,6 +264,11 @@ public struct MuesliQwen3AsrModels: Sendable {
     }
 
     private static func loadMuesliQwen3EmbeddingWeights(from directory: URL) throws -> MuesliQwen3EmbeddingWeights {
+        #if !arch(arm64)
+        // Fail loading with a clear error instead of reaching the fatalError in
+        // embedding(for:) on non-Apple-Silicon machines.
+        throw MuesliQwen3AsrError.unsupportedHardware
+        #endif
         let path = directory.appendingPathComponent(MuesliQwen3ModelFiles.embeddings)
         guard FileManager.default.fileExists(atPath: path.path) else {
             throw MuesliQwen3AsrError.modelNotFound("qwen3_asr_embeddings.bin")
@@ -277,9 +284,9 @@ public struct MuesliQwen3AsrModels: Sendable {
     }
 
     private static func loadVocabulary(from directory: URL) throws -> [Int: String] {
-        let vocabPath = directory.appendingPathComponent("vocab.json")
+        let vocabPath = directory.appendingPathComponent(MuesliQwen3ModelFiles.vocab)
         guard FileManager.default.fileExists(atPath: vocabPath.path) else {
-            throw MuesliQwen3AsrError.modelNotFound("vocab.json")
+            throw MuesliQwen3AsrError.modelNotFound(MuesliQwen3ModelFiles.vocab)
         }
 
         let data = try Data(contentsOf: vocabPath)
@@ -387,6 +394,8 @@ public enum MuesliQwen3AsrError: Error, LocalizedError {
     case decoderFailed(String)
     case generationFailed(String)
     case downloadUnavailable(String)
+    case audioTooLong(String)
+    case unsupportedHardware
 
     public var errorDescription: String? {
         switch self {
@@ -402,6 +411,10 @@ public enum MuesliQwen3AsrError: Error, LocalizedError {
             return "Generation failed: \(detail)"
         case .downloadUnavailable(let detail):
             return detail
+        case .audioTooLong(let detail):
+            return detail
+        case .unsupportedHardware:
+            return "Qwen3-ASR requires Apple Silicon (arm64)"
         }
     }
 }

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -147,12 +147,40 @@ public struct MuesliQwen3AsrModels: Sendable {
         }
 
         logger.info("Downloading Qwen3-ASR \(variant.rawValue) models via managed downloader...")
+        let plan = ManagedASRModelPlans.qwen3ASRInt8()
         _ = try await ManagedASRModelDownloader.downloadIfNeeded(
-            ManagedASRModelPlans.qwen3ASRInt8(),
+            plan,
             progress: { fraction, _ in progressHandler?(fraction) }
         )
+
+        // The managed plan installs into its canonical cache directory. Honor a
+        // caller-provided destination by copying the artifacts there, so
+        // `downloadAndLoad(to:)` always loads from a directory that has them.
+        if let directory,
+           directory.standardizedFileURL != plan.cacheDirectory.standardizedFileURL {
+            try installArtifacts(from: plan.cacheDirectory, to: directory)
+        }
+
         logger.info("Successfully downloaded Qwen3-ASR \(variant.rawValue) models")
         return targetDir
+    }
+
+    /// Copy the artifacts in `source` into `destination`, replacing any existing
+    /// files with the same names. Creates `destination` if needed.
+    static func installArtifacts(from source: URL, to destination: URL) throws {
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: nil
+        )
+        try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+        for item in contents {
+            let target = destination.appendingPathComponent(item.lastPathComponent)
+            if fileManager.fileExists(atPath: target.path) {
+                try fileManager.removeItem(at: target)
+            }
+            try fileManager.copyItem(at: item, to: target)
+        }
     }
 
     /// Check if all required model files exist locally.

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -198,15 +198,15 @@ public struct MuesliQwen3AsrModels: Sendable {
     /// Copy the artifacts in `source` into `destination`, replacing any existing
     /// files with the same names. Creates `destination` if needed.
     ///
-    /// Stage-then-swap: artifacts are fully copied into a temporary sibling
-    /// directory first, then swapped into place. A failure mid-copy leaves the
-    /// existing installation untouched instead of deleting live artifacts before
-    /// their replacements are ready.
+    /// Stage-then-swap with rollback: artifacts are fully copied into a
+    /// temporary sibling directory first, the existing destination is moved
+    /// aside, and the staged set is moved into place. A failure at any step
+    /// restores the previous installation, so a broken copy can never leave the
+    /// destination unusable.
     static func installArtifacts(from source: URL, to destination: URL) throws {
         let fileManager = FileManager.default
-        let staging = destination
-            .deletingLastPathComponent()
-            .appendingPathComponent(".qwen3-install-\(UUID().uuidString)", isDirectory: true)
+        let parent = destination.deletingLastPathComponent()
+        let staging = parent.appendingPathComponent(".qwen3-install-\(UUID().uuidString)", isDirectory: true)
         defer { try? fileManager.removeItem(at: staging) }
 
         try fileManager.createDirectory(at: staging, withIntermediateDirectories: true)
@@ -221,10 +221,25 @@ public struct MuesliQwen3AsrModels: Sendable {
             )
         }
 
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
+        // Move the existing installation aside, then swap the staged set in.
+        // Restore the previous installation if the swap fails.
+        let old = fileManager.fileExists(atPath: destination.path)
+            ? parent.appendingPathComponent(".qwen3-old-\(UUID().uuidString)", isDirectory: true)
+            : nil
+        if let old {
+            try fileManager.moveItem(at: destination, to: old)
         }
-        try fileManager.moveItem(at: staging, to: destination)
+        do {
+            try fileManager.moveItem(at: staging, to: destination)
+        } catch {
+            if let old, fileManager.fileExists(atPath: old.path) {
+                try? fileManager.moveItem(at: old, to: destination)
+            }
+            throw error
+        }
+        if let old {
+            try? fileManager.removeItem(at: old)
+        }
     }
 
     /// Move a directory aside (rename) so its original location can be rebuilt.

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3AsrModels.swift
@@ -162,12 +162,22 @@ public struct MuesliQwen3AsrModels: Sendable {
             cacheBackup = nil
             destinationBackup = nil
         }
+        // The managed plan installs into its canonical cache directory. Honor a
+        // caller-provided destination by copying the artifacts there, so
+        // `downloadAndLoad(to:)` always loads from a directory that has them.
         do {
             _ = try await ManagedASRModelDownloader.downloadIfNeeded(
                 plan,
                 progress: { fraction, _ in progressHandler?(fraction) }
             )
+            if let directory,
+               directory.standardizedFileURL != plan.cacheDirectory.standardizedFileURL {
+                try installArtifacts(from: plan.cacheDirectory, to: directory)
+            }
         } catch {
+            // Roll back every staged-aside directory on ANY failure (download or
+            // artifact install), so a forced refresh can never leave the custom
+            // destination or the canonical cache unusable.
             if let cacheBackup {
                 try? Self.restore(staged: cacheBackup, to: plan.cacheDirectory, fileManager: .default)
             }
@@ -181,14 +191,6 @@ public struct MuesliQwen3AsrModels: Sendable {
         }
         if let destinationBackup {
             try? FileManager.default.removeItem(at: destinationBackup)
-        }
-
-        // The managed plan installs into its canonical cache directory. Honor a
-        // caller-provided destination by copying the artifacts there, so
-        // `downloadAndLoad(to:)` always loads from a directory that has them.
-        if let directory,
-           directory.standardizedFileURL != plan.cacheDirectory.standardizedFileURL {
-            try installArtifacts(from: plan.cacheDirectory, to: directory)
         }
 
         logger.info("Successfully downloaded Qwen3-ASR \(variant.rawValue) models")

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3RoPE.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3RoPE.swift
@@ -1,6 +1,6 @@
 // Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
 // Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
-// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+// Licensed under the Apache License, Version 2.0; see LICENSE-Apache-2.0 in this directory.
 import Foundation
 
 // MARK: - Rotary Position Embeddings for Qwen3-ASR

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3RoPE.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3RoPE.swift
@@ -1,0 +1,172 @@
+// Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
+// Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
+// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+import Foundation
+
+// MARK: - Rotary Position Embeddings for Qwen3-ASR
+
+/// Computes RoPE (Rotary Position Embedding) cos/sin values for the Qwen3 decoder.
+///
+/// Qwen3-ASR uses M-RoPE (Multi-dimensional Rotary Position Embedding) with
+/// interleaved sections [24, 20, 20] and rope_theta = 1,000,000.
+/// For ASR (no spatial dimensions), temporal position is used for all 3 sections,
+/// so this simplifies to standard RoPE with the full head_dim = 128.
+///
+/// All positions 0..<maxCacheSeqLen are precomputed at init to avoid per-token
+/// trigonometric calls in the hot decode loop.
+public struct MuesliQwen3RoPE: Sendable {
+    private let invFreq: [Float]
+    public let headDim: Int
+
+    /// Precomputed cos/sin tables for positions 0..<maxPosition.
+    /// Layout: [pos0(headDim), pos1(headDim), ...] — contiguous per position.
+    private let cosTable: [Float]
+    private let sinTable: [Float]
+    private let maxPosition: Int
+
+    /// Initialize with Qwen3-ASR config constants.
+    ///
+    /// inv_freq = 1.0 / (theta ^ (i / dim)) for i in [0, 2, 4, ..., dim-2]
+    /// Precomputes cos/sin for all positions up to maxCacheSeqLen.
+    public init() {
+        self.headDim = MuesliQwen3AsrConfig.headDim
+        self.maxPosition = MuesliQwen3AsrConfig.maxCacheSeqLen
+        let theta = Float(MuesliQwen3AsrConfig.ropeTheta)
+        let dim = Float(MuesliQwen3AsrConfig.headDim)
+
+        var freq = [Float](repeating: 0.0, count: MuesliQwen3AsrConfig.headDim / 2)
+        for i in stride(from: 0, to: MuesliQwen3AsrConfig.headDim, by: 2) {
+            let exponent = Float(i) / dim
+            freq[i / 2] = 1.0 / powf(theta, exponent)
+        }
+        self.invFreq = freq
+
+        // Precompute all positions
+        let halfDim = MuesliQwen3AsrConfig.headDim / 2
+        var cosVals = [Float](repeating: 0.0, count: maxPosition * MuesliQwen3AsrConfig.headDim)
+        var sinVals = [Float](repeating: 0.0, count: maxPosition * MuesliQwen3AsrConfig.headDim)
+
+        for p in 0..<maxPosition {
+            let pos = Float(p)
+            let offset = p * MuesliQwen3AsrConfig.headDim
+            for i in 0..<halfDim {
+                let angle = pos * freq[i]
+                let c = cosf(angle)
+                let s = sinf(angle)
+                // Concatenated-halves layout: [cos0,...,cos63, cos0,...,cos63]
+                // Matches CoreML model's rotate_half which splits at head_dim/2.
+                cosVals[offset + i] = c
+                cosVals[offset + i + halfDim] = c
+                sinVals[offset + i] = s
+                sinVals[offset + i + halfDim] = s
+            }
+        }
+        self.cosTable = cosVals
+        self.sinTable = sinVals
+    }
+
+    /// Copy precomputed cos/sin for a position directly into destination buffers.
+    ///
+    /// Writes headDim floats to each pointer. Avoids intermediate array allocation
+    /// in the hot decode loop.
+    public func fill(
+        position: Int,
+        cosPtr: UnsafeMutablePointer<Float>,
+        sinPtr: UnsafeMutablePointer<Float>
+    ) {
+        guard position < maxPosition else {
+            let (cos, sin) = computeDynamic(position: position)
+            cos.withUnsafeBufferPointer { src in
+                _ = memcpy(cosPtr, src.baseAddress!, headDim * MemoryLayout<Float>.stride)
+            }
+            sin.withUnsafeBufferPointer { src in
+                _ = memcpy(sinPtr, src.baseAddress!, headDim * MemoryLayout<Float>.stride)
+            }
+            return
+        }
+        let offset = position * headDim
+        cosTable.withUnsafeBufferPointer { buf in
+            _ = memcpy(cosPtr, buf.baseAddress! + offset, headDim * MemoryLayout<Float>.stride)
+        }
+        sinTable.withUnsafeBufferPointer { buf in
+            _ = memcpy(sinPtr, buf.baseAddress! + offset, headDim * MemoryLayout<Float>.stride)
+        }
+    }
+
+    /// Compute cos and sin embeddings for a given position.
+    ///
+    /// Returns (cos, sin) each of shape [headDim], suitable for creating
+    /// CoreML input tensors of shape [1, 1, headDim].
+    public func compute(position: Int) -> (cos: [Float], sin: [Float]) {
+        guard position < maxPosition else {
+            return computeDynamic(position: position)
+        }
+        let offset = position * headDim
+        return (
+            cos: Array(cosTable[offset..<(offset + headDim)]),
+            sin: Array(sinTable[offset..<(offset + headDim)])
+        )
+    }
+
+    /// Compute cos and sin embeddings for a contiguous range of positions.
+    ///
+    /// Returns flat arrays of length `count * headDim`, laid out as
+    /// `[pos0(128), pos1(128), ...]` for creating `[1, count, headDim]` tensors.
+    /// Used for batched prefill where all prompt positions are processed at once.
+    public func computeRange(startPosition: Int, count: Int) -> (cos: [Float], sin: [Float]) {
+        let endPosition = startPosition + count
+        guard endPosition <= maxPosition else {
+            return computeRangeDynamic(startPosition: startPosition, count: count)
+        }
+        let startOffset = startPosition * headDim
+        let endOffset = endPosition * headDim
+        return (
+            cos: Array(cosTable[startOffset..<endOffset]),
+            sin: Array(sinTable[startOffset..<endOffset])
+        )
+    }
+
+    // MARK: - Dynamic fallbacks for positions beyond precomputed table
+
+    private func computeDynamic(position: Int) -> (cos: [Float], sin: [Float]) {
+        let pos = Float(position)
+        var cosValues = [Float](repeating: 0.0, count: headDim)
+        var sinValues = [Float](repeating: 0.0, count: headDim)
+
+        let halfDim = headDim / 2
+        for i in 0..<halfDim {
+            let angle = pos * invFreq[i]
+            let c = cosf(angle)
+            let s = sinf(angle)
+            cosValues[i] = c
+            cosValues[i + halfDim] = c
+            sinValues[i] = s
+            sinValues[i + halfDim] = s
+        }
+
+        return (cos: cosValues, sin: sinValues)
+    }
+
+    private func computeRangeDynamic(startPosition: Int, count: Int) -> (cos: [Float], sin: [Float]) {
+        let totalSize = count * headDim
+        var cosValues = [Float](repeating: 0.0, count: totalSize)
+        var sinValues = [Float](repeating: 0.0, count: totalSize)
+
+        let halfDim = headDim / 2
+        for p in 0..<count {
+            let pos = Float(startPosition + p)
+            let offset = p * headDim
+            for i in 0..<halfDim {
+                let angle = pos * invFreq[i]
+                let c = cosf(angle)
+                let s = sinf(angle)
+                cosValues[offset + i] = c
+                cosValues[offset + i + halfDim] = c
+                sinValues[offset + i] = s
+                sinValues[offset + i + halfDim] = s
+            }
+        }
+
+        return (cos: cosValues, sin: sinValues)
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3StreamingManager.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3StreamingManager.swift
@@ -1,0 +1,191 @@
+// Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
+// Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
+// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "FluidAudio", category: "MuesliQwen3StreamingManager")
+
+// MARK: - Streaming Configuration
+
+/// Configuration for Qwen3 streaming transcription.
+public struct MuesliQwen3StreamingConfig: Sendable {
+    /// Minimum audio duration (seconds) before first transcription.
+    public let minAudioSeconds: Double
+
+    /// Chunk duration (seconds) - how often to re-transcribe.
+    public let chunkSeconds: Double
+
+    /// Maximum audio duration (seconds) to accumulate.
+    public let maxAudioSeconds: Double
+
+    /// Language hint for transcription.
+    public let language: MuesliQwen3AsrConfig.Language?
+
+    public init(
+        minAudioSeconds: Double = 1.0,
+        chunkSeconds: Double = 2.0,
+        maxAudioSeconds: Double = 30.0,
+        language: MuesliQwen3AsrConfig.Language? = nil
+    ) {
+        self.minAudioSeconds = minAudioSeconds
+        self.chunkSeconds = chunkSeconds
+        self.maxAudioSeconds = maxAudioSeconds
+        self.language = language
+    }
+
+    public static let `default` = MuesliQwen3StreamingConfig()
+}
+
+// MARK: - Streaming Result
+
+/// Result from a streaming transcription update.
+public struct MuesliQwen3StreamingResult: Sendable {
+    /// Current transcript (may change with more audio).
+    public let transcript: String
+
+    /// Audio duration processed so far (seconds).
+    public let audioDuration: Double
+
+    /// Whether this is a final result (no more audio expected).
+    public let isFinal: Bool
+}
+
+// MARK: - Streaming Manager
+
+/// Streaming transcription manager for Qwen3-ASR.
+///
+/// Accumulates audio chunks and provides incremental transcription updates.
+/// Uses sliding window approach - re-transcribes accumulated audio each update.
+///
+/// Usage:
+/// ```swift
+/// let streaming = MuesliQwen3StreamingManager(asrManager: manager)
+/// streaming.configure(config)
+///
+/// // Feed audio chunks as they arrive
+/// for chunk in audioChunks {
+///     if let result = try await streaming.addAudio(chunk) {
+///         print("Partial: \(result.transcript)")
+///     }
+/// }
+///
+/// // Get final result
+/// let final = try await streaming.finish()
+/// print("Final: \(final.transcript)")
+/// ```
+@available(macOS 15, iOS 18, *)
+public actor MuesliQwen3StreamingManager {
+    private let asrManager: MuesliQwen3AsrManager
+    private var config: MuesliQwen3StreamingConfig
+    private var audioBuffer: [Float] = []
+    private var lastTranscript: String = ""
+    private var lastTranscribeTime: CFAbsoluteTime = 0
+    private var samplesSinceLastTranscribe: Int = 0
+
+    public init(asrManager: MuesliQwen3AsrManager, config: MuesliQwen3StreamingConfig = .default) {
+        self.asrManager = asrManager
+        self.config = config
+    }
+
+    /// Configure streaming parameters.
+    public func configure(_ config: MuesliQwen3StreamingConfig) {
+        self.config = config
+    }
+
+    /// Reset streaming state for a new session.
+    public func reset() {
+        audioBuffer.removeAll()
+        lastTranscript = ""
+        lastTranscribeTime = 0
+        samplesSinceLastTranscribe = 0
+    }
+
+    /// Add audio samples and get transcription update if ready.
+    ///
+    /// - Parameter samples: 16kHz mono Float32 audio samples.
+    /// - Returns: Transcription result if enough audio accumulated, nil otherwise.
+    public func addAudio(_ samples: [Float]) async throws -> MuesliQwen3StreamingResult? {
+        audioBuffer.append(contentsOf: samples)
+        samplesSinceLastTranscribe += samples.count
+
+        let totalSeconds = Double(audioBuffer.count) / 16000.0
+        let secondsSinceLastTranscribe = Double(samplesSinceLastTranscribe) / 16000.0
+
+        // Check if we should transcribe
+        let hasMinAudio = totalSeconds >= config.minAudioSeconds
+        let chunkReady = secondsSinceLastTranscribe >= config.chunkSeconds
+
+        guard hasMinAudio && chunkReady else {
+            return nil
+        }
+
+        // Trim if exceeding max duration
+        let maxSamples = Int(config.maxAudioSeconds * 16000)
+        if audioBuffer.count > maxSamples {
+            let excess = audioBuffer.count - maxSamples
+            audioBuffer.removeFirst(excess)
+            logger.debug("Trimmed \(excess) samples to stay under \(self.config.maxAudioSeconds)s limit")
+        }
+
+        // Transcribe accumulated audio
+        let transcript = try await asrManager.transcribe(
+            audioSamples: audioBuffer,
+            language: config.language,
+            maxNewTokens: 512
+        )
+
+        lastTranscript = transcript
+        lastTranscribeTime = CFAbsoluteTimeGetCurrent()
+        samplesSinceLastTranscribe = 0
+
+        let duration = Double(audioBuffer.count) / 16000.0
+        logger.debug("Streaming update: \(String(format: "%.1f", duration))s audio -> \"\(transcript.prefix(50))...\"")
+
+        return MuesliQwen3StreamingResult(
+            transcript: transcript,
+            audioDuration: duration,
+            isFinal: false
+        )
+    }
+
+    /// Finish streaming and get final transcription.
+    ///
+    /// Transcribes any remaining audio and returns the final result.
+    public func finish() async throws -> MuesliQwen3StreamingResult {
+        let duration = Double(audioBuffer.count) / 16000.0
+
+        // If we have audio that hasn't been transcribed, do final transcription
+        if samplesSinceLastTranscribe > 0 && audioBuffer.count >= Int(config.minAudioSeconds * 16000) {
+            let transcript = try await asrManager.transcribe(
+                audioSamples: audioBuffer,
+                language: config.language,
+                maxNewTokens: 512
+            )
+            lastTranscript = transcript
+        }
+
+        logger.info("Streaming finished: \(String(format: "%.1f", duration))s audio")
+
+        let result = MuesliQwen3StreamingResult(
+            transcript: lastTranscript,
+            audioDuration: duration,
+            isFinal: true
+        )
+
+        // Reset for next session
+        reset()
+
+        return result
+    }
+
+    /// Get current transcript without triggering a new transcription.
+    public func currentTranscript() -> String {
+        lastTranscript
+    }
+
+    /// Get current audio duration in seconds.
+    public func currentAudioDuration() -> Double {
+        Double(audioBuffer.count) / 16000.0
+    }
+}

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3StreamingManager.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3StreamingManager.swift
@@ -1,6 +1,6 @@
 // Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
 // Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
-// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+// Licensed under the Apache License, Version 2.0; see LICENSE-Apache-2.0 in this directory.
 import Foundation
 import OSLog
 

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3StreamingManager.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/Qwen3StreamingManager.swift
@@ -140,7 +140,7 @@ public actor MuesliQwen3StreamingManager {
         samplesSinceLastTranscribe = 0
 
         let duration = Double(audioBuffer.count) / 16000.0
-        logger.debug("Streaming update: \(String(format: "%.1f", duration))s audio -> \"\(transcript.prefix(50))...\"")
+        logger.debug("Streaming update: \(String(format: "%.1f", duration))s audio transcribed")
 
         return MuesliQwen3StreamingResult(
             transcript: transcript,

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/WhisperMelSpectrogram.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/WhisperMelSpectrogram.swift
@@ -1,6 +1,6 @@
 // Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
 // Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
-// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+// Licensed under the Apache License, Version 2.0; see LICENSE-Apache-2.0 in this directory.
 import Accelerate
 import Foundation
 

--- a/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/WhisperMelSpectrogram.swift
+++ b/native/MuesliNative/Sources/MuesliCore/Qwen3ASR/WhisperMelSpectrogram.swift
@@ -1,0 +1,324 @@
+// Vendored from FluidAudio v0.15.1 (ASR/Qwen3/), Apache License 2.0.
+// Original: https://github.com/FluidInference/FluidAudio — types renamed with MuesliQwen3 prefix.
+// Licensed under the Apache License, Version 2.0; see NOTICE for the full license text.
+import Accelerate
+import Foundation
+
+/// Whisper-compatible mel spectrogram extraction for Qwen3-ASR.
+///
+/// Matches the HuggingFace `WhisperFeatureExtractor` used during training:
+/// - n_fft: 400 (window size and DFT length)
+/// - hop_length: 160
+/// - n_mels: 128 (from `MuesliQwen3AsrConfig.numMelBins`)
+/// - Window: periodic Hann (not symmetric)
+/// - No preemphasis
+/// - log10 (not ln)
+/// - Dynamic range compression + normalization
+/// - HTK mel scale with Slaney normalization
+///
+/// Implementation note: Apple's vDSP FFT requires lengths of form `f * 2^n` where
+/// `f ∈ {1,3,5,15}`, which excludes 400. We compute the DFT via a pre-computed
+/// DFT matrix (cos/sin tables), using vDSP vector operations for efficiency.
+/// This gives bit-exact results matching Python's `torch.stft(n_fft=400)`.
+///
+/// - Warning: This class is NOT thread-safe and NOT `Sendable` due to mutable
+///   reusable buffers. Each thread/task should use its own instance.
+public final class MuesliQwen3WhisperMelSpectrogram {
+
+    // MARK: Config
+
+    /// Window size and DFT length (Whisper-specific, not in MuesliQwen3AsrConfig).
+    private let nFFT: Int = 400
+    /// Hop length between frames (Whisper-specific, not in MuesliQwen3AsrConfig).
+    private let hopLength: Int = 160
+    /// Number of mel bins (matches `MuesliQwen3AsrConfig.numMelBins`).
+    private let nMels: Int = MuesliQwen3AsrConfig.numMelBins
+    /// Sample rate (matches `MuesliQwen3AsrConfig.sampleRate`).
+    private let sampleRate: Int = MuesliQwen3AsrConfig.sampleRate
+
+    /// Number of frequency bins used (nFFT / 2 + 1, including Nyquist).
+    private var numFreqBins: Int { nFFT / 2 + 1 }
+
+    // MARK: Pre-computed
+
+    private let hannWindow: [Float]
+    private let melFilterbankFlat: [Float]  // [nMels * numFreqBins] row-major
+    /// DFT cosine table: cos(-2π * k * n / N) for k=0..numFreqBins-1, n=0..nFFT-1
+    /// Stored as flat [numFreqBins * nFFT], row-major by k.
+    private let dftCos: [Float]
+    /// DFT sine table: sin(-2π * k * n / N), same layout.
+    private let dftSin: [Float]
+
+    // MARK: Reusable buffers
+
+    private var windowedFrame: [Float]
+    private var realPart: [Float]  // Re(X[k]) for k=0..numFreqBins-1
+    private var imagPart: [Float]  // Im(X[k])
+    private var powerSpec: [Float]
+    private var imagSq: [Float]  // Temporary for Im^2 in power spectrum
+    private var melFrame: [Float]
+
+    public init() {
+        let numFreqBins = nFFT / 2 + 1  // 201 (including Nyquist, matches Python)
+
+        // Periodic Hann window: np.hanning(n_fft + 1)[:-1]
+        self.hannWindow = Self.createPeriodicHannWindow(length: nFFT)
+
+        // HTK mel filterbank with Slaney normalization: [nMels, numFreqBins]
+        let filterbank = Self.createMelFilterbank(
+            nFFT: nFFT,
+            nMels: nMels,
+            sampleRate: sampleRate,
+            fMin: 0.0,
+            fMax: 8000.0
+        )
+
+        // Flatten row-major
+        var flat = [Float](repeating: 0, count: nMels * numFreqBins)
+        for m in 0..<nMels {
+            for f in 0..<numFreqBins {
+                flat[m * numFreqBins + f] = filterbank[m][f]
+            }
+        }
+        self.melFilterbankFlat = flat
+
+        // Pre-compute DFT cos/sin tables for k=0..numFreqBins-1, n=0..nFFT-1
+        // X[k] = sum_{n=0}^{N-1} x[n] * exp(-2πi*k*n/N)
+        //       = sum_{n=0}^{N-1} x[n] * (cos(-2π*k*n/N) + i*sin(-2π*k*n/N))
+        var cosTable = [Float](repeating: 0, count: numFreqBins * nFFT)
+        var sinTable = [Float](repeating: 0, count: numFreqBins * nFFT)
+        let invN = Float(2.0 * .pi) / Float(nFFT)
+        for k in 0..<numFreqBins {
+            for n in 0..<nFFT {
+                let angle = -invN * Float(k) * Float(n)
+                cosTable[k * nFFT + n] = cosf(angle)
+                sinTable[k * nFFT + n] = sinf(angle)
+            }
+        }
+        self.dftCos = cosTable
+        self.dftSin = sinTable
+
+        // Pre-allocate buffers
+        self.windowedFrame = [Float](repeating: 0, count: nFFT)
+        self.realPart = [Float](repeating: 0, count: numFreqBins)
+        self.imagPart = [Float](repeating: 0, count: numFreqBins)
+        self.powerSpec = [Float](repeating: 0, count: numFreqBins)
+        self.imagSq = [Float](repeating: 0, count: numFreqBins)
+        self.melFrame = [Float](repeating: 0, count: nMels)
+    }
+
+    // MARK: Public
+
+    /// Compute Whisper-compatible mel spectrogram from 16kHz audio samples.
+    ///
+    /// - Parameter audio: Audio samples at 16kHz, mono, Float32.
+    /// - Returns: Mel spectrogram as `[nMels][T]` where `T = audio.count / hopLength`.
+    ///   Suitable for `MuesliQwen3AsrManager.transcribe(melSpectrogram:)`.
+    public func compute(audio: [Float]) -> [[Float]] {
+        let numFrames = audio.count / hopLength
+        guard numFrames > 0 else { return [] }
+        let numFreqBins = self.numFreqBins
+
+        // Allocate mel output: [nMels][numFrames]
+        var mel = [[Float]](
+            repeating: [Float](repeating: 0, count: numFrames),
+            count: nMels
+        )
+
+        for frameIdx in 0..<numFrames {
+            let startIdx = frameIdx * hopLength
+
+            // Extract frame and apply window
+            for i in 0..<nFFT {
+                let audioIdx = startIdx + i
+                if audioIdx < audio.count {
+                    windowedFrame[i] = audio[audioIdx] * hannWindow[i]
+                } else {
+                    windowedFrame[i] = 0.0
+                }
+            }
+
+            // DFT via matrix-vector multiply:
+            // Re(X[k]) = sum(x[n] * cos(-2π*k*n/N))   = dot(dftCos[k], x)
+            // Im(X[k]) = sum(x[n] * sin(-2π*k*n/N))   = dot(dftSin[k], x)
+            // Power[k] = Re(X[k])^2 + Im(X[k])^2
+            //
+            // Using vDSP_mmul: [numFreqBins, nFFT] × [nFFT, 1] → [numFreqBins, 1]
+            dftCos.withUnsafeBufferPointer { cosPtr in
+                windowedFrame.withUnsafeBufferPointer { xPtr in
+                    realPart.withUnsafeMutableBufferPointer { outPtr in
+                        vDSP_mmul(
+                            cosPtr.baseAddress!, 1,
+                            xPtr.baseAddress!, 1,
+                            outPtr.baseAddress!, 1,
+                            vDSP_Length(numFreqBins),
+                            vDSP_Length(1),
+                            vDSP_Length(nFFT)
+                        )
+                    }
+                }
+            }
+
+            dftSin.withUnsafeBufferPointer { sinPtr in
+                windowedFrame.withUnsafeBufferPointer { xPtr in
+                    imagPart.withUnsafeMutableBufferPointer { outPtr in
+                        vDSP_mmul(
+                            sinPtr.baseAddress!, 1,
+                            xPtr.baseAddress!, 1,
+                            outPtr.baseAddress!, 1,
+                            vDSP_Length(numFreqBins),
+                            vDSP_Length(1),
+                            vDSP_Length(nFFT)
+                        )
+                    }
+                }
+            }
+
+            // Power spectrum: |X[k]|^2 = Re^2 + Im^2
+            vDSP_vsq(realPart, 1, &powerSpec, 1, vDSP_Length(numFreqBins))
+            vDSP_vsq(imagPart, 1, &imagSq, 1, vDSP_Length(numFreqBins))
+            vDSP_vadd(powerSpec, 1, imagSq, 1, &powerSpec, 1, vDSP_Length(numFreqBins))
+
+            // Apply mel filterbank: [nMels, numFreqBins] × [numFreqBins] → [nMels]
+            melFilterbankFlat.withUnsafeBufferPointer { filterPtr in
+                powerSpec.withUnsafeBufferPointer { specPtr in
+                    melFrame.withUnsafeMutableBufferPointer { outPtr in
+                        vDSP_mmul(
+                            filterPtr.baseAddress!, 1,
+                            specPtr.baseAddress!, 1,
+                            outPtr.baseAddress!, 1,
+                            vDSP_Length(nMels),
+                            vDSP_Length(1),
+                            vDSP_Length(numFreqBins)
+                        )
+                    }
+                }
+            }
+
+            // log10(clip(x, 1e-10)) - vectorized per frame
+            // Clip to minimum value first
+            var minClip: Float = 1e-10
+            var maxClip: Float = Float.greatestFiniteMagnitude
+            vDSP_vclip(melFrame, 1, &minClip, &maxClip, &melFrame, 1, vDSP_Length(nMels))
+
+            // log10 via vForce
+            var count = Int32(nMels)
+            vvlog10f(&melFrame, melFrame, &count)
+
+            // Copy to output
+            for melIdx in 0..<nMels {
+                mel[melIdx][frameIdx] = melFrame[melIdx]
+            }
+        }
+
+        // Dynamic range compression: max(x, globalMax - 8.0) - vectorized
+        var globalMax: Float = -Float.infinity
+        for melIdx in 0..<nMels {
+            var rowMax: Float = 0
+            vDSP_maxv(mel[melIdx], 1, &rowMax, vDSP_Length(numFrames))
+            globalMax = max(globalMax, rowMax)
+        }
+        let minVal = globalMax - 8.0
+
+        for melIdx in 0..<nMels {
+            var low = minVal
+            var high = Float.greatestFiniteMagnitude
+            mel[melIdx].withUnsafeMutableBufferPointer { buffer in
+                vDSP_vclip(buffer.baseAddress!, 1, &low, &high, buffer.baseAddress!, 1, vDSP_Length(numFrames))
+            }
+        }
+
+        // Whisper normalization: (x + 4.0) / 4.0 - vectorized
+        var addVal: Float = 4.0
+        var divVal: Float = 4.0
+        for melIdx in 0..<nMels {
+            mel[melIdx].withUnsafeMutableBufferPointer { buffer in
+                vDSP_vsadd(buffer.baseAddress!, 1, &addVal, buffer.baseAddress!, 1, vDSP_Length(numFrames))
+                vDSP_vsdiv(buffer.baseAddress!, 1, &divVal, buffer.baseAddress!, 1, vDSP_Length(numFrames))
+            }
+        }
+
+        return mel
+    }
+
+    // MARK: Private - Window
+
+    /// Create periodic Hann window matching `np.hanning(n + 1)[:-1]`.
+    private static func createPeriodicHannWindow(length: Int) -> [Float] {
+        var window = [Float](repeating: 0, count: length)
+        let n = Float(length)
+        for i in 0..<length {
+            window[i] = 0.5 * (1.0 - cosf(2.0 * .pi * Float(i) / n))
+        }
+        return window
+    }
+
+    // MARK: Private - Mel Filterbank
+
+    /// Create HTK mel filterbank with Slaney normalization.
+    ///
+    /// Matches HuggingFace `WhisperFeatureExtractor.get_mel_filters()`:
+    /// - HTK mel scale: mel = 2595 * log10(1 + f/700)
+    /// - Slaney normalization: 2 / (f_right - f_left)
+    /// - Returns `[nMels][nFFT/2+1]` (includes Nyquist bin, matches Python).
+    private static func createMelFilterbank(
+        nFFT: Int,
+        nMels: Int,
+        sampleRate: Int,
+        fMin: Float,
+        fMax: Float
+    ) -> [[Float]] {
+        let numFreqBins = nFFT / 2 + 1  // 201 (including Nyquist)
+
+        // FFT frequency bins (including Nyquist)
+        var fftFreqs = [Float](repeating: 0, count: numFreqBins)
+        for i in 0..<numFreqBins {
+            fftFreqs[i] = Float(i) * Float(sampleRate) / Float(nFFT)
+        }
+
+        // HTK mel scale
+        func hzToMel(_ hz: Float) -> Float {
+            2595.0 * log10f(1.0 + hz / 700.0)
+        }
+        func melToHz(_ mel: Float) -> Float {
+            700.0 * (powf(10.0, mel / 2595.0) - 1.0)
+        }
+
+        // Create nMels + 2 mel-spaced points
+        let melMin = hzToMel(fMin)
+        let melMax = hzToMel(fMax)
+        var melPoints = [Float](repeating: 0, count: nMels + 2)
+        for i in 0..<(nMels + 2) {
+            let mel = melMin + Float(i) * (melMax - melMin) / Float(nMels + 1)
+            melPoints[i] = melToHz(mel)
+        }
+
+        // Compute frequency differences between adjacent mel points
+        var fdiff = [Float](repeating: 0, count: nMels + 1)
+        for i in 0..<(nMels + 1) {
+            fdiff[i] = melPoints[i + 1] - melPoints[i]
+        }
+
+        // Build filterbank using ramp method (matches HuggingFace implementation)
+        var filterbank = [[Float]](
+            repeating: [Float](repeating: 0, count: numFreqBins),
+            count: nMels
+        )
+
+        for i in 0..<nMels {
+            for f in 0..<numFreqBins {
+                let lower = (fftFreqs[f] - melPoints[i]) / fdiff[i]
+                let upper = (melPoints[i + 2] - fftFreqs[f]) / fdiff[i + 1]
+                filterbank[i][f] = max(0, min(lower, upper))
+            }
+
+            // Slaney normalization: 2 / (f_right - f_left)
+            let enorm = 2.0 / (melPoints[i + 2] - melPoints[i])
+            for f in 0..<numFreqBins {
+                filterbank[i][f] *= enorm
+            }
+        }
+
+        return filterbank
+    }
+}

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -161,12 +161,12 @@ struct BackendOption: Equatable {
         model: "FluidInference/qwen3-asr-0.6b-coreml",
         label: "Qwen3 ASR",
         sizeLabel: "~1.3 GB",
-        description: "Strong multilingual transcription across 52 languages when accuracy matters more than instant results. Expect a short 2–3 second wait compared with Parakeet, and about 30 seconds of one-time preparation the first time it runs.",
+        description: "Experimental multilingual transcription across 52 languages. Accuracy can vary noticeably for accented English, so try it with your own voice before relying on it. Expect a short 2–3 second wait compared with Parakeet, and about 30 seconds of one-time preparation the first time it runs.",
         recommended: false
     )
 
     static let experimental: [BackendOption] = [
-        .senseVoiceSmall, .indicASR, .gemma4E2BLiteRT,
+        .senseVoiceSmall, .indicASR, .gemma4E2BLiteRT, .qwen3Asr,
     ]
 
     /// Native streaming backends used by low-latency product surfaces.
@@ -180,7 +180,6 @@ struct BackendOption: Equatable {
         let systemManaged: [BackendOption] = appleSpeechAvailable ? [.appleSpeechAnalyzer] : []
         let all = systemManaged
             + parakeetFamily
-            + [.qwen3Asr]
             + whisperFamily
             + [.cohereTranscribe]
             + streaming

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -383,6 +383,56 @@ enum Nemotron35Language: String, CaseIterable, Codable, Sendable {
     }
 }
 
+/// Language selection for the Qwen3 ASR backend.
+/// `auto` leaves detection to the model; explicit codes pin the decoding
+/// language (the vendored manager maps them to its own prompt languages).
+enum Qwen3AsrLanguage: Hashable, Sendable {
+    case auto
+    case pinned(MuesliQwen3AsrConfig.Language)
+
+    static let defaultLanguage: Self = .auto
+
+    static var allCases: [Qwen3AsrLanguage] {
+        [.auto] + MuesliQwen3AsrConfig.Language.allCases.map(Qwen3AsrLanguage.pinned)
+    }
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto-detect"
+        case .pinned(let language): return language.englishName
+        }
+    }
+
+    var rawValue: String {
+        switch self {
+        case .auto: return "auto"
+        case .pinned(let language): return language.rawValue
+        }
+    }
+
+    /// ISO code passed to the model, or nil for automatic detection.
+    var pinnedCode: String? {
+        switch self {
+        case .auto: return nil
+        case .pinned(let language): return language.rawValue
+        }
+    }
+
+    static func resolved(_ rawValue: String?) -> Self {
+        let normalized = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let normalized, !normalized.isEmpty, normalized != "auto" else {
+            return defaultLanguage
+        }
+        if let language = MuesliQwen3AsrConfig.Language(rawValue: normalized) {
+            return .pinned(language)
+        }
+        if let language = MuesliQwen3AsrConfig.Language(from: normalized) {
+            return .pinned(language)
+        }
+        return defaultLanguage
+    }
+}
+
 /// Language selection for multilingual WhisperKit models.
 /// `auto` enables WhisperKit `detectLanguage`; explicit codes pin decoding language.
 enum WhisperKitLanguage: String, CaseIterable, Codable, Sendable {
@@ -1140,6 +1190,7 @@ struct AppConfig: Codable {
     var indicASRLanguage: String = IndicASRLanguage.defaultLanguage.rawValue
     var nemotron35Language: String = Nemotron35Language.defaultLanguage.rawValue
     var whisperLanguage: String = WhisperKitLanguage.defaultLanguage.rawValue
+    var qwen3AsrLanguage: String = Qwen3AsrLanguage.defaultLanguage.rawValue
     var appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier
     var meetingTranscriptionBackend: String = BackendOption.whisper.backend
     var meetingTranscriptionModel: String = BackendOption.whisper.model
@@ -1580,6 +1631,10 @@ struct AppConfig: Codable {
 
     var resolvedWhisperLanguage: WhisperKitLanguage {
         WhisperKitLanguage.resolved(whisperLanguage)
+    }
+
+    var resolvedQwen3AsrLanguage: Qwen3AsrLanguage {
+        Qwen3AsrLanguage.resolved(qwen3AsrLanguage)
     }
 
     var resolvedAppleSpeechLanguage: String {

--- a/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Models.swift
@@ -431,6 +431,10 @@ enum Qwen3AsrLanguage: Hashable, Sendable {
         }
         return defaultLanguage
     }
+
+    static func resolvedCode(_ rawValue: String?) -> String {
+        resolved(rawValue).rawValue
+    }
 }
 
 /// Language selection for multilingual WhisperKit models.
@@ -1316,6 +1320,7 @@ struct AppConfig: Codable {
         case indicASRLanguage = "indic_asr_language"
         case nemotron35Language = "nemotron35_language"
         case whisperLanguage = "whisper_language"
+        case qwen3AsrLanguage = "qwen3_asr_language"
         case appleSpeechLanguage = "apple_speech_language"
         case meetingTranscriptionBackend = "meeting_transcription_backend"
         case meetingTranscriptionModel = "meeting_transcription_model"
@@ -1447,6 +1452,7 @@ struct AppConfig: Codable {
         indicASRLanguage = IndicASRLanguage.resolvedCode(try? c.decode(String.self, forKey: .indicASRLanguage))
         nemotron35Language = Nemotron35Language.resolvedCode(try? c.decode(String.self, forKey: .nemotron35Language))
         whisperLanguage = WhisperKitLanguage.resolvedCode(try? c.decode(String.self, forKey: .whisperLanguage))
+        qwen3AsrLanguage = Qwen3AsrLanguage.resolvedCode(try? c.decode(String.self, forKey: .qwen3AsrLanguage))
         appleSpeechLanguage = AppleSpeechLanguageOption.normalize(try? c.decode(String.self, forKey: .appleSpeechLanguage))
         meetingTranscriptionBackend = (try? c.decode(String.self, forKey: .meetingTranscriptionBackend)) ?? sttBackend
         meetingTranscriptionModel = (try? c.decode(String.self, forKey: .meetingTranscriptionModel)) ?? sttModel

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -593,6 +593,13 @@ struct ModelsView: View {
         )
     }
 
+    private var qwen3AsrLanguageSelection: Binding<Qwen3AsrLanguage> {
+        Binding(
+            get: { appState.config.resolvedQwen3AsrLanguage },
+            set: { controller.selectQwen3AsrLanguage($0) }
+        )
+    }
+
     private var appleSpeechLanguageSelection: Binding<String> {
         Binding(
             get: { appState.config.resolvedAppleSpeechLanguage },
@@ -1181,6 +1188,24 @@ struct ModelsView: View {
 
                     Picker("", selection: indicASRLanguageSelection) {
                         ForEach(IndicASRLanguage.allCases, id: \.self) { language in
+                            Text(language.label).tag(language)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: 220, alignment: .leading)
+                }
+            }
+
+            if option.backend == BackendOption.qwen3Asr.backend {
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    Text("Language")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .frame(width: 64, alignment: .leading)
+
+                    Picker("", selection: qwen3AsrLanguageSelection) {
+                        ForEach(Qwen3AsrLanguage.allCases, id: \.self) { language in
                             Text(language.label).tag(language)
                         }
                     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/ModelsView.swift
@@ -199,8 +199,6 @@ struct ModelsView: View {
                 options: BackendOption.parakeetFamily
             )
 
-            modelCard(option: .qwen3Asr, logo: "qwen-logo")
-
             familyCard(
                 title: "Whisper",
                 subtitle: "Dependable alternatives when you prefer Whisper's transcription style or need broader multilingual coverage.",

--- a/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/MuesliController.swift
@@ -2480,6 +2480,12 @@ public final class MuesliController: NSObject {
         }
     }
 
+    func selectQwen3AsrLanguage(_ language: Qwen3AsrLanguage) {
+        updateConfig {
+            $0.qwen3AsrLanguage = language.rawValue
+        }
+    }
+
     func selectIndicASRLanguage(_ language: IndicASRLanguage) {
         updateConfig {
             $0.indicASRLanguage = language.rawValue
@@ -4410,6 +4416,7 @@ public final class MuesliController: NSObject {
                     cohereLanguage: self.config.resolvedCohereLanguage,
                     indicASRLanguage: self.config.resolvedIndicASRLanguage,
                     whisperLanguage: self.config.resolvedWhisperLanguage,
+                    qwen3AsrLanguage: self.config.resolvedQwen3AsrLanguage,
                     appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage
                 )
                 let rawTranscript = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -7852,6 +7859,7 @@ public final class MuesliController: NSObject {
                     cohereLanguage: self.config.resolvedCohereLanguage,
                     indicASRLanguage: self.config.resolvedIndicASRLanguage,
                     whisperLanguage: self.config.resolvedWhisperLanguage,
+                    qwen3AsrLanguage: self.config.resolvedQwen3AsrLanguage,
                     appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage,
                     enablePostProcessor: false,
                     customWords: self.serializedCustomWords(),
@@ -9189,6 +9197,7 @@ public final class MuesliController: NSObject {
                     cohereLanguage: transcriptionLanguage,
                     indicASRLanguage: indicTranscriptionLanguage,
                     whisperLanguage: whisperTranscriptionLanguage,
+                    qwen3AsrLanguage: self.config.resolvedQwen3AsrLanguage,
                     appleSpeechLanguage: self.config.resolvedAppleSpeechLanguage,
                     enablePostProcessor: enableTranscriptCleanup,
                     customWords: self.serializedCustomWords(),

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -1,8 +1,9 @@
 import FluidAudio
+
 import Foundation
 import MuesliCore
 
-/// Resolves Qwen3 ASR cache paths used by FluidAudio.
+/// Resolves Qwen3 ASR cache paths (layout matches FluidAudio's original cache).
 ///
 /// FluidAudio's `Repo.folderName` strips the `-coreml` suffix for Qwen, so the
 /// on-disk cache is `qwen3-asr-0.6b/{int8,f32}` rather than
@@ -54,12 +55,12 @@ enum Qwen3AsrWarmupReadiness {
     }
 }
 
-/// Native Swift transcription backend using FluidAudio's Qwen3 ASR model
+/// Native Swift transcription backend using the vendored Qwen3 ASR manager
 /// running on Apple's Neural Engine (ANE) via CoreML.
 /// Requires macOS 15+ due to CoreML stateful decoder support.
 @available(macOS 15, *)
 actor Qwen3AsrTranscriber {
-    private var manager: Qwen3AsrManager?
+    private var manager: MuesliQwen3AsrManager?
 
     enum TranscriberError: Error, LocalizedError {
         case notLoaded
@@ -92,7 +93,7 @@ actor Qwen3AsrTranscriber {
             )
             progress?(0.95, preparing.message)
             progressSnapshot?(preparing)
-            let candidate = Qwen3AsrManager()
+            let candidate = MuesliQwen3AsrManager()
             try await candidate.loadModels(from: modelDir)
             self.manager = candidate
             fputs("[qwen3-asr] models loaded, running warmup inference...\n", stderr)

--- a/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/Qwen3AsrBackend.swift
@@ -122,12 +122,13 @@ actor Qwen3AsrTranscriber {
 
     /// Transcribe a WAV file URL.
     /// Returns the transcribed text (no token-level timings available).
-    func transcribe(wavURL: URL) async throws -> (text: String, processingTime: Double) {
+    /// `language` is an optional ISO code; nil keeps automatic language detection.
+    func transcribe(wavURL: URL, language: String? = nil) async throws -> (text: String, processingTime: Double) {
         guard let manager else { throw TranscriberError.notLoaded }
         let start = CFAbsoluteTimeGetCurrent()
         let converter = AudioConverter()
         let samples = try converter.resampleAudioFile(wavURL)
-        let text = try await manager.transcribe(audioSamples: samples)
+        let text = try await manager.transcribe(audioSamples: samples, language: language)
         let processingTime = CFAbsoluteTimeGetCurrent() - start
         return (text, processingTime)
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/TranscriptionRuntime.swift
@@ -789,6 +789,7 @@ actor TranscriptionCoordinator {
         cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
         indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
         whisperLanguage: WhisperKitLanguage = WhisperKitLanguage.defaultLanguage,
+        qwen3AsrLanguage: Qwen3AsrLanguage = Qwen3AsrLanguage.defaultLanguage,
         appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier,
         enablePostProcessor: Bool = false,
         customWords: [[String: Any]] = [],
@@ -815,6 +816,7 @@ actor TranscriptionCoordinator {
             cohereLanguage: cohereLanguage,
             indicASRLanguage: indicASRLanguage,
             whisperLanguage: whisperLanguage,
+            qwen3AsrLanguage: qwen3AsrLanguage,
             appleSpeechLanguage: appleSpeechLanguage
         )
         result = removeArtifacts(result)
@@ -841,6 +843,7 @@ actor TranscriptionCoordinator {
         cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
         indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
         whisperLanguage: WhisperKitLanguage = WhisperKitLanguage.defaultLanguage,
+        qwen3AsrLanguage: Qwen3AsrLanguage = Qwen3AsrLanguage.defaultLanguage,
         appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier
     ) async throws -> SpeechTranscriptionResult {
         // Meetings intentionally skip Qwen/custom-word post-processing. Keep deterministic artifact/filler cleanup only.
@@ -850,6 +853,7 @@ actor TranscriptionCoordinator {
             cohereLanguage: cohereLanguage,
             indicASRLanguage: indicASRLanguage,
             whisperLanguage: whisperLanguage,
+            qwen3AsrLanguage: qwen3AsrLanguage,
             appleSpeechLanguage: appleSpeechLanguage
         ))
     }
@@ -860,6 +864,7 @@ actor TranscriptionCoordinator {
         cohereLanguage: CohereTranscribeLanguage = CohereTranscribeLanguage.defaultLanguage,
         indicASRLanguage: IndicASRLanguage = IndicASRLanguage.defaultLanguage,
         whisperLanguage: WhisperKitLanguage = WhisperKitLanguage.defaultLanguage,
+        qwen3AsrLanguage: Qwen3AsrLanguage = Qwen3AsrLanguage.defaultLanguage,
         appleSpeechLanguage: String = AppleSpeechLanguageOption.systemIdentifier
     ) async throws -> SpeechTranscriptionResult {
         // Meeting chunks intentionally skip Qwen/custom-word post-processing for reconciliation.
@@ -882,6 +887,7 @@ actor TranscriptionCoordinator {
             cohereLanguage: cohereLanguage,
             indicASRLanguage: indicASRLanguage,
             whisperLanguage: whisperLanguage,
+            qwen3AsrLanguage: qwen3AsrLanguage,
             appleSpeechLanguage: appleSpeechLanguage
         ))
     }
@@ -1209,6 +1215,7 @@ actor TranscriptionCoordinator {
         cohereLanguage: CohereTranscribeLanguage,
         indicASRLanguage: IndicASRLanguage,
         whisperLanguage: WhisperKitLanguage,
+        qwen3AsrLanguage: Qwen3AsrLanguage,
         appleSpeechLanguage: String
     ) async throws -> SpeechTranscriptionResult {
         switch backend.backend {
@@ -1220,7 +1227,7 @@ actor TranscriptionCoordinator {
         case "nemotron35":
             return try await transcribeWithNemotron35(url: url)
         case "qwen":
-            return try await transcribeWithQwen3(url: url)
+            return try await transcribeWithQwen3(url: url, language: qwen3AsrLanguage)
         case "cohere":
             return try await transcribeWithCohere(url: url, language: cohereLanguage)
         case "indicasr":
@@ -1276,10 +1283,10 @@ actor TranscriptionCoordinator {
 
     // MARK: - Qwen3 ASR (Autoregressive CoreML on ANE)
 
-    private func transcribeWithQwen3(url: URL) async throws -> SpeechTranscriptionResult {
+    private func transcribeWithQwen3(url: URL, language: Qwen3AsrLanguage) async throws -> SpeechTranscriptionResult {
         if #available(macOS 15, *) {
             fputs("[muesli-native] transcribing with Qwen3 ASR: \(url.lastPathComponent)\n", stderr)
-            let result = try await qwen3Transcriber.transcribe(wavURL: url)
+            let result = try await qwen3Transcriber.transcribe(wavURL: url, language: language.pinnedCode)
             fputs("[muesli-native] Qwen3 ASR result: \(result.text.prefix(80)) (took \(String(format: "%.3f", result.processingTime))s)\n", stderr)
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             return SpeechTranscriptionResult(

--- a/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/ModelsTests.swift
@@ -82,10 +82,10 @@ struct BackendOptionTests {
         #expect(BackendOption.all.contains(.gemma4E2BLiteRT))
     }
 
-    @Test("Qwen ASR is a standard dictation model")
-    func qwenAsrIsNotExperimental() {
+    @Test("Qwen ASR is available but experimental")
+    func qwenAsrIsExperimental() {
         #expect(BackendOption.all.contains(.qwen3Asr))
-        #expect(!BackendOption.experimental.contains(.qwen3Asr))
+        #expect(BackendOption.experimental.contains(.qwen3Asr))
         #expect(BackendOption.qwen3Asr.description.contains("52 languages"))
         #expect(BackendOption.qwen3Asr.description.contains("2–3 second"))
     }

--- a/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
@@ -1,0 +1,46 @@
+import Testing
+import Foundation
+@testable import MuesliCore
+
+struct Qwen3VendorTests {
+
+    @available(macOS 15, *)
+    @Test("installArtifacts copies every artifact and replaces stale files")
+    func installArtifactsCopiesAllFiles() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("qwen3-vendor-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        let destination = root.appendingPathComponent("destination", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+
+        let encoderDir = source.appendingPathComponent("qwen3_asr_audio_encoder_v2.mlmodelc", isDirectory: true)
+        try fm.createDirectory(at: encoderDir, withIntermediateDirectories: true)
+        try Data([0x01]).write(to: encoderDir.appendingPathComponent("coremldata.bin"))
+        try Data([0x02]).write(to: source.appendingPathComponent("vocab.json"))
+
+        try MuesliQwen3AsrModels.installArtifacts(from: source, to: destination)
+
+        #expect(fm.fileExists(atPath: destination.appendingPathComponent("vocab.json").path))
+        #expect(fm.fileExists(
+            atPath: destination
+                .appendingPathComponent("qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin").path
+        ))
+
+        // Re-run with a stale destination file: it must be replaced, not duplicated.
+        try Data([0xFF]).write(to: destination.appendingPathComponent("vocab.json"))
+        try MuesliQwen3AsrModels.installArtifacts(from: source, to: destination)
+        let replaced = try Data(contentsOf: destination.appendingPathComponent("vocab.json"))
+        #expect(replaced == Data([0x02]))
+    }
+
+    @available(macOS 15, *)
+    @Test("default int8 cache directory matches the managed plan's install directory")
+    func defaultCacheMatchesManagedPlan() {
+        let plan = ManagedASRModelPlans.qwen3ASRInt8()
+        let cache = MuesliQwen3AsrModels.defaultCacheDirectory(variant: .int8)
+        #expect(cache.standardizedFileURL == plan.cacheDirectory.standardizedFileURL)
+    }
+}

--- a/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
@@ -38,6 +38,34 @@ struct Qwen3VendorTests {
     }
 
     @available(macOS 15, *)
+    @Test("installArtifacts swaps the whole directory, dropping stale files")
+    func installArtifactsSwapsWholeDirectory() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("qwen3-vendor-swap-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let source = root.appendingPathComponent("source", isDirectory: true)
+        let destination = root.appendingPathComponent("destination", isDirectory: true)
+        try fm.createDirectory(at: source, withIntermediateDirectories: true)
+        try fm.createDirectory(at: destination, withIntermediateDirectories: true)
+        try Data([0x02]).write(to: source.appendingPathComponent("vocab.json"))
+        // A stale file that exists in the old destination but not in the source.
+        try Data([0x99]).write(to: destination.appendingPathComponent("stale.bin"))
+
+        try MuesliQwen3AsrModels.installArtifacts(from: source, to: destination)
+
+        // Whole-directory swap: the stale artifact must be gone and the new
+        // artifact present. (This swap semantics is what keeps an existing
+        // installation intact until the new set is fully staged.)
+        #expect(fm.fileExists(atPath: destination.appendingPathComponent("vocab.json").path))
+        #expect(!fm.fileExists(atPath: destination.appendingPathComponent("stale.bin").path))
+        // No staging/backup leftovers next to the destination.
+        let siblings = try fm.contentsOfDirectory(atPath: root.path).sorted()
+        #expect(siblings == ["destination", "source"])
+    }
+
+    @available(macOS 15, *)
     @Test("default int8 cache directory matches the managed plan's install directory")
     func defaultCacheMatchesManagedPlan() {
         let plan = ManagedASRModelPlans.qwen3ASRInt8()
@@ -87,5 +115,18 @@ struct Qwen3LanguageSelectionTests {
         #expect(Qwen3AsrLanguage.pinned(.english).pinnedCode == "en")
         #expect(Qwen3AsrLanguage.pinned(.english).label == "English")
         #expect(Qwen3AsrLanguage.allCases.count == MuesliQwen3AsrConfig.Language.allCases.count + 1)
+    }
+
+    @available(macOS 15, *)
+    @Test("Qwen3AsrLanguage selection survives config encode/decode round-trip")
+    func persistenceRoundTrip() throws {
+        let selection = Qwen3AsrLanguage.pinned(.english)
+        var config = AppConfig()
+        config.qwen3AsrLanguage = selection.rawValue
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.resolvedQwen3AsrLanguage == .pinned(.english))
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
@@ -6,71 +6,20 @@ import Foundation
 struct Qwen3VendorTests {
 
     @available(macOS 15, *)
-    @Test("installArtifacts copies every artifact and replaces stale files")
-    func installArtifactsCopiesAllFiles() throws {
-        let fm = FileManager.default
-        let root = fm.temporaryDirectory
-            .appendingPathComponent("qwen3-vendor-test-\(UUID().uuidString)", isDirectory: true)
-        defer { try? fm.removeItem(at: root) }
-
-        let source = root.appendingPathComponent("source", isDirectory: true)
-        let destination = root.appendingPathComponent("destination", isDirectory: true)
-        try fm.createDirectory(at: source, withIntermediateDirectories: true)
-
-        let encoderDir = source.appendingPathComponent("qwen3_asr_audio_encoder_v2.mlmodelc", isDirectory: true)
-        try fm.createDirectory(at: encoderDir, withIntermediateDirectories: true)
-        try Data([0x01]).write(to: encoderDir.appendingPathComponent("coremldata.bin"))
-        try Data([0x02]).write(to: source.appendingPathComponent("vocab.json"))
-
-        try MuesliQwen3AsrModels.installArtifacts(from: source, to: destination)
-
-        #expect(fm.fileExists(atPath: destination.appendingPathComponent("vocab.json").path))
-        #expect(fm.fileExists(
-            atPath: destination
-                .appendingPathComponent("qwen3_asr_audio_encoder_v2.mlmodelc/coremldata.bin").path
-        ))
-
-        // Re-run with a stale destination file: it must be replaced, not duplicated.
-        try Data([0xFF]).write(to: destination.appendingPathComponent("vocab.json"))
-        try MuesliQwen3AsrModels.installArtifacts(from: source, to: destination)
-        let replaced = try Data(contentsOf: destination.appendingPathComponent("vocab.json"))
-        #expect(replaced == Data([0x02]))
-    }
-
-    @available(macOS 15, *)
-    @Test("installArtifacts swaps the whole directory, dropping stale files")
-    func installArtifactsSwapsWholeDirectory() throws {
-        let fm = FileManager.default
-        let root = fm.temporaryDirectory
-            .appendingPathComponent("qwen3-vendor-swap-\(UUID().uuidString)", isDirectory: true)
-        defer { try? fm.removeItem(at: root) }
-
-        let source = root.appendingPathComponent("source", isDirectory: true)
-        let destination = root.appendingPathComponent("destination", isDirectory: true)
-        try fm.createDirectory(at: source, withIntermediateDirectories: true)
-        try fm.createDirectory(at: destination, withIntermediateDirectories: true)
-        try Data([0x02]).write(to: source.appendingPathComponent("vocab.json"))
-        // A stale file that exists in the old destination but not in the source.
-        try Data([0x99]).write(to: destination.appendingPathComponent("stale.bin"))
-
-        try MuesliQwen3AsrModels.installArtifacts(from: source, to: destination)
-
-        // Whole-directory swap: the stale artifact must be gone and the new
-        // artifact present. (This swap semantics is what keeps an existing
-        // installation intact until the new set is fully staged.)
-        #expect(fm.fileExists(atPath: destination.appendingPathComponent("vocab.json").path))
-        #expect(!fm.fileExists(atPath: destination.appendingPathComponent("stale.bin").path))
-        // No staging/backup leftovers next to the destination.
-        let siblings = try fm.contentsOfDirectory(atPath: root.path).sorted()
-        #expect(siblings == ["destination", "source"])
-    }
-
-    @available(macOS 15, *)
     @Test("default int8 cache directory matches the managed plan's install directory")
     func defaultCacheMatchesManagedPlan() {
         let plan = ManagedASRModelPlans.qwen3ASRInt8()
         let cache = MuesliQwen3AsrModels.defaultCacheDirectory(variant: .int8)
         #expect(cache.standardizedFileURL == plan.cacheDirectory.standardizedFileURL)
+    }
+
+    @available(macOS 15, *)
+    @Test("qwen3ASRInt8(cacheDirectory:) honors an explicit install directory")
+    func explicitCacheDirectoryIsHonored() {
+        let custom = URL(fileURLWithPath: "/tmp/qwen3-custom-install")
+        let plan = ManagedASRModelPlans.qwen3ASRInt8(cacheDirectory: custom)
+        #expect(plan.cacheDirectory == custom)
+        #expect(plan.modelID == "FluidInference/qwen3-asr-0.6b-coreml")
     }
 }
 

--- a/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 @testable import MuesliCore
+@testable import MuesliNativeApp
 
 struct Qwen3VendorTests {
 
@@ -60,5 +61,31 @@ struct Qwen3LanguageTests {
         #expect(MuesliQwen3AsrConfig.Language(from: "eng") == nil)
         #expect(MuesliQwen3AsrConfig.Language(from: "") == nil)
         #expect(MuesliQwen3AsrConfig.Language(from: "chinese (simplified)") == nil)
+    }
+}
+
+struct Qwen3LanguageSelectionTests {
+
+    @available(macOS 15, *)
+    @Test("Qwen3AsrLanguage resolves auto and pinned languages")
+    func resolvesAutoAndPinned() {
+        #expect(Qwen3AsrLanguage.resolved(nil) == .auto)
+        #expect(Qwen3AsrLanguage.resolved("") == .auto)
+        #expect(Qwen3AsrLanguage.resolved("auto") == .auto)
+        #expect(Qwen3AsrLanguage.resolved("AUTO") == .auto)
+        #expect(Qwen3AsrLanguage.resolved("en") == .pinned(.english))
+        #expect(Qwen3AsrLanguage.resolved("English") == .pinned(.english))
+        #expect(Qwen3AsrLanguage.resolved("bogus") == .auto)
+    }
+
+    @available(macOS 15, *)
+    @Test("Qwen3AsrLanguage exposes codes and labels")
+    func exposesCodesAndLabels() {
+        #expect(Qwen3AsrLanguage.auto.pinnedCode == nil)
+        #expect(Qwen3AsrLanguage.auto.rawValue == "auto")
+        #expect(Qwen3AsrLanguage.auto.label == "Auto-detect")
+        #expect(Qwen3AsrLanguage.pinned(.english).pinnedCode == "en")
+        #expect(Qwen3AsrLanguage.pinned(.english).label == "English")
+        #expect(Qwen3AsrLanguage.allCases.count == MuesliQwen3AsrConfig.Language.allCases.count + 1)
     }
 }

--- a/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
+++ b/native/MuesliNative/Tests/MuesliTests/Qwen3VendorTests.swift
@@ -44,3 +44,21 @@ struct Qwen3VendorTests {
         #expect(cache.standardizedFileURL == plan.cacheDirectory.standardizedFileURL)
     }
 }
+
+struct Qwen3LanguageTests {
+
+    @Test("Language init parses ISO codes and English names")
+    func languageInitParsesCodesAndNames() {
+        #expect(MuesliQwen3AsrConfig.Language(from: "en") == .english)
+        #expect(MuesliQwen3AsrConfig.Language(from: "English") == .english)
+        #expect(MuesliQwen3AsrConfig.Language(from: "ENGLISH") == .english)
+        #expect(MuesliQwen3AsrConfig.Language(from: "hi") == .hindi)
+    }
+
+    @Test("Language init rejects unknown input")
+    func languageInitRejectsUnknownInput() {
+        #expect(MuesliQwen3AsrConfig.Language(from: "eng") == nil)
+        #expect(MuesliQwen3AsrConfig.Language(from: "") == nil)
+        #expect(MuesliQwen3AsrConfig.Language(from: "chinese (simplified)") == nil)
+    }
+}


### PR DESCRIPTION
## Summary
Moves FluidAudio's Qwen3 ASR implementation (Apache 2.0) into MuesliCore so Muesli keeps Qwen3 ASR after FluidAudio removed it in v0.15.3 — unblocking a future FluidAudio pin advance (0.15.6) that would otherwise drop the feature.

## What changed
- **`MuesliCore/Qwen3ASR/`** — 6 files vendored from FluidAudio v0.15.1 (`ASR/Qwen3/`), byte-for-byte with:
  - all public types renamed with a `MuesliQwen3*` prefix (avoids colliding with FluidAudio 0.15.1's exports while the pin is unchanged)
  - downloads routed through Muesli's managed model downloader (`ManagedASRModelPlans.qwen3ASRInt8` + `ManagedASRModelDownloader`) instead of FluidAudio's `DownloadUtils`; the `.f32` variant is currently unmanaged and throws a clear error
  - Apache 2.0 attribution headers on every vendored file
- **`Qwen3AsrBackend` + `muesli-cli`** now use `MuesliQwen3AsrManager`.
- **Qwen3 ASR moved to the Experimental section** in Models — accuracy varies noticeably for accented English, so it's no longer presented as a first-class option. Its models remain downloadable from the existing HuggingFace repo.

## Behavior
No transcription behavior change: same model artifacts (`FluidInference/qwen3-asr-0.6b-coreml/int8`), same inference code, same cache layout.

## Validation
- `swift build` — clean
- Full test suite — 1784 tests / 162 suites passed
- DevB lane (`dev-test.sh --lane B --local-only`) — installed and launched; Qwen3 dictation verified through the vendored module

## Stack
Draft PR 2 will stack on this branch: FluidAudio pin `0.15.1 → 0.15.6` + Parakeet Unified 0.6B as recommended English model + native over-fire guard wiring for advanced word recognition.

## Notes for review
- Vendored code is intentionally byte-for-byte (cleanup is a follow-up).
- This is a draft: full review-bot + CI pass pending before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789816975&installation_model_id=422865&pr_number=449&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F449&signature=b437b850a75536dd9fca38c801745ea2d2a30136103f9e63daaf5373ed685eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qwen3 speech-to-text transcription with automatic or selected language support.
  * Added streaming transcription with incremental results, finalization, duration tracking, and session reset controls.
  * Added model downloading, caching, and selectable model variants.
  * Added support for 30 transcription languages using ISO codes or language names.
* **Changes**
  * Qwen3 ASR is now labeled experimental and requires macOS 15 with compatible Core ML hardware.
  * Language preferences apply consistently across dictation and meeting transcription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->