### PR TITLE
Tidy up the sidebar: icon weight, left edge alignment, and a one-row footer

### DIFF
--- a/design-system/muesli-design-system.html
+++ b/design-system/muesli-design-system.html
@@ -479,16 +479,18 @@
 
   <h3>Sidebar Navigation</h3>
   <div class="icon-grid">
-    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F552;</span><div class="icon-label">clock.fill<br>Timeline</div></div>
-    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F399;</span><div class="icon-label">mic.fill<br>Dictations</div></div>
-    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F465;</span><div class="icon-label">person.2.fill<br>Meetings</div></div>
+    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F552;</span><div class="icon-label">clock<br>Timeline</div></div>
+    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x301C;</span><div class="icon-label">waveform<br>Dictations</div></div>
+    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F465;</span><div class="icon-label">person.wave.2<br>Meetings</div></div>
+    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F4CA;</span><div class="icon-label">chart.bar.xaxis<br>Insights</div></div>
     <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F4D6;</span><div class="icon-label">character.book.closed<br>Dictionary</div></div>
-    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x2B07;</span><div class="icon-label">square.and.arrow.down<br>Models</div></div>
-    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x2328;</span><div class="icon-label">keyboard<br>Shortcuts</div></div>
+    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x1F4BB;</span><div class="icon-label">cpu<br>Models</div></div>
+    <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x2318;</span><div class="icon-label">command<br>Shortcuts</div></div>
     <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x2699;</span><div class="icon-label">gearshape<br>Settings</div></div>
     <div class="icon-item"><span class="symbol" style="font-family:-apple-system">&#x2139;</span><div class="icon-label">info.circle<br>About</div></div>
   </div>
-  <p style="color:var(--text-secondary);font-size:13px;margin:8px 0">Timeline (clock.fill) leads: one chronological feed combining dictations and meetings. The Meetings row expands to reveal meeting folders. Insights (streak, words, pace, meetings) is a drill-in view with a back button, not a sidebar item.</p>
+  <p style="color:var(--text-secondary);font-size:13px;margin:8px 0">Timeline (clock) leads: one chronological feed combining dictations and meetings. The Meetings row expands to reveal meeting folders, with children indented as a group (position carries nesting, not icon size). Insights is a first-class sidebar item. Models, Shortcuts, Settings, and About sit in the bottom section. The rail collapses to a 68pt icon strip via the header toggle.</p>
+  <p style="color:var(--text-secondary);font-size:13px;margin:8px 0">Icons are outline-only at 14pt medium; <code>.fill</code> is reserved for selection state, keeping ink weight even across the column. The icon column is center-aligned and starts at the search field's inner padding, so row glyphs sit directly under the magnifier.</p>
 
   <h3>Floating Indicator Controls</h3>
   <table>

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -4,9 +4,14 @@ import MuesliCore
 struct SidebarView: View {
     private let sidebarIconColumnWidth: CGFloat = 20
     private let meetingsTrailingColumnWidth: CGFloat = 24
-    private let sidebarRowHorizontalPadding: CGFloat = 16
+    /// Совпадает с внутренним отступом поля поиска, поэтому колонка иконок строк
+    /// встаёт ровно под лупой, а не на 6 пунктов правее.
+    private let sidebarRowHorizontalPadding: CGFloat = 10
     private let sidebarRowOuterPadding: CGFloat = 8
-    private let folderDepthIndent: CGFloat = 8
+    /// Отступ вложенных строк раздела Meetings. Сайдбар узкий (260pt по умолчанию),
+    /// поэтому вложенность показываем сдвигом, но экономно.
+    private let meetingsChildIndent: CGFloat = 24
+    private let folderDepthIndent: CGFloat = 16
 
     let appState: AppState
     let controller: MuesliController
@@ -281,10 +286,11 @@ Even out the sidebar icon set)
 
     @ViewBuilder
     private var searchBar: some View {
-        HStack(spacing: MuesliTheme.spacing8) {
+        HStack(spacing: MuesliTheme.spacing12) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 12))
                 .foregroundStyle(MuesliTheme.textTertiary)
+                .frame(width: sidebarIconColumnWidth, alignment: .center)
             TextField("Search...", text: searchTextBinding)
                 .textFieldStyle(.plain)
                 .font(MuesliTheme.callout())
@@ -302,8 +308,8 @@ Even out the sidebar icon set)
                 .buttonStyle(.plain)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
+        .padding(.horizontal, sidebarRowHorizontalPadding)
+        .frame(height: 32)
         .background(MuesliTheme.backgroundRaised)
         .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
         .overlay(
@@ -380,6 +386,8 @@ Even out the sidebar icon set)
 
             if meetingsExpanded {
                 let folderTree = folderTreePresentation
+                // Дети раздела сдвинуты как группа: сейчас у них нулевой отступ,
+                // и вложенность читается только по мелкому кеглю иконки.
                 VStack(alignment: .leading, spacing: 2) {
                     meetingFilterRow(
                         icon: "tray.2",
@@ -443,6 +451,7 @@ Even out the sidebar icon set)
                         }
                     }
                 }
+                .padding(.leading, meetingsChildIndent)
                 .padding(.horizontal, sidebarRowOuterPadding)
             }
         }
@@ -686,9 +695,9 @@ Even out the sidebar icon set)
         disclosureAction: (() -> Void)? = nil,
         action: @escaping () -> Void
     ) -> some View {
-        HStack(spacing: MuesliTheme.spacing8) {
+        HStack(spacing: MuesliTheme.spacing12) {
             Image(systemName: icon)
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textTertiary)
                 .frame(width: sidebarIconColumnWidth)
             Text(label)
@@ -721,7 +730,7 @@ Even out the sidebar icon set)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .offset(x: 4)
+                .offset(x: -20)
             }
         }
     }

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -185,11 +185,13 @@ struct SidebarView: View {
             sidebarHeader
             searchBar
 
-            sidebarItem(tab: .timeline, icon: "clock.fill", label: "Timeline")
+            sidebarItem(tab: .timeline, icon: "clock", label: "Timeline")
             sidebarItem(tab: .dictations, icon: "waveform", label: "Dictations")
+Even out the sidebar icon set)
             meetingsSection
             sidebarItem(tab: .insights, icon: "chart.bar.xaxis", label: "Insights")
             sidebarItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
+Even out the sidebar icon set)
 
             Spacer()
 
@@ -330,7 +332,7 @@ struct SidebarView: View {
                     controller.showMeetingsHome()
                 } label: {
                     HStack(spacing: MuesliTheme.spacing12) {
-                        Image(systemName: "person.2.fill")
+                        Image(systemName: "person.wave.2")
                             .font(.system(size: 14, weight: .medium))
                             .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
                             .frame(width: sidebarIconColumnWidth)
@@ -397,7 +399,7 @@ struct SidebarView: View {
                                 .padding(.leading, CGFloat(depth) * folderDepthIndent)
                         } else {
                             meetingFilterRow(
-                                icon: hasChildren ? "folder.fill" : "folder",
+                                icon: "folder",
                                 label: folder.name,
                                 count: appState.meetingCountsByFolder[folder.id] ?? 0,
                                 isSelected: appState.selectedTab == .meetings && appState.selectedFolderID == folder.id,
@@ -589,7 +591,6 @@ struct SidebarView: View {
                     .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
                     .frame(width: sidebarIconColumnWidth, height: sidebarIconColumnWidth, alignment: .center)
-                    .offset(y: icon == "square.and.arrow.down" ? -1 : 0)
                 Text(label)
                     .font(MuesliTheme.headline())
                     .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)

--- a/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
+++ b/native/MuesliNative/Sources/MuesliNativeApp/SidebarView.swift
@@ -4,12 +4,12 @@ import MuesliCore
 struct SidebarView: View {
     private let sidebarIconColumnWidth: CGFloat = 20
     private let meetingsTrailingColumnWidth: CGFloat = 24
-    /// Совпадает с внутренним отступом поля поиска, поэтому колонка иконок строк
-    /// встаёт ровно под лупой, а не на 6 пунктов правее.
+    /// Matches the search field's inner padding so the row icon column sits
+    /// exactly under the magnifier instead of 6pt to its right.
     private let sidebarRowHorizontalPadding: CGFloat = 10
     private let sidebarRowOuterPadding: CGFloat = 8
-    /// Отступ вложенных строк раздела Meetings. Сайдбар узкий (260pt по умолчанию),
-    /// поэтому вложенность показываем сдвигом, но экономно.
+    /// Indent for nested Meetings section rows. The sidebar is narrow (260pt by
+    /// default), so show nesting by indent, but economically.
     private let meetingsChildIndent: CGFloat = 24
     private let folderDepthIndent: CGFloat = 16
 
@@ -118,9 +118,9 @@ struct SidebarView: View {
                 .padding(.top, MuesliTheme.spacing16)
                 .padding(.bottom, MuesliTheme.spacing12)
 
-            collapsedItem(tab: .timeline, icon: "clock.fill", label: "Timeline")
+            collapsedItem(tab: .timeline, icon: "clock", label: "Timeline")
             collapsedItem(tab: .dictations, icon: "waveform", label: "Dictations")
-            collapsedItem(tab: .meetings, icon: "person.2.fill", label: "Meetings")
+            collapsedItem(tab: .meetings, icon: "person.2", label: "Meetings")
             collapsedItem(tab: .insights, icon: "chart.bar.xaxis", label: "Insights")
             collapsedItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
 
@@ -192,11 +192,9 @@ struct SidebarView: View {
 
             sidebarItem(tab: .timeline, icon: "clock", label: "Timeline")
             sidebarItem(tab: .dictations, icon: "waveform", label: "Dictations")
-Even out the sidebar icon set)
             meetingsSection
             sidebarItem(tab: .insights, icon: "chart.bar.xaxis", label: "Insights")
             sidebarItem(tab: .dictionary, icon: "character.book.closed", label: "Dictionary")
-Even out the sidebar icon set)
 
             Spacer()
 
@@ -386,8 +384,8 @@ Even out the sidebar icon set)
 
             if meetingsExpanded {
                 let folderTree = folderTreePresentation
-                // Дети раздела сдвинуты как группа: сейчас у них нулевой отступ,
-                // и вложенность читается только по мелкому кеглю иконки.
+                // Section children are indented as a group: previously they had zero
+                // indent and nesting only read via the smaller icon size.
                 VStack(alignment: .leading, spacing: 2) {
                     meetingFilterRow(
                         icon: "tray.2",


### PR DESCRIPTION
## What this is

A design proposal rather than a bug fix, so treat it as a starting point for a conversation. The
sidebar works fine as it is; this is an attempt to tidy the navigation so the column reads as one
system. I am happy to take any part of it out, split it up, or drop it entirely if it does not match
where you want the app to go.

Everything below is measured rather than eyeballed: each SF Symbol was rendered to a bitmap at the
same 14pt medium the sidebar uses, and the covered area compared.

| Before | After |
|---|---|
| ![sidebar](https://raw.githubusercontent.com/esteugene/muesli/pr-assets/assets/sidebar-light.png) | |

Dark theme: ![dark](https://raw.githubusercontent.com/esteugene/muesli/pr-assets/assets/sidebar-dark.png)

## The three things it changes

**Icon weight.** The column mixes filled and outline symbols, so ink varies 2.4x even though every
glyph is drawn at one size: `clock.fill` 166, `person.2.fill` 134, `keyboard` 107,
`character.book.closed` 92, `gearshape` 86, `mic.fill` 82, `info.circle` 81,
`square.and.arrow.down` 69. Timeline and Meetings read as heavy blobs next to Models. Nothing is
filled any more, and the two widest glyphs are replaced: `person.2` was 19pt against 11pt for the
narrowest, and `keyboard` was the flattest of the set. Models moves from a download arrow to `cpu`,
which describes what the page lists rather than what the button does. Folders also stop switching to
`folder.fill` when they have children, which doubled their weight as a function of nesting that the
chevron already communicates. Ink now spans 71 to 92.

**Left edge alignment.** The search field's magnifier sits 18pt from the sidebar edge; every row's
icon column started at 24pt. Row padding now matches the search field's, so both start at 18pt, and
the magnifier moves into an icon column so their centres line up rather than merely sit near each
other. Measured in a running build: left edges at 21.0, 22.0 and 20.5pt, where the spread is glyph
shape rather than layout. The search field also grows from 25pt to 32pt, since against 36pt rows it
looked pinched, and its glyph now matches the others in size and weight.

**Hierarchy and the footer.** The Meetings children had no indent at all, so nesting was carried
only by a smaller 11pt icon. They are now indented as a group and their icons match the rest of the
sidebar, so position does that work. The bottom then collapses from five rows and a heading into one:
Settings and About as icon buttons, the share link labelled on the right, each with a 32pt tap
target. That returns roughly 150pt of height at the default 260pt sidebar width.

## Two calls worth arguing about

The share row keeps its milestone condition, so this changes the layout rather than when it is
offered, but it does drop the LinkedIn entry and label the remaining one. Two unlabelled marks in a
narrow column read as decoration, while one named button reads as an action. That is a product
decision, not a layout one, and it is a single commit to revert.

The theme toggle is removed rather than moved, because Settings already has Appearance -> Dark mode
bound to the same config value. If the sidebar copy was deliberate, say so and I will put it back.

About's update pill becomes a dot on the icon, keeping the same tooltip and accessibility label.

## Validation

- `swift test` across the touched suites: `SidebarHitAreaTests`, `ContributionMilestoneTests`,
  `UpdateFailureGuidanceTests`, `MeetingsNavigationTests`, `FeatureTourTests`, all passing.
- `scripts/test_ci_test_shards.sh` passes.
- Screenshots are a dev build on an empty database, both themes, with the share button forced
  visible for the shot.
- `SidebarHitAreaTests` anchored its source scan on `darkModeToggle`, so the anchor moves to the
  next declaration, and the same hit target rule now covers the new footer buttons.

## Contribution certification

- [x] Every non-merge commit in this pull request has a valid
      `Signed-off-by` trailer from its author under the
      [Developer Certificate of Origin](https://developercertificate.org/).
- [x] I created this contribution or otherwise have the right to submit it
      under Muesli's
      [MIT License](https://github.com/Muesli-HQ/muesli/blob/main/LICENSE).
- [x] I have obtained any permission required by an employer, client,
      institution, or other party that may have rights in this contribution.
- [x] I have identified all third-party code, models, datasets, media, and
      other assets introduced by this pull request, including their sources
      and licenses or terms.
- [x] I have disclosed material AI assistance and reviewed and tested the
      resulting changes.

### Third-party materials

None. The X mark is the existing bundled `x-logo.png`.

### AI assistance

Written with Claude Code. I reviewed the diff, ran the suites, and checked the result in a dev build
in both themes before opening this.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli/pr/450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789818635&installation_model_id=422865&pr_number=450&repository=Muesli-HQ%2Fmuesli&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli%2Fpull%2F450&signature=7b873c31aaf489bd52956e59a45323bc28301307301743d1a6818472ff743460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a collapsible sidebar with an icon-only navigation rail.
  - Added a header toggle to expand or collapse sidebar navigation.
  - Selecting Meetings from the collapsed rail now opens the Meetings home view.
  - Added Insights as a dedicated sidebar destination.
- **Improvements**
  - Updated navigation icons, alignment, spacing, folder indentation, and disclosure controls.
  - Standardized sidebar icon styling and improved consistency across navigation sections.
  - Updated design-system guidance to reflect the revised sidebar structure and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->